### PR TITLE
fix(telegram): don't burn network retry budget on system-DNS failures (Mac sleep/wake)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2575,6 +2575,29 @@ class TelegramAdapter(BasePlatformAdapter):
         BASE_DELAY = 5
         MAX_DELAY = 60
 
+        # If the system resolver itself is failing (nodename nor servname),
+        # the entire network is down — don't burn a retry on this.  Mac
+        # sleep/wake cycles can last hours and should not exhaust the retry
+        # budget; only count retries when the network is confirmed up but
+        # Telegram specifically fails.  Returning here is safe because PTB's
+        # polling loop stays alive and keeps calling the error callback, and
+        # the heartbeat/pending-updates probes cover the wedge case.
+        error_str = str(error).lower()
+        is_system_dns_down = (
+            "nodename nor servname" in error_str
+            or "name or service not known" in error_str
+            or "temporary failure in name resolution" in error_str
+        )
+        if is_system_dns_down:
+            logger.debug(
+                "[%s] System DNS appears down (network offline); not counting retry. Error: %s",
+                self.name, _redact_telegram_error_text(error),
+            )
+            # Still back off but don't count toward the fatal limit
+            self._send_path_degraded = True
+            await asyncio.sleep(MAX_DELAY)
+            return
+
         self._polling_network_error_count += 1
         self._send_path_degraded = True
         attempt = self._polling_network_error_count

--- a/tests/gateway/test_telegram_network_reconnect.py
+++ b/tests/gateway/test_telegram_network_reconnect.py
@@ -618,3 +618,105 @@ async def test_handle_polling_network_error_updater_stop_timeout():
     # The reconnect ladder must have advanced past the hung stop().
     assert drain_called, "_drain_polling_connections was not called after stop() timeout"
     assert start_polling_called, "start_polling was not called after stop() timeout"
+
+
+@pytest.mark.asyncio
+async def test_system_dns_down_does_not_count_retry_or_restart_polling():
+    """
+    A system-DNS failure (Mac sleep/wake, WiFi off) must not burn the network
+    retry budget and must not trigger a polling restart.
+
+    When the host sleeps for hours, the OS resolver fails with
+    ``nodename nor servname`` (macOS) or ``name or service not known`` /
+    ``temporary failure in name resolution`` (Linux).  The reconnect ladder
+    counts every error toward MAX_NETWORK_RETRIES and escalates to a
+    retryable-fatal gateway restart at the cap — so a long offline window
+    (or a slow WiFi reconnect on wake) can restart the gateway needlessly.
+    These errors are not Telegram's fault; only count retries when the
+    network is confirmed up but Telegram specifically fails.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 0
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._drain_polling_connections = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(
+            OSError("[Errno 8] nodename nor servname provided, or not known")
+        )
+
+    # The retry budget must be untouched and polling must not be restarted.
+    assert adapter._polling_network_error_count == 0
+    assert adapter._send_path_degraded is True
+    mock_updater.stop.assert_not_awaited()
+    adapter._drain_polling_connections.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_system_dns_down_at_retry_edge_does_not_escalate_to_fatal():
+    """
+    Even at the retry-cap edge, a DNS-down error must not escalate to a
+    retryable-fatal gateway restart.
+
+    A Mac that sleeps at the wrong moment (e.g. after several genuine
+    Telegram outages) must not be killed by the wake-up DNS failures; the
+    budget only escalates on confirmed-up-network errors.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 10  # at the edge of MAX_NETWORK_RETRIES
+
+    mock_updater = MagicMock()
+    mock_updater.running = True
+    mock_updater.stop = AsyncMock()
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._drain_polling_connections = AsyncMock()
+    adapter._set_fatal_error = MagicMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(
+            OSError("[Errno 8] nodename nor servname provided, or not known")
+        )
+
+    adapter._set_fatal_error.assert_not_called()
+    assert adapter._polling_network_error_count == 10
+
+
+@pytest.mark.asyncio
+async def test_real_network_error_still_counts_and_runs_ladder():
+    """
+    A genuine network error (network up, Telegram unreachable) must still
+    count toward the retry budget and run the reconnect ladder — the DNS
+    guard must not suppress real outages.
+    """
+    adapter = _make_adapter()
+    adapter._polling_network_error_count = 0
+
+    mock_updater = MagicMock()
+    mock_updater.running = False
+    mock_updater.start_polling = AsyncMock()
+
+    mock_app = MagicMock()
+    mock_app.updater = mock_updater
+    adapter._app = mock_app
+    adapter._drain_polling_connections = AsyncMock()
+    adapter._start_polling_once = AsyncMock()
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        await adapter._handle_polling_network_error(
+            OSError("Connection refused by api.telegram.org")
+        )
+
+    assert adapter._polling_network_error_count == 1
+    adapter._start_polling_once.assert_awaited_once()


### PR DESCRIPTION
## Problem

When the host Mac sleeps, the long-poll Telegram connection dies. On wake, WiFi reconnects slowly and the OS resolver fails with:

- `nodename nor servname provided, or not known` (macOS)
- `name or service not known` / `temporary failure in name resolution` (Linux)

Each such error enters `_handle_polling_network_error` and counts toward `MAX_NETWORK_RETRIES` (10). At the cap, the adapter escalates to **retryable-fatal** and the supervisor restarts the gateway process.

A long sleep (or slow WiFi reconnect on wake) can exhaust the whole budget on errors that are **not Telegram's fault** — restarting the gateway needlessly, dropping in-flight runs and messages. This is the documented trigger case: the handler's own docstring names "Mac sleep, WiFi switch, VPN reconnect" as the scenarios it exists for.

## Fix

Detect system-DNS-down errors before counting the retry:

- If the error indicates the *whole network* is down (resolver failing), back off for `MAX_DELAY` without incrementing `_polling_network_error_count`, mark the send path degraded, and return.
- Genuine network errors (network up, Telegram unreachable) still count and run the reconnect ladder exactly as before.

Early-return is safe: PTB's polling loop stays alive and keeps invoking the error callback, and the heartbeat probe + pending-updates probe cover the wedged-socket case — so recovery still happens when the network returns, without burning the budget.

## Tests

Added 3 regression tests to `tests/gateway/test_telegram_network_reconnect.py`:

1. DNS-down error does **not** increment the retry counter, does **not** call `updater.stop()`, does **not** drain, does **not** restart polling
2. DNS-down error **at the retry edge** (count = 10) does **not** escalate to retryable-fatal
3. A genuine network error still counts (count = 1) and runs the reconnect ladder

```
$ python -m pytest tests/gateway/test_telegram_network_reconnect.py tests/gateway/test_telegram_network.py -o 'addopts=' -q
36 passed in 6.21s
```

Also verified the full telegram suite passes: 509 passed.