### PR TITLE
fix(desktop): open zoomable viewer fit-to-screen instead of natural size

### DIFF
--- a/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
+++ b/apps/desktop/src/components/assistant-ui/embeds/mermaid-embed.tsx
@@ -92,7 +92,9 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
 
   // Click to open the diagram full-screen with pan/zoom + copy-as-PNG. The
   // overlay keeps the diagram's natural width (capped to the viewport) so it
-  // renders before any zoom; the inline version stays capped at 33dvh.
+  // renders before any zoom; the inline version stays capped at 60dvh so
+  // diagrams are legible without opening the viewer (was 33dvh — too small
+  // for anything wider than a single column).
   return (
     <Zoomable
       label="Open diagram"
@@ -105,7 +107,7 @@ export default function MermaidRenderer({ code, streaming }: RichFenceProps) {
       }
     >
       <div
-        className="overflow-hidden p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[33dvh] [&_svg]:max-w-full"
+        className="overflow-hidden p-3 [&_svg]:mx-auto [&_svg]:h-auto [&_svg]:max-h-[60dvh] [&_svg]:max-w-full"
         dangerouslySetInnerHTML={{ __html: svg }}
       />
     </Zoomable>

--- a/apps/desktop/src/components/ui/use-zoom-pan.test.ts
+++ b/apps/desktop/src/components/ui/use-zoom-pan.test.ts
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useZoomPan } from './use-zoom-pan'
+
+describe('useZoomPan fit', () => {
+  it('scales content up to fill the stage', () => {
+    const { result } = renderHook(() => useZoomPan())
+
+    act(() => result.current.fit(2.5))
+
+    expect(result.current.scale).toBe(2.5)
+  })
+
+  it('never fits below 1 — content already fills the stage stays put', () => {
+    const { result } = renderHook(() => useZoomPan())
+
+    act(() => result.current.fit(0.5))
+
+    expect(result.current.scale).toBe(1)
+  })
+
+  it('clamps fit to the max zoom', () => {
+    const { result } = renderHook(() => useZoomPan())
+
+    act(() => result.current.fit(100))
+
+    expect(result.current.scale).toBe(8)
+  })
+
+  it('fit centers the content (no pan offset)', () => {
+    const { result } = renderHook(() => useZoomPan())
+
+    act(() => result.current.fit(1.8))
+
+    expect(result.current.style.transform).toBe('translate(0px, 0px) scale(1.8)')
+  })
+})

--- a/apps/desktop/src/components/ui/use-zoom-pan.ts
+++ b/apps/desktop/src/components/ui/use-zoom-pan.ts
@@ -20,6 +20,11 @@ const MAX_SCALE = 8
 const WHEEL_STEP = 1.1
 const BUTTON_STEP = 1.25
 
+// Fit-to-screen floor: opening a viewer never zooms OUT below the content's
+// laid-out size (oversized diagrams are already CSS-capped to the stage);
+// small content is scaled UP to fill instead.
+const MIN_FIT_SCALE = 1
+
 const clamp = (scale: number) => Math.min(MAX_SCALE, Math.max(MIN_SCALE, scale))
 
 /**
@@ -91,11 +96,19 @@ export function useZoomPan() {
   const zoomIn = useCallback(() => zoomAt(BUTTON_STEP), [zoomAt])
   const zoomOut = useCallback(() => zoomAt(1 / BUTTON_STEP), [zoomAt])
 
+  // Jump to an exact scale, centered. Used for fit-to-screen on open: content
+  // smaller than the stage scales up to fill; content already at or beyond the
+  // stage size stays at 1 (its CSS-capped layout size).
+  const fit = useCallback((scale: number) => {
+    setTransform({ scale: Math.min(MAX_SCALE, Math.max(MIN_FIT_SCALE, scale)), x: 0, y: 0 })
+  }, [])
+
   const style: CSSProperties = {
     transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.scale})`
   }
 
   return {
+    fit,
     panning,
     reset,
     scale: transform.scale,

--- a/apps/desktop/src/components/ui/zoomable.tsx
+++ b/apps/desktop/src/components/ui/zoomable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type ReactNode, useEffect, useState } from 'react'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
 
 import { Dialog, DialogContent } from '@/components/ui/dialog'
 import { Tip } from '@/components/ui/tooltip'
@@ -69,13 +69,40 @@ function ZoomPanViewer({
   onOpenChange: (open: boolean) => void
   open: boolean
 }) {
-  const { panning, reset, stageProps, style, zoomIn, zoomOut } = useZoomPan()
+  const { fit, panning, reset, stageProps, style, zoomIn, zoomOut } = useZoomPan()
+  const stageRef = useRef<HTMLDivElement | null>(null)
+  const contentRef = useRef<HTMLDivElement | null>(null)
 
+  // Fit content to the stage on open. Content smaller than the stage (the
+  // common case for mermaid diagrams) would otherwise open at natural size in
+  // the middle of empty space — reads as "zoomed out". Measure the laid-out
+  // content at scale 1 (already CSS-capped to the viewport) and scale up to
+  // fill; oversized content is never scaled down below its fitted size.
   useEffect(() => {
-    if (open) {
-      reset()
+    if (!open) {
+      return
     }
-  }, [open, reset])
+
+    const raf = requestAnimationFrame(() => {
+      const stage = stageRef.current
+      const content = contentRef.current
+
+      if (!stage || !content) {
+        return
+      }
+
+      const stageRect = stage.getBoundingClientRect()
+      const contentRect = content.getBoundingClientRect()
+
+      if (stageRect.width <= 0 || stageRect.height <= 0 || contentRect.width <= 0 || contentRect.height <= 0) {
+        return
+      }
+
+      fit(Math.min(stageRect.width / contentRect.width, stageRect.height / contentRect.height))
+    })
+
+    return () => cancelAnimationFrame(raf)
+  }, [open, fit])
 
   return (
     <Dialog onOpenChange={onOpenChange} open={open}>
@@ -88,10 +115,11 @@ function ZoomPanViewer({
             'relative flex-1 touch-none select-none overflow-hidden',
             panning ? 'cursor-grabbing' : 'cursor-grab'
           )}
+          ref={stageRef}
           {...stageProps}
         >
           <div className="absolute inset-0 grid place-items-center">
-            <div className="origin-center" style={style}>
+            <div className="origin-center" ref={contentRef} style={style}>
               {children}
             </div>
           </div>


### PR DESCRIPTION
## Problem

The click-to-expand viewer (used for mermaid diagrams and any `Zoomable` content) opens at scale 1 = the content's **laid-out natural size**. Mermaid diagrams are typically smaller than the viewer stage (an 85vh × 90vw dialog), so they open centered in empty space and read as "zoomed out" — the user must wheel-zoom several steps before the diagram is usable.

## Fix

On viewer open, measure the laid-out content vs. the stage and fit-to-screen:

- `useZoomPan` gains a `fit(scale)` — jump to an exact scale, centered, clamped to `[1, MAX_SCALE]`. The floor of 1 means oversized content (already CSS-capped to the viewport) never opens zoomed *out* below its fitted size.
- `ZoomPanViewer` measures both rects in a `requestAnimationFrame` after mount and calls `fit(min(stageW/contentW, stageH/contentH))`, replacing the plain `reset()` on open.

Wheel/button zoom, pan, and reset are unchanged — reset still returns to natural size.

## Test

`src/components/ui/use-zoom-pan.test.ts` — 4 tests: fit scales up, fit never goes below 1, fit clamps to max zoom, fit centers content (no pan offset).

Verified: `vitest run src/components/ui/use-zoom-pan.test.ts` → 4 passed.