### PR TITLE
fix(bluebubbles): use UTC epoch for tempGuid instead of naive local time

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -15,7 +15,7 @@ import os
 import re
 import uuid
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -510,7 +510,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -566,7 +566,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -1,6 +1,7 @@
 """Tests for the BlueBubbles iMessage gateway adapter."""
 import asyncio
 import json
+import time
 
 import pytest
 
@@ -436,5 +437,59 @@ class TestBlueBubblesWebhookRegistration:
         )
         assert ok is True
         assert len(deleted_ids) == 2
+
+
+class TestBlueBubblesTempGuid:
+    """tempGuid must embed a UTC epoch (issue #79511).
+
+    ``datetime.utcnow()`` returns a NAIVE datetime, and ``.timestamp()`` on a
+    naive datetime interprets it as LOCAL time — so the old code produced an
+    epoch shifted by the machine's UTC offset (hours, not seconds). Both
+    outbound payload builders must use ``datetime.now(timezone.utc)`` instead.
+    """
+
+    @staticmethod
+    def _epoch_from_temp_guid(temp_guid):
+        # Format: "temp-<epoch>"
+        return float(temp_guid.split("-", 1)[1])
+
+    @staticmethod
+    def _assert_utc_epoch(temp_guid):
+        assert temp_guid.startswith("temp-")
+        # Tight tolerance (seconds) — a local-offset bug would drift by the
+        # TZ offset (hours), far beyond this window.
+        assert abs(TestBlueBubblesTempGuid._epoch_from_temp_guid(temp_guid) - time.time()) < 5
+
+    @pytest.mark.asyncio
+    async def test_create_chat_temp_guid_is_utc_epoch(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_api_post(path, payload):
+            captured["payload"] = payload
+            return {"data": {"guid": "msg-1"}}
+
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter._create_chat_for_handle("+155****0100", "hello")
+        assert result.success is True
+        self._assert_utc_epoch(captured["payload"]["tempGuid"])
+
+    @pytest.mark.asyncio
+    async def test_send_temp_guid_is_utc_epoch(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_resolve(chat_id):
+            return "iMessage;+;chat-guid"
+
+        async def fake_api_post(path, payload):
+            captured["payload"] = payload
+            return {"data": {"guid": "msg-1"}}
+
+        monkeypatch.setattr(adapter, "_resolve_chat_guid", fake_resolve)
+        monkeypatch.setattr(adapter, "_api_post", fake_api_post)
+        result = await adapter.send("+155****0100", "hello")
+        assert result.success is True
+        self._assert_utc_epoch(captured["payload"]["tempGuid"])
 
 


### PR DESCRIPTION
## Summary
`gateway/platforms/bluebubbles.py` built temporary message GUIDs with `datetime.utcnow().timestamp()`. `utcnow()` returns a **naive** datetime, and calling `.timestamp()` on a naive datetime interprets it as **local** time, not UTC — so the embedded epoch was offset by the machine's UTC offset (e.g. −8h on UTC+8, −3h on UTC−3).

## Root Cause
Two call sites (line ~513 `_create_chat_for_handle` and line ~569 chunked send path) used `datetime.utcnow().timestamp()`, producing a `temp-<epoch>` GUID whose timestamp is wrong by the local UTC offset.

## Change
- `gateway/platforms/bluebubbles.py`: both call sites now use `datetime.now(timezone.utc).timestamp()` (correct UTC epoch); `timezone` added to the `datetime` import.
- `tests/gateway/test_bluebubbles.py`: new `TestBlueBubblesTempGuid` class asserting both outbound payloads embed a UTC epoch within a 5s tolerance of `time.time()` (a local-offset bug drifts by hours, far beyond the window).

## Verification
- `tests/gateway/test_bluebubbles.py`: **20 passed** (18 pre-existing + 2 new).

Closes #79511