### PR TITLE
fix(mem0): neutralize CR/LF in .env values so a secret cannot inject a key

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -188,6 +188,22 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
     return oss_config, env_writes
 
 
+def _env_line_safe(value) -> str:
+    """Neutralize characters that would break ``.env`` line structure.
+
+    ``.env`` is strictly line-oriented (one ``KEY=VALUE`` per line) and values
+    are interpolated straight into that line. A pasted secret with an embedded
+    CR/LF spills onto a new line and is re-parsed as a *separate* ``KEY=VALUE``
+    entry on the next read, so a value carrying ``\\nOPENAI_API_KEY=...``
+    silently overwrites an unrelated provider key. Strip every separator
+    ``str.splitlines()`` recognizes, plus NUL, so a value can only occupy its
+    own line. Mirrors ``hermes_cli.memory_setup``, the openviking writer and
+    ``config.save_env_value``.
+    """
+    text = value if isinstance(value, str) else str(value)
+    return "".join(text.replace("\x00", "").splitlines())
+
+
 def _write_env(env_path: Path, env_writes: dict[str, str]) -> None:
     """Append or update env vars in .env file."""
     env_path.parent.mkdir(parents=True, exist_ok=True)
@@ -207,13 +223,13 @@ def _write_env(env_path: Path, env_writes: dict[str, str]) -> None:
     for line in existing_lines:
         key_match = line.split("=", 1)[0].strip() if "=" in line and not line.startswith("#") else None
         if key_match and key_match in env_writes:
-            new_lines.append(f"{key_match}={env_writes[key_match]}")
+            new_lines.append(f"{key_match}={_env_line_safe(env_writes[key_match])}")
             updated_keys.add(key_match)
         else:
             new_lines.append(line)
     for k, v in env_writes.items():
         if k not in updated_keys:
-            new_lines.append(f"{k}={v}")
+            new_lines.append(f"{k}={_env_line_safe(v)}")
 
     env_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
 

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -231,3 +231,55 @@ class TestConnectivityChecks:
         assert ok is True
 
 
+
+
+class TestEnvLineSafety:
+    """A pasted secret must not be able to define a second .env entry.
+
+    `.env` is line-oriented, so a value carrying a CR/LF spills onto a new
+    line and is re-parsed as its own KEY=VALUE on the next read. The other
+    three writers in the tree (hermes_cli.memory_setup, the openviking
+    plugin, config.save_env_value) neutralize this; this one did not.
+    """
+
+    @staticmethod
+    def _write(tmp_path, existing, writes):
+        from plugins.memory.mem0._setup import _write_env
+
+        env = tmp_path / ".env"
+        env.write_text(existing, encoding="utf-8")
+        _write_env(env, writes)
+        return env.read_text(encoding="utf-8").splitlines()
+
+    def test_newline_in_value_cannot_inject_another_key(self, tmp_path):
+        lines = self._write(
+            tmp_path,
+            "OPENAI_API_KEY=real-key\n",
+            {"MEM0_API_KEY": "pasted\nOPENAI_API_KEY=clobbered"},
+        )
+
+        assert "OPENAI_API_KEY=real-key" in lines
+        assert "OPENAI_API_KEY=clobbered" not in lines
+        assert sum(1 for line in lines if line.startswith("OPENAI_API_KEY=")) == 1
+
+    def test_crlf_and_nul_are_neutralized(self, tmp_path):
+        lines = self._write(
+            tmp_path, "", {"MEM0_API_KEY": "a\r\nb\x00c"},
+        )
+
+        assert lines == ["MEM0_API_KEY=abc"]
+
+    def test_updating_an_existing_key_is_also_guarded(self, tmp_path):
+        lines = self._write(
+            tmp_path,
+            "MEM0_API_KEY=old\nOPENAI_API_KEY=real-key\n",
+            {"MEM0_API_KEY": "new\nOPENAI_API_KEY=clobbered"},
+        )
+
+        assert "OPENAI_API_KEY=clobbered" not in lines
+        assert "OPENAI_API_KEY=real-key" in lines
+
+    def test_ordinary_value_is_written_unchanged(self, tmp_path):
+        lines = self._write(tmp_path, "", {"MEM0_API_KEY": "sk-plain-value"})
+
+        assert lines == ["MEM0_API_KEY=sk-plain-value"]


### PR DESCRIPTION
## What

Three writers in this tree already guard `.env` line structure — `hermes_cli/memory_setup.py::_env_line_safe`, the openviking plugin's writer, and `config.save_env_value`. The first one's docstring states the hazard and names the other two:

> `.env` is strictly line-oriented (one `KEY=VALUE` per line) and values are interpolated straight into that line. A pasted secret with an embedded CR/LF would spill onto a new line and be re-parsed as a *separate* `KEY=VALUE` entry on the next read — **injecting an arbitrary variable into the credentials file**. Strip every separator recognized by `str.splitlines()` plus NUL so a value can only occupy its own line. Mirrors the openviking plugin's writer and `config.save_env_value`.

`plugins/memory/mem0/_setup.py::_write_env` is the fourth writer and never got it. Both of its write sites interpolate the raw value:

```python
new_lines.append(f"{key_match}={env_writes[key_match]}")
...
new_lines.append(f"{k}={v}")
```

Running that writer against an existing credentials file, with a mem0 key pasted as `pasted\nOPENAI_API_KEY=clobbered`:

```
OPENAI_API_KEY=real-key
MEM0_API_KEY=pasted
OPENAI_API_KEY=clobbered
```

An unrelated provider credential is now redefined inside the user's own `.env`. `.env` loaders keep the first occurrence, so which key wins depends on ordering — and the stray line is copied forward verbatim by every later read-modify-write, so it outlives the setup run that created it.

The trigger does not need anything adversarial: a key pasted from a wrapped terminal or a web page routinely carries a trailing newline, and `_write_env` takes its values from `build_oss_config`, i.e. straight from `--oss-llm-key` / the interactive prompt.

## The fix

Add the same `_env_line_safe` helper the sibling writers use, and route both write sites through it. Values with no separators are written byte-identically, so an ordinary key is unaffected; a value carrying CR/LF/NUL is flattened onto its own line instead of defining a second entry.

Deliberately a copy of the existing helper rather than an import: `plugins/memory/mem0/` is a plugin and the openviking plugin keeps its own copy for the same reason — plugins are not supposed to reach into `hermes_cli` internals for this.

## Tests

Added `TestEnvLineSafety` to `tests/plugins/memory/test_mem0_setup.py`:

- a newline-bearing value cannot define a second `OPENAI_API_KEY`; the real one survives and exactly one such line remains
- CR/LF and NUL are all neutralized (`a\r\nb\x00c` → `MEM0_API_KEY=abc`)
- the update path (rewriting an existing key) is guarded too, not just the append path
- an ordinary value is written unchanged

Results:

```
23 passed
```

That is the whole file; the 19 pre-existing tests are unchanged.

Red without the source change:

```
E  AssertionError: assert 'OPENAI_API_KEY=clobbered' not in
     ['OPENAI_API_KEY=real-key', 'MEM0_API_KEY=pasted', 'OPENAI_API_KEY=clobbered']
E  AssertionError: assert ['MEM0_API_KEY=a', '', 'b\x00c'] == ['MEM0_API_KEY=abc']
3 failed
```

Regression over `tests/plugins/memory/` against the same files on main:

```
main:      7 failed   (excluding the 3 new tests failing as above)
with fix:  7 failed
```

Set difference is empty — no new failures. The 7 are identical before and after and sit in the hindsight and holographic suites, unrelated to this change. `scripts/check-windows-footguns.py` is clean on both files.