### PR TITLE
feat(provider): add prompt-cache policy hook

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2146,6 +2146,36 @@ def anthropic_prompt_cache_policy(
             logger.debug("MoA aggregator cache-policy resolution failed: %s", _moa_exc)
         return False, False
 
+    # External provider profiles may declare transport/model-scoped cache
+    # support. This keeps plugin IDs and endpoint-specific capabilities out of
+    # Hermes' built-in allowlists. ``None`` preserves the legacy fallback.
+    try:
+        from providers import get_provider_profile
+
+        profile = get_provider_profile(eff_provider)
+        if profile is not None:
+            declared = profile.prompt_cache_policy(
+                model=eff_model,
+                api_mode=eff_api_mode,
+                base_url=eff_base_url,
+            )
+            if declared is not None:
+                if (
+                    not isinstance(declared, tuple)
+                    or len(declared) != 2
+                    or not all(isinstance(value, bool) for value in declared)
+                ):
+                    raise TypeError(
+                        "prompt_cache_policy must return (bool, bool) or None"
+                    )
+                return declared
+    except Exception as exc:
+        logger.warning(
+            "Provider prompt-cache policy failed for %s; using core fallback: %s",
+            eff_provider,
+            exc,
+        )
+
     model_lower = eff_model.lower()
     provider_lower = eff_provider.lower()
     is_claude = "claude" in model_lower

--- a/providers/base.py
+++ b/providers/base.py
@@ -101,6 +101,27 @@ class ProviderProfile:
 
     # ── Hooks (override in subclass for complex providers) ───
 
+    def prompt_cache_policy(
+        self,
+        *,
+        model: str | None = None,
+        api_mode: str | None = None,
+        base_url: str | None = None,
+    ) -> tuple[bool, bool] | None:
+        """Return ``(enabled, native_layout)`` or ``None`` for core fallback.
+
+        ``enabled`` controls explicit ``cache_control`` marker injection.
+        ``native_layout`` selects inner content-block markers when true and
+        the OpenAI-wire envelope layout when false. Provider plugins override
+        this to declare model- and transport-scoped support without adding
+        provider IDs to shared allowlists.
+
+        Implementations must return exactly a two-boolean tuple or ``None``.
+        Invalid values and exceptions are logged and delegated to core fallback
+        so a plugin cannot abort a model call while resolving cache policy.
+        """
+        return None
+
     def get_hostname(self) -> str:
         """Return the provider's base hostname for URL-based detection.
 

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -1,7 +1,69 @@
 """Tests for the provider module registry and profiles."""
 
+import os
+from pathlib import Path
+import subprocess
+import sys
+
 from providers import get_provider_profile, _REGISTRY
 from providers.base import ProviderProfile, OMIT_TEMPERATURE
+
+
+class TestProviderCapabilityDefaults:
+    def test_prompt_cache_policy_is_unspecified(self):
+        profile = ProviderProfile(name="example")
+        assert profile.prompt_cache_policy(
+            model="model", api_mode="chat_completions", base_url="https://example.test"
+        ) is None
+
+
+def test_user_plugin_prompt_cache_policy_resolves_end_to_end(tmp_path):
+    hermes_home = tmp_path / "hermes"
+    plugin_dir = hermes_home / "plugins" / "model-providers" / "cache-provider"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: cache-provider\nkind: model-provider\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        """from providers import register_provider
+from providers.base import ProviderProfile
+
+class CacheProvider(ProviderProfile):
+    def prompt_cache_policy(self, *, model=None, api_mode=None, base_url=None):
+        if model == "cache-model-v1" and api_mode == "chat_completions":
+            return True, False
+        return None
+
+register_provider(CacheProvider(name="cache-provider"))
+""",
+        encoding="utf-8",
+    )
+
+    script = """from types import SimpleNamespace
+from agent.agent_runtime_helpers import anthropic_prompt_cache_policy
+
+agent = SimpleNamespace(
+    provider="cache-provider",
+    base_url="https://cache-provider.example/v1",
+    api_mode="chat_completions",
+    model="cache-model-v1",
+    _cache_disabled=False,
+)
+assert anthropic_prompt_cache_policy(agent) == (True, False)
+"""
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
 
 
 class TestRegistry:

--- a/tests/run_agent/test_anthropic_prompt_cache_policy.py
+++ b/tests/run_agent/test_anthropic_prompt_cache_policy.py
@@ -8,6 +8,7 @@ the native layout on OpenRouter) surfaces loudly.
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -31,6 +32,118 @@ def _make_agent(
     agent.client = MagicMock()
     agent.quiet_mode = True
     return agent
+
+
+class TestPluginDeclaredPolicy:
+    @staticmethod
+    def _register(monkeypatch, profile):
+        import providers
+
+        # Trigger normal discovery before installing the test profile so the
+        # test exercises the real registry lookup without leaking state.
+        providers.get_provider_profile("__discovery_probe__")
+        monkeypatch.setitem(providers._REGISTRY, profile.name, profile)
+
+    def test_profile_can_enable_transport_scoped_prompt_cache(self, monkeypatch):
+        from providers.base import ProviderProfile
+
+        observed = {}
+
+        class Profile(ProviderProfile):
+            def prompt_cache_policy(self, *, model=None, api_mode=None, base_url=None):
+                observed.update(model=model, api_mode=api_mode, base_url=base_url)
+                return True, False
+
+        profile = Profile(name="external-provider")
+        self._register(monkeypatch, profile)
+        agent = _make_agent(
+            provider="external-provider",
+            base_url="https://external.example/v1",
+            api_mode="chat_completions",
+            model="cache-model-v1",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, False)
+        assert observed == {
+            "model": "cache-model-v1",
+            "api_mode": "chat_completions",
+            "base_url": "https://external.example/v1",
+        }
+
+    def test_none_preserves_core_fallback(self, monkeypatch):
+        from providers.base import ProviderProfile
+
+        profile = ProviderProfile(name="external-provider")
+        self._register(monkeypatch, profile)
+        agent = _make_agent(
+            provider="external-provider",
+            base_url="https://gateway.example/anthropic",
+            api_mode="anthropic_messages",
+            model="claude-sonnet-4-6",
+        )
+        assert agent._anthropic_prompt_cache_policy() == (True, True)
+
+    @pytest.mark.parametrize(
+        "declared",
+        ([True, False], (True,), ("enabled", False)),
+    )
+    def test_invalid_return_warns_and_preserves_core_fallback(
+        self, monkeypatch, caplog, declared
+    ):
+        from providers.base import ProviderProfile
+
+        class Profile(ProviderProfile):
+            def prompt_cache_policy(self, **_kwargs):
+                return declared
+
+        self._register(monkeypatch, Profile(name="external-provider"))
+        agent = _make_agent(
+            provider="external-provider",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        with caplog.at_level(logging.WARNING):
+            assert agent._anthropic_prompt_cache_policy() == (True, False)
+        assert "Provider prompt-cache policy failed" in caplog.text
+
+    def test_hook_exception_warns_and_preserves_core_fallback(
+        self, monkeypatch, caplog
+    ):
+        from providers.base import ProviderProfile
+
+        class Profile(ProviderProfile):
+            def prompt_cache_policy(self, **_kwargs):
+                raise RuntimeError("profile unavailable")
+
+        self._register(monkeypatch, Profile(name="external-provider"))
+        agent = _make_agent(
+            provider="external-provider",
+            base_url="https://openrouter.ai/api/v1",
+            api_mode="chat_completions",
+            model="anthropic/claude-sonnet-4.6",
+        )
+        with caplog.at_level(logging.WARNING):
+            assert agent._anthropic_prompt_cache_policy() == (True, False)
+        assert "Provider prompt-cache policy failed" in caplog.text
+        assert "profile unavailable" in caplog.text
+
+    def test_operator_disable_takes_precedence_over_profile(self, monkeypatch):
+        from providers.base import ProviderProfile
+
+        called = False
+
+        class Profile(ProviderProfile):
+            def prompt_cache_policy(self, **_kwargs):
+                nonlocal called
+                called = True
+                return True, False
+
+        self._register(monkeypatch, Profile(name="external-provider"))
+        agent = _make_agent(provider="external-provider", model="cache-model-v1")
+        setattr(agent, "_cache_disabled", True)
+
+        assert agent._anthropic_prompt_cache_policy() == (False, False)
+        assert called is False
 
 
 class TestNativeAnthropic:

--- a/website/docs/developer-guide/model-provider-plugin.md
+++ b/website/docs/developer-guide/model-provider-plugin.md
@@ -114,6 +114,17 @@ from typing import Any
 from providers.base import ProviderProfile
 
 class AcmeProfile(ProviderProfile):
+    def prompt_cache_policy(self, *, model=None, api_mode=None, base_url=None):
+        """Declare explicit prompt-cache support for this request.
+
+        Return (enabled, native_layout), or None to use Hermes' existing
+        provider/model detection. native_layout=False selects the OpenAI-wire
+        cache-control envelope; True selects native inner-block markers.
+        """
+        if model == "acme-large-v3" and api_mode == "chat_completions":
+            return True, False
+        return None
+
     def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Provider-specific message preprocessing. Runs after codex
         sanitization, before developer-role swap. Default: pass-through."""
@@ -142,6 +153,11 @@ class AcmeProfile(ProviderProfile):
         (Bedrock → None), or public/unauthenticated catalogs (OpenRouter)."""
         return super().fetch_models(api_key=api_key, base_url=base_url, timeout=timeout)
 ```
+
+`prompt_cache_policy()` must return exactly a two-boolean tuple or `None`.
+Hermes logs and ignores invalid values or exceptions, preserving its core
+fallback. An explicit user cache disable always takes precedence over a
+provider profile.
 
 ## Hook reference examples
 


### PR DESCRIPTION
## What does this PR do?

Adds a narrow `ProviderProfile.prompt_cache_policy()` hook so model-provider plugins can declare request-scoped explicit prompt-cache support without adding plugin IDs or endpoint allowlists to Hermes core.

The hook returns `(enabled, native_layout)` or `None`. `None`, invalid values, and exceptions preserve the existing core detection path. An explicit operator cache disable still wins, and MoA still resolves the acting aggregator before consulting its provider profile.

This extends the existing provider-profile abstraction rather than adding a second strategy manager or any core model-tool surface. The system prompt and conversation cache prefix are unchanged.

Prior art checked:

- #32707 proposed a much broader prompt-cache strategy abstraction and was closed; this PR adds one concrete capability hook to the existing `ProviderProfile` extension point.
- #76336 is an operator-config opt-in for aliased endpoints; this PR is plugin-owned, request-scoped capability metadata and is orthogonal.
- #13528 and #75886 add built-in provider/model rules; this hook prevents standalone provider plugins from requiring more core allowlist entries.
- #17339 proposed a general provider capability registry; this PR does not add a new registry.

## Related Issue

Fixes #79602

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/base.py`: add the optional, fail-safe `prompt_cache_policy()` provider hook and document its contract.
- `agent/agent_runtime_helpers.py`: resolve plugin policy after operator-disable and MoA-provider resolution, before legacy core rules.
- `tests/providers/test_provider_profiles.py`: add the default contract and a fresh-process `$HERMES_HOME` provider-plugin discovery test.
- `tests/run_agent/test_anthropic_prompt_cache_policy.py`: cover request context, legacy fallback, malformed returns, exceptions, and operator-disable precedence.
- `website/docs/developer-guide/model-provider-plugin.md`: document the new hook for external provider authors.

## How to Test

1. Run the focused policy and discovery suite:
   ```bash
   scripts/run_tests.sh \
     tests/providers/test_provider_profiles.py \
     tests/agent/test_prompt_caching.py \
     tests/run_agent/test_anthropic_prompt_cache_policy.py
   ```
2. Run the wider cache/fallback suite:
   ```bash
   scripts/run_tests.sh \
     tests/providers/test_provider_profiles.py \
     tests/agent/test_prompt_caching.py \
     tests/agent/test_moa_aggregator_cache_control.py \
     tests/agent/test_cache_disabled_on_stubs.py \
     tests/run_agent/test_anthropic_prompt_cache_policy.py \
     tests/run_agent/test_background_fallback_cache_parity.py \
     tests/run_agent/test_conversation_fallback_state.py \
     tests/run_agent/test_run_agent.py
   ```
3. Run lint and whitespace validation:
   ```bash
   uvx --from ruff==0.15.10 ruff check \
     agent/agent_runtime_helpers.py providers/base.py \
     tests/providers/test_provider_profiles.py \
     tests/run_agent/test_anthropic_prompt_cache_policy.py
   git diff --check origin/main...HEAD
   ```

Local results:

- Focused suite: **72 passed, 0 failed**.
- Wider cache/fallback suite: **334 passed, 0 failed**.
- Ruff and `git diff --check`: passed.
- The full canonical suite was also attempted in an isolated `[all,dev]` environment: **25,618 passed, 69 failed** in 27 untouched optional-dependency/platform-specific files. Representative failures require non-`[all]` lazy dependencies such as the Anthropic SDK, Parallel SDK, wake-word runtime, and audio backends. The changed policy/discovery tests passed in that run; CI remains authoritative for the repository-wide matrix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `ProviderProfile` docstring and model-provider authoring guide
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, this extends the existing `ProviderProfile` hook surface
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral Python path; fresh-process discovery test uses no shell-specific behavior
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tools or schemas changed

## Screenshots / Logs

No UI changes.

AI assistance was used to help draft and review the implementation and tests; all commands and validation reported above were run in the contributor checkout.
