### PR TITLE
fix(gateway): finish the split-delivery bug class behind the swallowed-finals fix (salvages #78558)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24828,9 +24828,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # stream completion never reached any API call (#71643).
                 # Reconcile the recorded turn-final payload against the
                 # completed response; only a demonstrable mismatch (False)
-                # overrides the flag — None (no record / multi-message split
-                # delivery) keeps the legacy trust so overflow splits are not
-                # re-sent.
+                # overrides the flag — including payload-less multi-message
+                # split delivery (#78541). None (no record on a non-split
+                # legacy path) keeps the legacy trust so ambiguous-timeout
+                # dedup is not regressed.
                 matcher = getattr(consumer, "delivered_final_matches", None)
                 if callable(matcher):
                     try:
@@ -25621,8 +25622,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # Reconcile the consumer's recorded turn-final payload against the
             # completed response: on a demonstrable mismatch (False) neither
             # final_response_sent nor final_content_delivered may suppress the
-            # normal final send. None (no record / multi-message split
-            # delivery) keeps legacy trust; the failed-finalize family
+            # normal final send. False also covers payload-less multi-message
+            # split delivery (#78541). None (no record on a non-split legacy
+            # path) keeps legacy trust; the failed-finalize family
             # (#51828 / #33793) is unaffected because those paths leave the
             # flags False or record the complete fallback payload.
             _stale_finalized = False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25668,9 +25668,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # user gets one corrected message; on edit failure fall through
                 # with already_sent unset so the normal final send delivers the
                 # complete text.
+                #
+                # Not valid for a multi-message split delivery: there
+                # ``message_id`` is only the LAST chunk, so editing it with the
+                # complete response would repeat every sealed head chunk's text
+                # inside the tail message. Fall through to the normal final send
+                # instead (#78541).
                 _sc_msg_id = _sc.message_id
                 _sc_adapter = getattr(_sc, "adapter", None)
-                if _sc_msg_id and _sc_msg_id != "__no_edit__" and _sc_adapter is not None:
+                if getattr(_sc, "_turn_split_delivery", False):
+                    logger.info(
+                        "Stale streamed finalize detected for session %s on a multi-message split; skipping the in-place reconciliation edit and delivering the complete response via normal final send (#78541).",
+                        session_key or "?",
+                    )
+                elif _sc_msg_id and _sc_msg_id != "__no_edit__" and _sc_adapter is not None:
                     try:
                         _reconcile_res = await _sc_adapter.edit_message(
                             chat_id=source.chat_id,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -219,6 +219,10 @@ class GatewayStreamConsumer:
         self._initial_reply_to_id = initial_reply_to_id
         self._queue: queue.Queue = queue.Queue()
         self._accumulated = ""
+        # Full segment text mirror of ``_accumulated`` that is NOT truncated
+        # when overflow splits seal head chunks.  Used to record a reconciliable
+        # turn-final payload for multi-message deliveries (#78541).
+        self._stream_ledger = ""
         self._message_id: Optional[str] = None
         # Wall-clock timestamp (time.monotonic) when ``_message_id`` was
         # first assigned from a successful first-send.  Used by the
@@ -270,9 +274,11 @@ class GatewayStreamConsumer:
         self._delivered_final_text: Optional[str] = None
         # True when the current turn's answer was delivered across multiple
         # sealed messages (overflow split / adapter continuation adoption).
-        # Payload-equality against a single recorded string is meaningless in
-        # that shape, so delivered_final_matches() falls back to legacy trust
-        # rather than risking a duplicate re-send of a multi-message reply.
+        # When a payload was recorded (via ``_stream_ledger`` /
+        # ``_record_turn_final_payload``), ``delivered_final_matches`` can still
+        # reconcile.  Payload-less split delivery must NOT inherit legacy trust
+        # (#78541) — that combination was swallowing complete Telegram group
+        # replies after an early/partial multi-message delivery.
         self._turn_split_delivery = False
         self._delivered_commentary_texts: list[str] = []
         # Retains the finalized visible text of each streaming segment so
@@ -405,20 +411,30 @@ class GatewayStreamConsumer:
                 pass
         return await self.adapter.edit_message(**kwargs)
 
+    def _append_accumulated(self, text: str) -> None:
+        """Append to the live buffer and the split-stable stream ledger."""
+        if not text:
+            return
+        self._accumulated += text
+        self._stream_ledger += text
+
     def _record_turn_final_payload(self, text: str) -> None:
         """Record the exact cleaned payload of a turn-final delivery.
 
         Normalized the same way ``_send_or_edit`` normalizes outgoing text
         (media-directive strip + fence closing) so the gateway can compare it
-        against the completed ``final_response`` (#71643). No-op when the turn
-        was delivered across multiple sealed messages — payload equality is
-        undefined there and ``delivered_final_matches`` returns ``None``.
+        against the completed ``final_response`` (#71643).
+
+        For multi-message split delivery, prefer ``_stream_ledger`` (the
+        unsplit segment text) so reconciliation still works (#78541).  Older
+        code cleared the record on split and forced legacy trust; that let a
+        payload-less stale flag suppress later complete replies.
         """
-        if self._turn_split_delivery:
-            self._delivered_final_text = None
-            return
+        source = text or ""
+        if self._turn_split_delivery and self._stream_ledger:
+            source = self._stream_ledger
         self._delivered_final_text = ensure_closed_code_fences(
-            self._clean_for_display(text or "")
+            self._clean_for_display(source)
         ).strip()
 
     def delivered_final_matches(self, final_text: str) -> Optional[bool]:
@@ -432,21 +448,23 @@ class GatewayStreamConsumer:
           delivered segment/commentary) matches ``final_text``; suppressing
           the normal final send is safe.
         - ``False`` — a turn-final delivery was recorded but its payload
-          demonstrably differs from ``final_text``; the user has NOT seen the
-          complete response and the normal final send must run.
-        - ``None``  — no payload comparison is possible (multi-message split
-          delivery, or a legacy/uncertain path that recorded nothing). The
-          caller keeps the pre-existing flag-trusting behavior so overflow
-          splits and ambiguous-timeout dedup are not regressed.
+          demonstrably differs from ``final_text``, OR this was a
+          payload-less multi-message split delivery (#78541) whose flag
+          alone must not suppress the normal final send.
+        - ``None``  — no payload comparison is possible on a non-split
+          legacy/uncertain path that recorded nothing. The caller keeps
+          the pre-existing flag-trusting behavior so ambiguous-timeout
+          dedup is not regressed.
         """
-        if self._turn_split_delivery:
-            return None
-        if self._delivered_final_text is None:
-            return None
         target = ensure_closed_code_fences(
             self._clean_for_display(final_text or "")
         ).strip()
         if not target:
+            return None
+        if self._delivered_final_text is None:
+            if self._turn_split_delivery:
+                # #78541: refuse legacy trust for payload-less split delivery.
+                return False
             return None
         if self._delivered_final_text.strip() == target:
             return True
@@ -541,6 +559,7 @@ class GatewayStreamConsumer:
         self._message_id = None
         self._message_created_ts = None
         self._accumulated = ""
+        self._stream_ledger = ""
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
@@ -666,7 +685,7 @@ class GatewayStreamConsumer:
 
                 if best_len:
                     # Emit text before the tag, enter think block
-                    self._accumulated += buf[:best_idx]
+                    self._append_accumulated(buf[:best_idx])
                     self._in_think_block = True
                     buf = buf[best_idx + best_len:]
                 else:
@@ -678,7 +697,7 @@ class GatewayStreamConsumer:
                             if lower_buf.endswith(tag_lower[:i]) and i > held_back:
                                 held_back = i
                     if held_back:
-                        self._accumulated += buf[:-held_back]
+                        self._append_accumulated(buf[:-held_back])
                         self._think_buffer = buf[-held_back:]
                     else:
                         # No (partial) open tag — but the model may have
@@ -687,7 +706,7 @@ class GatewayStreamConsumer:
                         # matched open, or when upstream stripping is
                         # incomplete). Strip those before accumulating so
                         # they never reach the user.
-                        self._accumulated += self._strip_orphan_close_tags(buf)
+                        self._append_accumulated(self._strip_orphan_close_tags(buf))
                     return
 
     @classmethod
@@ -732,7 +751,7 @@ class GatewayStreamConsumer:
         if self._think_buffer and not self._in_think_block:
             # Strip any orphan close tags that may have been held back —
             # see _filter_and_accumulate for context.
-            self._accumulated += self._strip_orphan_close_tags(self._think_buffer)
+            self._append_accumulated(self._strip_orphan_close_tags(self._think_buffer))
             self._think_buffer = ""
 
     async def run(self) -> None:
@@ -939,11 +958,14 @@ class GatewayStreamConsumer:
                             self._final_response_sent = chunks_delivered and tail_delivered
                             if self._final_response_sent:
                                 self._final_content_delivered = True
-                                # Multi-message split delivery — payload
-                                # equality against a single record is
-                                # undefined (#71643).
+                                # Multi-message split delivery — record the
+                                # unsplit ledger payload so the gateway can
+                                # still reconcile against final_response
+                                # (#71643, #78541).
                                 self._turn_split_delivery = True
-                                self._delivered_final_text = None
+                                self._record_turn_final_payload(
+                                    self._stream_ledger or "".join(chunks)
+                                )
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -1987,6 +2009,7 @@ class GatewayStreamConsumer:
         self._preview_message_ids = set()
         self._message_id = None
         self._accumulated = ""
+        self._stream_ledger = ""
         self._last_sent_text = ""
         self._already_sent = False
         self._final_response_sent = False

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -419,16 +419,19 @@ class GatewayStreamConsumer:
         self._stream_ledger += text
 
     def _record_turn_final_payload(self, text: str) -> None:
-        """Record the exact cleaned payload of a turn-final delivery.
+        """Record what the user has actually seen as this turn's final answer.
 
         Normalized the same way ``_send_or_edit`` normalizes outgoing text
         (media-directive strip + fence closing) so the gateway can compare it
         against the completed ``final_response`` (#71643).
 
-        For multi-message split delivery, prefer ``_stream_ledger`` (the
-        unsplit segment text) so reconciliation still works (#78541).  Older
-        code cleared the record on split and forced legacy trust; that let a
-        payload-less stale flag suppress later complete replies.
+        ``text`` is what the *calling* path just delivered. On a multi-message
+        split that is only the trailing chunk — the overflow paths truncate
+        ``_accumulated`` once head chunks are sealed — so ``_stream_ledger``
+        (the un-truncated segment text) is preferred there and ``text`` is
+        ignored. Without that substitution a split turn records a tail-only
+        payload, which the gateway reads as a mismatch and re-sends on top of
+        an answer the user already received (#78541).
         """
         source = text or ""
         if self._turn_split_delivery and self._stream_ledger:
@@ -945,6 +948,16 @@ class GatewayStreamConsumer:
                             self._message_created_ts = None
                             self._last_sent_text = ""
 
+                        if chunks_delivered:
+                            # A sealed head is on screen, so this turn is now a
+                            # multi-message delivery.  Flag it BEFORE the tail
+                            # send below: the fresh-final route replaces every
+                            # tracked preview with one message, which is only
+                            # valid while the active message holds the whole
+                            # answer.  Once heads are sealed it does not, and
+                            # deleting them would drop delivered text (#78541).
+                            self._turn_split_delivery = True
+
                         self._last_edit_time = time.monotonic()
                         if got_done:
                             tail_delivered = True
@@ -963,9 +976,7 @@ class GatewayStreamConsumer:
                                 # still reconcile against final_response
                                 # (#71643, #78541).
                                 self._turn_split_delivery = True
-                                self._record_turn_final_payload(
-                                    self._stream_ledger or "".join(chunks)
-                                )
+                                self._record_turn_final_payload(self._accumulated)
                             return
                         if got_segment_break:
                             self._message_id = None
@@ -1422,7 +1433,11 @@ class GatewayStreamConsumer:
                 self._final_response_sent = True
                 self._final_content_delivered = True
                 # The visible partial equals the complete final text (#71643).
-                self._delivered_final_text = final_text.strip()
+                # Route through the recorder so a split turn records the full
+                # ledger rather than this tail-only payload — an unrecorded or
+                # tail-only split now reads as a mismatch and would re-send
+                # text the user already has (#78541).
+                self._record_turn_final_payload(final_text)
                 return
 
         raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
@@ -1528,7 +1543,10 @@ class GatewayStreamConsumer:
         # The fallback delivered the complete ``final_text`` (as one message
         # or prefix + continuation chunks that union to it), so record it as
         # the turn-final payload for the gateway's reconciliation (#71643).
-        self._delivered_final_text = final_text.strip()
+        # On a split turn ``final_text`` is only the tail — the recorder
+        # substitutes the unsplit ledger so the sealed heads count as
+        # delivered too (#78541).
+        self._record_turn_final_payload(final_text)
         self._last_sent_text = chunks[-1]
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
@@ -1600,7 +1618,9 @@ class GatewayStreamConsumer:
         self._final_response_sent = True
         self._final_content_delivered = True
         # Fresh commit of the complete answer after a failed finalize (#71643).
-        self._delivered_final_text = final_text.strip()
+        # Recorder-routed so a split turn records the unsplit ledger instead of
+        # a tail-only payload the gateway would read as stale (#78541).
+        self._record_turn_final_payload(final_text)
         self._last_sent_text = final_text
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False
@@ -1923,6 +1943,15 @@ class GatewayStreamConsumer:
         # current one plus any continuation fragments tracked while streaming
         # (an oversized reply split across the platform's edit limit).  All of
         # them are replaced by the single fresh message below.
+        #
+        # That replacement is only sound while ``text`` holds the whole answer.
+        # On a multi-message split the head chunks were sealed and dropped out
+        # of ``_accumulated``, so ``text`` is just the tail — deleting the
+        # sealed heads would erase text the user already received and leave the
+        # complete reply nowhere on screen (#78541).  Keep the sealed messages
+        # and take the normal edit path instead.
+        if self._turn_split_delivery:
+            return False
         stale_ids = set(self._preview_message_ids)
         if self._message_id and self._message_id != "__no_edit__":
             stale_ids.add(self._message_id)
@@ -2226,9 +2255,12 @@ class GatewayStreamConsumer:
                             self._final_content_delivered = True
                             # ``text`` is already cleaned/fence-closed here and
                             # equals the visible prefix — the on-screen content
-                            # IS this finalize payload (#71643).
-                            if not self._turn_split_delivery:
-                                self._delivered_final_text = text.strip()
+                            # IS this finalize payload (#71643).  Record it on
+                            # split turns too: post-#78541 an unrecorded split
+                            # reads as a mismatch and would re-send this
+                            # already-visible answer, reintroducing the
+                            # duplicate #45517 fixed (#36965 / #25349).
+                            self._record_turn_final_payload(text)
                         raw_response = getattr(result, "raw_response", None)
                         if isinstance(raw_response, dict) and raw_response.get("partial_overflow"):
                             # Telegram edited/sent one or more overflow chunks,

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -257,6 +257,96 @@ async def test_equal_text_control_still_suppresses_duplicate_send(
     assert len(full_sends) <= 1, f"duplicate final delivery: {full_sends!r}"
 
 
+class _PayloadLessSplitConsumer(GatewayStreamConsumer):
+    """Force the #78541 shape after a normal stream drain.
+
+    Claims final delivery via the multi-message split path but leaves no
+    recorded payload — the pre-fix gateway treated matcher ``None`` as
+    legacy trust and swallowed the complete ``final_response``.
+    """
+
+    async def run(self):
+        await super().run()
+        self._final_response_sent = True
+        self._final_content_delivered = True
+        self._turn_split_delivery = True
+        self._delivered_final_text = None
+        self._stream_ledger = ""
+
+
+@pytest.mark.asyncio
+async def test_payload_less_split_does_not_suppress_complete_response(
+    monkeypatch, tmp_path
+):
+    """#78541 — payload-less split-delivery flags must not swallow the reply."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {"tool_progress": "off", "interim_assistant_messages": False},
+                "streaming": {
+                    "enabled": True,
+                    "edit_interval": 0.01,
+                    "buffer_threshold": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = StalePrefixAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    stream_consumer_mod = importlib.import_module("gateway.stream_consumer")
+    # run.py imports GatewayStreamConsumer locally inside _run_agent — patch
+    # the defining module so the local import picks up the sabotage subclass.
+    monkeypatch.setattr(
+        stream_consumer_mod, "GatewayStreamConsumer", _PayloadLessSplitConsumer
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    adapter = FinalizeCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1004492624436",
+        chat_type="group",
+        thread_id="1",
+    )
+    result = await runner._run_agent(
+        message="describe this photo",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-78541-payload-less-split",
+        session_key="agent:main:telegram:group:-1004492624436:1",
+    )
+
+    assert result["final_response"] == FULL_RESPONSE
+    all_payloads = [c["content"] for c in adapter.sent] + [
+        e["content"] for e in adapter.edits
+    ]
+    assert any(FULL_RESPONSE in payload for payload in all_payloads), (
+        f"complete response never reached the platform; payloads: {all_payloads!r}"
+    )
+    # Must not silently claim delivery without putting the complete text on
+    # the wire (the production ghost: already_sent with no full payload).
+    if result.get("already_sent"):
+        assert any(
+            FULL_RESPONSE in payload for payload in all_payloads
+        ), "already_sent=True but complete response never reached the platform"
+
+
 # ---------------------------------------------------------------------------
 # Consumer unit coverage: delivered_final_matches tri-state
 # ---------------------------------------------------------------------------
@@ -284,11 +374,27 @@ class TestDeliveredFinalMatches:
         consumer._record_turn_final_payload(STREAMED_PREFIX)
         assert consumer.delivered_final_matches(FULL_RESPONSE) is False
 
-    def test_split_delivery_returns_none(self):
+    def test_payload_less_split_delivery_returns_false(self):
+        """#78541 — payload-less split must not inherit legacy trust."""
         consumer = _consumer()
         consumer._turn_split_delivery = True
+        consumer._delivered_final_text = None
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is False
+
+    def test_split_delivery_with_matching_ledger_returns_true(self):
+        """Complete overflow split that recorded its ledger still suppresses."""
+        consumer = _consumer()
+        consumer._turn_split_delivery = True
+        consumer._stream_ledger = FULL_RESPONSE
+        consumer._record_turn_final_payload(STREAMED_PREFIX)  # tail only; ledger wins
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is True
+
+    def test_split_delivery_with_stale_ledger_returns_false(self):
+        consumer = _consumer()
+        consumer._turn_split_delivery = True
+        consumer._stream_ledger = STREAMED_PREFIX
         consumer._record_turn_final_payload(STREAMED_PREFIX)
-        assert consumer.delivered_final_matches(FULL_RESPONSE) is None
+        assert consumer.delivered_final_matches(FULL_RESPONSE) is False
 
     def test_empty_final_text_returns_none(self):
         consumer = _consumer()
@@ -308,3 +414,4 @@ class TestDeliveredFinalMatches:
         consumer._reset_segment_state()
         assert consumer._delivered_final_text is None
         assert consumer._turn_split_delivery is False
+        assert consumer._stream_ledger == ""

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -20,6 +20,7 @@ with a live ``GatewayStreamConsumer``), per the review guidance on #71643:
 Plus unit coverage for ``GatewayStreamConsumer.delivered_final_matches``.
 """
 
+import asyncio
 import importlib
 import sys
 import types
@@ -336,15 +337,18 @@ async def test_payload_less_split_does_not_suppress_complete_response(
     all_payloads = [c["content"] for c in adapter.sent] + [
         e["content"] for e in adapter.edits
     ]
-    assert any(FULL_RESPONSE in payload for payload in all_payloads), (
-        f"complete response never reached the platform; payloads: {all_payloads!r}"
+    # The contract is "the complete reply is not swallowed", which has two
+    # legitimate shapes: _run_agent puts the full text on the wire itself
+    # (reconcile edit), or it declines to claim delivery so the caller's normal
+    # final send delivers it. A multi-message split takes the second shape --
+    # the reconcile edit is deliberately skipped there because it would repeat
+    # every sealed head chunk inside the tail message (#78541). Asserting only
+    # the first shape would pin the recovery route rather than the guarantee.
+    delivered_here = any(FULL_RESPONSE in payload for payload in all_payloads)
+    assert delivered_here or not result.get("already_sent"), (
+        "complete response was neither delivered nor left to the normal final "
+        f"send; already_sent={result.get('already_sent')!r} payloads={all_payloads!r}"
     )
-    # Must not silently claim delivery without putting the complete text on
-    # the wire (the production ghost: already_sent with no full payload).
-    if result.get("already_sent"):
-        assert any(
-            FULL_RESPONSE in payload for payload in all_payloads
-        ), "already_sent=True but complete response never reached the platform"
 
 
 # ---------------------------------------------------------------------------
@@ -415,3 +419,151 @@ class TestDeliveredFinalMatches:
         assert consumer._delivered_final_text is None
         assert consumer._turn_split_delivery is False
         assert consumer._stream_ledger == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end split delivery: drive the real overflow-split loop (no hand-set
+# private flags) and assert the no-duplicate / no-swallow contract on both
+# sides.  These are the shapes that #78541's boundary fix has to not regress:
+# a genuine complete split must still suppress, and an incomplete one must not.
+# ---------------------------------------------------------------------------
+
+
+class _SplittingAdapter(FinalizeCaptureAdapter):
+    """Small message cap so real prose trips the consumer's overflow split.
+
+    Also records deletions and can be told to fail edits, so the fresh-final
+    and flood-control paths can be driven without patching internals.
+    """
+
+    MAX_MESSAGE_LENGTH = 220
+
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(platform)
+        self.deleted = []
+        self.fail_edits = False
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        if self.fail_edits:
+            return SendResult(
+                success=False, error="Flood control exceeded. Retry in 12 seconds"
+            )
+        return await super().edit_message(
+            chat_id, message_id, content, finalize=finalize, metadata=metadata
+        )
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.deleted.append(message_id)
+        return True
+
+    def truncate_message(self, text, limit, len_fn=len):
+        chunks, rest = [], text
+        while len_fn(rest) > limit:
+            cut = rest.rfind("\n", 0, limit)
+            if cut < limit // 2:
+                cut = limit
+            chunks.append(rest[:cut])
+            rest = rest[cut:].lstrip("\n")
+        chunks.append(rest)
+        return chunks
+
+
+def _split_consumer():
+    adapter = _SplittingAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-split",
+        StreamConsumerConfig(
+            edit_interval=0.0, buffer_threshold=1, cursor="",
+            fresh_final_after_seconds=0.0,
+        ),
+    )
+    return adapter, consumer
+
+
+async def _drain_split_turn(consumer, lines):
+    task = asyncio.create_task(consumer.run())
+    for line in lines:
+        consumer.on_delta(line + "\n")
+        await asyncio.sleep(0.005)
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=10)
+
+
+@pytest.mark.asyncio
+async def test_complete_overflow_split_still_suppresses_duplicate():
+    """A fully delivered multi-message reply must NOT be re-sent (#45517)."""
+    adapter, consumer = _split_consumer()
+    lines = [f"line {i} " + "x" * 60 for i in range(12)]
+    await _drain_split_turn(consumer, lines)
+
+    complete = "\n".join(lines)
+    assert consumer._turn_split_delivery is True, "overflow split never triggered"
+    # The user received the whole answer across several messages, so the
+    # gateway must keep suppressing its own final send.
+    assert consumer.delivered_final_matches(complete) is True
+
+
+@pytest.mark.asyncio
+async def test_split_delivery_missing_tail_does_not_suppress():
+    """#78541 — when the completed response exceeds what the split delivered,
+    the matcher must report a mismatch so the gateway still sends it."""
+    adapter, consumer = _split_consumer()
+    lines = [f"line {i} " + "x" * 60 for i in range(12)]
+    await _drain_split_turn(consumer, lines)
+
+    never_streamed = "\n".join(lines) + "\n\n" + "tail the user never saw " * 8
+    assert consumer._turn_split_delivery is True
+    assert consumer.delivered_final_matches(never_streamed) is False
+
+
+@pytest.mark.asyncio
+async def test_split_delivery_keeps_sealed_heads_on_fresh_final():
+    """The fresh-final route must not delete sealed head messages.
+
+    ``_try_fresh_final`` replaces every tracked preview with one fresh message,
+    which only holds the whole answer on a single-message turn.  After a split
+    the sealed heads carry text that the fresh message does not, so deleting
+    them would drop delivered content (#78541).
+    """
+    adapter, consumer = _split_consumer()
+    head_id = await consumer._send_new_chunk("HEAD text. " * 12, None, final=False)
+    consumer._turn_split_delivery = True
+
+    assert head_id in consumer._preview_message_ids
+    assert await consumer._try_fresh_final("TAIL text. " * 12) is False
+    assert head_id not in adapter.deleted, "sealed head chunk was deleted"
+
+
+@pytest.mark.asyncio
+async def test_failed_final_edit_after_split_records_visible_payload():
+    """A flood-controlled cosmetic final edit must not cause a duplicate.
+
+    The complete answer is already on screen; only the cursor-strip edit
+    failed.  Recording the visible payload keeps the gateway suppressing its
+    own send instead of posting the whole answer twice (#36965 / #25349).
+    """
+    adapter = _SplittingAdapter()
+    cursor = " \u2589"
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-split",
+        StreamConsumerConfig(
+            edit_interval=0.0, buffer_threshold=1, cursor=cursor,
+            fresh_final_after_seconds=0.0,
+        ),
+    )
+    full = "The complete answer. " * 8
+    # Streaming already put the whole answer on screen, cursor and all.
+    await consumer._send_or_edit(full + cursor)
+    assert consumer._last_sent_text.endswith(cursor)
+    consumer._turn_split_delivery = True
+    consumer._stream_ledger = full
+    adapter.fail_edits = True
+
+    # The cosmetic cursor-strip edit is rate-limited and fails.
+    assert await consumer._send_or_edit(full, finalize=True) is False
+    assert consumer._final_content_delivered is True
+    assert consumer.delivered_final_matches(full) is True


### PR DESCRIPTION
## Summary

Salvages #78558 (@HexLab98) onto current `main` and finishes the bug class it opened.

The original fix is correct about the cause: on a multi-message split delivery the stream consumer set `final_content_delivered=True` without recording a payload, `delivered_final_matches()` returned `None`, and `gateway/run.py` treated `None` as "trust the flag" — so the completed reply was suppressed and never sent. That's #78541: 165 suppressed events with 100–3000 char replies lost over 48h across three Telegram groups.

But six code paths set `_turn_split_delivery`, and only one was taught to record a payload. The other five inherited the new "payload-less split ⇒ mismatch" verdict without being able to satisfy it, which swapped the swallow for the opposite defect. This PR fixes the producers rather than only distrusting them at the boundary.

## Context — what actually changed for a user

**Before (on `main`):** a long Telegram group reply that overflows into several messages, where the stream ends before the tail arrives. Log shows the reply is ready, and it is never sent:

```
INFO gateway.run: Suppressing normal final send for session agent:main:telegram:group:-1004492624436:1: final delivery already confirmed (streamed=True previewed=False content_delivered=True).
INFO gateway.run: response ready: platform=telegram chat=-1004492624436 time=55.0s api_calls=2 response=1939 chars
```

The 1939-char answer never reaches the chat. Reproduced with a probe driving the real `run()` loop:

```
BEFORE (main)                      AFTER (this PR)
user saw the tail? : False         user saw the tail? : False
matcher verdict    : None          matcher verdict    : False
=> SUPPRESSES?  True               => SUPPRESSES?  False
   reply swallowed (#78541)           complete reply is delivered
```

**What #78558 alone would have shipped.** Same probe harness, three shapes it does not cover:

| shape | main | #78558 alone | this PR |
|---|---|---|---|
| complete overflow split, everything delivered | suppress ✅ | suppress ✅ | suppress ✅ |
| split + flood-controlled cosmetic final edit | suppress ✅ | **re-send ❌ duplicate** | suppress ✅ |
| split + fallback final send (tail-only record) | suppress ✅ | **re-send ❌ duplicate** | suppress ✅ |
| split on Telegram's fresh-final route | **swallow ❌** | **swallow ❌** | delivered ✅ |

The duplicate on row 2 is the regression that matters most: it re-opens the double-answer #45517 fixed (#36965 / #25349). Row 4 is why the reported symptom would likely have persisted — `_try_fresh_final` is Telegram's default finalize route.

## Changes

Kept from #78558 (@HexLab98's two commits, authorship preserved): `_stream_ledger` (an un-truncated mirror of `_accumulated`, since the overflow paths truncate `_accumulated` to the tail once heads are sealed), the `False`-on-payload-less-split verdict, and the tri-state reordering. Confirmed the ledger is genuinely load-bearing — nothing else records the union of a multi-message delivery: `_delivered_segment_texts` is only appended in `_reset_segment_state` (which the split paths never reach; they clear `_last_sent_text` first), and `has_delivered_text` compares whole-string equality per entry, so it structurally cannot match `chunk1 + chunk2`.

Added on top:

- **`_send_or_edit` failed-final-edit branch** — record the visible payload on split turns too. It deliberately skipped recording, which now reads as a mismatch and re-sends an answer already on screen.
- **`_send_fallback_final` (×2) + `_send_empty_fallback_final`** — route through `_record_turn_final_payload` instead of assigning `_delivered_final_text` directly. On a split turn their `final_text` is only the trailing chunk, so a fully delivered heads+tail reply recorded a tail-only payload and was re-sent in full.
- **`_try_fresh_final`** — refuse the fresh-final route once a head chunk is sealed. It replaces every tracked preview with one message, which only holds the whole answer on a single-message turn; after a split it deleted the sealed heads while sending just the tail.
- **Set `_turn_split_delivery` at seal time** rather than after the tail send, so the tail's own finalize sees the split state. The sibling overflow path already did this — that divergence is what let fresh-final delete the heads.
- **`run.py` stale-finalize reconciliation** — skip the in-place edit on a split delivery. `message_id` is only the *last* chunk there, so editing it with the complete response repeated every sealed head's text inside the tail message. Falls through to the normal final send.
- Dropped a dead `or "".join(chunks)` fallback (all growth funnels through `_append_accumulated`, so the ledger is never empty at that call site; and joined chunks carry injected fence markers that could never equal `final_response`), and documented that `_record_turn_final_payload` intentionally ignores its argument on split turns.

## Validation

| | result |
|---|---|
| `tests/gateway/test_stale_finalize_suppression.py` | 16 passed |
| `tests/gateway/ -k 'stream or consumer or final or deliver or suppress or overflow or split or telegram'` | **1062 passed**, 1 skipped (pre-existing `mautrix` mock skip) |
| ruff + `py_compile` on all three files | clean |
| probes vs `main`, real `run()` loop | 7/7 shapes correct (see table above) |

**Mutation-checked** — reverting any individual fix turns its own test red, so none of the new tests are vacuous:

| mutation | result |
|---|---|
| revert `_try_fresh_final` split guard | `test_split_delivery_keeps_sealed_heads_on_fresh_final` fails |
| revert failed-final-edit recorder | `test_failed_final_edit_after_split_records_visible_payload` fails |
| revert `delivered_final_matches` to pre-PR | 7 tests fail |

Four new tests drive the **real overflow-split loop** rather than hand-setting private flags: complete split still suppresses (no duplicate), split missing a tail does not suppress, fresh-final keeps sealed heads, and a flood-controlled final edit after a split stays suppressed.

One pre-existing assertion relaxed: the gateway-boundary test asserted the recovery *route* (that `_run_agent` performs the reconcile edit) rather than the guarantee. Since a split delivery now deliberately skips that edit, it asserts the real contract — either `_run_agent` puts the complete text on the wire, or it declines to claim delivery so the caller's normal final send does. Verified the latter holds: `already_sent` comes back falsy.

## Credit

@HexLab98 diagnosed the root cause and wrote the ledger mechanism; both commits are preserved with authorship intact.

Also closes #78556 (@686f6c61), which fixed the same issue independently. Its approach records `"".join(chunks[:-1]) + _accumulated`, but the splitter strips the newline separators (`.lstrip("\n")`) and injects fence markers at boundaries, so the join can never equal `final_response` — verified it returns `False` on *every* complete overflow split, i.e. duplicate sends on all long replies. Credited for independent diagnosis.

Closes #78541
