### PR TITLE
fix(plugins): allow eager platform tool registration

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -309,6 +309,11 @@ class PluginManifest:
     #              in ~/.hermes/plugins/ still gated by ``plugins.enabled``
     #              (untrusted code).
     kind: str = "standalone"
+    # Bundled platform plugins are normally deferred to avoid importing every
+    # platform SDK during ordinary chat startup.  A platform that also exposes
+    # non-gateway capabilities (for example model tools) may opt into eager
+    # registration through its manifest.
+    eager_load: bool = False
     # Registry key — path-derived, used by ``plugins.enabled``/``disabled``
     # lookups and by ``hermes plugins list``. For a flat plugin at
     # ``plugins/disk-cleanup/`` the key is ``disk-cleanup``; for a nested
@@ -1665,6 +1670,7 @@ class PluginManager:
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,
+                eager_load=data.get("eager_load") is True,
                 key=key,
             )
         except Exception as exc:
@@ -1727,15 +1733,21 @@ class PluginManager:
         return name
 
     def _register_deferred_platform(self, manifest: PluginManifest) -> None:
-        """Register a lazy loader for a bundled platform plugin.
+        """Register a loader for a bundled platform plugin.
 
-        The platform adapter module is imported only when the gateway / cron /
-        setup / send_message path first asks the ``platform_registry`` for this
-        platform. Until then we record a lightweight ``LoadedPlugin`` so
-        ``hermes plugins list`` still shows the platform as available, and we
-        hand the registry a loader that runs the normal eager-load path.
+        Most platform adapters are imported only when the gateway / cron /
+        setup / send_message path first asks the ``platform_registry`` for the
+        platform.  Manifests with ``eager_load: true`` are loaded immediately;
+        this supports platform plugins that also register capabilities needed
+        outside inbound gateway sessions while preserving the lazy default.
         """
         lookup_key = manifest.key or manifest.name
+
+        if manifest.eager_load:
+            logger.debug("Eager-loading platform plugin: %s", lookup_key)
+            self._load_plugin(manifest)
+            return
+
         platform_name = self._platform_name_from_manifest(manifest)
 
         # Record an enabled placeholder for introspection (`hermes plugins

--- a/plugins/platforms/a2a/plugin.yaml
+++ b/plugins/platforms/a2a/plugin.yaml
@@ -1,6 +1,7 @@
 name: a2a-platform
 label: A2A
 kind: platform
+eager_load: true
 version: 1.0.0
 description: >
   A2A (Agent-to-Agent) protocol v1.0 support for Hermes Agent — both directions

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -238,6 +238,96 @@ class TestPluginDiscovery:
 class TestPluginLoading:
     """Tests for plugin module loading."""
 
+    def test_eager_platform_registers_tools_while_ordinary_platform_is_deferred(
+        self, tmp_path, monkeypatch
+    ):
+        """Manifest metadata can opt a tool-providing platform out of deferral."""
+        bundled = tmp_path / "bundled"
+        platforms = bundled / "platforms"
+        eager = platforms / "a2a"
+        lazy = platforms / "ordinary"
+        eager.mkdir(parents=True)
+        lazy.mkdir(parents=True)
+
+        (eager / "plugin.yaml").write_text(
+            (
+                Path(__file__).parents[2]
+                / "plugins"
+                / "platforms"
+                / "a2a"
+                / "plugin.yaml"
+            ).read_text()
+        )
+        (eager / "__init__.py").write_text(
+            "def register(ctx):\n"
+            "    ctx.register_tool(\n"
+            "        name='a2a_discover', toolset='a2a',\n"
+            "        schema={'type': 'function', 'function': {'name': 'a2a_discover'}},\n"
+            "        handler=lambda args: args,\n"
+            "    )\n"
+        )
+        (lazy / "plugin.yaml").write_text(
+            yaml.safe_dump({"name": "ordinary-platform", "kind": "platform"})
+        )
+        (lazy / "__init__.py").write_text(
+            "raise AssertionError('ordinary platform was imported eagerly')\n"
+        )
+
+        monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled)
+        monkeypatch.setattr(PluginManager, "_scan_entry_points", lambda self: [])
+        monkeypatch.setattr("tools.registry.registry.register", MagicMock())
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+
+        from gateway.platform_registry import platform_registry
+
+        original_entries = dict(platform_registry._entries)
+        original_deferred = dict(platform_registry._deferred)
+        platform_registry._entries.clear()
+        platform_registry._deferred.clear()
+        try:
+            manager = PluginManager()
+            manager.discover_and_load()
+
+            assert manager._plugins["a2a-platform"].enabled is True
+            assert manager._plugins["a2a-platform"].deferred is False
+            assert manager._plugins["a2a-platform"].tools_registered == ["a2a_discover"]
+            assert manager._plugins["ordinary-platform"].deferred is True
+            assert "ordinary" in platform_registry._deferred
+        finally:
+            platform_registry._entries.clear()
+            platform_registry._entries.update(original_entries)
+            platform_registry._deferred.clear()
+            platform_registry._deferred.update(original_deferred)
+            sys.modules.pop("hermes_plugins.a2a_platform", None)
+
+    def test_real_a2a_platform_eager_load_registers_client_tools(
+        self, tmp_path, monkeypatch
+    ):
+        """The bundled A2A plugin must expose outbound tools during startup."""
+        from tools.registry import registry
+
+        expected_tools = {
+            "a2a_call",
+            "a2a_discover",
+            "a2a_history",
+            "a2a_list",
+            "a2a_orchestrate",
+        }
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+        monkeypatch.setattr(PluginManager, "_scan_entry_points", lambda self: [])
+
+        for tool_name in expected_tools:
+            registry.deregister(tool_name)
+
+        manager = PluginManager()
+        manager.discover_and_load()
+
+        loaded = manager._plugins["a2a-platform"]
+        assert loaded.enabled is True
+        assert loaded.deferred is False
+        assert expected_tools.issubset(set(loaded.tools_registered))
+        assert expected_tools.issubset(registry._tools.keys())
+        assert {registry._tools[name].toolset for name in expected_tools} == {"a2a"}
 
 
     def test_load_registers_namespace_module(self, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- adds manifest-level `eager_load: true` support for bundled platform plugins
- marks the bundled A2A platform plugin eager so its outbound `a2a_*` tools register in normal chat sessions
- keeps ordinary platform plugins deferred by default
- adds regression coverage proving eager platform tools register while ordinary platforms remain lazy
- adds integration coverage loading the real bundled A2A plugin and asserting all five client tools register under the `a2a` toolset

## Why
A2A is both an inbound gateway platform and an outbound agent-to-agent tool provider. Deferring the whole platform plugin means enabled A2A client tools can be missing from normal sessions until inbound platform materialization happens.

## Test plan
- `uv run --with pytest pytest tests/hermes_cli/test_plugins.py -q -o addopts=`
- `uv run --with pytest pytest tests/plugins/test_a2a_plugin.py -q -o addopts=`
- `git diff --check`
