### PR TITLE
refactor(gateway): extract proxy/text/media mixins from base.py (shard s1)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -24,6 +24,28 @@ from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
 
+from gateway.platforms.proxy_utils import (
+    _detect_macos_system_proxy,
+    _no_proxy_entries,
+    _no_proxy_entry_matches,
+    _split_host_port,
+    is_host_excluded_by_no_proxy,
+    proxy_kwargs_for_aiohttp,
+    proxy_kwargs_for_bot,
+    resolve_proxy_url,
+    should_bypass_proxy,
+)
+from gateway.platforms.routing_metadata import (
+    _mark_notify_metadata,
+    _reply_anchor_for_event,
+    _thread_metadata_for_source,
+)
+from gateway.platforms.text_metrics import (
+    _custom_unit_to_cp,
+    _prefix_within_utf16_limit,
+    utf16_len,
+)
+
 logger = logging.getLogger(__name__)
 
 # Audio file extensions Hermes recognizes for native audio delivery.
@@ -61,81 +83,6 @@ def _float_env(name: str, default: float) -> float:
         return float(raw)
     except (TypeError, ValueError):
         return default
-
-
-def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
-    """Build platform-aware thread metadata for adapter sends.
-
-    Most platforms route threaded sends with a generic ``thread_id`` metadata
-    value. Telegram private-chat topics created through Hermes' DM-topic helper
-    are exposed in updates as ``message_thread_id`` plus a reply anchor. Live
-    user-message replies route with ``message_thread_id`` + ``reply_to_message_id``;
-    synthetic/resumed sends that have no reply anchor fall back to Telegram's
-    ``direct_messages_topic_id`` when the Bot API supports it.
-    """
-    thread_id = getattr(source, "thread_id", None)
-    metadata = {"thread_id": thread_id} if thread_id is not None else {}
-    # Slack workspace identity is durable routing state, not ephemeral event
-    # metadata. Carry it on every outbound path (including unthreaded sends)
-    # so a multi-workspace Socket Mode gateway never falls back to its primary
-    # WebClient after an async, stream, or recovery boundary.
-    if _platform_name(getattr(source, "platform", None)) == "slack":
-        scope_id = getattr(source, "scope_id", None)
-        if scope_id:
-            metadata["slack_team_id"] = str(scope_id)
-    if not metadata:
-        return None
-    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
-        metadata["telegram_dm_topic_reply_fallback"] = True
-        tid = str(thread_id)
-        if tid and tid not in {"", "1"}:
-            metadata["direct_messages_topic_id"] = tid
-        anchor = reply_to_message_id or getattr(source, "message_id", None)
-        if anchor is not None:
-            metadata["telegram_reply_to_message_id"] = str(anchor)
-    return metadata
-
-
-def _mark_notify_metadata(metadata: dict | None) -> dict:
-    """Clone metadata and mark a user-visible reply as notify-worthy."""
-    notify_metadata = dict(metadata) if metadata else {}
-    notify_metadata["notify"] = True
-    return notify_metadata
-
-
-def _reply_anchor_for_event(event) -> str | None:
-    """Return reply_to id for platforms that need reply semantics.
-
-    Telegram forum/supergroup topics should be routed by topic metadata, not by
-    replying to the triggering message. Hermes-created Telegram private-chat
-    topic lanes prefer replying to the triggering user message so the answer
-    stays attached to the active lane; synthetic/resumed sends fall back to
-    ``direct_messages_topic_id`` metadata when no message id is available.
-    """
-    source = getattr(event, "source", None)
-    platform = _platform_name(getattr(source, "platform", None))
-    thread_id = getattr(source, "thread_id", None)
-    raw_message = getattr(event, "raw_message", None)
-    if (
-        platform == "slack"
-        and isinstance(raw_message, dict)
-        and raw_message.get("_hermes_no_thread_response")
-    ):
-        # Slack reaction handoffs into a configured target channel are meant
-        # to create a new top-level message there. Returning the synthetic
-        # event's message_id as reply_to would make
-        # SlackAdapter._resolve_thread_ts() treat it as a thread anchor and
-        # reply in a (nonexistent) thread anyway.
-        return None
-    if platform == "telegram" and thread_id and getattr(source, "chat_type", None) == "dm":
-        # Reply to the triggering user message. Replying to Telegram's earlier
-        # topic seed/anchor can render the bot response outside the active lane.
-        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
-    if platform == "telegram" and thread_id:
-        return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
-    return getattr(event, "message_id", None)
 
 
 def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bool:
@@ -187,59 +134,6 @@ def build_auto_tts_output_path(platform) -> str:
     return audio_path
 
 
-def utf16_len(s: str) -> int:
-    """Count UTF-16 code units in *s*.
-
-    Telegram's message-length limit (4 096) is measured in UTF-16 code units,
-    **not** Unicode code-points.  Characters outside the Basic Multilingual
-    Plane (emoji like 😀, CJK Extension B, musical symbols, …) are encoded as
-    surrogate pairs and therefore consume **two** UTF-16 code units each, even
-    though Python's ``len()`` counts them as one.
-
-    Ported from nearai/ironclaw#2304 which discovered the same discrepancy in
-    Rust's ``chars().count()``.
-    """
-    return len(s.encode("utf-16-le")) // 2
-
-
-def _prefix_within_utf16_limit(s: str, limit: int) -> str:
-    """Return the longest prefix of *s* whose UTF-16 length ≤ *limit*.
-
-    Unlike a plain ``s[:limit]``, this respects surrogate-pair boundaries so
-    we never slice a multi-code-unit character in half.
-    """
-    if utf16_len(s) <= limit:
-        return s
-    # Binary search for the longest safe prefix
-    lo, hi = 0, len(s)
-    while lo < hi:
-        mid = (lo + hi + 1) // 2
-        if utf16_len(s[:mid]) <= limit:
-            lo = mid
-        else:
-            hi = mid - 1
-    return s[:lo]
-
-
-def _custom_unit_to_cp(s: str, budget: int, len_fn) -> int:
-    """Return the largest codepoint offset *n* such that ``len_fn(s[:n]) <= budget``.
-
-    Used by :meth:`BasePlatformAdapter.truncate_message` when *len_fn* measures
-    length in units different from Python codepoints (e.g. UTF-16 code units).
-    Falls back to binary search which is O(log n) calls to *len_fn*.
-    """
-    if len_fn(s) <= budget:
-        return len(s)
-    lo, hi = 0, len(s)
-    while lo < hi:
-        mid = (lo + hi + 1) // 2
-        if len_fn(s[:mid]) <= budget:
-            lo = mid
-        else:
-            hi = mid - 1
-    return lo
-
-
 def is_network_accessible(host: str) -> bool:
     """Return True if *host* would expose the server beyond loopback.
 
@@ -273,268 +167,6 @@ def is_network_accessible(host: str) -> bool:
         return False
     except (_socket.gaierror, OSError):
         return True
-
-
-def _detect_macos_system_proxy() -> str | None:
-    """Read the macOS system HTTP(S) proxy via ``scutil --proxy``.
-
-    Returns an ``http://host:port`` URL string if an HTTP or HTTPS proxy is
-    enabled, otherwise *None*.  Falls back silently on non-macOS or on any
-    subprocess error.
-    """
-    if sys.platform != "darwin":
-        return None
-    try:
-        out = subprocess.check_output(
-            ["scutil", "--proxy"], timeout=3, text=True, encoding='utf-8', errors='replace', stderr=subprocess.DEVNULL,
-        )
-    except Exception:
-        return None
-
-    props: dict[str, str] = {}
-    for line in out.splitlines():
-        line = line.strip()
-        if " : " in line:
-            key, _, val = line.partition(" : ")
-            props[key.strip()] = val.strip()
-
-    # Prefer HTTPS, fall back to HTTP
-    for enable_key, host_key, port_key in (
-        ("HTTPSEnable", "HTTPSProxy", "HTTPSPort"),
-        ("HTTPEnable", "HTTPProxy", "HTTPPort"),
-    ):
-        if props.get(enable_key) == "1":
-            host = props.get(host_key)
-            port = props.get(port_key)
-            if host and port:
-                return f"http://{host}:{port}"
-    return None
-
-
-def _split_host_port(value: str) -> tuple[str, int | None]:
-    raw = str(value or "").strip()
-    if not raw:
-        return "", None
-    if "://" in raw:
-        parsed = urlsplit(raw)
-        return (parsed.hostname or "").lower().rstrip("."), parsed.port
-    if raw.startswith("[") and "]" in raw:
-        host, _, rest = raw[1:].partition("]")
-        port = None
-        if rest.startswith(":") and rest[1:].isdigit():
-            port = int(rest[1:])
-        return host.lower().rstrip("."), port
-    if raw.count(":") == 1:
-        host, _, maybe_port = raw.rpartition(":")
-        if maybe_port.isdigit():
-            return host.lower().rstrip("."), int(maybe_port)
-    return raw.lower().strip("[]").rstrip("."), None
-
-
-def _no_proxy_entries() -> list[str]:
-    entries: list[str] = []
-    for key in ("NO_PROXY", "no_proxy"):
-        raw = os.environ.get(key, "")
-        entries.extend(part.strip() for part in raw.split(",") if part.strip())
-    return entries
-
-
-def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
-    token = str(entry or "").strip().lower()
-    if not token:
-        return False
-    if token == "*":
-        return True
-
-    token_host, token_port = _split_host_port(token)
-    if token_port is not None and port is not None and token_port != port:
-        return False
-    if token_port is not None and port is None:
-        return False
-    if not token_host:
-        return False
-
-    try:
-        network = ipaddress.ip_network(token_host, strict=False)
-        try:
-            return ipaddress.ip_address(host) in network
-        except ValueError:
-            return False
-    except ValueError:
-        pass
-
-    try:
-        token_ip = ipaddress.ip_address(token_host)
-        try:
-            return ipaddress.ip_address(host) == token_ip
-        except ValueError:
-            return False
-    except ValueError:
-        pass
-
-    if token_host.startswith("*."):
-        suffix = token_host[1:]
-        return host.endswith(suffix)
-    if token_host.startswith("."):
-        return host == token_host[1:] or host.endswith(token_host)
-    return host == token_host or host.endswith(f".{token_host}")
-
-
-def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[str] | None) -> bool:
-    """Return True when NO_PROXY/no_proxy matches at least one target host.
-
-    Supports exact hosts, domain suffixes, wildcard suffixes, IP literals,
-    CIDR ranges, optional host:port entries, and ``*``.
-    """
-    entries = _no_proxy_entries()
-    if not entries or not target_hosts:
-        return False
-    if isinstance(target_hosts, str):
-        candidates = [target_hosts]
-    else:
-        candidates = list(target_hosts)
-    for candidate in candidates:
-        host, port = _split_host_port(str(candidate))
-        if not host:
-            continue
-        if any(_no_proxy_entry_matches(entry, host, port) for entry in entries):
-            return True
-    return False
-
-
-def resolve_proxy_url(
-    platform_env_var: str | None = None,
-    *,
-    target_hosts: str | list[str] | tuple[str, ...] | set[str] | None = None,
-) -> str | None:
-    """Return a proxy URL from env vars, or macOS system proxy.
-
-    Check order:
-      0. *platform_env_var* (e.g. ``DISCORD_PROXY``) — highest priority
-      1. HTTPS_PROXY / HTTP_PROXY / ALL_PROXY (and lowercase variants)
-      2. macOS system proxy via ``scutil --proxy`` (auto-detect)
-
-    Returns *None* if no proxy is found, or if NO_PROXY/no_proxy matches one
-    of ``target_hosts``.
-    """
-    if platform_env_var:
-        value = (os.environ.get(platform_env_var) or "").strip()
-        if value:
-            if should_bypass_proxy(target_hosts):
-                return None
-            return normalize_proxy_url(value)
-    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
-                "https_proxy", "http_proxy", "all_proxy"):
-        value = (os.environ.get(key) or "").strip()
-        if value:
-            if should_bypass_proxy(target_hosts):
-                return None
-            return normalize_proxy_url(value)
-    detected = normalize_proxy_url(_detect_macos_system_proxy())
-    if detected and should_bypass_proxy(target_hosts):
-        return None
-    return detected
-
-
-def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
-    """Build kwargs for ``commands.Bot()`` / ``discord.Client()`` with proxy.
-
-    Returns:
-      - SOCKS URL  → ``{"connector": ProxyConnector(..., rdns=True)}``
-      - HTTP URL   → ``{"proxy": url}``
-      - *None*     → ``{}``
-
-    ``rdns=True`` forces remote DNS resolution through the proxy — required
-    by many SOCKS implementations (Shadowrocket, Clash) and essential for
-    bypassing DNS pollution behind the GFW.
-    """
-    if not proxy_url:
-        return {}
-    if proxy_url.lower().startswith("socks"):
-        try:
-            from aiohttp_socks import ProxyConnector
-
-            connector = ProxyConnector.from_url(proxy_url, rdns=True)
-            return {"connector": connector}
-        except ImportError:
-            logger.warning(
-                "aiohttp_socks not installed — SOCKS proxy %s ignored. "
-                "Run: pip install aiohttp-socks",
-                proxy_url,
-            )
-            return {}
-    return {"proxy": proxy_url}
-
-
-def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
-    """Build kwargs for standalone ``aiohttp.ClientSession`` with proxy.
-
-    Returns ``(session_kwargs, request_kwargs)`` where:
-      - With aiohttp-socks → ``({"connector": ProxyConnector(...)}, {})``
-        for *all* proxy schemes (SOCKS **and** HTTP/HTTPS).
-      - HTTP without aiohttp-socks → ``({}, {"proxy": url})``.
-      - None → ``({}, {})``.
-
-    Prefer the connector path: it works transparently with libraries
-    (like mautrix) that call ``session.request()`` without forwarding
-    per-request ``proxy=`` kwargs.
-
-    Usage::
-
-        sess_kw, req_kw = proxy_kwargs_for_aiohttp(proxy_url)
-        async with aiohttp.ClientSession(**sess_kw) as session:
-            async with session.get(url, **req_kw) as resp:
-                ...
-    """
-    if not proxy_url:
-        return {}, {}
-    try:
-        from aiohttp_socks import ProxyConnector
-
-        connector = ProxyConnector.from_url(proxy_url, rdns=True)
-        return {"connector": connector}, {}
-    except ImportError:
-        if proxy_url.lower().startswith("socks"):
-            logger.warning(
-                "aiohttp_socks not installed — SOCKS proxy %s ignored. "
-                "Run: pip install aiohttp-socks",
-                proxy_url,
-            )
-            return {}, {}
-        return {}, {"proxy": proxy_url}
-
-
-def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = None) -> bool:
-    """Return True when ``hostname`` matches a ``NO_PROXY`` entry.
-
-    Supports comma- or whitespace-separated entries with optional leading dots
-    and ``*.`` wildcards, which match both the apex domain and subdomains.
-    """
-    raw = no_proxy_value
-    if raw is None:
-        raw = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
-
-    raw = raw.strip()
-    if not raw:
-        return False
-
-    lower_hostname = hostname.lower()
-    for entry in re.split(r"[\s,]+", raw):
-        normalized = entry.strip().lower()
-        if not normalized:
-            continue
-        if normalized == "*":
-            return True
-
-        if normalized.startswith("*."):
-            normalized = normalized[2:]
-        elif normalized.startswith("."):
-            normalized = normalized[1:]
-
-        if lower_hostname == normalized or lower_hostname.endswith(f".{normalized}"):
-            return True
-
-    return False
 
 
 import dataclasses

--- a/gateway/platforms/proxy_utils.py
+++ b/gateway/platforms/proxy_utils.py
@@ -1,0 +1,282 @@
+"""Proxy resolution and NO_PROXY matching for gateway platform adapters.
+
+Extracted from ``gateway/platforms/base.py`` (god-file decomposition
+campaign, wave 1 — shard s1, cluster c6, 36 move votes). Every function is
+moved verbatim; ``base.py`` re-exports them so ``from
+gateway.platforms.base import ...`` call sites are unchanged. The
+module-level ``logger`` reuses the historical ``gateway.platforms.base``
+logger name so log records are byte-identical.
+"""
+
+import ipaddress
+import logging
+import os
+import re
+import subprocess
+import sys
+from urllib.parse import urlsplit
+
+from utils import normalize_proxy_url
+
+logger = logging.getLogger("gateway.platforms.base")
+
+def _detect_macos_system_proxy() -> str | None:
+    """Read the macOS system HTTP(S) proxy via ``scutil --proxy``.
+
+    Returns an ``http://host:port`` URL string if an HTTP or HTTPS proxy is
+    enabled, otherwise *None*.  Falls back silently on non-macOS or on any
+    subprocess error.
+    """
+    if sys.platform != "darwin":
+        return None
+    try:
+        out = subprocess.check_output(
+            ["scutil", "--proxy"], timeout=3, text=True, encoding='utf-8', errors='replace', stderr=subprocess.DEVNULL,
+        )
+    except Exception:
+        return None
+
+    props: dict[str, str] = {}
+    for line in out.splitlines():
+        line = line.strip()
+        if " : " in line:
+            key, _, val = line.partition(" : ")
+            props[key.strip()] = val.strip()
+
+    # Prefer HTTPS, fall back to HTTP
+    for enable_key, host_key, port_key in (
+        ("HTTPSEnable", "HTTPSProxy", "HTTPSPort"),
+        ("HTTPEnable", "HTTPProxy", "HTTPPort"),
+    ):
+        if props.get(enable_key) == "1":
+            host = props.get(host_key)
+            port = props.get(port_key)
+            if host and port:
+                return f"http://{host}:{port}"
+    return None
+
+
+def _split_host_port(value: str) -> tuple[str, int | None]:
+    raw = str(value or "").strip()
+    if not raw:
+        return "", None
+    if "://" in raw:
+        parsed = urlsplit(raw)
+        return (parsed.hostname or "").lower().rstrip("."), parsed.port
+    if raw.startswith("[") and "]" in raw:
+        host, _, rest = raw[1:].partition("]")
+        port = None
+        if rest.startswith(":") and rest[1:].isdigit():
+            port = int(rest[1:])
+        return host.lower().rstrip("."), port
+    if raw.count(":") == 1:
+        host, _, maybe_port = raw.rpartition(":")
+        if maybe_port.isdigit():
+            return host.lower().rstrip("."), int(maybe_port)
+    return raw.lower().strip("[]").rstrip("."), None
+
+
+def _no_proxy_entries() -> list[str]:
+    entries: list[str] = []
+    for key in ("NO_PROXY", "no_proxy"):
+        raw = os.environ.get(key, "")
+        entries.extend(part.strip() for part in raw.split(",") if part.strip())
+    return entries
+
+
+def _no_proxy_entry_matches(entry: str, host: str, port: int | None = None) -> bool:
+    token = str(entry or "").strip().lower()
+    if not token:
+        return False
+    if token == "*":
+        return True
+
+    token_host, token_port = _split_host_port(token)
+    if token_port is not None and port is not None and token_port != port:
+        return False
+    if token_port is not None and port is None:
+        return False
+    if not token_host:
+        return False
+
+    try:
+        network = ipaddress.ip_network(token_host, strict=False)
+        try:
+            return ipaddress.ip_address(host) in network
+        except ValueError:
+            return False
+    except ValueError:
+        pass
+
+    try:
+        token_ip = ipaddress.ip_address(token_host)
+        try:
+            return ipaddress.ip_address(host) == token_ip
+        except ValueError:
+            return False
+    except ValueError:
+        pass
+
+    if token_host.startswith("*."):
+        suffix = token_host[1:]
+        return host.endswith(suffix)
+    if token_host.startswith("."):
+        return host == token_host[1:] or host.endswith(token_host)
+    return host == token_host or host.endswith(f".{token_host}")
+
+
+def should_bypass_proxy(target_hosts: str | list[str] | tuple[str, ...] | set[str] | None) -> bool:
+    """Return True when NO_PROXY/no_proxy matches at least one target host.
+
+    Supports exact hosts, domain suffixes, wildcard suffixes, IP literals,
+    CIDR ranges, optional host:port entries, and ``*``.
+    """
+    entries = _no_proxy_entries()
+    if not entries or not target_hosts:
+        return False
+    if isinstance(target_hosts, str):
+        candidates = [target_hosts]
+    else:
+        candidates = list(target_hosts)
+    for candidate in candidates:
+        host, port = _split_host_port(str(candidate))
+        if not host:
+            continue
+        if any(_no_proxy_entry_matches(entry, host, port) for entry in entries):
+            return True
+    return False
+
+
+def resolve_proxy_url(
+    platform_env_var: str | None = None,
+    *,
+    target_hosts: str | list[str] | tuple[str, ...] | set[str] | None = None,
+) -> str | None:
+    """Return a proxy URL from env vars, or macOS system proxy.
+
+    Check order:
+      0. *platform_env_var* (e.g. ``DISCORD_PROXY``) — highest priority
+      1. HTTPS_PROXY / HTTP_PROXY / ALL_PROXY (and lowercase variants)
+      2. macOS system proxy via ``scutil --proxy`` (auto-detect)
+
+    Returns *None* if no proxy is found, or if NO_PROXY/no_proxy matches one
+    of ``target_hosts``.
+    """
+    if platform_env_var:
+        value = (os.environ.get(platform_env_var) or "").strip()
+        if value:
+            if should_bypass_proxy(target_hosts):
+                return None
+            return normalize_proxy_url(value)
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
+                "https_proxy", "http_proxy", "all_proxy"):
+        value = (os.environ.get(key) or "").strip()
+        if value:
+            if should_bypass_proxy(target_hosts):
+                return None
+            return normalize_proxy_url(value)
+    detected = normalize_proxy_url(_detect_macos_system_proxy())
+    if detected and should_bypass_proxy(target_hosts):
+        return None
+    return detected
+
+
+def proxy_kwargs_for_bot(proxy_url: str | None) -> dict:
+    """Build kwargs for ``commands.Bot()`` / ``discord.Client()`` with proxy.
+
+    Returns:
+      - SOCKS URL  → ``{"connector": ProxyConnector(..., rdns=True)}``
+      - HTTP URL   → ``{"proxy": url}``
+      - *None*     → ``{}``
+
+    ``rdns=True`` forces remote DNS resolution through the proxy — required
+    by many SOCKS implementations (Shadowrocket, Clash) and essential for
+    bypassing DNS pollution behind the GFW.
+    """
+    if not proxy_url:
+        return {}
+    if proxy_url.lower().startswith("socks"):
+        try:
+            from aiohttp_socks import ProxyConnector
+
+            connector = ProxyConnector.from_url(proxy_url, rdns=True)
+            return {"connector": connector}
+        except ImportError:
+            logger.warning(
+                "aiohttp_socks not installed — SOCKS proxy %s ignored. "
+                "Run: pip install aiohttp-socks",
+                proxy_url,
+            )
+            return {}
+    return {"proxy": proxy_url}
+
+
+def proxy_kwargs_for_aiohttp(proxy_url: str | None) -> tuple[dict, dict]:
+    """Build kwargs for standalone ``aiohttp.ClientSession`` with proxy.
+
+    Returns ``(session_kwargs, request_kwargs)`` where:
+      - With aiohttp-socks → ``({"connector": ProxyConnector(...)}, {})``
+        for *all* proxy schemes (SOCKS **and** HTTP/HTTPS).
+      - HTTP without aiohttp-socks → ``({}, {"proxy": url})``.
+      - None → ``({}, {})``.
+
+    Prefer the connector path: it works transparently with libraries
+    (like mautrix) that call ``session.request()`` without forwarding
+    per-request ``proxy=`` kwargs.
+
+    Usage::
+
+        sess_kw, req_kw = proxy_kwargs_for_aiohttp(proxy_url)
+        async with aiohttp.ClientSession(**sess_kw) as session:
+            async with session.get(url, **req_kw) as resp:
+                ...
+    """
+    if not proxy_url:
+        return {}, {}
+    try:
+        from aiohttp_socks import ProxyConnector
+
+        connector = ProxyConnector.from_url(proxy_url, rdns=True)
+        return {"connector": connector}, {}
+    except ImportError:
+        if proxy_url.lower().startswith("socks"):
+            logger.warning(
+                "aiohttp_socks not installed — SOCKS proxy %s ignored. "
+                "Run: pip install aiohttp-socks",
+                proxy_url,
+            )
+            return {}, {}
+        return {}, {"proxy": proxy_url}
+
+
+def is_host_excluded_by_no_proxy(hostname: str, no_proxy_value: str | None = None) -> bool:
+    """Return True when ``hostname`` matches a ``NO_PROXY`` entry.
+
+    Supports comma- or whitespace-separated entries with optional leading dots
+    and ``*.`` wildcards, which match both the apex domain and subdomains.
+    """
+    raw = no_proxy_value
+    if raw is None:
+        raw = os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or ""
+
+    raw = raw.strip()
+    if not raw:
+        return False
+
+    lower_hostname = hostname.lower()
+    for entry in re.split(r"[\s,]+", raw):
+        normalized = entry.strip().lower()
+        if not normalized:
+            continue
+        if normalized == "*":
+            return True
+
+        if normalized.startswith("*."):
+            normalized = normalized[2:]
+        elif normalized.startswith("."):
+            normalized = normalized[1:]
+
+        if lower_hostname == normalized or lower_hostname.endswith(f".{normalized}"):
+            return True
+
+    return False

--- a/gateway/platforms/routing_metadata.py
+++ b/gateway/platforms/routing_metadata.py
@@ -1,0 +1,86 @@
+"""Platform-aware thread/reply routing metadata helpers.
+
+Extracted from ``gateway/platforms/base.py`` (god-file decomposition
+campaign, wave 1 — shard s1, cluster c1, 12 move votes). Functions moved
+verbatim; ``base.py`` re-exports them. ``_platform_name`` stays in
+``base.py`` (the audio-delivery helpers that remain there also use it) and
+is imported lazily inside the two functions that need it — the same
+cycle-avoidance pattern documented in ``gateway/authz_mixin.py`` — so this
+module never imports ``gateway.platforms.base`` at import time.
+"""
+
+def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) -> dict | None:
+    """Build platform-aware thread metadata for adapter sends.
+
+    Most platforms route threaded sends with a generic ``thread_id`` metadata
+    value. Telegram private-chat topics created through Hermes' DM-topic helper
+    are exposed in updates as ``message_thread_id`` plus a reply anchor. Live
+    user-message replies route with ``message_thread_id`` + ``reply_to_message_id``;
+    synthetic/resumed sends that have no reply anchor fall back to Telegram's
+    ``direct_messages_topic_id`` when the Bot API supports it.
+    """
+    from gateway.platforms.base import _platform_name
+    thread_id = getattr(source, "thread_id", None)
+    metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    # Slack workspace identity is durable routing state, not ephemeral event
+    # metadata. Carry it on every outbound path (including unthreaded sends)
+    # so a multi-workspace Socket Mode gateway never falls back to its primary
+    # WebClient after an async, stream, or recovery boundary.
+    if _platform_name(getattr(source, "platform", None)) == "slack":
+        scope_id = getattr(source, "scope_id", None)
+        if scope_id:
+            metadata["slack_team_id"] = str(scope_id)
+    if not metadata:
+        return None
+    if _platform_name(getattr(source, "platform", None)) == "telegram" and getattr(source, "chat_type", None) == "dm":
+        metadata["telegram_dm_topic_reply_fallback"] = True
+        tid = str(thread_id)
+        if tid and tid not in {"", "1"}:
+            metadata["direct_messages_topic_id"] = tid
+        anchor = reply_to_message_id or getattr(source, "message_id", None)
+        if anchor is not None:
+            metadata["telegram_reply_to_message_id"] = str(anchor)
+    return metadata
+
+
+def _mark_notify_metadata(metadata: dict | None) -> dict:
+    """Clone metadata and mark a user-visible reply as notify-worthy."""
+    notify_metadata = dict(metadata) if metadata else {}
+    notify_metadata["notify"] = True
+    return notify_metadata
+
+
+def _reply_anchor_for_event(event) -> str | None:
+    """Return reply_to id for platforms that need reply semantics.
+
+    Telegram forum/supergroup topics should be routed by topic metadata, not by
+    replying to the triggering message. Hermes-created Telegram private-chat
+    topic lanes prefer replying to the triggering user message so the answer
+    stays attached to the active lane; synthetic/resumed sends fall back to
+    ``direct_messages_topic_id`` metadata when no message id is available.
+    """
+    from gateway.platforms.base import _platform_name
+    source = getattr(event, "source", None)
+    platform = _platform_name(getattr(source, "platform", None))
+    thread_id = getattr(source, "thread_id", None)
+    raw_message = getattr(event, "raw_message", None)
+    if (
+        platform == "slack"
+        and isinstance(raw_message, dict)
+        and raw_message.get("_hermes_no_thread_response")
+    ):
+        # Slack reaction handoffs into a configured target channel are meant
+        # to create a new top-level message there. Returning the synthetic
+        # event's message_id as reply_to would make
+        # SlackAdapter._resolve_thread_ts() treat it as a thread anchor and
+        # reply in a (nonexistent) thread anyway.
+        return None
+    if platform == "telegram" and thread_id and getattr(source, "chat_type", None) == "dm":
+        # Reply to the triggering user message. Replying to Telegram's earlier
+        # topic seed/anchor can render the bot response outside the active lane.
+        return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
+    if platform == "telegram" and thread_id:
+        return None
+    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
+        return getattr(event, "reply_to_message_id", None)
+    return getattr(event, "message_id", None)

--- a/gateway/platforms/text_metrics.py
+++ b/gateway/platforms/text_metrics.py
@@ -1,0 +1,58 @@
+"""UTF-16 / codepoint text-metric helpers for message truncation.
+
+Extracted from ``gateway/platforms/base.py`` (god-file decomposition
+campaign, wave 1 — shard s1, cluster c4, 12 move votes). Functions moved
+verbatim; ``base.py`` re-exports them.
+"""
+
+def utf16_len(s: str) -> int:
+    """Count UTF-16 code units in *s*.
+
+    Telegram's message-length limit (4 096) is measured in UTF-16 code units,
+    **not** Unicode code-points.  Characters outside the Basic Multilingual
+    Plane (emoji like 😀, CJK Extension B, musical symbols, …) are encoded as
+    surrogate pairs and therefore consume **two** UTF-16 code units each, even
+    though Python's ``len()`` counts them as one.
+
+    Ported from nearai/ironclaw#2304 which discovered the same discrepancy in
+    Rust's ``chars().count()``.
+    """
+    return len(s.encode("utf-16-le")) // 2
+
+
+def _prefix_within_utf16_limit(s: str, limit: int) -> str:
+    """Return the longest prefix of *s* whose UTF-16 length ≤ *limit*.
+
+    Unlike a plain ``s[:limit]``, this respects surrogate-pair boundaries so
+    we never slice a multi-code-unit character in half.
+    """
+    if utf16_len(s) <= limit:
+        return s
+    # Binary search for the longest safe prefix
+    lo, hi = 0, len(s)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if utf16_len(s[:mid]) <= limit:
+            lo = mid
+        else:
+            hi = mid - 1
+    return s[:lo]
+
+
+def _custom_unit_to_cp(s: str, budget: int, len_fn) -> int:
+    """Return the largest codepoint offset *n* such that ``len_fn(s[:n]) <= budget``.
+
+    Used by :meth:`BasePlatformAdapter.truncate_message` when *len_fn* measures
+    length in units different from Python codepoints (e.g. UTF-16 code units).
+    Falls back to binary search which is O(log n) calls to *len_fn*.
+    """
+    if len_fn(s) <= budget:
+        return len(s)
+    lo, hi = 0, len(s)
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if len_fn(s[:mid]) <= budget:
+            lo = mid
+        else:
+            hi = mid - 1
+    return lo

--- a/tests/gateway/test_platform_base_extracted_w1.py
+++ b/tests/gateway/test_platform_base_extracted_w1.py
@@ -1,0 +1,317 @@
+"""Regression tests for the wave-1 extraction of ``gateway/platforms/base.py``.
+
+Shard s1 move clusters covered (verbatim extraction):
+
+* ``c6`` proxy resolution / NO_PROXY matching -> ``gateway/platforms/proxy_utils.py``
+* ``c4`` UTF-16 text metrics                       -> ``gateway/platforms/text_metrics.py``
+* ``c1`` thread/reply routing metadata             -> ``gateway/platforms/routing_metadata.py``
+
+Two contracts are asserted here:
+
+1. Behavior of the moved pure helpers (unchanged semantics).
+2. Re-export parity: every moved function is still importable from
+   ``gateway.platforms.base`` and is the *same object* as the one in its new
+   module, so all existing ``from gateway.platforms.base import ...`` call
+   sites (discord adapter, stream_consumer, helpers, tests, ...) keep working.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.platforms.base import (
+    _custom_unit_to_cp,
+    _mark_notify_metadata,
+    _prefix_within_utf16_limit,
+    _reply_anchor_for_event,
+    _split_host_port,
+    _thread_metadata_for_source,
+    is_host_excluded_by_no_proxy,
+    proxy_kwargs_for_aiohttp,
+    proxy_kwargs_for_bot,
+    resolve_proxy_url,
+    should_bypass_proxy,
+    utf16_len,
+)
+from gateway.platforms.proxy_utils import (
+    _detect_macos_system_proxy,
+    _no_proxy_entries,
+    _no_proxy_entry_matches,
+    is_host_excluded_by_no_proxy as proxy_is_host_excluded_by_no_proxy,
+    proxy_kwargs_for_aiohttp as proxy_proxy_kwargs_for_aiohttp,
+    proxy_kwargs_for_bot as proxy_proxy_kwargs_for_bot,
+    resolve_proxy_url as proxy_resolve_proxy_url,
+    should_bypass_proxy as proxy_should_bypass_proxy,
+)
+from gateway.platforms.routing_metadata import (
+    _mark_notify_metadata as routing_mark_notify_metadata,
+    _reply_anchor_for_event as routing_reply_anchor_for_event,
+    _thread_metadata_for_source as routing_thread_metadata_for_source,
+)
+from gateway.platforms.text_metrics import (
+    _custom_unit_to_cp as tm_custom_unit_to_cp,
+    _prefix_within_utf16_limit as tm_prefix_within_utf16_limit,
+    utf16_len as tm_utf16_len,
+)
+
+
+# ─── re-export parity ────────────────────────────────────────────────────────
+
+def test_reexport_identity_proxy():
+    assert should_bypass_proxy is proxy_should_bypass_proxy
+    assert resolve_proxy_url is proxy_resolve_proxy_url
+    assert proxy_kwargs_for_bot is proxy_proxy_kwargs_for_bot
+    assert proxy_kwargs_for_aiohttp is proxy_proxy_kwargs_for_aiohttp
+    assert is_host_excluded_by_no_proxy is proxy_is_host_excluded_by_no_proxy
+
+
+def test_reexport_identity_text_metrics():
+    assert utf16_len is tm_utf16_len
+    assert _prefix_within_utf16_limit is tm_prefix_within_utf16_limit
+    assert _custom_unit_to_cp is tm_custom_unit_to_cp
+
+
+def test_reexport_identity_routing_metadata():
+    assert _thread_metadata_for_source is routing_thread_metadata_for_source
+    assert _mark_notify_metadata is routing_mark_notify_metadata
+    assert _reply_anchor_for_event is routing_reply_anchor_for_event
+
+
+# ─── c4 text metrics ─────────────────────────────────────────────────────────
+
+def test_utf16_len_bmp_only():
+    assert utf16_len("hello") == 5
+    assert utf16_len("") == 0
+
+
+def test_utf16_len_surrogate_pairs():
+    # U+1F600 (😀) is outside the BMP: one code point, two UTF-16 code units.
+    assert utf16_len("😀") == 2
+    assert utf16_len("a😀b") == 4
+
+
+def test_prefix_within_utf16_limit_under_limit():
+    assert _prefix_within_utf16_limit("abcd", 10) == "abcd"
+    assert _prefix_within_utf16_limit("", 0) == ""
+
+
+def test_prefix_within_utf16_limit_respects_surrogate_boundary():
+    s = "a😀b"
+    assert _prefix_within_utf16_limit(s, 3) == "a😀"  # not "a" + half a surrogate
+    assert _prefix_within_utf16_limit(s, 2) == "a"
+    assert _prefix_within_utf16_limit(s, 4) == s
+
+
+def test_custom_unit_to_cp_with_utf16_units():
+    # len_fn measures UTF-16 units; codepoint offsets must not split pairs.
+    assert _custom_unit_to_cp("a😀b", 3, utf16_len) == 2
+    assert _custom_unit_to_cp("a😀b", 4, utf16_len) == 3
+    assert _custom_unit_to_cp("abcd", 2, len) == 2
+
+
+# ─── c6 proxy resolution / NO_PROXY ──────────────────────────────────────────
+
+def test_should_bypass_proxy_no_env(monkeypatch):
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    assert should_bypass_proxy(None) is False
+    assert should_bypass_proxy("api.example.com") is False
+
+
+def test_should_bypass_proxy_matches_env(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "example.com, .internal")
+    assert should_bypass_proxy("api.example.com") is True
+    assert should_bypass_proxy("svc.internal") is True
+    assert should_bypass_proxy("other.net") is False
+
+
+def test_should_bypass_proxy_lowercase_env(monkeypatch):
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.setenv("no_proxy", "*.example.com")
+    assert should_bypass_proxy("a.b.example.com") is True
+
+
+def test_no_proxy_entries_merges_both_env_vars(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "a.com")
+    if sys.platform == "win32":
+        # Windows environment variables are case-insensitive, so the two
+        # spellings alias a single variable; only one entry can exist.
+        assert set(_no_proxy_entries()) == {"a.com"}
+    else:
+        monkeypatch.setenv("no_proxy", "b.com")
+        assert set(_no_proxy_entries()) == {"a.com", "b.com"}
+
+
+def test_no_proxy_entry_matches_cidr_and_ip():
+    assert _no_proxy_entry_matches("10.0.0.0/8", "10.1.2.3") is True
+    assert _no_proxy_entry_matches("10.0.0.0/8", "11.1.2.3") is False
+    assert _no_proxy_entry_matches("192.168.1.5", "192.168.1.5") is True
+    assert _no_proxy_entry_matches("192.168.1.5", "192.168.1.6") is False
+
+
+def test_no_proxy_entry_matches_port_and_wildcard():
+    assert _no_proxy_entry_matches("example.com:443", "example.com", 443) is True
+    assert _no_proxy_entry_matches("example.com:443", "example.com", 80) is False
+    assert _no_proxy_entry_matches("example.com:443", "example.com") is False
+    assert _no_proxy_entry_matches("*", "anything.example") is True
+    assert _no_proxy_entry_matches("", "anything.example") is False
+
+
+def test_is_host_excluded_by_no_proxy():
+    assert is_host_excluded_by_no_proxy("api.example.com", "example.com") is True
+    assert is_host_excluded_by_no_proxy("example.com", "*.example.com") is True
+    assert is_host_excluded_by_no_proxy("sub.example.com", "*.example.com") is True
+    assert is_host_excluded_by_no_proxy("other.net", "*.example.com") is False
+    assert is_host_excluded_by_no_proxy("anything.io", "*") is True
+    assert is_host_excluded_by_no_proxy("api.example.com", " example.com , other.net ") is True
+
+
+def test_is_host_excluded_by_no_proxy_uses_env_when_none(monkeypatch):
+    monkeypatch.setenv("NO_PROXY", "example.com")
+    assert is_host_excluded_by_no_proxy("api.example.com") is True
+
+
+def test_split_host_port():
+    assert _split_host_port("") == ("", None)
+    assert _split_host_port("http://Example.COM:8080/path") == ("example.com", 8080)
+    assert _split_host_port("[::1]:8443") == ("::1", 8443)
+    assert _split_host_port("host.example:9090") == ("host.example", 9090)
+    assert _split_host_port("bare.example") == ("bare.example", None)
+
+
+def test_resolve_proxy_url_env_priority(monkeypatch):
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:3128")
+    monkeypatch.setenv("DISCORD_PROXY", "http://discord-proxy.local:3129")
+    assert resolve_proxy_url() == "http://proxy.local:3128"
+    assert resolve_proxy_url("DISCORD_PROXY") == "http://discord-proxy.local:3129"
+
+
+def test_resolve_proxy_url_socks_alias(monkeypatch):
+    monkeypatch.delenv("NO_PROXY", raising=False)
+    monkeypatch.delenv("no_proxy", raising=False)
+    monkeypatch.setenv("ALL_PROXY", "socks://127.0.0.1:1080")
+    assert resolve_proxy_url() == "socks5://127.0.0.1:1080"
+
+
+def test_resolve_proxy_url_bypass(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.local:3128")
+    monkeypatch.setenv("NO_PROXY", "api.example.com")
+    assert resolve_proxy_url(target_hosts="api.example.com") is None
+
+
+def test_resolve_proxy_url_none(monkeypatch):
+    for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY", "https_proxy", "http_proxy", "all_proxy"):
+        monkeypatch.delenv(key, raising=False)
+    assert resolve_proxy_url() is None
+
+
+def test_proxy_kwargs_for_bot_none_and_http():
+    assert proxy_kwargs_for_bot(None) == {}
+    assert proxy_kwargs_for_bot("http://proxy.local:3128") == {"proxy": "http://proxy.local:3128"}
+
+
+def test_proxy_kwargs_for_aiohttp_none_and_http():
+    assert proxy_kwargs_for_aiohttp(None) == ({}, {})
+    sess, req = proxy_kwargs_for_aiohttp("http://proxy.local:3128")
+    assert sess == {}
+    assert req == {"proxy": "http://proxy.local:3128"}
+
+
+@pytest.mark.skipif(sys.platform == "darwin", reason="scutil exists on macOS")
+def test_detect_macos_system_proxy_non_darwin():
+    assert _detect_macos_system_proxy() is None
+
+
+# ─── c1 routing metadata ─────────────────────────────────────────────────────
+
+def _source(**kwargs):
+    defaults = dict(
+        thread_id=None,
+        platform=None,
+        scope_id=None,
+        chat_type=None,
+        message_id=None,
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_thread_metadata_for_source_plain_thread_id():
+    src = _source(thread_id="42")
+    assert _thread_metadata_for_source(src) == {"thread_id": "42"}
+
+
+def test_thread_metadata_for_source_none():
+    assert _thread_metadata_for_source(_source()) is None
+
+
+def test_thread_metadata_for_source_slack_team_id():
+    src = _source(thread_id="1", platform="slack", scope_id="T123")
+    meta = _thread_metadata_for_source(src)
+    assert meta == {"thread_id": "1", "slack_team_id": "T123"}
+
+
+def test_thread_metadata_for_source_telegram_dm():
+    src = _source(thread_id="42", platform="telegram", chat_type="dm", message_id="7")
+    meta = _thread_metadata_for_source(src)
+    assert meta["telegram_dm_topic_reply_fallback"] is True
+    assert meta["direct_messages_topic_id"] == "42"
+    assert meta["telegram_reply_to_message_id"] == "7"
+    assert meta["thread_id"] == "42"
+
+
+def test_thread_metadata_for_source_telegram_dm_explicit_anchor():
+    src = _source(thread_id="42", platform="telegram", chat_type="dm")
+    meta = _thread_metadata_for_source(src, reply_to_message_id="99")
+    assert meta["telegram_reply_to_message_id"] == "99"
+
+
+def test_mark_notify_metadata_clones():
+    original = {"thread_id": "1"}
+    marked = _mark_notify_metadata(original)
+    assert marked == {"thread_id": "1", "notify": True}
+    assert "notify" not in original
+    assert _mark_notify_metadata(None) == {"notify": True}
+
+
+def test_reply_anchor_default_and_telegram_dm():
+    event = SimpleNamespace(
+        source=_source(platform="telegram", chat_type="dm", thread_id="42"),
+        raw_message=None,
+        message_id="m1",
+        reply_to_message_id=None,
+    )
+    assert _reply_anchor_for_event(event) == "m1"
+
+
+def test_reply_anchor_telegram_group_is_none():
+    event = SimpleNamespace(
+        source=_source(platform="telegram", chat_type="group", thread_id="42"),
+        raw_message=None,
+        message_id="m1",
+        reply_to_message_id=None,
+    )
+    assert _reply_anchor_for_event(event) is None
+
+
+def test_reply_anchor_slack_synthetic_is_none():
+    event = SimpleNamespace(
+        source=_source(platform="slack", thread_id=None),
+        raw_message={"_hermes_no_thread_response": True},
+        message_id="m1",
+        reply_to_message_id=None,
+    )
+    assert _reply_anchor_for_event(event) is None
+
+
+def test_reply_anchor_feishu_thread():
+    event = SimpleNamespace(
+        source=_source(platform="feishu", thread_id="42"),
+        raw_message=None,
+        message_id="m1",
+        reply_to_message_id="r9",
+    )
+    assert _reply_anchor_for_event(event) == "r9"


### PR DESCRIPTION
## Godfile kill — gateway/platforms/base.py shard s1

Extracts the proxy/text routing + media helpers mixins into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 767 added / 390 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701 #78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715 #78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729 #78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743 #78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757 #78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771 #78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785 #78786 #78787 #78788 #78789 #78790

Part of #78644
Part of #78647