### PR TITLE
refactor(kanban): extract board-path/integrity/policy mixins from kanban_db.py (shard s1)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/hermes_cli/kanban_board_paths.py
+++ b/hermes_cli/kanban_board_paths.py
@@ -1,0 +1,282 @@
+"""Kanban board state + path resolution for :mod:`hermes_cli.kanban_db`.
+
+Extracted verbatim from ``hermes_cli/kanban_db.py`` (wave-1 godfile
+decomposition, shard s1, clusters c7/c8 — ``kanban_board_paths.py``).
+Board selection state (the per-context override ``ContextVar``) and all
+on-disk path helpers live here; :mod:`hermes_cli.kanban_db` re-imports them
+so the module surface is unchanged.
+
+Shared constants/helpers that the rest of the kanban module still uses
+(``DEFAULT_BOARD``, ``_CURRENT_BOARD_OVERRIDE``, ``_BOARD_SLUG_RE``,
+``_assert_not_delegated_child_mutation``) stay defined in
+``hermes_cli.kanban_db`` and are imported at the bottom of this module.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from contextvars import ContextVar, Token
+from pathlib import Path
+from typing import Optional
+
+@contextlib.contextmanager
+def scoped_current_board(slug: str):
+    """Temporarily pin the active board for the current context only."""
+    token: Token[str | None] = _CURRENT_BOARD_OVERRIDE.set(slug)
+    try:
+        yield
+    finally:
+        _CURRENT_BOARD_OVERRIDE.reset(token)
+def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
+    """Lowercase + strip a slug; validate; return ``None`` for empty."""
+    if slug is None:
+        return None
+    s = str(slug).strip().lower()
+    if not s:
+        return None
+    if not _BOARD_SLUG_RE.match(s):
+        raise ValueError(
+            f"invalid board slug {slug!r}: must be 1-64 chars, lowercase "
+            f"alphanumerics / hyphens / underscores, not starting with '-' or '_'"
+        )
+    return s
+def kanban_home() -> Path:
+    """Return the shared Hermes root that anchors the kanban board.
+
+    Resolution order:
+
+    1. ``HERMES_KANBAN_HOME`` env var when set and non-empty (explicit
+       override for tests and unusual deployments).
+    2. ``get_default_hermes_root()``, which already returns ``<root>``
+       when ``HERMES_HOME`` is ``<root>/profiles/<name>``, and returns
+       ``HERMES_HOME`` directly for Docker / custom deployments.
+
+    The kanban board is shared across profiles **by design** (see the
+    module docstring). Resolving the kanban paths through the active
+    profile's ``HERMES_HOME`` would silently fork the board per profile,
+    which breaks the dispatcher / worker handoff.
+    """
+    override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
+    if override:
+        return Path(override).expanduser()
+    from hermes_constants import get_default_hermes_root
+    return get_default_hermes_root()
+def boards_root() -> Path:
+    """Return ``<root>/kanban/boards`` — the parent of non-default board dirs.
+
+    ``default`` is intentionally NOT under this directory — its DB lives at
+    ``<root>/kanban.db`` for back-compat with pre-boards installs. This
+    function returns the directory where *additional* named boards live,
+    used by :func:`list_boards` to enumerate them.
+    """
+    return kanban_home() / "kanban" / "boards"
+def current_board_path() -> Path:
+    """Return the path to ``<root>/kanban/current``.
+
+    One-line text file written by ``hermes kanban boards switch <slug>``
+    to persist the user's board selection across CLI invocations. Absent
+    by default (meaning: active board is ``default``).
+    """
+    return kanban_home() / "kanban" / "current"
+def get_current_board() -> str:
+    """Return the active board slug, honouring the resolution chain.
+
+    Order (highest precedence first):
+
+    1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
+       spawn, or manually for ad-hoc overrides).
+    2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
+       switch``), but only when that board still exists.
+    3. ``DEFAULT_BOARD`` (``"default"``).
+
+    A malformed or stale slug at any step falls through to the next layer
+    with a best-effort warning — the dispatcher must never crash because a
+    user hand-edited a file or removed a board directory.
+    """
+    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
+    if scoped:
+        try:
+            normed = _normalize_board_slug(scoped)
+            if normed and board_exists(normed):
+                return normed
+        except ValueError:
+            pass
+
+    env = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
+    if env:
+        try:
+            normed = _normalize_board_slug(env)
+            if normed and board_exists(normed):
+                return normed
+        except ValueError:
+            pass
+    try:
+        f = current_board_path()
+        if f.exists():
+            val = f.read_text(encoding="utf-8").strip()
+            if val:
+                try:
+                    normed = _normalize_board_slug(val)
+                    if normed and board_exists(normed):
+                        return normed
+                except ValueError:
+                    pass
+    except OSError:
+        pass
+    return DEFAULT_BOARD
+def set_current_board(slug: str) -> Path:
+    """Persist ``slug`` as the active board. Returns the file written.
+
+    Writes ``<root>/kanban/current``. The caller should validate the slug
+    exists first (via :func:`board_exists`) — this function does not —
+    so that ``hermes kanban boards switch <typo>`` returns an error
+    instead of silently pointing at nothing.
+    """
+    _assert_not_delegated_child_mutation()
+    normed = _normalize_board_slug(slug)
+    if not normed:
+        raise ValueError("board slug is required")
+    path = current_board_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(normed + "\n", encoding="utf-8")
+    return path
+def clear_current_board() -> None:
+    """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
+    _assert_not_delegated_child_mutation()
+    try:
+        current_board_path().unlink()
+    except FileNotFoundError:
+        pass
+def board_dir(board: Optional[str] = None) -> Path:
+    """Return the on-disk directory for ``board``.
+
+    ``default`` is ``<root>/kanban/boards/default/`` **for metadata only**
+    (board.json + workspaces/ + logs/). Its DB file stays at
+    ``<root>/kanban.db`` for back-compat — see :func:`kanban_db_path`.
+
+    All other boards live at ``<root>/kanban/boards/<slug>/`` with
+    everything inside that directory including the ``kanban.db``.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    return boards_root() / slug
+def board_exists(board: Optional[str] = None) -> bool:
+    """Return True if the board has persisted metadata or a DB on disk.
+
+    ``default`` is considered to always exist — its DB is created
+    on first :func:`connect` and there's no way for it to be missing
+    in a configuration where the kanban feature is usable at all.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    if slug == DEFAULT_BOARD:
+        return True
+    d = board_dir(slug)
+    return (d / "board.json").exists() or (d / "kanban.db").exists()
+def kanban_db_path(board: Optional[str] = None) -> Path:
+    """Return the path to the ``kanban.db`` for ``board``.
+
+    Resolution (highest precedence first):
+
+    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
+       back-compat and for the dispatcher→worker handoff (defense in
+       depth: dispatcher injects this into worker env so workers are
+       immune to any path-resolution disagreement).
+    2. When ``board`` arg is None, the active board from
+       :func:`get_current_board` is used.
+    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
+       Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
+    """
+    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+    if override:
+        return Path(override).expanduser()
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    if slug == DEFAULT_BOARD:
+        return kanban_home() / "kanban.db"
+    return board_dir(slug) / "kanban.db"
+def workspaces_root(board: Optional[str] = None) -> Path:
+    """Return the directory under which ``scratch`` workspaces are created.
+
+    Anchored per-board so workspaces don't leak between projects.
+    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (highest
+    precedence) — the dispatcher injects this into worker env.
+
+    ``default`` keeps the legacy path ``<root>/kanban/workspaces/`` so
+    that existing scratch workspaces from before the boards feature are
+    preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
+    """
+    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    if slug == DEFAULT_BOARD:
+        return kanban_home() / "kanban" / "workspaces"
+    return board_dir(slug) / "workspaces"
+def attachments_root(board: Optional[str] = None) -> Path:
+    """Return the directory under which task file attachments are stored.
+
+    Mirrors :func:`worker_logs_dir` / :func:`workspaces_root`: anchored
+    per-board so attachments don't leak between projects. Each task gets
+    its own ``<root>/.../attachments/<task_id>/`` subdirectory.
+
+    ``HERMES_KANBAN_ATTACHMENTS_ROOT`` pins the path directly (highest
+    precedence) for tests and unusual deployments.
+
+    ``default`` uses ``<root>/kanban/attachments/``; other boards use
+    ``<root>/kanban/boards/<slug>/attachments/``.
+
+    Workers (which run with full file-tool access) read attached files
+    by the absolute path surfaced in :func:`build_worker_context`. On the
+    local terminal backend — the default for kanban — that path resolves
+    directly. Remote backends (Docker/Modal) need this directory mounted;
+    see the kanban docs.
+    """
+    override = os.environ.get("HERMES_KANBAN_ATTACHMENTS_ROOT", "").strip()
+    if override:
+        return Path(override).expanduser()
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    if slug == DEFAULT_BOARD:
+        return kanban_home() / "kanban" / "attachments"
+    return board_dir(slug) / "attachments"
+def task_attachments_dir(task_id: str, board: Optional[str] = None) -> Path:
+    """Return the per-task attachment directory ``<root>/<task_id>/``."""
+    return attachments_root(board=board) / task_id
+def worker_logs_dir(board: Optional[str] = None) -> Path:
+    """Return the directory under which per-task worker logs are written.
+
+    ``default`` keeps the legacy path ``<root>/kanban/logs/``. Other
+    boards use ``<root>/kanban/boards/<slug>/logs/``. Logs follow the
+    board — makes ``hermes kanban log`` unambiguous even when multiple
+    boards have tasks with the same id.
+    """
+    slug = _normalize_board_slug(board)
+    if slug is None:
+        slug = get_current_board()
+    if slug == DEFAULT_BOARD:
+        return kanban_home() / "kanban" / "logs"
+    return board_dir(slug) / "logs"
+def board_metadata_path(board: Optional[str] = None) -> Path:
+    """Return the path to ``board.json`` for ``board``.
+
+    Stores display metadata (display name, description, icon, color,
+    created_at). The on-disk slug is the canonical identity; this file
+    is purely for presentation in the CLI / dashboard.
+    """
+    slug = _normalize_board_slug(board) or DEFAULT_BOARD
+    return board_dir(slug) / "board.json"
+
+
+# Imported at the bottom to break the import cycle with kanban_db.py (which
+# re-imports the moved functions from this module). Function bodies resolve
+# these names at call time, so bottom placement is safe.
+from hermes_cli.kanban_db import (  # noqa: E402
+    DEFAULT_BOARD,
+    _assert_not_delegated_child_mutation,
+    _BOARD_SLUG_RE,
+    _CURRENT_BOARD_OVERRIDE,
+)

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -239,29 +239,6 @@ DEFAULT_CLAIM_HEARTBEAT_MAX_STALE_SECONDS = 60 * 60
 RECLAIM_DEFER_GRACE_SECONDS = 120
 
 
-def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
-    """Return the effective claim TTL, honoring the kanban env override.
-
-    Explicit call-site values win. Otherwise a positive integer from
-    ``HERMES_KANBAN_CLAIM_TTL_SECONDS`` overrides the built-in default.
-    Invalid or non-positive env values fall back silently so existing
-    installs keep working.
-    """
-    if ttl_seconds is not None:
-        return max(1, int(ttl_seconds))
-
-    raw = os.environ.get("HERMES_KANBAN_CLAIM_TTL_SECONDS", "").strip()
-    if raw:
-        try:
-            parsed = int(raw)
-        except ValueError:
-            parsed = 0
-        if parsed > 0:
-            return parsed
-
-    return DEFAULT_CLAIM_TTL_SECONDS
-
-
 # Grace period after a task transitions to ``running`` during which
 # ``detect_crashed_workers`` skips the ``_pid_alive`` check. Covers the
 # fork() → /proc-visibility window where liveness can transiently report
@@ -280,47 +257,6 @@ DEFAULT_CRASH_GRACE_SECONDS = 30
 # conventional "temporary failure, retry later" code, and well clear of the
 # 0/1/2 codes the worker uses for success / generic failure / usage error.
 KANBAN_RATE_LIMIT_EXIT_CODE = 75
-
-
-def _resolve_crash_grace_seconds() -> int:
-    """Return the crash-detection grace period in seconds.
-
-    Reads ``HERMES_KANBAN_CRASH_GRACE_SECONDS`` from the environment;
-    falls back to ``DEFAULT_CRASH_GRACE_SECONDS`` when absent, empty,
-    non-integer, or negative. A value of 0 restores immediate-reclaim
-    behaviour (useful for tests).
-    """
-    raw = os.environ.get("HERMES_KANBAN_CRASH_GRACE_SECONDS", "").strip()
-    if raw:
-        try:
-            parsed = int(raw)
-        except ValueError:
-            parsed = -1
-        if parsed >= 0:
-            return parsed
-    return DEFAULT_CRASH_GRACE_SECONDS
-
-
-def _resolve_rate_limit_cooldown_seconds() -> int:
-    """Return the rate-limit requeue cooldown in seconds.
-
-    Reads ``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS`` from the environment;
-    falls back to ``DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS`` when absent, empty,
-    non-integer, or negative. A value of 0 disables the cooldown (re-spawn on
-    the next tick) — useful for tests that want to assert the task becomes
-    spawnable again immediately.
-    """
-    raw = os.environ.get(
-        "HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", ""
-    ).strip()
-    if raw:
-        try:
-            parsed = int(raw)
-        except ValueError:
-            parsed = -1
-        if parsed >= 0:
-            return parsed
-    return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
 
 
 # Worker-context caps so build_worker_context() stays bounded on
@@ -383,292 +319,12 @@ _CURRENT_BOARD_OVERRIDE: ContextVar[str | None] = ContextVar(
 )
 
 
-@contextlib.contextmanager
-def scoped_current_board(slug: str):
-    """Temporarily pin the active board for the current context only."""
-    token: Token[str | None] = _CURRENT_BOARD_OVERRIDE.set(slug)
-    try:
-        yield
-    finally:
-        _CURRENT_BOARD_OVERRIDE.reset(token)
-
 # Slug validator: lowercase alphanumerics, digits, hyphens; 1–64 chars.
 # Strict enough to stop traversal (`..`) and embedded path separators, loose
 # enough that kebab-case names like ``atm10-server`` or ``hermes-agent``
 # pass without fuss. Board names with display formatting (spaces, emoji)
 # live in ``board.json``; the slug is just the directory name.
 _BOARD_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9\-_]{0,63}$")
-
-
-def _normalize_board_slug(slug: Optional[str]) -> Optional[str]:
-    """Lowercase + strip a slug; validate; return ``None`` for empty."""
-    if slug is None:
-        return None
-    s = str(slug).strip().lower()
-    if not s:
-        return None
-    if not _BOARD_SLUG_RE.match(s):
-        raise ValueError(
-            f"invalid board slug {slug!r}: must be 1-64 chars, lowercase "
-            f"alphanumerics / hyphens / underscores, not starting with '-' or '_'"
-        )
-    return s
-
-
-def kanban_home() -> Path:
-    """Return the shared Hermes root that anchors the kanban board.
-
-    Resolution order:
-
-    1. ``HERMES_KANBAN_HOME`` env var when set and non-empty (explicit
-       override for tests and unusual deployments).
-    2. ``get_default_hermes_root()``, which already returns ``<root>``
-       when ``HERMES_HOME`` is ``<root>/profiles/<name>``, and returns
-       ``HERMES_HOME`` directly for Docker / custom deployments.
-
-    The kanban board is shared across profiles **by design** (see the
-    module docstring). Resolving the kanban paths through the active
-    profile's ``HERMES_HOME`` would silently fork the board per profile,
-    which breaks the dispatcher / worker handoff.
-    """
-    override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
-    if override:
-        return Path(override).expanduser()
-    from hermes_constants import get_default_hermes_root
-    return get_default_hermes_root()
-
-
-def boards_root() -> Path:
-    """Return ``<root>/kanban/boards`` — the parent of non-default board dirs.
-
-    ``default`` is intentionally NOT under this directory — its DB lives at
-    ``<root>/kanban.db`` for back-compat with pre-boards installs. This
-    function returns the directory where *additional* named boards live,
-    used by :func:`list_boards` to enumerate them.
-    """
-    return kanban_home() / "kanban" / "boards"
-
-
-def current_board_path() -> Path:
-    """Return the path to ``<root>/kanban/current``.
-
-    One-line text file written by ``hermes kanban boards switch <slug>``
-    to persist the user's board selection across CLI invocations. Absent
-    by default (meaning: active board is ``default``).
-    """
-    return kanban_home() / "kanban" / "current"
-
-
-def get_current_board() -> str:
-    """Return the active board slug, honouring the resolution chain.
-
-    Order (highest precedence first):
-
-    1. ``HERMES_KANBAN_BOARD`` env var (set by the dispatcher on worker
-       spawn, or manually for ad-hoc overrides).
-    2. ``<root>/kanban/current`` on disk (set by ``hermes kanban boards
-       switch``), but only when that board still exists.
-    3. ``DEFAULT_BOARD`` (``"default"``).
-
-    A malformed or stale slug at any step falls through to the next layer
-    with a best-effort warning — the dispatcher must never crash because a
-    user hand-edited a file or removed a board directory.
-    """
-    scoped = (_CURRENT_BOARD_OVERRIDE.get() or "").strip()
-    if scoped:
-        try:
-            normed = _normalize_board_slug(scoped)
-            if normed and board_exists(normed):
-                return normed
-        except ValueError:
-            pass
-
-    env = os.environ.get("HERMES_KANBAN_BOARD", "").strip()
-    if env:
-        try:
-            normed = _normalize_board_slug(env)
-            if normed and board_exists(normed):
-                return normed
-        except ValueError:
-            pass
-    try:
-        f = current_board_path()
-        if f.exists():
-            val = f.read_text(encoding="utf-8").strip()
-            if val:
-                try:
-                    normed = _normalize_board_slug(val)
-                    if normed and board_exists(normed):
-                        return normed
-                except ValueError:
-                    pass
-    except OSError:
-        pass
-    return DEFAULT_BOARD
-
-
-def set_current_board(slug: str) -> Path:
-    """Persist ``slug`` as the active board. Returns the file written.
-
-    Writes ``<root>/kanban/current``. The caller should validate the slug
-    exists first (via :func:`board_exists`) — this function does not —
-    so that ``hermes kanban boards switch <typo>`` returns an error
-    instead of silently pointing at nothing.
-    """
-    _assert_not_delegated_child_mutation()
-    normed = _normalize_board_slug(slug)
-    if not normed:
-        raise ValueError("board slug is required")
-    path = current_board_path()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(normed + "\n", encoding="utf-8")
-    return path
-
-
-def clear_current_board() -> None:
-    """Remove ``<root>/kanban/current`` so the active board reverts to ``default``."""
-    _assert_not_delegated_child_mutation()
-    try:
-        current_board_path().unlink()
-    except FileNotFoundError:
-        pass
-
-
-def board_dir(board: Optional[str] = None) -> Path:
-    """Return the on-disk directory for ``board``.
-
-    ``default`` is ``<root>/kanban/boards/default/`` **for metadata only**
-    (board.json + workspaces/ + logs/). Its DB file stays at
-    ``<root>/kanban.db`` for back-compat — see :func:`kanban_db_path`.
-
-    All other boards live at ``<root>/kanban/boards/<slug>/`` with
-    everything inside that directory including the ``kanban.db``.
-    """
-    slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    return boards_root() / slug
-
-
-def board_exists(board: Optional[str] = None) -> bool:
-    """Return True if the board has persisted metadata or a DB on disk.
-
-    ``default`` is considered to always exist — its DB is created
-    on first :func:`connect` and there's no way for it to be missing
-    in a configuration where the kanban feature is usable at all.
-    """
-    slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    if slug == DEFAULT_BOARD:
-        return True
-    d = board_dir(slug)
-    return (d / "board.json").exists() or (d / "kanban.db").exists()
-
-
-def kanban_db_path(board: Optional[str] = None) -> Path:
-    """Return the path to the ``kanban.db`` for ``board``.
-
-    Resolution (highest precedence first):
-
-    1. ``HERMES_KANBAN_DB`` env var — pins the path directly. Honoured for
-       back-compat and for the dispatcher→worker handoff (defense in
-       depth: dispatcher injects this into worker env so workers are
-       immune to any path-resolution disagreement).
-    2. When ``board`` arg is None, the active board from
-       :func:`get_current_board` is used.
-    3. Board ``default`` → ``<root>/kanban.db`` (back-compat path).
-       Other boards → ``<root>/kanban/boards/<slug>/kanban.db``.
-    """
-    override = os.environ.get("HERMES_KANBAN_DB", "").strip()
-    if override:
-        return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
-    if slug is None:
-        slug = get_current_board()
-    if slug == DEFAULT_BOARD:
-        return kanban_home() / "kanban.db"
-    return board_dir(slug) / "kanban.db"
-
-
-def workspaces_root(board: Optional[str] = None) -> Path:
-    """Return the directory under which ``scratch`` workspaces are created.
-
-    Anchored per-board so workspaces don't leak between projects.
-    ``HERMES_KANBAN_WORKSPACES_ROOT`` pins the path directly (highest
-    precedence) — the dispatcher injects this into worker env.
-
-    ``default`` keeps the legacy path ``<root>/kanban/workspaces/`` so
-    that existing scratch workspaces from before the boards feature are
-    preserved. Other boards use ``<root>/kanban/boards/<slug>/workspaces/``.
-    """
-    override = os.environ.get("HERMES_KANBAN_WORKSPACES_ROOT", "").strip()
-    if override:
-        return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
-    if slug is None:
-        slug = get_current_board()
-    if slug == DEFAULT_BOARD:
-        return kanban_home() / "kanban" / "workspaces"
-    return board_dir(slug) / "workspaces"
-
-
-def attachments_root(board: Optional[str] = None) -> Path:
-    """Return the directory under which task file attachments are stored.
-
-    Mirrors :func:`worker_logs_dir` / :func:`workspaces_root`: anchored
-    per-board so attachments don't leak between projects. Each task gets
-    its own ``<root>/.../attachments/<task_id>/`` subdirectory.
-
-    ``HERMES_KANBAN_ATTACHMENTS_ROOT`` pins the path directly (highest
-    precedence) for tests and unusual deployments.
-
-    ``default`` uses ``<root>/kanban/attachments/``; other boards use
-    ``<root>/kanban/boards/<slug>/attachments/``.
-
-    Workers (which run with full file-tool access) read attached files
-    by the absolute path surfaced in :func:`build_worker_context`. On the
-    local terminal backend — the default for kanban — that path resolves
-    directly. Remote backends (Docker/Modal) need this directory mounted;
-    see the kanban docs.
-    """
-    override = os.environ.get("HERMES_KANBAN_ATTACHMENTS_ROOT", "").strip()
-    if override:
-        return Path(override).expanduser()
-    slug = _normalize_board_slug(board)
-    if slug is None:
-        slug = get_current_board()
-    if slug == DEFAULT_BOARD:
-        return kanban_home() / "kanban" / "attachments"
-    return board_dir(slug) / "attachments"
-
-
-def task_attachments_dir(task_id: str, board: Optional[str] = None) -> Path:
-    """Return the per-task attachment directory ``<root>/<task_id>/``."""
-    return attachments_root(board=board) / task_id
-
-
-def worker_logs_dir(board: Optional[str] = None) -> Path:
-    """Return the directory under which per-task worker logs are written.
-
-    ``default`` keeps the legacy path ``<root>/kanban/logs/``. Other
-    boards use ``<root>/kanban/boards/<slug>/logs/``. Logs follow the
-    board — makes ``hermes kanban log`` unambiguous even when multiple
-    boards have tasks with the same id.
-    """
-    slug = _normalize_board_slug(board)
-    if slug is None:
-        slug = get_current_board()
-    if slug == DEFAULT_BOARD:
-        return kanban_home() / "kanban" / "logs"
-    return board_dir(slug) / "logs"
-
-
-def board_metadata_path(board: Optional[str] = None) -> Path:
-    """Return the path to ``board.json`` for ``board``.
-
-    Stores display metadata (display name, description, icon, color,
-    created_at). The on-disk slug is the canonical identity; this file
-    is purely for presentation in the CLI / dashboard.
-    """
-    slug = _normalize_board_slug(board) or DEFAULT_BOARD
-    return board_dir(slug) / "board.json"
 
 
 def _default_board_display_name(slug: str) -> str:
@@ -1661,61 +1317,6 @@ def _maybe_checkpoint_wal(conn: sqlite3.Connection, db_path: Path) -> None:
         _log.debug("kanban WAL checkpoint on %s skipped: %s", key, exc)
 
 
-def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
-    """Return True for a TLS record header at ``data[offset:]``."""
-    if len(data) < offset + 5:
-        return False
-    content_type = data[offset]
-    major = data[offset + 1]
-    minor = data[offset + 2]
-    length = int.from_bytes(data[offset + 3:offset + 5], "big")
-    return (
-        content_type in {0x14, 0x15, 0x16, 0x17}
-        and major == 0x03
-        and minor in {0x00, 0x01, 0x02, 0x03, 0x04}
-        and 0 < length <= 18432
-    )
-
-
-def _validate_sqlite_header(path: Path) -> None:
-    """Fail early with an actionable error for non-SQLite Kanban DB files.
-
-    ``sqlite3.connect()`` creates missing and zero-byte files, so those are
-    allowed. Existing non-empty files must have the SQLite header before we
-    hand them to SQLite/WAL setup. This keeps corrupted page-0 failures from
-    being collapsed into a generic PRAGMA error and lets the gateway's corrupt
-    board handling identify the board by fingerprint.
-    """
-    try:
-        stat = path.stat()
-    except FileNotFoundError:
-        return
-    except OSError:
-        return
-    if stat.st_size == 0:
-        return
-    # Byte-level probe, so it must run BEFORE any connection to this path
-    # exists (connect() calls it under the init lock, ahead of _sqlite_connect).
-    # read_header_bytes_preopen refuses once a connection is live, because the
-    # close() would cancel this process's POSIX locks on the file.
-    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
-
-    head = read_header_bytes_preopen(path, length=64)
-    if head is None:
-        return
-    if head.startswith(_SQLITE_HEADER):
-        return
-    signature = ""
-    if head.startswith(b"SQLit") and _looks_like_tls_record_at(head, 5):
-        signature = " (TLS record header detected at byte offset 5)"
-    elif _looks_like_tls_record_at(head, 0):
-        signature = " (TLS record header detected at byte offset 0)"
-    raise sqlite3.DatabaseError(
-        "file is not a database: invalid SQLite header for "
-        f"{path}{signature}; first_32={head[:32].hex(' ')}"
-    )
-
-
 class KanbanDbCorruptError(RuntimeError):
     """Raised when an existing kanban DB file fails integrity checks.
 
@@ -1735,130 +1336,6 @@ class KanbanDbCorruptError(RuntimeError):
         )
 
 
-def _prune_corrupt_backups(
-    parent: Path, base_name: str, keep: Optional[Path] = None,
-) -> None:
-    """Cap the number of retained ``<db>.corrupt.<hash>.bak`` files.
-
-    Content-addressed backups dedupe identical corrupt bytes, but a board
-    whose file keeps changing between corruption events (partial repairs,
-    ongoing damage, fleets of retrying dispatchers) can still accumulate
-    backups without bound — a user reported 124 of them. After creating a
-    new backup we keep only the ``_CORRUPT_BACKUP_RETENTION`` most recent
-    (by mtime) and delete the rest, including their copied ``-wal``/``-shm``
-    sidecars. ``keep`` (the just-created backup) is never pruned regardless
-    of its mtime — ``shutil.copy2`` preserves the source file's timestamp,
-    which may be older than existing backups. Best-effort: prune failures
-    never mask the corruption error the caller is about to raise.
-    """
-    try:
-        backups = [
-            candidate
-            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
-            if candidate.is_file() and candidate != keep
-        ]
-    except OSError:
-        return
-    budget = _CORRUPT_BACKUP_RETENTION - (1 if keep is not None else 0)
-    budget = max(budget, 0)
-    if len(backups) <= budget:
-        return
-
-    def _mtime(item: Path) -> float:
-        try:
-            return item.stat().st_mtime
-        except OSError:
-            return 0.0
-
-    backups.sort(key=_mtime, reverse=True)
-    for stale in backups[budget:]:
-        for victim in (
-            stale,
-            stale.with_name(stale.name + "-wal"),
-            stale.with_name(stale.name + "-shm"),
-        ):
-            try:
-                victim.unlink(missing_ok=True)
-            except OSError:
-                pass
-
-
-def _backup_corrupt_db(path: Path) -> Optional[Path]:
-    """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
-
-    The backup filename is deterministic in the main DB's sha256, so repeated
-    quarantines of the same corrupt bytes (gateway restarts, dispatcher retries,
-    multi-profile fleets all hitting the same shared DB) reuse one backup
-    instead of amplifying disk usage by N. If the corrupt bytes actually
-    change between attempts — e.g. a partial repair or further damage — the
-    fingerprint changes and a separate backup is preserved.
-
-    Returns the backup path of the main DB file, or ``None`` if the copy
-    itself failed (the caller still raises loudly in that case).
-
-    Writes are confined to the original DB's parent directory. The backup
-    basename is derived purely from ``path.name`` and a content hash, never
-    from caller-supplied directory segments — no traversal is possible.
-    """
-    # Resolve once and pin the parent so subsequent path operations cannot
-    # escape it. ``Path.resolve()`` collapses any ``..`` segments and
-    # symlinks, and we only ever write inside ``parent``.
-    resolved = path.resolve()
-    parent = resolved.parent
-    base_name = resolved.name  # basename only
-    # This reads the whole DB file to fingerprint it. That is a close()-on-a-
-    # database-file hazard (it cancels this process's POSIX advisory locks --
-    # see hermes_cli.sqlite_safe_read), so it must only run once the board has
-    # been taken out of service. Every caller reaches here on the corrupt/
-    # quarantine path after closing its probe connection, but another
-    # SessionDB/kanban connection elsewhere in the process would still be at
-    # risk -- so REFUSE rather than warn-and-proceed. Losing a forensic copy
-    # is strictly better than corrupting the live database we are trying to
-    # rescue.
-    from hermes_cli.sqlite_safe_read import has_live_connection
-
-    if has_live_connection(resolved):
-        _log.error(
-            "refusing to quarantine %s: a connection to it is still open in "
-            "this process, and fingerprinting the file would cancel that "
-            "connection's POSIX locks. Close all connections first.",
-            resolved,
-        )
-        return None
-    digest = hashlib.sha256()
-    try:
-        with resolved.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-    except OSError:
-        return None
-    token = digest.hexdigest()[:16]
-    candidate = parent / f"{base_name}.corrupt.{token}.bak"
-    # Defensive: candidate must still be inside parent after construction.
-    if candidate.parent != parent:
-        return None
-    if not candidate.exists():
-        try:
-            shutil.copy2(resolved, candidate)
-        except OSError:
-            return None
-        # A NEW backup landed on disk — enforce the retention cap so
-        # mutating-corruption loops can't accumulate quarantines forever.
-        _prune_corrupt_backups(parent, base_name, keep=candidate)
-    for suffix in ("-wal", "-shm"):
-        sidecar = parent / (base_name + suffix)
-        if sidecar.parent != parent or not sidecar.exists():
-            continue
-        sidecar_backup = parent / (candidate.name + suffix)
-        if sidecar_backup.parent != parent or sidecar_backup.exists():
-            continue
-        try:
-            shutil.copy2(sidecar, sidecar_backup)
-        except OSError:
-            pass
-    return candidate
-
-
 # Repairable integrity_check error classes. Both shapes are *index-scoped*:
 # the table b-tree is intact and only a secondary index disagrees with it,
 # which REINDEX rebuilds losslessly from the table data. The index name is
@@ -1870,174 +1347,6 @@ _REPAIRABLE_INDEX_ERROR_PATTERNS = (
     re.compile(r"^wrong # of entries in index (?P<index>.+)$"),
     re.compile(r"^row \d+ missing from index (?P<index>.+)$"),
 )
-
-
-def _integrity_messages_ok(messages: list[str]) -> bool:
-    """True iff ``PRAGMA integrity_check`` output is the single ``ok`` row."""
-    return len(messages) == 1 and messages[0].strip().lower() == "ok"
-
-
-def _run_integrity_check(conn: sqlite3.Connection) -> list[str]:
-    """Return all ``PRAGMA integrity_check`` message rows as strings."""
-    rows = conn.execute("PRAGMA integrity_check").fetchall()
-    return [str(row[0]) for row in rows if row is not None and row[0] is not None]
-
-
-def _repairable_index_names(messages: list[str]) -> Optional[list[str]]:
-    """Return the distinct index names iff EVERY message is index-repairable.
-
-    ``None`` when any line falls outside the repairable index-class errors
-    (or when there are no messages at all) — the caller must then fail
-    closed exactly as before. Order of first appearance is preserved so the
-    REINDEX pass is deterministic.
-    """
-    names: list[str] = []
-    saw_any = False
-    for raw in messages:
-        message = (raw or "").strip()
-        if not message:
-            continue
-        for pattern in _REPAIRABLE_INDEX_ERROR_PATTERNS:
-            match = pattern.match(message)
-            if match:
-                break
-        else:
-            return None
-        saw_any = True
-        name = match.group("index").strip()
-        if name and name not in names:
-            names.append(name)
-    if not saw_any or not names:
-        return None
-    return names
-
-
-def _attempt_index_reindex_repair(
-    path: Path, index_names: list[str],
-) -> tuple[bool, list[str]]:
-    """REINDEX the named indexes, then re-run ``PRAGMA integrity_check``.
-
-    Tries a per-index ``REINDEX "<name>"`` first (cheapest, most targeted);
-    if any per-index statement fails — e.g. the parsed name does not resolve
-    because integrity_check reported an internal/auto index — falls back to
-    a bare ``REINDEX`` of the whole database. Returns
-    ``(clean, post_repair_messages)``; never raises. Callers must hold the
-    board's cross-process init flock so no other process connects mid-repair.
-    """
-    try:
-        conn = _sqlite_connect(path)
-    except sqlite3.Error as exc:
-        return False, [f"could not reopen for REINDEX: {exc}"]
-    try:
-        try:
-            for name in index_names:
-                escaped = name.replace('"', '""')
-                conn.execute(f'REINDEX "{escaped}"')
-        except sqlite3.Error:
-            # Per-index rebuild failed (unresolvable parsed name, auto
-            # index, …) — bare REINDEX rebuilds every index in the DB.
-            conn.execute("REINDEX")
-        messages = _run_integrity_check(conn)
-    except sqlite3.Error as exc:
-        return False, [f"REINDEX failed: {exc}"]
-    finally:
-        conn.close()
-    return _integrity_messages_ok(messages), messages
-
-
-def _guard_existing_db_is_healthy(path: Path) -> None:
-    """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
-
-    Opens the probe in read/write mode so SQLite can recover or
-    checkpoint a healthy WAL/hot-journal DB before we declare it
-    corrupt.
-
-    **Narrow auto-repair:** when the integrity failure consists *only* of
-    index-scoped errors (``wrong # of entries in index <name>`` / ``row N
-    missing from index <name>``), the table b-trees are intact and REINDEX
-    rebuilds the damaged indexes losslessly. In that case we take the
-    corrupt backup FIRST (same content-addressed quarantine as the
-    fail-closed path), run REINDEX under the caller-held init flock,
-    re-run ``integrity_check``, and proceed only if it comes back clean.
-    Anything else — page corruption, ``malformed`` images, a REINDEX that
-    does not produce a clean re-check — fails closed exactly as before:
-    copy the file (and any WAL/SHM sidecars) to a backup and raise
-    :class:`KanbanDbCorruptError` so callers cannot silently recreate the
-    schema on top of a damaged DB.
-
-    Transient lock/busy errors (``sqlite3.OperationalError``) are NOT
-    treated as corruption; they propagate raw so the caller sees a
-    normal lock failure and no spurious ``.corrupt`` backup is made.
-
-    No-op for missing files, zero-byte files (treated as fresh), and
-    paths already proven healthy this process (cache hit).
-
-    Path-trust note: ``path`` arrives via :func:`connect`, which itself
-    resolves it from an explicit ``db_path`` argument, the
-    :func:`kanban_db_path` env-var chain, or the kanban-home default —
-    all sources Hermes treats as user-controlled-but-trusted on the
-    user's own machine. We additionally resolve the path here and
-    confine all filesystem writes to its parent directory so any
-    accidental ``..`` segments are collapsed before any I/O happens.
-    """
-    # Resolve before any I/O. ``Path.resolve()`` normalizes ``..`` and
-    # symlinks, giving us a canonical path whose parent dir we can pin.
-    try:
-        resolved = path.resolve()
-    except OSError:
-        return
-    try:
-        if not resolved.exists() or resolved.stat().st_size == 0:
-            return
-    except OSError:
-        return
-    if str(resolved) in _INITIALIZED_PATHS:
-        return
-    reason: Optional[str] = None
-    messages: list[str] = []
-    try:
-        probe = _sqlite_connect(resolved)
-        try:
-            messages = _run_integrity_check(probe)
-        finally:
-            probe.close()
-        if not _integrity_messages_ok(messages):
-            reason = (
-                f"integrity_check returned "
-                f"{messages[0] if messages else '<no row>'!r}"
-            )
-    except sqlite3.OperationalError:
-        # Lock contention, busy, transient IO — not corruption. Let it propagate.
-        raise
-    except sqlite3.DatabaseError as exc:
-        reason = f"sqlite refused to open file: {exc}"
-    if reason is None:
-        return
-    # Quarantine FIRST — both the repair path and the fail-closed path
-    # preserve the pre-touch bytes before anything mutates the file.
-    backup = _backup_corrupt_db(resolved)
-    index_names = _repairable_index_names(messages)
-    if index_names:
-        _log.warning(
-            "kanban DB %s failed integrity_check with index-only errors "
-            "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
-            resolved, ", ".join(index_names),
-            backup if backup is not None else "<backup failed>",
-        )
-        repaired, post = _attempt_index_reindex_repair(resolved, index_names)
-        if repaired:
-            _log.warning(
-                "kanban DB %s auto-repaired via REINDEX (%s); "
-                "integrity_check now clean. Pre-repair copy kept at %s.",
-                resolved, ", ".join(index_names),
-                backup if backup is not None else "<backup failed>",
-            )
-            return
-        reason = (
-            f"{reason}; REINDEX auto-repair attempted but integrity_check "
-            f"still returned {post[0] if post else '<no row>'!r}"
-        )
-    raise KanbanDbCorruptError(resolved, backup, reason)
 
 
 @dataclass
@@ -5825,7 +5134,6 @@ def block_task(
         reason=reason,
     )
     return True
-
 
 
 def promote_task(
@@ -10273,3 +9581,48 @@ def latest_summaries(
         ids,
     ).fetchall()
     return {r["task_id"]: r["summary"] for r in rows}
+
+
+# ---------------------------------------------------------------------------
+# Board path/state and DB-integrity helpers now live in sibling modules
+# (wave-1 godfile decomposition). Re-exported here so every existing caller
+# (``from hermes_cli import kanban_db as kb``, ``from
+# hermes_cli.kanban_db import <name>``, dashboard plugin, CLI, tools, tests)
+# keeps working unchanged. Imports sit at the end of the module to break the
+# import cycle: the sibling modules import shared constants/helpers from this
+# module, and this module imports the moved functions back.
+# ---------------------------------------------------------------------------
+from hermes_cli.kanban_board_paths import (  # noqa: E402
+    _normalize_board_slug,
+    attachments_root,
+    board_dir,
+    board_exists,
+    board_metadata_path,
+    boards_root,
+    clear_current_board,
+    current_board_path,
+    get_current_board,
+    kanban_db_path,
+    kanban_home,
+    scoped_current_board,
+    set_current_board,
+    task_attachments_dir,
+    worker_logs_dir,
+    workspaces_root,
+)
+from hermes_cli.kanban_integrity import (  # noqa: E402
+    _attempt_index_reindex_repair,
+    _backup_corrupt_db,
+    _guard_existing_db_is_healthy,
+    _integrity_messages_ok,
+    _looks_like_tls_record_at,
+    _prune_corrupt_backups,
+    _repairable_index_names,
+    _run_integrity_check,
+    _validate_sqlite_header,
+)
+from hermes_cli.kanban_policy import (  # noqa: E402
+    _resolve_claim_ttl_seconds,
+    _resolve_crash_grace_seconds,
+    _resolve_rate_limit_cooldown_seconds,
+)

--- a/hermes_cli/kanban_integrity.py
+++ b/hermes_cli/kanban_integrity.py
@@ -1,0 +1,366 @@
+"""Corrupt-DB detection / quarantine / auto-repair for :mod:`hermes_cli.kanban_db`.
+
+Extracted verbatim from ``hermes_cli/kanban_db.py`` (wave-1 godfile
+decomposition, shard s1, cluster c13 — ``kanban_integrity.py``). These are the
+fail-closed guards that refuse to silently recreate a corrupt board file:
+header probing, content-addressed quarantine backups with a retention cap,
+``PRAGMA integrity_check``, and the narrow REINDEX auto-repair path.
+
+Shared constants/helpers that the rest of the kanban module still uses
+(``_SQLITE_HEADER``, ``_CORRUPT_BACKUP_RETENTION``, ``_INITIALIZED_PATHS``,
+``_REPAIRABLE_INDEX_ERROR_PATTERNS``, ``_sqlite_connect``,
+``KanbanDbCorruptError``, ``_log``) stay defined in ``hermes_cli.kanban_db``
+and are imported at the bottom of this module.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+def _looks_like_tls_record_at(data: bytes, offset: int) -> bool:
+    """Return True for a TLS record header at ``data[offset:]``."""
+    if len(data) < offset + 5:
+        return False
+    content_type = data[offset]
+    major = data[offset + 1]
+    minor = data[offset + 2]
+    length = int.from_bytes(data[offset + 3:offset + 5], "big")
+    return (
+        content_type in {0x14, 0x15, 0x16, 0x17}
+        and major == 0x03
+        and minor in {0x00, 0x01, 0x02, 0x03, 0x04}
+        and 0 < length <= 18432
+    )
+def _validate_sqlite_header(path: Path) -> None:
+    """Fail early with an actionable error for non-SQLite Kanban DB files.
+
+    ``sqlite3.connect()`` creates missing and zero-byte files, so those are
+    allowed. Existing non-empty files must have the SQLite header before we
+    hand them to SQLite/WAL setup. This keeps corrupted page-0 failures from
+    being collapsed into a generic PRAGMA error and lets the gateway's corrupt
+    board handling identify the board by fingerprint.
+    """
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return
+    except OSError:
+        return
+    if stat.st_size == 0:
+        return
+    # Byte-level probe, so it must run BEFORE any connection to this path
+    # exists (connect() calls it under the init lock, ahead of _sqlite_connect).
+    # read_header_bytes_preopen refuses once a connection is live, because the
+    # close() would cancel this process's POSIX locks on the file.
+    from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+
+    head = read_header_bytes_preopen(path, length=64)
+    if head is None:
+        return
+    if head.startswith(_SQLITE_HEADER):
+        return
+    signature = ""
+    if head.startswith(b"SQLit") and _looks_like_tls_record_at(head, 5):
+        signature = " (TLS record header detected at byte offset 5)"
+    elif _looks_like_tls_record_at(head, 0):
+        signature = " (TLS record header detected at byte offset 0)"
+    raise sqlite3.DatabaseError(
+        "file is not a database: invalid SQLite header for "
+        f"{path}{signature}; first_32={head[:32].hex(' ')}"
+    )
+def _prune_corrupt_backups(
+    parent: Path, base_name: str, keep: Optional[Path] = None,
+) -> None:
+    """Cap the number of retained ``<db>.corrupt.<hash>.bak`` files.
+
+    Content-addressed backups dedupe identical corrupt bytes, but a board
+    whose file keeps changing between corruption events (partial repairs,
+    ongoing damage, fleets of retrying dispatchers) can still accumulate
+    backups without bound — a user reported 124 of them. After creating a
+    new backup we keep only the ``_CORRUPT_BACKUP_RETENTION`` most recent
+    (by mtime) and delete the rest, including their copied ``-wal``/``-shm``
+    sidecars. ``keep`` (the just-created backup) is never pruned regardless
+    of its mtime — ``shutil.copy2`` preserves the source file's timestamp,
+    which may be older than existing backups. Best-effort: prune failures
+    never mask the corruption error the caller is about to raise.
+    """
+    try:
+        backups = [
+            candidate
+            for candidate in parent.glob(f"{base_name}.corrupt.*.bak")
+            if candidate.is_file() and candidate != keep
+        ]
+    except OSError:
+        return
+    budget = _CORRUPT_BACKUP_RETENTION - (1 if keep is not None else 0)
+    budget = max(budget, 0)
+    if len(backups) <= budget:
+        return
+
+    def _mtime(item: Path) -> float:
+        try:
+            return item.stat().st_mtime
+        except OSError:
+            return 0.0
+
+    backups.sort(key=_mtime, reverse=True)
+    for stale in backups[budget:]:
+        for victim in (
+            stale,
+            stale.with_name(stale.name + "-wal"),
+            stale.with_name(stale.name + "-shm"),
+        ):
+            try:
+                victim.unlink(missing_ok=True)
+            except OSError:
+                pass
+def _backup_corrupt_db(path: Path) -> Optional[Path]:
+    """Copy a corrupt DB (and its WAL/SHM sidecars) to a content-addressed backup.
+
+    The backup filename is deterministic in the main DB's sha256, so repeated
+    quarantines of the same corrupt bytes (gateway restarts, dispatcher retries,
+    multi-profile fleets all hitting the same shared DB) reuse one backup
+    instead of amplifying disk usage by N. If the corrupt bytes actually
+    change between attempts — e.g. a partial repair or further damage — the
+    fingerprint changes and a separate backup is preserved.
+
+    Returns the backup path of the main DB file, or ``None`` if the copy
+    itself failed (the caller still raises loudly in that case).
+
+    Writes are confined to the original DB's parent directory. The backup
+    basename is derived purely from ``path.name`` and a content hash, never
+    from caller-supplied directory segments — no traversal is possible.
+    """
+    # Resolve once and pin the parent so subsequent path operations cannot
+    # escape it. ``Path.resolve()`` collapses any ``..`` segments and
+    # symlinks, and we only ever write inside ``parent``.
+    resolved = path.resolve()
+    parent = resolved.parent
+    base_name = resolved.name  # basename only
+    # This reads the whole DB file to fingerprint it. That is a close()-on-a-
+    # database-file hazard (it cancels this process's POSIX advisory locks --
+    # see hermes_cli.sqlite_safe_read), so it must only run once the board has
+    # been taken out of service. Every caller reaches here on the corrupt/
+    # quarantine path after closing its probe connection, but another
+    # SessionDB/kanban connection elsewhere in the process would still be at
+    # risk -- so REFUSE rather than warn-and-proceed. Losing a forensic copy
+    # is strictly better than corrupting the live database we are trying to
+    # rescue.
+    from hermes_cli.sqlite_safe_read import has_live_connection
+
+    if has_live_connection(resolved):
+        _log.error(
+            "refusing to quarantine %s: a connection to it is still open in "
+            "this process, and fingerprinting the file would cancel that "
+            "connection's POSIX locks. Close all connections first.",
+            resolved,
+        )
+        return None
+    digest = hashlib.sha256()
+    try:
+        with resolved.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    token = digest.hexdigest()[:16]
+    candidate = parent / f"{base_name}.corrupt.{token}.bak"
+    # Defensive: candidate must still be inside parent after construction.
+    if candidate.parent != parent:
+        return None
+    if not candidate.exists():
+        try:
+            shutil.copy2(resolved, candidate)
+        except OSError:
+            return None
+        # A NEW backup landed on disk — enforce the retention cap so
+        # mutating-corruption loops can't accumulate quarantines forever.
+        _prune_corrupt_backups(parent, base_name, keep=candidate)
+    for suffix in ("-wal", "-shm"):
+        sidecar = parent / (base_name + suffix)
+        if sidecar.parent != parent or not sidecar.exists():
+            continue
+        sidecar_backup = parent / (candidate.name + suffix)
+        if sidecar_backup.parent != parent or sidecar_backup.exists():
+            continue
+        try:
+            shutil.copy2(sidecar, sidecar_backup)
+        except OSError:
+            pass
+    return candidate
+def _integrity_messages_ok(messages: list[str]) -> bool:
+    """True iff ``PRAGMA integrity_check`` output is the single ``ok`` row."""
+    return len(messages) == 1 and messages[0].strip().lower() == "ok"
+def _run_integrity_check(conn: sqlite3.Connection) -> list[str]:
+    """Return all ``PRAGMA integrity_check`` message rows as strings."""
+    rows = conn.execute("PRAGMA integrity_check").fetchall()
+    return [str(row[0]) for row in rows if row is not None and row[0] is not None]
+def _repairable_index_names(messages: list[str]) -> Optional[list[str]]:
+    """Return the distinct index names iff EVERY message is index-repairable.
+
+    ``None`` when any line falls outside the repairable index-class errors
+    (or when there are no messages at all) — the caller must then fail
+    closed exactly as before. Order of first appearance is preserved so the
+    REINDEX pass is deterministic.
+    """
+    names: list[str] = []
+    saw_any = False
+    for raw in messages:
+        message = (raw or "").strip()
+        if not message:
+            continue
+        for pattern in _REPAIRABLE_INDEX_ERROR_PATTERNS:
+            match = pattern.match(message)
+            if match:
+                break
+        else:
+            return None
+        saw_any = True
+        name = match.group("index").strip()
+        if name and name not in names:
+            names.append(name)
+    if not saw_any or not names:
+        return None
+    return names
+def _attempt_index_reindex_repair(
+    path: Path, index_names: list[str],
+) -> tuple[bool, list[str]]:
+    """REINDEX the named indexes, then re-run ``PRAGMA integrity_check``.
+
+    Tries a per-index ``REINDEX "<name>"`` first (cheapest, most targeted);
+    if any per-index statement fails — e.g. the parsed name does not resolve
+    because integrity_check reported an internal/auto index — falls back to
+    a bare ``REINDEX`` of the whole database. Returns
+    ``(clean, post_repair_messages)``; never raises. Callers must hold the
+    board's cross-process init flock so no other process connects mid-repair.
+    """
+    try:
+        conn = _sqlite_connect(path)
+    except sqlite3.Error as exc:
+        return False, [f"could not reopen for REINDEX: {exc}"]
+    try:
+        try:
+            for name in index_names:
+                escaped = name.replace('"', '""')
+                conn.execute(f'REINDEX "{escaped}"')
+        except sqlite3.Error:
+            # Per-index rebuild failed (unresolvable parsed name, auto
+            # index, …) — bare REINDEX rebuilds every index in the DB.
+            conn.execute("REINDEX")
+        messages = _run_integrity_check(conn)
+    except sqlite3.Error as exc:
+        return False, [f"REINDEX failed: {exc}"]
+    finally:
+        conn.close()
+    return _integrity_messages_ok(messages), messages
+def _guard_existing_db_is_healthy(path: Path) -> None:
+    """Run ``PRAGMA integrity_check`` on an existing non-empty DB file.
+
+    Opens the probe in read/write mode so SQLite can recover or
+    checkpoint a healthy WAL/hot-journal DB before we declare it
+    corrupt.
+
+    **Narrow auto-repair:** when the integrity failure consists *only* of
+    index-scoped errors (``wrong # of entries in index <name>`` / ``row N
+    missing from index <name>``), the table b-trees are intact and REINDEX
+    rebuilds the damaged indexes losslessly. In that case we take the
+    corrupt backup FIRST (same content-addressed quarantine as the
+    fail-closed path), run REINDEX under the caller-held init flock,
+    re-run ``integrity_check``, and proceed only if it comes back clean.
+    Anything else — page corruption, ``malformed`` images, a REINDEX that
+    does not produce a clean re-check — fails closed exactly as before:
+    copy the file (and any WAL/SHM sidecars) to a backup and raise
+    :class:`KanbanDbCorruptError` so callers cannot silently recreate the
+    schema on top of a damaged DB.
+
+    Transient lock/busy errors (``sqlite3.OperationalError``) are NOT
+    treated as corruption; they propagate raw so the caller sees a
+    normal lock failure and no spurious ``.corrupt`` backup is made.
+
+    No-op for missing files, zero-byte files (treated as fresh), and
+    paths already proven healthy this process (cache hit).
+
+    Path-trust note: ``path`` arrives via :func:`connect`, which itself
+    resolves it from an explicit ``db_path`` argument, the
+    :func:`kanban_db_path` env-var chain, or the kanban-home default —
+    all sources Hermes treats as user-controlled-but-trusted on the
+    user's own machine. We additionally resolve the path here and
+    confine all filesystem writes to its parent directory so any
+    accidental ``..`` segments are collapsed before any I/O happens.
+    """
+    # Resolve before any I/O. ``Path.resolve()`` normalizes ``..`` and
+    # symlinks, giving us a canonical path whose parent dir we can pin.
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return
+    try:
+        if not resolved.exists() or resolved.stat().st_size == 0:
+            return
+    except OSError:
+        return
+    if str(resolved) in _INITIALIZED_PATHS:
+        return
+    reason: Optional[str] = None
+    messages: list[str] = []
+    try:
+        probe = _sqlite_connect(resolved)
+        try:
+            messages = _run_integrity_check(probe)
+        finally:
+            probe.close()
+        if not _integrity_messages_ok(messages):
+            reason = (
+                f"integrity_check returned "
+                f"{messages[0] if messages else '<no row>'!r}"
+            )
+    except sqlite3.OperationalError:
+        # Lock contention, busy, transient IO — not corruption. Let it propagate.
+        raise
+    except sqlite3.DatabaseError as exc:
+        reason = f"sqlite refused to open file: {exc}"
+    if reason is None:
+        return
+    # Quarantine FIRST — both the repair path and the fail-closed path
+    # preserve the pre-touch bytes before anything mutates the file.
+    backup = _backup_corrupt_db(resolved)
+    index_names = _repairable_index_names(messages)
+    if index_names:
+        _log.warning(
+            "kanban DB %s failed integrity_check with index-only errors "
+            "(%s); pre-repair backup at %s — attempting REINDEX auto-repair.",
+            resolved, ", ".join(index_names),
+            backup if backup is not None else "<backup failed>",
+        )
+        repaired, post = _attempt_index_reindex_repair(resolved, index_names)
+        if repaired:
+            _log.warning(
+                "kanban DB %s auto-repaired via REINDEX (%s); "
+                "integrity_check now clean. Pre-repair copy kept at %s.",
+                resolved, ", ".join(index_names),
+                backup if backup is not None else "<backup failed>",
+            )
+            return
+        reason = (
+            f"{reason}; REINDEX auto-repair attempted but integrity_check "
+            f"still returned {post[0] if post else '<no row>'!r}"
+        )
+    raise KanbanDbCorruptError(resolved, backup, reason)
+
+
+# Imported at the bottom to break the import cycle with kanban_db.py (which
+# re-imports the moved functions from this module). Function bodies resolve
+# these names at call time, so bottom placement is safe.
+from hermes_cli.kanban_db import (  # noqa: E402
+    KanbanDbCorruptError,
+    _CORRUPT_BACKUP_RETENTION,
+    _INITIALIZED_PATHS,
+    _REPAIRABLE_INDEX_ERROR_PATTERNS,
+    _SQLITE_HEADER,
+    _log,
+    _sqlite_connect,
+)

--- a/hermes_cli/kanban_policy.py
+++ b/hermes_cli/kanban_policy.py
@@ -1,0 +1,83 @@
+"""Kanban policy knobs (claim TTL, crash grace, rate-limit cooldown).
+
+Extracted verbatim from ``hermes_cli/kanban_db.py`` (wave-1 godfile
+decomposition, shard s1, cluster c2 — ``kanban_policy.py``). Each resolver
+reads its ``HERMES_KANBAN_*`` env override and falls back to a built-in
+default; the defaults stay defined in ``hermes_cli.kanban_db`` (they are
+referenced by tests and by staying dispatcher code) and are imported at the
+bottom of this module.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+def _resolve_claim_ttl_seconds(ttl_seconds: Optional[int] = None) -> int:
+    """Return the effective claim TTL, honoring the kanban env override.
+
+    Explicit call-site values win. Otherwise a positive integer from
+    ``HERMES_KANBAN_CLAIM_TTL_SECONDS`` overrides the built-in default.
+    Invalid or non-positive env values fall back silently so existing
+    installs keep working.
+    """
+    if ttl_seconds is not None:
+        return max(1, int(ttl_seconds))
+
+    raw = os.environ.get("HERMES_KANBAN_CLAIM_TTL_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+
+    return DEFAULT_CLAIM_TTL_SECONDS
+def _resolve_crash_grace_seconds() -> int:
+    """Return the crash-detection grace period in seconds.
+
+    Reads ``HERMES_KANBAN_CRASH_GRACE_SECONDS`` from the environment;
+    falls back to ``DEFAULT_CRASH_GRACE_SECONDS`` when absent, empty,
+    non-integer, or negative. A value of 0 restores immediate-reclaim
+    behaviour (useful for tests).
+    """
+    raw = os.environ.get("HERMES_KANBAN_CRASH_GRACE_SECONDS", "").strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_CRASH_GRACE_SECONDS
+def _resolve_rate_limit_cooldown_seconds() -> int:
+    """Return the rate-limit requeue cooldown in seconds.
+
+    Reads ``HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS`` from the environment;
+    falls back to ``DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS`` when absent, empty,
+    non-integer, or negative. A value of 0 disables the cooldown (re-spawn on
+    the next tick) — useful for tests that want to assert the task becomes
+    spawnable again immediately.
+    """
+    raw = os.environ.get(
+        "HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", ""
+    ).strip()
+    if raw:
+        try:
+            parsed = int(raw)
+        except ValueError:
+            parsed = -1
+        if parsed >= 0:
+            return parsed
+    return DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
+
+
+# Imported at the bottom to break the import cycle with kanban_db.py (which
+# re-imports the moved functions from this module). Function bodies resolve
+# these names at call time, so bottom placement is safe.
+from hermes_cli.kanban_db import (  # noqa: E402
+    DEFAULT_CLAIM_TTL_SECONDS,
+    DEFAULT_CRASH_GRACE_SECONDS,
+    DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS,
+)

--- a/tests/hermes_cli/test_kanban_board_paths.py
+++ b/tests/hermes_cli/test_kanban_board_paths.py
@@ -1,0 +1,175 @@
+"""Regression tests for the board-state / board-path functions extracted to
+``hermes_cli/kanban_board_paths.py`` (wave-1 godfile decomposition, s1 c7/c8).
+
+Every moved function is exercised both through the new module (direct import)
+and through the ``hermes_cli.kanban_db`` re-export surface (``kb.*``), which
+is what all existing callers (CLI, dashboard, tools, tests) use.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_board_paths as kbp
+
+
+@pytest.fixture
+def fresh_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with no prior kanban state."""
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for var in (
+        "HERMES_KANBAN_DB",
+        "HERMES_KANBAN_WORKSPACES_ROOT",
+        "HERMES_KANBAN_HOME",
+        "HERMES_KANBAN_BOARD",
+        "HERMES_KANBAN_ATTACHMENTS_ROOT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    return home
+
+
+def _make_board(home: Path, slug: str) -> Path:
+    """Create a board dir with a board.json so ``board_exists`` is True."""
+    d = home / "kanban" / "boards" / slug
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "board.json").write_text("{}", encoding="utf-8")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Re-export surface: the extraction must be invisible to kanban_db importers
+# ---------------------------------------------------------------------------
+
+
+def test_moved_functions_are_re_exported_from_kanban_db():
+    """kb.<name> must resolve to the exact objects in the new module."""
+    for name in (
+        "scoped_current_board",
+        "_normalize_board_slug",
+        "kanban_home",
+        "boards_root",
+        "current_board_path",
+        "get_current_board",
+        "set_current_board",
+        "clear_current_board",
+        "board_dir",
+        "board_exists",
+        "kanban_db_path",
+        "workspaces_root",
+        "attachments_root",
+        "task_attachments_dir",
+        "worker_logs_dir",
+        "board_metadata_path",
+    ):
+        assert getattr(kb, name) is getattr(kbp, name), name
+
+
+# ---------------------------------------------------------------------------
+# Slug normalisation
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_board_slug_valid(fresh_home):
+    assert kbp._normalize_board_slug("atm10-server") == "atm10-server"
+    assert kbp._normalize_board_slug("HerMes-Agent") == "hermes-agent"
+    assert kbp._normalize_board_slug(None) is None
+    assert kbp._normalize_board_slug("") is None
+    assert kbp._normalize_board_slug("   ") is None
+
+
+def test_normalize_board_slug_rejects_traversal(fresh_home):
+    for bad in ("..", "../etc", "a/b", "a b", "-lead", "_lead", "x" * 65):
+        with pytest.raises(ValueError):
+            kbp._normalize_board_slug(bad)
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+def test_kanban_db_path_default_and_named(fresh_home):
+    assert kbp.kanban_db_path() == fresh_home / "kanban.db"
+    assert kbp.kanban_db_path(board="default") == fresh_home / "kanban.db"
+    assert kbp.kanban_db_path(board="atm10-server") == (
+        fresh_home / "kanban" / "boards" / "atm10-server" / "kanban.db"
+    )
+
+
+def test_kanban_db_path_env_override(fresh_home, monkeypatch):
+    forced = fresh_home / "elsewhere" / "pinned.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(forced))
+    assert kbp.kanban_db_path() == forced
+    assert kbp.kanban_db_path(board="ignored") == forced
+
+
+def test_board_dir_and_exists(fresh_home):
+    assert kbp.board_dir() == fresh_home / "kanban" / "boards" / "default"
+    assert kbp.board_exists("default") is True
+    assert kbp.board_exists("missing-board") is False
+    _make_board(fresh_home, "atm10-server")
+    assert kbp.board_exists("atm10-server") is True
+
+
+def test_roots(fresh_home):
+    assert kbp.boards_root() == fresh_home / "kanban" / "boards"
+    assert kbp.workspaces_root() == fresh_home / "kanban" / "workspaces"
+    assert kbp.attachments_root() == fresh_home / "kanban" / "attachments"
+    assert kbp.worker_logs_dir() == fresh_home / "kanban" / "logs"
+    assert kbp.board_metadata_path() == (
+        fresh_home / "kanban" / "boards" / "default" / "board.json"
+    )
+    assert kbp.task_attachments_dir("task-1") == (
+        fresh_home / "kanban" / "attachments" / "task-1"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Current-board selection (state + persistence)
+# ---------------------------------------------------------------------------
+
+
+def test_scoped_current_board_pins_then_resets(fresh_home):
+    _make_board(fresh_home, "atm10-server")
+    assert kbp.get_current_board() == "default"
+    with kbp.scoped_current_board("atm10-server"):
+        assert kbp.get_current_board() == "atm10-server"
+    assert kbp.get_current_board() == "default"
+
+
+def test_set_and_clear_current_board(fresh_home):
+    _make_board(fresh_home, "atm10-server")
+    path = kbp.set_current_board("atm10-server")
+    assert path.read_text(encoding="utf-8").strip() == "atm10-server"
+    assert kbp.get_current_board() == "atm10-server"
+    kbp.clear_current_board()
+    assert kbp.get_current_board() == "default"
+
+
+def test_env_board_override(fresh_home, monkeypatch):
+    # Env var beats the on-disk pointer.
+    _make_board(fresh_home, "disk-board")
+    _make_board(fresh_home, "env-board")
+    kbp.set_current_board("disk-board")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "env-board")
+    assert kbp.get_current_board() == "env-board"
+
+
+def test_scoped_board_via_kb_re_export(fresh_home):
+    """The re-exported kb.scoped_current_board must share the same ContextVar."""
+    _make_board(fresh_home, "kb-scope")
+    with kb.scoped_current_board("kb-scope"):
+        assert kbp.get_current_board() == "kb-scope"
+        assert kb.get_current_board() == "kb-scope"

--- a/tests/hermes_cli/test_kanban_db_repair.py
+++ b/tests/hermes_cli/test_kanban_db_repair.py
@@ -144,6 +144,10 @@ def test_corrupt_backup_retention_cap_prunes_oldest(tmp_path, monkeypatch):
     mutation. The cap keeps only the newest ``_CORRUPT_BACKUP_RETENTION``.
     """
     monkeypatch.setattr(kb, "_CORRUPT_BACKUP_RETENTION", 3)
+    # The moved function reads the cap from kanban_integrity's namespace;
+    # patch the canonical kanban_db binding too (kept for kb.* access).
+    import hermes_cli.kanban_integrity as _ki
+    monkeypatch.setattr(_ki, "_CORRUPT_BACKUP_RETENTION", 3)
     db_path = tmp_path / "kanban.db"
     _write_page_corrupt_db(db_path)
 

--- a/tests/hermes_cli/test_kanban_integrity.py
+++ b/tests/hermes_cli/test_kanban_integrity.py
@@ -1,0 +1,185 @@
+"""Regression tests for the corrupt-DB guards extracted to
+``hermes_cli/kanban_integrity.py`` (wave-1 godfile decomposition, s1 c13).
+
+The moved functions are exercised through the new module directly AND through
+the ``hermes_cli.kanban_db`` re-export surface (``kb.*``), which is what all
+existing callers (connect/repair paths, tests) use.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_integrity as ki
+
+_SQLITE_HEADER_BYTES = b"SQLite format 3\x00"
+
+
+@pytest.fixture
+def clean_cache(tmp_path):
+    """Ensure the moved guard's _INITIALIZED_PATHS check sees a fresh path."""
+    yield tmp_path
+    kb._INITIALIZED_PATHS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Re-export surface
+# ---------------------------------------------------------------------------
+
+
+def test_moved_functions_are_re_exported_from_kanban_db():
+    for name in (
+        "_looks_like_tls_record_at",
+        "_validate_sqlite_header",
+        "_prune_corrupt_backups",
+        "_backup_corrupt_db",
+        "_integrity_messages_ok",
+        "_run_integrity_check",
+        "_repairable_index_names",
+        "_attempt_index_reindex_repair",
+        "_guard_existing_db_is_healthy",
+    ):
+        assert getattr(kb, name) is getattr(ki, name), name
+
+
+# ---------------------------------------------------------------------------
+# TLS-record sniffing (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_looks_like_tls_record_at():
+    handshake = bytes([0x16, 0x03, 0x03, 0x00, 0x05]) + b"\x01\x00\x00\x00\x00"
+    assert ki._looks_like_tls_record_at(handshake, 0) is True
+    assert ki._looks_like_tls_record_at(b"SQLit" + handshake, 5) is True
+    assert ki._looks_like_tls_record_at(b"not tls here", 0) is False
+    assert ki._looks_like_tls_record_at(b"\x16\x03\x03\x00\x05", 1) is False  # too short
+    assert ki._looks_like_tls_record_at(b"\x99\x03\x03\x00\x05\x00", 0) is False  # bad type
+
+
+# ---------------------------------------------------------------------------
+# Header validation (pure, file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_sqlite_header_missing_file_is_fine(tmp_path):
+    ki._validate_sqlite_header(tmp_path / "does-not-exist.db")  # no raise
+
+
+def test_validate_sqlite_header_zero_byte_is_fine(tmp_path):
+    p = tmp_path / "empty.db"
+    p.write_bytes(b"")
+    ki._validate_sqlite_header(p)  # no raise
+
+
+def test_validate_sqlite_header_accepts_real_header(tmp_path):
+    p = tmp_path / "valid.db"
+    p.write_bytes(_SQLITE_HEADER_BYTES + b"\x00" * 4096)
+    ki._validate_sqlite_header(p)  # no raise
+
+
+def test_validate_sqlite_header_rejects_garbage(tmp_path):
+    p = tmp_path / "junk.db"
+    p.write_bytes(b"this is not a sqlite database at all")
+    with pytest.raises(sqlite3.DatabaseError):
+        ki._validate_sqlite_header(p)
+
+
+# ---------------------------------------------------------------------------
+# Integrity-check message helpers (pure)
+# ---------------------------------------------------------------------------
+
+
+def test_integrity_messages_ok():
+    assert ki._integrity_messages_ok(["ok"]) is True
+    assert ki._integrity_messages_ok(["OK"]) is True
+    assert ki._integrity_messages_ok(["ok", "extra"]) is False
+    assert ki._integrity_messages_ok([]) is False
+
+
+def test_repairable_index_names():
+    msgs = [
+        "wrong # of entries in index idx_tasks_status",
+        "row 42 missing from index idx_tasks_status",
+    ]
+    assert ki._repairable_index_names(msgs) == ["idx_tasks_status"]
+    # Order of first appearance preserved.
+    msgs2 = ["row 1 missing from index b_idx", "wrong # of entries in index a_idx"]
+    assert ki._repairable_index_names(msgs2) == ["b_idx", "a_idx"]
+    # A non-index error poisons the whole batch -> fail closed.
+    assert ki._repairable_index_names(["database disk image is malformed"]) is None
+    assert ki._repairable_index_names(["wrong # of entries in index x", "page 5 is corrupt"]) is None
+    assert ki._repairable_index_names([]) is None
+    assert ki._repairable_index_names([""]) is None
+
+
+def test_run_integrity_check(tmp_path):
+    db = tmp_path / "real.db"
+    conn = sqlite3.connect(db)
+    conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY)")
+    conn.commit()
+    conn.close()
+    conn2 = sqlite3.connect(db)
+    try:
+        assert ki._run_integrity_check(conn2) == ["ok"]
+    finally:
+        conn2.close()
+
+
+# ---------------------------------------------------------------------------
+# Quarantine backups (pure, file-based)
+# ---------------------------------------------------------------------------
+
+
+def test_prune_corrupt_backups_retention_cap(tmp_path, monkeypatch):
+    monkeypatch.setattr(ki, "_CORRUPT_BACKUP_RETENTION", 3)
+    base = tmp_path / "kanban.db"
+    for i in range(5):
+        (tmp_path / f"kanban.db.corrupt.aaaa{i}.bak").write_bytes(b"x")
+    ki._prune_corrupt_backups(tmp_path, "kanban.db")
+    remaining = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert len(remaining) == 3
+
+
+def test_prune_corrupt_backups_keeps_just_minted(tmp_path, monkeypatch):
+    monkeypatch.setattr(ki, "_CORRUPT_BACKUP_RETENTION", 3)
+    for i in range(5):
+        (tmp_path / f"kanban.db.corrupt.aaaa{i}.bak").write_bytes(b"x")
+    keep = tmp_path / "kanban.db.corrupt.zzzz.bak"
+    keep.write_bytes(b"x")
+    ki._prune_corrupt_backups(tmp_path, "kanban.db", keep=keep)
+    remaining = sorted(tmp_path.glob("kanban.db.corrupt.*.bak"))
+    assert len(remaining) == 3
+    assert keep in remaining
+
+
+def test_backup_corrupt_db_content_addressed(tmp_path):
+    db = tmp_path / "kanban.db"
+    db.write_bytes(_SQLITE_HEADER_BYTES + b"corrupt page data here")
+    backup = ki._backup_corrupt_db(db)
+    assert backup is not None
+    assert backup.name.startswith("kanban.db.corrupt.")
+    assert backup.name.endswith(".bak")
+    assert backup.exists()
+    assert backup.read_bytes() == db.read_bytes()
+    # Same corrupt bytes -> same content-addressed name (no duplicate).
+    again = ki._backup_corrupt_db(db)
+    assert again == backup
+
+
+# ---------------------------------------------------------------------------
+# End-to-end guard through the re-exported surface (matches repair test style)
+# ---------------------------------------------------------------------------
+
+
+def test_guard_existing_db_is_healthy_raises_on_corrupt(tmp_path, clean_cache):
+    db = tmp_path / "kanban.db"
+    db.write_bytes(b"not a database at all, just plain text bytes here")
+    kb._INITIALIZED_PATHS.discard(str(db.resolve()))
+    with pytest.raises(kb.KanbanDbCorruptError) as excinfo:
+        ki._guard_existing_db_is_healthy(db)
+    assert excinfo.value.backup_path is not None
+    assert excinfo.value.backup_path.exists()

--- a/tests/hermes_cli/test_kanban_policy.py
+++ b/tests/hermes_cli/test_kanban_policy.py
@@ -1,0 +1,61 @@
+"""Regression tests for the kanban policy resolvers extracted to
+``hermes_cli/kanban_policy.py`` (wave-1 godfile decomposition, s1 c2).
+
+Every moved resolver is exercised both through the new module (direct import)
+and through the ``hermes_cli.kanban_db`` re-export surface (``kb.*``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_policy as kp
+
+
+def test_moved_functions_are_re_exported_from_kanban_db():
+    for name in (
+        "_resolve_claim_ttl_seconds",
+        "_resolve_crash_grace_seconds",
+        "_resolve_rate_limit_cooldown_seconds",
+    ):
+        assert getattr(kb, name) is getattr(kp, name), name
+
+
+def test_claim_ttl_explicit_value_wins(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", "999")
+    assert kp._resolve_claim_ttl_seconds(60) == 60
+    assert kp._resolve_claim_ttl_seconds(0) == 1  # clamped to >= 1
+
+
+def test_claim_ttl_env_and_default(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", raising=False)
+    assert kp._resolve_claim_ttl_seconds() == kb.DEFAULT_CLAIM_TTL_SECONDS
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", "321")
+    assert kp._resolve_claim_ttl_seconds() == 321
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", "not-an-int")
+    assert kp._resolve_claim_ttl_seconds() == kb.DEFAULT_CLAIM_TTL_SECONDS
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_TTL_SECONDS", "-5")
+    assert kp._resolve_claim_ttl_seconds() == kb.DEFAULT_CLAIM_TTL_SECONDS
+
+
+def test_crash_grace_env_and_default(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", raising=False)
+    assert kp._resolve_crash_grace_seconds() == kb.DEFAULT_CRASH_GRACE_SECONDS
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "0")
+    assert kp._resolve_crash_grace_seconds() == 0  # immediate-reclaim mode
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "42")
+    assert kp._resolve_crash_grace_seconds() == 42
+    monkeypatch.setenv("HERMES_KANBAN_CRASH_GRACE_SECONDS", "junk")
+    assert kp._resolve_crash_grace_seconds() == kb.DEFAULT_CRASH_GRACE_SECONDS
+
+
+def test_rate_limit_cooldown_env_and_default(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", raising=False)
+    assert kp._resolve_rate_limit_cooldown_seconds() == kb.DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS
+    monkeypatch.setenv("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", "0")
+    assert kp._resolve_rate_limit_cooldown_seconds() == 0  # re-spawn next tick
+    monkeypatch.setenv("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", "77")
+    assert kp._resolve_rate_limit_cooldown_seconds() == 77
+    monkeypatch.setenv("HERMES_KANBAN_RATE_LIMIT_COOLDOWN_SECONDS", "-1")
+    assert kp._resolve_rate_limit_cooldown_seconds() == kb.DEFAULT_RATE_LIMIT_COOLDOWN_SECONDS


### PR DESCRIPTION
## Godfile kill — hermes_cli/kanban_db.py shard s1

Extracts the board-paths/integrity/policy mixins (c7+c8, c13, c2) into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 1203 added / 692 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701 #78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715 #78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729 #78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743 #78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757 #78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771 #78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785 #78786 #78787 #78788 #78789 #78790

Part of #78632
Part of #78647
