### PR TITLE
refactor(gateway): extract topic-session helpers from base.py (shard s5)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -23,6 +23,8 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from gateway.platforms.session_lifecycle_mixin import SessionLifecycleMixin
+from gateway.platforms.source_builder_mixin import SourceBuilderMixin
 
 logger = logging.getLogger(__name__)
 
@@ -2626,7 +2628,7 @@ def _strip_media_directives(text: str) -> str:
     return _strip_media_tag_directives(text)
 
 
-class BasePlatformAdapter(ABC):
+class BasePlatformAdapter(SourceBuilderMixin, SessionLifecycleMixin, ABC):
     """
     Base class for platform adapters.
     
@@ -6570,103 +6572,6 @@ class BasePlatformAdapter(ABC):
                 state.task.cancel()
         self._text_debounce_store().clear()
 
-    def has_pending_interrupt(self, session_key: str) -> bool:
-        """Check if there's a pending interrupt for a session."""
-        return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
-    
-    def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
-        """Get and clear any pending message for a session."""
-        return self._pending_messages.pop(session_key, None)
-    
-    def build_source(
-        self,
-        chat_id: str,
-        chat_name: Optional[str] = None,
-        chat_type: str = "dm",
-        user_id: Optional[str] = None,
-        user_name: Optional[str] = None,
-        thread_id: Optional[str] = None,
-        chat_topic: Optional[str] = None,
-        user_id_alt: Optional[str] = None,
-        chat_id_alt: Optional[str] = None,
-        is_bot: bool = False,
-        scope_id: Optional[str] = None,
-        guild_id: Optional[str] = None,
-        parent_chat_id: Optional[str] = None,
-        message_id: Optional[str] = None,
-        role_authorized: bool = False,
-        auto_thread_created: bool = False,
-        auto_thread_initial_name: Optional[str] = None,
-    ) -> SessionSource:
-        """Helper to build a SessionSource for this platform.
-
-        When ``gateway.profile_routes`` is configured, the routing engine
-        resolves the matching profile from guild/chat/thread and stamps it on
-        ``source.profile``. Downstream code (``_resolve_profile_home_for_source``
-        in run.py) reads that field to enter ``_profile_runtime_scope`` for
-        per-profile HERMES_HOME isolation.
-        """
-        # Normalize empty topic to None
-        if chat_topic is not None and not chat_topic.strip():
-            chat_topic = None
-
-        # Resolve profile from configured routes (None when no match / no routes)
-        profile = None
-        runner = getattr(self, "gateway_runner", None)
-        if runner is not None:
-            try:
-                profile = runner._profile_name_for_source(
-                    SessionSource(
-                        platform=self.platform,
-                        chat_id=str(chat_id),
-                        chat_name=chat_name,
-                        chat_type=chat_type,
-                        user_id=str(user_id) if user_id else None,
-                        user_name=user_name,
-                        thread_id=str(thread_id) if thread_id else None,
-                        chat_topic=chat_topic.strip() if chat_topic else None,
-                        user_id_alt=user_id_alt,
-                        chat_id_alt=chat_id_alt,
-                        is_bot=is_bot,
-                        scope_id=str(scope_id) if scope_id else None,
-                        guild_id=str(guild_id) if guild_id else None,
-                        parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
-                        message_id=str(message_id) if message_id else None,
-                    )
-                )
-            except Exception:
-                logger.warning(
-                    "Profile resolution failed for %s/%s, defaulting to active profile",
-                    self.platform, chat_id, exc_info=True,
-                )
-
-        source = SessionSource(
-            platform=self.platform,
-            chat_id=str(chat_id),
-            chat_name=chat_name,
-            chat_type=chat_type,
-            user_id=str(user_id) if user_id else None,
-            user_name=user_name,
-            thread_id=str(thread_id) if thread_id else None,
-            chat_topic=chat_topic.strip() if chat_topic else None,
-            user_id_alt=user_id_alt,
-            chat_id_alt=chat_id_alt,
-            is_bot=is_bot,
-            scope_id=str(scope_id) if scope_id else None,
-            guild_id=str(guild_id) if guild_id else None,
-            parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
-            message_id=str(message_id) if message_id else None,
-            profile=profile,
-            role_authorized=role_authorized,
-            auto_thread_created=auto_thread_created,
-            auto_thread_initial_name=auto_thread_initial_name,
-        )
-        # In-process transport provenance is deliberately not serialized by
-        # SessionSource.to_dict(). The live receiving adapter is authoritative
-        # for this turn even when profile_routes selects a different runtime.
-        source._transport_adapter_ref = weakref.ref(self)
-        return source
-    
     @abstractmethod
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """

--- a/gateway/platforms/session_lifecycle_mixin.py
+++ b/gateway/platforms/session_lifecycle_mixin.py
@@ -1,0 +1,24 @@
+"""Session-lifecycle helpers for gateway platform adapters.
+
+Extracted verbatim from ``gateway/platforms/base.py`` (class
+``BasePlatformAdapter``) — godfile decomposition shard s5.  Mixed into
+``BasePlatformAdapter``; instance state (``_active_sessions``,
+``_pending_messages``) resolves through the adapter via MRO.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from gateway.platforms.base import MessageEvent
+
+
+class SessionLifecycleMixin:
+    def has_pending_interrupt(self, session_key: str) -> bool:
+        """Check if there's a pending interrupt for a session."""
+        return session_key in self._active_sessions and self._active_sessions[session_key].is_set()
+    
+    def get_pending_message(self, session_key: str) -> Optional[MessageEvent]:
+        """Get and clear any pending message for a session."""
+        return self._pending_messages.pop(session_key, None)

--- a/gateway/platforms/source_builder_mixin.py
+++ b/gateway/platforms/source_builder_mixin.py
@@ -1,0 +1,108 @@
+"""SessionSource-building helper for gateway platform adapters.
+
+Extracted verbatim from ``gateway/platforms/base.py`` (class
+``BasePlatformAdapter``) — godfile decomposition shard s5.  Mixed into
+``BasePlatformAdapter``; instance state (``self.platform``) resolves through
+the adapter via MRO.
+"""
+
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Optional
+
+from gateway.session import SessionSource
+
+logger = logging.getLogger(__name__)
+
+
+class SourceBuilderMixin:
+    def build_source(
+        self,
+        chat_id: str,
+        chat_name: Optional[str] = None,
+        chat_type: str = "dm",
+        user_id: Optional[str] = None,
+        user_name: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        chat_topic: Optional[str] = None,
+        user_id_alt: Optional[str] = None,
+        chat_id_alt: Optional[str] = None,
+        is_bot: bool = False,
+        scope_id: Optional[str] = None,
+        guild_id: Optional[str] = None,
+        parent_chat_id: Optional[str] = None,
+        message_id: Optional[str] = None,
+        role_authorized: bool = False,
+        auto_thread_created: bool = False,
+        auto_thread_initial_name: Optional[str] = None,
+    ) -> SessionSource:
+        """Helper to build a SessionSource for this platform.
+
+        When ``gateway.profile_routes`` is configured, the routing engine
+        resolves the matching profile from guild/chat/thread and stamps it on
+        ``source.profile``. Downstream code (``_resolve_profile_home_for_source``
+        in run.py) reads that field to enter ``_profile_runtime_scope`` for
+        per-profile HERMES_HOME isolation.
+        """
+        # Normalize empty topic to None
+        if chat_topic is not None and not chat_topic.strip():
+            chat_topic = None
+
+        # Resolve profile from configured routes (None when no match / no routes)
+        profile = None
+        runner = getattr(self, "gateway_runner", None)
+        if runner is not None:
+            try:
+                profile = runner._profile_name_for_source(
+                    SessionSource(
+                        platform=self.platform,
+                        chat_id=str(chat_id),
+                        chat_name=chat_name,
+                        chat_type=chat_type,
+                        user_id=str(user_id) if user_id else None,
+                        user_name=user_name,
+                        thread_id=str(thread_id) if thread_id else None,
+                        chat_topic=chat_topic.strip() if chat_topic else None,
+                        user_id_alt=user_id_alt,
+                        chat_id_alt=chat_id_alt,
+                        is_bot=is_bot,
+                        scope_id=str(scope_id) if scope_id else None,
+                        guild_id=str(guild_id) if guild_id else None,
+                        parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+                        message_id=str(message_id) if message_id else None,
+                    )
+                )
+            except Exception:
+                logger.warning(
+                    "Profile resolution failed for %s/%s, defaulting to active profile",
+                    self.platform, chat_id, exc_info=True,
+                )
+
+        source = SessionSource(
+            platform=self.platform,
+            chat_id=str(chat_id),
+            chat_name=chat_name,
+            chat_type=chat_type,
+            user_id=str(user_id) if user_id else None,
+            user_name=user_name,
+            thread_id=str(thread_id) if thread_id else None,
+            chat_topic=chat_topic.strip() if chat_topic else None,
+            user_id_alt=user_id_alt,
+            chat_id_alt=chat_id_alt,
+            is_bot=is_bot,
+            scope_id=str(scope_id) if scope_id else None,
+            guild_id=str(guild_id) if guild_id else None,
+            parent_chat_id=str(parent_chat_id) if parent_chat_id else None,
+            message_id=str(message_id) if message_id else None,
+            profile=profile,
+            role_authorized=role_authorized,
+            auto_thread_created=auto_thread_created,
+            auto_thread_initial_name=auto_thread_initial_name,
+        )
+        # In-process transport provenance is deliberately not serialized by
+        # SessionSource.to_dict(). The live receiving adapter is authoritative
+        # for this turn even when profile_routes selects a different runtime.
+        source._transport_adapter_ref = weakref.ref(self)
+        return source

--- a/tests/gateway/test_s5_mixins_extraction.py
+++ b/tests/gateway/test_s5_mixins_extraction.py
@@ -1,0 +1,157 @@
+"""Regression tests for the wave-1 shard-s5 mixin extraction from base.py.
+
+Covers the methods moved out of ``BasePlatformAdapter`` into the new
+``gateway.platforms.session_lifecycle_mixin`` and
+``gateway.platforms.source_builder_mixin`` modules:
+
+- ``has_pending_interrupt`` / ``get_pending_message`` (cluster c7,
+  SessionLifecycleMixin)
+- ``build_source`` (cluster c8, SourceBuilderMixin)
+
+The methods are still reachable through the adapter class via MRO; these
+tests pin their behavior so the extraction cannot silently change it.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.platforms.session_lifecycle_mixin import SessionLifecycleMixin
+from gateway.platforms.source_builder_mixin import SourceBuilderMixin
+from gateway.session import SessionSource
+
+
+class DummyAdapter(BasePlatformAdapter):
+    """Minimal concrete adapter: implements only the abstract methods."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+def _event(message_id: str = "1") -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(platform=Platform.TELEGRAM, chat_id="c1", chat_type="dm"),
+        message_id=message_id,
+    )
+
+
+def test_mixins_are_in_adapter_mro():
+    assert SessionLifecycleMixin in BasePlatformAdapter.__mro__
+    assert SourceBuilderMixin in BasePlatformAdapter.__mro__
+
+
+def test_has_pending_interrupt_via_mixin():
+    adapter = DummyAdapter()
+    key = "session-1"
+    assert adapter.has_pending_interrupt(key) is False
+
+    interrupt = asyncio.Event()
+    adapter._active_sessions[key] = interrupt
+    assert adapter.has_pending_interrupt(key) is False  # not set yet
+
+    interrupt.set()
+    assert adapter.has_pending_interrupt(key) is True
+
+    # unrelated sessions are never reported as interrupting
+    assert adapter.has_pending_interrupt("session-other") is False
+    assert adapter.has_pending_interrupt("") is False
+
+
+def test_get_pending_message_via_mixin():
+    adapter = DummyAdapter()
+    key = "session-2"
+    assert adapter.get_pending_message(key) is None
+
+    event = _event()
+    adapter._pending_messages[key] = event
+    # pop semantics: returns the message AND clears it
+    assert adapter.get_pending_message(key) is event
+    assert adapter.get_pending_message(key) is None
+
+
+def test_build_source_defaults_and_stringification():
+    adapter = DummyAdapter()
+    source = adapter.build_source(
+        chat_id=123,
+        chat_name="Test Chat",
+        chat_type="group",
+        user_id=42,
+        user_name="alice",
+        thread_id=7,
+        guild_id="g1",
+        parent_chat_id="p1",
+        message_id="m1",
+    )
+    assert isinstance(source, SessionSource)
+    assert source.platform == Platform.TELEGRAM
+    assert source.chat_id == "123"
+    assert source.chat_name == "Test Chat"
+    assert source.chat_type == "group"
+    assert source.user_id == "42"
+    assert source.user_name == "alice"
+    assert source.thread_id == "7"
+    # SessionSource.__post_init__ mirrors the deprecated guild_id alias onto
+    # scope_id (pre-existing dataclass behavior, unchanged by the extraction).
+    assert source.scope_id == "g1"
+    assert source.guild_id == "g1"
+    assert source.parent_chat_id == "p1"
+    assert source.message_id == "m1"
+    assert source.profile is None
+    assert source.role_authorized is False
+
+
+def test_build_source_scope_id_is_canonical():
+    adapter = DummyAdapter()
+    source = adapter.build_source(chat_id="1", scope_id="s1", guild_id="g1")
+    # scope_id wins on conflict (SessionSource.__post_init__ semantics).
+    assert source.scope_id == "s1"
+    assert source.guild_id == "s1"
+
+
+def test_build_source_normalizes_blank_topic():
+    adapter = DummyAdapter()
+    assert adapter.build_source(chat_id="1", chat_topic="   ").chat_topic is None
+    assert adapter.build_source(chat_id="1", chat_topic="").chat_topic is None
+    assert adapter.build_source(chat_id="1", chat_topic="General").chat_topic == "General"
+
+
+def test_build_source_stamps_transport_ref():
+    adapter = DummyAdapter()
+    source = adapter.build_source(chat_id="1")
+    ref = getattr(source, "_transport_adapter_ref", None)
+    assert ref is not None
+    assert ref() is adapter
+
+
+def test_build_source_resolves_profile_from_runner():
+    adapter = DummyAdapter()
+    runner = SimpleNamespace(_profile_name_for_source=lambda source: "alice")
+    adapter.gateway_runner = runner
+    source = adapter.build_source(chat_id="1", guild_id="g1", thread_id="t1")
+    assert source.profile == "alice"
+
+
+def test_build_source_runner_failure_defaults_profile():
+    adapter = DummyAdapter()
+
+    class Boom:
+        def _profile_name_for_source(self, source):
+            raise RuntimeError("boom")
+
+    adapter.gateway_runner = Boom()
+    source = adapter.build_source(chat_id="1")
+    assert source.profile is None


### PR DESCRIPTION
## Godfile kill — gateway/platforms/base.py shard s5

Extracts the topic-session helpers mixins into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 294 added / 98 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701 #78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715 #78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729 #78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743 #78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757 #78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771 #78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785 #78786 #78787 #78788 #78789 #78790

Part of #78644
Part of #78647