### PR TITLE
fix(auth): auth reset must bypass disk-cooldown merge resurrection

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -774,7 +774,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        reset_cooldowns: bool = False,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -782,6 +787,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                reset_cooldowns=reset_cooldowns,
             )
 
     def _is_terminal_auth_failure(
@@ -2350,7 +2356,12 @@ class CredentialPool:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
-                self._persist()
+                # reset_cooldowns=True: this is an explicit user reset, so the
+                # write must bypass _merge_disk_cooldown_state — otherwise the
+                # recency merge resurrects every still-binding on-disk cooldown
+                # (cleared last_status_at=None sorts older than the active
+                # timestamp) and the reset silently never lands on disk.
+                self._persist(reset_cooldowns=True)
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1727,6 +1727,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    reset_cooldowns: bool = False,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -1745,6 +1746,16 @@ def write_credential_pool(
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
     merge does not resurrect them from the on-disk copy.
+
+    Pass ``reset_cooldowns=True`` ONLY for an explicit user-initiated reset
+    (``hermes auth reset``): it skips the status-field merge entirely, so even
+    still-binding on-disk cooldowns are erased. This is a deliberate user
+    override of the lost-update protection — never pass it from automatic
+    rotation/exhaustion/refresh paths, or a stale snapshot could erase a fresh
+    cooldown and every process would resume hammering a rate-limited key.
+    Entries present on disk but missing from the snapshot are still preserved
+    (with their own status), and all entries still pass through
+    ``sanitize_borrowed_credential_payload``.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -1771,11 +1782,11 @@ def write_credential_pool(
             if isinstance(entry, dict) and entry.get("id")
         }
         merged: List[Dict[str, Any]] = [
-            _merge_disk_cooldown_state(
+            entry
+            if not isinstance(entry, dict) or reset_cooldowns
+            else _merge_disk_cooldown_state(
                 entry, existing_by_id.get(entry.get("id")), provider_id
             )
-            if isinstance(entry, dict)
-            else entry
             for entry in sanitized_entries
         ]
         for disk_entry in existing_list:

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,192 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+# ---------------------------------------------------------------------------
+# hermes auth reset (explicit user reset) must bypass the disk-cooldown merge
+# ---------------------------------------------------------------------------
+
+def _pool_payload(entries):
+    return {
+        "version": 1,
+        "credential_pool": {"openai-codex": entries},
+    }
+
+
+def _exhausted_entry(entry_id, label, *, age_seconds, error_code=429):
+    """A still-binding (or expired, per age_seconds) exhausted pool entry."""
+    return {
+        "id": entry_id,
+        "label": label,
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": f"sk-mock-{entry_id}",
+        "last_status": "exhausted",
+        "last_status_at": time.time() - age_seconds,
+        "last_error_code": error_code,
+        "last_error_reason": "rate_limit_error",
+        "last_error_message": "mock upstream message",
+        "last_error_reset_at": None,
+    }
+
+
+def test_reset_statuses_clears_active_cooldowns_on_disk(tmp_path, monkeypatch):
+    """The user-reset regression: an active on-disk cooldown must not be
+    resurrected by the recency merge when `hermes auth reset` persists."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload(
+            [
+                _exhausted_entry("cred-1", "alice", age_seconds=60),
+                _exhausted_entry("cred-2", "bob", age_seconds=120, error_code=402),
+            ]
+        ),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+
+    count = pool.reset_statuses()
+
+    assert count == 2
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    for entry in auth_payload["credential_pool"]["openai-codex"]:
+        if entry["id"] in ("cred-1", "cred-2"):
+            assert entry.get("last_status") is None
+            assert entry.get("last_status_at") is None
+            assert entry.get("last_error_code") is None
+            assert entry.get("last_error_reason") is None
+            assert entry.get("last_error_message") is None
+            # identity must survive the reset untouched
+            assert entry["id"] in ("cred-1", "cred-2")
+            assert entry["access_token"] == f"sk-mock-{entry["id"]}"
+
+    # A fresh load must see the pool as healthy again.
+    reloaded = load_pool("openai-codex")
+    assert reloaded.has_available() is True
+
+
+def test_reset_statuses_noop_when_nothing_to_reset(tmp_path, monkeypatch):
+    """No statuses -> count 0 and no disk write."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    healthy = _exhausted_entry("cred-1", "alice", age_seconds=60)
+    for key in (
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ):
+        healthy.pop(key, None)
+    _write_auth_store(tmp_path, _pool_payload([healthy]))
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    auth_file = tmp_path / "hermes" / "auth.json"
+    before = auth_file.read_bytes()
+
+    assert pool.reset_statuses() == 0
+    assert auth_file.read_bytes() == before
+
+
+def test_reset_statuses_clears_expired_cooldowns_too(tmp_path, monkeypatch):
+    """Expired cooldowns (already ignored by selection) are also cleared, and
+    the reset write must not resurrect them either."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=3 * 3600)]),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.reset_statuses() == 1
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert entry.get("last_status") is None
+    assert entry.get("last_status_at") is None
+
+
+def test_normal_persist_still_resurrects_active_disk_cooldown(tmp_path, monkeypatch):
+    """Regression guard for the lost-update protection (3d67f00fe1): a normal
+    (non-reset) persist from a stale in-memory snapshot must STILL resurrect an
+    active on-disk cooldown. Only the explicit user reset may bypass it."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=60)]),
+    )
+
+    from agent.credential_pool import load_pool, replace
+
+    pool = load_pool("openai-codex")
+    # Simulate another process marking the key exhausted on disk AFTER this
+    # process took its healthy in-memory snapshot.
+    pool._entries = [
+        replace(
+            pool._entries[0],
+            last_status=None,
+            last_status_at=None,
+            last_error_code=None,
+            last_error_reason=None,
+            last_error_message=None,
+            last_error_reset_at=None,
+        )
+    ]
+    pool._persist()
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entry = auth_payload["credential_pool"]["openai-codex"][0]
+    assert entry.get("last_status") == "exhausted"
+    assert entry.get("last_status_at") is not None
+
+
+def test_reset_statuses_preserves_concurrent_disk_entries(tmp_path, monkeypatch):
+    """A reset write must not drop entries another process added to disk after
+    this pool snapshot was loaded (the missing-entry append path survives)."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        _pool_payload([_exhausted_entry("cred-1", "alice", age_seconds=60)]),
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+
+    # Concurrent writer adds cred-2 (healthy) to disk behind our back.
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    concurrent = _exhausted_entry("cred-2", "bob", age_seconds=60)
+    for key in (
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ):
+        concurrent.pop(key, None)
+    auth_payload["credential_pool"]["openai-codex"].append(concurrent)
+    (tmp_path / "hermes" / "auth.json").write_text(json.dumps(auth_payload))
+
+    assert pool.reset_statuses() == 1
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    by_id = {e["id"]: e for e in auth_payload["credential_pool"]["openai-codex"]}
+    assert set(by_id) == {"cred-1", "cred-2"}
+    assert by_id["cred-1"].get("last_status") is None
+    assert by_id["cred-2"].get("last_status") is None

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2143,7 +2143,7 @@ def test_reset_statuses_clears_active_cooldowns_on_disk(tmp_path, monkeypatch):
             assert entry.get("last_error_message") is None
             # identity must survive the reset untouched
             assert entry["id"] in ("cred-1", "cred-2")
-            assert entry["access_token"] == f"sk-mock-{entry["id"]}"
+            assert entry["access_token"] == f"sk-mock-{entry['id']}"
 
     # A fresh load must see the pool as healthy again.
     reloaded = load_pool("openai-codex")

--- a/tests/hermes_cli/test_auth_reset_cooldowns.py
+++ b/tests/hermes_cli/test_auth_reset_cooldowns.py
@@ -1,0 +1,111 @@
+"""CLI-level tests for `hermes auth reset` (interactive menu option 3).
+
+The reset must clear exhaustion/rate-limit status on disk even while the
+cooldowns are still active — the regression where the recency merge in
+``write_credential_pool`` resurrected every still-binding on-disk cooldown.
+
+All credentials here are synthetic mock data.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from agent.credential_pool import load_pool
+from hermes_cli.auth_commands import auth_reset_command
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def _exhausted_entry(entry_id, label, *, age_seconds, error_code=429):
+    return {
+        "id": entry_id,
+        "label": label,
+        "auth_type": "api_key",
+        "priority": 0,
+        "source": "manual",
+        "access_token": f"sk-mock-{entry_id}",
+        "last_status": "exhausted",
+        "last_status_at": time.time() - age_seconds,
+        "last_error_code": error_code,
+        "last_error_reason": "rate_limit_error",
+        "last_error_message": "mock upstream message",
+        "last_error_reset_at": None,
+    }
+
+
+def _setup_pool(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    # Prevent auto-seeding from host Codex CLI tokens / anthropic config.
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    monkeypatch.setattr(
+        "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    _exhausted_entry("cred-1", "alice", age_seconds=60),
+                    _exhausted_entry("cred-2", "bob", age_seconds=120, error_code=402),
+                ]
+            },
+        },
+    )
+
+
+def test_auth_reset_command_clears_active_cooldowns(tmp_path, monkeypatch, capsys):
+    """Menu option 3: `hermes auth reset <provider>` must land on disk even
+    while cooldowns are still active (the resurrection regression)."""
+    _setup_pool(tmp_path, monkeypatch)
+
+    pool = load_pool("openai-codex")
+    assert pool.has_available() is False
+
+    auth_reset_command(SimpleNamespace(provider="openai-codex"))
+
+    out = capsys.readouterr().out
+    assert "Reset status on 2 openai-codex credentials" in out
+
+    auth_payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    for entry in auth_payload["credential_pool"]["openai-codex"]:
+        assert entry.get("last_status") is None
+        assert entry.get("last_status_at") is None
+        assert entry.get("last_error_code") is None
+
+    # A fresh pool load (what the runtime does) sees healthy credentials.
+    reloaded = load_pool("openai-codex")
+    assert reloaded.has_available() is True
+
+
+def test_auth_reset_command_prints_zero_when_clean(tmp_path, monkeypatch, capsys):
+    """A pool with no statuses reports 0 and leaves the file untouched."""
+    _setup_pool(tmp_path, monkeypatch)
+    auth_file = tmp_path / "hermes" / "auth.json"
+    payload = json.loads(auth_file.read_text())
+    for entry in payload["credential_pool"]["openai-codex"]:
+        for key in (
+            "last_status",
+            "last_status_at",
+            "last_error_code",
+            "last_error_reason",
+            "last_error_message",
+            "last_error_reset_at",
+        ):
+            entry.pop(key, None)
+    auth_file.write_text(json.dumps(payload))
+    before = auth_file.read_bytes()
+
+    auth_reset_command(SimpleNamespace(provider="openai-codex"))
+
+    assert "Reset status on 0 openai-codex credentials" in capsys.readouterr().out
+    assert auth_file.read_bytes() == before


### PR DESCRIPTION
## Bug Description

`hermes auth reset <provider>` (interactive menu option 3) reports success — "Reset status on N credentials" — but the exhaustion/rate-limit statuses never actually leave the pool. `hermes auth list` keeps showing the entries with their cooldown countdowns still ticking after the reset.

## Root Cause

`reset_statuses()` clears `last_status` / `last_status_at` / `last_error_*` on the in-memory entries and persists. But `write_credential_pool()` re-merges every entry with its on-disk copy via `_merge_disk_cooldown_state()` (added in 3d67f00fe1 to stop lost-update cooldown erasure across processes). The merge keeps whichever side has the newer `last_status_at` — and a reset entry's `last_status_at=None` sorts *older* than the still-binding on-disk timestamp. The merge therefore resurrects every cooldown that has not yet expired, and the reset write silently never lands on disk.

The merge cannot tell an explicit user reset apart from a stale snapshot, so the lost-update protection defeats the user-facing reset command.

## Fix

`write_credential_pool()` gains a `reset_cooldowns: bool = False` parameter that skips the status-field merge for the caller's entries (all other paths — sanitization, the missing-entry append for concurrent writers, `removed_ids` — are unchanged). Only the explicit user-reset path passes it: `reset_statuses() -> _persist(reset_cooldowns=True)`.

Automatic rotation/exhaustion/refresh writes never pass it, so the cross-process lost-update protection from 3d67f00fe1 is fully preserved — a stale snapshot still cannot erase a fresh cooldown.

## How to Verify

1. Create a pool with an active cooldown (e.g. a 429 `exhausted` entry with a live TTL).
2. `hermes auth list` → entry shows `rate-limited ... (N m left)`.
3. `hermes auth reset <provider>` → prints "Reset status on N credentials".
4. `hermes auth list` → status columns are gone, entry is healthy again.
5. `hermes auth status <provider>` → pool selects the entry again.

## Test Plan

- [x] Added regression test for this bug (pool level: `test_reset_statuses_clears_active_cooldowns_on_disk`)
- [x] Added CLI-level regression test (`tests/hermes_cli/test_auth_reset_cooldowns.py`)
- [x] Reset is a no-op on clean pools (count 0, no disk write)
- [x] Expired cooldowns are cleared too
- [x] Regression guard: a normal (non-reset) persist still resurrects an active on-disk cooldown — the lost-update protection is unchanged
- [x] A reset write preserves entries another process added to disk concurrently
- [x] Existing tests still pass: full `tests/agent/test_credential_pool.py` + related `hermes_cli` auth suites (84 passed)

## Risk Assessment

Low — the behavior change is scoped to the explicit user-reset path only (`auth reset` / `reset_statuses`). All automatic pool writes keep the existing merge behavior; the regression guard test pins that down. The only intentional semantic change: a user-initiated reset now also erases cooldowns that another process wrote concurrently — which is precisely what the user asked the reset to do.
