### PR TITLE
fix(session): persist provider on model switch and use it on resume

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1901,7 +1901,9 @@ class GatewaySlashCommandsMixin:
                                     event.source
                                 )
                                 await _sess_db.update_session_model(
-                                    _sess_entry.session_id, result.new_model
+                                    _sess_entry.session_id,
+                                    result.new_model,
+                                    provider=result.target_provider,
                                 )
                             except Exception as exc:
                                 logger.debug(
@@ -2211,7 +2213,9 @@ class GatewaySlashCommandsMixin:
                     if getattr(_sess_entry, "was_auto_reset", False):
                         _sess_entry.was_auto_reset = False
                     await _sess_db.update_session_model(
-                        _sess_entry.session_id, result.new_model
+                        _sess_entry.session_id,
+                        result.new_model,
+                        provider=result.target_provider,
                     )
                 except Exception as exc:
                     logger.debug(

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4312,7 +4312,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
-    def update_session_model(self, session_id: str, model: str) -> None:
+    def update_session_model(
+        self, session_id: str, model: str, provider: Optional[str] = None
+    ) -> None:
         """Update the model for a session after a mid-session switch.
 
         Unlike ``update_token_counts`` which uses ``COALESCE(model, ?)``
@@ -4322,6 +4324,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         footer metadata is rebuilt on the next turn. A successful /model
         switch explicitly replaces any confirmed Browser runtime lock while
         preserving unrelated lineage markers in ``model_config``.
+
+        When the caller knows the resolved provider (the /model handlers
+        do), it is merged into ``model_config`` alongside the model
+        (``$.model`` / ``$.provider``) so a later resume recombines the
+        persisted model with the provider that actually serves it instead of
+        the config.yaml primary provider (#79536). Callers without provider
+        knowledge leave any stored provider untouched.
         """
         # This write bypasses the token queue, so deltas enqueued before the
         # switch must land first: a still-queued first delta carries the
@@ -4332,20 +4341,43 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self.flush_token_counts()
 
         def _do(conn):
-            conn.execute(
-                """UPDATE sessions SET
-                   model = ?,
-                   model_config = CASE
-                       WHEN model_config IS NULL THEN NULL
-                       WHEN json_valid(model_config)
-                           THEN json_remove(model_config, '$.browser_model_lock')
-                       ELSE model_config
-                   END,
-                   system_prompt = NULL,
-                   system_prompt_hash = NULL
-                   WHERE id = ?""",
-                (model, session_id),
-            )
+            if provider:
+                conn.execute(
+                    """UPDATE sessions SET
+                      model = ?,
+                      model_config = CASE
+                          WHEN model_config IS NULL THEN NULL
+                          WHEN json_valid(model_config)
+                              THEN json_set(
+                                  json_remove(model_config, '$.browser_model_lock'),
+                                  '$.model', ?,
+                                  '$.provider', ?
+                              )
+                          ELSE model_config
+                      END,
+                      system_prompt = NULL,
+                      system_prompt_hash = NULL
+                      WHERE id = ?""",
+                    (model, model, provider, session_id),
+                )
+            else:
+                conn.execute(
+                    """UPDATE sessions SET
+                      model = ?,
+                      model_config = CASE
+                          WHEN model_config IS NULL THEN NULL
+                          WHEN json_valid(model_config)
+                              THEN json_set(
+                                  json_remove(model_config, '$.browser_model_lock'),
+                                  '$.model', ?
+                              )
+                          ELSE model_config
+                      END,
+                      system_prompt = NULL,
+                      system_prompt_hash = NULL
+                      WHERE id = ?""",
+                    (model, model, session_id),
+                )
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4346,7 +4346,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     """UPDATE sessions SET
                       model = ?,
                       model_config = CASE
-                          WHEN model_config IS NULL THEN NULL
+                          WHEN model_config IS NULL THEN json_object('model', ?, 'provider', ?)
                           WHEN json_valid(model_config)
                               THEN json_set(
                                   json_remove(model_config, '$.browser_model_lock'),
@@ -4358,14 +4358,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       system_prompt = NULL,
                       system_prompt_hash = NULL
                       WHERE id = ?""",
-                    (model, model, provider, session_id),
+                    (model, model, provider, model, provider, session_id),
                 )
             else:
                 conn.execute(
                     """UPDATE sessions SET
                       model = ?,
                       model_config = CASE
-                          WHEN model_config IS NULL THEN NULL
+                          WHEN model_config IS NULL THEN json_object('model', ?)
                           WHEN json_valid(model_config)
                               THEN json_set(
                                   json_remove(model_config, '$.browser_model_lock'),
@@ -4376,7 +4376,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                       system_prompt = NULL,
                       system_prompt_hash = NULL
                       WHERE id = ?""",
-                    (model, model, session_id),
+                    (model, model, model, session_id),
                 )
             self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -316,6 +316,54 @@ class TestSessionLifecycle:
         assert "browser_model_lock" not in model_config
         assert model_config["_branched_from"] == "parent-session"
 
+    def test_update_session_model_persists_provider_in_model_config(self, db):
+        """A /model switch must persist the resolved provider alongside the model
+        so resume recombines the model with the provider that serves it, not the
+        config.yaml primary (#79536)."""
+        db.create_session(
+            session_id="s1",
+            source="hermes_browser",
+            model="x-ai/grok-4.5",
+            model_config={
+                "_branched_from": "parent-session",
+                "browser_model_lock": {
+                    "provider": "nous",
+                    "model": "x-ai/grok-4.5",
+                    "confirmed": True,
+                },
+            },
+        )
+
+        db.update_session_model(
+            "s1", "deepseek/deepseek-r1", provider="deepseek"
+        )
+
+        session = db.get_session("s1")
+        model_config = json.loads(session["model_config"])
+        assert session["model"] == "deepseek/deepseek-r1"
+        assert model_config["model"] == "deepseek/deepseek-r1"
+        assert model_config["provider"] == "deepseek"
+        assert "browser_model_lock" not in model_config
+        assert model_config["_branched_from"] == "parent-session"
+
+    def test_update_session_model_without_provider_leaves_provider_unset(self, db):
+        """Callers that do not know the provider (legacy fallback paths) must not
+        introduce a bare/empty provider into model_config."""
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            model="m1",
+            model_config={"_branched_from": "parent-session"},
+        )
+
+        db.update_session_model("s1", "m2")
+
+        session = db.get_session("s1")
+        model_config = json.loads(session["model_config"])
+        assert session["model"] == "m2"
+        assert "provider" not in model_config
+        assert model_config["_branched_from"] == "parent-session"
+
 
 
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3023,6 +3023,45 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     assert ov["model_override"]["provider"] == "custom:myendpoint"
 
 
+def test_stored_session_runtime_overrides_restores_persisted_provider():
+    """Resume must restore the provider persisted by a /model switch
+    (model_config.provider), and fall back to the last turn's
+    gateway_runtime.provider for legacy rows that only carry that (#79536).
+    """
+    # Top-level provider written by update_session_model is restored.
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "deepseek/deepseek-r1",
+            "model_config": {"provider": "deepseek"},
+        }
+    )
+    assert ov["provider_override"] == "deepseek"
+    assert ov["model_override"]["provider"] == "deepseek"
+
+    # Legacy row: only gateway_runtime.provider is present — still restored.
+    ov = server._stored_session_runtime_overrides(
+        {
+            "model": "deepseek/deepseek-r1",
+            "model_config": {
+                "gateway_runtime": {
+                    "provider": "deepseek",
+                    "base_url": "https://api.deepseek.com/v1",
+                }
+            },
+        }
+    )
+    assert ov["provider_override"] == "deepseek"
+    assert ov["model_override"]["provider"] == "deepseek"
+
+    # Neither present: provider stays unset so resume falls back to the
+    # configured default rather than guessing.
+    ov = server._stored_session_runtime_overrides(
+        {"model": "deepseek/deepseek-r1", "model_config": {}}
+    )
+    assert "provider_override" not in ov
+    assert ov["model_override"]["provider"] is None
+
+
 def test_stored_session_runtime_overrides_restores_explicit_normal_tier():
     overrides = server._stored_session_runtime_overrides(
         {

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3621,6 +3621,16 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
     # Only restore an explicit provider; otherwise leave it unset so resume falls back to
     # the configured default, matching the working CLI path.
     explicit_provider = str(model_config.get("provider") or "").strip()
+    if not explicit_provider:
+        # Legacy rows predating provider persistence in update_session_model:
+        # the last turn's resolved route is captured under ``gateway_runtime``
+        # (see gateway/run.py _sync_session_model_from_agent) but older builds
+        # never wrote a top-level ``provider``. Restore it so resume does not
+        # recombine the persisted model with the config.yaml primary provider
+        # that does not serve it (#79536).
+        gateway_runtime = model_config.get("gateway_runtime")
+        if isinstance(gateway_runtime, dict):
+            explicit_provider = str(gateway_runtime.get("provider") or "").strip()
     billing_provider = str(
         model_config.get("billing_provider") or row.get("billing_provider") or ""
     ).strip()


### PR DESCRIPTION
## Summary
When a session falls back from the primary model to a fallback on a **different provider**, and the user then switches to that fallback model with `/model`, the session persisted only the model **name** in `state.db` — never its **provider**. On resume, the runtime recombined the persisted model with the primary provider from `config.yaml` (which doesn't serve that model), producing a guaranteed 404 on every turn.

## Root Cause
`update_session_model()` (in `hermes_state.py`) wrote the model name to the `sessions.model` column but never wrote `model`/`provider` keys into the `model_config` JSON blob — the provider/model pair was lost across restarts.

## Change
- **Write side (Option A):** `update_session_model(session_id, model, provider=None)` now merges `{"model": ..., "provider": ...}` into the `model_config` JSON when a provider is passed (`json_set`/`json_remove` SQL preserving lineage markers and the `browser_model_lock` behavior). Both `/model` call sites in `gateway/slash_commands.py` pass the resolved `target_provider`.
- **Read side (Option B, defensive):** in `tui_gateway/server.py::_stored_session_runtime_overrides`, when `model_config` has no top-level `provider`, fall back to `model_config.gateway_runtime.provider` (written by `_sync_session_model_from_agent` on the last turn) instead of the `config.yaml` primary provider. Precedence: top-level → `gateway_runtime` → `billing_provider` → default.

## Verification
- `tests/test_hermes_state.py` + `tests/test_tui_gateway_server.py`: **698 passed** (pre-existing + new coverage for provider persistence and defensive resume).

Closes #79536