### PR TITLE
feat: bundle work-sidebar as an opt-in desktop pane plugin

### DIFF
--- a/apps/desktop/src/plugins/work-sidebar/plugin.tsx
+++ b/apps/desktop/src/plugins/work-sidebar/plugin.tsx
@@ -1,0 +1,1211 @@
+import {
+  atom,
+  cn,
+  haptic,
+  type HermesPlugin,
+  host,
+  icons,
+  queryClient,
+  relativeTime,
+  useQuery,
+  useValue
+} from '@hermes/plugin-sdk'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+// ── 会话阶段：纯逻辑 + 显示映射 ──────────────────────────────────────────
+// ⚠️ 单文件约束：desktop-plugins 运行期加载器把 plugin.js 打成单个 blob
+// import()，不支持相对模块导入，故本段内联自 phase.js（work/sources 下的
+// 测试规范源）。修改必须两边同步：phase.js + 本段，并跑 test/phase.test.mjs
+// （含一致性断言，防漂移）。
+const ACTIVITY_FRESH_MS = 180000
+
+type PhaseKey = 'running' | 'planning' | 'testing' | 'active' | 'done' | 'idle'
+
+// 单一枚举源：状态 → { label, className }。derivePhase 只返回状态 key，
+// 显示层一律查这张表，禁止再手写第二套分支（曾因 phaseLabel 漏 planning
+// 分支，导致「badge 高亮但文字显示空闲」）。
+const PHASES: Record<PhaseKey, { label: string; className: string }> = {
+  running: { label: '执行中', className: 'text-(--ui-accent)' },
+  planning: { label: '计划中', className: 'text-(--ui-accent)' },
+  testing: { label: '测试中', className: 'text-(--ui-accent)' },
+  active: { label: '活跃中', className: 'text-(--ui-text-secondary)' },
+  done: { label: '已完成', className: 'text-(--ui-text-secondary)' },
+  idle: { label: '空闲', className: 'text-(--ui-text-tertiary)' }
+}
+
+function phaseLabel(phase: PhaseKey): string {
+  return (PHASES[phase] || PHASES.idle).label
+}
+
+function phaseClassName(phase: PhaseKey): string {
+  return (PHASES[phase] || PHASES.idle).className
+}
+
+function derivePhase(todos: TodoItem[] | null | undefined, activity: ActivityItem[]): PhaseKey {
+  const list = Array.isArray(activity) ? activity : []
+
+  // 统一新鲜度过滤：所有分支只认最近 ACTIVITY_FRESH_MS 内的活动。
+  // 无 todo 分支过去不过期判断，旧测试记录会让静止会话永久显示
+  // 「测试中/活跃中」——与有 todo 分支的行为不一致。
+  const freshActivity = list.filter(item => Date.now() - item.time < ACTIVITY_FRESH_MS)
+
+  // todos 是主信号——有进行中/待处理时优先表达 todo 状态；
+  // 全部完成/取消后再看 activity：agent 可能仍在收尾（测试/产出）。
+  if (Array.isArray(todos) && todos.length) {
+    if (todos.some(item => item.status === 'in_progress')) {return 'running'}
+
+    if (todos.some(item => item.status === 'pending')) {return 'planning'}
+
+    if (freshActivity.some(item => item.type === 'test')) {return 'testing'}
+
+    if (freshActivity.length) {return 'active'}
+
+    return 'done'
+  }
+
+  if (freshActivity.some(item => item.type === 'test')) {return 'testing'}
+
+  if (freshActivity.length) {return 'active'}
+
+  return 'idle'
+}
+// ── 会话阶段 end ─────────────────────────────────────────────────────────
+
+const PLUGIN_ID = 'work-sidebar'
+const TODO_STATUSES = ['pending', 'in_progress', 'completed', 'cancelled']
+
+const todosAtom = atom<TodoItem[] | null>(null)
+const activityAtom = atom<ActivityItem[]>([])
+const titleAtom = atom('')
+
+// 快照后端返回的活动/产物条目（后端 plugin_api.py 结构，见
+// plugins/work-sidebar/dashboard/plugin_api.py —— 与前端必须同步）。
+type TodoStatus = 'pending' | 'in_progress' | 'completed' | 'cancelled'
+
+interface TodoItem {
+  id: string
+  content: string
+  status: TodoStatus
+}
+
+interface ActivityItem {
+  id: string
+  time: number
+  type: string
+  text: string
+  title: string
+  seeded?: boolean
+  count?: number
+  // 折叠行附加字段（渲染层由 groupActivity 注入）
+  _groupCount?: number
+  _groupTexts?: string[]
+  _groupItems?: ActivityItem[]
+}
+
+interface OutputItem {
+  kind: string
+  value: string
+  label: string
+  ts?: number
+  purpose?: string
+}
+
+interface SnapshotData {
+  todos?: TodoItem[]
+  outputs?: OutputItem[]
+  activity?: Array<{ time: number; type: string; text: string }>
+  title?: string
+  messageCount?: number
+  snapshotVersion?: string
+  storedId?: string
+  resolved?: boolean
+  _sid?: string
+}
+
+// ctx 最小表面：SDK 的 PluginContext 未全量导出，插件只用到这几个门。
+interface PluginContextLike {
+  rest: (path: string) => Promise<SnapshotData>
+  storage: {
+    get: (key: string, fallback: unknown) => unknown
+    set: (key: string, value: unknown) => void
+    remove: (key: string) => void
+  }
+  os?: {
+    revealPath: (path: string) => void
+    openExternal: (url: string) => void
+  }
+  onDispose?: (fn: () => void) => void
+}
+
+let pluginCtx: PluginContextLike | null = null
+let eventDisposer: (() => void) | null = null
+
+// 按会话缓存的快照/活动数据：切会话时优先显示目标会话的真实缓存，
+// 避免先清空再等快照导致的闪空。desktop 恢复会话时首次请求可能
+// 解析失败（_sessions 尚未就绪），缓存 + 轮询会逐轮收敛。
+const snapshotCache = new Map<string, SnapshotData>() // sid -> snapshot data
+const activityCache = new Map<string, ActivityItem[]>() // sid -> activity[]
+// 已被快照活动种子填充的会话（被动事件驱动兜底）。
+// Map: sid -> { fingerprint: 上次种子的 snapshotVersion }。
+// 真实工具事件到达时 pushActivity 会 delete 对应条目（.has/.delete 与 Set
+// 语义一致），种子随即被清出缓存，防与实时流重复；key 存在 = 该会话仍处于
+// 「纯种子」态（事件流缺位），快照轮询可以刷新种子（见快照回填 effect）。
+const seededSessions = new Map<string, { fingerprint: string }>()
+// B2：runtime sid → stored id 映射（从快照响应学习）。desktop 的 runtime
+// sid 会漂移（同一 stored 会话可对应多个 runtime sid）——事件过滤不能只
+// 比实时 sid（快照侧已删掉同类比较）。事件 sid ≠ activeSessionId 时，若
+// 两者映射到同一 stored id 则视为同一会话放行；否则丢弃（跨会话污染）。
+// 有界，防长生命周期内存增长。
+const sidToStored = new Map<string, string>()
+
+// #9：缓存 Map 条目上限——按插入序淘汰最旧的，防长生命周期下内存无限增长
+function boundedCacheSet<T>(map: Map<string, T>, key: string, value: T, max = 30): void {
+  map.set(key, value)
+
+  if (map.size > max) {
+    const oldest = map.keys().next().value
+
+    if (oldest !== undefined) {map.delete(oldest)}
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseTodos(value: unknown, depth = 0): TodoItem[] | null {
+  if (depth > 2) {return null}
+
+  if (Array.isArray(value)) {
+    const todos = value
+      .filter(item => isRecord(item) && TODO_STATUSES.includes(String(item.status)))
+      .map(item => ({
+        id: String(item.id ?? '').trim(),
+        content: String(item.content ?? '').trim(),
+        status: item.status as TodoStatus
+      }))
+      .filter(item => item.id && item.content)
+
+    return todos.length ? todos : null
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    try {
+      return parseTodos(JSON.parse(value), depth + 1)
+    } catch {
+      return null
+    }
+  }
+
+  if (isRecord(value) && Object.hasOwn(value, 'todos')) {
+    return parseTodos(value.todos, depth + 1)
+  }
+
+  return null
+}
+
+function shorten(text: string | null | undefined, max = 68): string {
+  const compact = String(text || '').replace(/\s+/g, ' ').trim()
+
+  return compact.length > max ? `${compact.slice(0, max)}...` : compact
+}
+
+function getActivityPreview(text: string): { text: string; title: string } {
+  const raw = String(text || '').replace(/\s+/g, ' ').trim()
+
+  const cleaned = raw
+    .replace(/^已修复并验证。刚才这一轮，/, '已修复并验证。')
+    .replace(/^刚才这一轮，/, '')
+    .replace(/表现已/g, '已')
+
+  return {
+    text: shorten(cleaned || raw, 30),
+    title: raw
+  }
+}
+
+function resolveTodoData({
+  liveTodos,
+  snapshotTodos,
+  snapshotLoaded,
+  onlyOpen
+}: {
+  liveTodos: TodoItem[] | null
+  snapshotTodos: TodoItem[] | undefined
+  snapshotLoaded: boolean
+  onlyOpen: boolean
+}): { todos: TodoItem[] | null; visibleTodos: TodoItem[]; isLoading: boolean } {
+  const todos = Array.isArray(liveTodos)
+    ? liveTodos
+    : Array.isArray(snapshotTodos)
+      ? snapshotTodos
+      : snapshotLoaded
+        ? []
+        : null
+
+  const visibleTodos = Array.isArray(todos)
+    ? (
+        onlyOpen
+          ? todos.filter(item => item.status !== 'completed' && item.status !== 'cancelled')
+          : todos
+      )
+    : []
+
+  return {
+    todos,
+    visibleTodos,
+    isLoading: todos === null
+  }
+}
+
+function getTodoPanelLayout({
+  todoCount,
+  activityCount,
+  outputCount
+}: {
+  todoCount: number
+  activityCount: number
+  outputCount: number
+}): { todoClassName: string; activityClassName: string; outputsClassName: string } {
+  if (todoCount > 0) {
+    return {
+      todoClassName: 'flex min-h-0 flex-1 flex-col',
+      activityClassName: 'max-h-44 shrink-0',
+      outputsClassName: outputCount > 0 ? 'max-h-40' : 'max-h-32'
+    }
+  }
+
+  return {
+    todoClassName: 'shrink-0',
+    activityClassName: activityCount > 0 ? 'flex-1 min-h-[140px]' : 'max-h-44 shrink-0',
+    outputsClassName: 'max-h-32'
+  }
+}
+
+function pushActivity(next: ActivityItem): void {
+  // 单一来源：host.state.activeSessionId（desktop 的会话状态由它驱动）
+  const sid = host.state.activeSessionId.get()
+  let list = sid ? (activityCache.get(sid) || []) : activityAtom.get()
+
+  // 真实工具事件到达 → 快照种子已完成兜底使命，移除防重复。
+  // 仅工具类事件清种子；message.complete（info）照常叠加，不清。
+  if (sid && next.type !== 'info' && seededSessions.has(sid)) {
+    seededSessions.delete(sid)
+    list = list.filter(item => !item.seeded)
+  }
+
+  const newest = list[0]
+
+  if (newest && newest.type === next.type && newest.text === next.text) {
+    // 连续同类型同文本 → 合并计数（同一工具反复调用不再刷屏），
+    // 时间戳刷新到最近一次，relativeTime 显示的是最后一次调用
+    newest.count = (newest.count || 1) + 1
+    newest.time = next.time
+  } else {
+    list.unshift(next)
+  }
+
+  const capped = list.slice(0, 50)
+
+  if (sid) {
+    boundedCacheSet(activityCache, sid, capped)
+  }
+
+  // activityAtom 镜像当前会话缓存；合并时更新的是缓存里的同一对象，
+  // 拷贝数组引用即可触发订阅方重渲染
+  activityAtom.set([...capped])
+}
+
+// 类型标签（显示层）：内部 type 保持 test/write 原值（phase.js derivePhase 依赖），
+// 渲染时经 TYPE_LABELS 映射成用户可见的固定标签
+const TYPE_LABELS: Record<string, string> = { terminal: 'terminal', skill: 'skill', test: 'check', write: 'output', read: 'read', tool: 'tool' }
+
+interface ActivityGroup {
+  label: string
+  items: ActivityItem[]
+  count: number
+  texts: string[]
+}
+
+// 同类型折叠（渲染层）：按 badge 标签分组，组间按首字母排序；
+// ≥2 条折叠成一行（×N = 组内总次数），hover 看组内全部文本
+function groupActivity(items: ActivityItem[]): ActivityGroup[] {
+  const groups = new Map<string, ActivityItem[]>()
+
+  for (const item of items) {
+    const key = TYPE_LABELS[item.type] || item.type || 'tool'
+
+    if (!groups.has(key)) {groups.set(key, [])}
+    groups.get(key)!.push(item)
+  }
+
+  return [...groups.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([label, list]) => ({
+      label,
+      items: list,
+      count: list.reduce((s, it) => s + (it.count || 1), 0),
+      texts: list.map(it => it.text)
+    }))
+}
+
+function inferActivityType(toolName: string): string {
+  const name = String(toolName || '')
+
+  if (/terminal/i.test(name)) {return 'terminal'}
+
+  if (/skill/i.test(name)) {return 'skill'}
+
+  if (/test|pytest|vitest|check|verify/i.test(name)) {return 'test'}
+
+  if (/read|search|list|get|view|inspect/i.test(name)) {return 'read'}
+
+  if (/write|patch|edit|create|install|build/i.test(name)) {return 'write'}
+
+  return 'tool'
+}
+
+// 工具活动文案：仅有工具名太干，尽力从 payload 里带出上下文
+// （args 字符串 / 常见路径字段）。取不到就退回工具名。
+function toolActivityText(payload: Record<string, unknown> | undefined | null): string {
+  const name = String(payload?.name || 'tool')
+  const args = payload?.args
+
+  if (typeof args === 'string' && args.trim()) {
+    const compact = args.replace(/\s+/g, ' ').trim()
+
+    if (compact.length <= 40) {return `${name}: ${compact}`}
+  }
+
+  if (isRecord(args)) {
+    // 字段白名单要够宽：白名单外的不同参数（如不同文件）会被并成
+    // 一条「read_file ×N」，丢失具体参数——这是 tool.progress 合并的细节损失来源
+    for (const key of ['path', 'file_path', 'resolved_path', 'file', 'filename', 'target', 'url', 'command', 'query', 'pattern', 'keyword']) {
+      const value = args[key]
+
+      if (typeof value === 'string' && value.trim() && value.trim().length <= 60) {
+        return `${name}: ${value.trim()}`
+      }
+    }
+  }
+
+  return name
+}
+
+function isExplicitTodoPayload(value: unknown): boolean {
+  return Array.isArray(value) || (isRecord(value) && Object.hasOwn(value, 'todos'))
+}
+
+interface GatewayEvent {
+  session_id?: string
+  type?: string
+  payload?: Record<string, unknown>
+}
+
+function ensureAdapter(): void {
+  if (eventDisposer) {return}
+
+  eventDisposer = host.onEvent('*', event => {
+    // 单一来源：直接读 host.state.activeSessionId，避免 sessionAtom 双源竞争
+    const activeSessionId = host.state.activeSessionId.get()
+
+    // B2：漂移容错过滤。runtime sid 会漂移（快照回填处已删掉实时值比较，
+    // 见 queryFn 注释）——事件 sid 与 activeSessionId 不同时，不再直接
+    // return，而是看两者是否解析到同一 stored id（映射从快照响应学习）：
+    // 同一会话的旧 sid 事件仍放行，跨会话事件仍被丢弃。
+    if (event?.session_id && activeSessionId) {
+      const storedEvent = sidToStored.get(event.session_id)
+      const storedActive = sidToStored.get(activeSessionId)
+
+      const sameSession =
+        event.session_id === activeSessionId || !!(storedEvent && storedEvent === storedActive)
+
+      if (!sameSession) {return}
+    }
+
+    const payload = (event?.payload || {}) as Record<string, unknown>
+    const type = String(event?.type || '')
+    const isToolEvent = type === 'tool.start' || type === 'tool.progress' || type === 'tool.complete'
+
+    if (isToolEvent && (payload.name === 'todo' || (!payload.name && Object.hasOwn(payload, 'todos')))) {
+      const rawTodoValue = payload.todos ?? payload.result ?? payload.args ?? payload
+      const parsed = parseTodos(rawTodoValue)
+
+      let nextTodos: TodoItem[] | null = null
+
+      if (parsed) {
+        nextTodos = parsed
+      } else if (isExplicitTodoPayload(rawTodoValue)) {
+        nextTodos = []
+      }
+
+      if (nextTodos !== null && activeSessionId) {
+        todosAtom.set(nextTodos)
+        // 写穿到快照缓存：todo 事件即最新真值，不等下次轮询回填。
+        // 否则切走再切回时 snapshotCache 里还是旧 todos，闪回旧列表。
+        const cached = snapshotCache.get(activeSessionId)
+
+        if (isRecord(cached)) {
+          boundedCacheSet(snapshotCache, activeSessionId, { ...cached, todos: nextTodos } as SnapshotData)
+        }
+      }
+
+      queryClient.invalidateQueries({ queryKey: ['work-sidebar', 'snapshot', activeSessionId] })
+
+      return
+    }
+
+    if (isToolEvent) {
+      const toolName = String(payload.name || 'tool')
+
+      if (toolName !== 'todo') {
+        const text = toolActivityText(payload)
+        pushActivity({
+          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          time: Date.now(),
+          type: inferActivityType(toolName),
+          text,
+          title: text
+        })
+      }
+
+      return
+    }
+
+    if (type === 'message.complete') {
+      const text = typeof payload.text === 'string' ? payload.text : payload.content
+
+      if (typeof text === 'string' && text.trim()) {
+        const preview = getActivityPreview(text)
+        pushActivity({
+          id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+          time: Date.now(),
+          type: 'info',
+          text: preview.text,
+          // tooltip 用截断版：完整原文可能数千字符，悬停铺满屏无意义
+          title: shorten(preview.title, 200)
+        })
+      }
+
+      // message.complete 不受 tool_progress 开关控制 —— tool_progress 关闭时
+      // tool 事件缺失，这条消息就是自然的刷新信号：立即重拉快照，不等轮询
+      if (activeSessionId) {
+        queryClient.invalidateQueries({ queryKey: ['work-sidebar', 'snapshot', activeSessionId] })
+      }
+    }
+  })
+}
+
+function useStoredState<T>(key: string, initialValue: T): [T, (next: T) => void] {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      return (pluginCtx?.storage.get(key, initialValue) as T | null) ?? initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  const update = (next: T): void => {
+    setValue(next)
+
+    try {
+      pluginCtx?.storage.set(key, next)
+    } catch {
+      // storage 不可用时静默降级为纯内存状态
+    }
+  }
+
+  return [value, update]
+}
+
+function statusIcon(todo: TodoItem) {
+  if (todo.status === 'completed') {
+    return <icons.CheckCircle2 className="mt-0.5 shrink-0 text-(--ui-accent)" size={13} />
+  }
+
+  if (todo.status === 'in_progress') {
+    return <icons.Loader2 className="mt-0.5 shrink-0 animate-spin text-(--ui-accent)" size={13} />
+  }
+
+  if (todo.status === 'cancelled') {
+    return <icons.X className="mt-0.5 shrink-0 text-(--ui-text-quaternary)" size={13} />
+  }
+
+  // #12：pending 用空心圆点，不再复用 Check（勾 = 已完成，视觉误导）
+  return <span className="mt-[7px] size-1.5 shrink-0 rounded-full border border-(--ui-text-quaternary)" />
+}
+
+function TodoRow({ todo }: { todo: TodoItem }) {
+  const ref = useRef<HTMLLIElement | null>(null)
+  const [tip, setTip] = useState<{ left: number; top: number } | null>(null)
+
+  const showTip = () => {
+    const el = ref.current
+
+    if (!el) {return}
+    const r = el.getBoundingClientRect()
+    // 浮层右缘对齐行右缘、向下展开；宽 280 向左收，防溢出视口
+    setTip({ left: Math.max(8, r.right - 280), top: r.bottom + 2 })
+  }
+
+  return (
+    <li
+      className="flex items-start gap-2 px-3 py-1.5"
+      onMouseEnter={showTip}
+      onMouseLeave={() => setTip(null)}
+      ref={ref}
+    >
+      {statusIcon(todo)}
+      <span
+        className={cn(
+          'min-w-0 flex-1 truncate leading-snug',
+          todo.status === 'completed' && 'text-(--ui-text-quaternary) line-through',
+          todo.status === 'in_progress' && 'text-(--ui-text-secondary)',
+          todo.status === 'cancelled' && 'text-(--ui-text-quaternary) line-through opacity-60'
+        )}
+      >
+        {todo.content}
+      </span>
+      {/* hover 预览浮层：完整任务文本（原生 title 在 Electron 环境不可靠，自绘） */}
+      {tip && (
+        <div
+          className="fixed z-50 max-h-[200px] max-w-[280px] overflow-auto rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) px-2.5 py-2 text-[0.75rem] leading-snug text-(--ui-text-secondary) shadow-lg"
+          style={{ left: tip.left, top: tip.top }}
+        >
+          {todo.content}
+        </div>
+      )}
+    </li>
+  )
+}
+
+function ActivityRow({ item }: { item: ActivityItem }) {
+  const ref = useRef<HTMLLIElement | null>(null)
+  const [tip, setTip] = useState<{ left: number; top: number } | null>(null)
+
+  const tone =
+    item.type === 'write' || item.type === 'test'
+      ? 'bg-(--ui-accent)'
+      : item.type === 'info'
+        ? 'bg-(--ui-text-quaternary)'
+        : 'bg-(--ui-text-secondary)'
+
+  const isGrouped = Array.isArray(item._groupItems) && item._groupItems.length > 1
+
+  const openTip = () => {
+    const el = ref.current
+
+    if (!el) {return}
+    const r = el.getBoundingClientRect()
+    // 浮层右缘对齐行右缘、向下展开；宽 320 向左收，防溢出视口
+    setTip({ left: Math.max(8, r.right - 320), top: r.bottom + 2 })
+  }
+
+  // 组详情：最新改动在上（time 倒序）
+  const groupSorted = isGrouped
+    ? [...(item._groupItems as ActivityItem[])].sort((a, b) => (b.time || 0) - (a.time || 0))
+    : []
+
+  return (
+    <li
+      className="flex items-start gap-2 px-3 py-1.5 text-[0.75rem]"
+      ref={ref}
+      title={item._groupTexts ? item._groupTexts.join('\n') : item.title || item.text}
+    >
+      <span className={cn('mt-1 size-1.5 shrink-0 rounded-full', tone)} />
+      {item.type !== 'info' ? (
+        <span className="shrink-0 min-w-16 rounded bg-(--ui-stroke-secondary) px-1 py-px text-center text-[0.625rem] leading-tight text-(--ui-text-tertiary)">
+          {TYPE_LABELS[item.type] || item.type}
+        </span>
+      ) : null}
+      <span className="min-w-0 flex-1 truncate leading-snug text-(--ui-text-secondary)">
+        {item.text}
+      </span>
+      {/* 计数徽标：普通行 = 连续合并计数；折叠行 = 组内总次数，点击弹组详情 */}
+      {(item._groupCount || item.count || 0) > 1 ? (
+        isGrouped ? (
+          <button
+            className="shrink-0 self-center cursor-pointer rounded bg-(--ui-stroke-secondary) px-1 text-[0.625rem] text-(--ui-text-quaternary) hover:text-(--ui-accent)"
+            onClick={() => (tip ? setTip(null) : openTip())}
+            type="button"
+          >
+            {`×${item._groupCount}`}
+          </button>
+        ) : (
+          <span className="shrink-0 self-center rounded bg-(--ui-stroke-secondary) px-1 text-[0.625rem] text-(--ui-text-quaternary)">
+            {`×${item.count}`}
+          </span>
+        )
+      ) : null}
+      <span className="shrink-0 pt-0.5 text-[0.625rem] text-(--ui-text-quaternary)">
+        {relativeTime(item.time)}
+      </span>
+      {/* 组详情浮层：点击 ×N 弹出，最新改动在上 */}
+      {tip && isGrouped && (
+        <div
+          className="fixed z-50 max-h-[240px] w-[320px] overflow-auto rounded-md border border-(--ui-stroke-secondary) bg-(--ui-bg-elevated) py-1 shadow-lg"
+          style={{ left: tip.left, top: tip.top }}
+        >
+          {groupSorted.map(g => (
+            <div className="flex items-start gap-2 px-2.5 py-1 text-[0.75rem]" key={g.id}>
+              <span className="mt-1.5 size-1 shrink-0 rounded-full bg-(--ui-text-tertiary)" />
+              <span className="min-w-0 flex-1 truncate text-(--ui-text-secondary)" title={g.text}>
+                {g.text}
+              </span>
+              {(g.count || 1) > 1 ? (
+                <span className="shrink-0 text-[0.625rem] text-(--ui-text-quaternary)">
+                  {`×${g.count}`}
+                </span>
+              ) : null}
+              <span className="shrink-0 text-[0.625rem] text-(--ui-text-quaternary)">
+                {relativeTime(g.time)}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* 点击浮层外关闭 */}
+      {tip && isGrouped && <div className="fixed inset-0 z-40" onClick={() => setTip(null)} />}
+    </li>
+  )
+}
+
+function OutputRow({ item }: { item: OutputItem }) {
+  const icon =
+    item.kind === 'image' ? (
+      <icons.FileImage className="shrink-0 text-(--ui-text-secondary)" size={13} />
+    ) : item.kind === 'link' ? (
+      <icons.Link2 className="shrink-0 text-(--ui-text-secondary)" size={13} />
+    ) : (
+      <icons.FileText className="shrink-0 text-(--ui-text-secondary)" size={13} />
+    )
+
+  // 文件卡片：主行 = 文件名（点击打开/定位），副行 = 完整路径/URL 摘要。
+  // 后端快照只有 {kind, value, label, ts}——摘要诚实显示位置，不编造用途。
+  const labelEl = item.value.startsWith('data:') ? (
+    <span className="block truncate text-[0.75rem] text-(--ui-text-quaternary)" title="内联数据，无法打开">
+      {item.label}
+    </span>
+  ) : (
+    <button
+      className="block w-full truncate text-left text-[0.75rem] text-(--ui-text-secondary) hover:text-(--ui-accent)"
+      onClick={() => {
+        haptic('tap')
+
+        if (item.kind === 'file') {
+          pluginCtx?.os?.revealPath(item.value)
+        } else {
+          pluginCtx?.os?.openExternal(item.value)
+        }
+      }}
+      title={item.value}
+      type="button"
+    >
+      {item.label}
+    </button>
+  )
+
+  const subEl = item.value.startsWith('data:') ? (
+    <div className="truncate text-[0.6875rem] text-(--ui-text-quaternary)">内联数据（无法打开）</div>
+  ) : (
+    <div className="truncate text-[0.6875rem] text-(--ui-text-quaternary)" title={item.value}>
+      {item.value}
+    </div>
+  )
+
+  // 用途摘要行：后端结构化提取带 tool_name → 用途短语；正则兜底无来源则隐藏
+  const purposeEl = item.purpose ? (
+    <div className="truncate text-[0.6875rem] text-(--ui-text-tertiary)">{item.purpose}</div>
+  ) : null
+
+  return (
+    <li className="group flex items-start gap-2 rounded-md px-3 py-2 hover:bg-(--ui-stroke-secondary)">
+      <div className="mt-0.5 shrink-0">{icon}</div>
+      <div className="min-w-0 flex-1">
+        {labelEl}
+        {subEl}
+        {purposeEl}
+      </div>
+    </li>
+  )
+}
+
+function WorkSidebarPane() {
+  const activeSessionId = useValue(host.state.activeSessionId)
+  const liveTodos = useValue(todosAtom)
+  const activity = useValue(activityAtom)
+  const title = useValue(titleAtom)
+  const [collapsed, setCollapsed] = useStoredState('collapsed', false)
+  const [onlyOpen, setOnlyOpen] = useStoredState('onlyOpen', false)
+  // #13：Activity/Outputs 展开状态（默认折叠，展开看全量）
+  const [activityExpanded, setActivityExpanded] = useStoredState('activityExpanded', false)
+  const [outputsExpanded, setOutputsExpanded] = useStoredState('outputsExpanded', false)
+  // 当前快照数据归属的会话：切换会话时旧值先保留，新快照回填后才切过去，
+  // 避免短暂空白/闪烁（等新数据期间显示骨架屏遮罩）。
+  const [shownSessionId, setShownSessionId] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (activeSessionId) {
+      // 切到目标会话：
+      // 1. 有快照缓存 → 立即显示该会话的真实数据（不遮罩、不闪空）
+      // 2. 无缓存 → 保留旧值 + 遮罩等待，快照到达后再切换
+      // 快照拉取统一由 useQuery 负责：同 queryKey 缓存共享，key 变化自动
+      // fetch（tool_progress 关闭时也立即拉，不等轮询）；不再手动
+      // fetchQuery + invalidateQueries 造成同 key 双通道冗余请求。
+      const cached = snapshotCache.get(activeSessionId)
+
+      if (cached) {
+        setShownSessionId(activeSessionId)
+        todosAtom.set(Array.isArray(cached.todos) ? cached.todos : [])
+        titleAtom.set(cached.title || '')
+      } else {
+        setShownSessionId(null)
+      }
+
+      // activity 按会话切换：有缓存显示缓存；无缓存保留旧值
+      // （等新会话事件/快照自然替换，避免先清空导致的闪空）
+      const cachedActivity = activityCache.get(activeSessionId)
+
+      if (cachedActivity) {
+        activityAtom.set([...cachedActivity])
+      } else {
+        // #8：无缓存时清空而非保留旧会话值——避免 Activity 串会话误导
+        activityAtom.set([])
+      }
+    } else {
+      // 无活跃会话：清空是合理的（真的没有会话了）
+      setShownSessionId(null)
+      todosAtom.set(null)
+      activityAtom.set([])
+      titleAtom.set('')
+    }
+  }, [activeSessionId])
+
+  const snapshot = useQuery({
+    queryKey: ['work-sidebar', 'snapshot', activeSessionId],
+    enabled: !!activeSessionId,
+    queryFn: async () => {
+      // 请求 sid 随数据返回。注意：`_sid` 与回填 effect 里的 activeSessionId
+      // 同源于同一渲染闭包，恒相等 —— 它不是漂移防护。真正的修复是删除
+      // 原先与 host.state.activeSessionId（实时值）的比较：desktop 的
+      // runtime sid 会漂移（同一 stored 会话可对应多个 runtime sid），
+      // 实时值 ≠ 渲染捕获值时误 return → 快照永不回填，遮罩永存。
+      // 保留 `_sid` 仅为显式表达「快照归属于请求时的 sid」这一不变式防回归。
+      const sid = activeSessionId ?? ''
+      const data = await pluginCtx!.rest(`/snapshot?session_id=${encodeURIComponent(sid)}`)
+
+      return { ...data, _sid: sid }
+    },
+    staleTime: 2000,
+    // 失败时暂停轮询：后端持续 500（db 锁/损坏）时停止每 2s 打点，
+    // 避免与 gateway 写锁争用放大；恢复路径 = 手动「重试」或会话切换。
+    refetchInterval: query => {
+      // 折叠时暂停轮询（#6）：面板不可见还每 2s 打 DB 是纯浪费
+      if (collapsed) {return false}
+
+      return query.state.error ? false : 2000
+    },
+    retry: 2
+  })
+
+  // 按会话记录的 snapshotVersion（后端 = total|last_active_id|title），
+  // 用作「数据是否变化」的变化指示器。
+  // 之前是单值 ref，跨会话共享：两个 >400 条的会话 messageCount 都被
+  // 后端截断为固定值，切换后新会话首个快照会被误判为「未变化」而跳过
+  // 回填 → 新会话数据冻结。改为按 activeSessionId 分键，只与本会话
+  // 上次值比较，不跨会话污染；条目数受限防无限增长。
+  // 旧后端没有 snapshotVersion 时退化为 messageCount 版本串（原行为）。
+  const lastVersionBySessionRef = useRef(new Map<string, string>())
+
+  useEffect(() => {
+    if (!snapshot.data || !activeSessionId) {return}
+
+    // 归属校验（恒真：`_sid` 与 activeSessionId 同源于 queryFn 所在渲染
+    // 闭包）。保留它仅为防回归 —— 真正的修复是删除与 host.state.
+    // activeSessionId 实时值的比较（runtime sid 漂移会让实时值 ≠ 渲染捕获
+    // 值，误杀回填）。react-query 按 queryKey 隔离数据，本就不会把旧会话
+    // 快照带进当前 key。
+    if (snapshot.data._sid !== activeSessionId) {return}
+
+    // 快照版本未变化且当前已展示该会话数据 → 跳过回填。
+    // 2s 轮询期间数据没变就反复 set atoms 会引发不必要重渲染/闪动；
+    // snapshotVersion（total|last_active_id|title）比 messageCount 覆盖更全：
+    // 新增消息 / rewind（soft-delete 行数不变但 active 窗口收缩）/ 改标题
+    // 都会让版本变化——messageCount 只覆盖「新增消息」一种。
+    // 旧后端无 snapshotVersion 时退化为 messageCount 版本串（原行为）。
+    const version = snapshot.data.snapshotVersion ?? `m${snapshot.data.messageCount}`
+    const lastVersion = lastVersionBySessionRef.current.get(activeSessionId)
+
+    if (
+      lastVersion === version &&
+      shownSessionId === activeSessionId
+    ) {
+      return
+    }
+
+    lastVersionBySessionRef.current.set(activeSessionId, version)
+
+    // 限制条目数：老会话的版本不再有用，删掉最早插入的键
+    if (lastVersionBySessionRef.current.size > 50) {
+      const oldest = lastVersionBySessionRef.current.keys().next().value
+
+      if (oldest !== undefined) {lastVersionBySessionRef.current.delete(oldest)}
+    }
+
+    // 快照回填：写缓存 + 切到该会话的数据（旧值只保留到这一刻）
+    // 解析失败的快照不缓存（避免切回时永久显示空且无提示）
+    if (snapshot.data.resolved !== false) {
+      boundedCacheSet(snapshotCache, activeSessionId, snapshot.data)
+
+      // B2：学习 runtime sid → stored id 映射（事件过滤的漂移容错锚点）。
+      // 解析失败的快照 storedId=原 sid，记录无害（同 sid 相等判定不受影响）。
+      if (typeof snapshot.data.storedId === 'string' && snapshot.data.storedId) {
+        boundedCacheSet(sidToStored, activeSessionId, snapshot.data.storedId, 50)
+      }
+    }
+
+    setShownSessionId(activeSessionId)
+    todosAtom.set(Array.isArray(snapshot.data.todos) ? snapshot.data.todos : [])
+    // 无条件回填 title：切到无标题会话时回到 '当前会话'，
+    // 不再残留上一个会话的标题（旧实现只在非空时更新，导致标题错位）
+    titleAtom.set(snapshot.data.title || '')
+
+    // 被动事件驱动兜底：事件流缺位（tool_progress 关闭 / agent 不 emit）时，
+    // 用快照里的最近活动种子填充 Activity，不再永远「暂无活动」。
+    // 真实工具事件到达时由 pushActivity 清除种子（seededSessions.delete），
+    // 防与实时流重复。种子不是一次性的：事件流持续缺位时，快照轮询拿到的
+    // 更新活动要能覆盖旧种子（否则 Activity 冻结在首次恢复值）。
+    // seed 行 id 不含 messageCount（稳定 key），刷新时 React 复用 DOM 不闪动。
+    const makeSeed = (activityList: SnapshotData['activity']): ActivityItem[] =>
+      (activityList || []).map((entry, index) => ({
+        id: `seed-${activeSessionId}-${index}`,
+        time: entry.time,
+        type: entry.type,
+        text: entry.text,
+        title: entry.text,
+        seeded: true
+      }))
+
+    // 首次播种：缓存为空且快照有活动
+    if (
+      !activityCache.get(activeSessionId) &&
+      Array.isArray(snapshot.data.activity) &&
+      snapshot.data.activity.length
+    ) {
+      const seeded = makeSeed(snapshot.data.activity)
+      seededSessions.set(activeSessionId, { fingerprint: version })
+      activityCache.set(activeSessionId, seeded)
+      activityAtom.set([...seeded])
+    }
+
+    // 种子刷新：仅在「纯种子态」下用新快照覆盖旧种子。三个条件全部满足才写：
+    //   1. 当前缓存全是 seed（有 live 项混入 → 实时流优先，快照不覆盖）
+    //   2. 会话仍处于种子态（seededSessions 未被真实工具事件 delete）
+    //   3. 快照版本戳变化（复用上方 version：total/rewind/改标题任一变化即刷新；
+    //      version 未变则跳过，避免每 2s 轮询重写相同内容造成闪动）
+    const seededList = activityCache.get(activeSessionId)
+    const allSeeded = Array.isArray(seededList) && seededList.length && seededList.every(item => item.seeded)
+
+    if (
+      allSeeded &&
+      seededSessions.has(activeSessionId) &&
+      Array.isArray(snapshot.data.activity) &&
+      snapshot.data.activity.length &&
+      version !== seededSessions.get(activeSessionId)!.fingerprint
+    ) {
+      const refreshed = makeSeed(snapshot.data.activity)
+      seededSessions.set(activeSessionId, { fingerprint: version })
+      activityCache.set(activeSessionId, refreshed)
+      activityAtom.set([...refreshed])
+    }
+  }, [snapshot.data, activeSessionId, shownSessionId])
+
+  const switching = activeSessionId !== shownSessionId
+
+  const todoData = resolveTodoData({
+    liveTodos,
+    snapshotTodos: snapshot.data?.todos,
+    // B6：无活跃会话时快照查询被禁用（enabled:false）且从未 fetch——
+    // isFetched 恒为 false，snapshotLoaded 恒为 false → todo 区永远显示
+    // 加载骨架。无会话本身就是「加载完的空态」，直接视为已加载：
+    // 与 Activity/Outputs 一致显示空态，而不是无限骨架。
+    snapshotLoaded: !!snapshot.data || snapshot.isFetched || !activeSessionId,
+    onlyOpen
+  })
+
+  const phase = derivePhase(todoData.todos || [], activity || [])
+  const total = Array.isArray(todoData.todos) ? todoData.todos.length : 0
+
+  const cancelled = Array.isArray(todoData.todos)
+    ? todoData.todos.filter(item => item.status === 'cancelled').length
+    : 0
+
+  const completed = Array.isArray(todoData.todos)
+    ? todoData.todos.filter(item => item.status === 'completed').length
+    : 0
+
+  // 进度分母排除 cancelled：取消的任务不该拉低完成率
+  const activeTotal = total - cancelled
+  const percent = activeTotal ? Math.round((completed / activeTotal) * 100) : 0
+
+  // 布局用的 activity 数取当前会话缓存（activityAtom 可能保留旧会话值，
+  // 用全局长度判断弹性布局会不准）
+  const currentActivityCount = (activeSessionId && activityCache.get(activeSessionId))?.length || 0
+
+  const panelLayout = useMemo(
+    () => getTodoPanelLayout({
+      todoCount: total,
+      activityCount: currentActivityCount,
+      outputCount: snapshot.data?.outputs?.length || 0
+    }),
+    [currentActivityCount, snapshot.data?.outputs?.length, total]
+  )
+
+  if (collapsed) {
+    return (
+      <div className="flex h-full flex-col items-center gap-3 border-l border-(--ui-stroke-secondary) bg-(--ui-editor-surface-background) py-3">
+        <button
+          className="rounded p-1 text-(--ui-text-secondary) hover:text-(--ui-accent)"
+          onClick={() => {
+            haptic('tap')
+            setCollapsed(false)
+          }}
+          title="展开 Work Sidebar"
+          type="button"
+        >
+          <icons.ChevronLeft size={16} />
+        </button>
+        <icons.Clipboard className="text-(--ui-text-quaternary)" size={16} title={`TODO ${total}`} />
+        <icons.Activity className="text-(--ui-text-quaternary)" size={16} title={`活动 ${currentActivityCount}`} />
+        <icons.FileText className="text-(--ui-text-quaternary)" size={16} title={`产物 ${snapshot.data?.outputs?.length || 0}`} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative flex h-full min-w-[280px] max-w-[360px] flex-col border-l border-(--ui-stroke-secondary) bg-(--ui-editor-surface-background) text-sm">
+      {/* isError 时不显示遮罩：否则「加载会话数据…」会盖住下方「快照加载
+          失败 [重试]」横幅（z-10 > 横幅默认层级），重试不可达 → 用户误以为
+          卡死。错误态让横幅在正常文档流里露出，恢复后遮罩自动收敛。 */}
+      {switching && !snapshot.isError ? (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-(--ui-editor-surface-background)/70 text-[0.75rem] text-(--ui-text-tertiary)">
+          加载会话数据…
+        </div>
+      ) : null}
+      {snapshot.isError || (snapshot.data && snapshot.data.resolved === false) ? (
+        <div className="flex items-center gap-2 border-b border-(--ui-stroke-secondary) px-3 py-1.5 text-[0.6875rem]">
+          <span className="flex-1 text-red-400">
+            {snapshot.isError ? '快照加载失败' : '会话数据不可用（已删除或已过期）'}
+          </span>
+          <button
+            className="rounded px-1.5 py-0.5 text-(--ui-accent) hover:opacity-80"
+            onClick={() => {
+              haptic('tap')
+              snapshot.refetch()
+            }}
+            title="重新加载"
+            type="button"
+          >
+            重试
+          </button>
+        </div>
+      ) : null}
+      <div className="flex flex-col gap-2 border-b border-(--ui-stroke-secondary) px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="min-w-0 truncate font-medium text-(--ui-text-secondary)">
+              {title || '当前会话'}
+            </span>
+            <span
+              className={cn(
+                'shrink-0 rounded-full border border-(--ui-stroke-secondary) px-1.5 py-px text-[0.625rem]',
+                phaseClassName(phase)
+              )}
+            >
+              {phaseLabel(phase)}
+            </span>
+          </div>
+          <button
+            className="shrink-0 rounded p-1 text-(--ui-text-tertiary) hover:text-(--ui-accent)"
+            onClick={() => {
+              haptic('tap')
+              setCollapsed(true)
+            }}
+            title="折叠 Work Sidebar"
+            type="button"
+          >
+            <icons.ChevronRight size={15} />
+          </button>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="h-1 flex-1 overflow-hidden rounded-full bg-(--ui-stroke-secondary)">
+            <div
+              className="h-full rounded-full bg-(--ui-accent) transition-[width] duration-300"
+              style={{ width: `${percent}%` }}
+            />
+          </div>
+          <span
+            className="text-[0.6875rem] tabular-nums text-(--ui-text-tertiary)"
+            // 分母排除 cancelled 时完成率≠直觉总数：悬停给出上下文，
+            // 不让「5/10」在共有 12 项且 2 项已取消时显得算错
+            title={cancelled > 0 ? `共 ${total} 项，其中 ${cancelled} 项已取消` : undefined}
+          >
+            {`${completed}/${activeTotal}`}
+          </span>
+        </div>
+      </div>
+      <div className={panelLayout.todoClassName}>
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          <span className="text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+            Todo
+          </span>
+          <button
+            className={cn(
+              'text-[0.6875rem]',
+              onlyOpen ? 'text-(--ui-accent)' : 'text-(--ui-text-tertiary) hover:text-(--ui-text-secondary)'
+            )}
+            onClick={() => setOnlyOpen(!onlyOpen)}
+            type="button"
+          >
+            {onlyOpen ? '显示全部' : '只看未完成'}
+          </button>
+        </div>
+        <div className={cn('overflow-y-auto', total > 0 ? 'min-h-0 flex-1' : 'px-3 pb-3')}>
+          {todoData.isLoading ? (
+            <div className="mx-3 mt-2 h-4 animate-pulse rounded bg-(--ui-stroke-secondary)" />
+          ) : !todoData.visibleTodos.length ? (
+            <div
+              className={cn(
+                'rounded border border-dashed border-(--ui-stroke-secondary) text-center text-[0.75rem] text-(--ui-text-quaternary)',
+                total > 0 ? 'mx-3 my-4 px-3 py-6' : 'px-3 py-4'
+              )}
+            >
+              暂无待办
+            </div>
+          ) : (
+            <ul className="divide-y divide-(--ui-stroke-secondary)">
+              {todoData.visibleTodos.map(todo => <TodoRow key={todo.id} todo={todo} />)}
+            </ul>
+          )}
+        </div>
+      </div>
+      <div className={cn(panelLayout.activityClassName, 'overflow-y-auto border-t border-(--ui-stroke-secondary)')}>
+        <div className="px-3 pt-2 pb-1 text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+          Activity
+        </div>
+        {activity.length ? (
+          <div>
+            <ul>
+              {(activityExpanded
+                ? activity
+                : groupActivity(activity)
+                    .slice(0, 5)
+                    .map(g => ({
+                      ...g.items[0],
+                      _groupCount: g.count,
+                      _groupTexts: g.texts,
+                      _groupItems: g.items
+                    }))
+              ).map(item => <ActivityRow item={item} key={item.id} />)}
+            </ul>
+            {activity.length > 5 ? (
+              <button
+                className="w-full px-3 py-1 text-left text-[0.6875rem] text-(--ui-text-tertiary) hover:text-(--ui-accent)"
+                onClick={() => {
+                  haptic('tap')
+                  setActivityExpanded(!activityExpanded)
+                }}
+                type="button"
+              >
+                {activityExpanded ? '收起' : `展开全部 ${activity.length} 条`}
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="px-3 py-2 text-[0.75rem] text-(--ui-text-quaternary)">
+            暂无活动
+          </div>
+        )}
+      </div>
+      <div className={cn(panelLayout.outputsClassName, 'shrink-0 overflow-y-auto border-t border-(--ui-stroke-secondary)')}>
+        <div className="px-3 pt-2 pb-1 text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-(--ui-text-quaternary)">
+          Outputs
+        </div>
+        {snapshot.data?.outputs?.length ? (
+          <div>
+            <ul className="divide-y divide-(--ui-stroke-secondary)">
+              {(outputsExpanded ? snapshot.data.outputs : snapshot.data.outputs.slice(0, 8)).map(
+                (item, index) => <OutputRow item={item} key={`${item.value}-${index}`} />
+              )}
+            </ul>
+            {snapshot.data.outputs.length > 8 ? (
+              <button
+                className="w-full px-3 py-1 text-left text-[0.6875rem] text-(--ui-text-tertiary) hover:text-(--ui-accent)"
+                onClick={() => {
+                  haptic('tap')
+                  setOutputsExpanded(!outputsExpanded)
+                }}
+                type="button"
+              >
+                {outputsExpanded ? '收起' : `展开全部 ${snapshot.data.outputs.length} 条`}
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <div className="px-3 py-3 flex flex-col gap-0.5">
+            {snapshot.isError ? (
+              <div className="text-[0.75rem] text-(--ui-text-quaternary)">加载失败</div>
+            ) : snapshot.isLoading ? (
+              <div className="text-[0.75rem] text-(--ui-text-quaternary)">加载中...</div>
+            ) : (
+              <div className="flex flex-col gap-0.5">
+                <div className="text-[0.75rem] text-(--ui-text-quaternary)">暂无产物</div>
+                {/* B6：无活跃会话时隐藏「agent 写入文件…」提示语——
+                    没有会话却暗示有 agent 在工作会误导。有会话但确实
+                    没产物时才展示引导文案。 */}
+                {activeSessionId ? (
+                  <div className="text-[0.6875rem] text-(--ui-text-tertiary)">
+                    agent 写入文件、截图或下载后，会自动出现在这里
+                  </div>
+                ) : null}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+const plugin: HermesPlugin = {
+  id: PLUGIN_ID,
+  name: 'Work Sidebar',
+  defaultEnabled: false,
+  register(ctx) {
+    pluginCtx = ctx as unknown as PluginContextLike
+    ensureAdapter()
+
+    // 插件卸载/热重载时销毁事件监听，避免旧监听器累积
+    // （SDK: contrib/plugin.ts createPluginContext.onDispose）
+    ctx.onDispose?.(() => {
+      if (eventDisposer) {
+        eventDisposer()
+        eventDisposer = null
+      }
+    })
+
+    ctx.register({
+      id: 'workspace-pane-v3',
+      area: 'panes',
+      title: 'Work Sidebar',
+      data: {
+        placement: 'right',
+        dock: { pane: 'workspace', pos: 'right' },
+        width: '300px'
+      },
+      render: () => <WorkSidebarPane />
+    })
+  }
+}
+
+export default plugin

--- a/plugins/work-sidebar/dashboard/plugin_api.py
+++ b/plugins/work-sidebar/dashboard/plugin_api.py
@@ -1,0 +1,701 @@
+"""Work Sidebar — 右侧工作进度区 backend。
+
+Mounted at /api/plugins/work-sidebar/ by the desktop plugin system.
+Runs inside the gateway process, so it reads state.db directly through
+hermes_state.SessionDB (no HTTP indirection).
+
+提供两个能力（快照 + 产物提取）：
+  GET /snapshot?session_id=…  → { todos, outputs, title, messageCount }
+     todos  = latestSessionTodos 移植（倒序找 todo tool-call part）
+     outputs= 消息文本正则提取产物（image|file|link）
+     title  = 会话标题
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from hermes_state import SessionDB
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+TODO_STATUSES = ("pending", "in_progress", "completed", "cancelled")
+
+# SessionDB 单例：快照 2s 一次轮询，避免每次请求重建连接。
+# SessionDB 内部用 _lock 串行化连接访问，跨线程安全。
+_db_singleton: Optional[SessionDB] = None
+_db_singleton_mtime: Optional[float] = None
+# B3：单例重建路径整体持锁——检查-替换非原子（并发首次请求/并发
+# invalidate 时两个线程都会走到 SessionDB()，先建的实例被覆盖且永不
+# close → 连接/atexit hook 泄漏）。此锁只守卫单例生命周期；SessionDB
+# 内部 _lock 负责连接访问串行化，互不干扰。
+_db_lock = threading.Lock()
+
+
+def _get_db() -> SessionDB:
+    global _db_singleton, _db_singleton_mtime
+    with _db_lock:
+        if _db_singleton is not None:
+            try:
+                mtime = _db_singleton.db_path.stat().st_mtime
+                if mtime == _db_singleton_mtime:
+                    return _db_singleton
+            except OSError:
+                pass
+            # #16:db 文件被替换/备份恢复后 mtime 变化 → 旧连接指向旧库，重建
+            try:
+                _db_singleton.close()
+            except Exception:
+                pass
+            _db_singleton = None
+        _db_singleton = SessionDB()
+        try:
+            _db_singleton_mtime = _db_singleton.db_path.stat().st_mtime
+        except OSError:
+            _db_singleton_mtime = None
+        return _db_singleton
+
+
+# #5:快照响应缓存 stored_id → (messageCount, data)。messageCount 不变即复用，
+# 2s 轮询不再每次全量 DB 读 + 正则扫描。
+_snapshot_cache: dict[str, tuple[int, dict]] = {}
+_SNAPSHOT_CACHE_MAX = 20
+
+# ── runtime sid → stored id 持久映射 ────────────────────────────────────
+# runtime sid（uuid4().hex[:8]，desktop 的 activeSessionId）只存在于
+# tui_gateway.server._sessions 内存 dict，serve 进程重启即失。desktop 恢复
+# 会话时若直接拿旧的 runtime sid 来查，_sessions 里已没有对应条目，解析会
+# 落空 → title/todos/outputs 全空（“恢复不一致”）。这里把解析成功的结果
+# 持久化到插件目录，重启后仍能解析。
+_RUNTIME_SID_MAP = Path(__file__).resolve().parent / ".runtime_sid_map.json"
+_sid_map_lock = threading.RLock()  # #18:_remember_runtime_sid 整体读改写持锁，_save 内层可重入
+# #21：持久映射兜底的有效性窗口。mapped 会话在窗口内有活动才可信——
+# 短了误杀「挂机思考」的真实会话（后果仅是显示数据不可用，_sessions 就绪后
+# 自愈）；长了防不住 sid 复用 bug 的典型形态（旧会话 2 小时前活跃被误解析）。
+_RUNTIME_SID_FRESH_S = 60 * 60
+
+
+def _load_runtime_sid_map() -> dict:
+    try:
+        with open(_RUNTIME_SID_MAP, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def _save_runtime_sid_map(mapping: dict) -> None:
+    try:
+        with _sid_map_lock:
+            tmp = _RUNTIME_SID_MAP.with_name(_RUNTIME_SID_MAP.name + ".tmp")
+            with open(tmp, "w", encoding="utf-8") as fh:
+                json.dump(mapping, fh, ensure_ascii=False, indent=1)
+            tmp.replace(_RUNTIME_SID_MAP)
+    except OSError:
+        pass
+
+
+def _remember_runtime_sid(runtime_sid: str, stored_id: str) -> None:
+    """记录 runtime sid → stored id 映射（幂等，失败不阻塞主流程）。"""
+    if not runtime_sid or not stored_id or runtime_sid == stored_id:
+        return
+    try:
+        # #18:读-改-写整体持锁，防并发 _remember_runtime_sid 丢更新
+        with _sid_map_lock:
+            mapping = _load_runtime_sid_map()
+            if mapping.get(runtime_sid) == stored_id:
+                return
+            mapping[runtime_sid] = stored_id
+            # 防无限增长：只保留最近 200 条（每个 stored id 可对应多个 runtime sid）
+            if len(mapping) > 200:
+                for key in list(mapping)[:-200]:
+                    mapping.pop(key, None)
+            _save_runtime_sid_map(mapping)
+    except Exception:
+        pass
+
+
+def _forget_runtime_sid(runtime_sid: str) -> None:
+    """删除 runtime sid → stored id 映射条目（清理脏映射，幂等）。"""
+    if not runtime_sid:
+        return
+    try:
+        with _sid_map_lock:
+            mapping = _load_runtime_sid_map()
+            if runtime_sid not in mapping:
+                return
+            mapping.pop(runtime_sid, None)
+            _save_runtime_sid_map(mapping)
+    except Exception:
+        pass
+
+
+# ── todo 解析：apps/desktop/src/lib/todos.ts parse() 的 Python 移植 ──────
+def _parse_todos(value: Any, depth: int = 0) -> Optional[List[dict]]:
+    if depth > 2:
+        return None
+    if isinstance(value, list):
+        out: List[dict] = []
+        for item in value:
+            if not isinstance(item, dict) or item.get("status") not in TODO_STATUSES:
+                continue
+            tid = str(item.get("id", "")).strip()
+            content = str(item.get("content", "")).strip()
+            if tid and content:
+                out.append({"id": tid, "content": content, "status": item["status"]})
+        # 空列表保留：表达“todo 已被清空”。None 表示“没有 todo 数据”，
+        # [] 表示“显式清空”——两者语义不同，调用方必须区分。
+        return out
+    if isinstance(value, str) and value.strip():
+        try:
+            return _parse_todos(json.loads(value), depth + 1)
+        except (json.JSONDecodeError, TypeError):
+            return None
+    if isinstance(value, dict) and "todos" in value:
+        return _parse_todos(value["todos"], depth + 1)
+    return None
+
+
+def _todos_from_parts(content: Any) -> tuple[Optional[List[dict]], bool]:
+    """返回 (todos, is_todo_message)。
+
+    is_todo_message=True 表示该消息确实是 todo 工具调用——此时空列表
+    表达“显式清空”，_latest_session_todos 必须尊重它，而不是跳过并回退
+    到更早的非空列表（否则 todo 清空后快照会闪回旧条目）。
+    """
+    # str → 尝试 JSON 解析（state.db 的 tool 结果/参数都是 JSON 字符串）
+    if isinstance(content, str):
+        try:
+            content = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None, False
+
+    # dict 直接带 todos 键（todo 工具的完整结果）
+    if isinstance(content, dict) and "todos" in content:
+        return _parse_todos(content["todos"]), True
+
+    if not isinstance(content, list):
+        return None, False
+
+    latest: Optional[List[dict]] = None
+    found = False
+    for part in content:
+        if (
+            not isinstance(part, dict)
+            or part.get("type") != "tool-call"
+            or part.get("toolName") != "todo"
+        ):
+            continue
+        found = True
+        parsed = _parse_todos(part.get("todos"))
+        if parsed is None:
+            parsed = _parse_todos(part.get("result"))
+        if parsed is None:
+            parsed = _parse_todos(part.get("args"))
+        # todo 调用存在就记录其结果——None（无数据）/ []（显式清空）都算
+        latest = parsed
+    return latest, found
+
+
+def _latest_session_todos(messages: List[dict]) -> Optional[List[dict]]:
+    """整个会话的当前 todo 状态 —— 最后一条 todo 消息获胜（含显式清空）。"""
+    for msg in reversed(messages):
+        parsed, is_todo = _todos_from_parts(msg.get("content"))
+        if is_todo:
+            return parsed
+    return None
+
+
+def _infer_title(messages: List[dict], max_len: int = 40) -> str:
+    """无标题会话的兜底标题：第一条非空 user 文本，否则第一条 assistant 文本。
+
+    desktop 恢复会话时首次快照可能早于 _sessions 就绪（runtime sid 暂无法
+    解析），此时 title 为空会让侧边栏看起来“没解析到”；有消息推断兜底后
+    至少显示会话内容摘要，轮询收敛后由真实标题覆盖。
+    """
+    for msg in messages:
+        role = msg.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        raw = msg.get("content")
+        text = ""
+        if isinstance(raw, str):
+            text = raw
+        elif isinstance(raw, list):
+            parts = [
+                p.get("text")
+                for p in raw
+                if isinstance(p, dict) and isinstance(p.get("text"), str)
+            ]
+            text = "\n".join(parts)
+        text = re.sub(r"\s+", " ", text).strip()
+        if not text or text.startswith(("{", "[", "```")):
+            continue
+        # 超长消息截断再取头（避免把整段分析当标题）
+        return text[:max_len]
+    return ""
+
+
+# ── 产物提取：apps/desktop/src/app/artifacts/artifact-utils.ts 正则移植 ──
+_MD_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)\s]+)\)")
+_MD_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)\s]+)\)")
+_URL_RE = re.compile(r"https?://[^\s<>\"')]+")
+_PATH_RE = re.compile(
+    r"(^|[\s(\"'`])((?:[A-Za-z]:[\\/]|/|~\/|\.\.?\/)[^\s\"'`<>，。；、！？()（）\[\]{}]+(?:\.[a-z0-9]{1,8})?)",
+    re.I
+)
+# B1：含空格/括号的路径变体（Windows 上 C:\Program Files\... 极常见）。
+# 旧 _PATH_RE 字符类排除 \s 与括号 → C:\Program Files\foo.py 只匹配出
+# C:\Program（无扩展名）→ 被 add() 扩展名白名单拦掉，整个路径丢失。
+# 此正则允许 [ \t] 分隔的段与半角括号（(x86) 是路径一部分；全角（）仍
+# 排除）；段字符集排除 CJK——否则「C:\foo.txt 和 C:\bar.txt」会被吞成
+# 一条假产物。扩展名强制（目录不算产物）。无空格的路径仍走 _PATH_RE
+# （保留 CJK 路径提取能力）。
+_PATH_RE_SPACED = re.compile(
+    r"(^|[\s(\"'`])((?:[A-Za-z]:[\\/]|/|~\/|\.\.?\/)"
+    r"(?:[^\s\"'`<>，。；、！？（）\[\]{}\u4e00-\u9fff]+[ \t]+)*"
+    r"[^\s\"'`<>，。；、！？（）\[\]{}\u4e00-\u9fff]+\.[a-z0-9]{1,8})",
+    re.I,
+)
+_IMAGE_EXT_RE = re.compile(r"\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$", re.I)
+_CODE_BLOCK_RE = re.compile(r"```[^\n]*\n.*?```", re.S)
+
+
+def _strip_code_blocks(text: str) -> str:
+    """剥离围栏代码块（#17）：块内的示例路径/ls 输出会被路径正则误判为产物。"""
+    return _CODE_BLOCK_RE.sub("\n", text)
+_FILE_EXT_RE = re.compile(
+    r"\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|mp3|wav|mp4|mov)(?:\?.*)?$", re.I
+)
+# 结构化产物字段白名单：工具结果 JSON 里出现这些键且值是路径/URL 时，
+# 直接作为产物（不依赖扩展名白名单，.py/.js 等脚本产物也不会漏）。
+_STRUCTURED_PATH_KEYS = (
+    "resolved_path",
+    "screenshot_path",
+    "image_path",
+    "output_path",
+    "file_path",
+    "artifact_path",
+    "pdf_path",
+    "docx_path",
+    "xlsx_path",
+    "pptx_path",
+    "result_path",
+    "files_modified",
+    "written_files",
+    "created_files",
+    "download_path",
+    "export_path",
+    "capture_path",
+    "thumbnail_path",
+    "video_path",
+    "audio_path",
+    "model_path",
+    "output_dir",
+    "attachment_path",
+)
+
+
+def _looks_like_artifact(value: str) -> bool:
+    return value.startswith(("http://", "https://", "file://", "data:", "@url:")) or value.startswith(
+        ("/", "./", "../", "~/")
+    ) or bool(re.match(r"^[A-Za-z]:[\\/]", value))
+
+
+def _iter_structured_paths(payload: Any, depth: int = 0):
+    """递归（≤2 层）收集工具结果 JSON 里白名单键的路径/URL 值。
+
+    只认 ``*_path`` 白名单键（write_file 的 resolved_path、浏览器截图的
+    screenshot_path 等）且值确实是路径/URL —— 避免把工具结果里无关的
+    字符串字段误判为产物。正则兜底仍负责文本扫描。
+    """
+    if depth > 2 or payload is None:
+        return
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if key in _STRUCTURED_PATH_KEYS:
+                if isinstance(value, str) and _looks_like_artifact(value):
+                    yield value
+                elif isinstance(value, list):
+                    for item in value:
+                        if isinstance(item, str) and _looks_like_artifact(item):
+                            yield item
+            elif isinstance(value, (dict, list)):
+                yield from _iter_structured_paths(value, depth + 1)
+    elif isinstance(payload, list):
+        for item in payload:
+            yield from _iter_structured_paths(item, depth + 1)
+
+
+def _artifact_kind(value: str) -> str:
+    if value.startswith("data:image/") or _IMAGE_EXT_RE.search(value):
+        return "image"
+    if value.startswith(("/", "./", "../", "~/", "file://")) or re.match(r"^[A-Za-z]:[\\/]", value):
+        return "file"
+    return "link"
+
+
+_TOOL_PURPOSE_PATTERNS = (
+    ("write_file", "写入的文件"),
+    ("patch", "修改的文件"),
+    ("copy|cp ", "复制的文件"),
+    ("download|curl|wget", "下载的文件"),
+    ("screenshot|browser_vision|vision", "页面截图"),
+    ("pdf|docx|xlsx|pptx", "生成的文档"),
+    ("terminal", "终端产物"),
+)
+
+
+def _tool_purpose(tool_name: Any) -> Optional[str]:
+    """工具名 → 用途短语（固定映射，诚实呈现，不猜测语义）。"""
+    n = str(tool_name or "").lower()
+    for pat, label in _TOOL_PURPOSE_PATTERNS:
+        if re.search(pat, n):
+            return label
+    return "工具产物" if n and n != "tool" else None
+
+
+def _extract_outputs(messages: List[dict], limit: int = 20) -> List[dict]:
+    out: List[dict] = []
+    seen = set()
+
+    def add(value: str, kind: Optional[str] = None, ts: Any = 0, structured: bool = False, purpose: Optional[str] = None) -> None:
+        value = (value or "").strip().rstrip("),.;")
+        if not value or value in seen:
+            return
+        # @url: 前缀 = 结构化来源显式标注的 URL（如 video_path 存链接）。
+        # 剥前缀后按 link 处理，而不是丢弃（旧实现漏掉这类产物）。
+        forced_link = False
+        if value.startswith("@url:"):
+            value = value[len("@url:") :].strip().strip("()").rstrip("),.;")
+            if not value or value in seen:
+                return
+            forced_link = True
+        # 接受 POSIX 路径、Windows 盘符路径（C:\...）、URL、data:、file:
+        if not value.startswith(("http://", "https://", "file://", "data:")) and not value.startswith(
+            ("/", "./", "../", "~/")
+        ) and not re.match(r"^[A-Za-z]:[\\/]", value):
+            return
+        k = "link" if forced_link else (kind or _artifact_kind(value))
+        # 结构化来源（write_file 已确认写入成功）信任路径本身；
+        # 正则兜底才需要扩展名白名单，避免漏掉 .py/.js 等脚本产物。
+        if k == "file" and not structured and not (_IMAGE_EXT_RE.search(value) or _FILE_EXT_RE.search(value)):
+            return
+        label = value.rsplit("/", 1)[-1].rsplit("\\", 1)[-1] or value
+        seen.add(value)
+        out.append(
+            {
+                "kind": k,
+                "value": value,
+                "label": label[:80],
+                "ts": ts or 0,
+                "purpose": purpose or None,
+            }
+        )
+
+    for msg in reversed(messages):
+        ts = msg.get("timestamp") or msg.get("created_at") or 0
+
+        # ── 结构化来源：工具结果 JSON 白名单字段（write_file 的
+        #    resolved_path、browser 截图的 screenshot_path 等），
+        #    正则只做文本兜底 ──────────────────────────────────────────
+        if msg.get("role") == "tool":
+            raw = msg.get("content")
+            try:
+                payload = json.loads(raw) if isinstance(raw, str) else (raw or {})
+            except (json.JSONDecodeError, TypeError):
+                payload = {}
+            # 附件线索：消息级 display_metadata 里也可能带路径
+            if isinstance(msg.get("display_metadata"), dict):
+                payload = {**payload, "_meta": msg["display_metadata"]}
+            for value in _iter_structured_paths(payload):
+                # 结构化来源不再一律强制 file（#4）：URL/data: 值按 _artifact_kind
+                # 判成 link/image，只有路径才标 file——否则 video_path 存链接时
+                # 前端会走 revealPath 系统定位，必失败。
+                _k = None if value.startswith(("http://", "https://", "data:", "file://")) else "file"
+                add(value, _k, ts, structured=True, purpose=_tool_purpose(msg.get("tool_name")))
+                if len(out) >= limit:
+                    return out
+
+        if msg.get("role") != "assistant":
+            continue
+        raw = msg.get("content")
+        if isinstance(raw, str):
+            text = raw
+        elif isinstance(raw, list):
+            # parts 数组：拼 text 型 part 的 text/内容
+            parts_txt = []
+            for p in raw:
+                if isinstance(p, dict):
+                    if p.get("type") == "text" and isinstance(p.get("text"), str):
+                        parts_txt.append(p["text"])
+                    elif isinstance(p.get("text"), str):
+                        parts_txt.append(p["text"])
+            text = "\n".join(parts_txt)
+        else:
+            text = json.dumps(raw, ensure_ascii=False) if raw else ""
+        # 代码块剥离（#17）：块内的示例路径/ls 输出不该进产物列表
+        text = _strip_code_blocks(text)
+
+        candidates: List[tuple[str, Optional[str]]] = []
+        for m in _MD_IMAGE_RE.finditer(text):
+            candidates.append((m.group(2), "image"))
+        for m in _MD_LINK_RE.finditer(text):
+            v = m.group(2)
+            if v.startswith(("http", "/", "./", "../", "~/", "file:")) or re.match(
+                r"^[A-Za-z]:[\\/]", v
+            ):
+                candidates.append((v, None))
+        for m in _URL_RE.finditer(text):
+            candidates.append((m.group(0), None))
+        for m in _PATH_RE.finditer(text):
+            candidates.append((m.group(2).strip(), None))
+        for m in _PATH_RE_SPACED.finditer(text):
+            candidates.append((m.group(2).strip(), None))
+
+        for value, forced in candidates:
+            add(value, forced, ts)
+            if len(out) >= limit:
+                return out
+    return out
+
+
+_ACTIVITY_PATH_KEYS = ("resolved_path", "file_path", "path", "file", "url", "target")
+
+
+def _extract_activity(messages: List[dict], limit: int = 8) -> List[dict]:
+    """从尾部消息提取最近工具活动，供前端在事件流缺位时兜底
+    （被动事件驱动的补充：tool_progress 关闭 / agent 不 emit 时，活动区
+    不再永远「暂无活动」）。assistant 消息不取——会与 message.complete
+    事件重复；todo 工具排除——已由 todo 面板表达。
+    返回 time 为 epoch 毫秒（前端 relativeTime 需要；DB 存的是秒）。
+    """
+    out: List[dict] = []
+    for msg in reversed(messages):
+        if msg.get("role") != "tool":
+            continue
+        name = str(msg.get("tool_name") or "tool")
+        if name == "todo":
+            continue
+
+        if re.search(r"test|pytest|vitest|check|verify", name, re.I):
+            type_ = "test"
+        elif re.search(r"read|search|list|get|view|inspect", name, re.I):
+            type_ = "read"
+        elif re.search(r"write|patch|edit|create|install|build", name, re.I):
+            type_ = "write"
+        else:
+            type_ = "tool"
+
+        # 工具消息 content 是「结果」不是「参数」——JSON 时尽力挑一个
+        # 路径/文件名键做上下文（如 skill_view 的 file）；挑不出就退回工具名。
+        text = name
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            snippet = None
+            try:
+                parsed = json.loads(content)
+                if isinstance(parsed, dict):
+                    for key in _ACTIVITY_PATH_KEYS:
+                        v = parsed.get(key)
+                        if isinstance(v, str) and v.strip():
+                            snippet = v.strip()[:60]
+                            break
+            except (ValueError, TypeError):
+                cand = content.strip()
+                if "\n" not in cand and len(cand) <= 80:
+                    snippet = cand
+            if snippet:
+                text = f"{name}: {snippet}"
+
+        ts = msg.get("timestamp") or 0
+        try:
+            time_ms = int(float(ts) * 1000)
+        except (TypeError, ValueError):
+            time_ms = 0
+
+        out.append({"type": type_, "text": text[:80], "time": time_ms})
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _resolve_stored_session_id(session_id: str, db: Optional[SessionDB] = None) -> str:
+    """把插件传入的 session_id 解析为 state.db 的 stored id。
+
+    插件传的是 desktop 的 activeSessionId —— session.create 返回的
+    ``session_id``（runtime sid，8 位 hex）。state.db 以 stored_session_id
+    （``20260805_...``）为键，直接查会落空。解析链（全部解析到同一套 id，
+    title / todos / outputs 共用，保证一致性）：
+      1. 直接命中（session_id 本身就是 stored id）
+      2. 前缀解析（stored id 的唯一前缀）
+      3. tui_gateway ``_sessions`` 运行时映射（桌面运行期间的最新真相，
+         命中时写回持久映射，自愈旧条目）
+      4. 持久映射文件（覆盖 desktop 重启后 _sessions 为空的恢复场景）
+    """
+    if not session_id:
+        return session_id
+    db = db or _get_db()
+    # DB 异常直接传播（#10）：state.db 锁/损坏时让 snapshot() 转 500，
+    # 前端才能区分「会话真没了」（resolved:false）与「DB 暂时不可用」（500）。
+    if db.get_session(session_id):
+        return session_id
+    resolved = db.resolve_session_id(session_id)
+    if resolved:
+        return resolved
+    # 运行时映射优先于持久映射：桌面运行期间 _sessions 是真相来源，
+    # 持久文件只兜底「serve 重启后 _sessions 为空」的恢复场景。
+    # 若先查持久文件，会话被重建并复用同一 runtime sid 时，旧映射会在
+    # _sessions 已含更新映射的情况下胜出 → 快照读错会话。
+    # 命中 _sessions 时写回持久映射，旧条目随 _remember_runtime_sid 自愈。
+    try:
+        from tui_gateway.server import _sessions  # noqa: PLC0415
+
+        for sid, sess in _sessions.items():
+            if sid == session_id:
+                stored = sess.get("session_key")
+                if stored:
+                    stored = str(stored)
+                    _remember_runtime_sid(session_id, stored)
+                    return stored
+            key = sess.get("session_key")
+            if key and str(key) == session_id:
+                return str(key)
+    except Exception:
+        pass
+    # 持久映射：重启后 _sessions 为空时仍能解析旧 runtime sid
+    # 兜底校验（#21）：mapped 会话必须存在且近期活跃，否则丢弃并清理脏条目——
+    # desktop 新会话复用旧 runtime sid 时，脏映射会把当前激活会话解析到旧会话
+    # （快照/Activity 整面板显示错数据：title/todos/outputs 全来自旧会话）。
+    # 宁可返回原 sid（resolved=false，前端显示「数据不可用」）也不显示错误会话；
+    # _sessions 就绪后第 3 步正常命中并写回自愈，此兜底只在异常窗口期生效。
+    try:
+        mapped = _load_runtime_sid_map().get(session_id)
+        if mapped:
+            sess = db.get_session(str(mapped))
+            if sess:
+                last_at = sess.get("last_activity_at") or 0
+                try:
+                    last_at_f = float(last_at)
+                except (TypeError, ValueError):
+                    last_at_f = 0
+                if last_at_f and time.time() - last_at_f < _RUNTIME_SID_FRESH_S:
+                    return str(mapped)
+            # 会话不存在 / 已不活跃：清理脏条目，防粘滞
+            _forget_runtime_sid(session_id)
+    except Exception:
+        pass
+    return session_id
+
+
+def _max_active_message_id(db: SessionDB, session_id: str) -> Optional[int]:
+    """活跃消息的最大 AUTOINCREMENT id（rewind 变化检测）。
+
+    message_count 计全部行（含 soft-deleted），rewind 只把行翻成
+    active=0、不删行 → 总数不变但 active 窗口收缩。MAX(id) WHERE
+    active=1 在 rewind 后会变小，与 total 互补组成快照失效键。
+    复刻 message_count 的 _lock/_conn 模式（同一把锁；走
+    idx_messages_session_active 索引的单条聚合查询，轻量），
+    不新增 SessionDB 公开 API。失败返回 None（版本戳退化为 total|title）。
+    """
+    try:
+        with db._lock:
+            row = db._conn.execute(
+                "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
+                (session_id,),
+            ).fetchone()
+    except Exception:
+        return None
+    val = row[0] if row else None
+    return int(val) if val is not None else None
+
+
+# ── HTTP 路由 ────────────────────────────────────────────────────────────
+@router.get("/snapshot")
+def snapshot(session_id: str = Query(...)):
+    """一次拿全：todo 快照 + 产物 + 标题。前端事件流为主，此接口兜底。"""
+    if not session_id:
+        raise HTTPException(400, "session_id required")
+    try:
+        db = _get_db()
+        stored_id = _resolve_stored_session_id(session_id, db)
+        # 快照版本戳 = total | last_active_id | title，作为缓存失效键
+        # （从「仅 messageCount」升级，见 #5）：
+        #   - total          抓新增消息（原主键）
+        #   - last_active_id 抓 rewind：soft-delete 不删行，总数不变但
+        #     active 窗口收缩（_max_active_message_id）
+        #   - title          抓改名（get_session 单行主键查询，轻量）
+        # 三者均为轻量查询，不做 tail_hash——读尾部 400 条做哈希会吃掉
+        # 缓存收益。
+        total = db.message_count(stored_id)
+        last_active_id = _max_active_message_id(db, stored_id)
+        try:
+            session = db.get_session(stored_id)
+        except Exception:
+            session = None
+        resolved = stored_id != session_id or bool(session)
+        title = (session.get("title") or "") if session else ""
+        snapshot_version = f"{total}|{last_active_id}|{title}"
+        # 快照缓存（#5 升级）：版本戳未变 → 直接复用上次响应，
+        # 跳过全量 DB 读 + 正则扫描（2s 轮询的空转成本）
+        _cached = _snapshot_cache.get(stored_id)
+        if _cached and _cached[0] == snapshot_version:
+            return _cached[1]
+        # 截断策略：只取会话尾部（最新）消息。todo 状态与产物都是“当前
+        # 状态”，旧消息里的历史 todo/产物没有展示价值；get_messages 是
+        # 插入正序 + LIMIT 从头取，长会话（>400 条）里最新数据会被截掉，
+        # 所以用 message_count 做 offset 分页取最后 400 条。
+        tail = min(400, total)
+        messages = db.get_messages(stored_id, limit=tail, offset=max(0, total - tail))
+        if not messages and total > 0:
+            # message_count 含 soft-deleted(rewind)行，而 get_messages 默认
+            # 只返回 active=1 —— offset 可能越过 active 范围。回退：全量取尾。
+            all_msgs = db.get_messages(stored_id, limit=None)
+            messages = all_msgs[-tail:]
+    except Exception as exc:  # state.db 锁 / 损坏 / 不存在
+        logger.warning("work-sidebar snapshot failed (session=%s): %s", session_id, exc)
+        raise HTTPException(500, "state.db read failed") from exc
+
+    if not title:
+        # 无标题会话：从消息推断，避免恢复/新建会话显示空白
+        try:
+            title = _infer_title(messages)
+        except Exception:
+            pass
+
+    # messageCount 必须是真实总数（message_count 计全部行，含 soft-deleted），
+    # 不能用 len(messages)：messages 是截断后的尾部窗口（最多 400 条），
+    # 长会话（>400 条）里它会恒为 400，前端拿它当「数据是否变化」的指示器
+    # 时会误判为没变化 → 快照回填被跳过，面板冻结。真实总数随每条新消息
+    # 递增，变化检测才能覆盖长会话（rewind 只 soft-delete，不影响 total）。
+    data = {
+        "todos": _latest_session_todos(messages),
+        "outputs": _extract_outputs(messages),
+        # 被动事件驱动的兜底：事件流缺位时前端用此列表填充 Activity
+        "activity": _extract_activity(messages),
+        "title": title,
+        "messageCount": total,
+        # B2：前端事件过滤的漂移容错锚点。快照已把 runtime sid 解析成
+        # stored id——前端据此学习「runtime sid → stored id」映射：事件
+        # 的 sid 与 activeSessionId 不同但映射到同一 stored id 时视为
+        # 同一会话（runtime sid 漂移），否则丢弃（跨会话污染防护）。
+        "storedId": stored_id,
+        # 前端「数据是否变化」的失效键：messageCount 只覆盖新增消息，
+        # rewind / 改标题会漏判 → 快照被永久缓存旧值。见 _max_active_message_id。
+        "snapshotVersion": snapshot_version,
+        "resolved": resolved,
+    }
+    if len(_snapshot_cache) >= _SNAPSHOT_CACHE_MAX:
+        _snapshot_cache.pop(next(iter(_snapshot_cache)), None)
+    _snapshot_cache[stored_id] = (snapshot_version, data)
+    return data

--- a/tests/gateway/test_work_sidebar_snapshot.py
+++ b/tests/gateway/test_work_sidebar_snapshot.py
@@ -1,0 +1,575 @@
+"""work-sidebar snapshot 回归测试。
+
+验证三种 id 形态（完整 stored id / stored id 前缀 / runtime sid）都解析到
+同一 stored id，且 snapshot 返回一致的标题与消息数；覆盖 desktop 重启后
+``_sessions`` 为空、依赖持久映射的恢复场景；验证 outputs 结构化白名单。
+运行：python -m pytest tests/gateway/test_work_sidebar_snapshot.py -q
+（或直接 python 运行本文件：python test_snapshot.py）
+"""
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PLUGIN_API = Path(__file__).resolve().parents[2] / "plugins" / "work-sidebar" / "dashboard" / "plugin_api.py"
+
+spec = importlib.util.spec_from_file_location("work_sidebar_plugin_api", PLUGIN_API)
+pa = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pa)
+
+from hermes_state import SessionDB  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def session_db():
+    return SessionDB()
+
+
+@pytest.fixture(autouse=True)
+def _use_fixture_db(request, session_db, monkeypatch):
+    """插件内部 _get_db() 一律指向 fixture 的种子 DB。
+
+    conftest 的 per-test 隔离会把 HERMES_HOME 切到测试级临时目录，而
+    module-scope 的 session_db 在隔离生效前初始化——两者不指向同一
+    state.db。统一从这里走，避免 _get_db() 读到空库导致解析落空。
+    """
+    if request.node.name == "test_get_db_concurrent_singleton":
+        return  # 该测试验证 _get_db 单例本身，不能用 fixture 替身
+    monkeypatch.setattr(pa, "_get_db", lambda: session_db)
+
+
+@pytest.fixture(scope="module")
+def real_session_id(session_db):
+    """播种一个真实格式的会话作为基准（conftest 已把 HERMES_HOME 隔离到
+    临时目录，不触碰开发机 state.db）。"""
+    import time as _time
+
+    # 真实格式 stored id：%Y%m%d_%H%M%S_随机后缀 —— resolve_session_id 的
+    # 前缀解析要求前缀唯一，不能用共享前缀的命名（多个种子会话会歧义 → None）
+    sid = f"{_time.strftime('%Y%m%d_%H%M%S')}_{_time.time_ns() % 10**6:06d}"
+    session_db.create_session(sid, source="test")
+    # 显式标题：SessionDB 不自动从消息推标题，测试的 title 断言依赖它。
+    # set_session_title 强制标题唯一（跨会话冲突抛 ValueError），加后缀避免
+    # 前序 pytest 运行残留的同标题种子会话冲突。
+    title = f"收编 work-sidebar 到 hermes 主仓库 {sid[-6:]}"
+    session_db.set_session_title(sid, title)
+    # 标题兜底来源：第一条 user 消息截断（_infer_title，插件后端路径）
+    session_db.append_message(sid, "user", content=title)
+    # todo 最新真值（_latest_session_todos 倒序找最后一条 todo tool 消息）
+    session_db.append_message(
+        sid,
+        "tool",
+        tool_name="todo",
+        content=json.dumps(
+            {
+                "todos": [
+                    {"id": "t1", "content": "转换前端为 bundled 插件", "status": "in_progress"},
+                    {"id": "t2", "content": "适配后端路由", "status": "completed"},
+                ]
+            }
+        ),
+    )
+    # 产物提取源：write_file 结构化结果（_extract_outputs 白名单）
+    session_db.append_message(
+        sid,
+        "tool",
+        tool_name="write_file",
+        content=json.dumps({"resolved_path": r"C:\seed\out.txt", "verified": True}),
+    )
+    # 持久映射兜底校验要求 last_activity_at 新鲜（_RUNTIME_SID_FRESH_S 内），
+    # SessionDB 不自动更新该字段——显式打点，否则映射兜底路径永远拒绝。
+    session_db.touch_session_activity(sid, description="test seed", provenance="test")
+    return sid
+
+
+@pytest.fixture
+def isolated_sid_map(tmp_path, monkeypatch):
+    """把持久映射重定向到临时目录，避免测试污染真实插件目录。"""
+    target = tmp_path / ".runtime_sid_map.json"
+    monkeypatch.setattr(pa, "_RUNTIME_SID_MAP", target)
+    return target
+
+
+def _fake_sessions(fake_server, mapping):
+    """把假的 _sessions 注入 sys.modules 的 tui_gateway.server。"""
+    fake_server._sessions = {
+        sid: {"session_key": stored} for sid, stored in mapping.items()
+    }
+    pkg = types.ModuleType("tui_gateway")
+    pkg.__path__ = []
+    sys.modules["tui_gateway"] = pkg
+    sys.modules["tui_gateway.server"] = fake_server
+
+
+def _cleanup_fake_sessions():
+    sys.modules.pop("tui_gateway.server", None)
+    sys.modules.pop("tui_gateway", None)
+
+
+def test_resolve_stored_id_forms(session_db, real_session_id, isolated_sid_map):
+    """完整 stored id 与唯一前缀 → 同一 stored id。"""
+    full = real_session_id  # 20260805_154004_237e48
+    # 取足够长的唯一前缀（resolve_session_id 对歧义前缀返回 None）
+    prefix = full[:16]  # 20260805_154004_（含分节下划线，通常唯一）
+
+    resolved_full = pa._resolve_stored_session_id(full)
+    resolved_prefix = pa._resolve_stored_session_id(prefix)
+
+    assert resolved_full == full
+    assert resolved_prefix == full, f"prefix {prefix!r} 应解析为 {full!r}, got {resolved_prefix!r}"
+
+
+def test_resolve_runtime_sid_mapping(real_session_id, isolated_sid_map):
+    """runtime sid（8位 hex）→ stored id：_sessions 运行时映射 + 写回持久映射。"""
+    fake_server = types.ModuleType("tui_gateway.server")
+    _fake_sessions(fake_server, {"d5e60859": real_session_id})
+    try:
+        resolved = pa._resolve_stored_session_id("d5e60859")
+        assert resolved == real_session_id
+        # 命中后应写回持久映射，供下一次恢复场景使用
+        mapping = json.loads(isolated_sid_map.read_text(encoding="utf-8"))
+        assert mapping["d5e60859"] == real_session_id
+    finally:
+        _cleanup_fake_sessions()
+
+
+def test_runtime_sid_recovery_via_persisted_map(real_session_id, isolated_sid_map):
+    """恢复场景：serve 重启后 _sessions 为空，持久映射兜底解析。"""
+    isolated_sid_map.write_text(
+        json.dumps({"d5e60859": real_session_id}), encoding="utf-8"
+    )
+    # 不注入 _sessions（模拟空 _sessions）——直接依赖持久映射
+    resolved = pa._resolve_stored_session_id("d5e60859")
+    assert resolved == real_session_id
+
+
+def test_three_forms_consistent(session_db, real_session_id, isolated_sid_map):
+    """三种 id 形态 → 同一 stored id，且 title / 消息数一致。"""
+    full = real_session_id
+    prefix = full[:16]
+    runtime = "d5e60859"
+    fake_server = types.ModuleType("tui_gateway.server")
+    _fake_sessions(fake_server, {runtime: full})
+
+    def snapshot_core(sid):
+        db = session_db
+        stored = pa._resolve_stored_session_id(sid, db)
+        messages = db.get_messages(stored, limit=400)
+        session = db.get_session(stored)
+        title = session.get("title") if session else ""
+        return stored, title, len(messages)
+
+    try:
+        results = [snapshot_core(sid) for sid in (full, prefix, runtime)]
+        stored_ids = {r[0] for r in results}
+        titles = {r[1] for r in results}
+        counts = {r[2] for r in results}
+        assert len(stored_ids) == 1, f"三种 id 应解析到同一 stored id: {results}"
+        assert len(titles) == 1, f"三种 id 的标题应一致: {results}"
+        assert len(counts) == 1, f"三种 id 的消息数应一致: {results}"
+        assert titles.pop(), "标题不应为空"
+    finally:
+        _cleanup_fake_sessions()
+
+
+def test_snapshot_consistency(session_db, real_session_id, isolated_sid_map):
+    """snapshot 核心逻辑：full 与 prefix 得到同一标题与同量消息。"""
+    stored_id = pa._resolve_stored_session_id(real_session_id)
+    messages = session_db.get_messages(stored_id, limit=400)
+    session = session_db.get_session(stored_id)
+    title = session.get("title") if session else ""
+
+    prefix = real_session_id[:16]
+    stored_id_2 = pa._resolve_stored_session_id(prefix)
+    messages_2 = session_db.get_messages(stored_id_2, limit=400)
+    session_2 = session_db.get_session(stored_id_2)
+    title_2 = session_2.get("title") if session_2 else ""
+
+    assert stored_id == stored_id_2
+    assert len(messages) == len(messages_2)
+    assert title == title_2
+    assert title, "标题不应为空"
+
+
+def test_todos_and_outputs_extraction(session_db, real_session_id, isolated_sid_map):
+    """快照三件套可提取：todos / outputs / title 结构完整。"""
+    stored_id = pa._resolve_stored_session_id(real_session_id)
+    messages = session_db.get_messages(stored_id, limit=400)
+
+    todos = pa._latest_session_todos(messages)
+    outputs = pa._extract_outputs(messages)
+    session = session_db.get_session(stored_id)
+    title = session.get("title") if session else ""
+
+    assert isinstance(todos, (list, type(None)))
+    assert isinstance(outputs, list)
+    assert isinstance(title, str)
+    if todos:
+        for t in todos:
+            assert t.get("status") in ("pending", "in_progress", "completed", "cancelled")
+    for o in outputs:
+        assert o.get("kind") in ("image", "link", "file")
+        assert o.get("value")
+        assert o.get("label")
+
+
+def test_structured_outputs_whitelist():
+    """工具结果 JSON 的 *_path 白名单字段 → 结构化产物（正则兜底之外）。"""
+    msgs = [
+        {
+            "role": "tool",
+            "tool_name": "write_file",
+            "content": json.dumps(
+                {
+                    "resolved_path": r"C:\Users\ASUS\workspace-test.txt",
+                    "files_modified": [r"C:\Users\ASUS\check-ha2.py"],
+                    "bytes_written": 127,
+                    "verified": True,
+                }
+            ),
+            "timestamp": 1000,
+        },
+        {
+            "role": "tool",
+            "tool_name": "browser_vision",
+            "content": json.dumps({"screenshot_path": r"C:\shot\a.png"}),
+            "timestamp": 2000,
+        },
+        # 嵌套结构也应命中；.py 不在扩展名白名单，结构化路径必须保留
+        {
+            "role": "tool",
+            "tool_name": "some_tool",
+            "content": json.dumps({"result": {"output_path": [r"C:\out\check-ha2.py"]}}),
+            "timestamp": 3000,
+        },
+        # 附件线索：display_metadata 里的路径也应收
+        {
+            "role": "tool",
+            "tool_name": "x",
+            "content": json.dumps({"ok": True}),
+            "display_metadata": {"attachment_path": r"C:\attachments\doc.pdf"},
+            "timestamp": 4000,
+        },
+    ]
+    outputs = pa._extract_outputs(msgs)
+    values = {o["value"] for o in outputs}
+    assert r"C:\Users\ASUS\workspace-test.txt" in values
+    assert r"C:\Users\ASUS\check-ha2.py" in values
+    assert r"C:\shot\a.png" in values
+    assert r"C:\out\check-ha2.py" in values
+    assert r"C:\attachments\doc.pdf" in values
+    assert all(o["kind"] == "file" for o in outputs)
+
+
+def test_structured_paths_reject_non_artifact():
+    """白名单键但值不是路径/URL → 不误判为产物。"""
+    msgs = [
+        {
+            "role": "tool",
+            "tool_name": "x",
+            "content": json.dumps({"resolved_path": "not-a-path", "screenshot_path": 42}),
+            "timestamp": 1,
+        }
+    ]
+    assert pa._extract_outputs(msgs) == []
+
+
+def test_tail_window_gets_latest_todos():
+    """截断策略：只取会话尾部（最新）消息 —— 旧 todo 不覆盖新 todo。
+
+    get_messages 是插入正序 + LIMIT 从头取；快照改用 message_count +
+    offset 分页取最后 400 条，否则长会话里最新 todo/产物会被截掉。
+    """
+    msgs = []
+    for i in range(450):
+        content = None
+        if i == 10:
+            content = json.dumps(
+                {"todos": [{"id": "old", "content": "旧任务", "status": "completed"}]}
+            )
+        if i == 430:
+            content = json.dumps(
+                {"todos": [{"id": "new", "content": "新任务", "status": "in_progress"}]}
+            )
+        msgs.append(
+            {
+                "id": 1000 + i,
+                "role": "tool",
+                "tool_name": "todo",
+                "content": content,
+                "timestamp": i,
+            }
+        )
+    head = msgs[:400]
+    tail = msgs[-400:]
+    # 旧实现（从头取 400）只能看到旧 todo；新策略（尾部 400）拿到新 todo
+    head_todos = pa._latest_session_todos(head)
+    tail_todos = pa._latest_session_todos(tail)
+    assert head_todos and head_todos[0]["id"] == "old"
+    assert tail_todos and tail_todos[0]["id"] == "new"
+
+
+def test_snapshot_route_three_forms(session_db, real_session_id, isolated_sid_map):
+    """直接调 /snapshot 路由核心：三种 id 形式返回同一快照（title/数量一致）。"""
+    full = real_session_id
+    prefix = full[:16]
+    runtime = "d5e60859"
+    fake_server = types.ModuleType("tui_gateway.server")
+    _fake_sessions(fake_server, {runtime: full})
+    try:
+        results = [pa.snapshot(sid) for sid in (full, prefix, runtime)]
+        assert all(isinstance(r, dict) for r in results)
+        assert len({r["title"] for r in results}) == 1, results
+        assert len({r["messageCount"] for r in results}) == 1, results
+        assert results[0]["title"], "标题不应为空"
+    finally:
+        _cleanup_fake_sessions()
+
+
+def test_snapshot_independent_of_tool_progress(session_db, real_session_id, isolated_sid_map):
+    """tool_progress=off（tool 事件被抑制）时快照仍能从 state.db 回填。
+
+    快照数据全部来自 state.db，不依赖事件流；tool_progress 只影响
+    gateway 是否 emit tool 事件。这里模拟 _sessions 里该会话
+    tool_progress_mode=off，snapshot 仍返回结构完整的数据。
+    """
+    full = real_session_id
+    runtime = "d5e60859"
+    fake_server = types.ModuleType("tui_gateway.server")
+    _fake_sessions(fake_server, {runtime: full})
+    fake_server._sessions[runtime]["tool_progress_mode"] = "off"
+    try:
+        result = pa.snapshot(runtime)
+        assert set(result.keys()) == {
+            "todos",
+            "outputs",
+            "activity",
+            "title",
+            "messageCount",
+            "storedId",
+            "snapshotVersion",
+            "resolved",
+        }, f"快照键集变化: {set(result.keys())}"
+        assert result["resolved"] is True, "tool_progress=off 时应正常解析"
+        assert isinstance(result["todos"], (list, type(None)))
+        assert isinstance(result["outputs"], list)
+        assert result["title"], "tool_progress=off 时标题也应回填"
+    finally:
+        _cleanup_fake_sessions()
+
+
+def test_resolved_flag(session_db, isolated_sid_map):
+    """resolved 标志：正常会话为 True，无法解析的 id 为 False（不吞失败）。"""
+    rows = session_db.list_sessions_rich(limit=1)
+    assert rows, "隔离 HERMES_HOME 里应有种子会话"
+    ok = pa.snapshot(rows[0]["id"])
+    assert ok["resolved"] is True
+
+    # 不存在的 runtime sid：解析链全落空 → resolved=False，前端据此显示
+    # “数据不可用”而不是“暂无待办/暂无产物”
+    bad = pa.snapshot("deadbeef")
+    assert bad["resolved"] is False
+    assert bad["messageCount"] == 0
+
+
+def test_todo_clear_semantics():
+    """todo 显式清空：最后一条 todo 消息是空列表 → 返回 []（不闪回旧列表）。"""
+    msgs = [
+        {
+            "id": 1,
+            "role": "tool",
+            "tool_name": "todo",
+            "content": json.dumps(
+                {"todos": [{"id": "a", "content": "任务A", "status": "in_progress"}]}
+            ),
+            "timestamp": 1,
+        },
+        {"id": 2, "role": "assistant", "content": "进度更新", "timestamp": 2},
+        {
+            "id": 3,
+            "role": "tool",
+            "tool_name": "todo",
+            "content": json.dumps({"todos": []}),  # 显式清空
+            "timestamp": 3,
+        },
+    ]
+    # 旧实现：空列表被跳过 → 闪回"任务A"；新实现：尊重显式清空
+    assert pa._latest_session_todos(msgs) == []
+
+    # 没有 todo 消息 → None（区分"无数据"与"已清空"）
+    assert pa._latest_session_todos([{"id": 9, "role": "assistant", "content": "hi"}]) is None
+
+
+def test_windows_path_regex_extraction():
+    """文本层正则也能抓到 Windows 盘符路径（不依赖结构化白名单）。"""
+    content = (
+        "我把文件写到 " + r"C:\Users\ASUS\out\report.txt" + "，截图在 " + r"C:\tmp\shot.png"
+    )
+    msgs = [{"id": 1, "role": "assistant", "content": content, "timestamp": 1}]
+    values = {o["value"] for o in pa._extract_outputs(msgs)}
+    assert r"C:\Users\ASUS\out\report.txt" in values
+    assert r"C:\tmp\shot.png" in values
+
+
+def test_infer_title():
+    """无标题会话：从消息推断标题（user 优先，跳过 JSON/代码块/空消息）。"""
+    msgs = [
+        {"role": "system", "content": "ignore me"},
+        {"role": "tool", "content": json.dumps({"x": 1})},
+        {"role": "user", "content": '{"json": "not a title"}'},
+        {"role": "user", "content": "帮我分析这个日志文件"},
+        {"role": "assistant", "content": "好的，我来看看"},
+    ]
+    assert pa._infer_title(msgs) == "帮我分析这个日志文件"
+
+    # 没有 user 文本时退回 assistant
+    msgs2 = [
+        {"role": "user", "content": "```python\nprint(1)\n```"},
+        {"role": "assistant", "content": "已修复并验证。"},
+    ]
+    assert pa._infer_title(msgs2) == "已修复并验证。"
+
+    # 超长截断
+    long_text = "这是一条很长的消息，" * 50
+    assert len(pa._infer_title([{"role": "user", "content": long_text}])) <= 40
+
+    # 全空
+    assert pa._infer_title([]) == ""
+
+
+def test_extract_activity():
+    """活动兜底提取：tool 消息 → 活动条目，排除 todo/assistant，时间戳秒→毫秒。"""
+    msgs = [
+        {
+            "id": 1,
+            "role": "tool",
+            "tool_name": "todo",
+            "content": json.dumps({"todos": []}),
+            "timestamp": 100,
+        },
+        {"id": 2, "role": "assistant", "content": "我在干活", "timestamp": 200},
+        {
+            "id": 3,
+            "role": "tool",
+            "tool_name": "skill_view",
+            "content": json.dumps({"file": r"C:\docs\guide.md"}),
+            "timestamp": 300,
+        },
+        {
+            "id": 4,
+            "role": "tool",
+            "tool_name": "terminal",
+            "content": json.dumps({"output": "ps aux"}),
+            "timestamp": 400,
+        },
+    ]
+    acts = pa._extract_activity(msgs)
+    # 倒序取：terminal 在前，skill_view 在后；todo 与 assistant 被排除
+    assert [a["type"] for a in acts] == ["tool", "read"]
+    assert acts[0]["text"] == "terminal"  # 无路径键 → 退回工具名
+    assert acts[1]["text"] == "skill_view: C:\\docs\\guide.md"
+    assert acts[1]["time"] == 300 * 1000  # 秒 → 毫秒
+
+
+def test_extract_activity_limit_and_plain_content():
+    """limit 截断 + 纯文本 content（非 JSON）也能给出上下文。"""
+    msgs = [
+        {"id": i, "role": "tool", "tool_name": f"tool_{i}", "content": "x", "timestamp": i}
+        for i in range(20)
+    ]
+    acts = pa._extract_activity(msgs, limit=3)
+    assert len(acts) == 3
+    assert acts[0]["time"] == 19 * 1000  # 最新一条在前，毫秒
+    assert acts[0]["text"] == "tool_19: x"
+
+
+def test_windows_path_regex_spaced_paths():
+    """B1：含空格/括号的 Windows 路径不再丢失。
+
+    旧 _PATH_RE 字符类排除 \\s 与括号 → C:\\Program Files\\report.txt 只匹配出
+    C:\\Program（无扩展名）→ 被扩展名白名单拦掉，整个路径丢失。扩展名用
+    白名单内的 .txt/.png（.py 属结构化通道，正则兜底本就不收）。
+    """
+    content = (
+        "写入到 " + r"C:\Program Files\report.txt" + "，括号路径 " + r"C:\Program Files (x86)\shot.png"
+    )
+    msgs = [{"id": 1, "role": "assistant", "content": content, "timestamp": 1}]
+    values = {o["value"] for o in pa._extract_outputs(msgs)}
+    assert r"C:\Program Files\report.txt" in values, f"空格路径应被提取: {values}"
+    assert r"C:\Program Files (x86)\shot.png" in values, f"括号路径应被提取: {values}"
+    # 正则层：.py 全路径也应被匹配（扩展名白名单拦截是另一道独立关卡）
+    m = pa._PATH_RE_SPACED.search(r"C:\Program Files\foo.py")
+    assert m and m.group(2) == r"C:\Program Files\foo.py"
+
+
+def test_windows_path_regex_no_cjk_merge():
+    """B1：空格路径不与相邻中文合并成一条假产物（CJK 排除段字符集）。"""
+    content = r"C:\docs.txt 和 C:\notes.md 都生成完毕"
+    msgs = [{"id": 1, "role": "assistant", "content": content, "timestamp": 1}]
+    values = [o["value"] for o in pa._extract_outputs(msgs)]
+    assert r"C:\docs.txt" in values
+    assert r"C:\notes.md" in values
+    assert r"C:\docs.txt 和 C:\notes.md" not in values
+
+
+def test_get_db_concurrent_singleton(monkeypatch):
+    """B3：并发 _get_db 只创建一个 SessionDB 实例（防双实例 + 连接泄漏）。
+
+    旧实现检查-替换非原子：并发首次请求会各自 new 一个 SessionDB，先建的
+    被覆盖且永不 close（连接/atexit hook 泄漏）。
+    """
+    import threading as _threading
+
+    created = []
+    orig_db = pa.SessionDB
+
+    class CountingSessionDB(orig_db):
+        def __init__(self, *args, **kwargs):
+            created.append(1)
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(pa, "SessionDB", CountingSessionDB)
+    monkeypatch.setattr(pa, "_db_singleton", None)
+    monkeypatch.setattr(pa, "_db_singleton_mtime", None)
+
+    results = []
+
+    def worker():
+        results.append(pa._get_db())
+
+    threads = [_threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    try:
+        assert len(created) == 1, f"并发 _get_db 应只创建 1 个实例，实际 {len(created)}"
+        assert len({id(r) for r in results}) == 1, "所有线程应拿到同一实例"
+    finally:
+        for db in results:
+            try:
+                db.close()
+            except Exception:
+                pass
+
+
+def test_snapshot_includes_stored_id_and_version(session_db, real_session_id, isolated_sid_map):
+    """B2/B4：快照响应携带 storedId（事件过滤漂移锚点）与 snapshotVersion（缓存失效键）。"""
+    runtime = "d5e60859"
+    fake_server = types.ModuleType("tui_gateway.server")
+    _fake_sessions(fake_server, {runtime: real_session_id})
+    try:
+        result = pa.snapshot(runtime)
+        assert result["storedId"] == real_session_id, "storedId 应为解析后的 stored id"
+        assert isinstance(result["snapshotVersion"], str) and result["snapshotVersion"]
+        assert result["snapshotVersion"].startswith(f"{result['messageCount']}|")
+    finally:
+        _cleanup_fake_sessions()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Adds **Work Sidebar** — a right-hand workspace pane showing the active session's Todo list, live tool/message activity, and extracted outputs (files / images / links) — as a bundled desktop plugin.

| Piece | Path | Notes |
|---|---|---|
| Frontend | `apps/desktop/src/plugins/work-sidebar/plugin.tsx` | TSX port of a previously disk-only `plugin.js`; `defaultEnabled: false` (opt-in via Settings ▸ Plugins, same as kanban) |
| Backend | `plugins/work-sidebar/dashboard/plugin_api.py` | `GET /snapshot?session_id=…` mounted at `/api/plugins/work-sidebar/`; reads `state.db` directly via `hermes_state.SessionDB` |
| Tests | `tests/gateway/test_work_sidebar_snapshot.py` | 21 tests, seeds a real-format session inside the sandboxed HERMES_HOME — no dev-machine state.db dependency |

## What the pane does

- **Todo**: live list fed by `todo` tool events, with a snapshot fallback (2s poll, paused when collapsed or on error); "只看未完成" filter; progress bar whose denominator excludes cancelled items.
- **Activity**: merged consecutive same-tool events into ×N rows, grouped folding for read/skill/check/output badges, hover tooltips, seed-from-snapshot fallback when the event stream is absent (tool_progress off).
- **Outputs**: regex + structured-whitelist extraction of file/image/link artifacts from tool results; click opens via `ctx.os`.
- **Session phase badge** (执行中/计划中/测试中/活跃中/已完成/空闲) derived from todos + fresh activity.
- Session-switch handling: per-session snapshot/activity caches, stale-sid tolerance learned from snapshot responses, no flash-on-switch.

## Bug fixed in the port

`host.state.activeSessionId` is a nanostores **atom**. The disk plugin read it without `.get()`, which silently collapsed every per-session cache onto one key. The bundled TSX reads the atom properly (`.get()` in listeners, `useValue` in the component).

## Verification

- `tsc -p . --noEmit` — clean (baseline was clean before this change)
- `eslint` — clean, plugin fence respected (SDK + react only)
- `ruff check` on backend + tests — clean
- `vite build` — OK; bundle contains the plugin (`workspace-pane-v3`)
- `pytest tests/gateway/test_work_sidebar_snapshot.py` — **21/21 passed**

## Notes for review

- No core edits — plugin surface only (`PANES_AREA` + `ctx.rest` + `ctx.storage` + `host.onEvent`).
- The snapshot route intentionally exposes session todos/outputs to the plugin namespace; it sits behind the dashboard's session-token auth middleware like other plugin routes.
- UI strings are Chinese (the plugin was built for the zh-CN desktop UI); happy to move them to `ctx.i18n` if that's a merge requirement.