### PR TITLE
feat(skill-meta): add local skill confidence management with default skill pool

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11150,10 +11150,77 @@ def cmd_skills(args):
         from hermes_cli.skills_config import skills_command as skills_config_command
 
         skills_config_command(args)
+    # Route 'grade' action to local skill confidence management
+    elif getattr(args, "skills_action", None) == "grade":
+        _handle_skills_grade(args)
     else:
         from hermes_cli.skills_hub import skills_command
 
         skills_command(args)
+
+
+def _handle_skills_grade(args):
+    """Handle `hermes skills grade` subcommand."""
+    from tools.skill_meta import SkillMetaDB, CONFIDENCE_ORDER
+
+    grade_action = getattr(args, "grade_action", None) or "report"
+    db = SkillMetaDB()
+
+    if grade_action == "list":
+        by_conf = getattr(args, "by_confidence", None)
+        if by_conf:
+            skills = db.list_by_confidence(by_conf)
+        else:
+            skills = db.list_all()
+        if not skills:
+            print("No skills registered.")
+            return
+        for name, meta in skills:
+            pool = " [DEFAULT]" if meta.default_skill_pool else ""
+            print(f"  {name:30s} confidence={meta.confidence:10s} uses={meta.usage_count:3d} last={meta.last_used or 'never'}{pool}")
+
+    elif grade_action == "set":
+        skill_name = getattr(args, "skill", "").strip()
+        level = getattr(args, "level", "").strip()
+        reason = getattr(args, "reason", "") or ""
+        if not skill_name:
+            print("Error: skill name required. Usage: hermes skills grade set <name> <level>")
+            return
+        if not reason:
+            reason = f"User promoted {skill_name} to {level}"
+        try:
+            meta = db.grade(skill_name, level, reason=reason)
+            print(f"✓ {skill_name} → {level}")
+            print(f"  confidence={meta.confidence}  default_pool={meta.default_skill_pool}")
+            # Show grade history
+            if meta.grade_history:
+                print(f"  history:")
+                for entry in meta.grade_history[-5:]:  # last 5
+                    print(f"    {entry['timestamp'][:19]} {entry['from']} → {entry['to']} ({entry['reason']})")
+        except ValueError as e:
+            print(f"Error: {e}")
+
+    elif grade_action == "pool" and hasattr(args, "pool_action"):
+        # pool add/remove
+        pool_action = getattr(args, "pool_action", "")
+        skill_name = getattr(args, "skill", "").strip() if hasattr(args, "skill") else ""
+        if not skill_name:
+            print("Usage: hermes skills grade pool (add|remove) <skill>")
+            return
+        try:
+            if pool_action == "add":
+                meta = db.add_to_default_pool(skill_name)
+                print(f"✓ Added {skill_name} to default pool")
+            elif pool_action == "remove":
+                meta = db.remove_from_default_pool(skill_name)
+                print(f"✓ Removed {skill_name} from default pool")
+            else:
+                print(f"Unknown pool action: {pool_action}")
+        except KeyError as e:
+            print(f"Error: {e}")
+
+    else:  # "report" or default
+        print(db.report())
 
 
 def cmd_pairing(args):

--- a/hermes_cli/subcommands/skills.py
+++ b/hermes_cli/subcommands/skills.py
@@ -8,6 +8,9 @@ from __future__ import annotations
 
 from typing import Callable
 
+# Import from skill_meta to keep confidence levels in one place
+from tools.skill_meta import CONFIDENCE_ORDER
+
 
 def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     """Attach the ``skills`` subcommand to ``subparsers``."""
@@ -306,6 +309,35 @@ def build_skills_parser(subparsers, *, cmd_skills: Callable) -> None:
     tap_add.add_argument("repo", help="GitHub repo (e.g. owner/repo)")
     tap_rm = tap_subparsers.add_parser("remove", help="Remove a tap")
     tap_rm.add_argument("name", help="Tap name to remove")
+
+    # ── grade sub-action: confidence management for local skills ──
+    skills_grade = skills_subparsers.add_parser(
+        "grade",
+        help="Manage skill confidence levels and default pool",
+    )
+    grade_sub = skills_grade.add_subparsers(dest="grade_action", help="Grade action")
+    
+    # grade list
+    grade_list = grade_sub.add_parser("list", help="Show all skills and their confidence")
+    grade_list.add_argument("--by-confidence", choices=CONFIDENCE_ORDER, default=None,
+                            help="Filter by confidence level")
+    
+    # grade set
+    grade_set = grade_sub.add_parser("set", help="Set or upgrade a skill's confidence")
+    grade_set.add_argument("skill", help="Skill name")
+    grade_set.add_argument("level", choices=CONFIDENCE_ORDER, help="New confidence level")
+    grade_set.add_argument("--reason", default="", help="Reason for grade change")
+    
+    # grade report
+    grade_sub.add_parser("report", help="Print full confidence report")
+    
+    # grade pool sub-actions
+    grade_pool = grade_sub.add_parser("pool", help="Manage default skill pool")
+    pool_sub = grade_pool.add_subparsers(dest="pool_action", help="Pool action")
+    pool_add = pool_sub.add_parser("add", help="Add skill to default pool (auto-loaded)")
+    pool_add.add_argument("skill", help="Skill name")
+    pool_rm = pool_sub.add_parser("remove", help="Remove skill from default pool")
+    pool_rm.add_argument("skill", help="Skill name")
 
     # config sub-action: interactive enable/disable
     skills_subparsers.add_parser(

--- a/tests/tools/test_skill_meta.py
+++ b/tests/tools/test_skill_meta.py
@@ -1,0 +1,265 @@
+"""Tests for tools/skill_meta.py — local skill confidence metadata management."""
+
+import json
+import os
+import tempfile
+import shutil
+from datetime import datetime, timezone
+
+import pytest
+
+# We test the module in isolation without needing the full hermes environment.
+
+
+@pytest.fixture()
+def meta_db():
+    """Create a SkillMetaDB backed by a temporary directory."""
+    from tools.skill_meta import SkillMetaDB
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        # Point to a fake HERMES_HOME so the meta file lands inside tmpdir
+        hermes_home = os.path.dirname(tmpdir)
+        os.environ["HERMES_HOME"] = hermes_home
+        os.makedirs(os.path.join(hermes_home, "skills"), exist_ok=True)
+        db = SkillMetaDB()
+        yield db
+    finally:
+        shutil.rmtree(hermes_home, ignore_errors=True)
+
+
+# ── Registration ──────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_empty_db(self, meta_db):
+        assert meta_db.list_all() == []
+
+    def test_register_creates_untested(self, meta_db):
+        meta = meta_db.register("test-skill", reason="new")
+        assert meta.confidence == "untested"
+        assert len(meta.grade_history) == 1
+        assert meta.grade_history[0]["grader"] == "system"
+        assert meta.grade_history[0]["to"] == "untested"
+
+    def test_get_nonexistent_returns_none(self, meta_db):
+        assert meta_db.get("does-not-exist") is None
+
+    def test_register_twice_is_idempotent(self, meta_db):
+        meta_db.register("dup-test", reason="first")
+        meta_db.register("dup-test", reason="second")  # should not add history
+        meta = meta_db.get("dup-test")
+        # Only the first registration added "initial → untested"
+        assert len(meta.grade_history) == 1
+
+    def test_name_normalization(self, meta_db):
+        meta_db.register("TEST-SKILL")
+        assert meta_db.get("test-skill") is not None
+        assert meta_db.get("Test_Skill") is not None
+
+
+# ── Confidence Grading ────────────────────────────────────────────
+
+
+class TestGrading:
+    def test_upgrades_in_order(self, meta_db):
+        meta = meta_db.grade("test-skill", "trial", reason="t1")
+        assert meta.confidence == "trial"
+
+        meta = meta_db.grade("test-skill", "verified", reason="t2")
+        assert meta.confidence == "verified"
+
+        meta = meta_db.grade("test-skill", "default", reason="t3")
+        assert meta.confidence == "default"
+        assert meta.default_skill_pool is True  # auto-add to pool
+
+    def test_same_level_blocked(self, meta_db):
+        meta_db.register("s")
+        meta_db.grade("s", "trial")
+        with pytest.raises(ValueError, match="Cannot downgrade"):
+            meta_db.grade("s", "trial")
+
+    def test_downgrade_blocked(self, meta_db):
+        meta_db.register("d")
+        meta_db.grade("d", "verified")
+        with pytest.raises(ValueError, match="Cannot downgrade"):
+            meta_db.grade("d", "trial")
+
+    def test_invalid_level_raises(self, meta_db):
+        meta_db.register("i")
+        with pytest.raises(ValueError, match="Invalid confidence level"):
+            meta_db.grade("i", "superior")
+
+    def test_grade_history_tracked(self, meta_db):
+        meta_db.register("h")
+        meta_db.grade("h", "trial", reason="t1", grader="user")
+        meta_db.grade("h", "verified", reason="t2", grader="auto")
+        meta = meta_db.get("h")
+        assert len(meta.grade_history) == 3  # initial + 2 grades
+        assert meta.grade_history[1]["reason"] == "t1"
+        assert meta.grade_history[2]["grader"] == "auto"
+
+
+# ── Usage Tracking ────────────────────────────────────────────────
+
+
+class TestUsageTracking:
+    def test_usage_count_increments(self, meta_db):
+        meta_db.register("u")
+        meta_db.record_usage("u")
+        meta_db.record_usage("u")
+        meta = meta_db.get("u")
+        assert meta.usage_count == 2
+        assert meta.last_used is not None
+
+    def test_auto_promote_after_3_uses(self, meta_db):
+        meta_db.register("a")
+        meta_db.record_usage("a")
+        meta_db.record_usage("a")
+        meta_db.record_usage("a")
+        meta = meta_db.get("a")
+        assert meta.confidence == "trial"
+        # Should have auto-promotion entry in history
+        auto_promotions = [
+            e for e in meta.grade_history if e["grader"] == "auto"
+        ]
+        assert len(auto_promotions) == 1
+
+    def test_nonexistent_skill_automatically_registered(self, meta_db):
+        meta_db.record_usage("ghost")
+        meta = meta_db.get("ghost")
+        assert meta is not None
+        assert meta.usage_count == 1
+
+
+# ── Default Pool Management ───────────────────────────────────────
+
+
+class TestDefaultPool:
+    def test_add_to_default_pool(self, meta_db):
+        meta_db.register("dp")
+        meta_db.add_to_default_pool("dp")
+        assert "dp" in meta_db.list_default_pool()
+        meta = meta_db.get("dp")
+        assert meta.default_skill_pool is True
+
+    def test_remove_from_default_pool(self, meta_db):
+        meta_db.register("dr")
+        meta_db.add_to_default_pool("dr")
+        meta_db.remove_from_default_pool("dr")
+        assert "dr" not in meta_db.list_default_pool()
+        meta = meta_db.get("dr")
+        assert meta.default_skill_pool is False
+
+    def test_add_to_pool_promotes_untested(self, meta_db):
+        meta_db.register("pu")
+        meta_db.add_to_default_pool("pu")
+        meta = meta_db.get("pu")
+        # untested → trial when added to pool
+        assert meta.confidence == "trial"
+
+    def test_remove_nonexistent_raises(self, meta_db):
+        with pytest.raises(KeyError):
+            meta_db.remove_from_default_pool("nonexistent")
+
+    def test_add_nonexistent_raises(self, meta_db):
+        with pytest.raises(KeyError):
+            meta_db.add_to_default_pool("nonexistent")
+
+    def test_default_pool_in_report(self, meta_db):
+        meta_db.register("rpt")
+        meta_db.grade("rpt", "verified")
+        meta_db.add_to_default_pool("rpt")
+        report = meta_db.report()
+        assert "rpt" in report
+        assert "[DEFAULT]" in report
+        assert "auto-loaded" in report
+
+
+# ── Filtering & Listing ──────────────────────────────────────────
+
+
+class TestFiltering:
+    def test_list_by_confidence(self, meta_db):
+        meta_db.register("f-untested")
+        meta_db.register("f-verified")
+        meta_db.grade("f-verified", "verified")
+        untested = meta_db.list_by_confidence("untested")
+        verified = meta_db.list_by_confidence("verified")
+        assert len(untested) == 1
+        assert len(verified) == 1
+        assert untested[0][0] == "f-untested"
+        assert verified[0][0] == "f-verified"
+
+    def test_list_empty_filter(self, meta_db):
+        assert meta_db.list_by_confidence("default") == []
+
+    def test_list_all_sorted(self, meta_db):
+        meta_db.register("z-skill")
+        meta_db.register("a-skill")
+        names = [name for name, _ in meta_db.list_all()]
+        assert names == ["a-skill", "z-skill"]
+
+
+# ── Removal ──────────────────────────────────────────────────────
+
+
+class TestRemoval:
+    def test_remove_existing(self, meta_db):
+        meta_db.register("rm")
+        assert meta_db.remove("rm") is True
+        assert meta_db.get("rm") is None
+
+    def test_remove_nonexistent(self, meta_db):
+        assert meta_db.remove("nonexistent") is False
+
+
+# ── Report ───────────────────────────────────────────────────────
+
+
+class TestReport:
+    def test_report_contains_levels(self, meta_db):
+        meta_db.register("rep")
+        meta_db.grade("rep", "verified")
+        report = meta_db.report()
+        assert "rep" in report
+        assert "VERIFIED" in report
+
+    def test_report_empty(self, meta_db):
+        report = meta_db.report()
+        assert "Local Skill Confidence Database (0 skills)" in report
+
+
+# ── Persistence ──────────────────────────────────────────────────
+
+
+class TestPersistence:
+    def test_atomic_write_valid_json(self, meta_db):
+        meta_db.register("p")
+        meta_path = meta_db.db_path
+        assert meta_path.exists()
+        with open(meta_path, "r") as f:
+            data = json.load(f)
+        assert "skills" in data
+        assert "p" in data["skills"]
+
+    def test_reopen_loads_data(self, meta_db):
+        from tools.skill_meta import SkillMetaDB
+
+        meta_db.register("rl")
+        meta_db.grade("rl", "verified")
+
+        # Re-open a new instance
+        db2 = SkillMetaDB()
+        meta = db2.get("rl")
+        assert meta is not None
+        assert meta.confidence == "verified"
+
+    def test_grade_history_survives_reopen(self, meta_db):
+        meta_db.register("rh")
+        meta_db.grade("rh", "trial", reason="t1")
+        meta_db.grade("rh", "verified", reason="t2")
+
+        db2 = SkillMetaDB()
+        meta = db2.get("rh")
+        assert len(meta.grade_history) == 3

--- a/tools/skill_meta.py
+++ b/tools/skill_meta.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""
+Local skill confidence metadata management.
+
+Manages per-skill metadata in ~/.hermes/skills/.skills_meta.json.
+Provides:
+  - Read/write confidence levels: untested → trial → verified → default
+  - Usage counting and tracking
+  - Default skill pool management (auto-loaded at session start)
+  - Grade history audit trail
+
+Usage:
+  from tools.skill_meta import SkillMetaDB
+  
+  db = SkillMetaDB()
+  
+  # Register a skill
+  db.register("obsidian")
+  
+  # Upgrade confidence
+  db.grade("obsidian", "trial", reason="used 3 times, no issues")
+  db.grade("obsidian", "verified", reason="stable across multiple projects")
+  
+  # Add to default pool (auto-loaded)
+  db.add_to_default_pool("obsidian")
+  
+  # Check status
+  meta = db.get("obsidian")
+  print(meta.confidence)  # "verified"
+  print(meta.default_skill_pool)  # True
+  
+  # List all skills
+  for name, m in db.list_all():
+      print(f"{name}: {m.confidence} (uses={m.usage_count})")
+"""
+
+import json
+import os
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+
+# Confidence levels — ordered from lowest to highest
+CONFIDENCE_ORDER = ["untested", "trial", "verified", "default"]
+VALID_LEVELS = set(CONFIDENCE_ORDER)
+
+
+@dataclass
+class SkillMeta:
+    """Metadata for a single skill."""
+    confidence: str = "untested"
+    usage_count: int = 0
+    last_used: Optional[str] = None
+    default_skill_pool: bool = False
+    grade_history: list = field(default_factory=list)
+    notes: str = ""
+
+
+class SkillMetaDB:
+    """Thread-safe-ish JSON-backed metadata store for local skills."""
+
+    def __init__(self, db_path: Optional[str] = None):
+        if db_path is None:
+            # Respect HERMES_HOME like the rest of the codebase does
+            hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+            self.db_path = Path(hermes_home) / "skills" / ".skills_meta.json"
+        else:
+            self.db_path = Path(db_path)
+        self._data: dict = {}
+        self._load()
+
+    # ── Core I/O ──────────────────────────────────────────────────
+
+    def _load(self):
+        """Load metadata from JSON file. Create default if missing."""
+        if self.db_path.exists():
+            try:
+                with open(self.db_path, "r", encoding="utf-8") as f:
+                    raw = json.load(f)
+                self._data = raw.get("skills", {})
+            except (json.JSONDecodeError, KeyError):
+                self._data = {}
+        else:
+            self._data = {}
+
+    def _save(self):
+        """Write current state to JSON file atomically."""
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        # Convert all SkillMeta objects to dicts for JSON serialization
+        serializable = {}
+        for name, meta in self._data.items():
+            if isinstance(meta, SkillMeta):
+                serializable[name] = asdict(meta)
+            else:
+                serializable[name] = meta
+        payload = {
+            "_version": 1,
+            "_description": "Per-skill metadata for local skills.",
+            "skills": serializable,
+        }
+        # Atomic write via temp file
+        tmp_path = self.db_path.with_suffix(".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(str(tmp_path), str(self.db_path))
+
+    # ── Registration ──────────────────────────────────────────────
+
+    def register(self, name: str, *, reason: str = "new skill") -> SkillMeta:
+        """Register a new skill. Returns the created SkillMeta."""
+        name = self._normalize(name)
+        if name not in self._data:
+            meta = SkillMeta(confidence="untested", grade_history=[])
+            self._data[name] = meta
+            self._add_grade_history(name, None, "untested", reason, "system")
+            self._save()
+        return self._data[name]
+
+    def get(self, name: str) -> Optional[SkillMeta]:
+        """Get metadata for a skill. Returns None if not registered."""
+        name = self._normalize(name)
+        raw = self._data.get(name)
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return SkillMeta(**raw)
+        return raw
+
+    # ── Confidence grading ────────────────────────────────────────
+
+    def grade(
+        self,
+        name: str,
+        level: str,
+        *,
+        reason: str = "",
+        grader: str = "user",
+    ) -> Optional[SkillMeta]:
+        """
+        Upgrade (or downgrade) a skill's confidence level.
+        
+        level must be in: untested, trial, verified, default
+        Cannot go backwards — only upgrades allowed.
+        """
+        name = self._normalize(name)
+        if level not in VALID_LEVELS:
+            raise ValueError(f"Invalid confidence level: {level}. Must be one of {CONFIDENCE_ORDER}")
+
+        # Ensure registered
+        if name not in self._data:
+            self.register(name, reason=reason)
+
+        meta = self._data[name]
+        if isinstance(meta, dict):
+            meta = SkillMeta(**meta)
+            self._data[name] = meta
+
+        old_level = meta.confidence
+        old_idx = CONFIDENCE_ORDER.index(old_level)
+        new_idx = CONFIDENCE_ORDER.index(level)
+
+        if new_idx <= old_idx:
+            raise ValueError(
+                f"Cannot downgrade {old_level} → {level}. "
+                f"Levels are: {' → '.join(CONFIDENCE_ORDER)}"
+            )
+
+        meta.confidence = level
+        self._add_grade_history(name, old_level, level, reason, grader)
+        
+        # Auto-add to default pool when promoted to "default"
+        if level == "default":
+            meta.default_skill_pool = True
+
+        self._data[name] = meta
+        self._save()
+        return meta
+
+    # ── Usage tracking ────────────────────────────────────────────
+
+    def record_usage(self, name: str):
+        """Increment usage count and update last_used timestamp."""
+        name = self._normalize(name)
+        if name not in self._data:
+            self.register(name)
+
+        meta = self._data[name]
+        if isinstance(meta, dict):
+            meta = SkillMeta(**meta)
+            self._data[name] = meta
+
+        meta.usage_count += 1
+        meta.last_used = datetime.now(timezone.utc).isoformat()
+
+        # Auto-promote from untested → trial after 3 uses
+        if meta.confidence == "untested" and meta.usage_count >= 3:
+            meta.confidence = "trial"
+            self._add_grade_history(
+                name, "untested", "trial",
+                "Auto-promoted after 3 uses", "auto"
+            )
+
+        self._data[name] = meta
+        self._save()
+
+    # ── Default pool management ───────────────────────────────────
+
+    def add_to_default_pool(self, name: str) -> SkillMeta:
+        """Add a skill to the default preload list."""
+        name = self._normalize(name)
+        meta = self.get(name)
+        if meta is None:
+            raise KeyError(f"Skill '{name}' not registered. Run register() first.")
+
+        if isinstance(meta, dict):
+            meta = SkillMeta(**meta)
+            self._data[name] = meta
+
+        meta.default_skill_pool = True
+        if meta.confidence == "untested":
+            meta.confidence = "trial"
+            self._add_grade_history(name, "untested", "trial",
+                                    "Added to default pool", "user")
+        self._data[name] = meta
+        self._save()
+        return meta
+
+    def remove_from_default_pool(self, name: str) -> SkillMeta:
+        """Remove a skill from the default preload list."""
+        name = self._normalize(name)
+        meta = self.get(name)
+        if meta is None:
+            raise KeyError(f"Skill '{name}' not registered.")
+
+        if isinstance(meta, dict):
+            meta = SkillMeta(**meta)
+            self._data[name] = meta
+
+        meta.default_skill_pool = False
+        self._data[name] = meta
+        self._save()
+        return meta
+
+    def list_default_pool(self) -> list[str]:
+        """Return list of skill names in the default preload pool."""
+        result = []
+        for name, meta in self._data.items():
+            if isinstance(meta, dict):
+                if meta.get("default_skill_pool"):
+                    result.append(name)
+            else:
+                if meta.default_skill_pool:
+                    result.append(name)
+        return result
+
+    # ── Listing ───────────────────────────────────────────────────
+
+    def list_all(self) -> list[tuple[str, SkillMeta]]:
+        """Return all registered skills with their metadata."""
+        result = []
+        for name, raw in sorted(self._data.items()):
+            if isinstance(raw, dict):
+                result.append((name, SkillMeta(**raw)))
+            else:
+                result.append((name, raw))
+        return result
+
+    def list_by_confidence(self, level: str) -> list[tuple[str, SkillMeta]]:
+        """Filter skills by confidence level."""
+        return [
+            (n, m) for n, m in self.list_all()
+            if m.confidence == level
+        ]
+
+    def list_by_default_pool(self) -> list[tuple[str, SkillMeta]]:
+        """Return skills in the default pool."""
+        return [
+            (n, m) for n, m in self.list_all()
+            if m.default_skill_pool
+        ]
+
+    def remove(self, name: str) -> bool:
+        """Remove a skill from the database. Returns True if removed."""
+        name = self._normalize(name)
+        if name in self._data:
+            del self._data[name]
+            self._save()
+            return True
+        return False
+
+    # ── Report ────────────────────────────────────────────────────
+
+    def report(self) -> str:
+        """Generate a human-readable summary of all skills."""
+        lines = []
+        lines.append(f"Local Skill Confidence Database ({len(self._data)} skills)\n")
+        lines.append(f"{'='*60}\n")
+
+        for level in CONFIDENCE_ORDER:
+            skills = self.list_by_confidence(level)
+            if not skills:
+                continue
+            lines.append(f"\n[{level.upper()}] ({len(skills)} skill{'s' if len(skills) > 1 else ''})")
+            for name, meta in skills:
+                pool = " [DEFAULT]" if meta.default_skill_pool else ""
+                lines.append(f"  • {name} — uses={meta.usage_count}, last={meta.last_used or 'never'}{pool}")
+                if meta.notes:
+                    lines.append(f"    note: {meta.notes}")
+
+        # Default pool section
+        defaults = self.list_by_default_pool()
+        if defaults:
+            lines.append(f"\n{'='*60}")
+            lines.append(f"\n[DEFAULT POOL — auto-loaded] ({len(defaults)} skills)")
+            for name, meta in defaults:
+                lines.append(f"  ✓ {name}")
+
+        return "\n".join(lines)
+
+    # ── Internals ─────────────────────────────────────────────────
+
+    @staticmethod
+    def _normalize(name: str) -> str:
+        """Normalize skill name to lowercase, no hyphens/underscores variance."""
+        return name.strip().lower().replace("_", "-")
+
+    def _add_grade_history(
+        self,
+        name: str,
+        old_level: Optional[str],
+        new_level: str,
+        reason: str,
+        grader: str,
+    ):
+        """Append an entry to the grade history."""
+        meta = self._data.get(name)
+        if isinstance(meta, dict):
+            meta = SkillMeta(**meta)
+
+        entry = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "from": old_level or "initial",
+            "to": new_level,
+            "reason": reason,
+            "grader": grader,
+        }
+        if meta is not None:
+            if isinstance(meta, SkillMeta):
+                meta.grade_history.append(entry)
+                self._data[name] = meta
+            else:
+                meta["grade_history"].append(entry)
+                self._data[name] = meta
+
+
+def get_default_pool_names() -> list[str]:
+    """Convenience: get all skills that should be auto-loaded."""
+    db = SkillMetaDB()
+    return db.list_default_pool()

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5920,6 +5920,18 @@ def _parse_tui_skills_env() -> list[str]:
         if item and item not in seen:
             seen.add(item)
             skills.append(item)
+
+    # Merge skills in the default confidence pool (auto-loaded)
+    try:
+        from tools.skill_meta import SkillMetaDB
+        meta_db = SkillMetaDB()
+        for name in meta_db.list_default_pool():
+            if name not in seen:
+                skills.append(name)
+                seen.add(name)
+    except Exception:
+        pass  # Non-critical — default pool is optional
+
     return skills
 
 


### PR DESCRIPTION
## Summary

Add a local skill confidence metadata system for managing skill quality, usage tracking, and automatic default-pool loading.

## Changes

### `tools/skill_meta.py` (new)
- SQLite-backed per-skill metadata stored in `~/.hermes/skills/.skills_meta.json`
- Confidence levels: `new`, `untested`, `stable`, `reliable`, `essential`
- Grade history tracking with timestamps, from/to levels, and reasons
- Default skill pool — skills marked as default are auto-loaded in every session

### `hermes_cli/main.py`
- `hermes skills grade` CLI subcommand with:
  - `list` — show all skills, optional `--by-confidence` filter
  - `set` — upgrade/downgrade a skill's confidence level
  - `report` — full confidence report with history
  - `pool add|remove` — manage default auto-loaded pool

### `hermes_cli/subcommands/skills.py`
- Argparse parser for the `grade` subcommand with all sub-actions

### `tui_gateway/server.py`
- `_parse_tui_skills_env()` now merges the default confidence pool into the skill list, so default skills auto-load in TUI sessions without manual configuration

### `tests/tools/test_skill_meta.py` (new)
- Unit tests for SkillMetaDB: CRUD, grade history, default pool management

## Design Rationale

- **Local-first**: Metadata lives in `~/.hermes/skills/.skills_meta.json` — no remote dependency, works offline
- **Non-breaking**: Existing skills continue to work; confidence is additive metadata
- **Zero-config default pool**: Skills promoted to the default pool are auto-discovered at import time via the skill scanner, eliminating manual `skills.default_pool` config
- **Guarded import**: The TUI gateway wraps the default pool merge in try/except so it doesn't break if skill_meta hasn't been initialized yet