### PR TITLE
fix(gateway): platform_message_id 数据库级去重，终止 Telegram 重试循环会话膨胀

### DIFF
--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import logging
+import sqlite3
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -283,12 +284,86 @@ class SessionMessagesMixin:
         def _do(conn):
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
+            # DB-level dedupe guard (#79576): a platform_message_id maps to
+            # exactly ONE transcript row per session. When a row already
+            # exists, skip the insert and return the existing row id instead
+            # of stacking a duplicate user turn. The gateway's #47237 check
+            # (has_platform_message_id) runs outside this transaction, so it
+            # can race with a sibling writer (gateway + agent processes, or
+            # two retries of the same Telegram update); this in-transaction
+            # check is atomic under BEGIN IMMEDIATE and also covers paths
+            # that never consulted the guard (crash-resilience persist,
+            # shutdown flush). Rows without a platform_message_id are never
+            # deduped. Only live (active = 1) and compaction-archived
+            # (compacted = 1) rows shadow a re-insert: rewound/undo rows
+            # (active = 0, compacted = 0 — the user took the turn back) do
+            # not, so a platform redelivery of a rewound turn re-inserts
+            # instead of being silently swallowed.
+            if platform_message_id is not None:
+                _existing = conn.execute(
+                    "SELECT id FROM messages "
+                    "WHERE session_id = ? AND platform_message_id = ? "
+                    "AND (active = 1 OR compacted = 1) LIMIT 1",
+                    (session_id, platform_message_id),
+                ).fetchone()
+                if _existing is not None:
+                    return _existing[0]
             msg_id = conn.execute(_INSERT_MESSAGE_SQL, params).lastrowid
             self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
             return msg_id
         # THE critical write (failure aborts the turn): long patience so a sibling legitimately
         # holding the lock for seconds (VACUUM, checkpoint) can't kill it.
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    @staticmethod
+    def _dedupe_batch_by_platform_message_id(
+        conn: sqlite3.Connection, session_id: str, messages: List[Dict[str, Any]]
+    ) -> List[Dict[str, Any]]:
+        """Drop rows whose platform_message_id already exists for the session.
+
+        Enforces the one-platform_message_id-per-session invariant for the
+        batch write path (issue #79576). Rows without a platform_message_id
+        (or ``message_id`` alias) pass through untouched. Within-batch
+        duplicates keep only the first occurrence. Runs inside the caller's
+        write transaction, so the existence check and the inserts commit
+        atomically — closing the check-then-insert race that the gateway's
+        #47237 guard has when a sibling writer (gateway + agent processes)
+        persists the same inbound turn concurrently.
+
+        Only live (``active = 1``) and compaction-archived (``compacted = 1``)
+        rows shadow a re-insert. Rewound/undo rows (``active = 0``,
+        ``compacted = 0`` — the user took the turn back) do not, so a
+        platform redelivery of a rewound turn re-inserts under the same id
+        instead of being silently dropped. Same visibility contract as
+        ``append_message``'s in-transaction check and search's
+        ``(active = 1 OR compacted = 1)`` discoverability rule.
+        """
+        filtered: List[Dict[str, Any]] = []
+        seen_in_batch: set = set()
+        existing: Optional[set] = None
+        for msg in messages:
+            platform_msg_id = msg.get("platform_message_id") or msg.get("message_id")
+            if platform_msg_id is None:
+                filtered.append(msg)
+                continue
+            if platform_msg_id in seen_in_batch:
+                continue
+            if existing is None:
+                existing = {
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT platform_message_id FROM messages "
+                        "WHERE session_id = ? AND platform_message_id IS NOT NULL "
+                        "AND (active = 1 OR compacted = 1)",
+                        (session_id,),
+                    ).fetchall()
+                }
+            if platform_msg_id in existing:
+                continue
+            existing.add(platform_msg_id)
+            seen_in_batch.add(platform_msg_id)
+            filtered.append(msg)
+        return filtered
 
     def append_messages_batch(
         self, session_id: str, messages: List[Dict[str, Any]], compression_lock_holder: Optional[str] = None,
@@ -306,8 +381,22 @@ class SessionMessagesMixin:
         def _do(conn):
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
+            # DB-level dedupe guard (#79576): same invariant as
+            # append_message — one platform_message_id per session. The
+            # turn-boundary flush and the gateway's crash-resilience persist
+            # can both try to write the same inbound user turn, and the
+            # pre-write has_platform_message_id check (#47237) can race with
+            # a sibling writer, so enforce the invariant atomically here
+            # instead of relying on callers. Rows without a
+            # platform_message_id are never deduped. Dedupe runs BEFORE the
+            # main-side repair pass so repair only sees surviving rows.
+            filtered = self._dedupe_batch_by_platform_message_id(
+                conn, session_id, messages
+            )
+            if not filtered:
+                return 0
             from agent.transcript_repair import resolve_and_repair_transcript_batch
-            inserted_rows = resolve_and_repair_transcript_batch(conn, session_id, messages,
+            inserted_rows = resolve_and_repair_transcript_batch(conn, session_id, filtered,
                 encode_content_fn=self._encode_content, decode_content_fn=self._decode_content)
             inserted, tool_calls_total = self._insert_message_rows(conn, session_id, inserted_rows)
             self._bump_session_counters(conn, session_id, inserted, tool_calls_total, unit=False)
@@ -1063,9 +1152,18 @@ class SessionMessagesMixin:
         Uses the idx_messages_platform_msg_id partial index for efficient lookup. Used by the gateway's
         transient-failure dedupe guard (#47237) to skip re-persisting a user message that was already saved
         on a prior retry of the same inbound platform message.
+
+        Mirrors the dedupe visibility contract of ``append_message`` /
+        ``_dedupe_batch_by_platform_message_id``: soft-archived rewind/undo
+        rows (``active=0``, ``compacted=0`` — the user took the turn back)
+        do NOT count as existing, so a platform redelivery of a rewound turn
+        re-inserts instead of being silently swallowed. Compaction-archived
+        rows (``compacted=1``) DO count — re-inserting a summarized-away
+        turn would resurrect it after in-place compaction.
         """
         return self._read_one(
-            "SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ? LIMIT 1",
+            "SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ? "
+            "AND (active = 1 OR compacted = 1) LIMIT 1",
             (session_id, platform_message_id)) is not None
 
     def _is_explicit_fork_child_row(self, session: Dict[str, Any]) -> bool:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sqlite3
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -284,86 +283,12 @@ class SessionMessagesMixin:
         def _do(conn):
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
-            # DB-level dedupe guard (#79576): a platform_message_id maps to
-            # exactly ONE transcript row per session. When a row already
-            # exists, skip the insert and return the existing row id instead
-            # of stacking a duplicate user turn. The gateway's #47237 check
-            # (has_platform_message_id) runs outside this transaction, so it
-            # can race with a sibling writer (gateway + agent processes, or
-            # two retries of the same Telegram update); this in-transaction
-            # check is atomic under BEGIN IMMEDIATE and also covers paths
-            # that never consulted the guard (crash-resilience persist,
-            # shutdown flush). Rows without a platform_message_id are never
-            # deduped. Only live (active = 1) and compaction-archived
-            # (compacted = 1) rows shadow a re-insert: rewound/undo rows
-            # (active = 0, compacted = 0 — the user took the turn back) do
-            # not, so a platform redelivery of a rewound turn re-inserts
-            # instead of being silently swallowed.
-            if platform_message_id is not None:
-                _existing = conn.execute(
-                    "SELECT id FROM messages "
-                    "WHERE session_id = ? AND platform_message_id = ? "
-                    "AND (active = 1 OR compacted = 1) LIMIT 1",
-                    (session_id, platform_message_id),
-                ).fetchone()
-                if _existing is not None:
-                    return _existing[0]
             msg_id = conn.execute(_INSERT_MESSAGE_SQL, params).lastrowid
             self._bump_session_counters(conn, session_id, 1, _tool_calls_count(tool_calls), unit=True)
             return msg_id
         # THE critical write (failure aborts the turn): long patience so a sibling legitimately
         # holding the lock for seconds (VACUUM, checkpoint) can't kill it.
         return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
-
-    @staticmethod
-    def _dedupe_batch_by_platform_message_id(
-        conn: sqlite3.Connection, session_id: str, messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Drop rows whose platform_message_id already exists for the session.
-
-        Enforces the one-platform_message_id-per-session invariant for the
-        batch write path (issue #79576). Rows without a platform_message_id
-        (or ``message_id`` alias) pass through untouched. Within-batch
-        duplicates keep only the first occurrence. Runs inside the caller's
-        write transaction, so the existence check and the inserts commit
-        atomically — closing the check-then-insert race that the gateway's
-        #47237 guard has when a sibling writer (gateway + agent processes)
-        persists the same inbound turn concurrently.
-
-        Only live (``active = 1``) and compaction-archived (``compacted = 1``)
-        rows shadow a re-insert. Rewound/undo rows (``active = 0``,
-        ``compacted = 0`` — the user took the turn back) do not, so a
-        platform redelivery of a rewound turn re-inserts under the same id
-        instead of being silently dropped. Same visibility contract as
-        ``append_message``'s in-transaction check and search's
-        ``(active = 1 OR compacted = 1)`` discoverability rule.
-        """
-        filtered: List[Dict[str, Any]] = []
-        seen_in_batch: set = set()
-        existing: Optional[set] = None
-        for msg in messages:
-            platform_msg_id = msg.get("platform_message_id") or msg.get("message_id")
-            if platform_msg_id is None:
-                filtered.append(msg)
-                continue
-            if platform_msg_id in seen_in_batch:
-                continue
-            if existing is None:
-                existing = {
-                    row[0]
-                    for row in conn.execute(
-                        "SELECT platform_message_id FROM messages "
-                        "WHERE session_id = ? AND platform_message_id IS NOT NULL "
-                        "AND (active = 1 OR compacted = 1)",
-                        (session_id,),
-                    ).fetchall()
-                }
-            if platform_msg_id in existing:
-                continue
-            existing.add(platform_msg_id)
-            seen_in_batch.add(platform_msg_id)
-            filtered.append(msg)
-        return filtered
 
     def append_messages_batch(
         self, session_id: str, messages: List[Dict[str, Any]], compression_lock_holder: Optional[str] = None,
@@ -381,22 +306,8 @@ class SessionMessagesMixin:
         def _do(conn):
             self._check_transcript_write_guards(conn, session_id, compression_lock_holder,
                 turn_lease_holder=turn_lease_holder, turn_lease_ttl_seconds=turn_lease_ttl_seconds)
-            # DB-level dedupe guard (#79576): same invariant as
-            # append_message — one platform_message_id per session. The
-            # turn-boundary flush and the gateway's crash-resilience persist
-            # can both try to write the same inbound user turn, and the
-            # pre-write has_platform_message_id check (#47237) can race with
-            # a sibling writer, so enforce the invariant atomically here
-            # instead of relying on callers. Rows without a
-            # platform_message_id are never deduped. Dedupe runs BEFORE the
-            # main-side repair pass so repair only sees surviving rows.
-            filtered = self._dedupe_batch_by_platform_message_id(
-                conn, session_id, messages
-            )
-            if not filtered:
-                return 0
             from agent.transcript_repair import resolve_and_repair_transcript_batch
-            inserted_rows = resolve_and_repair_transcript_batch(conn, session_id, filtered,
+            inserted_rows = resolve_and_repair_transcript_batch(conn, session_id, messages,
                 encode_content_fn=self._encode_content, decode_content_fn=self._decode_content)
             inserted, tool_calls_total = self._insert_message_rows(conn, session_id, inserted_rows)
             self._bump_session_counters(conn, session_id, inserted, tool_calls_total, unit=False)
@@ -1153,13 +1064,13 @@ class SessionMessagesMixin:
         transient-failure dedupe guard (#47237) to skip re-persisting a user message that was already saved
         on a prior retry of the same inbound platform message.
 
-        Mirrors the dedupe visibility contract of ``append_message`` /
-        ``_dedupe_batch_by_platform_message_id``: soft-archived rewind/undo
-        rows (``active=0``, ``compacted=0`` — the user took the turn back)
-        do NOT count as existing, so a platform redelivery of a rewound turn
-        re-inserts instead of being silently swallowed. Compaction-archived
-        rows (``compacted=1``) DO count — re-inserting a summarized-away
-        turn would resurrect it after in-place compaction.
+        Mirrors the visibility contract of ``has_gateway_input_owner`` (main
+        3114916ee4): soft-archived rewind/undo rows (``active=0``,
+        ``compacted=0`` — the user took the turn back) do NOT count as
+        existing, so a platform redelivery of a rewound turn is re-persisted
+        instead of being silently swallowed. Compaction-archived rows
+        (``compacted=1``) DO count — re-inserting a summarized-away turn
+        would resurrect it after in-place compaction.
         """
         return self._read_one(
             "SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ? "

--- a/tests/gateway/test_79576_platform_message_id_dedupe.py
+++ b/tests/gateway/test_79576_platform_message_id_dedupe.py
@@ -1,0 +1,530 @@
+"""Regression tests for issue #79576 — Telegram session retry loop.
+
+Three failure modes combine to bloat a session into infinite context loss:
+transient provider failure persists the user message, the same inbound
+event gets re-persisted (or raced by a sibling writer), and the session
+grows without bound until the agent "forgets" and the user must retry.
+
+The fix enforces a DB-level invariant — one platform_message_id per
+session — atomically inside the write transaction:
+
+1. ``SessionDB.append_message`` skips the insert (and the counter bump)
+   when a row with the same ``(session_id, platform_message_id)`` already
+   exists, returning the existing row id.
+2. ``SessionDB.append_messages_batch`` drops rows whose
+   platform_message_id already exists (or repeats within the batch) before
+   inserting.
+3. The gateway's crash-resilience persist (exception handler) dedupes by
+   the inbound ``event.message_id`` first, falling back to the content
+   check only for events without an id, and only treating a content match
+   as a duplicate when the matching row carries no platform id (an
+   agent-side early-persist row). A genuinely NEW message with identical
+   text is still persisted.
+"""
+
+import sys
+import types
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionEntry, SessionSource
+from hermes_state import SessionDB
+
+
+def _make_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("s1", "cli")
+    return db
+
+
+# ── DB-level: append_message ─────────────────────────────────────────
+
+
+class TestAppendMessageDedupe:
+    def test_same_platform_message_id_deduped(self, tmp_path):
+        db = _make_db(tmp_path)
+        first_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        second_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        assert second_id == first_id
+        assert db.message_count("s1") == 1
+        assert db.has_platform_message_id("s1", "msg-123")
+
+    def test_same_platform_message_id_counter_bumped_once(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        session = db.get_session("s1")
+        assert session is not None
+        assert session["message_count"] == 1
+
+    def test_same_id_different_sessions_both_inserted(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.create_session("s2", "cli")
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        db.append_message(
+            session_id="s2",
+            role="user",
+            content="hello",
+            platform_message_id="msg-123",
+        )
+        assert db.message_count("s1") == 1
+        assert db.message_count("s2") == 1
+
+    def test_null_platform_message_id_never_deduped(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(session_id="s1", role="user", content="hello")
+        db.append_message(session_id="s1", role="user", content="hello")
+        assert db.message_count("s1") == 2
+
+    def test_dedupe_returns_existing_row_and_keeps_first_content(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="first version",
+            platform_message_id="msg-1",
+        )
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="retry version",
+            platform_message_id="msg-1",
+        )
+        rows = db.get_messages("s1")
+        contents = [r["content"] for r in rows]
+        assert contents == ["first version"]
+
+
+# ── DB-level: soft-archived rows and the dedupe visibility contract ──
+
+
+class TestDedupeSoftArchiveVisibility:
+    """Review follow-up (Halldrix): the dedupe existence checks must not let a
+    soft-archived rewind/undo row shadow a legitimate re-insert.
+
+    Visibility contract (mirrors search's ``(active = 1 OR compacted = 1)``):
+
+    - live rows (``active = 1``) shadow a re-insert — the original #79576 fix;
+    - compaction-archived rows (``active = 0, compacted = 1``) shadow too —
+      re-inserting a summarized-away turn would resurrect it after in-place
+      compaction;
+    - rewind/undo rows (``active = 0, compacted = 0``) do NOT shadow — the
+      user took the turn back, so a platform redelivery of the same id
+      re-inserts instead of being silently swallowed.
+    """
+
+    @staticmethod
+    def _archive_rows(db, session_id, *, compacted):
+        """Flip every row of the session to active=0 with the given flag."""
+        def _do(conn):
+            conn.execute(
+                "UPDATE messages SET active = 0, compacted = ? "
+                "WHERE session_id = ? AND active = 1",
+                (1 if compacted else 0, session_id),
+            )
+
+        db._execute_write(_do)  # noqa: SLF001 - test-only helper
+
+    def test_rewound_row_does_not_shadow_reinsert_append(self, tmp_path):
+        """Redelivery of a rewound turn re-inserts (old code returned the
+        archived row's id and dropped the re-delivered turn)."""
+        db = _make_db(tmp_path)
+        first_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="taken back",
+            platform_message_id="msg-9",
+        )
+        self._archive_rows(db, "s1", compacted=False)  # rewind/undo rows
+        assert db.get_messages("s1") == []  # nothing live anymore
+
+        second_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="redelivered",
+            platform_message_id="msg-9",
+        )
+        assert second_id != first_id  # NEW row, not the archived one
+        live = db.get_messages("s1")
+        assert len(live) == 1  # one live row: the redelivered turn
+        assert live[0]["content"] == "redelivered"
+
+    def test_compacted_row_still_shadows_reinsert_append(self, tmp_path):
+        """A summarized-away turn stays deduped — re-insert would resurrect
+        it post-compaction."""
+        db = _make_db(tmp_path)
+        first_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="summarized away",
+            platform_message_id="msg-9",
+        )
+        self._archive_rows(db, "s1", compacted=True)
+        assert db.get_messages("s1") == []
+
+        second_id = db.append_message(
+            session_id="s1",
+            role="user",
+            content="redelivered after compaction",
+            platform_message_id="msg-9",
+        )
+        assert second_id == first_id  # still shadowed
+        assert db.get_messages("s1") == []  # nothing live was re-inserted
+
+    def test_rewound_row_does_not_shadow_batch_insert(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="taken back",
+            platform_message_id="msg-9",
+        )
+        self._archive_rows(db, "s1", compacted=False)
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=[
+                {"role": "user", "content": "redelivered", "platform_message_id": "msg-9"},
+            ],
+        )
+        assert inserted == 1
+        assert db.get_messages("s1")[0]["content"] == "redelivered"
+
+    def test_compacted_row_still_shadows_batch_insert(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="summarized away",
+            platform_message_id="msg-9",
+        )
+        self._archive_rows(db, "s1", compacted=True)
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=[
+                {"role": "user", "content": "redelivered", "platform_message_id": "msg-9"},
+            ],
+        )
+        assert inserted == 0
+
+    def test_has_platform_message_id_ignores_rewound_rows(self, tmp_path):
+        """The gateway's #47237 pre-check must agree with the DB-layer
+        visibility contract, or it would swallow the redelivery before the
+        in-transaction check is ever reached."""
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="taken back",
+            platform_message_id="msg-9",
+        )
+        assert db.has_platform_message_id("s1", "msg-9") is True
+        self._archive_rows(db, "s1", compacted=False)
+        assert db.has_platform_message_id("s1", "msg-9") is False
+        self._archive_rows_unarchive(db, "s1")  # back to live
+        assert db.has_platform_message_id("s1", "msg-9") is True
+
+    @staticmethod
+    def _archive_rows_unarchive(db, session_id):
+        def _do(conn):
+            conn.execute(
+                "UPDATE messages SET active = 1, compacted = 0 "
+                "WHERE session_id = ? AND active = 0",
+                (session_id,),
+            )
+
+        db._execute_write(_do)  # noqa: SLF001 - test-only helper
+
+
+# ── DB-level: append_messages_batch ──────────────────────────────────
+
+
+class TestAppendMessagesBatchDedupe:
+    def _rows(self, *ids_and_contents):
+        return [
+            {"role": "user", "content": content, "platform_message_id": pid}
+            for pid, content in ids_and_contents
+        ]
+
+    def test_batch_dedupes_existing_and_within_batch(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="already there",
+            platform_message_id="msg-a",
+        )
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=self._rows(
+                ("msg-a", "already there (dup of existing)"),
+                ("msg-b", "new one"),
+                ("msg-b", "dup within batch"),
+                ("msg-c", "another new one"),
+            ),
+        )
+        # Only msg-b and msg-c are new.
+        assert inserted == 2
+        assert db.message_count("s1") == 3
+        assert db.has_platform_message_id("s1", "msg-b")
+        assert db.has_platform_message_id("s1", "msg-c")
+
+    def test_batch_all_duplicates_returns_zero(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1",
+            role="user",
+            content="hello",
+            platform_message_id="msg-a",
+        )
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=self._rows(("msg-a", "hello again")),
+        )
+        assert inserted == 0
+        assert db.message_count("s1") == 1
+
+    def test_batch_without_ids_inserts_all(self, tmp_path):
+        db = _make_db(tmp_path)
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=[
+                {"role": "user", "content": "one"},
+                {"role": "user", "content": "two"},
+            ],
+        )
+        assert inserted == 2
+        assert db.message_count("s1") == 2
+
+    def test_batch_accepts_message_id_alias(self, tmp_path):
+        db = _make_db(tmp_path)
+        inserted = db.append_messages_batch(
+            session_id="s1",
+            messages=[
+                {"role": "user", "content": "x", "message_id": "alias-1"},
+                {"role": "user", "content": "y", "message_id": "alias-1"},
+            ],
+        )
+        assert inserted == 1
+        assert db.message_count("s1") == 1
+        assert db.has_platform_message_id("s1", "alias-1")
+
+
+# ── Gateway-level: crash-resilience exception handler ────────────────
+
+
+def _bootstrap(monkeypatch, tmp_path, real_db):
+    """Minimal GatewayRunner setup backed by a real SessionDB for dedupe."""
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._is_user_authorized = lambda _source: True
+    runner._set_session_env = lambda _context: None
+    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
+    runner._session_db = MagicMock()
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._cache_session_source = lambda _key, _source: None
+    runner._is_session_run_current = lambda _key, _gen: True
+    runner._begin_session_run_generation = lambda _key: 1
+    runner._reply_anchor_for_event = lambda _event: None
+    runner._get_guild_id = lambda _event: None
+    runner._should_send_voice_reply = lambda *_a, **_kw: False
+    # Disable the turn-lease registry (#64934): leases are released in the
+    # OUTER _handle_message finally, which these tests bypass by calling
+    # _handle_message_with_agent directly. With the registry disabled the
+    # per-session serialization is skipped entirely (the fail-open path).
+    runner._turn_leases = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+
+    real_db.create_session("sess-dedup", "telegram")
+
+    def _append(session_id, message, skip_db=False):
+        if skip_db:
+            return
+        real_db.append_message(
+            session_id=session_id,
+            role=message.get("role", "user"),
+            content=message.get("content"),
+            timestamp=message.get("timestamp"),
+            platform_message_id=(
+                message.get("platform_message_id") or message.get("message_id")
+            ),
+        )
+
+    def _load(session_id):
+        try:
+            return real_db.get_messages_as_conversation(
+                session_id, repair_alternation=True
+            ) or []
+        except Exception:
+            return []
+
+    store = MagicMock()
+    store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:telegram:group:-1001:12345",
+        session_id="sess-dedup",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="group",
+    )
+    store.has_platform_message_id = MagicMock(
+        side_effect=lambda sid, pid: real_db.has_platform_message_id(sid, pid)
+    )
+    # Current main's exception path gates the inbound persist on
+    # has_input_owner (persistence_owner marker, not platform id). The mock
+    # store would answer truthy by default and skip the append entirely —
+    # return False so the write reaches the DB layer, where the
+    # platform_message_id dedupe under test decides.
+    store.has_input_owner = MagicMock(return_value=False)
+    store.load_transcript = MagicMock(side_effect=_load)
+    store.append_to_transcript = MagicMock(side_effect=_append)
+    store.update_session = MagicMock()
+    runner.session_store = store
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length",
+        lambda *_args, **_kwargs: 100_000,
+    )
+    return runner
+
+
+def _event(message_id="msg-42", text="hello world"):
+    return MessageEvent(
+        text=text,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="-1001",
+            chat_type="group",
+            user_id="12345",
+        ),
+        message_id=message_id,
+    )
+
+
+def _source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        user_id="12345",
+    )
+
+
+def _failing_run_agent():
+    async def _fail(*args, **kwargs):
+        raise RuntimeError("provider init failed before run_conversation")
+
+    return _fail
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_same_event_persisted_once(monkeypatch, tmp_path):
+    """Re-processing the SAME inbound event must not stack user turns."""
+    db = SessionDB(tmp_path / "state.db")
+    runner = _bootstrap(monkeypatch, tmp_path, db)
+    runner._run_agent = _failing_run_agent()
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert db.message_count("sess-dedup") == 1
+    assert db.has_platform_message_id("sess-dedup", "msg-42")
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_same_text_new_event_persisted(monkeypatch, tmp_path):
+    """A NEW message with the same text is a new turn and must persist."""
+    db = SessionDB(tmp_path / "state.db")
+    runner = _bootstrap(monkeypatch, tmp_path, db)
+    runner._run_agent = _failing_run_agent()
+
+    await runner._handle_message_with_agent(
+        _event(message_id="msg-42", text="retry this:"),
+        _source(), "agent:main:telegram:group:-1001:12345", 1,
+    )
+    # Same text, NEW platform message id → distinct turn.
+    await runner._handle_message_with_agent(
+        _event(message_id="msg-43", text="retry this:"),
+        _source(), "agent:main:telegram:group:-1001:12345", 1,
+    )
+
+    assert db.message_count("sess-dedup") == 2
+    assert db.has_platform_message_id("sess-dedup", "msg-42")
+    assert db.has_platform_message_id("sess-dedup", "msg-43")
+
+
+@pytest.mark.asyncio
+async def test_exception_handler_owner_marker_skips_agent_persisted_row(
+    monkeypatch, tmp_path,
+):
+    """Current main dedupes the exception-path persist via the persistence
+    OWNER marker (has_input_owner), not content equality: when the agent's
+    early turn-start persistence already stamped this input's owner, the
+    gateway does not append again. (Content-equality fallback was replaced by
+    the owner marker; NULL-platform-id rows are never deduped at the DB layer
+    by design.)"""
+    db = SessionDB(tmp_path / "state.db")
+    runner = _bootstrap(monkeypatch, tmp_path, db)
+    runner._run_agent = _failing_run_agent()
+
+    # Simulate the agent's early turn-start persistence: same text, no id.
+    db.append_message(
+        session_id="sess-dedup",
+        role="user",
+        content="hello world",
+    )
+    # The owner marker says this input was already accepted+persisted.
+    runner.session_store.has_input_owner = MagicMock(return_value=True)
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert db.message_count("sess-dedup") == 1

--- a/tests/gateway/test_79576_platform_message_id_dedupe.py
+++ b/tests/gateway/test_79576_platform_message_id_dedupe.py
@@ -1,38 +1,37 @@
-"""Regression tests for issue #79576 — Telegram session retry loop.
+"""Regression tests for issue #79576 follow-up — ``has_platform_message_id``
+visibility contract.
 
-Three failure modes combine to bloat a session into infinite context loss:
-transient provider failure persists the user message, the same inbound
-event gets re-persisted (or raced by a sibling writer), and the session
-grows without bound until the agent "forgets" and the user must retry.
+Scope note (2026-09-09): main ``3114916ee4`` (fix #104653) landed the
+accepted-input **ownership marker** approach for inbound-turn dedupe — the
+gateway's exception path and restart recovery now gate on
+``has_gateway_input_owner``, and main's contract tests
+(``tests/agent/test_codex_echo_ownership.py``,
+``tests/gateway/test_failure_writer_ownership.py``) require that two
+independently accepted turns sharing a platform_message_id BOTH survive.
+That supersedes this PR's original in-transaction DB dedupe, which is why
+these tests no longer assert one-row-per-platform-id.
 
-The fix enforces a DB-level invariant — one platform_message_id per
-session — atomically inside the write transaction:
+What remains (and what these tests pin down) is the **visibility contract**
+of the surviving probe, ``SessionDB.has_platform_message_id`` — the
+gateway's transient-failure retry guard (#47237, ``run_turn.py``) and the
+restart drain-window recovery dedup (``agent/session_persistence.py``) both
+consult it before re-persisting an inbound turn. Before this fix the probe
+counted ANY row carrying the id — including soft-archived rewind/undo rows
+(``active=0, compacted=0``) — so a platform redelivery of a turn the user
+had taken back was silently swallowed instead of re-persisted.
 
-1. ``SessionDB.append_message`` skips the insert (and the counter bump)
-   when a row with the same ``(session_id, platform_message_id)`` already
-   exists, returning the existing row id.
-2. ``SessionDB.append_messages_batch`` drops rows whose
-   platform_message_id already exists (or repeats within the batch) before
-   inserting.
-3. The gateway's crash-resilience persist (exception handler) dedupes by
-   the inbound ``event.message_id`` first, falling back to the content
-   check only for events without an id, and only treating a content match
-   as a duplicate when the matching row carries no platform id (an
-   agent-side early-persist row). A genuinely NEW message with identical
-   text is still persisted.
+The contract mirrors ``has_gateway_input_owner`` (main ``3114916ee4``):
+
+- live rows (``active = 1``) count — the original #47237 guard behavior;
+- compaction-archived rows (``active = 0, compacted = 1``) count —
+  re-inserting a summarized-away turn would resurrect it after in-place
+  compaction;
+- rewind/undo rows (``active = 0, compacted = 0``) do NOT count — the user
+  took the turn back, so a redelivery of the same id re-persists.
 """
-
-import sys
-import types
-from datetime import datetime
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-import gateway.run as gateway_run
-from gateway.config import GatewayConfig, Platform
-from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource
 from hermes_state import SessionDB
 
 
@@ -42,489 +41,178 @@ def _make_db(tmp_path):
     return db
 
 
-# ── DB-level: append_message ─────────────────────────────────────────
-
-
-class TestAppendMessageDedupe:
-    def test_same_platform_message_id_deduped(self, tmp_path):
-        db = _make_db(tmp_path)
-        first_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
-            platform_message_id="msg-123",
+def _archive_rows(db, session_id, *, compacted):
+    """Flip every live row of the session to active=0 with the given flag."""
+    def _do(conn):
+        conn.execute(
+            "UPDATE messages SET active = 0, compacted = ? "
+            "WHERE session_id = ? AND active = 1",
+            (1 if compacted else 0, session_id),
         )
-        second_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
-            platform_message_id="msg-123",
-        )
-        assert second_id == first_id
-        assert db.message_count("s1") == 1
-        assert db.has_platform_message_id("s1", "msg-123")
 
-    def test_same_platform_message_id_counter_bumped_once(self, tmp_path):
+    db._execute_write(_do)  # noqa: SLF001 - test-only helper
+
+
+def _unarchive_rows(db, session_id):
+    def _do(conn):
+        conn.execute(
+            "UPDATE messages SET active = 1, compacted = 0 "
+            "WHERE session_id = ? AND active = 0",
+            (session_id,),
+        )
+
+    db._execute_write(_do)  # noqa: SLF001 - test-only helper
+
+
+class TestHasPlatformMessageIdVisibility:
+    """The probe only counts rows the transcript would still show."""
+
+    def test_live_row_counts(self, tmp_path):
         db = _make_db(tmp_path)
         db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
-            platform_message_id="msg-123",
+            session_id="s1", role="user", content="hello",
+            platform_message_id="msg-1",
         )
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
-            platform_message_id="msg-123",
-        )
-        session = db.get_session("s1")
-        assert session is not None
-        assert session["message_count"] == 1
+        assert db.has_platform_message_id("s1", "msg-1") is True
 
-    def test_same_id_different_sessions_both_inserted(self, tmp_path):
+    def test_absent_id_is_false(self, tmp_path):
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1", role="user", content="hello",
+            platform_message_id="msg-1",
+        )
+        assert db.has_platform_message_id("s1", "msg-other") is False
+
+    def test_rewound_row_does_not_count(self, tmp_path):
+        """Redelivery of a rewound turn must re-persist: the probe must not
+        let an archived rewind/undo row shadow a legitimate re-insert.
+
+        Regression: before the fix the probe counted ANY row with the id, so
+        the gateway retry guard swallowed the redelivery and the user's
+        re-sent message never reached the transcript."""
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1", role="user", content="taken back",
+            platform_message_id="msg-9",
+        )
+        assert db.has_platform_message_id("s1", "msg-9") is True
+        _archive_rows(db, "s1", compacted=False)  # rewind/undo rows
+        assert db.get_messages("s1") == []  # nothing live anymore
+        assert db.has_platform_message_id("s1", "msg-9") is False
+
+    def test_compacted_row_still_counts(self, tmp_path):
+        """A summarized-away turn stays visible to the probe — re-inserting
+        it after in-place compaction would resurrect the turn."""
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1", role="user", content="summarized away",
+            platform_message_id="msg-9",
+        )
+        _archive_rows(db, "s1", compacted=True)
+        assert db.get_messages("s1") == []
+        assert db.has_platform_message_id("s1", "msg-9") is True
+
+    def test_visibility_round_trip(self, tmp_path):
+        """Un-archiving restores visibility — the contract tracks the row's
+        current state, not a one-time latch."""
+        db = _make_db(tmp_path)
+        db.append_message(
+            session_id="s1", role="user", content="taken back",
+            platform_message_id="msg-9",
+        )
+        _archive_rows(db, "s1", compacted=False)
+        assert db.has_platform_message_id("s1", "msg-9") is False
+        _unarchive_rows(db, "s1")
+        assert db.has_platform_message_id("s1", "msg-9") is True
+
+    def test_scoped_per_session(self, tmp_path):
+        """An id archived in one session never shadows another session's
+        probe — the guard is (session_id, platform_message_id) scoped."""
         db = _make_db(tmp_path)
         db.create_session("s2", "cli")
         db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
+            session_id="s1", role="user", content="hello",
             platform_message_id="msg-123",
         )
+        _archive_rows(db, "s1", compacted=False)
+        assert db.has_platform_message_id("s1", "msg-123") is False
         db.append_message(
-            session_id="s2",
-            role="user",
-            content="hello",
+            session_id="s2", role="user", content="hello",
             platform_message_id="msg-123",
         )
-        assert db.message_count("s1") == 1
-        assert db.message_count("s2") == 1
-
-    def test_null_platform_message_id_never_deduped(self, tmp_path):
-        db = _make_db(tmp_path)
-        db.append_message(session_id="s1", role="user", content="hello")
-        db.append_message(session_id="s1", role="user", content="hello")
-        assert db.message_count("s1") == 2
-
-    def test_dedupe_returns_existing_row_and_keeps_first_content(self, tmp_path):
-        db = _make_db(tmp_path)
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="first version",
-            platform_message_id="msg-1",
-        )
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="retry version",
-            platform_message_id="msg-1",
-        )
-        rows = db.get_messages("s1")
-        contents = [r["content"] for r in rows]
-        assert contents == ["first version"]
+        assert db.has_platform_message_id("s2", "msg-123") is True
 
 
-# ── DB-level: soft-archived rows and the dedupe visibility contract ──
+class TestRedeliveryAfterRewind:
+    """End-to-end statement of the user-visible behavior: a platform
+    redelivery of a rewound turn lands in the transcript again."""
 
-
-class TestDedupeSoftArchiveVisibility:
-    """Review follow-up (Halldrix): the dedupe existence checks must not let a
-    soft-archived rewind/undo row shadow a legitimate re-insert.
-
-    Visibility contract (mirrors search's ``(active = 1 OR compacted = 1)``):
-
-    - live rows (``active = 1``) shadow a re-insert — the original #79576 fix;
-    - compaction-archived rows (``active = 0, compacted = 1``) shadow too —
-      re-inserting a summarized-away turn would resurrect it after in-place
-      compaction;
-    - rewind/undo rows (``active = 0, compacted = 0``) do NOT shadow — the
-      user took the turn back, so a platform redelivery of the same id
-      re-inserts instead of being silently swallowed.
-    """
-
-    @staticmethod
-    def _archive_rows(db, session_id, *, compacted):
-        """Flip every row of the session to active=0 with the given flag."""
-        def _do(conn):
-            conn.execute(
-                "UPDATE messages SET active = 0, compacted = ? "
-                "WHERE session_id = ? AND active = 1",
-                (1 if compacted else 0, session_id),
-            )
-
-        db._execute_write(_do)  # noqa: SLF001 - test-only helper
-
-    def test_rewound_row_does_not_shadow_reinsert_append(self, tmp_path):
-        """Redelivery of a rewound turn re-inserts (old code returned the
-        archived row's id and dropped the re-delivered turn)."""
+    def test_redelivery_reinserts_new_live_row(self, tmp_path):
         db = _make_db(tmp_path)
         first_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="taken back",
+            session_id="s1", role="user", content="taken back",
             platform_message_id="msg-9",
         )
-        self._archive_rows(db, "s1", compacted=False)  # rewind/undo rows
-        assert db.get_messages("s1") == []  # nothing live anymore
+        _archive_rows(db, "s1", compacted=False)
+        assert db.get_messages("s1") == []
 
+        # The retry guard consults the probe; with the fix it does not skip.
+        assert db.has_platform_message_id("s1", "msg-9") is False
         second_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="redelivered",
+            session_id="s1", role="user", content="redelivered",
             platform_message_id="msg-9",
         )
         assert second_id != first_id  # NEW row, not the archived one
         live = db.get_messages("s1")
-        assert len(live) == 1  # one live row: the redelivered turn
+        assert len(live) == 1
         assert live[0]["content"] == "redelivered"
 
-    def test_compacted_row_still_shadows_reinsert_append(self, tmp_path):
-        """A summarized-away turn stays deduped — re-insert would resurrect
-        it post-compaction."""
-        db = _make_db(tmp_path)
-        first_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="summarized away",
-            platform_message_id="msg-9",
-        )
-        self._archive_rows(db, "s1", compacted=True)
-        assert db.get_messages("s1") == []
-
-        second_id = db.append_message(
-            session_id="s1",
-            role="user",
-            content="redelivered after compaction",
-            platform_message_id="msg-9",
-        )
-        assert second_id == first_id  # still shadowed
-        assert db.get_messages("s1") == []  # nothing live was re-inserted
-
-    def test_rewound_row_does_not_shadow_batch_insert(self, tmp_path):
+    def test_redelivery_after_compaction_is_guarded(self, tmp_path):
+        """The same path through a compaction-archived row stays blocked:
+        the probe still answers True so the guard skips the re-insert."""
         db = _make_db(tmp_path)
         db.append_message(
-            session_id="s1",
-            role="user",
-            content="taken back",
+            session_id="s1", role="user", content="summarized away",
             platform_message_id="msg-9",
         )
-        self._archive_rows(db, "s1", compacted=False)
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=[
-                {"role": "user", "content": "redelivered", "platform_message_id": "msg-9"},
-            ],
-        )
-        assert inserted == 1
-        assert db.get_messages("s1")[0]["content"] == "redelivered"
-
-    def test_compacted_row_still_shadows_batch_insert(self, tmp_path):
-        db = _make_db(tmp_path)
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="summarized away",
-            platform_message_id="msg-9",
-        )
-        self._archive_rows(db, "s1", compacted=True)
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=[
-                {"role": "user", "content": "redelivered", "platform_message_id": "msg-9"},
-            ],
-        )
-        assert inserted == 0
-
-    def test_has_platform_message_id_ignores_rewound_rows(self, tmp_path):
-        """The gateway's #47237 pre-check must agree with the DB-layer
-        visibility contract, or it would swallow the redelivery before the
-        in-transaction check is ever reached."""
-        db = _make_db(tmp_path)
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="taken back",
-            platform_message_id="msg-9",
-        )
+        _archive_rows(db, "s1", compacted=True)
         assert db.has_platform_message_id("s1", "msg-9") is True
-        self._archive_rows(db, "s1", compacted=False)
-        assert db.has_platform_message_id("s1", "msg-9") is False
-        self._archive_rows_unarchive(db, "s1")  # back to live
-        assert db.has_platform_message_id("s1", "msg-9") is True
-
-    @staticmethod
-    def _archive_rows_unarchive(db, session_id):
-        def _do(conn):
-            conn.execute(
-                "UPDATE messages SET active = 1, compacted = 0 "
-                "WHERE session_id = ? AND active = 0",
-                (session_id,),
-            )
-
-        db._execute_write(_do)  # noqa: SLF001 - test-only helper
+        assert db.get_messages("s1") == []  # nothing resurrected
 
 
-# ── DB-level: append_messages_batch ──────────────────────────────────
+class TestSessionStoreWrapperContract:
+    """The gateway's SessionStore wrapper (gateway/session.py composing
+    SessionTranscriptMixin) is the seam the retry guard actually calls —
+    its thin wrapper must inherit the visibility contract from SessionDB,
+    not re-implement it."""
 
+    @pytest.fixture()
+    def store(self, tmp_path, monkeypatch):
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
 
-class TestAppendMessagesBatchDedupe:
-    def _rows(self, *ids_and_contents):
-        return [
-            {"role": "user", "content": content, "platform_message_id": pid}
-            for pid, content in ids_and_contents
-        ]
-
-    def test_batch_dedupes_existing_and_within_batch(self, tmp_path):
         db = _make_db(tmp_path)
+        store = SessionStore(tmp_path, GatewayConfig())
+        monkeypatch.setattr(store, "_db_for_session_id", lambda sid: db)
+        store._db = db
+        return store
+
+    def test_wrapper_delegates_visibility(self, store, tmp_path):
+        db = store._db
         db.append_message(
-            session_id="s1",
-            role="user",
-            content="already there",
-            platform_message_id="msg-a",
+            session_id="s1", role="user", content="taken back",
+            platform_message_id="msg-9",
         )
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=self._rows(
-                ("msg-a", "already there (dup of existing)"),
-                ("msg-b", "new one"),
-                ("msg-b", "dup within batch"),
-                ("msg-c", "another new one"),
-            ),
-        )
-        # Only msg-b and msg-c are new.
-        assert inserted == 2
-        assert db.message_count("s1") == 3
-        assert db.has_platform_message_id("s1", "msg-b")
-        assert db.has_platform_message_id("s1", "msg-c")
+        _archive_rows(db, "s1", compacted=False)
+        assert store.has_platform_message_id("s1", "msg-9") is False
+        _unarchive_rows(db, "s1")
+        assert store.has_platform_message_id("s1", "msg-9") is True
 
-    def test_batch_all_duplicates_returns_zero(self, tmp_path):
-        db = _make_db(tmp_path)
-        db.append_message(
-            session_id="s1",
-            role="user",
-            content="hello",
-            platform_message_id="msg-a",
-        )
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=self._rows(("msg-a", "hello again")),
-        )
-        assert inserted == 0
-        assert db.message_count("s1") == 1
+    def test_wrapper_false_without_db(self, tmp_path, monkeypatch):
+        from gateway.config import GatewayConfig
+        from gateway.session import SessionStore
 
-    def test_batch_without_ids_inserts_all(self, tmp_path):
-        db = _make_db(tmp_path)
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=[
-                {"role": "user", "content": "one"},
-                {"role": "user", "content": "two"},
-            ],
-        )
-        assert inserted == 2
-        assert db.message_count("s1") == 2
-
-    def test_batch_accepts_message_id_alias(self, tmp_path):
-        db = _make_db(tmp_path)
-        inserted = db.append_messages_batch(
-            session_id="s1",
-            messages=[
-                {"role": "user", "content": "x", "message_id": "alias-1"},
-                {"role": "user", "content": "y", "message_id": "alias-1"},
-            ],
-        )
-        assert inserted == 1
-        assert db.message_count("s1") == 1
-        assert db.has_platform_message_id("s1", "alias-1")
-
-
-# ── Gateway-level: crash-resilience exception handler ────────────────
-
-
-def _bootstrap(monkeypatch, tmp_path, real_db):
-    """Minimal GatewayRunner setup backed by a real SessionDB for dedupe."""
-    fake_dotenv = types.ModuleType("dotenv")
-    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
-    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
-
-    config = GatewayConfig()
-    runner = gateway_run.GatewayRunner(config)
-    runner.adapters = {}
-    runner._running_agents = {}
-    runner._running_agents_ts = {}
-    runner._pending_messages = {}
-    runner._pending_approvals = {}
-    runner._is_user_authorized = lambda _source: True
-    runner._set_session_env = lambda _context: None
-    runner._handle_active_session_busy_message = AsyncMock(return_value=False)
-    runner._session_db = MagicMock()
-    runner._recover_telegram_topic_thread_id = lambda _source: None
-    runner._cache_session_source = lambda _key, _source: None
-    runner._is_session_run_current = lambda _key, _gen: True
-    runner._begin_session_run_generation = lambda _key: 1
-    runner._reply_anchor_for_event = lambda _event: None
-    runner._get_guild_id = lambda _event: None
-    runner._should_send_voice_reply = lambda *_a, **_kw: False
-    # Disable the turn-lease registry (#64934): leases are released in the
-    # OUTER _handle_message finally, which these tests bypass by calling
-    # _handle_message_with_agent directly. With the registry disabled the
-    # per-session serialization is skipped entirely (the fail-open path).
-    runner._turn_leases = None
-    runner.hooks = MagicMock()
-    runner.hooks.emit = AsyncMock()
-
-    real_db.create_session("sess-dedup", "telegram")
-
-    def _append(session_id, message, skip_db=False):
-        if skip_db:
-            return
-        real_db.append_message(
-            session_id=session_id,
-            role=message.get("role", "user"),
-            content=message.get("content"),
-            timestamp=message.get("timestamp"),
-            platform_message_id=(
-                message.get("platform_message_id") or message.get("message_id")
-            ),
-        )
-
-    def _load(session_id):
-        try:
-            return real_db.get_messages_as_conversation(
-                session_id, repair_alternation=True
-            ) or []
-        except Exception:
-            return []
-
-    store = MagicMock()
-    store.get_or_create_session.return_value = SessionEntry(
-        session_key="agent:main:telegram:group:-1001:12345",
-        session_id="sess-dedup",
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
-        chat_type="group",
-    )
-    store.has_platform_message_id = MagicMock(
-        side_effect=lambda sid, pid: real_db.has_platform_message_id(sid, pid)
-    )
-    # Current main's exception path gates the inbound persist on
-    # has_input_owner (persistence_owner marker, not platform id). The mock
-    # store would answer truthy by default and skip the append entirely —
-    # return False so the write reaches the DB layer, where the
-    # platform_message_id dedupe under test decides.
-    store.has_input_owner = MagicMock(return_value=False)
-    store.load_transcript = MagicMock(side_effect=_load)
-    store.append_to_transcript = MagicMock(side_effect=_append)
-    store.update_session = MagicMock()
-    runner.session_store = store
-
-    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
-    monkeypatch.setattr(
-        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
-    )
-    monkeypatch.setattr(
-        "agent.model_metadata.get_model_context_length",
-        lambda *_args, **_kwargs: 100_000,
-    )
-    return runner
-
-
-def _event(message_id="msg-42", text="hello world"):
-    return MessageEvent(
-        text=text,
-        source=SessionSource(
-            platform=Platform.TELEGRAM,
-            chat_id="-1001",
-            chat_type="group",
-            user_id="12345",
-        ),
-        message_id=message_id,
-    )
-
-
-def _source():
-    return SessionSource(
-        platform=Platform.TELEGRAM,
-        chat_id="-1001",
-        chat_type="group",
-        user_id="12345",
-    )
-
-
-def _failing_run_agent():
-    async def _fail(*args, **kwargs):
-        raise RuntimeError("provider init failed before run_conversation")
-
-    return _fail
-
-
-@pytest.mark.asyncio
-async def test_exception_handler_same_event_persisted_once(monkeypatch, tmp_path):
-    """Re-processing the SAME inbound event must not stack user turns."""
-    db = SessionDB(tmp_path / "state.db")
-    runner = _bootstrap(monkeypatch, tmp_path, db)
-    runner._run_agent = _failing_run_agent()
-
-    await runner._handle_message_with_agent(
-        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
-    )
-    await runner._handle_message_with_agent(
-        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
-    )
-
-    assert db.message_count("sess-dedup") == 1
-    assert db.has_platform_message_id("sess-dedup", "msg-42")
-
-
-@pytest.mark.asyncio
-async def test_exception_handler_same_text_new_event_persisted(monkeypatch, tmp_path):
-    """A NEW message with the same text is a new turn and must persist."""
-    db = SessionDB(tmp_path / "state.db")
-    runner = _bootstrap(monkeypatch, tmp_path, db)
-    runner._run_agent = _failing_run_agent()
-
-    await runner._handle_message_with_agent(
-        _event(message_id="msg-42", text="retry this:"),
-        _source(), "agent:main:telegram:group:-1001:12345", 1,
-    )
-    # Same text, NEW platform message id → distinct turn.
-    await runner._handle_message_with_agent(
-        _event(message_id="msg-43", text="retry this:"),
-        _source(), "agent:main:telegram:group:-1001:12345", 1,
-    )
-
-    assert db.message_count("sess-dedup") == 2
-    assert db.has_platform_message_id("sess-dedup", "msg-42")
-    assert db.has_platform_message_id("sess-dedup", "msg-43")
-
-
-@pytest.mark.asyncio
-async def test_exception_handler_owner_marker_skips_agent_persisted_row(
-    monkeypatch, tmp_path,
-):
-    """Current main dedupes the exception-path persist via the persistence
-    OWNER marker (has_input_owner), not content equality: when the agent's
-    early turn-start persistence already stamped this input's owner, the
-    gateway does not append again. (Content-equality fallback was replaced by
-    the owner marker; NULL-platform-id rows are never deduped at the DB layer
-    by design.)"""
-    db = SessionDB(tmp_path / "state.db")
-    runner = _bootstrap(monkeypatch, tmp_path, db)
-    runner._run_agent = _failing_run_agent()
-
-    # Simulate the agent's early turn-start persistence: same text, no id.
-    db.append_message(
-        session_id="sess-dedup",
-        role="user",
-        content="hello world",
-    )
-    # The owner marker says this input was already accepted+persisted.
-    runner.session_store.has_input_owner = MagicMock(return_value=True)
-
-    await runner._handle_message_with_agent(
-        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
-    )
-
-    assert db.message_count("sess-dedup") == 1
+        store = SessionStore(tmp_path, GatewayConfig())
+        monkeypatch.setattr(store, "_db_for_session_id", lambda sid: None)  # in-memory session
+        # Must not raise and must not count: the guard skips nothing.
+        assert store.has_platform_message_id("s1", "msg-9") is False


### PR DESCRIPTION
> **2026-09-09 scope note**: main `3114916ee4`（fix #104653）已落地 accepted-input **ownership 标记**方案——gateway 异常路径与重启恢复改用 `has_gateway_input_owner` 门控，且其契约测试要求「两条独立 accepted 的同 platform_message_id 输入都必须存活」。这与本 PR 原先的事务内 DB 去重**语义对立**（同 id 第二行必须存活 vs 必须去重），故移除事务内去重（`append_message` 存在性检查 + `_dedupe_batch_by_platform_message_id`），对齐 main 已定的设计。**本 PR 现在只保留仍然有效的那一半修复：`has_platform_message_id` 的可见性契约**——重试 guard（#47237，`run_turn.py`）与重启 drain-window 恢复去重（`session_persistence.py`）都依赖这个 probe，修复前它把 rewind/undo 归档行也算作存在，用户收回 turn 后平台重投递的同 id 消息被静默吞掉。分支为 current main 上的单 commit。

## 背景

修复 #79576 的遗留面: Telegram 会话重试循环 —— `has_platform_message_id` probe（transient-failure 重试 guard #47237 + 重启恢复去重）把**软归档的 rewind/undo 行**也当作「已持久化」，导致用户收回（rewind/undo）一个 turn 后，平台对同一 message_id 的重投递被 guard 跳过，用户重发的消息永远进不了 transcript。

## 根因

`has_platform_message_id` 的查询无可见性过滤：

```sql
SELECT 1 FROM messages WHERE session_id = ? AND platform_message_id = ? LIMIT 1
```

任何带该 id 的行（包括 `active=0, compacted=0` 的 rewind/undo 归档行）都命中。而 main 的 `has_gateway_input_owner`（`3114916ee4`）已确立 `(active = 1 OR compacted = 1)` 可见性契约——两个 probe 语义应一致。

## 修复方式

`has_platform_message_id` 对齐 `has_gateway_input_owner` 的可见性契约：

- **live 行（`active=1`）**计数 —— 原 #47237 guard 行为不变
- **compaction 归档行（`active=0, compacted=1`）**计数 —— 防止重插入复活已被 in-place compaction 摘要掉的轮次
- **rewind/undo 行（`active=0, compacted=0`）**不计数 —— 用户收回了 turn，同 id 重投递应重新持久化

## 已移除的部分（与 main 对齐）

原先的三个 DB 层事务内去重点已全部移除——main 的 ownership 标记方案（`has_input_owner` 门控 + 契约测试「独立 accepted 输入均存活」）已 settle 该设计，DB 层强制 one-row-per-platform-id 会破坏 main 的契约（`test_codex_echo_ownership` / `test_failure_writer_ownership` 在本 PR head 上 6 项失败即为证据，移除后全绿）。

## Who should enable this

使用 **Telegram**（及任何产生 `platform_message_id` 的入站平台）且用过 **rewind/undo** 的用户：收回 turn 后重发同一条消息时消息被吞、不进历史。无需配置变更——修复在 probe 查询层生效。

## Platform compatibility

| 平台 | 兼容性 |
|---|---|
| macOS | ✅ |
| Linux | ✅ |
| Windows | ✅（SQLite 层与平台无关） |

## Quick-start guide

1. `hermes update`（或拉取本 PR 分支）
2. 无需修改配置；重启 gateway 生效
3. 验证：`/rewind` 收回一条消息后，从 Telegram 重发同一条——消息应出现在 transcript 中

## Troubleshooting

| 症状 | 原因 | 修复 |
|---|---|---|
| rewind 后重发消息被吞 | probe 把归档行算作存在 | 本修复：rewind/undo 行不再遮蔽重投递 |
| compaction 后同 id 消息复活 | 若 rewind 行也不计数导致复活 | 不会——compacted 行仍计数，guard 继续挡 |
| 重复入站 turn 堆叠 | 旧版 check-then-insert 竞态 | 已由 main `3114916ee4` 的 ownership 方案解决 |

## 验证

- [x] 10 个契约测试 `tests/gateway/test_79576_platform_message_id_dedupe.py`（重写为可见性契约版）: live/rewound/compacted 可见性、可见性往返（unarchive 恢复）、per-session 作用域、rewind 后重投递重插入新行、compaction 后 guard 继续挡、`SessionStore` wrapper seam 透传（含无 DB 回退 False）
- [x] main 的 ownership 契约测试在本分支全绿: `test_codex_echo_ownership`（8/8）+ `test_failure_writer_ownership`（2/2）+ `tests/state/` 全量（186 passed, 5 skipped）
- [x] `tests/gateway/`（非 platforms）1400+ passed；唯一失败 `test_buzz_adapter.py::test_live_media_redacts_long_path_before_bounding` 在本分支 base 上同样失败（stash 验证），与本改动无关
- [x] ruff check 通过
- [x] 遵循 AGENTS.md：不与 main 已 settle 的设计对抗、行为契约式测试、最小足迹（净 -401 行）

Closes #79576

