### PR TITLE
feat(cron): add durable delivery retries

### DIFF
--- a/cron/executions.py
+++ b/cron/executions.py
@@ -1,32 +1,61 @@
-"""Profile-local durable audit ledger for cron execution attempts.
+"""Profile-local durable ledger for cron execution and delivery attempts.
 
-The ledger records what is known about each attempt; it is not a retry queue.
-Interrupted attempts become ``unknown`` only after their exact owner process is
-proved gone. Terminal states are immutable.
+Delivery state machine (all transitions are committed in SQLite):
+
+``pending -> delivering -> delivered``
+``pending -> delivering -> retry_wait -> delivering`` (bounded retries)
+``delivering -> exhausted`` (permanent failure or retry limit)
+``pending|retry_wait -> exhausted`` (job cancellation)
+``delivering -> unknown`` (only after its exact owner is proved dead)
+
+``delivered``, ``exhausted``, and ``unknown`` are terminal. An interrupted
+network send is deliberately ``unknown`` and is never retried because the
+platform may have accepted it before the process died.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import sqlite3
 import threading
 import uuid
 from contextlib import contextmanager
-from typing import Any, Dict, Iterator, List, Optional
+from datetime import timedelta, timezone
+from typing import Any, Dict, Iterator, List, Optional, cast
 
 from hermes_constants import get_hermes_home
 from hermes_time import now as _hermes_now
 
 EXECUTIONS_FILE = get_hermes_home().resolve() / "cron" / "executions.db"
+_IMPORT_EXECUTIONS_FILE = EXECUTIONS_FILE
 MAX_TERMINAL_EXECUTIONS = 1000
+MAX_DELIVERY_ATTEMPTS = 4
+# The built-in scheduler wakes every 60 seconds, so a smaller first delay would
+# promise timing it cannot deliver. These are minimum delays; Chronos retries
+# only at its next warm callback/startup reconciliation point.
+DELIVERY_RETRY_DELAYS_SECONDS = (60, 120, 600)
 _TERMINAL_STATES = ("completed", "failed", "unknown")
 _lock = threading.RLock()
 _PROCESS_ID = uuid.uuid4().hex
 
 
+def _current_executions_file():
+    """Resolve the active profile's ledger while honoring test overrides."""
+    if EXECUTIONS_FILE != _IMPORT_EXECUTIONS_FILE:
+        return EXECUTIONS_FILE
+    return get_hermes_home().resolve() / "cron" / "executions.db"
+
+
 def _connect() -> sqlite3.Connection:
-    EXECUTIONS_FILE.parent.mkdir(parents=True, exist_ok=True)
-    return sqlite3.connect(EXECUTIONS_FILE, timeout=5)
+    executions_file = _current_executions_file()
+    executions_file.parent.mkdir(parents=True, exist_ok=True)
+    return sqlite3.connect(executions_file, timeout=5)
+
+
+def _delivery_now():
+    """Use UTC for lexically sortable retry timestamps across DST changes."""
+    return _hermes_now().astimezone(timezone.utc)
 
 
 def _initialize_schema(conn: sqlite3.Connection) -> None:
@@ -60,31 +89,114 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         "CREATE INDEX IF NOT EXISTS idx_executions_status_claimed "
         "ON executions(status, claimed_at DESC, id DESC)"
     )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS deliveries (
+             execution_id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             job_json TEXT,
+             content TEXT,
+             targets_json TEXT NOT NULL,
+             status TEXT NOT NULL CHECK(status IN
+               ('pending','delivering','retry_wait','delivered','exhausted','unknown')),
+             attempt_count INTEGER NOT NULL DEFAULT 0,
+             next_attempt_at TEXT,
+             last_error TEXT,
+             permanent_error TEXT,
+             terminal_reason TEXT,
+             claim_token TEXT,
+             claim_process_id TEXT,
+             claim_pid INTEGER,
+             claim_process_started_at INTEGER,
+             created_at TEXT NOT NULL,
+             updated_at TEXT NOT NULL
+           )"""
+    )
+    # Additive migration for databases created by an earlier build of this
+    # branch. No table rewrite and no change to the existing status CHECK.
+    delivery_columns = {
+        row["name"] for row in conn.execute("PRAGMA table_info(deliveries)").fetchall()
+    }
+    for column, ddl in (
+        ("permanent_error", "TEXT"),
+        ("terminal_reason", "TEXT"),
+        ("claim_token", "TEXT"),
+        ("claim_process_id", "TEXT"),
+        ("claim_pid", "INTEGER"),
+        ("claim_process_started_at", "INTEGER"),
+    ):
+        if column not in delivery_columns:
+            conn.execute(f"ALTER TABLE deliveries ADD COLUMN {column} {ddl}")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_deliveries_due "
+        "ON deliveries(status, next_attempt_at, created_at)"
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS delivery_attempts (
+             id INTEGER PRIMARY KEY AUTOINCREMENT,
+             execution_id TEXT NOT NULL,
+             attempt_number INTEGER NOT NULL,
+             targets_json TEXT NOT NULL,
+             started_at TEXT NOT NULL,
+             finished_at TEXT,
+             outcome TEXT,
+             error TEXT,
+             UNIQUE(execution_id, attempt_number)
+           )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_delivery_attempts_execution "
+        "ON delivery_attempts(execution_id, attempt_number)"
+    )
 
 
 @contextmanager
-def _transaction() -> Iterator[sqlite3.Connection]:
-    """Open a connection, commit/rollback on exit, always close.
+def _transaction(*, immediate: bool = False) -> Iterator[sqlite3.Connection]:
+    """Open one explicit SQLite transaction and always close its connection.
 
-    ``sqlite3.Connection.__enter__``/``__exit__`` only commit or roll back
-    the transaction; it does not close the connection. Relying on that alone
-    leaks a connection (and its WAL/SHM file descriptors) on every call,
-    since closing then depends on the garbage collector. Schema init runs
-    inside the ``try`` too, so a PRAGMA/DDL failure after a successful
-    ``connect()`` still closes the connection instead of leaking it.
+    Schema setup/migration is committed first. Write-side state transitions use
+    ``BEGIN IMMEDIATE`` so the read/compare/update sequence owns SQLite's write
+    reservation before it observes state; a second process waits, then sees the
+    committed winner and cannot claim the same delivery. Read-only callers use
+    a deferred transaction. Commit/rollback is explicit and the connection is
+    closed on every path.
     """
     with _lock:
         conn = _connect()
         try:
             _initialize_schema(conn)
-            with conn:
+            conn.commit()
+            conn.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
+            try:
                 yield conn
+            except BaseException:
+                conn.rollback()
+                raise
+            else:
+                conn.commit()
         finally:
             conn.close()
 
 
 def _record(row: Optional[sqlite3.Row]) -> Optional[Dict[str, Any]]:
     return dict(row) if row is not None else None
+
+
+def _delivery_record(row: Optional[sqlite3.Row]) -> Optional[Dict[str, Any]]:
+    if row is None:
+        return None
+    record = dict(row)
+    job_json = cast(Optional[str], record.pop("job_json", None))
+    targets_json = cast(str, record.pop("targets_json", "[]"))
+    record["job"] = json.loads(job_json) if job_json else None
+    record["targets"] = json.loads(targets_json or "[]")
+    return record
+
+
+def _attempt_record(row: sqlite3.Row) -> Dict[str, Any]:
+    record = dict(row)
+    targets_json = cast(str, record.pop("targets_json", "[]"))
+    record["targets"] = json.loads(targets_json or "[]")
+    return record
 
 
 def _emit_execution_state(
@@ -115,20 +227,42 @@ def _owner_is_live(pid: int, started_at: Optional[int]) -> bool:
     except Exception:
         return True  # fail safe: inability to prove death must not rewrite state
     if started_at is None:
-        return pid == os.getpid()
+        # The PID exists but its start-time identity is unavailable. That is
+        # insufficient evidence to declare the owner dead; fail closed even
+        # when the live PID belongs to another scheduler process.
+        return True
     current = _process_start_time(pid)
     return current is not None and current == started_at
 
 
 def _prune_unlocked(conn: sqlite3.Connection) -> None:
     limit = max(0, int(MAX_TERMINAL_EXECUTIONS))
-    conn.execute(
-        """DELETE FROM executions WHERE id IN (
-             SELECT id FROM executions
-             WHERE status IN ('completed','failed','unknown')
-             ORDER BY claimed_at DESC, id DESC LIMIT -1 OFFSET ?
-           )""",
+    rows = conn.execute(
+        """SELECT id FROM executions e
+           WHERE status IN ('completed','failed','unknown')
+             AND NOT EXISTS (
+               SELECT 1 FROM deliveries d
+               WHERE d.execution_id=e.id
+                 AND d.status IN ('pending','delivering','retry_wait')
+             )
+           ORDER BY claimed_at DESC, id DESC LIMIT -1 OFFSET ?""",
         (limit,),
+    ).fetchall()
+    stale_ids = [row["id"] for row in rows]
+    if not stale_ids:
+        return
+    placeholders = ",".join("?" for _ in stale_ids)
+    conn.execute(
+        f"DELETE FROM delivery_attempts WHERE execution_id IN ({placeholders})",
+        stale_ids,
+    )
+    conn.execute(
+        f"DELETE FROM deliveries WHERE execution_id IN ({placeholders})",
+        stale_ids,
+    )
+    conn.execute(
+        f"DELETE FROM executions WHERE id IN ({placeholders})",
+        stale_ids,
     )
 
 
@@ -137,7 +271,7 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
     now = _hermes_now().isoformat()
     execution_id = uuid.uuid4().hex
     pid = os.getpid()
-    with _transaction() as conn:
+    with _transaction(immediate=True) as conn:
         conn.execute(
             """INSERT INTO executions
                (id, job_id, source, process_id, pid, process_started_at,
@@ -157,7 +291,7 @@ def create_execution(job_id: str, *, source: str) -> Dict[str, Any]:
 def mark_execution_running(execution_id: str) -> Optional[Dict[str, Any]]:
     """Transition one claimed attempt to running exactly once."""
     now = _hermes_now().isoformat()
-    with _transaction() as conn:
+    with _transaction(immediate=True) as conn:
         cur = conn.execute(
             """UPDATE executions SET status='running', started_at=?
                WHERE id=? AND status='claimed'""",
@@ -180,7 +314,7 @@ def finish_execution(
     now = _hermes_now().isoformat()
     status = "completed" if success else "failed"
     detail = None if success else (str(error) if error else "unknown failure")
-    with _transaction() as conn:
+    with _transaction(immediate=True) as conn:
         cur = conn.execute(
             """UPDATE executions SET status=?, finished_at=?, error=?
                WHERE id=? AND status IN ('claimed','running')""",
@@ -198,10 +332,10 @@ def finish_execution(
 
 def recover_interrupted_executions() -> int:
     """Mark provably abandoned attempts unknown without scheduling retries."""
-    now = _hermes_now().isoformat()
+    now = _delivery_now().isoformat()
     changed = 0
     recovered: List[Dict[str, Any]] = []
-    with _transaction() as conn:
+    with _transaction(immediate=True) as conn:
         rows = conn.execute(
             """SELECT id, process_id, pid, process_started_at FROM executions
                WHERE status IN ('claimed','running')"""
@@ -231,6 +365,322 @@ def recover_interrupted_executions() -> int:
     for record in recovered:
         _emit_execution_state(record)
     return changed
+
+
+def enqueue_delivery(
+    execution_id: str,
+    *,
+    job: Dict[str, Any],
+    content: str,
+    targets: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Persist an exact post-execution delivery before any network send.
+
+    The execution id is the idempotency key. A repeated prepare returns the
+    existing record instead of replacing an in-flight or terminal outcome.
+    """
+    now = _delivery_now().isoformat()
+    job_id = str(job.get("id") or "")
+    if not job_id:
+        raise ValueError("delivery job snapshot requires an id")
+    if not targets:
+        raise ValueError("delivery requires at least one concrete target")
+    with _transaction(immediate=True) as conn:
+        conn.execute(
+            """INSERT OR IGNORE INTO deliveries
+               (execution_id, job_id, job_json, content, targets_json, status,
+                attempt_count, next_attempt_at, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?)""",
+            (
+                str(execution_id),
+                job_id,
+                json.dumps(job, separators=(",", ":"), sort_keys=True),
+                str(content),
+                json.dumps(targets, separators=(",", ":"), sort_keys=True),
+                now,
+                now,
+                now,
+            ),
+        )
+        row = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?", (str(execution_id),)
+        ).fetchone()
+    return _delivery_record(row)  # type: ignore[return-value]
+
+
+def get_delivery(execution_id: str) -> Optional[Dict[str, Any]]:
+    with _transaction() as conn:
+        row = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?", (str(execution_id),)
+        ).fetchone()
+    return _delivery_record(row)
+
+
+def list_due_deliveries(*, limit: int = 50) -> List[Dict[str, Any]]:
+    """Return delivery batches whose network attempt is safe to claim now."""
+    now = _delivery_now().isoformat()
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM deliveries
+               WHERE status IN ('pending','retry_wait')
+                 AND next_attempt_at <= ?
+               ORDER BY next_attempt_at, created_at
+               LIMIT ?""",
+            (now, max(1, min(int(limit), 500))),
+        ).fetchall()
+    return [_delivery_record(row) for row in rows]  # type: ignore[misc]
+
+
+def list_pending_deliveries(*, limit: int = 500) -> List[Dict[str, Any]]:
+    """Return every safely cancellable queued/backoff batch, due or future."""
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM deliveries
+               WHERE status IN ('pending','retry_wait')
+               ORDER BY created_at LIMIT ?""",
+            (max(1, min(int(limit), 5000)),),
+        ).fetchall()
+    return [_delivery_record(row) for row in rows]  # type: ignore[misc]
+
+
+def claim_delivery(execution_id: str) -> Optional[Dict[str, Any]]:
+    """Atomically claim one due batch and begin its append-only attempt row.
+
+    The ``BEGIN IMMEDIATE`` boundary covers due-state read, compare/update, and
+    attempt insertion. The returned token is required to finish the attempt.
+    """
+    now = _delivery_now().isoformat()
+    claim_token = uuid.uuid4().hex
+    pid = os.getpid()
+    process_started_at = _process_start_time(pid)
+    with _transaction(immediate=True) as conn:
+        row = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?",
+            (str(execution_id),),
+        ).fetchone()
+        if (
+            row is None
+            or row["status"] not in ("pending", "retry_wait")
+            or not row["next_attempt_at"]
+            or row["next_attempt_at"] > now
+        ):
+            return None
+        attempt_number = int(row["attempt_count"]) + 1
+        cur = conn.execute(
+            """UPDATE deliveries
+               SET status='delivering', attempt_count=?, updated_at=?,
+                   claim_token=?, claim_process_id=?, claim_pid=?,
+                   claim_process_started_at=?
+               WHERE execution_id=? AND status=? AND attempt_count=?""",
+            (
+                attempt_number,
+                now,
+                claim_token,
+                _PROCESS_ID,
+                pid,
+                process_started_at,
+                str(execution_id),
+                row["status"],
+                row["attempt_count"],
+            ),
+        )
+        if cur.rowcount != 1:
+            return None
+        conn.execute(
+            """INSERT INTO delivery_attempts
+               (execution_id, attempt_number, targets_json, started_at)
+               VALUES (?, ?, ?, ?)""",
+            (str(execution_id), attempt_number, row["targets_json"], now),
+        )
+        claimed = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?", (str(execution_id),)
+        ).fetchone()
+    return _delivery_record(claimed)
+
+
+def finish_delivery_attempt(
+    execution_id: str,
+    *,
+    claim_token: str,
+    failed_targets: List[Dict[str, Any]],
+    error: Optional[str] = None,
+    permanent_error: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Finish the exact claimed attempt and either retire or reschedule it."""
+    now_dt = _delivery_now()
+    now = now_dt.isoformat()
+    with _transaction(immediate=True) as conn:
+        row = conn.execute(
+            """SELECT * FROM deliveries
+               WHERE execution_id=? AND status='delivering' AND claim_token=?""",
+            (str(execution_id), str(claim_token)),
+        ).fetchone()
+        if row is None:
+            return None
+        attempt_number = int(row["attempt_count"])
+        detail = str(error) if error else None
+        stored_permanent = str(row["permanent_error"] or "").strip()
+        new_permanent = str(permanent_error or "").strip()
+        permanent_parts = [part for part in (stored_permanent, new_permanent) if part]
+        combined_permanent = "; ".join(dict.fromkeys(permanent_parts)) or None
+        terminal_reason = None
+        if failed_targets and attempt_number < MAX_DELIVERY_ATTEMPTS:
+            status = "retry_wait"
+            delay_index = min(
+                attempt_number - 1, len(DELIVERY_RETRY_DELAYS_SECONDS) - 1
+            )
+            next_attempt_at = (
+                now_dt + timedelta(seconds=DELIVERY_RETRY_DELAYS_SECONDS[delay_index])
+            ).isoformat()
+        elif failed_targets:
+            status = "exhausted"
+            terminal_reason = "max_attempts"
+            next_attempt_at = None
+            detail = detail or "delivery attempts exhausted"
+        elif combined_permanent:
+            status = "exhausted"
+            terminal_reason = "permanent_failure"
+            next_attempt_at = None
+            detail = combined_permanent
+        else:
+            status = "delivered"
+            next_attempt_at = None
+
+        terminal = status in ("delivered", "exhausted")
+        targets_json = json.dumps(
+            [] if terminal else failed_targets,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+        conn.execute(
+            """UPDATE deliveries
+               SET status=?, targets_json=?, next_attempt_at=?, last_error=?,
+                   permanent_error=?, terminal_reason=?, job_json=?, content=?,
+                   claim_token=NULL, claim_process_id=NULL, claim_pid=NULL,
+                   claim_process_started_at=NULL, updated_at=?
+               WHERE execution_id=? AND status='delivering' AND claim_token=?""",
+            (
+                status,
+                targets_json,
+                next_attempt_at,
+                detail,
+                combined_permanent,
+                terminal_reason,
+                None if terminal else row["job_json"],
+                None if terminal else row["content"],
+                now,
+                str(execution_id),
+                str(claim_token),
+            ),
+        )
+        conn.execute(
+            """UPDATE delivery_attempts
+               SET finished_at=?, outcome=?, error=?
+               WHERE execution_id=? AND attempt_number=? AND finished_at IS NULL""",
+            (now, status, detail, str(execution_id), attempt_number),
+        )
+        finished = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?", (str(execution_id),)
+        ).fetchone()
+    return _delivery_record(finished)
+
+
+def cancel_delivery(
+    execution_id: str,
+    *,
+    reason: str,
+    claim_token: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Cancel an unsent batch and scrub its sensitive retry payload.
+
+    Pending/backoff rows need no token. A worker that already claimed a row may
+    cancel only with its own token, after re-checking job state before network
+    I/O. Other processes cannot cancel somebody else's in-flight send.
+    """
+    now = _delivery_now().isoformat()
+    with _transaction(immediate=True) as conn:
+        if claim_token is None:
+            where = "execution_id=? AND status IN ('pending','retry_wait')"
+            params = (str(execution_id),)
+        else:
+            where = "execution_id=? AND status='delivering' AND claim_token=?"
+            params = (str(execution_id), str(claim_token))
+        row = conn.execute(f"SELECT * FROM deliveries WHERE {where}", params).fetchone()
+        if row is None:
+            return None
+        conn.execute(
+            f"""UPDATE deliveries
+                SET status='exhausted', terminal_reason='cancelled',
+                    targets_json='[]', next_attempt_at=NULL, last_error=?,
+                    job_json=NULL, content=NULL, claim_token=NULL,
+                    claim_process_id=NULL, claim_pid=NULL,
+                    claim_process_started_at=NULL, updated_at=?
+                WHERE {where}""",
+            (str(reason), now, *params),
+        )
+        if row["status"] == "delivering":
+            conn.execute(
+                """UPDATE delivery_attempts
+                   SET finished_at=?, outcome='exhausted', error=?
+                   WHERE execution_id=? AND attempt_number=? AND finished_at IS NULL""",
+                (now, str(reason), str(execution_id), row["attempt_count"]),
+            )
+        cancelled = conn.execute(
+            "SELECT * FROM deliveries WHERE execution_id=?", (str(execution_id),)
+        ).fetchone()
+    return _delivery_record(cancelled)
+
+
+def recover_interrupted_deliveries() -> int:
+    """Mark only provably dead delivery owners unknown; never requeue them."""
+    now = _delivery_now().isoformat()
+    error = (
+        "Scheduler restarted while delivery was in flight; whether the target "
+        "received it is unknown, so Hermes will not retry automatically."
+    )
+    changed = 0
+    with _transaction(immediate=True) as conn:
+        rows = conn.execute(
+            """SELECT execution_id, attempt_count, claim_process_id, claim_pid,
+                      claim_process_started_at FROM deliveries """
+            "WHERE status='delivering'"
+        ).fetchall()
+        for row in rows:
+            if row["claim_process_id"] == _PROCESS_ID:
+                continue
+            if row["claim_pid"] is not None and _owner_is_live(
+                int(row["claim_pid"]), row["claim_process_started_at"]
+            ):
+                continue
+            cur = conn.execute(
+                """UPDATE deliveries
+                   SET status='unknown', targets_json='[]', next_attempt_at=NULL,
+                       last_error=?, terminal_reason='ambiguous', job_json=NULL,
+                       content=NULL, claim_token=NULL, claim_process_id=NULL,
+                       claim_pid=NULL, claim_process_started_at=NULL, updated_at=?
+                   WHERE execution_id=? AND status='delivering'""",
+                (error, now, row["execution_id"]),
+            )
+            if cur.rowcount != 1:
+                continue
+            changed += 1
+            conn.execute(
+                """UPDATE delivery_attempts
+                   SET finished_at=?, outcome='unknown', error=?
+                   WHERE execution_id=? AND attempt_number=? AND finished_at IS NULL""",
+                (now, error, row["execution_id"], row["attempt_count"]),
+            )
+    return changed
+
+
+def list_delivery_attempts(execution_id: str) -> List[Dict[str, Any]]:
+    with _transaction() as conn:
+        rows = conn.execute(
+            """SELECT * FROM delivery_attempts WHERE execution_id=?
+               ORDER BY attempt_number""",
+            (str(execution_id),),
+        ).fetchall()
+    return [_attempt_record(row) for row in rows]
 
 
 def list_executions(

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1687,7 +1687,8 @@ def remove_job(job_id: str) -> bool:
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
-                 delivery_error: Optional[str] = None):
+                 delivery_error: Optional[str] = None,
+                 execution_id: Optional[str] = None):
     """
     Mark a job as having been run.
     
@@ -1696,6 +1697,8 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
 
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
+    ``execution_id`` identifies which run owns that delivery outcome so a
+    delayed retry from an older run cannot overwrite a newer run's result.
     """
     with _jobs_lock():
         jobs = load_jobs()
@@ -1707,6 +1710,8 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 job["last_error"] = error if not success else None
                 # Track delivery failures separately — cleared on successful delivery
                 job["last_delivery_error"] = delivery_error
+                if execution_id is not None:
+                    job["last_execution_id"] = str(execution_id)
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None
@@ -1790,6 +1795,41 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                 return
 
         logger.warning("mark_job_run: job_id %s not found, skipping save", job_id)
+
+
+def mark_job_delivery(job_id: str, error: Optional[str] = None, *,
+                      execution_id: Optional[str] = None) -> bool:
+    """Update a delivery outcome only when it still belongs to the latest run."""
+    with _jobs_lock():
+        jobs = load_jobs()
+        for job in jobs:
+            if job["id"] == job_id:
+                if execution_id is not None:
+                    expected_execution_id = job.get("last_execution_id")
+                    if expected_execution_id is None:
+                        # Additive migration for jobs whose run was recorded by
+                        # an earlier build of this branch. Consult the durable
+                        # ledger rather than accepting an unowned retry update.
+                        try:
+                            from cron.executions import latest_execution
+
+                            latest = latest_execution(job_id)
+                            expected_execution_id = latest.get("id") if latest else None
+                        except Exception:
+                            expected_execution_id = None
+                    if expected_execution_id != str(execution_id):
+                        logger.debug(
+                            "Ignoring stale delivery outcome for job %s execution %s",
+                            job_id,
+                            execution_id,
+                        )
+                        return False
+                    job["last_execution_id"] = str(execution_id)
+                job["last_delivery_error"] = str(error) if error else None
+                save_jobs(jobs)
+                return True
+    logger.debug("mark_job_delivery: job_id %s not found", job_id)
+    return False
 
 
 def _write_wedged_oneshot_diagnostic(job: Dict[str, Any]) -> None:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -282,8 +283,28 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_runs, claim_dispatch, heartbeat_run_claim
-from cron.executions import create_execution, finish_execution, mark_execution_running
+from cron.jobs import (
+    advance_next_runs,
+    claim_dispatch,
+    get_due_jobs,
+    get_job,
+    heartbeat_run_claim,
+    mark_job_delivery,
+    mark_job_run,
+    save_job_output,
+)
+from cron.executions import (
+    cancel_delivery,
+    claim_delivery,
+    create_execution,
+    enqueue_delivery,
+    finish_delivery_attempt,
+    finish_execution,
+    list_due_deliveries,
+    list_pending_deliveries,
+    mark_execution_running,
+    recover_interrupted_deliveries,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
@@ -1458,7 +1479,65 @@ def _is_channel_dm_topic(
     return is_channel
 
 
-def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
+@dataclass(frozen=True)
+class DeliveryReport:
+    """Concrete fan-out outcome used by the durable delivery queue."""
+
+    error: Optional[str]
+    delivered_targets: List[dict]
+    failed_targets: List[dict]
+    retryable_failed_targets: Optional[List[dict]] = None
+    permanent_errors: Optional[List[str]] = None
+
+    def __post_init__(self) -> None:
+        # Three-argument construction remains compatible: historical/internal
+        # test doubles treat every failure as retryable unless classified.
+        if self.retryable_failed_targets is None:
+            object.__setattr__(
+                self,
+                "retryable_failed_targets",
+                [dict(target) for target in self.failed_targets],
+            )
+        if self.permanent_errors is None:
+            object.__setattr__(self, "permanent_errors", [])
+
+
+def _is_permanent_delivery_error(error: str) -> bool:
+    """Classify deterministic target/config/auth failures that retries cannot fix."""
+    text = str(error or "").lower()
+    if (
+        "unknown platform" in text
+        or "not configured/enabled" in text
+        or "unauthorized" in text
+        or "forbidden" in text
+        or "authentication" in text
+        or re.search(r"\b(401|403)\b", text)
+    ):
+        return True
+    # Reuse the gateway's platform-neutral classification instead of growing a
+    # second list of provider-specific strings in cron. Retrying the same
+    # missing target, invalid format, or over-limit payload cannot recover.
+    try:
+        from gateway.platforms.base import classify_send_error
+
+        return classify_send_error(None, error_text=text) in {
+            "not_found",
+            "bad_format",
+            "too_long",
+        }
+    except Exception:
+        return False
+
+
+def _deliver_result(
+    job: dict,
+    content: str,
+    adapters=None,
+    loop=None,
+    *,
+    targets_override: Optional[List[dict]] = None,
+    return_report: bool = False,
+) -> Optional[str] | DeliveryReport:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
 
@@ -1467,13 +1546,43 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     the standalone HTTP path cannot encrypt.  Falls back to standalone send if
     the adapter path fails or is unavailable.
 
-    Returns None on success, or an error string on failure.
+    Returns None on success, or an error string on failure. Durable retry
+    callers may request a structured per-target report and pass the exact
+    previously-failed concrete targets, avoiding duplicate fan-out sends.
     """
-    targets = _resolve_delivery_targets(job)
+    targets = (
+        [dict(target) for target in targets_override]
+        if targets_override is not None
+        else _resolve_delivery_targets(job)
+    )
+    delivered_targets: List[dict] = []
+    failed_targets: List[dict] = []
+    retryable_failed_targets: List[dict] = []
+    permanent_errors: List[str] = []
+
+    def _result(error: Optional[str]):
+        if return_report:
+            return DeliveryReport(
+                error=error,
+                delivered_targets=delivered_targets,
+                failed_targets=failed_targets,
+                retryable_failed_targets=retryable_failed_targets,
+                permanent_errors=permanent_errors,
+            )
+        return error
+
+    def _record_target_failure(target: dict, error: str) -> None:
+        if target not in failed_targets:
+            failed_targets.append(dict(target))
+        if _is_permanent_delivery_error(error):
+            permanent_errors.append(str(error))
+        elif target not in retryable_failed_targets:
+            retryable_failed_targets.append(dict(target))
+
     if not targets:
         deliver_value = _normalize_deliver_value(job.get("deliver", "local"))
         if deliver_value == "local":
-            return None  # local-only jobs don't deliver — not a failure
+            return _result(None)  # local-only jobs don't deliver — not a failure
         # deliver=origin with no resolvable origin and no configured home
         # channels: treat as local rather than reporting an error.  CLI-created
         # jobs never capture a {platform, chat_id} origin, so failing here would
@@ -1486,10 +1595,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 "skipping delivery (output saved in last_output)",
                 job.get("name", job.get("id", "?")),
             )
-            return None
+            return _result(None)
         msg = f"no delivery target resolved for deliver={deliver_value}"
         logger.warning("Job '%s': %s", job["id"], msg)
-        return msg
+        return _result(msg)
 
     from tools.send_message_tool import _send_to_platform
     from gateway.config import load_gateway_config, Platform
@@ -1541,7 +1650,9 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     except Exception as e:
         msg = f"failed to load gateway config: {e}"
         logger.error("Job '%s': %s", job["id"], msg)
-        return msg
+        failed_targets.extend(dict(target) for target in targets)
+        retryable_failed_targets.extend(dict(target) for target in targets)
+        return _result(msg)
 
     delivery_errors = []
 
@@ -1583,6 +1694,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             msg = f"unknown platform '{platform_name}'"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
+            _record_target_failure(target, msg)
             continue
 
         from gateway.delivery import resolve_delivery_transport
@@ -1601,6 +1713,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             msg = f"platform '{platform_name}' not configured/enabled"
             logger.warning("Job '%s': %s", job["id"], msg)
             delivery_errors.append(msg)
+            _record_target_failure(target, msg)
             continue
 
         # Prefer the resolved live transport when the gateway is running. This
@@ -2017,6 +2130,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         f"relay delivery to {platform_name}:{chat_id} failed"
                     )
                 delivery_errors.extend(target_errors)
+                _record_target_failure(target, "; ".join(target_errors))
                 continue
             # If the interpreter is finalizing (gateway SIGTERM / restart /
             # OOM), scheduling any new delivery is futile — asyncio.run and a
@@ -2029,6 +2143,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.warning("Job '%s': %s", job["id"], msg)
                 target_errors.append(msg)
                 delivery_errors.extend(target_errors)
+                _record_target_failure(target, "; ".join(target_errors))
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
             coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
@@ -2048,6 +2163,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                     logger.warning("Job '%s': %s", job["id"], msg)
                     target_errors.append(msg)
                     delivery_errors.extend(target_errors)
+                    _record_target_failure(target, "; ".join(target_errors))
                     continue
                 # The thread-pool fallback can itself raise (SMTP ConnectionError,
                 # future.result timeout, etc.). An exception raised inside this
@@ -2072,17 +2188,20 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                         logger.warning("Job '%s': %s", job["id"], msg)
                         target_errors.append(msg)
                         delivery_errors.extend(target_errors)
+                        _record_target_failure(target, "; ".join(target_errors))
                         continue
                     msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                     logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                     target_errors.extend([msg])
                     delivery_errors.extend(target_errors)
+                    _record_target_failure(target, "; ".join(target_errors))
                     continue
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"
                 logger.error("Job '%s': %s", job["id"], msg, exc_info=True)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                _record_target_failure(target, "; ".join(target_errors))
                 continue
 
             if result and result.get("error"):
@@ -2090,18 +2209,197 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 logger.error("Job '%s': %s", job["id"], msg)
                 target_errors.extend([msg])
                 delivery_errors.extend(target_errors)
+                _record_target_failure(target, "; ".join(target_errors))
                 continue
 
             logger.info("Job '%s': delivered to %s:%s", job["id"], platform_name, chat_id)
+            delivered = True
             _maybe_mirror_cron_delivery(
                 job, platform_name, chat_id, mirror_text,
                 thread_id=thread_id, user_id=origin_user_id,
                 enabled=mirror_this_target and not thread_seeded,
             )
 
+        if delivered and target not in delivered_targets:
+            delivered_targets.append(dict(target))
+
     if delivery_errors:
-        return "; ".join(delivery_errors)
+        return _result("; ".join(delivery_errors))
+    return _result(None)
+
+
+_DELIVERY_SNAPSHOT_FIELDS = (
+    "id",
+    "name",
+    "deliver",
+    "origin",
+    "attach_to_session",
+)
+
+
+def _delivery_job_snapshot(job: dict) -> dict:
+    """Keep only fields required to reproduce delivery, excluding the prompt."""
+    return {key: job[key] for key in _DELIVERY_SNAPSHOT_FIELDS if key in job}
+
+
+def _coerce_delivery_report(result, targets: List[dict]) -> DeliveryReport:
+    """Normalize patched/legacy delivery implementations at the internal seam."""
+    if isinstance(result, DeliveryReport):
+        return result
+    error = str(result) if result else None
+    permanent = bool(error and _is_permanent_delivery_error(error))
+    return DeliveryReport(
+        error=error,
+        delivered_targets=[] if error else [dict(target) for target in targets],
+        failed_targets=[dict(target) for target in targets] if error else [],
+        retryable_failed_targets=[] if permanent else None,
+        permanent_errors=[error] if permanent and error else [],
+    )
+
+
+def _deliver_durably(
+    execution_id: str,
+    job: dict,
+    content: str,
+    *,
+    adapters=None,
+    loop=None,
+) -> Optional[str]:
+    """Persist, claim, and attempt one post-execution delivery batch."""
+    targets = _resolve_delivery_targets(job)
+    if not targets:
+        # Preserve local/unresolved/invalid-target compatibility without
+        # manufacturing an empty queue record.
+        result = _deliver_result(job, content, adapters=adapters, loop=loop)
+        return str(result) if result else None
+
+    try:
+        enqueue_delivery(
+            execution_id,
+            job=_delivery_job_snapshot(job),
+            content=content,
+            targets=targets,
+        )
+        claimed = claim_delivery(execution_id)
+    except Exception as exc:
+        logger.error("Failed to persist delivery for job %s: %s", job["id"], exc)
+        return f"durable delivery prepare failed: {exc}"
+    if claimed is None:
+        return "durable delivery could not be claimed; send skipped"
+
+    claimed_targets = claimed["targets"]
+    try:
+        result = _deliver_result(
+            claimed["job"],
+            claimed["content"],
+            adapters=adapters,
+            loop=loop,
+            targets_override=claimed_targets,
+            return_report=True,
+        )
+        report = _coerce_delivery_report(result, claimed_targets)
+    except Exception as exc:
+        logger.error("Delivery failed for job %s: %s", job["id"], exc)
+        report = DeliveryReport(str(exc), [], claimed_targets)
+
+    finish_delivery_attempt(
+        execution_id,
+        claim_token=claimed["claim_token"],
+        failed_targets=report.retryable_failed_targets or [],
+        error=report.error,
+        permanent_error="; ".join(report.permanent_errors or []) or None,
+    )
+    return report.error
+
+
+def _pending_delivery_cancel_reason(job_id: str) -> Optional[str]:
+    """Return why an unsent retry must be cancelled, or None when still valid."""
+    current = get_job(job_id)
+    if current is None:
+        return "job was deleted before delivery retry"
+    state = str(current.get("state") or "")
+    if state == "paused" or (
+        current.get("enabled") is False and state != "completed"
+    ):
+        return "job was disabled before delivery retry"
     return None
+
+
+def cancel_invalid_deliveries(*, limit: int = 500) -> int:
+    """Cancel and scrub queued batches whose job was deleted or disabled.
+
+    This scans future backoff rows as well as currently due rows, which matters
+    for Chronos: a job mutation is a warm callback, but there may be no later
+    process wake after the last job is deleted.
+    """
+    cancelled = 0
+    for pending in list_pending_deliveries(limit=limit):
+        reason = _pending_delivery_cancel_reason(pending["job_id"])
+        if reason and cancel_delivery(pending["execution_id"], reason=reason):
+            cancelled += 1
+    return cancelled
+
+
+def retry_due_deliveries(*, adapters=None, loop=None, limit: int = 50) -> int:
+    """Reconcile safe post-execution retries without ever re-running an agent."""
+    # Another scheduler process may have died since this process started. The
+    # owner/PID identity checks make this safe at every wake and keep ambiguous
+    # sends from remaining indefinitely in ``delivering``.
+    recover_interrupted_deliveries()
+    cancel_invalid_deliveries()
+    processed = 0
+    for due in list_due_deliveries(limit=limit):
+        execution_id = due["execution_id"]
+        cancel_reason = _pending_delivery_cancel_reason(due["job_id"])
+        if cancel_reason:
+            cancel_delivery(execution_id, reason=cancel_reason)
+            continue
+        claimed = claim_delivery(execution_id)
+        if claimed is None:
+            continue
+        # Re-check after the atomic claim and before network I/O. This closes
+        # the normal delete/disable-vs-reconciler race without allowing another
+        # process to cancel an attempt it does not own.
+        cancel_reason = _pending_delivery_cancel_reason(claimed["job_id"])
+        if cancel_reason:
+            cancel_delivery(
+                execution_id,
+                reason=cancel_reason,
+                claim_token=claimed["claim_token"],
+            )
+            continue
+        targets = claimed["targets"]
+        try:
+            result = _deliver_result(
+                claimed["job"],
+                claimed["content"],
+                adapters=adapters,
+                loop=loop,
+                targets_override=targets,
+                return_report=True,
+            )
+            report = _coerce_delivery_report(result, targets)
+        except Exception as exc:
+            logger.error(
+                "Retry delivery failed for job %s: %s", claimed["job_id"], exc
+            )
+            report = DeliveryReport(str(exc), [], targets)
+
+        finished = finish_delivery_attempt(
+            execution_id,
+            claim_token=claimed["claim_token"],
+            failed_targets=report.retryable_failed_targets or [],
+            error=report.error,
+            permanent_error="; ".join(report.permanent_errors or []) or None,
+        )
+        if finished is not None:
+            mark_job_delivery(
+                claimed["job_id"],
+                None if finished["status"] == "delivered" else finished["last_error"],
+                execution_id=execution_id,
+            )
+        processed += 1
+    return processed
 
 
 _DEFAULT_SCRIPT_TIMEOUT = 3600  # seconds (1 hour)
@@ -4022,7 +4320,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
                     and not _resolve_delivery_targets(job)
                 )
                 try:
-                    delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                    delivery_error = _deliver_durably(
+                        execution_id,
+                        job,
+                        deliver_content,
+                        adapters=adapters,
+                        loop=loop,
+                    )
                 except Exception as de:
                     delivery_error = str(de)
                     logger.error("Delivery failed for job %s: %s", job["id"], de)
@@ -4041,7 +4345,13 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
             error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
         if not _consume_interrupted_flag(job["id"]):
-            mark_job_run(job["id"], success, error, delivery_error=delivery_error)
+            mark_job_run(
+                job["id"],
+                success,
+                error,
+                delivery_error=delivery_error,
+                execution_id=execution_id,
+            )
         normalized_deliver = _normalize_deliver_value(job.get("deliver", "local"))
         if delivery_error:
             delivery_outcome = "failed"
@@ -4073,7 +4383,9 @@ def run_one_job(job: dict, *, adapters=None, loop=None, verbose: bool = False) -
         logger.error("Error processing job %s: %s", job['id'], _err_text)
         try:
             if not _consume_interrupted_flag(job["id"]):
-                mark_job_run(job["id"], False, _err_text)
+                mark_job_run(
+                    job["id"], False, _err_text, execution_id=execution_id
+                )
         except Exception as record_err:
             # Never let bookkeeping mask the original interruption.
             logger.error(

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -88,6 +88,18 @@ class CronScheduler(ABC):
 
         return recover_interrupted_executions()
 
+    def recover_interrupted_deliveries(self) -> int:
+        """Classify ambiguous in-flight sends without retrying them."""
+        from cron.executions import recover_interrupted_deliveries
+
+        return recover_interrupted_deliveries()
+
+    def retry_deliveries(self, *, adapters: Any = None, loop: Any = None) -> int:
+        """Reconcile due post-execution sends at this provider's wake points."""
+        from cron.scheduler import retry_due_deliveries
+
+        return retry_due_deliveries(adapters=adapters, loop=loop)
+
     def fire_due(self, job_id: str, *, adapters: Any = None, loop: Any = None) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -184,7 +196,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes=None,
     ):
         import logging
-        from cron.scheduler import tick as cron_tick
+        from cron.scheduler import retry_due_deliveries, tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -219,6 +231,12 @@ class InProcessCronScheduler(CronScheduler):
                 "Marked %d interrupted cron execution(s) unknown after restart",
                 recovered,
             )
+        recovered_deliveries = self.recover_interrupted_deliveries()
+        if recovered_deliveries:
+            logger.warning(
+                "Marked %d in-flight cron delivery attempt(s) unknown after restart",
+                recovered_deliveries,
+            )
         # Heartbeat once before the first sleep so `hermes cron status` sees a
         # live ticker immediately after startup, not only after the first tick.
         record_ticker_heartbeat()
@@ -228,6 +246,7 @@ class InProcessCronScheduler(CronScheduler):
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
                 else:
+                    retry_due_deliveries(adapters=adapters, loop=loop)
                     cron_tick(
                         verbose=False,
                         adapters=adapters,
@@ -279,7 +298,7 @@ class InProcessCronScheduler(CronScheduler):
         ``web_server.py`` scopes per-profile cron API calls.
         """
         import logging
-        from cron.scheduler import tick as cron_tick
+        from cron.scheduler import retry_due_deliveries, tick as cron_tick
         from cron.jobs import (
             clear_ticker_error,
             record_ticker_error,
@@ -308,6 +327,13 @@ class InProcessCronScheduler(CronScheduler):
                             recovered,
                             home,
                         )
+                    recovered_deliveries = self.recover_interrupted_deliveries()
+                    if recovered_deliveries:
+                        logger.warning(
+                            "Marked %d in-flight cron delivery attempt(s) for profile at %s unknown",
+                            recovered_deliveries,
+                            home,
+                        )
                     record_ticker_heartbeat()
             finally:
                 reset_hermes_home_override(home_token)
@@ -323,6 +349,7 @@ class InProcessCronScheduler(CronScheduler):
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                retry_due_deliveries(adapters=adapters, loop=loop)
                                 cron_tick(
                                     verbose=False,
                                     adapters=adapters,

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -18,6 +18,11 @@ Design constraints (see the plan's DQ-1):
   - reconcile runs only on a warm process (start / on_jobs_changed / piggybacked
     on a fire), never as a periodic wake of a sleeping machine.
 
+Delivery retries remain durable in the profile-local SQLite ledger while the
+gateway is scaled to zero. Their ``next_attempt_at`` is an eligibility time,
+not a Chronos wake request: retries execute at the next warm lifecycle callback
+(startup, job change, or fire), which may be later than the recorded backoff.
+
 Inert unless ``cron.provider: chronos``. ``resolve_cron_scheduler`` falls back
 to the built-in if Chronos is unavailable, so cron never loses its trigger.
 
@@ -110,6 +115,8 @@ class ChronosCronScheduler(CronScheduler):
         # process did. Classify those attempts unknown for audit only; do not
         # requeue them here.
         self.recover_interrupted()
+        self.recover_interrupted_deliveries()
+        self.retry_deliveries(adapters=adapters, loop=loop)
         try:
             self.reconcile()
         except Exception as e:
@@ -122,6 +129,15 @@ class ChronosCronScheduler(CronScheduler):
     def on_jobs_changed(self) -> None:
         """A job was created/updated/removed/paused/resumed — reconcile the NAS
         registry so the affected one-shot is (re-)armed or cancelled."""
+        # Scrub deliveries for deleted/disabled jobs immediately. Chronos has
+        # no periodic wake, so deferring this to the next due timestamp could
+        # retain payloads forever after the final job is removed.
+        try:
+            from cron.scheduler import cancel_invalid_deliveries
+
+            cancel_invalid_deliveries()
+        except Exception as e:
+            logger.debug("Chronos delivery cancellation reconcile failed: %s", e)
         try:
             self.reconcile()
         except Exception as e:
@@ -224,6 +240,9 @@ class ChronosCronScheduler(CronScheduler):
         If the job is gone (one-shot completed / repeat-N exhausted), get_job
         returns None → nothing to re-arm (the schedule naturally stops).
         """
+        # A callback is also a safe warm-process reconciliation point for
+        # result deliveries that failed on an earlier fire.
+        self.retry_deliveries(adapters=adapters, loop=loop)
         ran = super().fire_due(job_id, adapters=adapters, loop=loop)
         if ran:
             from cron.jobs import get_job

--- a/tests/cron/test_durable_delivery_hardening.py
+++ b/tests/cron/test_durable_delivery_hardening.py
@@ -1,0 +1,344 @@
+"""Crash, concurrency, and terminal-state contracts for durable cron delivery."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _point_ledger(monkeypatch, tmp_path):
+    import cron.executions as executions
+
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    return executions
+
+
+def _queued(executions, job_id="job", *, target=None):
+    execution = executions.create_execution(job_id, source="builtin")
+    target = target or {"platform": "telegram", "chat_id": "1", "thread_id": None}
+    executions.enqueue_delivery(
+        execution["id"],
+        job={"id": job_id, "name": job_id},
+        content="persisted result",
+        targets=[target],
+    )
+    return execution, target
+
+
+def test_result_persisted_before_send_survives_process_restart(tmp_path):
+    """Crash after enqueue/before claim leaves a safely retryable pending row."""
+    home = tmp_path / "home"
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(home), "PYTHONPATH": str(repo)})
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from cron.executions import create_execution, enqueue_delivery; "
+            "e=create_execution('restart-pending', source='builtin'); "
+            "enqueue_delivery(e['id'], job={'id':'restart-pending'}, content='result', "
+            "targets=[{'platform':'telegram','chat_id':'1'}]); print(e['id'])",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    execution_id = create.stdout.strip()
+
+    inspect = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import json; from cron.executions import list_due_deliveries; "
+            "print(json.dumps(list_due_deliveries()))",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    due = json.loads(inspect.stdout)
+    assert [row["execution_id"] for row in due] == [execution_id]
+    assert due[0]["content"] == "result"
+
+
+def test_two_processes_cannot_claim_same_delivery(tmp_path):
+    home = tmp_path / "home"
+    gate = tmp_path / "start"
+    repo = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env.update({"HERMES_HOME": str(home), "PYTHONPATH": str(repo)})
+    create = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from cron.executions import create_execution, enqueue_delivery; "
+            "e=create_execution('contended', source='builtin'); "
+            "enqueue_delivery(e['id'], job={'id':'contended'}, content='result', "
+            "targets=[{'platform':'telegram','chat_id':'1'}]); print(e['id'])",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    execution_id = create.stdout.strip()
+    claimant = (
+        "import json,time; from pathlib import Path; "
+        "from cron.executions import claim_delivery; "
+        f"gate=Path({str(gate)!r}); "
+        "\nwhile not gate.exists(): time.sleep(0.005)\n"
+        f"row=claim_delivery({execution_id!r}); "
+        "print(json.dumps({'claimed': row is not None, "
+        "'token': row.get('claim_token') if row else None}))"
+    )
+    processes = [
+        subprocess.Popen(
+            [sys.executable, "-c", claimant],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        for _ in range(2)
+    ]
+    gate.touch()
+    results = []
+    for process in processes:
+        stdout, stderr = process.communicate(timeout=15)
+        assert process.returncode == 0, stderr
+        results.append(json.loads(stdout))
+
+    assert sum(result["claimed"] for result in results) == 1
+    assert len({result["token"] for result in results if result["claimed"]}) == 1
+
+
+def test_live_delivery_owner_is_not_recovered(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution, _ = _queued(executions, "live-owner")
+    claimed = executions.claim_delivery(execution["id"])
+
+    assert claimed["claim_token"]
+    assert executions.recover_interrupted_deliveries() == 0
+    assert executions.get_delivery(execution["id"])["status"] == "delivering"
+
+
+def test_live_owner_without_start_time_is_not_declared_dead(monkeypatch, tmp_path):
+    """A live PID with unavailable identity metadata is not proof of death."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(executions, "_process_start_time", lambda _pid: None)
+    execution, _ = _queued(executions, "live-owner-no-start")
+    executions.claim_delivery(execution["id"])
+    monkeypatch.setattr(executions, "_PROCESS_ID", "other-reconciler")
+    other_pid = os.getpid() + 1
+    monkeypatch.setattr(executions.os, "getpid", lambda: other_pid)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda _pid: True)
+
+    assert executions.recover_interrupted_deliveries() == 0
+    assert executions.get_delivery(execution["id"])["status"] == "delivering"
+
+
+def test_crash_during_delivery_becomes_unknown_and_never_due(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution, _ = _queued(executions, "crash-during-send")
+    executions.claim_delivery(execution["id"])
+    monkeypatch.setattr(executions, "_PROCESS_ID", "replacement-process")
+    monkeypatch.setattr(executions, "_owner_is_live", lambda *_args: False)
+
+    assert executions.recover_interrupted_deliveries() == 1
+    recovered = executions.get_delivery(execution["id"])
+    assert recovered["status"] == "unknown"
+    assert recovered["content"] is None
+    assert executions.list_due_deliveries() == []
+
+
+def test_crash_after_send_before_completion_is_fail_closed(monkeypatch, tmp_path):
+    """The ledger cannot distinguish this from an in-flight send: no duplicate."""
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution, _ = _queued(executions, "sent-not-acked")
+    executions.claim_delivery(execution["id"])
+    monkeypatch.setattr(executions, "_PROCESS_ID", "replacement-process")
+    monkeypatch.setattr(executions, "_owner_is_live", lambda *_args: False)
+
+    executions.recover_interrupted_deliveries()
+
+    assert executions.get_delivery(execution["id"])["status"] == "unknown"
+    assert executions.claim_delivery(execution["id"]) is None
+
+
+def test_retry_backoff_is_durable_and_matches_sixty_second_tick(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    clock = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(executions, "_hermes_now", lambda: clock)
+    execution, target = _queued(executions, "backoff")
+    claimed = executions.claim_delivery(execution["id"])
+
+    waiting = executions.finish_delivery_attempt(
+        execution["id"],
+        claim_token=claimed["claim_token"],
+        failed_targets=[target],
+        error="temporary outage",
+    )
+
+    assert waiting["status"] == "retry_wait"
+    assert waiting["next_attempt_at"] == "2026-08-05T12:01:00+00:00"
+    assert executions.get_delivery(execution["id"])["status"] == "retry_wait"
+    assert executions.list_due_deliveries() == []
+
+
+def test_permanent_failure_is_not_retried_and_scrubs_payload(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution, target = _queued(executions, "auth-failure")
+    claimed = executions.claim_delivery(execution["id"])
+
+    failed = executions.finish_delivery_attempt(
+        execution["id"],
+        claim_token=claimed["claim_token"],
+        failed_targets=[],
+        error="401 unauthorized",
+        permanent_error="telegram: 401 unauthorized",
+    )
+
+    assert failed["status"] == "exhausted"
+    assert failed["terminal_reason"] == "permanent_failure"
+    assert failed["attempt_count"] == 1
+    assert failed["content"] is None
+    assert failed["job"] is None
+    assert failed["targets"] == []
+    assert executions.list_due_deliveries() == []
+    attempts = executions.list_delivery_attempts(execution["id"])
+    assert attempts[0]["targets"] == [target]
+    assert "401" in attempts[0]["error"]
+
+
+def test_cancel_pending_delivery_is_terminal_and_scrubbed(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution, _ = _queued(executions, "cancelled")
+
+    cancelled = executions.cancel_delivery(
+        execution["id"], reason="job was deleted before retry"
+    )
+
+    assert cancelled["status"] == "exhausted"
+    assert cancelled["terminal_reason"] == "cancelled"
+    assert cancelled["content"] is None
+    assert cancelled["job"] is None
+    assert executions.list_due_deliveries() == []
+
+
+def test_deleted_job_is_cancelled_even_during_future_backoff(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+
+    executions = _point_ledger(monkeypatch, tmp_path)
+    clock = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(executions, "_hermes_now", lambda: clock)
+    execution, target = _queued(executions, "deleted-in-backoff")
+    claimed = executions.claim_delivery(execution["id"])
+    executions.finish_delivery_attempt(
+        execution["id"],
+        claim_token=claimed["claim_token"],
+        failed_targets=[target],
+        error="temporary outage",
+    )
+    monkeypatch.setattr(scheduler, "get_job", lambda _job_id: None)
+
+    assert scheduler.cancel_invalid_deliveries() == 1
+    cancelled = executions.get_delivery(execution["id"])
+    assert cancelled["status"] == "exhausted"
+    assert cancelled["terminal_reason"] == "cancelled"
+    assert cancelled["content"] is None
+
+
+def test_profile_delivery_ledgers_are_isolated(tmp_path):
+    repo = Path(__file__).resolve().parents[2]
+    homes = [tmp_path / "alpha", tmp_path / "beta"]
+    for index, home in enumerate(homes):
+        env = os.environ.copy()
+        env.update({"HERMES_HOME": str(home), "PYTHONPATH": str(repo)})
+        subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "from cron.executions import create_execution, enqueue_delivery; "
+                f"e=create_execution('job-{index}', source='builtin'); "
+                f"enqueue_delivery(e['id'], job={{'id':'job-{index}'}}, content='result', "
+                "targets=[{'platform':'telegram','chat_id':'1'}])",
+            ],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    for index, home in enumerate(homes):
+        env = os.environ.copy()
+        env.update({"HERMES_HOME": str(home), "PYTHONPATH": str(repo)})
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import json; from cron.executions import list_due_deliveries; "
+                "print(json.dumps([r['job_id'] for r in list_due_deliveries()]))",
+            ],
+            cwd=repo,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert json.loads(result.stdout) == [f"job-{index}"]
+
+
+def test_builtin_and_chronos_reconciliation_send_once(monkeypatch, tmp_path):
+    """Both provider wake paths may race, but the SQLite claim has one winner."""
+    import cron.executions as executions
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(
+        executions, "EXECUTIONS_FILE", tmp_path / "cron" / "executions.db"
+    )
+    execution, target = _queued(executions, "provider-race")
+    monkeypatch.setattr(
+        scheduler, "get_job", lambda _job_id: {"state": "completed"}, raising=False
+    )
+    sends = []
+    sends_lock = threading.Lock()
+
+    def deliver(*_args, **_kwargs):
+        with sends_lock:
+            sends.append(_kwargs["targets_override"])
+        return scheduler.DeliveryReport(None, [target], [])
+
+    monkeypatch.setattr(scheduler, "_deliver_result", deliver)
+    barrier = threading.Barrier(3)
+    results = []
+
+    def reconcile():
+        barrier.wait()
+        results.append(scheduler.retry_due_deliveries())
+
+    threads = [threading.Thread(target=reconcile) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(results) == [0, 1]
+    assert sends == [[target]]
+    assert executions.get_delivery(execution["id"])["status"] == "delivered"

--- a/tests/cron/test_execution_ledger.py
+++ b/tests/cron/test_execution_ledger.py
@@ -7,6 +7,7 @@ import os
 import sqlite3
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 
@@ -65,6 +66,34 @@ def test_retention_bounds_terminal_history_but_preserves_inflight(monkeypatch, t
     assert executions.latest_execution("live")["status"] == "running"
 
 
+def test_retention_preserves_terminal_execution_with_pending_delivery(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    monkeypatch.setattr(executions, "MAX_TERMINAL_EXECUTIONS", 1)
+    pending = executions.create_execution("pending-delivery", source="builtin")
+    executions.finish_execution(pending["id"], success=True)
+    executions.enqueue_delivery(
+        pending["id"],
+        job={"id": "pending-delivery"},
+        content="result",
+        targets=[{"platform": "telegram", "chat_id": "1"}],
+    )
+    for index in range(4):
+        row = executions.create_execution(f"newer-{index}", source="builtin")
+        executions.finish_execution(row["id"], success=True)
+
+    assert executions.latest_execution("pending-delivery")["id"] == pending["id"]
+    assert executions.get_delivery(pending["id"])["status"] == "pending"
+
+
+def test_execution_ledger_path_follows_active_profile(monkeypatch, tmp_path):
+    import cron.executions as executions
+
+    profile = tmp_path / "profiles" / "ops"
+    monkeypatch.setattr(executions, "get_hermes_home", lambda: profile)
+
+    assert executions._current_executions_file() == profile / "cron" / "executions.db"
+
+
 def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     executions = _point_ledger(monkeypatch, tmp_path)
     executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
@@ -73,6 +102,45 @@ def test_corrupt_store_fails_closed_without_overwrite(monkeypatch, tmp_path):
     with __import__("pytest").raises(sqlite3.DatabaseError):
         executions.create_execution("new", source="builtin")
     assert executions.EXECUTIONS_FILE.read_bytes() == b"not a sqlite database"
+
+
+def test_delivery_schema_additively_migrates_pre_hardening_database(
+    monkeypatch, tmp_path
+):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    executions.EXECUTIONS_FILE.parent.mkdir(parents=True)
+    conn = sqlite3.connect(executions.EXECUTIONS_FILE)
+    conn.execute(
+        """CREATE TABLE deliveries (
+             execution_id TEXT PRIMARY KEY,
+             job_id TEXT NOT NULL,
+             job_json TEXT,
+             content TEXT,
+             targets_json TEXT NOT NULL,
+             status TEXT NOT NULL,
+             attempt_count INTEGER NOT NULL DEFAULT 0,
+             next_attempt_at TEXT,
+             last_error TEXT,
+             created_at TEXT NOT NULL,
+             updated_at TEXT NOT NULL
+           )"""
+    )
+    conn.execute(
+        """INSERT INTO deliveries
+           (execution_id, job_id, job_json, content, targets_json, status,
+            attempt_count, next_attempt_at, created_at, updated_at)
+           VALUES ('legacy', 'job', '{"id":"job"}', 'result', '[]',
+                   'retry_wait', 1, '2099-01-01T00:00:00+00:00', 'now', 'now')"""
+    )
+    conn.commit()
+    conn.close()
+
+    migrated = executions.get_delivery("legacy")
+
+    assert migrated["status"] == "retry_wait"
+    assert migrated["permanent_error"] is None
+    assert migrated["terminal_reason"] is None
+    assert migrated["claim_token"] is None
 
 
 def test_cron_runs_cli_prints_execution_history(monkeypatch, tmp_path, capsys):
@@ -165,6 +233,131 @@ def test_restart_marks_interrupted_execution_unknown_without_requeue(tmp_path):
     assert [r["status"] for r in records] == ["unknown"]
 
 
+def test_delivery_retry_keeps_only_failed_targets(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    clock = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(executions, "_hermes_now", lambda: clock)
+    execution = executions.create_execution("fanout", source="builtin")
+    telegram = {"platform": "telegram", "chat_id": "1", "thread_id": None}
+    discord = {"platform": "discord", "chat_id": "2", "thread_id": "3"}
+
+    queued = executions.enqueue_delivery(
+        execution["id"],
+        job={"id": "fanout", "name": "Fan out", "deliver": "all"},
+        content="exact agent result",
+        targets=[telegram, discord],
+    )
+    assert queued["status"] == "pending"
+    assert queued["targets"] == [telegram, discord]
+
+    claimed = executions.claim_delivery(execution["id"])
+    assert claimed["status"] == "delivering"
+    assert claimed["attempt_count"] == 1
+
+    waiting = executions.finish_delivery_attempt(
+        execution["id"],
+        claim_token=claimed["claim_token"],
+        failed_targets=[discord],
+        error="discord unavailable",
+    )
+    assert waiting["status"] == "retry_wait"
+    assert waiting["targets"] == [discord]
+    assert waiting["next_attempt_at"] == "2026-08-05T12:01:00+00:00"
+    assert executions.list_due_deliveries() == []
+
+    monkeypatch.setattr(
+        executions,
+        "_hermes_now",
+        lambda: datetime(2026, 8, 5, 12, 1, tzinfo=timezone.utc),
+    )
+    assert [row["execution_id"] for row in executions.list_due_deliveries()] == [
+        execution["id"]
+    ]
+
+    attempts = executions.list_delivery_attempts(execution["id"])
+    assert len(attempts) == 1
+    assert attempts[0]["outcome"] == "retry_wait"
+    assert attempts[0]["targets"] == [telegram, discord]
+
+
+def test_completed_delivery_discards_sensitive_payload(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution = executions.create_execution("private", source="builtin")
+    executions.enqueue_delivery(
+        execution["id"],
+        job={"id": "private", "origin": {"user_id": "secret-user"}},
+        content="private response",
+        targets=[{"platform": "telegram", "chat_id": "1"}],
+    )
+    claimed = executions.claim_delivery(execution["id"])
+
+    completed = executions.finish_delivery_attempt(
+        execution["id"], claim_token=claimed["claim_token"], failed_targets=[]
+    )
+
+    assert completed["status"] == "delivered"
+    assert completed["content"] is None
+    assert completed["job"] is None
+    assert completed["targets"] == []
+
+
+def test_delivery_attempts_exhaust_with_bounded_backoff(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    target = {"platform": "telegram", "chat_id": "1"}
+    current = datetime(2026, 8, 5, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(executions, "_hermes_now", lambda: current)
+    execution = executions.create_execution("bounded", source="builtin")
+    executions.enqueue_delivery(
+        execution["id"], job={"id": "bounded"}, content="payload", targets=[target]
+    )
+
+    expected_delays = [60, 120, 600]
+    for delay in expected_delays:
+        claimed = executions.claim_delivery(execution["id"])
+        record = executions.finish_delivery_attempt(
+            execution["id"],
+            claim_token=claimed["claim_token"],
+            failed_targets=[target],
+            error="offline",
+        )
+        assert record["status"] == "retry_wait"
+        current = datetime.fromisoformat(record["next_attempt_at"])
+
+    claimed = executions.claim_delivery(execution["id"])
+    exhausted = executions.finish_delivery_attempt(
+        execution["id"],
+        claim_token=claimed["claim_token"],
+        failed_targets=[target],
+        error="still offline",
+    )
+    assert exhausted["status"] == "exhausted"
+    assert exhausted["attempt_count"] == 4
+    assert exhausted["content"] is None
+    assert exhausted["job"] is None
+    assert len(executions.list_delivery_attempts(execution["id"])) == 4
+
+
+def test_recovery_marks_inflight_delivery_unknown_without_retry(monkeypatch, tmp_path):
+    executions = _point_ledger(monkeypatch, tmp_path)
+    execution = executions.create_execution("ambiguous-delivery", source="builtin")
+    executions.enqueue_delivery(
+        execution["id"],
+        job={"id": "ambiguous-delivery"},
+        content="may already have been sent",
+        targets=[{"platform": "telegram", "chat_id": "1"}],
+    )
+    executions.claim_delivery(execution["id"])
+    monkeypatch.setattr(executions, "_PROCESS_ID", "replacement-process")
+    monkeypatch.setattr(executions, "_owner_is_live", lambda *_args: False)
+
+    assert executions.recover_interrupted_deliveries() == 1
+    recovered = executions.get_delivery(execution["id"])
+    assert recovered["status"] == "unknown"
+    assert recovered["content"] is None
+    assert executions.list_due_deliveries() == []
+    assert executions.list_delivery_attempts(execution["id"])[0]["outcome"] == "unknown"
+
+
 def test_generic_submit_failure_finishes_attempt_and_releases_guard(monkeypatch):
     import cron.scheduler as scheduler
 
@@ -238,11 +431,21 @@ def test_provider_start_recovers_interrupted_records_before_tick(monkeypatch):
         lambda: events.append("recover") or 0,
         raising=False,
     )
+    monkeypatch.setattr(
+        "cron.executions.recover_interrupted_deliveries",
+        lambda: events.append("recover-delivery") or 0,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler.retry_due_deliveries",
+        lambda **_kwargs: events.append("retry-delivery") or 0,
+        raising=False,
+    )
     monkeypatch.setattr("cron.jobs.record_ticker_heartbeat", lambda **_kwargs: events.append("heartbeat"))
 
     provider.InProcessCronScheduler().start(stop, interval=1)
 
-    assert events[:2] == ["recover", "heartbeat"]
+    assert events[:3] == ["recover", "recover-delivery", "heartbeat"]
 
 
 def test_external_provider_start_recovers_interrupted_records(monkeypatch):
@@ -255,11 +458,19 @@ def test_external_provider_start_recovers_interrupted_records(monkeypatch):
         "cron.executions.recover_interrupted_executions",
         lambda: events.append("recover") or 0,
     )
+    monkeypatch.setattr(
+        "cron.executions.recover_interrupted_deliveries",
+        lambda: events.append("recover-delivery") or 0,
+    )
+    monkeypatch.setattr(
+        "cron.scheduler.retry_due_deliveries",
+        lambda **_kwargs: events.append("retry-delivery") or 0,
+    )
     monkeypatch.setattr(provider, "reconcile", lambda: events.append("reconcile"))
 
     provider.start(__import__("threading").Event())
 
-    assert events == ["recover", "reconcile"]
+    assert events == ["recover", "recover-delivery", "retry-delivery", "reconcile"]
 
 
 class _TrackingConnection:

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -17,6 +17,7 @@ from cron.jobs import (
     pause_job,
     resume_job,
     remove_job,
+    mark_job_delivery,
     mark_job_run,
     advance_next_run,
     claim_dispatch,
@@ -379,6 +380,47 @@ class TestMarkJobRun:
         assert updated["last_status"] == "ok"
         assert updated["last_error"] is None
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+
+    def test_delivery_retry_update_does_not_count_another_run(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error="offline")
+        before = get_job(job["id"])
+
+        assert mark_job_delivery(job["id"], None) is True
+
+        after = get_job(job["id"])
+        assert after["last_delivery_error"] is None
+        assert after["last_run_at"] == before["last_run_at"]
+        assert after["repeat"]["completed"] == before["repeat"]["completed"]
+
+    def test_older_retry_cannot_clear_newer_execution_failure(self, tmp_cron_dir):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=True, delivery_error="old failure", execution_id="old"
+        )
+        mark_job_run(
+            job["id"], success=True, delivery_error="new failure", execution_id="new"
+        )
+
+        assert mark_job_delivery(job["id"], None, execution_id="old") is False
+        updated = get_job(job["id"])
+        assert updated["last_execution_id"] == "new"
+        assert updated["last_delivery_error"] == "new failure"
+
+    def test_pre_upgrade_job_uses_ledger_to_accept_latest_retry(
+        self, tmp_cron_dir, monkeypatch
+    ):
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True, delivery_error="offline")
+        monkeypatch.setattr(
+            "cron.executions.latest_execution",
+            lambda _job_id: {"id": "legacy-latest"},
+        )
+
+        assert (
+            mark_job_delivery(job["id"], None, execution_id="legacy-latest") is True
+        )
+        assert get_job(job["id"])["last_delivery_error"] is None
 
 
     def test_recurring_cron_not_disabled_when_croniter_missing(self, tmp_cron_dir, monkeypatch):

--- a/tests/cron/test_run_one_job.py
+++ b/tests/cron/test_run_one_job.py
@@ -31,7 +31,7 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
         calls.append(("deliver", job["id"]))
         return None
 
-    def fake_mark(jid, ok, err=None, delivery_error=None):
+    def fake_mark(jid, ok, err=None, delivery_error=None, execution_id=None):
         calls.append(("mark", jid, ok))
 
     monkeypatch.setattr(s, "run_job", fake_run_job)
@@ -39,6 +39,65 @@ def _patch_pipeline(monkeypatch, *, success=True, output="out", final="final res
     monkeypatch.setattr(s, "_deliver_result", fake_deliver)
     monkeypatch.setattr(s, "mark_job_run", fake_mark)
     return calls
+
+
+def test_run_one_job_persists_and_claims_delivery_before_send(monkeypatch):
+    """A completed agent result crosses a durable boundary before network I/O."""
+    calls = []
+    target = {"platform": "telegram", "chat_id": "1", "thread_id": None}
+
+    monkeypatch.setattr(s, "claim_dispatch", lambda _job_id: True)
+    monkeypatch.setattr(s, "mark_execution_running", lambda _execution_id: None)
+    monkeypatch.setattr(s, "finish_execution", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        s,
+        "run_job",
+        lambda job, *, defer_agent_teardown=None: (True, "output", "response", None),
+    )
+    monkeypatch.setattr(s, "save_job_output", lambda *_args: "/tmp/output.md")
+    monkeypatch.setattr(s, "mark_job_run", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(s, "_resolve_delivery_targets", lambda _job: [target])
+    monkeypatch.setattr(
+        s,
+        "enqueue_delivery",
+        lambda execution_id, **kwargs: calls.append(("enqueue", execution_id, kwargs))
+        or {"execution_id": execution_id},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        s,
+        "claim_delivery",
+        lambda execution_id: calls.append(("claim", execution_id))
+        or {
+            "execution_id": execution_id,
+            "job": {"id": "durable", "name": "Durable"},
+            "content": "response",
+            "targets": [target],
+            "claim_token": "claim-1",
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        s,
+        "_deliver_result",
+        lambda *_args, **_kwargs: calls.append(("deliver", _kwargs["targets_override"]))
+        or s.DeliveryReport("offline", [], [target]),
+    )
+    monkeypatch.setattr(
+        s,
+        "finish_delivery_attempt",
+        lambda execution_id, **kwargs: calls.append(("finish_delivery", execution_id, kwargs)),
+        raising=False,
+    )
+
+    assert s.run_one_job(
+        {"id": "durable", "name": "Durable", "deliver": "telegram", "execution_id": "exec-1"}
+    ) is True
+    assert [call[0] for call in calls] == [
+        "enqueue", "claim", "deliver", "finish_delivery"
+    ]
+    assert calls[0][2]["content"] == "response"
+    assert calls[3][2]["failed_targets"] == [target]
 
 
 def test_tick_process_job_sequence(monkeypatch):
@@ -107,5 +166,3 @@ def test_run_one_job_installs_secret_scope_under_multiplex(monkeypatch, tmp_path
     assert scope_during_run["base_url"] == "https://openrouter.ai/api/v1"
     # And it was torn down after run_one_job returned (no leak).
     assert ss.current_secret_scope() is None
-
-

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -440,6 +440,264 @@ class TestDeliverResultErrorReturns:
         assert result is not None
         assert "not configured" in result
 
+    def test_structured_report_isolates_failed_concrete_targets(self):
+        from gateway.config import Platform
+
+        telegram_cfg = MagicMock()
+        telegram_cfg.enabled = True
+        discord_cfg = MagicMock()
+        discord_cfg.enabled = False
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {
+            Platform.TELEGRAM: telegram_cfg,
+            Platform.DISCORD: discord_cfg,
+        }
+        telegram = {"platform": "telegram", "chat_id": "1", "thread_id": None}
+        discord = {"platform": "discord", "chat_id": "2", "thread_id": None}
+
+        async def successful_send(*_args, **_kwargs):
+            return {"success": True}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("gateway.delivery.resolve_delivery_transport", return_value=None), \
+             patch("tools.send_message_tool._send_to_platform", side_effect=successful_send):
+            report = _deliver_result(
+                {"id": "fanout", "deliver": "all"},
+                "Output.",
+                targets_override=[telegram, discord],
+                return_report=True,
+            )
+
+        assert report.error is not None
+        assert "discord" in report.error
+        assert report.delivered_targets == [telegram]
+        assert report.failed_targets == [discord]
+
+    def test_legacy_return_contract_remains_string_or_none(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = False
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        target = {"platform": "telegram", "chat_id": "1", "thread_id": None}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg):
+            result = _deliver_result(
+                {"id": "legacy", "deliver": "telegram"},
+                "Output.",
+                targets_override=[target],
+            )
+
+        assert isinstance(result, str)
+        assert "not configured" in result
+
+    def test_authentication_failure_is_permanent(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        target = {"platform": "telegram", "chat_id": "1", "thread_id": None}
+
+        async def rejected(*_args, **_kwargs):
+            return {"error": "401 unauthorized token"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("gateway.delivery.resolve_delivery_transport", return_value=None), \
+             patch("tools.send_message_tool._send_to_platform", side_effect=rejected):
+            report = _deliver_result(
+                {"id": "auth", "deliver": "telegram"},
+                "Output.",
+                targets_override=[target],
+                return_report=True,
+            )
+
+        assert report.failed_targets == [target]
+        assert report.retryable_failed_targets == []
+        assert any("401" in error for error in report.permanent_errors)
+
+    def test_missing_target_failure_is_permanent(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+        target = {"platform": "telegram", "chat_id": "missing", "thread_id": None}
+
+        async def rejected(*_args, **_kwargs):
+            return {"error": "Bad Request: chat not found"}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_response": False}}), \
+             patch("gateway.delivery.resolve_delivery_transport", return_value=None), \
+             patch("tools.send_message_tool._send_to_platform", side_effect=rejected):
+            report = _deliver_result(
+                {"id": "missing", "deliver": "telegram:missing"},
+                "Output.",
+                targets_override=[target],
+                return_report=True,
+            )
+
+        assert report.failed_targets == [target]
+        assert report.retryable_failed_targets == []
+        assert any("chat not found" in error for error in report.permanent_errors)
+
+
+def test_retry_due_deliveries_claims_and_sends_failed_targets_only(monkeypatch):
+    import cron.scheduler as scheduler
+
+    target = {"platform": "discord", "chat_id": "2", "thread_id": None}
+    batch = {
+        "execution_id": "exec-retry",
+        "job_id": "job-retry",
+        "job": {"id": "job-retry", "name": "Retry"},
+        "content": "saved response",
+        "targets": [target],
+        "claim_token": "claim-retry",
+    }
+    calls = []
+    monkeypatch.setattr(scheduler, "list_due_deliveries", lambda **_kwargs: [batch], raising=False)
+    monkeypatch.setattr(
+        scheduler,
+        "get_job",
+        lambda _job_id: {"id": "job-retry", "enabled": True, "state": "scheduled"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "claim_delivery",
+        lambda execution_id: calls.append(("claim", execution_id)) or batch,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda job, content, **kwargs: calls.append(
+            ("deliver", job, content, kwargs["targets_override"])
+        ) or scheduler.DeliveryReport(None, [target], []),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "finish_delivery_attempt",
+        lambda execution_id, **kwargs: calls.append(("finish", execution_id, kwargs))
+        or {"status": "delivered"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "mark_job_delivery",
+        lambda job_id, error=None, **kwargs: calls.append(
+            ("mark", job_id, error, kwargs)
+        ),
+        raising=False,
+    )
+
+    assert scheduler.retry_due_deliveries() == 1
+    assert calls[0] == ("claim", "exec-retry")
+    assert calls[1][0] == "deliver"
+    assert calls[1][3] == [target]
+    assert calls[2][2]["failed_targets"] == []
+    assert calls[3] == (
+        "mark",
+        "job-retry",
+        None,
+        {"execution_id": "exec-retry"},
+    )
+
+
+def test_retry_reconciliation_classifies_dead_delivery_owners(monkeypatch):
+    import cron.scheduler as scheduler
+
+    events = []
+    monkeypatch.setattr(
+        scheduler,
+        "recover_interrupted_deliveries",
+        lambda: events.append("recover") or 0,
+        raising=False,
+    )
+    monkeypatch.setattr(scheduler, "list_pending_deliveries", lambda **_kwargs: [])
+    monkeypatch.setattr(scheduler, "list_due_deliveries", lambda **_kwargs: [])
+
+    assert scheduler.retry_due_deliveries() == 0
+    assert events == ["recover"]
+
+
+def test_retry_due_deliveries_cancels_deleted_job(monkeypatch):
+    import cron.scheduler as scheduler
+
+    batch = {"execution_id": "deleted", "job_id": "gone"}
+    calls = []
+    monkeypatch.setattr(scheduler, "list_due_deliveries", lambda **_kwargs: [batch])
+    monkeypatch.setattr(scheduler, "get_job", lambda _job_id: None, raising=False)
+    monkeypatch.setattr(
+        scheduler,
+        "cancel_delivery",
+        lambda execution_id, **kwargs: calls.append((execution_id, kwargs)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not send")),
+    )
+
+    assert scheduler.retry_due_deliveries() == 0
+    assert calls == [("deleted", {"reason": "job was deleted before delivery retry"})]
+
+
+def test_retry_due_deliveries_cancels_paused_job(monkeypatch):
+    import cron.scheduler as scheduler
+
+    batch = {"execution_id": "paused", "job_id": "job-paused"}
+    calls = []
+    monkeypatch.setattr(scheduler, "list_due_deliveries", lambda **_kwargs: [batch])
+    monkeypatch.setattr(
+        scheduler,
+        "get_job",
+        lambda _job_id: {"id": "job-paused", "enabled": False, "state": "paused"},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "cancel_delivery",
+        lambda execution_id, **kwargs: calls.append((execution_id, kwargs)),
+        raising=False,
+    )
+
+    assert scheduler.retry_due_deliveries() == 0
+    assert calls[0][0] == "paused"
+
+
+def test_invalid_unresolved_target_is_not_enqueued_for_retry(monkeypatch):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_resolve_delivery_targets", lambda _job: [])
+    monkeypatch.setattr(
+        scheduler,
+        "_deliver_result",
+        lambda *_args, **_kwargs: "no delivery target resolved for deliver=bogus",
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "enqueue_delivery",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("permanently invalid targets must not enter retry state")
+        ),
+    )
+
+    error = scheduler._deliver_durably(
+        "invalid-execution",
+        {"id": "invalid-job", "deliver": "bogus"},
+        "result",
+    )
+
+    assert error == "no delivery target resolved for deliver=bogus"
+
 
 class TestRunJobSessionPersistence:
     def test_run_job_passes_session_db_and_cron_platform(self, tmp_path):
@@ -959,12 +1217,15 @@ class TestSilentDelivery:
             tick(verbose=False)
 
         deliver_mock.assert_not_called()
-        mark_mock.assert_called_once_with(
+        mark_mock.assert_called_once()
+        args, kwargs = mark_mock.call_args
+        assert args == (
             "monitor-job",
             False,
             "Agent completed but produced empty response (model error, timeout, or misconfiguration)",
-            delivery_error=None,
         )
+        assert kwargs["delivery_error"] is None
+        assert kwargs["execution_id"]
 
 
 class TestOneShotDispatchClaim:
@@ -1855,7 +2116,15 @@ class TestMultiTargetDeliveryContinuesOnFailure:
             fail_future.result.side_effect = ConnectionError("SMTP connection refused")
             ok_future = MagicMock()
             ok_future.result.return_value = {"success": True}
-            mock_pool.submit.side_effect = [fail_future, ok_future]
+            futures = iter([fail_future, ok_future])
+
+            def submit_without_worker(_fn, coro):
+                # This test replaces the executor, so it also owns the coroutine
+                # that a real worker would consume.
+                coro.close()
+                return next(futures)
+
+            mock_pool.submit.side_effect = submit_without_worker
 
             result = _deliver_result(job, "Report content")
 
@@ -1884,7 +2153,12 @@ class TestMultiTargetDeliveryContinuesOnFailure:
 
             fail_future = MagicMock()
             fail_future.result.side_effect = ConnectionError("connection refused")
-            mock_pool.submit.return_value = fail_future
+
+            def submit_without_worker(_fn, coro):
+                coro.close()
+                return fail_future
+
+            mock_pool.submit.side_effect = submit_without_worker
 
             result = _deliver_result(job, "Report content")
 
@@ -1907,5 +2181,3 @@ class TestSetCronSessionTitle:
         out = _set_cron_session_title(db, "sess-1", "Nightly Synthesis")
         assert out == "Nightly Synthesis #2"
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
-
-

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -280,6 +280,30 @@ def test_failing_tick_records_liveness_but_not_success():
     assert all(b is False for b in beats), "a failing tick wrongly bumped the success marker"
 
 
+def test_builtin_reconciles_due_deliveries_before_each_tick():
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    events = []
+    stop = threading.Event()
+
+    def retry(**_kwargs):
+        events.append("retry")
+
+    def tick(**_kwargs):
+        events.append("tick")
+        stop.set()
+
+    with patch("cron.executions.recover_interrupted_executions", return_value=0), \
+         patch("cron.executions.recover_interrupted_deliveries", return_value=0), \
+         patch("cron.scheduler.retry_due_deliveries", side_effect=retry), \
+         patch("cron.scheduler.tick", side_effect=tick), \
+         patch("cron.jobs.record_ticker_heartbeat"), \
+         patch("cron.jobs.clear_ticker_error"):
+        InProcessCronScheduler().start(stop, interval=0)
+
+    assert events == ["retry", "tick"]
+
+
 def test_heartbeat_roundtrip_and_age(tmp_path, monkeypatch):
     """record_ticker_heartbeat writes fresh timestamps atomically; the age
     getters read them back as small positive ages."""
@@ -412,5 +436,4 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
     assert len(tick_count) >= len(profile_homes), \
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
-
 

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -91,6 +91,22 @@ def test_reconcile_arms_all_enabled(temp_home, chronos, monkeypatch):
     assert fake.cancels == []
 
 
+def test_job_change_cancels_invalid_delivery_before_registry_reconcile(
+    chronos, monkeypatch
+):
+    prov, _fake = chronos
+    events = []
+    monkeypatch.setattr(
+        "cron.scheduler.cancel_invalid_deliveries",
+        lambda: events.append("cancel-delivery") or 1,
+    )
+    monkeypatch.setattr(prov, "reconcile", lambda: events.append("reconcile"))
+
+    prov.on_jobs_changed()
+
+    assert events == ["cancel-delivery", "reconcile"]
+
+
 # -- fire_due re-arm ----------------------------------------------------------
 
 def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):
@@ -104,5 +120,4 @@ def test_fire_due_rearms_next_oneshot(chronos, monkeypatch):
     assert prov.fire_due("j1") is True
     assert [p["job_id"] for p in fake.provisions] == ["j1"]
     assert fake.provisions[0]["fire_at"] == "2026-06-18T12:05:00+00:00"
-
 


### PR DESCRIPTION
## What does this PR do?

Adds profile-local durable cron-result delivery so completed agent output survives restarts and transient platform failures without rerunning the agent. SQLite claim tokens serialize workers; ambiguous in-flight sends become `unknown` and are never retried automatically.

Chronos retry rows remain durable, but when Chronos is scaled to zero they become eligible only at the next warm lifecycle callback, not at an exact scheduled wake.

## Related Issue

Related to #23118 and #58818. No single issue is closed by this PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add SQLite-backed delivery batches, per-destination attempts, atomic claims, and bounded retry eligibility.
- Retry only failed destinations; retain successful destinations and classify permanent or ambiguous outcomes safely.
- Reconcile built-in and Chronos delivery state across restarts, job disable/delete, concurrent workers, and profiles.
- Add focused crash, concurrency, migration, gateway, and Chronos regression coverage, including `tests/cron/test_durable_delivery_hardening.py`.

## How to Test

1. Run the relevant cron, scheduler, Chronos, gateway, and database suite through `scripts/run_tests.sh -j 4`.
2. Run Ruff, Python compilation, and `git diff --check` on the changed files.
3. Expected local result: 539 tests passed, 0 failed; focused hardening suite: 17 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline documentation/comments updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No UI changes. Local verification: 539 passed, 0 failed.
