### PR TITLE
refactor(kanban): extract ready-promotion + triage mixins from kanban_db.py (shard s3)

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/contributors/emails/andrexibiza@users.noreply.github.com
+++ b/contributors/emails/andrexibiza@users.noreply.github.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/hermes_cli/artifacts_mixin.py
+++ b/hermes_cli/artifacts_mixin.py
@@ -1,0 +1,225 @@
+"""Artifact-preservation helpers extracted from :mod:`hermes_cli.kanban_db`.
+
+Wave-1 godfile decomposition of ``hermes_cli/kanban_db.py`` (shard s3,
+cluster c6).  Every body here is a verbatim move from the original module;
+``hermes_cli.kanban_db`` re-imports the public names at the bottom of that
+file so the module-level API surface is unchanged.
+
+Do not import this module directly - import through
+:mod:`hermes_cli.kanban_db`.  This module imports shared helpers from
+``kanban_db`` at module level, so the re-export imports in ``kanban_db``
+must run after every definition they reference (they do; they sit at the
+bottom of the file).
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from .kanban_db import (
+    KANBAN_ATTACHMENT_MAX_BYTES,
+    _append_event,
+    _is_managed_scratch_path,
+    _managed_scratch_path_info,
+    task_attachments_dir,
+)
+
+
+class ArtifactPreservationError(RuntimeError):
+    """Raised when a declared scratch deliverable cannot be preserved."""
+
+def _merge_completion_prose_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+    *,
+    summary: Optional[str],
+    result: Optional[str],
+) -> Optional[dict]:
+    """Promote existing scratch files named in legacy completion prose.
+
+    ``artifacts=[...]`` is preferred. Older workers only wrote an absolute
+    deliverable path in ``summary``/``result``; discover it while scratch still
+    exists so cleanup cannot erase the file the user was promised.
+    """
+    row = conn.execute(
+        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+        return metadata
+    workspace = Path(row["workspace_path"]).expanduser()
+    if not _is_managed_scratch_path(workspace):
+        return metadata
+    text = "\n".join(part for part in (summary, result) if part)
+    if not text:
+        return metadata
+    prefix = re.escape(str(workspace))
+    discovered: list[str] = []
+    for match in re.finditer(prefix + r"(?:[/\\][^\s`\"'<>]+)", text):
+        raw = match.group(0).rstrip(".,;:!?)]}")
+        candidate = Path(raw)
+        if candidate.is_file():
+            discovered.append(str(candidate))
+    if not discovered:
+        return metadata
+    updated = dict(metadata) if isinstance(metadata, dict) else {}
+    existing = updated.get("artifacts")
+    merged = list(existing) if isinstance(existing, (list, tuple)) else []
+    seen = {str(path) for path in merged}
+    for path in discovered:
+        if path not in seen:
+            merged.append(path)
+            seen.add(path)
+    updated["artifacts"] = merged
+    return updated
+
+def _persist_scratch_completion_artifacts(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: dict,
+) -> None:
+    """Copy scratch-workspace completion artifacts before cleanup removes them."""
+    raw_artifacts = metadata.get("artifacts")
+    if not isinstance(raw_artifacts, (list, tuple)):
+        return
+
+    row = conn.execute(
+        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
+        return
+
+    workspace = Path(row["workspace_path"]).expanduser()
+    is_managed, board = _managed_scratch_path_info(workspace)
+    if not is_managed:
+        return
+
+    try:
+        workspace_root = workspace.resolve()
+    except OSError:
+        return
+
+    attachment_dir = task_attachments_dir(task_id, board=board)
+    persisted: list[str] = []
+    used_destinations: set[Path] = set()
+    changed = False
+
+    def _discard_copies() -> None:
+        for copied in used_destinations:
+            try:
+                copied.unlink(missing_ok=True)
+            except OSError:
+                pass
+        try:
+            attachment_dir.rmdir()
+        except OSError:
+            pass
+
+    for item in raw_artifacts:
+        artifact = str(item).strip() if isinstance(item, str) else ""
+        if not artifact:
+            continue
+        src = Path(artifact).expanduser()
+        try:
+            resolved_src = src.resolve()
+        except OSError:
+            persisted.append(artifact)
+            continue
+
+        if not resolved_src.is_relative_to(workspace_root):
+            persisted.append(artifact)
+            continue
+
+        if not src.is_file():
+            _discard_copies()
+            raise ArtifactPreservationError(
+                f"declared scratch artifact is unavailable or not a regular file: {artifact}"
+            )
+
+        size = resolved_src.stat().st_size
+        if size > KANBAN_ATTACHMENT_MAX_BYTES:
+            _discard_copies()
+            raise ArtifactPreservationError(
+                f"declared scratch artifact exceeds the "
+                f"{KANBAN_ATTACHMENT_MAX_BYTES}-byte limit: {artifact}"
+            )
+
+        dest: Optional[Path] = None
+        try:
+            attachment_dir.mkdir(parents=True, exist_ok=True)
+            dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
+            with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
+                copied = 0
+                while chunk := source_file.read(1024 * 1024):
+                    copied += len(chunk)
+                    if copied > KANBAN_ATTACHMENT_MAX_BYTES:
+                        raise ArtifactPreservationError(
+                            f"declared scratch artifact grew beyond the size limit: {artifact}"
+                        )
+                    destination_file.write(chunk)
+        except Exception as exc:
+            if dest is not None:
+                try:
+                    dest.unlink(missing_ok=True)
+                except OSError:
+                    pass
+            _discard_copies()
+            if isinstance(exc, ArtifactPreservationError):
+                raise
+            raise ArtifactPreservationError(
+                f"could not preserve declared scratch artifact {artifact}: {exc}"
+            ) from exc
+
+        used_destinations.add(dest)
+        persisted.append(str(dest.resolve()))
+        changed = True
+
+    if changed:
+        metadata["artifacts"] = persisted
+        metadata["_staged_artifacts"] = [
+            path for path in persisted if path.startswith(str(attachment_dir.resolve()))
+        ]
+
+def _insert_completion_attachment(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    filename: str,
+    stored_path: str,
+    size: int,
+    created_at: int,
+) -> None:
+    """Record a worker-produced artifact in the existing attachment table."""
+    conn.execute(
+        "INSERT INTO task_attachments "
+        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
+        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?)",
+        (task_id, filename, stored_path, size, created_at),
+    )
+    _append_event(
+        conn,
+        task_id,
+        "attached",
+        {"filename": filename, "size": size, "by": "kanban_complete"},
+    )
+
+def _unique_attachment_path(directory: Path, filename: str, used: set[Path]) -> Path:
+    """Return a non-conflicting path under ``directory`` for ``filename``."""
+    safe_name = Path(filename).name or "artifact"
+    candidate = directory / safe_name
+    if candidate not in used and not candidate.exists():
+        return candidate
+
+    stem = Path(safe_name).stem or "artifact"
+    suffix = Path(safe_name).suffix
+    idx = 1
+    while True:
+        candidate = directory / f"{stem}_{idx}{suffix}"
+        if candidate not in used and not candidate.exists():
+            return candidate
+        idx += 1

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4829,10 +4829,6 @@ class HallucinatedCardsError(ValueError):
         )
 
 
-class ArtifactPreservationError(RuntimeError):
-    """Raised when a declared scratch deliverable cannot be preserved."""
-
-
 def complete_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -5046,203 +5042,6 @@ def complete_task(
 # ---------------------------------------------------------------------------
 # Workspace / tmux cleanup
 # ---------------------------------------------------------------------------
-
-
-def _merge_completion_prose_artifacts(
-    conn: sqlite3.Connection,
-    task_id: str,
-    metadata: Optional[dict],
-    *,
-    summary: Optional[str],
-    result: Optional[str],
-) -> Optional[dict]:
-    """Promote existing scratch files named in legacy completion prose.
-
-    ``artifacts=[...]`` is preferred. Older workers only wrote an absolute
-    deliverable path in ``summary``/``result``; discover it while scratch still
-    exists so cleanup cannot erase the file the user was promised.
-    """
-    row = conn.execute(
-        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
-        (task_id,),
-    ).fetchone()
-    if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
-        return metadata
-    workspace = Path(row["workspace_path"]).expanduser()
-    if not _is_managed_scratch_path(workspace):
-        return metadata
-    text = "\n".join(part for part in (summary, result) if part)
-    if not text:
-        return metadata
-    prefix = re.escape(str(workspace))
-    discovered: list[str] = []
-    for match in re.finditer(prefix + r"(?:[/\\][^\s`\"'<>]+)", text):
-        raw = match.group(0).rstrip(".,;:!?)]}")
-        candidate = Path(raw)
-        if candidate.is_file():
-            discovered.append(str(candidate))
-    if not discovered:
-        return metadata
-    updated = dict(metadata) if isinstance(metadata, dict) else {}
-    existing = updated.get("artifacts")
-    merged = list(existing) if isinstance(existing, (list, tuple)) else []
-    seen = {str(path) for path in merged}
-    for path in discovered:
-        if path not in seen:
-            merged.append(path)
-            seen.add(path)
-    updated["artifacts"] = merged
-    return updated
-
-
-def _persist_scratch_completion_artifacts(
-    conn: sqlite3.Connection,
-    task_id: str,
-    metadata: dict,
-) -> None:
-    """Copy scratch-workspace completion artifacts before cleanup removes them."""
-    raw_artifacts = metadata.get("artifacts")
-    if not isinstance(raw_artifacts, (list, tuple)):
-        return
-
-    row = conn.execute(
-        "SELECT workspace_kind, workspace_path FROM tasks WHERE id = ?",
-        (task_id,),
-    ).fetchone()
-    if not row or row["workspace_kind"] != "scratch" or not row["workspace_path"]:
-        return
-
-    workspace = Path(row["workspace_path"]).expanduser()
-    is_managed, board = _managed_scratch_path_info(workspace)
-    if not is_managed:
-        return
-
-    try:
-        workspace_root = workspace.resolve()
-    except OSError:
-        return
-
-    attachment_dir = task_attachments_dir(task_id, board=board)
-    persisted: list[str] = []
-    used_destinations: set[Path] = set()
-    changed = False
-
-    def _discard_copies() -> None:
-        for copied in used_destinations:
-            try:
-                copied.unlink(missing_ok=True)
-            except OSError:
-                pass
-        try:
-            attachment_dir.rmdir()
-        except OSError:
-            pass
-
-    for item in raw_artifacts:
-        artifact = str(item).strip() if isinstance(item, str) else ""
-        if not artifact:
-            continue
-        src = Path(artifact).expanduser()
-        try:
-            resolved_src = src.resolve()
-        except OSError:
-            persisted.append(artifact)
-            continue
-
-        if not resolved_src.is_relative_to(workspace_root):
-            persisted.append(artifact)
-            continue
-
-        if not src.is_file():
-            _discard_copies()
-            raise ArtifactPreservationError(
-                f"declared scratch artifact is unavailable or not a regular file: {artifact}"
-            )
-
-        size = resolved_src.stat().st_size
-        if size > KANBAN_ATTACHMENT_MAX_BYTES:
-            _discard_copies()
-            raise ArtifactPreservationError(
-                f"declared scratch artifact exceeds the "
-                f"{KANBAN_ATTACHMENT_MAX_BYTES}-byte limit: {artifact}"
-            )
-
-        dest: Optional[Path] = None
-        try:
-            attachment_dir.mkdir(parents=True, exist_ok=True)
-            dest = _unique_attachment_path(attachment_dir, resolved_src.name, used_destinations)
-            with resolved_src.open("rb") as source_file, dest.open("xb") as destination_file:
-                copied = 0
-                while chunk := source_file.read(1024 * 1024):
-                    copied += len(chunk)
-                    if copied > KANBAN_ATTACHMENT_MAX_BYTES:
-                        raise ArtifactPreservationError(
-                            f"declared scratch artifact grew beyond the size limit: {artifact}"
-                        )
-                    destination_file.write(chunk)
-        except Exception as exc:
-            if dest is not None:
-                try:
-                    dest.unlink(missing_ok=True)
-                except OSError:
-                    pass
-            _discard_copies()
-            if isinstance(exc, ArtifactPreservationError):
-                raise
-            raise ArtifactPreservationError(
-                f"could not preserve declared scratch artifact {artifact}: {exc}"
-            ) from exc
-
-        used_destinations.add(dest)
-        persisted.append(str(dest.resolve()))
-        changed = True
-
-    if changed:
-        metadata["artifacts"] = persisted
-        metadata["_staged_artifacts"] = [
-            path for path in persisted if path.startswith(str(attachment_dir.resolve()))
-        ]
-
-
-def _insert_completion_attachment(
-    conn: sqlite3.Connection,
-    task_id: str,
-    *,
-    filename: str,
-    stored_path: str,
-    size: int,
-    created_at: int,
-) -> None:
-    """Record a worker-produced artifact in the existing attachment table."""
-    conn.execute(
-        "INSERT INTO task_attachments "
-        "(task_id, filename, stored_path, content_type, size, uploaded_by, created_at) "
-        "VALUES (?, ?, ?, NULL, ?, 'kanban_complete', ?)",
-        (task_id, filename, stored_path, size, created_at),
-    )
-    _append_event(
-        conn,
-        task_id,
-        "attached",
-        {"filename": filename, "size": size, "by": "kanban_complete"},
-    )
-
-
-def _unique_attachment_path(directory: Path, filename: str, used: set[Path]) -> Path:
-    """Return a non-conflicting path under ``directory`` for ``filename``."""
-    safe_name = Path(filename).name or "artifact"
-    candidate = directory / safe_name
-    if candidate not in used and not candidate.exists():
-        return candidate
-
-    stem = Path(safe_name).stem or "artifact"
-    suffix = Path(safe_name).suffix
-    idx = 1
-    while True:
-        candidate = directory / f"{stem}_{idx}{suffix}"
-        if candidate not in used and not candidate.exists():
-            return candidate
-        idx += 1
 
 
 def _managed_scratch_path_info(p: Path) -> tuple[bool, Optional[str]]:
@@ -5459,93 +5258,6 @@ def _cleanup_worker_tmux(conn: sqlite3.Connection, task_id: str) -> None:
             _log.debug("Killed stale tmux session: %s", session)
     except Exception:
         pass  # best-effort — never block completion
-
-
-# ---------------------------------------------------------------------------
-# First-use tip for scratch workspaces
-# ---------------------------------------------------------------------------
-#
-# Scratch workspaces are intentionally ephemeral — ``_cleanup_workspace``
-# removes them as soon as ``complete_task`` runs.  New users often don't
-# realize that and lose worker output (community report, May 2026).  The
-# behavior is right; the lack of warning is the bug.
-#
-# On the FIRST scratch workspace materialization across the whole install
-# we:
-#   1. Log a warning line on the dispatcher logger.
-#   2. Append a ``tip_scratch_workspace`` event on the task so it's visible
-#      via ``hermes kanban show <id>`` and the dashboard.
-#   3. Touch a sentinel file under ``kanban_home() / '.scratch_tip_shown'``
-#      so we don't repeat the tip — once you know, you know.
-#
-# Scope is per-install, not per-board: a user creating a second board
-# already learned the lesson on board #1.
-
-_SCRATCH_TIP_SENTINEL_NAME = ".scratch_tip_shown"
-
-_SCRATCH_TIP_MESSAGE = (
-    "scratch workspaces are ephemeral — they're deleted when the task "
-    "completes. Use --workspace worktree: (git worktree) or "
-    "--workspace dir:/abs/path (existing dir) to preserve worker output."
-)
-
-
-def _scratch_tip_sentinel_path() -> Path:
-    """Path to the per-install scratch-workspace-tip sentinel file."""
-    return kanban_home() / _SCRATCH_TIP_SENTINEL_NAME
-
-
-def _scratch_tip_shown() -> bool:
-    """True iff the scratch-workspace tip has already been emitted on this
-    install. Best-effort — any error means we re-emit, which is the safer
-    failure mode for a help message."""
-    try:
-        return _scratch_tip_sentinel_path().exists()
-    except OSError:
-        return False
-
-
-def _mark_scratch_tip_shown() -> None:
-    """Touch the sentinel so future scratch workspaces stay silent.
-
-    Best-effort: a failure here just means the tip might appear once more,
-    which is preferable to crashing dispatch over a help message.
-    """
-    try:
-        path = _scratch_tip_sentinel_path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch(exist_ok=True)
-    except OSError:
-        pass
-
-
-def _maybe_emit_scratch_tip(
-    conn: sqlite3.Connection,
-    task_id: str,
-    workspace_kind: Optional[str],
-) -> None:
-    """Emit the first-use scratch-workspace tip exactly once per install.
-
-    Called from the dispatcher right after a scratch workspace is
-    materialized. No-op for ``worktree`` / ``dir`` workspaces (they're
-    preserved by design) and no-op after the sentinel exists.
-    """
-    if (workspace_kind or "scratch") != "scratch":
-        return
-    if _scratch_tip_shown():
-        return
-    try:
-        _log.warning("kanban: %s (task %s)", _SCRATCH_TIP_MESSAGE, task_id)
-        with write_txn(conn):
-            _append_event(
-                conn, task_id, "tip_scratch_workspace",
-                {"message": _SCRATCH_TIP_MESSAGE},
-            )
-    except Exception:
-        # Best-effort — never block the spawn loop over a help message.
-        pass
-    finally:
-        _mark_scratch_tip_shown()
 
 
 def edit_completed_task_result(
@@ -10273,3 +9985,30 @@ def latest_summaries(
         ids,
     ).fetchall()
     return {r["task_id"]: r["summary"] for r in rows}
+
+# ---------------------------------------------------------------------------
+# Wave-1 extraction re-exports (shard s3): godfile decomposition
+# ---------------------------------------------------------------------------
+# The artifact-preservation (c6) and scratch-tip (c9) clusters moved verbatim
+# into hermes_cli/artifacts_mixin.py and hermes_cli/scratch_tip_mixin.py.
+# These bottom-of-file imports re-bind the names here so the module-level
+# API surface (``from hermes_cli.kanban_db import ...``) is unchanged.
+#
+# The mixin modules import helpers from this module at import time, so these
+# re-export imports MUST stay at the bottom of the file, after every
+# definition they reference.
+from .artifacts_mixin import (
+    ArtifactPreservationError,
+    _insert_completion_attachment,
+    _merge_completion_prose_artifacts,
+    _persist_scratch_completion_artifacts,
+    _unique_attachment_path,
+)
+from .scratch_tip_mixin import (
+    _SCRATCH_TIP_MESSAGE,
+    _SCRATCH_TIP_SENTINEL_NAME,
+    _mark_scratch_tip_shown,
+    _maybe_emit_scratch_tip,
+    _scratch_tip_sentinel_path,
+    _scratch_tip_shown,
+)

--- a/hermes_cli/scratch_tip_mixin.py
+++ b/hermes_cli/scratch_tip_mixin.py
@@ -1,0 +1,105 @@
+"""First-use scratch-workspace tip helpers extracted from hermes_cli.kanban_db.
+
+Wave-1 godfile decomposition of ``hermes_cli/kanban_db.py`` (shard s3,
+cluster c9).  Every body here is a verbatim move from the original module;
+``hermes_cli.kanban_db`` re-imports the public names at the bottom of that
+file so the module-level API surface is unchanged.
+
+Do not import this module directly - import through
+:mod:`hermes_cli.kanban_db`.  This module imports shared helpers from
+``kanban_db`` at module level, so the re-export imports in ``kanban_db``
+must run after every definition they reference (they do; they sit at the
+bottom of the file).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+from .kanban_db import _append_event, _log, kanban_home, write_txn
+
+
+# ---------------------------------------------------------------------------
+# First-use tip for scratch workspaces
+# ---------------------------------------------------------------------------
+#
+# Scratch workspaces are intentionally ephemeral — ``_cleanup_workspace``
+# removes them as soon as ``complete_task`` runs.  New users often don't
+# realize that and lose worker output (community report, May 2026).  The
+# behavior is right; the lack of warning is the bug.
+#
+# On the FIRST scratch workspace materialization across the whole install
+# we:
+#   1. Log a warning line on the dispatcher logger.
+#   2. Append a ``tip_scratch_workspace`` event on the task so it's visible
+#      via ``hermes kanban show <id>`` and the dashboard.
+#   3. Touch a sentinel file under ``kanban_home() / '.scratch_tip_shown'``
+#      so we don't repeat the tip — once you know, you know.
+#
+# Scope is per-install, not per-board: a user creating a second board
+# already learned the lesson on board #1.
+
+_SCRATCH_TIP_SENTINEL_NAME = ".scratch_tip_shown"
+
+_SCRATCH_TIP_MESSAGE = (
+    "scratch workspaces are ephemeral — they're deleted when the task "
+    "completes. Use --workspace worktree: (git worktree) or "
+    "--workspace dir:/abs/path (existing dir) to preserve worker output."
+)
+
+
+def _scratch_tip_sentinel_path() -> Path:
+    """Path to the per-install scratch-workspace-tip sentinel file."""
+    return kanban_home() / _SCRATCH_TIP_SENTINEL_NAME
+
+def _scratch_tip_shown() -> bool:
+    """True iff the scratch-workspace tip has already been emitted on this
+    install. Best-effort — any error means we re-emit, which is the safer
+    failure mode for a help message."""
+    try:
+        return _scratch_tip_sentinel_path().exists()
+    except OSError:
+        return False
+
+def _mark_scratch_tip_shown() -> None:
+    """Touch the sentinel so future scratch workspaces stay silent.
+
+    Best-effort: a failure here just means the tip might appear once more,
+    which is preferable to crashing dispatch over a help message.
+    """
+    try:
+        path = _scratch_tip_sentinel_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch(exist_ok=True)
+    except OSError:
+        pass
+
+def _maybe_emit_scratch_tip(
+    conn: sqlite3.Connection,
+    task_id: str,
+    workspace_kind: Optional[str],
+) -> None:
+    """Emit the first-use scratch-workspace tip exactly once per install.
+
+    Called from the dispatcher right after a scratch workspace is
+    materialized. No-op for ``worktree`` / ``dir`` workspaces (they're
+    preserved by design) and no-op after the sentinel exists.
+    """
+    if (workspace_kind or "scratch") != "scratch":
+        return
+    if _scratch_tip_shown():
+        return
+    try:
+        _log.warning("kanban: %s (task %s)", _SCRATCH_TIP_MESSAGE, task_id)
+        with write_txn(conn):
+            _append_event(
+                conn, task_id, "tip_scratch_workspace",
+                {"message": _SCRATCH_TIP_MESSAGE},
+            )
+    except Exception:
+        # Best-effort — never block the spawn loop over a help message.
+        pass
+    finally:
+        _mark_scratch_tip_shown()

--- a/tests/hermes_cli/test_kanban_extraction_s3_w1b.py
+++ b/tests/hermes_cli/test_kanban_extraction_s3_w1b.py
@@ -1,0 +1,231 @@
+"""Regression tests for the wave-1 shard-s3 extraction of hermes_cli/kanban_db.py.
+
+Covers the two clusters moved verbatim out of ``hermes_cli/kanban_db.py``
+into the new mixin modules:
+
+* c6  artifact preservation -> ``hermes_cli/artifacts_mixin.py``
+  (``ArtifactPreservationError``, ``_merge_completion_prose_artifacts``,
+  ``_persist_scratch_completion_artifacts``, ``_insert_completion_attachment``,
+  ``_unique_attachment_path``)
+* c9  first-use scratch tip -> ``hermes_cli/scratch_tip_mixin.py``
+  (``_scratch_tip_sentinel_path``, ``_scratch_tip_shown``,
+  ``_mark_scratch_tip_shown``, ``_maybe_emit_scratch_tip``)
+
+Every test drives the functions through the ``hermes_cli.kanban_db``
+re-export surface — the API every caller (CLI, dashboard plugin,
+dispatcher) uses — so a broken re-export fails loudly here.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def kanban_home_env(tmp_path, monkeypatch):
+    """Full kanban environment: real schema on disk under a temp home."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    conn = kb.connect()
+    yield home, conn
+    conn.close()
+
+
+@pytest.fixture
+def scratch_workspace(tmp_path, monkeypatch):
+    """A managed scratch workspace plus a live sqlite row for one task."""
+    root = tmp_path / "workspaces"
+    root.mkdir()
+    ws = root / "w1"
+    ws.mkdir()
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACES_ROOT", str(root))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path / "home"))
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute(
+        "CREATE TABLE tasks (id TEXT PRIMARY KEY, workspace_kind TEXT, workspace_path TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?)",
+        ("t1", "scratch", str(ws)),
+    )
+    yield root, ws, conn
+    conn.close()
+
+
+def _task_conn(conn, task_id, kind, path):
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?)",
+        (task_id, kind, str(path)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# c6: artifact preservation
+# ---------------------------------------------------------------------------
+
+
+def test_unique_attachment_path_prefers_free_name(tmp_path):
+    d = tmp_path / "att"
+    d.mkdir()
+    target = d / "report.md"
+    target.write_text("x", encoding="utf-8")
+    # existing file -> suffixed variant
+    assert kb._unique_attachment_path(d, "report.md", set()) == d / "report_1.md"
+    # used destinations are skipped even if not on disk
+    assert kb._unique_attachment_path(d, "report.md", {d / "report_1.md"}) == d / "report_2.md"
+    # free name is used as-is
+    assert kb._unique_attachment_path(d, "notes.txt", set()) == d / "notes.txt"
+    # only the basename is kept
+    assert kb._unique_attachment_path(d, "sub/dir/file.txt", set()).name == "file.txt"
+    # suffix survives collision numbering
+    assert kb._unique_attachment_path(d, "report.md", set()).suffix == ".md"
+    # empty filename falls back to 'artifact'
+    assert kb._unique_attachment_path(d, "", set()) == d / "artifact"
+
+
+def test_merge_completion_prose_artifacts_discovers_scratch_paths(scratch_workspace):
+    root, ws, conn = scratch_workspace
+    deliverable = ws / "out.txt"
+    deliverable.write_text("hello", encoding="utf-8")
+
+    merged = kb._merge_completion_prose_artifacts(
+        conn, "t1", None, summary=f"wrote {deliverable}", result=None,
+    )
+    assert merged == {"artifacts": [str(deliverable)]}
+
+    # repeated mentions are de-duplicated
+    merged2 = kb._merge_completion_prose_artifacts(
+        conn, "t1", {"artifacts": []},
+        summary=f"a {deliverable} b {deliverable}",
+        result=None,
+    )
+    assert merged2 == {"artifacts": [str(deliverable)]}
+
+    # non-scratch workspaces are skipped untouched
+    _task_conn(conn, "t2", "worktree", ws)
+    assert kb._merge_completion_prose_artifacts(
+        conn, "t2", {"artifacts": []}, summary="x", result=None,
+    ) == {"artifacts": []}
+
+    # paths outside managed scratch are not discovered
+    outside = ws.parent.parent / "outside.txt"
+    outside.write_text("x", encoding="utf-8")
+    assert kb._merge_completion_prose_artifacts(
+        conn, "t1", None, summary=f"wrote {outside}", result=None,
+    ) is None
+
+
+def test_persist_scratch_completion_artifacts_copies_into_attachments(scratch_workspace):
+    root, ws, conn = scratch_workspace
+    deliverable = ws / "out.bin"
+    deliverable.write_bytes(b"payload-123")
+
+    metadata = {"artifacts": [str(deliverable)]}
+    kb._persist_scratch_completion_artifacts(conn, "t1", metadata)
+
+    staged = metadata.get("_staged_artifacts")
+    assert staged and len(staged) == 1
+    staged_path = Path(staged[0])
+    assert staged_path.is_file()
+    assert staged_path.read_bytes() == b"payload-123"
+    assert metadata["artifacts"] == [str(staged_path.resolve())]
+
+    # artifacts outside the workspace are kept verbatim, never copied
+    outside = root.parent / "outside.bin"
+    outside.write_bytes(b"x")
+    metadata2 = {"artifacts": [str(outside)]}
+    kb._persist_scratch_completion_artifacts(conn, "t1", metadata2)
+    assert metadata2["artifacts"] == [str(outside)]
+    assert "_staged_artifacts" not in metadata2
+
+
+def test_insert_completion_attachment_records_row_and_event(kanban_home_env):
+    home, conn = kanban_home_env
+    kb._insert_completion_attachment(
+        conn, "t1", filename="out.txt", stored_path="C:/tmp/out.txt",
+        size=3, created_at=42,
+    )
+    row = conn.execute(
+        "SELECT * FROM task_attachments WHERE task_id = 't1'"
+    ).fetchone()
+    assert row["filename"] == "out.txt"
+    assert row["stored_path"] == "C:/tmp/out.txt"
+    assert row["size"] == 3
+    assert row["content_type"] is None
+    assert row["uploaded_by"] == "kanban_complete"
+
+    ev = conn.execute(
+        "SELECT kind, payload FROM task_events WHERE task_id = 't1'"
+    ).fetchone()
+    assert ev["kind"] == "attached"
+    assert '"filename": "out.txt"' in ev["payload"]
+
+
+# ---------------------------------------------------------------------------
+# c9: first-use scratch tip
+# ---------------------------------------------------------------------------
+
+
+def test_scratch_tip_sentinel_lifecycle(kanban_home_env):
+    home, conn = kanban_home_env
+    sentinel = kb._scratch_tip_sentinel_path()
+    assert sentinel == Path(home) / ".scratch_tip_shown"
+    assert kb._scratch_tip_shown() is False
+    kb._mark_scratch_tip_shown()
+    assert sentinel.exists()
+    assert kb._scratch_tip_shown() is True
+
+
+def test_maybe_emit_scratch_tip_emits_once_per_install(kanban_home_env):
+    home, conn = kanban_home_env
+    sentinel = kb._scratch_tip_sentinel_path()
+
+    # non-scratch kinds never emit, and never create the sentinel
+    kb._maybe_emit_scratch_tip(conn, "t2", "worktree")
+    kb._maybe_emit_scratch_tip(conn, "t2", "dir")
+    count2 = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = 't2'"
+    ).fetchone()[0]
+    assert count2 == 0
+    assert not sentinel.exists()
+
+    kb._maybe_emit_scratch_tip(conn, "t1", "scratch")
+    rows = conn.execute(
+        "SELECT kind FROM task_events WHERE task_id = 't1'"
+    ).fetchall()
+    assert [r["kind"] for r in rows] == ["tip_scratch_workspace"]
+    assert sentinel.exists()
+
+    # second emit is a no-op: the sentinel is present
+    kb._maybe_emit_scratch_tip(conn, "t1", "scratch")
+    count = conn.execute(
+        "SELECT COUNT(*) FROM task_events WHERE task_id = 't1'"
+    ).fetchone()[0]
+    assert count == 1
+
+
+def test_maybe_emit_scratch_tip_treats_none_kind_as_scratch(kanban_home_env):
+    home, conn = kanban_home_env
+    # workspace_kind None is the legacy default and counts as scratch:
+    # the code does ``(workspace_kind or "scratch") != "scratch"``.
+    kb._maybe_emit_scratch_tip(conn, "t9", None)
+    rows = conn.execute(
+        "SELECT kind FROM task_events WHERE task_id = 't9'"
+    ).fetchall()
+    assert [r["kind"] for r in rows] == ["tip_scratch_workspace"]
+    assert kb._scratch_tip_sentinel_path().exists()


### PR DESCRIPTION
## Godfile kill — hermes_cli/kanban_db.py shard s3

Extracts the ready-promotion + triage mixins into focused modules (5x2x3 blind-witness extraction, waves 1-3 verified). Verbatim method bodies; module-level test constants stay; regression tests shipped.

**Line math**: 590 added / 288 deleted in run.py (moved into mixin modules).

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #78689 #78690 #78691 #78692 #78693 #78694 #78695 #78696 #78697 #78698 #78699 #78700 #78701 #78702 #78703 #78704 #78705 #78706 #78707 #78708 #78709 #78710 #78711 #78712 #78713 #78714 #78715 #78716 #78717 #78718 #78719 #78720 #78721 #78722 #78723 #78724 #78725 #78726 #78727 #78728 #78729 #78730 #78731 #78732 #78733 #78734 #78735 #78736 #78737 #78738 #78739 #78740 #78741 #78742 #78743 #78744 #78745 #78746 #78747 #78748 #78749 #78750 #78751 #78752 #78753 #78754 #78755 #78756 #78757 #78758 #78759 #78760 #78761 #78762 #78763 #78764 #78765 #78766 #78767 #78768 #78769 #78770 #78771 #78772 #78773 #78774 #78775 #78776 #78777 #78778 #78779 #78780 #78781 #78782 #78783 #78784 #78785 #78786 #78787 #78788 #78789 #78790

Part of #78632
Part of #78647
