### PR TITLE
feat(desktop): add declared cross-plugin read services

### DIFF
--- a/apps/desktop/src/contrib/plugin-services.test.ts
+++ b/apps/desktop/src/contrib/plugin-services.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createPluginContext } from './plugin'
+import { $pluginRecords, publishPlugin } from './plugins-store'
+
+const readModel = {
+  rest: [{ id: 'read-model', methods: ['GET'], paths: ['/boards', '/board'] }]
+} as const
+
+const requiresReadModel = {
+  rest: [{ provider: 'provider', capability: 'read-model' }]
+} as const
+
+function provider(status: 'disabled' | 'error' | 'loaded' = 'loaded') {
+  publishPlugin({
+    id: 'provider',
+    name: 'Provider',
+    kind: 'bundled',
+    status,
+    provides: readModel
+  })
+}
+
+beforeEach(() => {
+  $pluginRecords.set({})
+  Object.defineProperty(window, 'hermesDesktop', {
+    configurable: true,
+    value: { api: vi.fn(async request => request) }
+  })
+})
+
+describe('declared plugin REST capabilities', () => {
+  it('fails closed when the consumer did not declare the capability', async () => {
+    provider()
+    const ctx = createPluginContext('consumer')
+
+    await expect(ctx.services.rest('provider', 'read-model', '/boards')).rejects.toMatchObject({
+      code: 'consumer_undeclared'
+    })
+  })
+
+  it('reaches only the declared provider namespace with a granted GET route', async () => {
+    provider()
+    const ctx = createPluginContext('consumer', undefined, requiresReadModel)
+
+    await ctx.services.rest('provider', 'read-model', '/board?board=alpha')
+
+    expect(window.hermesDesktop.api).toHaveBeenCalledWith(
+      expect.objectContaining({ path: '/api/plugins/provider/board?board=alpha', method: 'GET' })
+    )
+    await expect(ctx.services.rest('other', 'read-model', '/board')).rejects.toMatchObject({
+      code: 'consumer_undeclared'
+    })
+  })
+
+  it('rejects writes and traversal before touching the desktop bridge', async () => {
+    provider()
+    const ctx = createPluginContext('consumer', undefined, requiresReadModel)
+
+    await expect(
+      ctx.services.rest('provider', 'read-model', '/board', { method: 'POST', body: {} })
+    ).rejects.toMatchObject({ code: 'method_not_allowed' })
+    await expect(ctx.services.rest('provider', 'read-model', '/../other')).rejects.toMatchObject({
+      code: 'path_not_allowed'
+    })
+    expect(window.hermesDesktop.api).not.toHaveBeenCalled()
+  })
+
+  it('rejects provider namespace injection before touching the desktop bridge', async () => {
+    publishPlugin({
+      id: '../provider',
+      name: 'Invalid Provider',
+      kind: 'disk',
+      status: 'loaded',
+      provides: readModel
+    })
+    const ctx = createPluginContext('consumer', undefined, {
+      rest: [{ provider: '../provider', capability: 'read-model' }]
+    })
+
+    await expect(ctx.services.rest('../provider', 'read-model', '/board')).rejects.toMatchObject({
+      code: 'path_not_allowed'
+    })
+    expect(window.hermesDesktop.api).not.toHaveBeenCalled()
+  })
+
+  it('reports missing and disabled providers distinctly', async () => {
+    const ctx = createPluginContext('consumer', undefined, requiresReadModel)
+
+    await expect(ctx.services.rest('provider', 'read-model', '/boards')).rejects.toMatchObject({
+      code: 'provider_missing'
+    })
+
+    provider('disabled')
+    await expect(ctx.services.rest('provider', 'read-model', '/boards')).rejects.toMatchObject({
+      code: 'provider_disabled'
+    })
+  })
+
+  it('preserves same-plugin ctx.rest behavior', async () => {
+    const ctx = createPluginContext('consumer')
+
+    await ctx.rest('/write', { method: 'POST', body: { ok: true } })
+
+    expect(window.hermesDesktop.api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/api/plugins/consumer/write',
+        method: 'POST',
+        body: { ok: true }
+      })
+    )
+  })
+})

--- a/apps/desktop/src/contrib/plugin.ts
+++ b/apps/desktop/src/contrib/plugin.ts
@@ -17,6 +17,7 @@ import { createPluginI18n, type PluginI18n } from '@/i18n'
 import { readKey, writeKey } from '@/lib/storage'
 import { dispatchPluginNativeNotification, type PluginNativeNotificationInput } from '@/store/native-notifications'
 
+import { $pluginRecords } from './plugins-store'
 import { registry } from './registry'
 import type { Contribution } from './types'
 
@@ -33,6 +34,50 @@ export interface PluginStorage {
   get<T>(key: string, fallback: T): T
   set(key: string, value: unknown): void
   remove(key: string): void
+}
+
+export type PluginServiceErrorCode =
+  | 'capability_missing'
+  | 'consumer_undeclared'
+  | 'method_not_allowed'
+  | 'path_not_allowed'
+  | 'provider_disabled'
+  | 'provider_error'
+  | 'provider_missing'
+
+export class PluginServiceError extends Error {
+  readonly code: PluginServiceErrorCode
+
+  constructor(code: PluginServiceErrorCode, message: string) {
+    super(message)
+    this.name = 'PluginServiceError'
+    this.code = code
+  }
+}
+
+/** Provider-owned, named read-only REST surface. Route paths are exact; query
+ *  strings remain caller-owned. GET is intentionally the only first-tier method. */
+export interface PluginRestCapability {
+  id: string
+  methods: readonly ['GET']
+  paths: readonly string[]
+}
+
+export interface PluginProvides {
+  rest?: readonly PluginRestCapability[]
+}
+
+export interface PluginRequirement {
+  capability: string
+  provider: string
+}
+
+export interface PluginRequires {
+  rest?: readonly PluginRequirement[]
+}
+
+export interface PluginServices {
+  rest: <T>(provider: string, capability: string, path: string, opts?: PluginRestOptions) => Promise<T>
 }
 
 /** The curated OS door — every way a plugin reaches outside the app window,
@@ -77,6 +122,8 @@ export interface PluginContext {
    *  returned. Resolves to a no-op on OAuth remotes — treat it as an
    *  accelerator over your polling, never a replacement. */
   socket: (path: string, onMessage: (data: unknown) => void) => () => void
+  /** Two-party cross-plugin capability door: consumer requirement plus provider grant. */
+  services: PluginServices
   /** The curated OS door: native notification, open-external, reveal-in-file-
    *  manager, clipboard — attributed to this plugin, result-shaped (never
    *  throws for a missing capability). */
@@ -97,6 +144,10 @@ export interface HermesPlugin {
    *  for opt-in plugins: they inventory in Settings ▸ Plugins, off until the
    *  user flips the switch. */
   defaultEnabled?: boolean
+  /** Named exact-path GET surfaces granted to declared consumers. */
+  provides?: PluginProvides
+  /** Cross-plugin REST capabilities this plugin intends to consume. */
+  requires?: PluginRequires
   /** Called once at load; wire contributions through `ctx`. */
   register: (ctx: PluginContext) => void
 }
@@ -156,7 +207,11 @@ function createPluginOs(pluginId: string): PluginOs {
 
 /** Build the scoped context handed to a plugin's `register`. `onDispose`
  *  receives every registration's disposer (the loader's unload/reload hook). */
-export function createPluginContext(pluginId: string, onDispose?: (dispose: () => void) => void): PluginContext {
+export function createPluginContext(
+  pluginId: string,
+  onDispose?: (dispose: () => void) => void,
+  requires: PluginRequires = {}
+): PluginContext {
   const source = `plugin:${pluginId}`
   const scope = (c: PluginContribution): Contribution => ({ ...c, id: `${pluginId}:${c.id}`, source })
 
@@ -166,6 +221,66 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     return dispose
   }
 
+  const serviceRest = async <T>(
+    providerId: string,
+    capabilityId: string,
+    path: string,
+    opts: PluginRestOptions = {}
+  ): Promise<T> => {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(providerId)) {
+      throw new PluginServiceError('path_not_allowed', `Invalid plugin provider id "${providerId}"`)
+    }
+
+    const declared = requires.rest?.some(
+      requirement => requirement.provider === providerId && requirement.capability === capabilityId
+    )
+
+    if (!declared) {
+      throw new PluginServiceError(
+        'consumer_undeclared',
+        `Plugin "${pluginId}" did not declare ${providerId}:${capabilityId}`
+      )
+    }
+
+    const provider = $pluginRecords.get()[providerId]
+
+    if (!provider) {
+      throw new PluginServiceError('provider_missing', `Plugin provider "${providerId}" is not installed`)
+    }
+    if (provider.status === 'disabled') {
+      throw new PluginServiceError('provider_disabled', `Plugin provider "${providerId}" is disabled`)
+    }
+    if (provider.status === 'error') {
+      throw new PluginServiceError('provider_error', `Plugin provider "${providerId}" failed to load`)
+    }
+
+    const capability = provider.provides?.rest?.find(candidate => candidate.id === capabilityId)
+
+    if (!capability) {
+      throw new PluginServiceError(
+        'capability_missing',
+        `Plugin provider "${providerId}" does not grant capability "${capabilityId}"`
+      )
+    }
+
+    const method = (opts.method ?? 'GET').toUpperCase()
+
+    if (method !== 'GET' || !capability.methods.includes('GET')) {
+      throw new PluginServiceError('method_not_allowed', `Capability "${capabilityId}" permits GET only`)
+    }
+
+    const routePath = (path.startsWith('/') ? path : `/${path}`).split(/[?#]/, 1)[0]
+
+    if (routePath.split('/').includes('..') || !capability.paths.includes(routePath)) {
+      throw new PluginServiceError(
+        'path_not_allowed',
+        `Capability "${capabilityId}" does not grant route "${routePath}"`
+      )
+    }
+
+    return pluginRest<T>(providerId, path, { ...opts, method: 'GET' })
+  }
+
   return {
     source,
     register: c => track(registry.register(scope(c))),
@@ -173,6 +288,7 @@ export function createPluginContext(pluginId: string, onDispose?: (dispose: () =
     onDispose: fn => void track(fn),
     rest: <T>(path: string, opts?: PluginRestOptions) => pluginRest<T>(pluginId, path, opts),
     socket: (path, onMessage) => track(pluginSocket(pluginId, path, onMessage)),
+    services: { rest: serviceRest },
     os: createPluginOs(pluginId),
     storage: createPluginStorage(pluginId),
     i18n: createPluginI18n(pluginId, track)

--- a/apps/desktop/src/contrib/plugins-store.ts
+++ b/apps/desktop/src/contrib/plugins-store.ts
@@ -10,6 +10,8 @@
 
 import { atom } from 'nanostores'
 
+import type { PluginProvides, PluginRequires } from './plugin'
+
 export type PluginKind = 'bundled' | 'disk' | 'runtime'
 export type PluginStatus = 'disabled' | 'error' | 'loaded'
 
@@ -22,6 +24,9 @@ export interface PluginRecord {
   error?: string
   /** Absolute plugin.js path (disk plugins) — powers "Reveal in Finder". */
   file?: string
+  /** Provider grants and consumer requirements used by the service boundary. */
+  provides?: PluginProvides
+  requires?: PluginRequires
 }
 
 // Explicit user enable/disable choices, id -> boolean. ABSENCE means "no

--- a/apps/desktop/src/contrib/plugins.ts
+++ b/apps/desktop/src/contrib/plugins.ts
@@ -40,7 +40,13 @@ export function discoverBundledPlugins(): void {
     // Same inventory + live-toggle contract as runtime plugins: each bundled
     // plugin publishes a record with activate/deactivate handles, and a
     // persisted disable survives boots by skipping registration here.
-    const record = { id: plugin.id, name: plugin.name ?? plugin.id, kind: 'bundled' as const }
+    const record = {
+      id: plugin.id,
+      name: plugin.name ?? plugin.id,
+      kind: 'bundled' as const,
+      provides: plugin.provides,
+      requires: plugin.requires
+    }
     let disposers: (() => void)[] = []
 
     const activate = () => {
@@ -48,7 +54,7 @@ export function discoverBundledPlugins(): void {
       disposers = []
 
       try {
-        plugin.register(createPluginContext(plugin.id, dispose => disposers.push(dispose)))
+        plugin.register(createPluginContext(plugin.id, dispose => disposers.push(dispose), plugin.requires))
         publishPlugin({ ...record, status: 'loaded' })
       } catch (error) {
         console.error(`[plugins] ${plugin.id} failed to register`, error)

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -140,14 +140,16 @@ export async function loadRuntimePlugin(
       id: plugin.id,
       name: plugin.name ?? plugin.id,
       kind: options.kind ?? 'disk',
-      file: options.file
+      file: options.file,
+      provides: plugin.provides,
+      requires: plugin.requires
     }
 
     const activate = () => {
       // Reload = dispose the previous incarnation, then register fresh.
       unloadRuntimePlugin(plugin.id)
       const disposers: (() => void)[] = []
-      plugin.register(createPluginContext(plugin.id, dispose => disposers.push(dispose)))
+      plugin.register(createPluginContext(plugin.id, dispose => disposers.push(dispose), plugin.requires))
       loaded.set(plugin.id, disposers)
       publishPlugin({ ...record, status: 'loaded' })
     }

--- a/apps/desktop/src/plugins/kanban/plugin.tsx
+++ b/apps/desktop/src/plugins/kanban/plugin.tsx
@@ -81,6 +81,9 @@ const plugin: HermesPlugin = {
   id: 'kanban',
   name: 'Kanban',
   defaultEnabled: false,
+  provides: {
+    rest: [{ id: 'read-model', methods: ['GET'], paths: ['/boards', '/board'] }]
+  },
   register(ctx) {
     ctx.i18n.register(KANBAN_LOCALES)
     ctx.onDispose(bindApi(ctx.rest, ctx.storage, ctx.socket))

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -202,7 +202,11 @@ export type {
   PluginContribution,
   PluginNativeNotificationInput,
   PluginOs,
+  PluginProvides,
+  PluginRequires,
   PluginRestOptions,
+  PluginServiceErrorCode,
+  PluginServices,
   PluginStorage
 } from '@/contrib/plugin'
 


### PR DESCRIPTION
## Summary

Add a narrow Desktop plugin SDK seam for declared cross-plugin read services.

A provider declares a named REST capability with exact GET paths. A consumer must declare the matching provider and capability before it can call `ctx.services.rest`. The host verifies both declarations, the provider's loaded state, the GET method, the exact route, and the provider namespace before using the existing profile-aware plugin REST transport.

The bundled Kanban plugin declares its existing `/boards` and `/board` read models as the first concrete provider. No consumer-specific code is added.

## Security properties

- provider and consumer declarations must agree;
- missing, disabled, or load-error providers fail closed;
- undeclared capabilities and paths fail closed;
- provider identifiers cannot inject a namespace;
- traversal segments and write methods are rejected before bridge invocation;
- the host forces the transport method to GET;
- existing same-plugin `ctx.rest` behavior is unchanged;
- no new raw renderer bridge is exposed.

## Tests

- imported regression test: meaningful RED before implementation;
- focused capability suite on current main: 6 passed;
- directly affected plugin suites: 13 passed;
- Desktop renderer TypeScript noEmit: passed;
- complete Desktop UI suite: 397 files and 3,495 tests passed.
