### PR TITLE
fix(tui): harden resize and scroll recovery

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -104,6 +104,32 @@ describe('Ink resize healing', () => {
     ink.unmount()
   })
 
+  it('lets destructive alt-screen re-entry supersede a pending resize heal', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+
+    ink.setAltScreenActive(true)
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    stdout.chunks = []
+
+    stdout.columns = 12
+    stdout.emit('resize')
+    await vi.advanceTimersByTimeAsync(0)
+
+    ink.reassertTerminalModes(true)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expectCleanRepaint(stdout)
+
+    const writesAfterReentry = stdout.chunks.length
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(stdout.chunks).toHaveLength(writesAfterReentry)
+
+    ink.unmount()
+  })
+
   it('heals same-dimension alt-screen resize events with an erase before repaint', async () => {
     const stdout = new FakeTty()
     const ink = makeInk(stdout)

--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events'
 
 import React from 'react'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Text from './components/Text.js'
 import Ink from './ink.js'
@@ -21,21 +21,92 @@ class FakeTty extends EventEmitter {
   }
 }
 
-const tick = () => new Promise<void>(resolve => queueMicrotask(resolve))
+const settleResize = async () => {
+  await vi.advanceTimersByTimeAsync(160)
+  await vi.runAllTimersAsync()
+}
+
+const makeInk = (stdout: FakeTty, stdin = new FakeTty(), stderr = new FakeTty()) =>
+  new Ink({
+    exitOnCtrlC: false,
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+const expectCleanRepaint = (stdout: FakeTty) => {
+  const out = stdout.chunks.join('')
+
+  expect(out).toContain(ERASE_SCREEN)
+  expect(out).toContain(CURSOR_HOME)
+  expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+}
 
 describe('Ink resize healing', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('waits for a resize burst to settle before emitting one clean repaint', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(Text, null, 'hello'))
+      ink.onRender()
+      stdout.chunks = []
+
+      stdout.columns = 12
+      stdout.rows = 8
+      stdout.emit('resize')
+
+      await vi.advanceTimersByTimeAsync(0)
+
+      const duringResize = stdout.chunks.join('')
+
+      expect(duringResize).not.toContain(ERASE_SCREEN)
+      expect(duringResize).not.toContain('hello')
+
+      await vi.advanceTimersByTimeAsync(159)
+      expect(stdout.chunks.join('')).not.toContain(ERASE_SCREEN)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await vi.runAllTimersAsync()
+
+      expectCleanRepaint(stdout)
+    } finally {
+      ink.unmount()
+    }
+  })
+
+  it('lets a manual redraw supersede a pending resize heal', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+
+    ink.setAltScreenActive(true)
+    ink.render(React.createElement(Text, null, 'hello'))
+    ink.onRender()
+    stdout.chunks = []
+
+    stdout.columns = 12
+    stdout.emit('resize')
+    await vi.advanceTimersByTimeAsync(0)
+
+    ink.forceRedraw()
+    expectCleanRepaint(stdout)
+
+    const writesAfterRedraw = stdout.chunks.length
+
+    await vi.advanceTimersByTimeAsync(200)
+    expect(stdout.chunks).toHaveLength(writesAfterRedraw)
+
+    ink.unmount()
+  })
+
   it('heals same-dimension alt-screen resize events with an erase before repaint', async () => {
     const stdout = new FakeTty()
-    const stdin = new FakeTty()
-    const stderr = new FakeTty()
-
-    const ink = new Ink({
-      exitOnCtrlC: false,
-      patchConsole: false,
-      stderr: stderr as unknown as NodeJS.WriteStream,
-      stdin: stdin as unknown as NodeJS.ReadStream,
-      stdout: stdout as unknown as NodeJS.WriteStream
-    })
+    const ink = makeInk(stdout)
 
     ink.setAltScreenActive(true)
     ink.render(React.createElement(Text, null, 'hello'))
@@ -43,38 +114,23 @@ describe('Ink resize healing', () => {
     stdout.chunks = []
 
     stdout.emit('resize')
-    ink.onRender()
-    await tick()
+    await settleResize()
 
     // The heal may also erase scrollback (CSI 3J interposed between 2J and H)
     // depending on which recovery path runs, so assert the invariant — screen
     // erased, then content repainted after — rather than an exact byte run.
-    const out = stdout.chunks.join('')
-    expect(out).toContain(ERASE_SCREEN)
-    expect(out).toContain(CURSOR_HOME)
-    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+    expectCleanRepaint(stdout)
 
     ink.unmount()
   })
 
   // Regression for issue #18449: dragging the terminal back and forth quickly
-  // emits a BURST of resize events (the single-event test above only covers one
-  // tick). Each tick resets the frame buffers and arms needsEraseBeforePaint, so
-  // the burst must still converge to a clean erase+repaint — a stacked event
-  // must never consume the erase and leave the final paint as a partial diff
-  // that lets stale glyphs survive.
+  // emits a BURST of resize events. Intermediate paints race the terminal
+  // host's physical reflow and can strand stale glyphs. The burst must stay
+  // quiet until it settles, then converge through one clean erase+repaint.
   it('converges to a clean erased frame after a rapid resize burst', async () => {
     const stdout = new FakeTty()
-    const stdin = new FakeTty()
-    const stderr = new FakeTty()
-
-    const ink = new Ink({
-      exitOnCtrlC: false,
-      patchConsole: false,
-      stderr: stderr as unknown as NodeJS.WriteStream,
-      stdin: stdin as unknown as NodeJS.ReadStream,
-      stdout: stdout as unknown as NodeJS.WriteStream
-    })
+    const ink = makeInk(stdout)
 
     ink.setAltScreenActive(true)
     ink.render(React.createElement(Text, null, 'hello'))
@@ -98,17 +154,16 @@ describe('Ink resize healing', () => {
       stdout.emit('resize')
     }
 
-    ink.onRender()
-    await tick()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(stdout.chunks.join('')).not.toContain(ERASE_SCREEN)
+
+    await settleResize()
 
     // The heal can erase scrollback too (CSI 3J interposed), so assert the
     // semantic invariant rather than an exact byte sequence: the screen was
     // erased and the content was repainted AFTER the erase — i.e. the final
     // frame is a clean repaint, not a partial diff over drifted cells.
-    const out = stdout.chunks.join('')
-    expect(out).toContain(ERASE_SCREEN)
-    expect(out).toContain(CURSOR_HOME)
-    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+    expectCleanRepaint(stdout)
 
     ink.unmount()
   })
@@ -120,16 +175,7 @@ describe('Ink resize healing', () => {
   // diff path cannot see (see log-update "drift repro").
   it('heals a same-dimension resize even when no React commit changes the tree', async () => {
     const stdout = new FakeTty()
-    const stdin = new FakeTty()
-    const stderr = new FakeTty()
-
-    const ink = new Ink({
-      exitOnCtrlC: false,
-      patchConsole: false,
-      stderr: stderr as unknown as NodeJS.WriteStream,
-      stdin: stdin as unknown as NodeJS.ReadStream,
-      stdout: stdout as unknown as NodeJS.WriteStream
-    })
+    const ink = makeInk(stdout)
 
     ink.setAltScreenActive(true)
     ink.render(React.createElement(Text, null, 'hello'))
@@ -138,13 +184,9 @@ describe('Ink resize healing', () => {
 
     // Dimensions are identical to the initial render — the tree never changes.
     stdout.emit('resize')
-    ink.onRender()
-    await tick()
+    await settleResize()
 
-    const out = stdout.chunks.join('')
-    expect(out).toContain(ERASE_SCREEN)
-    expect(out).toContain(CURSOR_HOME)
-    expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('hello'))
+    expectCleanRepaint(stdout)
 
     ink.unmount()
   })

--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -3,8 +3,8 @@ import { EventEmitter } from 'events'
 import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import Text from './components/Text.js'
 import { TerminalSizeContext } from './components/TerminalSizeContext.js'
+import Text from './components/Text.js'
 import Ink from './ink.js'
 import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
 

--- a/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/ink-resize.test.ts
@@ -4,6 +4,7 @@ import React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import Text from './components/Text.js'
+import { TerminalSizeContext } from './components/TerminalSizeContext.js'
 import Ink from './ink.js'
 import { CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
 
@@ -80,6 +81,134 @@ describe('Ink resize healing', () => {
     }
   })
 
+  it('keeps the repaint guard active through the final React commit', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+    let commitUpdate: ((phase: string) => void) | undefined
+
+    const CommitUpdate = () => {
+      const [phase, setPhase] = React.useState('initial')
+
+      commitUpdate = nextPhase => setPhase(nextPhase)
+
+      return React.createElement(Text, null, phase)
+    }
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(CommitUpdate))
+      ink.onRender()
+      stdout.chunks = []
+
+      stdout.columns = 12
+      stdout.rows = 8
+      stdout.emit('resize')
+      await vi.advanceTimersByTimeAsync(0)
+
+      const originalRender = ink.render.bind(ink)
+      let injectCommitUpdate = true
+
+      vi.spyOn(ink, 'render').mockImplementation(node => {
+        if (injectCommitUpdate) {
+          injectCommitUpdate = false
+          commitUpdate?.('intermediate')
+        }
+
+        originalRender(node)
+        commitUpdate?.('settled')
+      })
+
+      await vi.advanceTimersByTimeAsync(159)
+      expect(stdout.chunks.join('')).not.toContain('intermediate')
+
+      await vi.advanceTimersByTimeAsync(1)
+      await vi.runAllTimersAsync()
+
+      const out = stdout.chunks.join('')
+
+      expect(out).toContain(ERASE_SCREEN)
+      expect(out).toContain(CURSOR_HOME)
+      expect(out).not.toContain('intermediate')
+      expect(out).toContain('settled')
+      expect(out.indexOf(ERASE_SCREEN)).toBeLessThan(out.lastIndexOf('settled'))
+    } finally {
+      ink.unmount()
+    }
+  })
+
+  it('heals once more after a late terminal-host reflow', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(Text, null, 'hello'))
+      ink.onRender()
+      stdout.chunks = []
+
+      stdout.columns = 8
+      stdout.rows = 3
+      stdout.emit('resize')
+
+      await vi.advanceTimersByTimeAsync(160)
+      await vi.advanceTimersToNextTimerAsync()
+      expectCleanRepaint(stdout)
+
+      // The host can reflow its physical buffer after the fast heal. Ink has
+      // no terminal-side damage signal, so model that late drift by dropping
+      // the already-painted bytes and requiring one bounded follow-up heal.
+      stdout.chunks = []
+
+      await vi.advanceTimersByTimeAsync(499)
+      expect(stdout.chunks.join('')).not.toContain(ERASE_SCREEN)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await vi.advanceTimersByTimeAsync(40)
+      expectCleanRepaint(stdout)
+
+      const writesAfterLateHeal = stdout.chunks.length
+
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(stdout.chunks).toHaveLength(writesAfterLateHeal)
+    } finally {
+      ink.unmount()
+    }
+  })
+
+  it('resynchronizes missed terminal dimensions during a manual redraw', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+
+    const TerminalSize = () => {
+      const size = React.useContext(TerminalSizeContext)
+
+      return React.createElement(Text, null, `${size?.columns}x${size?.rows}`)
+    }
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(TerminalSize))
+      ink.onRender()
+      stdout.chunks = []
+
+      // Model a terminal host that updates the PTY dimensions but drops the
+      // final resize event after a large shrink/grow and a skin repaint.
+      stdout.columns = 37
+      stdout.rows = 11
+
+      ink.forceRedraw()
+      await vi.advanceTimersByTimeAsync(40)
+
+      const out = stdout.chunks.join('')
+
+      expect(out).toContain(ERASE_SCREEN)
+      expect(out).toContain('37x11')
+      expect(out).not.toContain('20x5')
+    } finally {
+      ink.unmount()
+    }
+  })
+
   it('lets a manual redraw supersede a pending resize heal', async () => {
     const stdout = new FakeTty()
     const ink = makeInk(stdout)
@@ -94,6 +223,7 @@ describe('Ink resize healing', () => {
     await vi.advanceTimersByTimeAsync(0)
 
     ink.forceRedraw()
+    await vi.advanceTimersByTimeAsync(40)
     expectCleanRepaint(stdout)
 
     const writesAfterRedraw = stdout.chunks.length
@@ -102,6 +232,37 @@ describe('Ink resize healing', () => {
     expect(stdout.chunks).toHaveLength(writesAfterRedraw)
 
     ink.unmount()
+  })
+
+  it('resynchronizes application listeners even when Ink already matches the PTY', async () => {
+    const stdout = new FakeTty()
+    const ink = makeInk(stdout)
+    let applicationColumns = 7
+    const syncApplicationColumns = () => {
+      applicationColumns = stdout.columns
+    }
+
+    stdout.on('resize', syncApplicationColumns)
+
+    try {
+      ink.setAltScreenActive(true)
+      ink.render(React.createElement(Text, null, 'hello'))
+      ink.onRender()
+      stdout.chunks = []
+
+      // Ink and stdout both remain at 20 columns, but model an application
+      // listener whose coalesced state was stranded at an earlier width.
+      ink.forceRedraw()
+
+      expect(applicationColumns).toBe(20)
+      expect(stdout.chunks.join('')).not.toContain(ERASE_SCREEN)
+
+      await vi.advanceTimersByTimeAsync(40)
+      expectCleanRepaint(stdout)
+    } finally {
+      stdout.off('resize', syncApplicationColumns)
+      ink.unmount()
+    }
   })
 
   it('lets destructive alt-screen re-entry supersede a pending resize heal', async () => {

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1480,6 +1480,15 @@ export default class Ink {
    * stays true. ENTER_ALT_SCREEN is a terminal-side no-op if already in alt.
    */
   private reenterAltScreen(): void {
+    // Re-entry erases the physical alt screen immediately, so it must
+    // supersede a pending resize heal. Otherwise the resize guard suppresses
+    // scheduleRender() below and leaves the terminal blank until the trailing
+    // settle timer fires.
+    if (this.resizeSettleTimer !== null) {
+      clearTimeout(this.resizeSettleTimer)
+      this.resizeSettleTimer = null
+    }
+
     // DISABLE_MOUSE_TRACKING before enableMouseTrackingFor — same as
     // setAltScreenMouseTracking / AlternateScreen mount / handleResize.
     // DEC private modes have no atomic "set this bitmask" sequence, only

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -597,6 +597,10 @@ export default class Ink {
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
       this.render(this.currentNode!)
+      // React may bail out when the current tree is referentially unchanged.
+      // The physical terminal still needs the trailing erase+repaint, so do
+      // not depend on a reconciler commit to schedule it.
+      this.onRender()
     }, 160)
   }
 
@@ -686,6 +690,16 @@ export default class Ink {
   }
   onRender() {
     if (this.isUnmounted || this.isPaused) {
+      return
+    }
+
+    // A terminal host reflows its physical buffer while a resize burst is in
+    // flight. Writing intermediate frames during that window races the host:
+    // cells painted for one geometry can be reflowed again by the next event,
+    // leaving stale rows that Ink's virtual diff can no longer see. Keep
+    // layout commits current, but defer terminal output until the trailing
+    // resize heal can erase and repaint exactly once at the settled geometry.
+    if (this.altScreenActive && this.resizeSettleTimer !== null) {
       return
     }
 
@@ -1255,6 +1269,13 @@ export default class Ink {
   forceRedraw(): void {
     if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) {
       return
+    }
+
+    // Manual recovery must not be swallowed by the resize-output guard above.
+    // Cancel the trailing heal; this full repaint supersedes it.
+    if (this.resizeSettleTimer !== null) {
+      clearTimeout(this.resizeSettleTimer)
+      this.resizeSettleTimer = null
     }
 
     this.options.stdout.write(ERASE_SCREEN + CURSOR_HOME)

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -131,6 +131,11 @@ const ERASE_THEN_HOME_PATCH = Object.freeze({
   content: ERASE_SCREEN + CURSOR_HOME
 })
 
+// App-level resize listeners may coalesce for one 32ms frame. A recovery
+// redraw must run after their trailing update, not merely after Ink's own
+// terminalColumns field has converged.
+const REDRAW_RESYNC_DELAY_MS = 40
+
 const DEEP_ERASE_THEN_HOME_PATCH = Object.freeze({
   type: 'stdout' as const,
   content: ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME
@@ -309,6 +314,8 @@ export default class Ink {
   // expensive tree rebuild defers.
   private pendingResizeRender = false
   private resizeSettleTimer: ReturnType<typeof setTimeout> | null = null
+  private resizeLateHealTimer: ReturnType<typeof setTimeout> | null = null
+  private redrawResyncTimer: ReturnType<typeof setTimeout> | null = null
 
   // Fold synchronous re-entry (selection fanout, onFrame callback)
   // into one follow-up microtask instead of stacking renders.
@@ -524,6 +531,16 @@ export default class Ink {
       this.resizeSettleTimer = null
     }
 
+    if (this.resizeLateHealTimer !== null) {
+      clearTimeout(this.resizeLateHealTimer)
+      this.resizeLateHealTimer = null
+    }
+
+    if (this.redrawResyncTimer !== null) {
+      clearTimeout(this.redrawResyncTimer)
+      this.redrawResyncTimer = null
+    }
+
     // Alt screen: reset frame buffers so the next render repaints from
     // scratch (prevFrameContaminated → every cell written, wrapped in
     // BSU/ESU — old content stays visible until the new frame swaps
@@ -578,6 +595,16 @@ export default class Ink {
       this.resizeSettleTimer = null
     }
 
+    if (this.resizeLateHealTimer !== null) {
+      clearTimeout(this.resizeLateHealTimer)
+      this.resizeLateHealTimer = null
+    }
+
+    if (this.redrawResyncTimer !== null) {
+      clearTimeout(this.redrawResyncTimer)
+      this.redrawResyncTimer = null
+    }
+
     // Mouse tracking — DISABLE first so we land in the exact preset state
     // even if an external app/terminal/tmux left DEC 1003 hover asserted.
     // DISABLE_MOUSE_TRACKING is idempotent (resets all four modes
@@ -587,21 +614,81 @@ export default class Ink {
     this.resetFramesForAltScreen()
     this.needsEraseBeforePaint = true
 
-    this.resizeSettleTimer = setTimeout(() => {
-      this.resizeSettleTimer = null
+    const settleTimer = setTimeout(() => {
+      if (this.resizeSettleTimer !== settleTimer) {
+        return
+      }
 
       if (!this.canAltScreenRepaint()) {
+        this.resizeSettleTimer = null
+
         return
       }
 
       this.resetFramesForAltScreen()
       this.needsEraseBeforePaint = true
-      this.render(this.currentNode!)
-      // React may bail out when the current tree is referentially unchanged.
-      // The physical terminal still needs the trailing erase+repaint, so do
-      // not depend on a reconciler commit to schedule it.
-      this.onRender()
+
+      try {
+        // Keep the settle sentinel armed while React commits and flushes
+        // synchronous layout effects. Those commits call onRender; letting
+        // them write would expose intermediate frames.
+        this.render(this.currentNode!)
+      } catch (error) {
+        if (this.resizeSettleTimer === settleTimer) {
+          this.resizeSettleTimer = null
+        }
+
+        throw error
+      }
+
+      // React may still have passive/state work queued in its scheduler after
+      // render() returns. Keep the sentinel armed through the next event-loop
+      // turn, then cancel the ordinary scheduled paint and publish one final
+      // full frame. A newer resize or manual recovery replaces/clears the
+      // sentinel and wins.
+      setTimeout(() => {
+        if (this.resizeSettleTimer !== settleTimer) {
+          return
+        }
+
+        this.scheduleRender.cancel?.()
+        this.resizeSettleTimer = null
+
+        if (!this.canAltScreenRepaint()) {
+          return
+        }
+
+        // React may bail out when the current tree is referentially unchanged.
+        // The physical terminal still needs the trailing erase+repaint, so do
+        // not depend on a reconciler commit to schedule it.
+        this.onRender()
+
+        if (this.resizeSettleTimer !== null) {
+          return
+        }
+
+        const lateHealTimer = setTimeout(() => {
+          if (this.resizeLateHealTimer !== lateHealTimer) {
+            return
+          }
+
+          this.resizeLateHealTimer = null
+
+          if (this.resizeSettleTimer !== null || !this.canAltScreenRepaint()) {
+            return
+          }
+
+          // Large terminal reflows can finish after the fast settle repaint.
+          // Reuse the proven manual recovery once, after a bounded quiet
+          // period, so the physical buffer converges without polling.
+          this.forceRedraw()
+        }, 500)
+
+        this.resizeLateHealTimer = lateHealTimer
+      }, 0)
     }, 160)
+
+    this.resizeSettleTimer = settleTimer
   }
 
   resolveExitPromise: () => void = () => {}
@@ -1278,6 +1365,52 @@ export default class Ink {
       this.resizeSettleTimer = null
     }
 
+    if (this.resizeLateHealTimer !== null) {
+      clearTimeout(this.resizeLateHealTimer)
+      this.resizeLateHealTimer = null
+    }
+
+    if (this.redrawResyncTimer !== null) {
+      clearTimeout(this.redrawResyncTimer)
+      this.redrawResyncTimer = null
+    }
+
+    // Ink can already match stdout.columns while application-level listeners
+    // are still stuck on an earlier coalesced width. Always rebroadcast the
+    // current PTY geometry; comparing only Ink's own fields misses that split.
+    this.options.stdout.emit('resize')
+
+    const resyncTimer = setTimeout(() => {
+      if (this.redrawResyncTimer !== resyncTimer) {
+        return
+      }
+
+      this.redrawResyncTimer = null
+
+      if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) {
+        return
+      }
+
+      // The synthetic resize installed normal settle/late timers. This repaint
+      // supersedes them once downstream listeners have committed the current
+      // geometry after a full coalescing window.
+      if (this.resizeSettleTimer !== null) {
+        clearTimeout(this.resizeSettleTimer)
+        this.resizeSettleTimer = null
+      }
+
+      if (this.resizeLateHealTimer !== null) {
+        clearTimeout(this.resizeLateHealTimer)
+        this.resizeLateHealTimer = null
+      }
+
+      this.performFullRedraw()
+    }, REDRAW_RESYNC_DELAY_MS)
+
+    this.redrawResyncTimer = resyncTimer
+  }
+
+  private performFullRedraw(): void {
     this.options.stdout.write(ERASE_SCREEN + CURSOR_HOME)
 
     if (this.altScreenActive) {
@@ -1487,6 +1620,16 @@ export default class Ink {
     if (this.resizeSettleTimer !== null) {
       clearTimeout(this.resizeSettleTimer)
       this.resizeSettleTimer = null
+    }
+
+    if (this.resizeLateHealTimer !== null) {
+      clearTimeout(this.resizeLateHealTimer)
+      this.resizeLateHealTimer = null
+    }
+
+    if (this.redrawResyncTimer !== null) {
+      clearTimeout(this.redrawResyncTimer)
+      this.redrawResyncTimer = null
     }
 
     // DISABLE_MOUSE_TRACKING before enableMouseTrackingFor — same as
@@ -2514,6 +2657,16 @@ export default class Ink {
     if (this.resizeSettleTimer !== null) {
       clearTimeout(this.resizeSettleTimer)
       this.resizeSettleTimer = null
+    }
+
+    if (this.resizeLateHealTimer !== null) {
+      clearTimeout(this.resizeLateHealTimer)
+      this.resizeLateHealTimer = null
+    }
+
+    if (this.redrawResyncTimer !== null) {
+      clearTimeout(this.redrawResyncTimer)
+      this.redrawResyncTimer = null
     }
 
     reconciler.updateContainerSync(null, this.container, null, noop)

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -199,6 +199,47 @@ describe('LogUpdate.render diff contract', () => {
     expect(hasDecstbm(stdoutOnly(diff))).toBe(true)
   })
 
+  it('repairs fixed cells outside narrow damage after a DECSTBM scroll', () => {
+    const w = 12
+    const h = 6
+    const prev = mkScreen(w, h)
+    const next = mkScreen(w, h)
+    const edge = ['A', 'B', 'C', 'D']
+
+    for (let i = 0; i < edge.length; i++) {
+      const y = i + 1
+      const cell = {
+        char: edge[i]!,
+        styleId: stylePool.none,
+        width: CellWidth.Narrow,
+        hyperlink: undefined
+      }
+
+      setCellAt(prev, w - 1, y, cell)
+      setCellAt(next, w - 1, y, cell)
+    }
+
+    // The ScrollBox only dirtied its narrow inner content. DECSTBM still
+    // shifts every terminal column in the row range, including this fixed
+    // right edge, so LogUpdate must repair outside the original damage.
+    prev.damage = undefined
+    next.damage = { x: 0, y: 1, width: 4, height: 4 }
+
+    const nextFrame: Frame = {
+      ...mkFrame(next, w, h),
+      scrollHint: { top: 1, bottom: 4, delta: 1 }
+    }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const written = stdoutOnly(log.render(mkFrame(prev, w, h), nextFrame, true, true))
+
+    expect(hasDecstbm(written)).toBe(true)
+
+    for (const char of edge) {
+      expect(written).toContain(char)
+    }
+  })
+
   it('skips DECSTBM when scroll region touches the bottom row', () => {
     const w = 12
     const h = 6

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.ts
@@ -3,7 +3,7 @@ import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi
 import { logForDebugging } from '../utils/debug.js'
 
 import type { Diff, FlickerReason, Frame } from './frame.js'
-import type { Point } from './layout/geometry.js'
+import { type Point, unionRect } from './layout/geometry.js'
 import {
   type Cell,
   cellAt,
@@ -177,6 +177,18 @@ export class LogUpdate {
       // layouts we reserve that lane for status/cursor parking, and scrolling
       // it can leave transient ghosting/bleed artifacts until a later repaint.
       if (top >= 0 && bottom < prev.screen.height - 1 && bottom < next.screen.height - 1) {
+        // DECSTBM scrolls complete terminal rows, not just the ScrollBox's
+        // horizontal bounds. Expand damage across the full screen width so
+        // fixed siblings and borders outside the ScrollBox's narrow damage
+        // are repainted after shiftRows mirrors the hardware operation.
+        const scrollDamage = {
+          x: 0,
+          y: top,
+          width: next.screen.width,
+          height: bottom - top + 1
+        }
+
+        next.screen.damage = next.screen.damage ? unionRect(next.screen.damage, scrollDamage) : scrollDamage
         shiftRows(prev.screen, top, bottom, delta)
         scrollPatch = [
           {

--- a/ui-tui/packages/hermes-ink/src/ink/stringWidth.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/stringWidth.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { stringWidth } from './stringWidth.js'
+
+describe('stringWidth emoji presentation', () => {
+  it('keeps text-default symbols narrow', () => {
+    expect(stringWidth('⚔')).toBe(1)
+    expect(stringWidth('⚔︎')).toBe(1)
+    expect(stringWidth('⚕')).toBe(1)
+    expect(stringWidth('⚕︎')).toBe(1)
+    expect(stringWidth('⚠')).toBe(1)
+  })
+
+  it('keeps explicit and default emoji wide', () => {
+    expect(stringWidth('⚔️')).toBe(2)
+    expect(stringWidth('⚠️')).toBe(2)
+    expect(stringWidth('⌚')).toBe(2)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/stringWidth.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/stringWidth.ts
@@ -7,6 +7,7 @@ import { getGraphemeSegmenter } from '../utils/intl.js'
 import { lruEvict } from './lru.js'
 
 const EMOJI_REGEX = emojiRegex()
+const DEFAULT_EMOJI_PRESENTATION_REGEX = /\p{Emoji_Presentation}/u
 
 /**
  * Fallback JavaScript implementation of stringWidth when Bun.stringWidth is not available.
@@ -160,7 +161,29 @@ function getEmojiWidth(grapheme: string): number {
     }
   }
 
-  return 2
+  // emoji-regex also matches symbols whose Unicode default presentation is
+  // text (for example ⚔, ⚕, and ⚠). Treating every match as two cells makes
+  // Ink's virtual cursor drift from xterm-style terminals, which render those
+  // bare symbols as one cell. The drift becomes visible as stale right-edge
+  // border fragments after rows are scrolled.
+  if (grapheme.includes('\ufe0e')) {
+    return eastAsianWidth(first, { ambiguousAsWide: false })
+  }
+
+  if (
+    grapheme.includes('\ufe0f') ||
+    grapheme.includes('\u200d') ||
+    [...grapheme].some(char => {
+      const codePoint = char.codePointAt(0)!
+
+      return codePoint >= 0x1f3fb && codePoint <= 0x1f3ff
+    }) ||
+    DEFAULT_EMOJI_PRESENTATION_REGEX.test(grapheme)
+  ) {
+    return 2
+  }
+
+  return eastAsianWidth(first, { ambiguousAsWide: false })
 }
 
 function isZeroWidth(codePoint: number): boolean {

--- a/ui-tui/src/app/useMainApp.test.ts
+++ b/ui-tui/src/app/useMainApp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { transcriptContentColumns } from '../lib/inputMetrics.js'
+
+import { tuiLayoutColumns } from './useMainApp.js'
+
+describe('tuiLayoutColumns', () => {
+  it('reserves the final physical column to avoid terminal pending-wrap corruption', () => {
+    expect(tuiLayoutColumns(169)).toBe(168)
+    expect(tuiLayoutColumns(80)).toBe(79)
+  })
+
+  it('keeps tiny and invalid widths usable', () => {
+    expect(tuiLayoutColumns(1)).toBe(1)
+    expect(tuiLayoutColumns(0)).toBe(1)
+    expect(tuiLayoutColumns(Number.NaN)).toBe(1)
+  })
+})
+
+describe('transcriptContentColumns', () => {
+  it('reserves rails, scrollbar gutter, and inner padding', () => {
+    expect(transcriptContentColumns(171, 0)).toBe(167)
+    expect(transcriptContentColumns(171, 6)).toBe(161)
+  })
+
+  it('never over-allocates tiny or invalid viewports', () => {
+    expect(transcriptContentColumns(3, 0)).toBe(1)
+    expect(transcriptContentColumns(Number.NaN, Number.NaN)).toBe(1)
+  })
+})

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -139,10 +139,19 @@ export async function startPromptLiveSession({
   return sid
 }
 
+/**
+ * Keep the final physical terminal column blank. Writing a border into the
+ * last column leaves xterm-family hosts in pending-wrap state; after a resize
+ * that column can disappear or reappear as detached vertical-line ghosts.
+ */
+export function tuiLayoutColumns(columns: number): number {
+  return Number.isFinite(columns) ? Math.max(1, Math.floor(columns) - 1) : 1
+}
+
 export function useMainApp(gw: GatewayClient) {
   const { exit } = useApp()
   const { stdout } = useStdout()
-  const [cols, setCols] = useState(stdout?.columns ?? 80)
+  const [cols, setCols] = useState(() => tuiLayoutColumns(stdout?.columns ?? 80))
 
   useEffect(() => {
     if (!stdout) {
@@ -156,7 +165,10 @@ export function useMainApp(gw: GatewayClient) {
     // first event reflows immediately (the drag stays responsive), the rest
     // collapse to at most one reflow per RESIZE_COALESCE_MS, and the trailing
     // edge always applies the final width so the settled layout is exact.
-    const coalescer = createResizeCoalescer(() => setCols(stdout.columns ?? 80), RESIZE_COALESCE_MS)
+    const coalescer = createResizeCoalescer(
+      () => setCols(tuiLayoutColumns(stdout.columns ?? 80)),
+      RESIZE_COALESCE_MS
+    )
     const sync = () => coalescer.schedule()
 
     stdout.on('resize', sync)

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -18,7 +18,8 @@ import {
   COMPOSER_PROMPT_GAP_WIDTH,
   composerPromptWidth,
   inputVisualHeight,
-  stableComposerColumns
+  stableComposerColumns,
+  transcriptContentColumns
 } from '../lib/inputMetrics.js'
 import { PerfPane } from '../lib/perfPane.js'
 import { composerPromptText } from '../lib/prompt.js'
@@ -144,14 +145,15 @@ const TranscriptPane = memo(function TranscriptPane({
   const ui = useStore($uiState)
   const petBox = useStore($petBox)
   const railCols = useAmbientRailWidth('left') + useAmbientRailWidth('right')
+  const transcriptCols = transcriptContentColumns(composer.cols, railCols)
 
   // Keep transcript text clear of the floating pet, responsively:
   //  - wide terminals: reserve a right gutter so lines wrap to the pet's left
   //    (as long as enough width is left for comfortable reading);
   //  - narrow terminals: keep full width and reserve bottom rows instead, so
   //    the newest lines sit above the pet rather than getting cramped.
-  const useGutter = !!petBox && composer.cols - railCols - petBox.width >= MIN_GUTTER_BODY_COLS
-  const bodyCols = Math.max(28, (useGutter && petBox ? composer.cols - petBox.width : composer.cols) - railCols)
+  const useGutter = !!petBox && transcriptCols - petBox.width >= MIN_GUTTER_BODY_COLS
+  const bodyCols = Math.max(1, useGutter && petBox ? transcriptCols - petBox.width : transcriptCols)
   const petBandRows = petBox && !useGutter ? petBox.height : 0
 
   // LiveTodoPanel rides as a child of the latest user-message row so it
@@ -205,12 +207,12 @@ const TranscriptPane = memo(function TranscriptPane({
 
               {row.msg.kind === 'intro' ? (
                 <Box flexDirection="column" paddingTop={1}>
-                  <Banner maxWidth={Math.max(1, composer.cols - 2)} t={ui.theme} />
+                  <Banner maxWidth={transcriptCols} t={ui.theme} />
 
                   {row.msg.info && (
                     <SessionPanel
                       info={row.msg.info}
-                      maxWidth={Math.max(1, composer.cols - 2)}
+                      maxWidth={transcriptCols}
                       sid={ui.sid}
                       t={ui.theme}
                     />
@@ -532,8 +534,12 @@ export const AppLayout = memo(function AppLayout({
 
   return (
     <Shell {...shellProps}>
-      <Box flexDirection="column" flexGrow={1} position="relative">
-        <Box flexDirection="row" flexGrow={1}>
+      {/* Keep the transcript scrollbar inside the app's safe layout width.
+          Without an explicit root width, flexGrow expands back into the final
+          physical terminal column and a visible scrollbar triggers xterm's
+          pending-wrap corruption even though composer.cols reserved it. */}
+      <Box flexDirection="column" flexGrow={1} position="relative" width={composer.cols}>
+        <Box flexDirection="row" flexGrow={1} flexShrink={1} minHeight={0}>
           {!overlay.agents && !overlay.journey && <AmbientRail side="left" />}
           {overlay.agents ? (
             <PerfPane id="agents">

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -490,7 +490,15 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   )
 
   return (
-    <Box borderColor={t.color.border} borderStyle="round" marginBottom={1} paddingX={2} paddingY={1}>
+    <Box
+      alignSelf="flex-start"
+      borderColor={t.color.border}
+      borderStyle="round"
+      marginBottom={1}
+      maxWidth={cols}
+      paddingX={2}
+      paddingY={1}
+    >
       <WidgetGrid
         cols={wide ? leftW + 2 + w : w}
         columns={wide ? [leftW, { fr: 1 }] : 1}

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -3,6 +3,8 @@ import { stringWidth, wrapAnsi } from '@hermes/ink'
 import type { Role } from '../types.js'
 
 export const COMPOSER_PROMPT_GAP_WIDTH = 1
+const TRANSCRIPT_SCROLLBAR_GUTTER_COLUMNS = 2
+const TRANSCRIPT_INNER_PADDING_COLUMNS = 2
 
 let _seg: Intl.Segmenter | null = null
 const seg = () => (_seg ??= new Intl.Segmenter(undefined, { granularity: 'grapheme' }))
@@ -200,4 +202,15 @@ export function stableComposerColumns(totalCols: number, promptWidth: number, te
   const reserveScrollbar = afterPrompt >= (termuxMode ? 36 : 24) ? 2 : 0
 
   return Math.max(1, totalCols - promptWidth - 2 - reserveScrollbar)
+}
+
+/** Width available inside the transcript ScrollBox content viewport. */
+export function transcriptContentColumns(columns: number, railColumns: number): number {
+  const safeColumns = Number.isFinite(columns) ? Math.max(1, Math.floor(columns)) : 1
+  const safeRails = Number.isFinite(railColumns) ? Math.max(0, Math.floor(railColumns)) : 0
+
+  return Math.max(
+    1,
+    safeColumns - safeRails - TRANSCRIPT_SCROLLBAR_GUTTER_COLUMNS - TRANSCRIPT_INNER_PADDING_COLUMNS
+  )
 }


### PR DESCRIPTION
## Summary

- serialize resize settle output through the final React/app geometry commit
- add one bounded late recovery and make `/redraw` resync PTY and app columns
- reserve the terminal's pending-wrap column and use the real transcript viewport width
- repair the whole physical scroll region and keep SessionPanel borders inside its clip
- fix fallback Unicode width for text-default symbols such as Ares' `⚔` and `⚕`

## Problem

Aggressive terminal shrink→grow transitions could leave duplicated rows, missing right borders, and detached vertical-line fragments beside the transcript scrollbar. The residue could move to different rows after PageUp/PageDown or wheel scrolling. Skin changes altered the content and timing that exposed the defect, but per-skin offsets were not the cause or solution.

The failure combined several shared contracts:

1. React/app layout could commit after Ink's first resize repaint.
2. The terminal host could complete reflow after the fast settle pass.
3. Transcript children could be wider than the ScrollBox content viewport, placing a right border on its clip boundary or final physical column.
4. Terminal scroll repair could omit columns moved by the physical scroll operation.
5. The fallback width calculator treated every `emoji-regex` match as two cells. Orca DSR measurements show bare/text-presentation `⚔` and `⚕` are one cell, so Ares' virtual x coordinates drifted from the physical terminal and scroll left right-edge residue.

## Fix

- Keep the resize guard armed through the next scheduler task and emit one settled full frame.
- Run one bounded late recovery; cancel stale recovery generations on newer resize/manual recovery/unmount.
- Re-emit current dimensions from `/redraw`, wait for the app resize coalescer, and then repaint.
- Leave the final physical column blank.
- Derive transcript child width from app columns minus ambient rails, scrollbar gap, and inner padding.
- Prevent SessionPanel stretch from crossing the ScrollBox clip boundary.
- Expand scroll repair to the full physical scroll region.
- For text-default and VS15 symbols, return the base character's East Asian Width (measured `⚔`/`⚕` are 1); retain width 2 for VS16, ZWJ/modifier sequences, and default `Emoji_Presentation` characters.

No skin-specific correction was added.

## Validation

Official-base candidate (`6564f319a647b47de391cab2f608660323804a2b`):

- focused resize/app/geometry/scroll/Unicode tests: 25 passed
- TypeScript typecheck: passed
- TUI build: passed
- `git diff --check`: passed
- actual uninstrumented Orca PTY, Poseidon and Ares:
  - skin transition;
  - aggressive width/height shrink→grow;
  - visible scrollbar;
  - automatic settle without `/redraw`;
  - PageUp/PageDown/wheel scroll;
  - no stale right-border fragments, missing corners, or banner residue
- actual Orca cursor report: `⚔`, `⚔︎`, `⚕`, `⚕︎` = 1 cell; patched Hermes fallback matches

The earlier LIVE candidate was rolled back after E2E failure. This candidate has not been applied to LIVE Hermes. LIVE planning is separately blocked by an overlapping pre-existing private dirty `appLayout.tsx`; that conflict is not bypassed by this PR artifact.
