### PR TITLE
fix(qqbot): send markdown (msg_type 2) in _send_qqbot so cron deliveries render tables

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2039,7 +2039,12 @@ async def _send_qqbot(pconfig, chat_id, message):
                 "Authorization": f"QQBot {access_token}",
                 "Content-Type": "application/json",
             }
-            payload = {"content": message[:4000], "msg_type": 0}
+            # markdown 消息（msg_type=2）使表格能渲染，与 live adapter 的
+            # _build_text_body() 保持一致：markdown 内容包在 markdown.content 里。
+            payload = {
+                "markdown": {"content": message[:4000]},
+                "msg_type": 2,
+            }
 
             # Try channel endpoint first (works for guild channels)
             url = f"https://api.sgroup.qq.com/channels/{chat_id}/messages"


### PR DESCRIPTION
## Problem

QQ Bot messages delivered by **cron jobs** never render markdown (tables show as raw `|` pipes), while **agent replies** in the same chat render them fine.

## Root Cause

Two different send paths:

| Path | Function | msg_type | Tables? |
|------|----------|----------|---------|
| Agent reply (live) | `QQAdapter.send()` → `_build_text_body()` | `2` (markdown) | ✅ |
| Cron delivery | `_send_qqbot()` in `tools/send_message_tool.py` | `0` (plain text, hardcoded) | ❌ |

`_send_qqbot()` hardcoded `msg_type: 0` with content in the top-level `content` field, so the QQ Open Platform never parses markdown.

## Fix

Align the standalone sender with the live adapter:

```python
payload = {
    "markdown": {"content": message[:4000]},
    "msg_type": 2,
}
```

## Verification

- Sent a markdown table via `_send_qqbot()` → **renders** in QQ C2C chat ✅
- Triggered a real cron job (asset report with multiple markdown tables) → **renders** ✅
- Agent reply path unaffected (already markdown)

## Related

Issue: #79677