### PR TITLE
fix(cron): skip invalid lifecycle script paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -316,6 +316,11 @@ def _contains_unsafe_gateway_action(
             return True
 
     for script_path in _iter_referenced_shell_scripts(command, cwd=cwd):
+        # An embedded NUL can never name a filesystem entry.  Skip it before
+        # resolution or either local/remote reader gets a chance to reject it
+        # with ``ValueError: embedded null byte``.
+        if "\x00" in os.fspath(script_path):
+            continue
         try:
             resolved = script_path.resolve(strict=False)
         except (OSError, ValueError):

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -709,6 +709,21 @@ class TestLifecycleGuardModule:
         assert text is None
         assert unsafe is False
 
+    def test_command_with_nul_path_skips_script_readers(self):
+        """Invalid referenced paths must not reach local or remote readers."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        def _remote_read(_path: str):
+            raise AssertionError("invalid path reached remote reader")
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "/tmp/hermes\x00script.sh --run",
+            read_remote_script=_remote_read,
+        )
+        assert result is False
+
     def test_remote_read_fallback_binary_does_not_crash_guard(self):
         """#77703: in the gateway the referenced-script walk carries a
         ``read_remote_script`` fallback (SSH/Modal/Daytona backends read the


### PR DESCRIPTION
## Summary
- skips NUL-bearing referenced script paths before path resolution or local/remote file reads
- prevents `ValueError: embedded null byte` from escaping lifecycle guard scans
- adds regression coverage for command scanning with an invalid NUL path

## Why
The lifecycle guard already handles several binary/NUL cases, but a malformed referenced path can still reach resolution or a remote reader path. Invalid paths should be treated as unscannable non-matches, not crash the guard and block unrelated terminal commands.

## Test plan
- `uv run --with pytest pytest tests/hermes_cli/test_gateway_restart_loop.py -q -k 'nul or binary_does_not_crash_guard' -o addopts=`
- `python3 -m py_compile cron/lifecycle_guard.py tests/hermes_cli/test_gateway_restart_loop.py`
- `git diff --check`
