### PR TITLE
fix(mem0): stop the mem0.json merge-write from wiping unread settings

### DIFF
--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -219,14 +219,33 @@ def _write_env(env_path: Path, env_writes: dict[str, str]) -> None:
 
 
 def _save_mem0_json(hermes_home: str, data: dict) -> None:
-    """Merge-write to mem0.json."""
+    """Merge-write to mem0.json.
+
+    The merge is only a merge while the existing file can be read. Swallowing
+    a read failure left ``existing`` empty and turned the write into a full
+    replacement, so a mem0.json that merely carried a UTF-8 BOM (any GUI
+    editor) lost every key this call does not set — ``api_key`` and ``host``
+    among them. Read BOM-tolerantly, and if the file exists but still cannot
+    be parsed, refuse the write instead of overwriting settings we could not
+    read.
+    """
     config_path = Path(hermes_home) / "mem0.json"
-    existing = {}
+    existing: dict = {}
     if config_path.exists():
         try:
-            existing = json.loads(config_path.read_text(encoding="utf-8"))
-        except Exception:
-            pass
+            loaded = json.loads(config_path.read_text(encoding="utf-8-sig"))
+        except Exception as exc:
+            raise RuntimeError(
+                f"{config_path} exists but could not be read ({exc}); refusing "
+                "to overwrite it. Fix or move the file, then re-run setup — "
+                "your current settings are untouched."
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise RuntimeError(
+                f"{config_path} does not contain a JSON object; refusing to "
+                "overwrite it. Fix or move the file, then re-run setup."
+            )
+        existing = loaded
     existing.update(data)
     config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
 

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -231,3 +231,80 @@ class TestConnectivityChecks:
         assert ok is True
 
 
+
+
+class TestMem0JsonMergeWrite:
+    """The merge-write must never turn into a full replacement.
+
+    _save_mem0_json reads mem0.json, updates it, and writes the whole file
+    back. Swallowing the read left `existing` empty, so every key the call
+    does not set was dropped — api_key and host among them.
+    """
+
+    @staticmethod
+    def _save(home, data):
+        from plugins.memory.mem0._setup import _save_mem0_json
+
+        _save_mem0_json(str(home), data)
+
+    def test_bom_prefixed_config_keeps_untouched_keys(self, tmp_path):
+        import json
+
+        original = {
+            "mode": "platform",
+            "api_key": "sk-user-key",
+            "host": "https://mem0.example",
+            "custom": {"keep": "me"},
+        }
+        path = tmp_path / "mem0.json"
+        path.write_bytes(b"\xef\xbb\xbf" + json.dumps(original, indent=2).encode())
+
+        self._save(tmp_path, {"mode": "oss", "agent_id": "hermes"})
+
+        after = json.loads(path.read_text(encoding="utf-8-sig"))
+        assert after["api_key"] == "sk-user-key"
+        assert after["host"] == "https://mem0.example"
+        assert after["custom"] == {"keep": "me"}
+        assert after["mode"] == "oss"
+        assert after["agent_id"] == "hermes"
+
+    def test_unreadable_config_is_not_overwritten(self, tmp_path):
+        import pytest as _pytest
+
+        path = tmp_path / "mem0.json"
+        path.write_text("{ truncated", encoding="utf-8")
+
+        with _pytest.raises(RuntimeError):
+            self._save(tmp_path, {"mode": "oss"})
+
+        assert path.read_text(encoding="utf-8") == "{ truncated"
+
+    def test_non_object_config_is_not_overwritten(self, tmp_path):
+        import pytest as _pytest
+
+        path = tmp_path / "mem0.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+
+        with _pytest.raises(RuntimeError):
+            self._save(tmp_path, {"mode": "oss"})
+
+        assert path.read_text(encoding="utf-8") == "[1, 2, 3]"
+
+    def test_missing_file_is_created(self, tmp_path):
+        import json
+
+        self._save(tmp_path, {"mode": "oss", "user_id": "alice"})
+
+        after = json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert after == {"mode": "oss", "user_id": "alice"}
+
+    def test_plain_config_merges_normally(self, tmp_path):
+        import json
+
+        path = tmp_path / "mem0.json"
+        path.write_text(json.dumps({"api_key": "k", "mode": "platform"}), encoding="utf-8")
+
+        self._save(tmp_path, {"mode": "oss"})
+
+        after = json.loads(path.read_text(encoding="utf-8"))
+        assert after == {"api_key": "k", "mode": "oss"}


### PR DESCRIPTION
## What

`_save_mem0_json` reads `mem0.json`, updates it, and writes the whole file back. The read swallowed every failure and left `existing` empty, so the "merge" silently became a **full replacement** of the user's config with only the keys that call happens to set:

```python
existing = {}
if config_path.exists():
    try:
        existing = json.loads(config_path.read_text(encoding="utf-8"))
    except Exception:
        pass                      # <- existing stays {}
existing.update(data)
config_path.write_text(json.dumps(existing, indent=2) + "\n", ...)
```

A UTF-8 BOM is enough to trigger it — any GUI editor leaves one, and the read used strict `utf-8`. Running the real writer against a BOM'd platform-mode config:

```
before: ['api_key', 'custom', 'host', 'mode', 'user_id']
after : ['agent_id', 'mode', 'oss', 'user_id']
```

`api_key` and `host` are gone: the user's mem0 platform credential and endpoint, destroyed by a setup run that reported success. Every other key the caller does not set goes with them, and the two call sites only ever set `mode`, `user_id`, `agent_id` and `oss`.

This is the same shape the repo has already fixed twice at P0/P1 — `fix(memory): don't wipe MEMORY.md when a read-modify-write reads it as unreadable` (#69745) and `fix(cli): stop hermes import-agent from destroying an unreadable config.yaml` (#76698). This writer never got it.

## The fix

- Read with `utf-8-sig`, so the BOM case stops being a failure at all — the same treatment `_write_env` in this file already carries for `.env`, and the canonical readers in `hermes_cli/config.py` use.
- If the file exists but still cannot be parsed as a JSON object, **refuse the write** and raise with the path, instead of replacing settings that could not be read. The message states the existing file is untouched so the user can fix or move it and re-run.

A missing file still creates one; a readable file still merges exactly as before.

## Tests

Added `TestMem0JsonMergeWrite` to `tests/plugins/memory/test_mem0_setup.py`:

- a BOM-prefixed config keeps `api_key`, `host` and a nested custom key while the new keys merge in
- a truncated config raises and the file is left byte-identical
- a JSON array (valid JSON, wrong shape) is also refused rather than replaced
- a missing file is created
- an ordinary config merges normally — the new key wins, the untouched key survives

Results:

```
24 passed
```

That is the whole file; the 19 pre-existing tests are unchanged.

Red without the source change:

```
FAILED TestMem0JsonMergeWrite::test_bom_prefixed_config_keeps_untouched_keys
FAILED TestMem0JsonMergeWrite::test_unreadable_config_is_not_overwritten
FAILED TestMem0JsonMergeWrite::test_non_object_config_is_not_overwritten
E   Failed: DID NOT RAISE <class 'RuntimeError'>
3 failed, 2 passed
```

The two controls pass on both sides, which is what they are for.

Regression over `tests/plugins/memory/` against the same files on main: **7 failed before, 7 after, set difference empty** — the 7 are the pre-existing hindsight and holographic failures, unrelated to this change. `scripts/check-windows-footguns.py` is clean on both files.