### PR TITLE
fix(cli): stage skill imports so import-agent can't destroy the skill it is replacing

### DIFF
--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -292,20 +292,38 @@ def backup_memory_file(path: Path) -> Optional[Path]:
 
 
 def discard_path(path: Path) -> None:
-    """Remove a staging/backup path, without ever raising.
+    """Remove a staging/backup path, logging rather than raising on failure.
 
     Only called while unwinding a failed directory swap, where the exception
-    that is already in flight is the one worth reporting: a cleanup error
-    would mask it, and the leftover is a hidden sibling of the destination,
-    not user data.
+    already in flight is the one worth reporting: a cleanup error must not
+    mask it.  It must not vanish either, though —
+    ``rmtree(..., ignore_errors=True)`` would swallow a permission or I/O
+    problem outright and leave a hidden ``.import-*`` / ``.bak-*`` sibling
+    behind with no signal at all.  So failures are collected and logged while
+    the removal still gets as far as it can.
     """
+    failures: List[Tuple[str, Any]] = []
+
+    def on_error(_func, failed_path, error) -> None:
+        # ``onexc`` (3.12+) passes the exception instance; ``onerror`` (3.11)
+        # passes a sys.exc_info() triple.  Same split as
+        # ``hermes_cli.profiles._rmtree_with_retry``.
+        failures.append(
+            (str(failed_path), error[1] if isinstance(error, tuple) else error)
+        )
+
     try:
         if path.is_symlink() or path.is_file():
             path.unlink()
         elif path.is_dir():
-            shutil.rmtree(path, ignore_errors=True)
-    except OSError:
-        logger.debug("Could not remove temporary path %s", path, exc_info=True)
+            if sys.version_info >= (3, 12):
+                shutil.rmtree(path, onexc=on_error)
+            else:
+                shutil.rmtree(path, onerror=on_error)
+    except OSError as exc:
+        failures.append((str(path), exc))
+    for failed_path, error in failures:
+        logger.debug("Could not remove temporary path %s: %s", failed_path, error)
 
 
 def merge_entries(

--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -44,6 +44,7 @@ import re
 import shutil
 import sys
 import time
+import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -289,6 +290,22 @@ def backup_memory_file(path: Path) -> Optional[Path]:
     shutil.copy2(path, backup)
     return backup
 
+
+def discard_path(path: Path) -> None:
+    """Remove a staging/backup path, without ever raising.
+
+    Only called while unwinding a failed directory swap, where the exception
+    that is already in flight is the one worth reporting: a cleanup error
+    would mask it, and the leftover is a hidden sibling of the destination,
+    not user data.
+    """
+    try:
+        if path.is_symlink() or path.is_file():
+            path.unlink()
+        elif path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+    except OSError:
+        logger.debug("Could not remove temporary path %s", path, exc_info=True)
 
 
 def merge_entries(
@@ -822,19 +839,108 @@ class AgentImporter:
             return
         for skill_dir in skill_dirs:
             destination = destination_root / skill_dir.name
-            if destination.exists() and not self.overwrite:
+            # ``exists()`` follows symlinks, so a DANGLING link at the
+            # destination used to read as "nothing here" — and the import then
+            # deleted it without ``--overwrite`` ever being asked for.  A link
+            # the user put there is state, present or not.
+            occupied = destination.exists() or destination.is_symlink()
+            if occupied and not self.overwrite:
                 self.record("skill", skill_dir, destination, "conflict",
                             "Destination skill already exists")
                 continue
             if self.execute:
-                destination.parent.mkdir(parents=True, exist_ok=True)
-                if destination.exists():
-                    shutil.rmtree(destination)
-                shutil.copytree(skill_dir, destination)
+                try:
+                    self._install_skill_dir(skill_dir, destination)
+                except OSError as exc:
+                    # ``shutil.Error`` subclasses OSError, so this covers a
+                    # partially-failed copytree too.  Recording the failure
+                    # instead of raising keeps ONE bad skill from aborting the
+                    # run: the caller's ``except Exception`` in
+                    # import_agent_command returns without ever calling
+                    # print_import_report, so an escaping exception would hide
+                    # the config.yaml and MEMORY.md entries that already landed.
+                    self.record("skill", skill_dir, destination, "error",
+                                f"Could not import skill directory: {exc}")
+                    continue
                 self.record("skill", skill_dir, destination, "imported")
             else:
                 self.record("skill", skill_dir, destination, "imported",
                             "Would copy skill directory")
+
+    def _install_skill_dir(self, source: Path, destination: Path) -> None:
+        """Stage a copy of ``source`` beside ``destination``, then swap it in.
+
+        The previous implementation called ``shutil.rmtree(destination)`` and
+        *then* ``shutil.copytree`` into the hole it had just made, so any
+        failure during the copy — a full disk, an unreadable member, a symlink
+        it could not follow — left the user's skill deleted and half-rebuilt,
+        with no backup and no way back.  Skills are the only one of
+        ``import-agent``'s four destinations that had no such safety net; this
+        restores the invariant the other three already hold (see
+        :func:`load_yaml_file`, :func:`dump_yaml_file` and
+        :func:`backup_memory_file`): build the replacement first, swap it in
+        second, and keep the previous state until the swap has succeeded.
+
+        Staging and backup live beside the destination so the swap is a rename
+        on one filesystem rather than a second full copy.
+        """
+        token = uuid.uuid4().hex[:8]
+        destination.parent.mkdir(parents=True, exist_ok=True)
+
+        # A symlinked destination is a deliberate choice by the user, so write
+        # THROUGH it and leave the link itself alone — the same thing
+        # ``atomic_replace`` does for a symlinked config.yaml.  It also keeps
+        # ``shutil.rmtree`` away from a symlink, which it refuses outright
+        # ("Cannot call rmtree on a symbolic link").
+        target = destination
+        if destination.is_symlink():
+            resolved = destination.resolve()
+            if resolved.is_dir():
+                target = resolved
+            else:
+                # Dangling, or pointing at a non-directory: there is no skill
+                # behind the link to preserve, and ``copytree`` would abort on
+                # the link itself with FileExistsError.
+                destination.unlink()
+
+        staged = target.parent / f".{target.name}.import-{token}"
+        backup = target.parent / f".{target.name}.bak-{token}"
+
+        # 1. Build the replacement completely, off to the side.  ``symlinks``
+        #    reproduces links AS links: a skill directory may legitimately hold
+        #    a dangling or absolute symlink, and dereferencing one aborts the
+        #    copy part-way through (hermes_cli/profiles.py passes the same flag
+        #    when cloning and exporting profiles, for the same reason).
+        try:
+            shutil.copytree(source, staged, symlinks=True)
+        except BaseException:
+            discard_path(staged)
+            raise
+
+        # 2. Move the old tree aside, swap the new one in, drop the old.
+        backed_up = False
+        try:
+            if target.exists():
+                target.rename(backup)
+                backed_up = True
+            staged.rename(target)
+        except BaseException:
+            discard_path(staged)
+            if backed_up and not target.exists():
+                try:
+                    backup.rename(target)
+                except OSError:
+                    # Never delete the backup when the restore failed — the
+                    # user's skill is still on disk under this name.  Report
+                    # the original failure, not this one.
+                    logger.error(
+                        "Could not restore %s after a failed skill import; "
+                        "the previous contents are preserved at %s",
+                        target, backup,
+                    )
+            raise
+        if backed_up:
+            discard_path(backup)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/agent_import.py
+++ b/hermes_cli/agent_import.py
@@ -413,6 +413,38 @@ def sanitize_mcp_env(env: Any) -> Tuple[Dict[str, str], List[str]]:
     return kept, stripped
 
 
+def _credential_copytree_ignore(skipped: List[str]):
+    """Build a ``copytree`` ignore callback that drops credential files.
+
+    :data:`_CREDENTIAL_FILENAMES` names the files this module's docstring
+    promises are "NEVER imported", but nothing consulted it.  ``skills/`` is
+    the one destination that copies a whole subtree rather than reading
+    named keys out of a config, and it copied every member verbatim — so a
+    ``.credentials.json`` or ``auth.json`` a user keeps inside
+    ``skills/<name>/`` landed in ``HERMES_HOME/skills/<category>/<name>/``.
+    This is the file-level counterpart of :func:`sanitize_mcp_env`, and the
+    same thing ``hermes_cli/profiles.py`` does with
+    ``_clone_all_copytree_ignore`` when it clones a profile.
+
+    Matching is on the entry NAME, so a credential file is excluded at ANY
+    depth in the skill tree, and — because the copy passes ``symlinks=True``
+    — a *symlink* named ``auth.json`` is dropped as a name rather than
+    reproduced as a link that still resolves to the real secret.
+
+    Every excluded path is appended to ``skipped``: this module's rule for
+    secrets is strip *and report*, so the user can move one across
+    deliberately if it was never a credential after all.
+    """
+    matcher = shutil.ignore_patterns(*_CREDENTIAL_FILENAMES)
+
+    def _ignore(directory: str, names: List[str]) -> List[str]:
+        ignored = sorted(matcher(directory, names))
+        skipped.extend(str(Path(directory) / name) for name in ignored)
+        return ignored
+
+    return _ignore
+
+
 # ---------------------------------------------------------------------------
 # Importer
 # ---------------------------------------------------------------------------
@@ -868,7 +900,8 @@ class AgentImporter:
                 continue
             if self.execute:
                 try:
-                    self._install_skill_dir(skill_dir, destination)
+                    skipped_credentials = self._install_skill_dir(
+                        skill_dir, destination)
                 except OSError as exc:
                     # ``shutil.Error`` subclasses OSError, so this covers a
                     # partially-failed copytree too.  Recording the failure
@@ -880,12 +913,19 @@ class AgentImporter:
                     self.record("skill", skill_dir, destination, "error",
                                 f"Could not import skill directory: {exc}")
                     continue
-                self.record("skill", skill_dir, destination, "imported")
+                details: Dict[str, Any] = {}
+                if skipped_credentials:
+                    # Same contract as the stripped MCP env vars: the secret
+                    # is left behind AND named, never dropped in silence.
+                    self.stripped_secrets.extend(skipped_credentials)
+                    details["skipped_credentials"] = skipped_credentials
+                self.record("skill", skill_dir, destination, "imported",
+                            **details)
             else:
                 self.record("skill", skill_dir, destination, "imported",
                             "Would copy skill directory")
 
-    def _install_skill_dir(self, source: Path, destination: Path) -> None:
+    def _install_skill_dir(self, source: Path, destination: Path) -> List[str]:
         """Stage a copy of ``source`` beside ``destination``, then swap it in.
 
         The previous implementation called ``shutil.rmtree(destination)`` and
@@ -901,6 +941,9 @@ class AgentImporter:
 
         Staging and backup live beside the destination so the swap is a rename
         on one filesystem rather than a second full copy.
+
+        Returns the credential files that were left behind (their paths in
+        ``source``), so the caller can report them.
         """
         token = uuid.uuid4().hex[:8]
         destination.parent.mkdir(parents=True, exist_ok=True)
@@ -929,8 +972,14 @@ class AgentImporter:
         #    a dangling or absolute symlink, and dereferencing one aborts the
         #    copy part-way through (hermes_cli/profiles.py passes the same flag
         #    when cloning and exporting profiles, for the same reason).
+        #    ``ignore`` keeps credential files out of the copy entirely, so
+        #    they are never written to disk under HERMES_HOME even briefly.
+        skipped_credentials: List[str] = []
         try:
-            shutil.copytree(source, staged, symlinks=True)
+            shutil.copytree(
+                source, staged, symlinks=True,
+                ignore=_credential_copytree_ignore(skipped_credentials),
+            )
         except BaseException:
             discard_path(staged)
             raise
@@ -959,6 +1008,7 @@ class AgentImporter:
             raise
         if backed_up:
             discard_path(backup)
+        return skipped_credentials
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -334,6 +334,101 @@ class TestSecretsNeverImported:
         config = yaml.safe_load((hermes_home / "config.yaml").read_text())
         assert config["mcp_servers"]["remote"]["headers"] == {"X-Region": "us-east"}
 
+    # -- credential files INSIDE a skill directory -------------------------
+    #
+    # The cases above hold by accident: every fixture plants its credential
+    # file at the ROOT of the source tree, and no importer reads root-level
+    # files.  skills/ is the one destination that copies a whole subtree, and
+    # it copied every member verbatim -- so `_CREDENTIAL_FILENAMES`, the list
+    # the module docstring promises is "NEVER imported", was enforced nowhere.
+
+    SKILL_SECRETS = {
+        ".credentials.json": "sk-ant-INSIDE-SKILL",
+        "auth.json": "sk-oai-INSIDE-SKILL",
+        "credentials.json": "pw-INSIDE-SKILL",
+    }
+
+    @pytest.fixture()
+    def skill_with_credentials(self, claude_tree):
+        """A source skill the user keeps their agent credentials inside."""
+        skill = claude_tree / "skills" / "deploy-helper"
+        for name, secret in self.SKILL_SECRETS.items():
+            (skill / name).write_text(
+                json.dumps({"key": secret}), encoding="utf-8")
+        # ... and one a directory deeper, beside a file that must still copy.
+        nested = skill / "helpers"
+        nested.mkdir()
+        (nested / "auth.json").write_text(
+            json.dumps({"key": "sk-oai-NESTED"}), encoding="utf-8")
+        (nested / "run.sh").write_text("echo deploying\n", encoding="utf-8")
+        return skill
+
+    def test_skill_imports_without_its_credential_files(
+            self, claude_tree, skill_with_credentials, hermes_home):
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["imported"]
+        dest = hermes_home / "skills" / "claude-code-imports" / "deploy-helper"
+        # The skill itself lands, in full ...
+        assert "Deploy things." in (dest / "SKILL.md").read_text(encoding="utf-8")
+        assert (dest / "helpers" / "run.sh").exists()
+        # ... minus every credential file, at the top level ...
+        for name in self.SKILL_SECRETS:
+            assert not (dest / name).exists()
+        # ... and nested, which is what makes this a name match and not a
+        # top-level-only one.
+        assert not (dest / "helpers" / "auth.json").exists()
+
+    def test_no_skill_credential_values_anywhere(
+            self, claude_tree, skill_with_credentials, hermes_home):
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+        blob = "".join(
+            p.read_text(encoding="utf-8", errors="replace")
+            for p in hermes_home.rglob("*") if p.is_file()
+        )
+        for secret in self.SKILL_SECRETS.values():
+            assert secret not in blob
+        assert "sk-oai-NESTED" not in blob
+
+    def test_symlinked_credential_file_is_excluded_not_followed(
+            self, claude_tree, hermes_home, tmp_path):
+        """``symlinks=True`` reproduces links AS links, so a link named
+        ``auth.json`` would otherwise still resolve to the real secret."""
+        real = tmp_path / "real-auth.json"
+        real.write_text(json.dumps({"key": "sk-oai-BEHIND-LINK"}),
+                        encoding="utf-8")
+        (claude_tree / "skills" / "deploy-helper" / "auth.json").symlink_to(real)
+
+        run_import("claude-code", claude_tree, hermes_home, execute=True)
+
+        dest = hermes_home / "skills" / "claude-code-imports" / "deploy-helper"
+        assert not (dest / "auth.json").is_symlink()
+        assert not (dest / "auth.json").exists()
+        blob = "".join(
+            p.read_text(encoding="utf-8", errors="replace")
+            for p in hermes_home.rglob("*") if p.is_file()
+        )
+        assert "sk-oai-BEHIND-LINK" not in blob
+
+    def test_skipped_skill_credentials_are_reported(
+            self, claude_tree, skill_with_credentials, hermes_home):
+        """Strip *and* tell the user -- the same contract the MCP env-var
+        stripper holds, so a file left behind can be moved across
+        deliberately if it was never a credential."""
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True)
+
+        item = skill_items(report)[0]
+        assert sorted(Path(p).name for p in item["skipped_credentials"]) == [
+            ".credentials.json", "auth.json", "auth.json", "credentials.json",
+        ]
+        assert (str(skill_with_credentials / "helpers" / "auth.json")
+                in item["skipped_credentials"])
+        # They surface in the same report section as the stripped env vars.
+        for name in self.SKILL_SECRETS:
+            assert str(skill_with_credentials / name) in report["stripped_secrets"]
+
 
 # ---------------------------------------------------------------------------
 # Malformed inputs: per-item skip/error reports, no crashes

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -675,6 +675,162 @@ class TestExistingConfigPreserved:
 
 
 # ---------------------------------------------------------------------------
+# skills/ durability (sibling of the MEMORY.md and config.yaml cases above)
+# ---------------------------------------------------------------------------
+
+SENTINEL = "keep me: hand-edited notes that exist nowhere else\n"
+
+
+def skill_items(report):
+    return [i for i in report["items"] if i["kind"] == "skill"]
+
+
+class TestImportSkillsDurability:
+    """An import must not destroy the skill directory it is replacing.
+
+    ``import_skills`` was the last of import-agent's four destinations with no
+    read-safety, no backup and no atomic swap: it called
+    ``shutil.rmtree(destination)`` and *then* ``shutil.copytree`` into the hole
+    it had just made.  Any failure in between left the user's skill deleted and
+    half-rebuilt, and the exception escaped past the per-item report — so the
+    user was not even told which items had already landed in config.yaml and
+    memories/MEMORY.md.
+    """
+
+    @pytest.fixture()
+    def dest_root(self, hermes_home):
+        root = hermes_home / "skills" / "claude-code-imports"
+        root.mkdir(parents=True)
+        return root
+
+    @pytest.fixture()
+    def seeded_skill(self, dest_root):
+        """A previously-imported skill the user has since edited."""
+        dest = dest_root / "deploy-helper"
+        dest.mkdir()
+        (dest / "SKILL.md").write_text("mine\n", encoding="utf-8")
+        (dest / "notes.md").write_text(SENTINEL, encoding="utf-8")
+        return dest
+
+    # -- destroy-then-copy: the copy fails, the skill is already gone ------
+
+    def test_failed_copy_leaves_the_existing_skill_intact(
+            self, claude_tree, hermes_home, seeded_skill, monkeypatch):
+        from hermes_cli import agent_import
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(agent_import.shutil, "copytree", boom)
+
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True, overwrite=True)
+
+        # The user's skill survives, byte for byte.
+        assert (seeded_skill / "SKILL.md").read_text(encoding="utf-8") == "mine\n"
+        assert (seeded_skill / "notes.md").read_text(encoding="utf-8") == SENTINEL
+        # ... and the failure is reported per item rather than aborting the run.
+        assert [i["status"] for i in skill_items(report)] == ["error"]
+        assert "no space left on device" in skill_items(report)[0]["reason"]
+
+    def test_failed_copy_leaves_no_staging_directory_behind(
+            self, claude_tree, hermes_home, dest_root, seeded_skill,
+            monkeypatch):
+        from hermes_cli import agent_import
+
+        def boom(*_args, **_kwargs):
+            raise OSError("no space left on device")
+
+        monkeypatch.setattr(agent_import.shutil, "copytree", boom)
+
+        run_import("claude-code", claude_tree, hermes_home,
+                   execute=True, overwrite=True)
+
+        assert sorted(p.name for p in dest_root.iterdir()) == ["deploy-helper"]
+
+    # -- symlinks in the SOURCE skill --------------------------------------
+
+    def test_source_skill_with_a_dangling_symlink_is_imported(
+            self, claude_tree, hermes_home):
+        """``copytree`` dereferenced source links, so one dangling link
+        aborted the copy — on a FIRST import, with no --overwrite involved."""
+        (claude_tree / "skills" / "deploy-helper" / "missing-link").symlink_to(
+            "does-not-exist.md")
+
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["imported"]
+        dest = hermes_home / "skills" / "claude-code-imports" / "deploy-helper"
+        assert (dest / "SKILL.md").exists()
+        # The link is reproduced as a link, still dangling — not dereferenced.
+        assert (dest / "missing-link").is_symlink()
+        assert not (dest / "missing-link").exists()
+
+    # -- symlinks at the DESTINATION ---------------------------------------
+
+    def test_symlinked_destination_is_written_through_not_clobbered(
+            self, claude_tree, hermes_home, dest_root, tmp_path):
+        """``rmtree`` refuses a symlink outright ("Cannot call rmtree on a
+        symbolic link"), so overwriting a symlinked skill always crashed."""
+        real = tmp_path / "external-deploy-helper"
+        real.mkdir()
+        (real / "SKILL.md").write_text("mine\n", encoding="utf-8")
+        link = dest_root / "deploy-helper"
+        link.symlink_to(real, target_is_directory=True)
+
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True, overwrite=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["imported"]
+        # The link the user set up deliberately survives ...
+        assert link.is_symlink()
+        assert link.resolve() == real.resolve()
+        # ... and the skill behind it is the imported one.
+        assert "Deploy things." in (real / "SKILL.md").read_text(encoding="utf-8")
+
+    def test_dangling_destination_symlink_is_a_conflict_without_overwrite(
+            self, claude_tree, hermes_home, dest_root):
+        """``exists()`` follows links, so a dangling one read as "nothing
+        here": no conflict was reported and ``copytree`` died on the link."""
+        link = dest_root / "deploy-helper"
+        link.symlink_to(dest_root / "gone")
+
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["conflict"]
+        assert link.is_symlink()
+
+    def test_dangling_destination_symlink_is_replaced_with_overwrite(
+            self, claude_tree, hermes_home, dest_root):
+        link = dest_root / "deploy-helper"
+        link.symlink_to(dest_root / "gone")
+
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True, overwrite=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["imported"]
+        assert not link.is_symlink()
+        assert "Deploy things." in (link / "SKILL.md").read_text(encoding="utf-8")
+
+    # -- the ordinary overwrite still works --------------------------------
+
+    def test_overwrite_replaces_the_skill_and_leaves_no_leftovers(
+            self, claude_tree, hermes_home, dest_root, seeded_skill):
+        report = run_import("claude-code", claude_tree, hermes_home,
+                            execute=True, overwrite=True)
+
+        assert [i["status"] for i in skill_items(report)] == ["imported"]
+        assert "Deploy things." in (
+            seeded_skill / "SKILL.md").read_text(encoding="utf-8")
+        # The stale member of the old skill is gone (a replace, not a merge) ...
+        assert not (seeded_skill / "notes.md").exists()
+        # ... and no staging/backup sibling is left behind.
+        assert sorted(p.name for p in dest_root.iterdir()) == ["deploy-helper"]
+
+
+# ---------------------------------------------------------------------------
 # CLI wiring
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_agent_import.py
+++ b/tests/hermes_cli/test_agent_import.py
@@ -11,6 +11,7 @@ the real ~/.hermes.
 """
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -813,6 +814,37 @@ class TestImportSkillsDurability:
         assert [i["status"] for i in skill_items(report)] == ["imported"]
         assert not link.is_symlink()
         assert "Deploy things." in (link / "SKILL.md").read_text(encoding="utf-8")
+
+    # -- cleanup failures are reported, not swallowed ----------------------
+
+    def test_failed_cleanup_is_logged_rather_than_swallowed(
+            self, tmp_path, caplog):
+        """``rmtree(..., ignore_errors=True)`` would drop a permission problem
+        on the floor, leaving a hidden ``.import-*`` sibling with no signal."""
+        import os
+
+        if os.name != "posix":
+            pytest.skip("chmod-based permission denial is POSIX-only")
+        if getattr(os, "geteuid", lambda: 1)() == 0:
+            pytest.skip("root bypasses file permissions")
+
+        from hermes_cli import agent_import
+
+        stray = tmp_path / ".deploy-helper.import-abcd1234"
+        locked = stray / "locked"
+        locked.mkdir(parents=True)
+        (locked / "SKILL.md").write_text("staged\n", encoding="utf-8")
+        # r-x: the child is readable but the directory is not writable, so it
+        # cannot be unlinked.
+        locked.chmod(0o500)
+        try:
+            with caplog.at_level(logging.DEBUG, logger=agent_import.__name__):
+                agent_import.discard_path(stray)  # must not raise
+        finally:
+            locked.chmod(0o700)
+
+        assert "Could not remove temporary path" in caplog.text
+        assert "SKILL.md" in caplog.text
 
     # -- the ordinary overwrite still works --------------------------------
 


### PR DESCRIPTION
## This is a sibling follow-up to #76698 (commit `981a5986`)

- **What the parent covered:** `hermes import-agent` was collapsing a
  present-but-unreadable `config.yaml` to `{}` and writing the merged section
  back over it. `981a5986` added `ConfigReadError` + `load_target_config` so the
  importer refuses instead; `22492f0c` extracted `atomic_write_text` to
  `utils.py`, and `9d6ef41a` finished off the review follow-ups.
- **What the parent did NOT touch:** `import_skills`. It is the **fourth and
  last** of `hermes import-agent`'s four destinations, and the only one still
  with **no read-safety, no backup, and no atomic swap**.
- **What this adds:** the same invariant for skill directories — build the
  replacement first, swap it in second, keep the previous state until the swap
  succeeded — plus per-item `error` records so one bad skill no longer aborts
  the run and suppresses the report.

## What does this PR do?

`AgentImporter.import_skills` called `shutil.rmtree(destination)` and *then*
`shutil.copytree` into the hole it had just made:

```python
if self.execute:
    destination.parent.mkdir(parents=True, exist_ok=True)
    if destination.exists():
        shutil.rmtree(destination)          # user's skill is gone here
    shutil.copytree(skill_dir, destination) # ...and anything below can fail
    self.record("skill", skill_dir, destination, "imported")
```

That ordering is the one this module explicitly rejects everywhere else, in its
own words:

| destination | guard on `main` |
|---|---|
| `config.yaml` (allowlist / denylist / MCP) | `load_yaml_file` raises `ConfigReadError` rather than collapse to `{}`, "because collapsing a present-but-unreadable file to `{}` would replace every existing setting with just the merged keys"; `dump_yaml_file` routes to `atomic_yaml_write` |
| `memories/MEMORY.md` | `_merge_memory_entries` calls `backup_memory_file` **before** the write and refuses to write at all if the backup fails — *"Never rewrite the store when the safety net failed"* — and records an `error` item |
| `skills/<category>/<name>/` | **none** |

`utils.atomic_write_text` exists so that *"every destructive file rewrite in the
codebase shares one implementation."* Directory replacement was the gap.

### Four failure modes, all fixed here

1. **Destroy-then-copy.** Any failure during the copy — `ENOSPC`, `EACCES` on a
   member, an unreadable file — left the user's skill **deleted and
   half-rebuilt**, with no backup and no way back.
2. **`rmtree` on a symlinked destination raises.** `destination.exists()`
   follows symlinks → `True`; `shutil.rmtree(<symlink to dir>)` →
   `OSError: Cannot call rmtree on a symbolic link`. Overwriting a symlinked
   skill always crashed.
3. **`copytree` dereferenced source symlinks.** With the default
   `symlinks=False`, one dangling symlink inside a Claude/Codex skill directory
   aborts the copy part-way through with `shutil.Error` — and this fires on a
   **first** import, no `--overwrite` needed. A dangling *destination* symlink
   was invisible to `exists()`: no conflict was recorded, and `copytree` then
   died with `FileExistsError`. `hermes_cli/profiles.py` passes `symlinks=True`
   at `:1069` and `:1958` for exactly this reason.
4. **Failure aborted the run and suppressed the report.** Unlike every sibling
   importer, this one recorded no `error` item. The exception escaped to
   `import_agent_command`'s `except Exception`, which prints `Import failed: …`
   and returns **without calling `print_import_report(report)`** — so the user
   was never told which entries had already landed in `config.yaml` and
   `memories/MEMORY.md`.

### Symptom a user reports

`hermes import-agent claude-code --overwrite` on a machine that runs out of
disk, or that has a symlinked skill, or a skill containing a dangling symlink:
the command prints `Import failed: …`, one of their skills is gone, and the
report that would have told them what *did* change is never printed.

## Related Issue

No filed issue — found while extending the safety-hardening arc this module has
been on since #76698.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/agent_import.py`
  - New `AgentImporter._install_skill_dir(source, destination)`: stages the copy
    into a hidden sibling `.{name}.import-{token}`, renames any existing tree to
    `.{name}.bak-{token}`, renames the staged copy into place, and only then
    drops the backup. Staging and backup are siblings of the destination, so the
    swap is a rename on one filesystem rather than a second full copy.
  - On failure: the staging directory is removed and the backup is restored. If
    the *restore* also fails, the backup is deliberately **not** deleted and its
    path is logged, so the user's skill is still recoverable on disk. The
    original exception is the one reported, not the cleanup error.
  - `shutil.copytree(..., symlinks=True)` — links are reproduced as links
    instead of being dereferenced.
  - A symlinked destination is written **through**, leaving the link in place —
    the same treatment `atomic_replace` gives a symlinked `config.yaml`. A
    dangling / non-directory link has nothing behind it to preserve and is
    replaced.
  - The occupancy check is now `destination.exists() or
    destination.is_symlink()`, so a **dangling** destination symlink is reported
    as a `conflict` rather than silently deleted without `--overwrite`.
  - Per-skill failures are recorded as `error` items and the loop continues
    (`shutil.Error` subclasses `OSError`, so one clause covers both).
  - New module-level `discard_path()` helper for never-raising cleanup of the
    staging/backup paths.
- `tests/hermes_cli/test_agent_import.py`
  - New `TestImportSkillsDurability` — 7 tests, **6 of which fail on
    unpatched `main`**.

## Coverage / sibling sweep

`grep -rn "shutil.rmtree" --include='*.py'` over the repo turns up other
rmtree-then-recreate sites. They are **deliberately excluded** — none shares
this root cause, and each is a separate reviewable change:

| site | why it is not in this PR |
|---|---|
| `hermes_cli/profiles.py:2118` | already safe: refuses when the destination exists and stages through `tempfile.TemporaryDirectory` |
| `hermes_cli/profiles.py:1069`, `:1107`, `:1958`, `:1972` | create-only, and already pass `symlinks=True` |
| `hermes_cli/backup.py:1465`, `cli.py:1749` | create-only or already staged |
| `hermes_cli/update_cmd.py:626-630` | operates on a staging dir, not live user state |
| `hermes_cli/plugins_cmd.py:534-536` | the same shape on plugin installs, but it is a distinct surface with its own semantics and a crowded PR queue — worth its own change |
| `hermes_cli/profile_distribution.py:572-574` | same shape, distinct surface |

## Related / positioning

Two open PRs are adjacent but touch **different files** and different code
paths; neither overlaps this change:

- **#56120** *fix(skills-sync): allow rmtree on symlinked skill subtrees* —
  `tools/skills_sync.py`, `scripts/reconcile_skills_manifest.py`.
- **#56822** *fix(cli): harden profile cloning against dangling skill symlinks* —
  `hermes_cli/profiles.py`.
- **#71025** *fix(cli): align branded box headers* — touches
  `hermes_cli/agent_import.py`, but only `import_agent_command`'s box-drawing
  header; no overlap with `import_skills`.

## How to Test

1. Seed an already-imported skill and make the copy fail:
   ```
   uv run --with pytest --with pytest-asyncio python3 -m pytest \
     tests/hermes_cli/test_agent_import.py -k TestImportSkillsDurability -v
   ```
2. Confirm the tests pin the production change: revert only
   `hermes_cli/agent_import.py` (`git checkout origin/main -- hermes_cli/agent_import.py`)
   and re-run. On `main` **6 of the 7 fail**:

   | test | failure on `main` |
   |---|---|
   | `test_failed_copy_leaves_the_existing_skill_intact` | `OSError` escapes the run; the seeded skill has already been `rmtree`d |
   | `test_failed_copy_leaves_no_staging_directory_behind` | same escape |
   | `test_source_skill_with_a_dangling_symlink_is_imported` | `shutil.Error` — `copytree` dereferenced the link |
   | `test_symlinked_destination_is_written_through_not_clobbered` | `OSError: Cannot call rmtree on a symbolic link` |
   | `test_dangling_destination_symlink_is_a_conflict_without_overwrite` | `FileExistsError` — `exists()` missed the link, no conflict recorded |
   | `test_dangling_destination_symlink_is_replaced_with_overwrite` | `FileExistsError` |
   | `test_overwrite_replaces_the_skill_and_leaves_no_leftovers` | passes on `main` — this one is the invariance check that the ordinary overwrite path is unchanged |
3. Restore the file: the full file is green — **55 passed**
   (48 pre-existing + 7 new).
4. Adjacent suites also green: `tests/hermes_cli/test_ollama_cloud_provider.py`
   and `tests/skills/test_openclaw_migration.py` — 43 passed.
5. `ruff check` on both touched files: clean. `ty check hermes_cli/agent_import.py`
   reports the same 2 diagnostics as unmodified `main` (both in
   `_merge_memory_entries`, untouched here).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the focused and adjacent suites instead (see "How to Test"); the full suite was not run
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), CPython 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on `_install_skill_dir` and `discard_path` state the invariant
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — considered but only verified on macOS: `Path.rename` refuses an existing target on Windows, which is why both staging and backup carry a unique token and the backup is dropped only after the swap; `copytree(symlinks=True)` on Windows needs symlink privileges, but that is the same requirement `hermes_cli/profiles.py` already has
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract Protected

**Invariant:** `hermes import-agent` never leaves a skill directory in a state
the user did not have before the command ran. Either the old skill is intact or
the new one is complete — never neither, and never half of each.

**Known-bad inputs now covered:** a copy that fails mid-way (`ENOSPC`/`EACCES`);
a destination that is a symlink to a real directory; a destination that is a
dangling symlink, with and without `--overwrite`; a source skill containing a
dangling symlink.

**Future-input coverage:** the guard is in the swap primitive
(`_install_skill_dir`), not in per-case branches, so any new failure mode inside
`copytree` — a new file type, a permission model change, a filesystem that
rejects a member — unwinds through the same restore path and is reported as an
`error` item rather than escaping.

**Negative case:** `test_overwrite_replaces_the_skill_and_leaves_no_leftovers`
asserts the ordinary `--overwrite` path still fully replaces the skill (stale
members removed, not merged) and leaves no `.import-*` / `.bak-*` sibling
behind — so the new safety net cannot be satisfied by simply refusing to write.


---

## Follow-up commit: credential files are now actually excluded from imported skills

`b9d44f6` adds a second, closely-related guarantee to the same copy this PR
rewrites. It is here rather than in its own PR because it is a one-argument
change to `_install_skill_dir`'s `copytree` — the exact call this PR introduces.

The module already promises, in its own docstring, that
*"Secrets are NEVER imported: credential files (.credentials.json, auth.json)
are ignored"*, and defines `_CREDENTIAL_FILENAMES` to say which ones. That
constant was referenced nowhere in the repository — `git grep` returned only its
own definition — and the skills `copytree` applied no `ignore=`, so a credential
file sitting inside `skills/<name>/` was copied verbatim into
`HERMES_HOME/skills/<category>/<name>/`.

The existing "Secrets are never copied" tests did not catch it because every
fixture places its credential file at the **root** of the source tree, which
nothing reads. The `skills/` subtree was the one path that could carry such a
file, and it was unfiltered.

- `_credential_copytree_ignore` feeds `shutil.ignore_patterns(*_CREDENTIAL_FILENAMES)`
  to the staged copy, reviving the existing constant rather than adding a second
  list. It mirrors `hermes_cli/profiles.py::_clone_all_copytree_ignore`, which
  already does this for profile clones.
- Matching is on basename, so it applies at any depth inside the skill, and with
  `symlinks=True` a symlink *named* `auth.json` is excluded too.
- Skipped files are not dropped silently: they are recorded on the skill's report
  item and surfaced under the report's existing
  "⚷ Secrets stripped (never imported)" section, matching how MCP server env vars
  are already stripped and reported so the user can re-add them deliberately.

Four regression tests cover it, verified in both directions (they fail on the
pre-fix production file and pass on restore).
