### PR TITLE
chore: add contributor email mapping for cryptoyasenka

### DIFF
--- a/contributors/emails/cryptoyasenka@users.noreply.github.com
+++ b/contributors/emails/cryptoyasenka@users.noreply.github.com
@@ -1,0 +1,1 @@
+cryptoyasenka


### PR DESCRIPTION
## What does this PR do?

Adds `contributors/emails/cryptoyasenka@users.noreply.github.com` so the Contributor Attribution Check can resolve my commits.

The job auto-resolves a GitHub noreply address only in the `id+login@users.noreply.github.com` form, where the login is part of the address itself:

```bash
if echo "$email" | grep -qP '\+.*@users\.noreply\.github\.com'; then
  continue  # GitHub id+login noreply emails auto-resolve
fi
```

My commits are authored under the bare `cryptoyasenka@users.noreply.github.com` address, which that pattern does not match. The `case` skip list above it does not match it either: it looks for `*noreply@github.com*`, with an `@` before `github.com`, not a dot. So the job has nothing to resolve, reports the address as unmapped, and the check fails on every PR I have open.

One note in case it is unintended: `contributors/README.md` currently says that both noreply forms auto-resolve and that no file is needed. That holds for the `+` form only. This PR just adds the file. If you would rather fix it once for everyone, I am happy to send a one-line change widening that regex instead, and to close this.

## Related Issue

No issue. This is repository metadata, and the failing job points contributors at exactly this remedy.

## Type of Change

None of the listed types fits exactly. This is contributor attribution data, closest to housekeeping: no code, no behaviour change.

## Changes Made

* `contributors/emails/cryptoyasenka@users.noreply.github.com`, one line, `cryptoyasenka`, LF terminated.

That is byte for byte what `scripts/add_contributor.py` writes for this address (re-running the script prints `present` and exits 0), and the same form as the 53 bare-noreply mappings already in that directory, plus 170 bare-form entries in `LEGACY_AUTHOR_MAP`. `scripts/audit_pr_attribution.py --fix`, the fixer the failing job recommends, resolves the bare form through the users API and writes exactly this file.

## How to Test

I ran the job's own shell logic from `.github/workflows/contributor-check.yml` against this branch:

* without the file, the email lands in `MISSING` and the step exits 1;
* with the file, `[ -f "contributors/emails/${email}" ]` matches and the step exits 0.

Repo checks, on Windows 11, Python 3.14:

```
pytest tests/scripts/ -q                          # 22 passed, including
                                                  # test_contributor_map.py (7), the only
                                                  # test that reads this directory
ruff check .                                      # clean
python scripts/check-windows-footguns.py --all    # clean, 915 files
```

`scripts/ci/classify_changes.py` classifies `contributors/emails/*` as `python` and `python_prod`, so the full Python lane and the attribution check itself run on this PR rather than a data-only subset.

Once this lands, the copy of this file that currently rides along on my other open PRs becomes unnecessary, since the check runs against the pull request merge ref and the mapping will be present through main. I will drop those commits then.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits (`chore: ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix: one file, one line
- [ ] I've run `pytest tests/ -q`. I ran `tests/scripts/` in full, which covers the only test that reads `contributors/emails/`. The full suite on a Windows host has pre-existing failures unrelated to this change.
- [x] Tests: N/A for a mapping file, and `tests/scripts/test_contributor_map.py` already validates the directory
- [x] I've tested on my platform: Windows 11, Python 3.14

### Documentation & Housekeeping

- [x] Documentation: see the `contributors/README.md` note above, happy to update it as part of the regex change if you prefer that route
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact: the file is written with an LF ending, matching the rest of the directory
- [x] Tool descriptions/schemas: N/A
