### PR TITLE
fix(dashboard): scope Memory admin to the selected management profile (#79655)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6057,25 +6057,26 @@ async def get_memory_provider_config(name: str, surface: Optional[str] = None, p
     return await asyncio.to_thread(_run)
 
 @app.post("/api/memory/providers/{name}/setup")
-async def setup_memory_provider(name: str, body: MemoryProviderSetupRequest):
+async def setup_memory_provider(name: str, body: MemoryProviderSetupRequest, profile: Optional[str] = None):
     _require_valid_memory_provider_name(name)
-    provider = _load_memory_provider(name)
-    if provider is None and not _memory_provider_manifest(name):
-        # No discoverable plugin directory → nothing whose manifest could
-        # legitimately declare setup commands. Refuse before the
-        # command-running path. (provider may be None with a manifest present
-        # when its pip deps aren't installed yet — that's the setup use case.)
-        raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-    if provider is not None and body.values:
-        try:
-            _write_memory_provider_config_values(name, provider, body.values)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except Exception:
-            _log.exception("Failed to persist memory provider setup values for %s", name)
-            raise HTTPException(status_code=500, detail="Internal server error")
-    _invalidate_plugins_hub_cache()
-    return _install_memory_provider_setup(name)
+    with _config_profile_scope(profile):
+        provider = _load_memory_provider(name)
+        if provider is None and not _memory_provider_manifest(name):
+            # No discoverable plugin directory → nothing whose manifest could
+            # legitimately declare setup commands. Refuse before the
+            # command-running path. (provider may be None with a manifest present
+            # when its pip deps aren't installed yet — that's the setup use case.)
+            raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+        if provider is not None and body.values:
+            try:
+                _write_memory_provider_config_values(name, provider, body.values)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except Exception:
+                _log.exception("Failed to persist memory provider setup values for %s", name)
+                raise HTTPException(status_code=500, detail="Internal server error")
+        _invalidate_plugins_hub_cache()
+        return _install_memory_provider_setup(name)
 
 
 @app.put("/api/memory/providers/{name}/config")
@@ -12737,63 +12738,66 @@ async def remove_credential_pool_entry(provider: str, index: int):
 
 
 @app.get("/api/memory")
-async def get_memory_status():
-    cfg = load_config()
-    active = ""
-    mem = cfg.get("memory")
-    if isinstance(mem, dict):
-        active = _normalize_memory_provider_name(mem.get("provider"))
+async def get_memory_status(profile: Optional[str] = None):
+    with _config_profile_scope(profile):
+        cfg = load_config()
+        active = ""
+        mem = cfg.get("memory")
+        if isinstance(mem, dict):
+            active = _normalize_memory_provider_name(mem.get("provider"))
 
-    # Built-in memory file sizes (so the UI can show what a reset would erase).
-    mem_dir = get_hermes_home() / "memories"
-    files = {}
-    for fname, key in (("MEMORY.md", "memory"), ("USER.md", "user")):
-        path = mem_dir / fname
-        files[key] = path.stat().st_size if path.exists() else 0
+        # Built-in memory file sizes (so the UI can show what a reset would erase).
+        mem_dir = get_hermes_home() / "memories"
+        files = {}
+        for fname, key in (("MEMORY.md", "memory"), ("USER.md", "user")):
+            path = mem_dir / fname
+            files[key] = path.stat().st_size if path.exists() else 0
 
-    return {
-        "active": active,
-        "providers": _discover_memory_provider_statuses(),
-        "builtin_files": files,
-    }
+        return {
+            "active": active,
+            "providers": _discover_memory_provider_statuses(),
+            "builtin_files": files,
+        }
 
 
 @app.put("/api/memory/provider")
-async def set_memory_provider(body: MemoryProviderSelect):
+async def set_memory_provider(body: MemoryProviderSelect, profile: Optional[str] = None):
     provider = _normalize_memory_provider_name(body.provider)
 
-    _require_memory_provider_ready(provider)
+    with _config_profile_scope(profile):
+        _require_memory_provider_ready(provider)
 
-    cfg = load_config()
-    if not isinstance(cfg.get("memory"), dict):
-        cfg["memory"] = {}
-    cfg["memory"]["provider"] = provider
-    save_config(cfg)
-    return {"ok": True, "active": provider}
+        cfg = load_config()
+        if not isinstance(cfg.get("memory"), dict):
+            cfg["memory"] = {}
+        cfg["memory"]["provider"] = provider
+        save_config(cfg)
+        return {"ok": True, "active": provider}
 
 
 @app.post("/api/memory/reset")
-async def reset_memory(body: MemoryReset):
+async def reset_memory(body: MemoryReset, profile: Optional[str] = None):
     target = (body.target or "all").strip().lower()
     if target not in {"all", "memory", "user"}:
         raise HTTPException(status_code=400, detail="target must be all, memory, or user")
 
-    mem_dir = get_hermes_home() / "memories"
-    deleted = []
-    targets = []
-    if target in {"all", "memory"}:
-        targets.append("MEMORY.md")
-    if target in {"all", "user"}:
-        targets.append("USER.md")
-    for fname in targets:
-        path = mem_dir / fname
-        if path.exists():
-            try:
-                path.unlink()
-                deleted.append(fname)
-            except OSError as exc:
-                raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
-    return {"ok": True, "deleted": deleted}
+    with _config_profile_scope(profile):
+        mem_dir = get_hermes_home() / "memories"
+        deleted = []
+        targets = []
+        if target in {"all", "memory"}:
+            targets.append("MEMORY.md")
+        if target in {"all", "user"}:
+            targets.append("USER.md")
+        for fname in targets:
+            path = mem_dir / fname
+            if path.exists():
+                try:
+                    path.unlink()
+                    deleted.append(fname)
+                except OSError as exc:
+                    raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
+        return {"ok": True, "deleted": deleted}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -734,6 +734,55 @@ class TestWebServerEndpoints:
         assert "secret-value" not in json.dumps(data)
 
 
+    def test_memory_admin_profile_scopes_status_and_reset(self):
+        """?profile=<name> must scope Memory admin to the selected profile.
+
+        The dashboard Memory admin (status / provider select / reset) resolves
+        the dashboard launch profile instead of the selected management
+        profile when the request omits ?profile= (#79655): builtin file sizes
+        come from the launch profile's memories dir and reset deletes the
+        launch profile's files. With ?profile=<name>, both must use the
+        selected profile's HERMES_HOME.
+        """
+        import hermes_cli.web_server as web_server
+        from hermes_cli import profiles as profiles_mod
+
+        worker_home = profiles_mod.get_profile_dir("worker")
+        worker_home.mkdir(parents=True)
+        worker_mem_dir = worker_home / "memories"
+        worker_mem_dir.mkdir(parents=True, exist_ok=True)
+        (worker_mem_dir / "MEMORY.md").write_text("w" * 3)
+        (worker_mem_dir / "USER.md").write_text("w" * 5)
+
+        default_mem_dir = web_server.get_hermes_home() / "memories"
+        default_mem_dir.mkdir(parents=True, exist_ok=True)
+        (default_mem_dir / "MEMORY.md").write_text("d" * 9)
+        (default_mem_dir / "USER.md").write_text("d" * 11)
+
+        # Status must reflect the selected profile's memory files.
+        resp = self.client.get("/api/memory?profile=worker")
+        assert resp.status_code == 200
+        builtin = resp.json()["builtin_files"]
+        assert builtin["memory"] == 3
+        assert builtin["user"] == 5
+
+        # Without ?profile= it keeps resolving the launch profile (default).
+        resp = self.client.get("/api/memory")
+        assert resp.status_code == 200
+        builtin = resp.json()["builtin_files"]
+        assert builtin["memory"] == 9
+        assert builtin["user"] == 11
+
+        # Reset must delete only the selected profile's files.
+        resp = self.client.post("/api/memory/reset?profile=worker", json={"target": "all"})
+        assert resp.status_code == 200
+        assert resp.json()["deleted"] == ["MEMORY.md", "USER.md"]
+        assert not (worker_mem_dir / "MEMORY.md").exists()
+        assert not (worker_mem_dir / "USER.md").exists()
+        assert (default_mem_dir / "MEMORY.md").exists()
+        assert (default_mem_dir / "USER.md").exists()
+
+
 
 
     # ── Memory provider config (Honcho host-block backend) ──────────────

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -118,6 +118,50 @@ describe("api.getModelOptions", () => {
   });
 });
 
+describe("api Memory admin profile scoping", () => {
+  it("appends the management profile to /api/memory status reads", async () => {
+    vi.stubGlobal("window", {});
+
+    const fetchMock = jsonFetchMock({
+      active: "",
+      providers: [],
+      builtin_files: { memory: 0, user: 0 },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { setManagementProfile } = await import("./api");
+    setManagementProfile("coder");
+
+    await api.getMemory();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory?profile=coder",
+      expect.objectContaining({ credentials: "include" }),
+    );
+
+    setManagementProfile("");
+  });
+
+  it("scopes memory reset to the management profile", async () => {
+    vi.stubGlobal("window", {});
+
+    const fetchMock = jsonFetchMock({ ok: true, deleted: [] });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { setManagementProfile } = await import("./api");
+    setManagementProfile("coder");
+
+    await api.resetMemory("all");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/memory/reset?profile=coder",
+      expect.objectContaining({ method: "POST" }),
+    );
+
+    setManagementProfile("");
+  });
+});
+
 describe("api OAuth helpers", () => {
   it("starts OAuth login in gated mode without requiring an injected session token", async () => {
     vi.stubGlobal("window", { __HERMES_AUTH_REQUIRED__: true });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -88,6 +88,10 @@ const PROFILE_SCOPED_PREFIXES = [
   // consults that one — approving into the global store would grant access
   // the running gateway never sees.
   "/api/pairing",
+  // Memory admin (status / provider select / reset / setup / config) reads
+  // and writes the managed profile's own HERMES_HOME — without the param it
+  // would touch the dashboard launch profile instead (issue #79655).
+  "/api/memory",
 ];
 
 function withManagementProfile(url: string): string {


### PR DESCRIPTION
## Summary

The web dashboard Memory admin does not consistently honor the selected management profile (#79655). Memory status, provider selection, provider setup, and memory reset all resolved the dashboard's **launch** profile instead of the profile selected in the dashboard profile switcher.

### Root cause
- Frontend: `web/src/lib/api.ts` did not include `/api/memory` in `PROFILE_SCOPED_PREFIXES`, so the SPA never appended `?profile=<selected>` to Memory admin calls.
- Backend: `/api/memory`, `/api/memory/provider`, `/api/memory/reset`, and `/api/memory/providers/{name}/setup` did not accept a `profile` query param at all, so even an explicit `?profile=` was ignored and `load_config()` / `get_hermes_home()` resolved the launch profile.

### Fix
- Backend (`hermes_cli/web_server.py`): added `profile: Optional[str] = None` to the four routes and wrapped each body in `_config_profile_scope(profile)`, so status reads, provider selection writes, reset deletion, and provider setup all resolve the selected profile's HERMES_HOME. (The provider `config` GET/PUT routes already accepted `profile`.)
- Frontend (`web/src/lib/api.ts`): added `/api/memory` to `PROFILE_SCOPED_PREFIXES` so `fetchJSON` appends `?profile=<selected>` to Memory admin calls.

### Tests
- Backend: `test_memory_admin_profile_scopes_status_and_reset` — asserts `GET /api/memory?profile=worker` reports the worker profile's builtin file sizes, and `POST /api/memory/reset?profile=worker` deletes only the worker profile's MEMORY.md/USER.md while the launch profile's files remain.
- Frontend: two vitest cases asserting `/api/memory` and `/api/memory/reset` are rewritten to `/api/memory?profile=coder` / `/api/memory/reset?profile=coder` when a management profile is set.

All targeted tests pass: `test_web_server.py -k "memory or honcho"` → 7 passed; `web/src/lib/api.test.ts` → 9 passed.

Closes #79655
