### PR TITLE
fix(tools): block config writes reached through a filesystem alias

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -213,6 +213,80 @@ class TestCheckSensitivePathMacOSBypass:
         assert _check_sensitive_path("/tmp/safe_file.txt") is None
 
 
+class TestHermesConfigAliasGuard:
+    """A second name for the config must not bypass the write denial (issue #78658).
+
+    The guard compares path strings, so any alias that names the config without
+    matching it lexically slips through: an NTFS 8.3 short name such as
+    ``CONFIG~1.YAM``, or a hard link on any platform. ``approvals.mode`` lives
+    in that file, so the bypass lets a prompt-injected agent turn off exec
+    approval through a name the guard does not recognise.
+    """
+
+    @pytest.fixture
+    def guarded_config(self, tmp_path: Path, monkeypatch):
+        """Point the guard at a real config file inside tmp_path."""
+        import tools.file_tools as file_tools
+
+        cfg = tmp_path / "hermes" / "config.yaml"
+        cfg.parent.mkdir()
+        cfg.write_text("approvals:\n  mode: ask\n")
+        resolved = str(cfg.resolve())
+        monkeypatch.setattr(file_tools, "_hermes_config_resolved", resolved)
+        monkeypatch.setattr(file_tools, "_hermes_config_resolved_loaded", True)
+        return cfg
+
+    def test_canonical_path_blocked(self, guarded_config: Path):
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path(str(guarded_config.resolve())) is not None
+
+    def test_hard_link_alias_blocked(self, guarded_config: Path, tmp_path: Path):
+        from tools.file_tools import _check_sensitive_path
+
+        alias = tmp_path / "hermes" / "innocent.txt"
+        try:
+            os.link(guarded_config, alias)
+        except (OSError, NotImplementedError, AttributeError) as exc:
+            pytest.skip(f"hard links unsupported on this filesystem: {exc}")
+        assert os.path.samefile(guarded_config, alias)
+        assert _check_sensitive_path(str(alias)) is not None
+
+    @pytest.mark.skipif(os.name != "nt", reason="8.3 short names are Windows-only")
+    def test_short_name_alias_blocked(self, guarded_config: Path):
+        import ctypes
+
+        from tools.file_tools import _check_sensitive_path
+
+        long_path = str(guarded_config.resolve())
+        buf = ctypes.create_unicode_buffer(1024)
+        if not ctypes.windll.kernel32.GetShortPathNameW(long_path, buf, 1024):
+            pytest.skip("GetShortPathNameW failed on this volume")
+        short_path = buf.value
+        if short_path.lower() == long_path.lower():
+            pytest.skip("8.3 short-name generation is disabled on this volume")
+        assert os.path.samefile(long_path, short_path)
+        assert _check_sensitive_path(short_path) is not None
+
+    def test_unrelated_existing_file_allowed(self, guarded_config: Path, tmp_path: Path):
+        other = tmp_path / "hermes" / "notes.txt"
+        other.write_text("hello")
+
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path(str(other)) is None
+
+    def test_new_file_still_allowed(self, guarded_config: Path, tmp_path: Path):
+        """A path that does not exist yet must stay writable.
+
+        The identity check refuses when it cannot resolve a path, so this pins
+        the one case that must not be refused: every write that creates a file.
+        """
+        from tools.file_tools import _check_sensitive_path
+
+        assert _check_sensitive_path(str(tmp_path / "hermes" / "brand-new.txt")) is None
+
+
 class TestAtomicWrite:
     """write_file / patch land via a temp-file + atomic rename.
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -672,6 +672,29 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _names_same_file(candidate: str, target: str) -> bool:
+    """Return True when *candidate* is another name on disk for *target*.
+
+    Path strings alone cannot answer this. An NTFS 8.3 short name
+    (``...\\hermes\\CONFIG~1.YAM``) or a hard link is a second name for the
+    same file that matches no lexical form of it, and on Windows
+    :func:`_resolve_path_for_task` is deliberately lexical (``ntpath.normpath``,
+    no filesystem access), so the string comparisons never see through either.
+    ``os.stat`` identity does.
+
+    Resolution failures are treated as "cannot prove this is not the target"
+    and answered with True, so the caller keeps denying. The one exception is a
+    missing path: a name that does not exist cannot be a second name for a file
+    that does, and every write to a new file lands here.
+    """
+    try:
+        return os.path.samefile(candidate, target)
+    except FileNotFoundError:
+        return False
+    except (OSError, ValueError):
+        return True
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -693,7 +716,11 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
     # prompt-injected agent could silently disable exec approval by writing to
     # this file.
     hermes_config = _get_hermes_config_resolved()
-    if hermes_config and (resolved == hermes_config or normalized == hermes_config):
+    if hermes_config and (
+        resolved == hermes_config
+        or normalized == hermes_config
+        or _names_same_file(resolved, hermes_config)
+    ):
         return (
             f"Refusing to write to Hermes config file: {filepath}\n"
             "Agent cannot modify security-sensitive configuration. "


### PR DESCRIPTION
## What does this PR do?

`_check_sensitive_path` refuses writes to the Hermes config file, because `approvals.mode` lives there and an agent that can rewrite it can turn off exec approval. The refusal compares path strings, so any second name for that file walks past it.

On Windows the two sides of the comparison are built differently. The guarded path comes from `Path.resolve()`, which hits the filesystem and returns the long name:

```python
_hermes_config_resolved = str(get_config_path().resolve())
```

The candidate path does not. On `win32`, `_resolve_path_for_task` is lexical by design, `ntpath.normpath` with no filesystem access:

```python
if ntpath.isabs(expanded):
    return Path(ntpath.normpath(expanded))
```

So an NTFS 8.3 short name stays short on the left and is compared against the long name on the right, and never matches. Measured on Windows 11 with 8.3 generation enabled on the volume, against `main` at `241605d1e`:

```
guarded config : C:\Users\<user>\AppData\Local\hermes\config.yaml
its 8.3 alias  : C:\Users\<user>\AppData\Local\hermes\CONFIG~1.YAM
os.path.samefile(long, short) -> True

_check_sensitive_path(long)   -> DENIED
_check_sensitive_path(short)  -> allowed
```

A hard link is the same class of hole and is not Windows specific: `Path.resolve()` follows symlinks, so a symlink to the config is already denied, but a hard link is a real second directory entry and resolves to itself.

Both reach `write_file_tool()` and the V4A patch path, which are the two callers of this guard.

## Related Issue

Closes #78658.

That issue was opened from a review of #76247 and marked `needs-repro`, since native Windows execution was not available at the time: *"short-name-to-target resolution remains environment-dependent and should be validated on a real Windows filesystem"*. The measurement above is that validation, on a volume with 8.3 generation on, plus a test that skips itself when generation is off.

**Interaction with `fe66596df`,** the protected agent-instruction gate that landed after this PR was opened. It does not cover this file, by design. It resolves its candidate with `os.path.realpath` and then returns early for anything inside the Hermes home, with the comment that the home is *"governed by its own guards (config.yaml hard-block, cross-profile guard, write_approval)"*. `get_config_path()` is `get_hermes_home() / "config.yaml"`, so an 8.3 alias of the config realpaths into the home, leaves the new gate by that early return, and lands back on the string comparison below. The two are complementary: the new gate takes project-local instruction files, the hard-block it defers to takes the config file, and this PR is what makes that hard-block hold for a second name on disk.

**Overlap with #76247, please read before merging either.** #76247 is open and rewrites this function, adding `_posix_form_for_sensitive_check()` and a canonical config comparison that covers separator, case, and trailing dot or space aliases. It does not cover filesystem identity, so this hole survives it, and the issue was filed as a residual class rather than a request to change that PR. The two touch the same lines, so whichever lands first, the other needs a rebase. If you would rather take #76247 first, say so and I will rebase this on top of it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

* `tools/file_tools.py`: new `_names_same_file()` helper, and the Hermes config comparison now also asks it. It answers with `os.path.samefile`, which compares stat identity rather than spelling.
* `tests/tools/test_file_write_safety.py`: new `TestHermesConfigAliasGuard`, five cases.

One commit, two files.

**Fail-closed semantics, since this is a guard.** `FileNotFoundError` answers `False`, every other `OSError` or `ValueError` answers `True` and the caller keeps denying. The distinction is not cosmetic: a path that does not exist cannot be a second name for a file that does, and that case is every write that creates a file, so it must stay allowed. Anything else means identity could not be established, and a guard that cannot see should refuse. `test_new_file_still_allowed` pins the allowed side so a future tightening cannot quietly break ordinary writes.

## How to Test

On a Windows host with 8.3 generation enabled (`fsutil 8dot3name query C:`), against your own config path:

```python
import ctypes, os
from tools.file_tools import _check_sensitive_path, _get_hermes_config_resolved

cfg = _get_hermes_config_resolved()
buf = ctypes.create_unicode_buffer(1024)
ctypes.windll.kernel32.GetShortPathNameW(cfg, buf, 1024)
print(os.path.samefile(cfg, buf.value))        # True, same file
print(_check_sensitive_path(cfg) is not None)  # True, denied
print(_check_sensitive_path(buf.value) is not None)  # False on main, True with this PR
```

On any platform, the hard-link case:

```
pytest tests/tools/test_file_write_safety.py -k HermesConfigAliasGuard -q
```

The 8.3 case skips itself where short names do not exist, and the hard-link case skips itself where `os.link` is unsupported, so neither turns red for an environment reason.

Verified on Windows 11, Python 3.13:

* new tests with `tools/file_tools.py` reverted to `main` and the tests in place: `2 failed, 3 passed`. The two failures are the alias cases, `AssertionError: assert None is not None` on `...\hermes\CONFIG~1.YAM` and on the hard link. The three that pass are the controls, the canonical path, an unrelated file, and a file that does not exist yet, so they hold before and after;
* with the fix: `5 passed`, no skips, so both alias cases really ran here;
* blast radius, the whole of `tests/tools/test_file_write_safety.py`, `test_file_tools.py`, `test_approval.py`, `test_approval_config_readonly.py`, `test_file_state_registry.py`, base against this branch: **8 failed, 26 passed -> 6 failed, 28 passed** in `test_file_write_safety.py`, which is the two alias cases going green and nothing else moving, and identical counts everywhere else (`test_file_tools.py` 6 failed 41 passed both ways, `test_approval.py` 2 failed 94 passed both ways, `test_approval_config_readonly.py` and `test_file_state_registry.py` fully green both ways). The 6 that stay red in `test_file_write_safety.py` are pre-existing on Windows and unrelated to this change: five in `TestCheckSensitivePathMacOSBypass`, which asserts POSIX prefixes like `/private/etc` that `ntpath.normpath` turns into backslash paths, plus `TestAtomicWrite::test_patch_routes_through_atomic_write`. The two reds in `test_approval.py` are `TestDetectDangerousRm` on symlinked temp dirs. All of them reproduce identically with this change reverted, so the count going from 8 to 6 is the fix and nothing else.

Green ubuntu run for this head: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31055721693

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows Conventional Commits (`fix(tools): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate. Nearest is #76247, disclosed above. The 8.3 reports in #52842, #61833 and #57526 are installer and profile-path issues, not this guard, and #51475 covers case-insensitive credential paths in a different module. No `samefile`, `GetFinalPathNameByHandle` or short-name handling exists anywhere in `tools/` on `main` today.
- [x] My PR contains **only** changes related to this fix: one commit, the source change and its test
- [ ] I've run `pytest tests/ -q`. Not honestly checkable here: the full suite on a Windows host has pre-existing failures unrelated to this change. I ran the files listed above, base against branch, and reported the exact counts.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.13

### Documentation & Housekeeping

- [x] Documentation: N/A, the reasoning lives in the helper docstring
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered. The check is not platform gated on purpose: it is one branch fewer, and the hard-link variant is real on POSIX too, where `resolve()` already handles symlinks so the extra call only fires on a true alias. `scripts/check-windows-footguns.py --all` and `ruff check` are both clean.
- [x] Tool descriptions/schemas: N/A

