### PR TITLE
fix(search): zero-match steering probe works on the grep fallback

### DIFF
--- a/tests/tools/test_search_zero_match_and_multipath.py
+++ b/tests/tools/test_search_zero_match_and_multipath.py
@@ -45,7 +45,10 @@ class TestZeroMatchProbe:
         (d / ".secretdir" / "conf.cfg").write_text("HIDDEN_ONLY_TOKEN = true\n")
         r = json.loads(search_tool("HIDDEN_ONLY_TOKEN", path=str(d), task_id="t-zm"))
         assert r["total_count"] == 0
-        assert "hidden or gitignored" in r.get("warning", "")
+        # "hidden" (not the full rg-only "hidden or gitignored" wording) so
+        # the assertion holds on both engines: rg names gitignored files,
+        # the grep fallback has no .gitignore awareness and only names hidden.
+        assert "hidden" in r.get("warning", "")
 
     def test_matching_search_unaffected(self, proj):
         r = json.loads(search_tool("TOKEN_ALPHA", path=str(proj / "proj"), task_id="t-zm"))
@@ -106,11 +109,11 @@ class TestZeroMatchProbeEngineParity:
     Fixed in 794d6c434e; these tests pin the wiring per engine so a future
     early return can't silently orphan it again.
 
-    The probe itself shells out to rg (by design: bounded, count-only), so a
-    grep-only host gets no hints even with correct wiring. The probe is
+    The probe shells out to the host's search engine (rg when installed,
+    grep otherwise), so the hint text differs per engine. The probe is
     therefore stubbed to a sentinel here — this isolates the *wiring* rather
-    than the probe's own dependency, and a naive parity test asserting real
-    hint text would fail on the grep leg for an unrelated reason.
+    than the probe's own engine dependency, and a naive parity test asserting
+    real hint text would fail on the grep leg for an unrelated reason.
     """
 
     @pytest.mark.parametrize("engine", ["rg", "grep"])
@@ -159,3 +162,64 @@ class TestZeroMatchProbeEngineParity:
             pytest.skip("rg not installed")
         r = ops.search("TOKEN_ALPHA\\nother", path=str(proj / "proj"), target="content")
         assert "line-oriented" not in (r.warning or "")
+
+
+class TestZeroMatchProbeGrepFallback:
+    """The real zero-match probe must fire on the grep fallback too.
+
+    Issue #79512: _zero_match_probe returned None immediately when rg was
+    missing, so grep-only hosts silently lost the case-insensitive / literal /
+    hidden-only hints. These tests pin the real probe (not a stub) against
+    the grep engine by faking rg's absence via _has_command.
+    """
+
+    @pytest.fixture
+    def grep_ops(self, proj, monkeypatch):
+        from tools.file_tools import _get_file_ops
+
+        ops = _get_file_ops(task_id="t-grep-probe")
+        real = ops._has_command
+        if not real("grep"):
+            pytest.skip("grep not installed")
+
+        def no_rg(cmd, _real=real):
+            # Forces the grep engine for content search AND the probe;
+            # other capability lookups pass through.
+            if cmd == "rg":
+                return False
+            return _real(cmd)
+
+        monkeypatch.setattr(ops, "_has_command", no_rg)
+        return ops
+
+    def test_case_mismatch_hint_without_rg(self, proj, grep_ops):
+        r = grep_ops.search("token_alpha", path=str(proj / "proj"), target="content")
+        assert r.total_count == 0
+        assert "case-insensitive" in (r.warning or "")
+
+    def test_literal_hint_without_rg(self, proj, grep_ops):
+        d = proj / "proj"
+        (d / "meta.py").write_text("result = lookup[key+1]\n")
+        r = grep_ops.search("lookup[key+1]", path=str(d), target="content")
+        assert r.total_count == 0
+        assert "literal match" in (r.warning or "")
+
+    def test_hidden_only_hint_without_rg(self, proj, grep_ops):
+        d = proj / "proj"
+        (d / ".secretdir").mkdir()
+        (d / ".secretdir" / "conf.cfg").write_text("HIDDEN_ONLY_TOKEN = true\n")
+        r = grep_ops.search("HIDDEN_ONLY_TOKEN", path=str(d), target="content")
+        assert r.total_count == 0
+        assert "hidden" in (r.warning or "")
+
+    def test_true_zero_match_no_hint_without_rg(self, proj, grep_ops):
+        r = grep_ops.search(
+            "zzz_totally_absent_zzz", path=str(proj / "proj"), target="content"
+        )
+        assert r.total_count == 0
+        assert not r.warning
+
+    def test_matching_search_unaffected_without_rg(self, proj, grep_ops):
+        r = grep_ops.search("TOKEN_ALPHA", path=str(proj / "proj"), target="content")
+        assert r.total_count >= 2
+        assert not r.warning

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2303,11 +2303,17 @@ class ShellFileOperations(FileOperations):
         13.9% of production content searches return zero matches and give
         the model nothing to steer by. Run ONE cheap case-insensitive count
         probe; if it hits, say so. If the pattern contains regex
-        metacharacters, also probe it as a fixed string. Bounded: two rg
-        invocations max, count-only output.
+        metacharacters, also probe it as a fixed string. Bounded: two
+        invocations max, count-only output. Works on BOTH engines: rg when
+        installed, otherwise the grep fallback (issue #79512).
         """
-        if not self._has_command('rg'):
-            return None
+        if self._has_command('rg'):
+            return self._zero_match_probe_rg(pattern, path, file_glob)
+        return self._zero_match_probe_grep(pattern, path, file_glob)
+
+    def _zero_match_probe_rg(self, pattern: str, path: str,
+                             file_glob: Optional[str]) -> Optional[str]:
+        """rg-backed zero-match probe (preferred engine)."""
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
@@ -2362,6 +2368,86 @@ class ShellFileOperations(FileOperations):
                 for line in (fixed.stdout or "").strip().splitlines()
                 if line.rpartition(":")[2].isdigit()
             )
+            if f_total > 0:
+                return (
+                    f"0 regex matches, but {f_total} literal match(es) — the "
+                    "pattern contains regex metacharacters that likely need "
+                    "escaping (or pass a simpler substring)."
+                )
+        return None
+
+    def _zero_match_probe_grep(self, pattern: str, path: str,
+                               file_glob: Optional[str]) -> Optional[str]:
+        """grep-backed zero-match probe for hosts without ripgrep.
+
+        The grep fallback excludes hidden directories (``--exclude-dir='.*'``)
+        and has no .gitignore awareness, so the probe variants map as:
+
+          - case-insensitive -> ``grep -i``
+          - literal -> ``grep -F`` (only when the pattern has regex metachars)
+          - hidden-only -> re-run without ``--exclude-dir`` (gitignored
+            files are already visible to plain grep, so only the hidden
+            axis applies)
+
+        Count-only (-c) output keeps it bounded, mirroring the rg probe.
+        """
+        if not self._has_command('grep'):
+            return None
+        include_expr = (
+            f" --include {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        )
+        # Mirrors the --exclude-dir='.*' used by the main grep fallback search.
+        hidden_excl = "--exclude-dir='.*'"
+
+        def _grep_counts(result) -> tuple:
+            total = 0
+            files = 0
+            for line in (result.stdout or "").strip().splitlines():
+                _p, _sep, n = line.rpartition(":")
+                if n.isdigit():
+                    total += int(n)
+                    files += 1
+            return total, files
+
+        ci = self._exec(
+            f"grep -r -i -c -H {hidden_excl}{include_expr} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"2>/dev/null | head -50",
+            timeout=30,
+        )
+        ci_total, ci_files = _grep_counts(ci)
+        if ci_total > 0:
+            return (
+                f"0 exact matches, but {ci_total} case-insensitive match(es) "
+                f"in {ci_files} file(s) — the pattern's casing may be wrong."
+            )
+        # Hidden probe: matches that live only in dot-directories are skipped
+        # by the default search; surface them instead of a bare zero.
+        hidden = self._exec(
+            f"grep -r -c -H {include_expr} "
+            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"2>/dev/null | head -50",
+            timeout=30,
+        )
+        h_total, h_files = _grep_counts(hidden)
+        if h_total > 0:
+            return (
+                f"0 matches in visible files, but {h_total} match(es) in "
+                f"{h_files} hidden file(s) — hidden files are excluded by "
+                "default. Search the hidden path explicitly to include them."
+            )
+        if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
+            fixed = self._exec(
+                f"grep -r -F -c -H {hidden_excl}{include_expr} "
+                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"2>/dev/null | head -50",
+                timeout=30,
+            )
+            f_total = 0
+            for line in (fixed.stdout or "").strip().splitlines():
+                _p, _sep, n = line.rpartition(":")
+                if n.isdigit():
+                    f_total += int(n)
             if f_total > 0:
                 return (
                     f"0 regex matches, but {f_total} literal match(es) — the "


### PR DESCRIPTION
## Summary
The `search_files` zero-match steering probe was a silent no-op on hosts without `ripgrep` installed. `_zero_match_probe` in `tools/file_operations.py` returned `None` immediately when `rg` was absent (`if not self._has_command('rg'): return None`), so all three zero-match hints ("case-insensitive matches — casing may be wrong" / "literal matches — metacharacters need escaping" / "match only in hidden or gitignored files") were lost even though the grep fallback search itself worked.

## Root Cause
The probe feature added in `5797b5028` was implemented only for the `rg` engine path; the grep fallback path bailed out before running any probe variants.

## Change
- `tools/file_operations.py`: `_zero_match_probe` is now a dispatcher — `rg` → `_zero_match_probe_rg` (original body, byte-identical, no regression), otherwise → new `_zero_match_probe_grep` that mirrors the three probe variants using the existing grep-fallback helpers (count-only output, `head -50`, `2>/dev/null`, 30s timeout):
  - case-insensitive: `grep -r -i -c -H --exclude-dir='.*' [--include glob] …` → "case-insensitive match(es) … casing may be wrong"
  - hidden-only: re-run without `--exclude-dir` → "N match(es) in N hidden file(s) — hidden files are excluded by default"
  - literal: `grep -r -F -c -H` (only when the pattern has metacharacters) → "literal match(es) … need escaping"
- `tests/tools/test_search_zero_match_and_multipath.py`: new coverage for the no-`rg` path (via `_has_command` patch) plus the existing `rg` path.

## Verification
- `tests/tools/test_search_zero_match_and_multipath.py`: **20 passed**.

Closes #79512