### PR TITLE
fix(mcp): keep tool errors out of server breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -170,6 +170,47 @@ def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
         _cleanup(mcp_tool, "srv")
 
 
+def test_tool_application_errors_do_not_trip_server_breaker(monkeypatch, tmp_path):
+    """A completed MCP RPC proves the server transport is healthy.
+
+    ``CallToolResult.isError`` reports an application/tool rejection (for
+    example invalid arguments or a missing resource), not a server outage.
+    Repeated application errors must remain visible to the caller without
+    opening the server-scoped circuit and blocking neighboring valid tools.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_rejected(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.isError = True
+        block = MagicMock()
+        block.text = "invalid arguments"
+        result.content = [block]
+        result.structuredContent = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_rejected)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "tool1", 10.0)
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1):
+            parsed = json.loads(handler({"unsupported": True}))
+            assert parsed.get("error") == "invalid arguments", parsed
+
+        assert call_count["n"] == mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+        assert "srv" not in mcp_tool._server_breaker_opened_at
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_reopens_on_probe_failure(monkeypatch, tmp_path):
     """If the half-open probe fails, the breaker must re-arm the
     cooldown (not let every subsequent call through).

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5045,15 +5045,12 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # A completed MCP RPC proves that the server transport is healthy.
+            # CallToolResult.isError is an application/tool rejection (invalid
+            # arguments, missing resource, policy denial, etc.), so it remains
+            # visible to the caller but must not trip the server-wide circuit
+            # and block neighboring valid tools.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Problem
Repeated `CallToolResult.isError` responses currently increment the server-wide MCP circuit breaker. Invalid arguments or missing resources can therefore block neighboring valid tools even though every RPC proved the transport healthy.

## Fix
Reset server-health breaker state after every completed MCP RPC. Tool-level errors remain unchanged and visible to the caller; transport/session exceptions continue to drive the breaker.

## Verification
- Reproduced on current `main`: the fourth application rejection was replaced by a server-unreachable error
- Added an invariant test proving repeated application errors remain visible without opening the breaker
- `scripts/run_tests.sh tests/tools/test_mcp_circuit_breaker.py tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_session_expired.py -q` — 111 passed
- Ruff check — passed
- `git diff --check` — passed