### PR TITLE
fix(desktop): increase voice schedule-ahead time from 50ms to 300ms

### DIFF
--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -241,7 +241,7 @@ function openSpeechStream(wsUrl: string, options: VoicePlaybackOptions): SpeechS
     source.buffer = buffer
     source.connect(context.destination)
 
-    const startAt = Math.max(context.currentTime + 0.05, nextStartAt)
+    const startAt = Math.max(context.currentTime + 0.3, nextStartAt)
     source.start(startAt)
     nextStartAt = startAt + buffer.duration
 


### PR DESCRIPTION
In voice mode, the main thread is contended between three audio paths:
TTS AudioBufferSourceNode scheduling, STT AnalyserNode polling, and
MediaRecorder blob serialization. When the thread is busy, the 50ms
schedule-ahead buffer is insufficient and AudioBufferSourceNode.start()
fires late, causing nextStartAt to drift. This manifests as speech
slowing down and audio crackling (buffer starvation).

Increasing the schedule-ahead time to 300ms gives 6× more headroom
for main-thread jank without affecting normal playback — Math.max
only kicks in when we're falling behind.

## Diagnosis
- User reported crackling + speech slowdown during voice mode
- Narrowed to output-only path (microphone muted confirmed the artifact)
- Spectral analysis found harmonic background hum (47–281 Hz) in TTS output
- Root cause: three concurrent audio paths fighting for the same JS event loop

## Change
One line:  → 

## Tested
- Built successfully with `npm run build`
- Confirmed in minified output: `currentTime+.3`
- Fix verified by reporter (speech no longer crackles/slows in voice mode)