### PR TITLE
fix(stt): expose turbo in model selectors

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -259,7 +259,7 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   // modal/daytona/ssh). Remote backends need extra env (image, tokens, host).
   'terminal.backend': ['local', 'docker', 'singularity', 'modal', 'daytona', 'ssh'],
   'stt.elevenlabs.model_id': ['scribe_v2', 'scribe_v1'],
-  'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3'],
+  'stt.local.model': ['tiny', 'base', 'small', 'medium', 'large-v3', 'turbo'],
   // Speech-to-text backends — kept in sync with the stt block in
   // hermes_cli/config.py (local/groq/openai/mistral/elevenlabs).
   'stt.provider': ['local', 'groq', 'openai', 'mistral', 'xai', 'elevenlabs'],

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -39,6 +39,10 @@ describe('voiceProviderKeys', () => {
 })
 
 describe('voice field option coverage', () => {
+  it('offers turbo for local faster-whisper transcription', () => {
+    expect(ENUM_OPTIONS['stt.local.model']).toContain('turbo')
+  })
+
   it('offers the current gpt-4o-mini-tts voice set, not just the tts-1 six', () => {
     const voices = ENUM_OPTIONS['tts.openai.voice']
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1799,7 +1799,7 @@ def _run_post_setup(post_setup_key: str):
             result = _pip_install(["-U", "faster-whisper", "--quiet"], timeout=300)
             if result.returncode == 0:
                 _print_success("    faster-whisper installed")
-                _print_info("    Model sizes: tiny, base (default), small, medium, large-v3")
+                _print_info("    Model sizes: tiny, base (default), small, medium, large-v3, turbo")
                 _print_info("    Change via stt.local.model in ~/.hermes/config.yaml")
             else:
                 _print_warning("    faster-whisper install failed:")
@@ -3978,10 +3978,10 @@ def _configure_videogen_model_for_plugin(plugin_name: str, config: dict) -> None
 # Per-provider STT model catalogs for the interactive picker. Keys are
 # ``stt.<provider>`` config sections; the first entry is the default.
 # Kept in sync with the dashboard selects (hermes_cli/web_server.py
-# _CONFIG_FIELD_META) and the desktop settings enums
+# _SCHEMA_OVERRIDES) and the desktop settings enums
 # (apps/desktop/src/app/settings/constants.ts).
 STT_MODEL_CATALOG = {
-    "local": ["base", "tiny", "small", "medium", "large-v3"],
+    "local": ["base", "tiny", "small", "medium", "large-v3", "turbo"],
     "groq": ["whisper-large-v3-turbo", "whisper-large-v3", "distil-whisper-large-v3-en"],
     "openai": ["whisper-1", "gpt-4o-mini-transcribe", "gpt-4o-transcribe", "gpt-transcribe"],
     "elevenlabs": ["scribe_v2", "scribe_v1"],

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -923,7 +923,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "stt.local.model": {
         "type": "select",
         "description": "Local faster-whisper model size",
-        "options": ["tiny", "base", "small", "medium", "large-v3"],
+        "options": ["tiny", "base", "small", "medium", "large-v3", "turbo"],
     },
     "stt.groq.model": {
         "type": "select",

--- a/tests/hermes_cli/test_stt_picker.py
+++ b/tests/hermes_cli/test_stt_picker.py
@@ -93,6 +93,12 @@ class TestModelPicker:
         assert set(STT_MODEL_CATALOG["openai"]) == OPENAI_MODELS
         assert set(STT_MODEL_CATALOG["groq"]) == GROQ_MODELS
 
+    def test_local_turbo_model_is_available_in_cli_and_dashboard(self):
+        from hermes_cli.web_server import _SCHEMA_OVERRIDES
+
+        assert "turbo" in STT_MODEL_CATALOG["local"]
+        assert "turbo" in _SCHEMA_OVERRIDES["stt.local.model"]["options"]
+
 
 
 


### PR DESCRIPTION
## Summary

- add the documented faster-whisper `turbo` model to the local STT selectors in the CLI, dashboard, and desktop settings
- update the post-install model hint so it matches the available choices
- cover the Python and desktop selectors with focused regression tests

## Tests

- `pytest tests/hermes_cli/test_stt_picker.py -v --tb=short -n 0` (12 passed)
- `npx vitest run --project ui src/app/settings/voice-provider-fields.test.ts` (8 passed)
- `npx tsc -p . --noEmit`
- `npx eslint src/app/settings/constants.ts src/app/settings/voice-provider-fields.test.ts`
- `uvx ruff check hermes_cli/tools_config.py hermes_cli/web_server.py tests/hermes_cli/test_stt_picker.py`

Fixes #79629
