### PR TITLE
fix(tui): deliver /background results to the TUI/Desktop chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/background-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/background-complete-event.test.tsx
@@ -1,0 +1,82 @@
+import { QueryClient } from '@tanstack/react-query'
+import { act, cleanup, render, waitFor } from '@testing-library/react'
+import { useEffect, useRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
+import { chatMessageText } from '@/lib/chat-messages'
+import type { RpcEvent } from '@/types/hermes'
+
+import { useMessageStream } from './index'
+
+const SID = 'session-1'
+
+let handleEvent: ((event: RpcEvent) => void) | null = null
+let latestState: ClientSessionState | null = null
+
+function Harness() {
+  const activeSessionIdRef = useRef<string | null>(SID)
+  const sessionStateByRuntimeIdRef = useRef(new Map<string, ClientSessionState>())
+  const queryClientRef = useRef(new QueryClient())
+
+  const stream = useMessageStream({
+    activeSessionIdRef,
+    hydrateFromStoredSession: vi.fn(async () => undefined),
+    queryClient: queryClientRef.current,
+    refreshHermesConfig: vi.fn(async () => undefined),
+    refreshSessions: vi.fn(async () => undefined),
+    sessionStateByRuntimeIdRef,
+    updateSessionState: (sessionId, updater) => {
+      const current = sessionStateByRuntimeIdRef.current.get(sessionId) ?? createClientSessionState()
+      const next = updater(current)
+      sessionStateByRuntimeIdRef.current.set(sessionId, next)
+      latestState = next
+      return next
+    }
+  })
+
+  useEffect(() => {
+    handleEvent = stream.handleGatewayEvent
+  }, [stream.handleGatewayEvent])
+
+  return null
+}
+
+async function mountStream() {
+  render(<Harness />)
+  await waitFor(() => expect(handleEvent).not.toBeNull())
+}
+
+const fireBackground = (payload: Record<string, unknown>) =>
+  act(() => handleEvent!({ payload, session_id: SID, type: 'background.complete' }))
+
+describe('useMessageStream background.complete', () => {
+  beforeEach(() => {
+    handleEvent = null
+    latestState = null
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('voegt een system-bericht toe met het background-resultaat', async () => {
+    await mountStream()
+    fireBackground({ text: 'het onderzoeksresultaat', task_id: 'bg_1234_ab' })
+
+    const messages = latestState?.messages ?? []
+    const last = messages[messages.length - 1]
+    expect(last?.role).toBe('system')
+    const text = chatMessageText(last)
+    expect(text).toContain('✅ Background task complete')
+    expect(text).toContain('bg_1234_ab')
+    expect(text).toContain('het onderzoeksresultaat')
+  })
+
+  it('voegt niets toe als de tekst leeg is', async () => {
+    await mountStream()
+    fireBackground({ text: '   ' })
+    expect(latestState?.messages ?? []).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -1112,6 +1112,32 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             ]
           }))
         }
+      } else if (event.type === 'background.complete') {
+        // A /background task finished after its slash.exec response was
+        // already returned, so the result arrives as an unsolicited event
+        // (tui_gateway/server.py _attach_worker drains it from the worker's
+        // stdout). Surface it as a persistent system message — same pattern
+        // as the review summary above. Deliberately NOT written to the
+        // backend history, so the active session's prompt cache and role
+        // alternation stay untouched.
+        const text = coerceGatewayText(payload?.text).trim()
+        const taskId = payload?.task_id
+
+        if (text && sessionId) {
+          flushQueuedDeltas(sessionId)
+          updateSessionState(sessionId, state => ({
+            ...state,
+            messages: [
+              ...state.messages,
+              {
+                id: `background-complete-${taskId ?? Date.now()}`,
+                role: 'system',
+                parts: [textPart(`✅ Background task complete${taskId ? ` (${taskId})` : ''}\n\n${text}`)],
+                timestamp: Math.floor(Date.now() / 1000)
+              }
+            ]
+          }))
+        }
       } else if (event.type === 'notification.show') {
         // Driver-agnostic agent notice (credits usage/grant/depleted/restored
         // from `agent/credits_tracker.py`). The Ink TUI renders these in its

--- a/apps/desktop/src/lib/chat-messages.ts
+++ b/apps/desktop/src/lib/chat-messages.ts
@@ -37,6 +37,8 @@ export type GatewayEventPayload = {
   status?: string
   message?: string
   id?: string
+  /** task_id of a finished /background task (background.complete event). */
+  task_id?: string
   name?: string
   tool_id?: string
   tool_call_id?: string

--- a/cli.py
+++ b/cli.py
@@ -4751,6 +4751,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # Background task tracking: {task_id: threading.Thread}
         self._background_tasks: Dict[str, threading.Thread] = {}
         self._background_task_counter = 0
+        # Optional delivery hook set by the TUI slash-worker so a finished
+        # /background task can stream its result back to the client as a JSON
+        # event frame (see tui_gateway/slash_worker.py). None in the classic
+        # CLI, where the console print remains the only delivery path.
+        self._background_complete_callback = None
 
     def _claim_active_session(self, surface: str = "cli", *, stderr: bool = False) -> bool:
         """Claim a global active-session slot for this CLI process."""

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -1964,6 +1964,13 @@ class CLICommandsMixin:
         task_num = self._background_task_counter
         task_id = f"bg_{datetime.now().strftime('%H%M%S')}_{uuid.uuid4().hex[:6]}"
 
+        # Optional delivery hook: the TUI slash-worker sets this to stream the
+        # final response back to the client as a JSON event frame. The console
+        # prints below are only visible in a classic terminal; in the
+        # TUI/Desktop route they land in a buffer nobody reads. Best-effort:
+        # a failing hook must never kill the background thread.
+        bg_callback = getattr(self, "_background_complete_callback", None)
+
         # Make sure we have valid credentials
         if not self._ensure_runtime_credentials():
             _cprint("  (>_<) Cannot start background task: no valid credentials.")
@@ -2032,6 +2039,12 @@ class CLICommandsMixin:
                 if not response and result and result.get("error"):
                     response = f"Error: {result['error']}"
 
+                if bg_callback is not None:
+                    try:
+                        bg_callback(task_id, response)
+                    except Exception:
+                        pass
+
                 # Display result in the CLI (thread-safe via patch_stdout).
                 # Force a TUI refresh first so spinner/status bar don't overlap
                 # with the output (fixes #2718).
@@ -2081,6 +2094,11 @@ class CLICommandsMixin:
                     time.sleep(0.05)
                 print()
                 _cprint(f"  ❌ Background task #{task_num} failed: {e}")
+                if bg_callback is not None:
+                    try:
+                        bg_callback(task_id, f"Error: {e}")
+                    except Exception:
+                        pass
             finally:
                 try:
                     set_sudo_password_callback(None)

--- a/tests/cli/test_cli_background_delivery_callback.py
+++ b/tests/cli/test_cli_background_delivery_callback.py
@@ -1,0 +1,154 @@
+"""Regression tests for the /background delivery hook (``_background_complete_callback``).
+
+Background
+----------
+``_handle_background_command`` spawns the background task in a daemon thread
+and returns immediately. The final response used to be printed to the console
+only — visible in a classic terminal, but lost in the TUI/Desktop route where
+the slash worker's stdout is a protocol channel nobody renders. The fix adds an
+optional ``_background_complete_callback(task_id, text)`` hook that the TUI
+slash-worker sets; the classic CLI keeps ``None`` and the console behaviour.
+
+These tests exercise the hook without running a real model: ``AIAgent`` is
+replaced by a fake whose ``run_conversation`` returns a canned response.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+
+def _make_cli():
+    """Create a HermesCLI instance with prompt_toolkit stubbed out."""
+    _clean_config = {
+        "model": {
+            "default": "anthropic/claude-opus-4.6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    clean_env = {"LLM_MODEL": "", "HERMES_MAX_ITERATIONS": ""}
+    prompt_toolkit_stubs = {
+        "prompt_toolkit": MagicMock(),
+        "prompt_toolkit.history": MagicMock(),
+        "prompt_toolkit.styles": MagicMock(),
+        "prompt_toolkit.patch_stdout": MagicMock(),
+        "prompt_toolkit.application": MagicMock(),
+        "prompt_toolkit.layout": MagicMock(),
+        "prompt_toolkit.layout.processors": MagicMock(),
+        "prompt_toolkit.filters": MagicMock(),
+        "prompt_toolkit.layout.dimension": MagicMock(),
+        "prompt_toolkit.layout.menus": MagicMock(),
+        "prompt_toolkit.widgets": MagicMock(),
+        "prompt_toolkit.key_binding": MagicMock(),
+        "prompt_toolkit.completion": MagicMock(),
+        "prompt_toolkit.formatted_text": MagicMock(),
+        "prompt_toolkit.auto_suggest": MagicMock(),
+    }
+    with patch.dict(sys.modules, prompt_toolkit_stubs), patch.dict(
+        "os.environ", clean_env, clear=False
+    ):
+        import cli as _cli_mod
+
+        _cli_mod = importlib.reload(_cli_mod)
+        with patch.object(_cli_mod, "get_tool_definitions", return_value=[]), patch.dict(
+            _cli_mod.__dict__, {"CLI_CONFIG": _clean_config}
+        ):
+            return _cli_mod.HermesCLI()
+
+
+class TestBackgroundCompleteCallback:
+    def test_callback_receives_final_response(self):
+        import cli as cli_module
+
+        seen = {}
+
+        def fake_callback(task_id, text):
+            seen["task_id"] = task_id
+            seen["text"] = text
+
+        cli = _make_cli()
+        cli._background_complete_callback = fake_callback
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **kwargs):
+                return {"final_response": "het onderzoeksresultaat", "messages": [], "completed": True}
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch.object(cli, "_ensure_runtime_credentials", return_value=True):
+            chat_console.return_value.print = MagicMock()
+            cli._handle_background_command("/btw onderzoek de specs")
+
+            for _thread in list(cli._background_tasks.values()):
+                _thread.join(timeout=10)
+
+        assert seen["text"] == "het onderzoeksresultaat"
+        assert seen["task_id"].startswith("bg_")
+        assert not cli._background_tasks
+
+    def test_callback_receives_error(self):
+        import cli as cli_module
+
+        seen = {}
+        cli = _make_cli()
+        cli._background_complete_callback = lambda task_id, text: seen.update(task_id=task_id, text=text)
+
+        class ExplodingAgent:
+            def __init__(self, **kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **kwargs):
+                raise RuntimeError("model kapot")
+
+        with patch.object(cli_module, "AIAgent", ExplodingAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch.object(cli, "_ensure_runtime_credentials", return_value=True):
+            chat_console.return_value.print = MagicMock()
+            cli._handle_background_command("/btw dit gaat mis")
+
+            for _thread in list(cli._background_tasks.values()):
+                _thread.join(timeout=10)
+
+        assert seen["text"].startswith("Error:")
+        assert seen["task_id"].startswith("bg_")
+
+    def test_without_callback_console_still_works(self):
+        """The classic CLI path (callback None) must keep working."""
+        import cli as cli_module
+
+        cli = _make_cli()
+        assert cli._background_complete_callback is None
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                self._print_fn = None
+                self.thinking_callback = None
+
+            def run_conversation(self, **kwargs):
+                return {"final_response": "ok", "messages": [], "completed": True}
+
+        with patch.object(cli_module, "AIAgent", FakeAgent), \
+             patch.object(cli_module, "_cprint"), \
+             patch.object(cli_module, "ChatConsole") as chat_console, \
+             patch.object(cli, "_ensure_runtime_credentials", return_value=True):
+            chat_console.return_value.print = MagicMock()
+            cli._handle_background_command("/btw gewone cli")
+
+            for _thread in list(cli._background_tasks.values()):
+                _thread.join(timeout=10)
+
+        assert not cli._background_tasks
+        # No callback registered → nothing to assert beyond the thread finishing.

--- a/tests/tui_gateway/test_slash_worker_background_events.py
+++ b/tests/tui_gateway/test_slash_worker_background_events.py
@@ -1,0 +1,136 @@
+"""Regression tests for /background result delivery through the TUI slash worker.
+
+Background
+----------
+In the TUI/Desktop route a ``/background`` task finishes AFTER its
+``slash.exec`` response was already returned, so the final response used to be
+printed to the slash-worker's stdout — a channel nobody reads. The fix routes
+the result back as an unsolicited JSON event frame:
+
+- ``slash_worker._emit_background_event`` writes ``{"event": "background.complete",
+  ...}`` on the worker's stdout;
+- ``SlashWorker._drain_stdout`` splits event frames into ``event_queue`` instead
+  of the request/response ``stdout_queue`` (so ``run()`` never has to skip them);
+- ``_attach_worker`` starts a drain thread that emits ``background.complete`` to
+  the connected client.
+
+These tests cover the frame emission and the queue split without spawning a
+real subprocess.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import queue
+import threading
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from tui_gateway import server
+from tui_gateway import slash_worker
+
+
+class TestEmitBackgroundEvent:
+    def test_writes_json_event_frame(self):
+        out = io.StringIO()
+        slash_worker._emit_background_event("bg_1234_ab", "het resultaat", stream=out)
+        frame = json.loads(out.getvalue())
+        assert frame == {
+            "event": "background.complete",
+            "task_id": "bg_1234_ab",
+            "text": "het resultaat",
+        }
+
+    def test_unicode_survives(self):
+        out = io.StringIO()
+        slash_worker._emit_background_event("bg_x", "✓ afgerond — klaar", stream=out)
+        assert "✓ afgerond — klaar" in json.loads(out.getvalue())["text"]
+
+
+class TestSlashWorkerEventSplit:
+    def _make_worker(self, lines):
+        worker = server._SlashWorker.__new__(server._SlashWorker)
+        worker.stdout_queue = queue.Queue()
+        worker.event_queue = queue.Queue()
+        worker.proc = SimpleNamespace(stdout=iter(lines))
+        return worker
+
+    def test_event_frames_go_to_event_queue(self):
+        worker = self._make_worker(
+            [
+                json.dumps({"id": 1, "ok": True, "output": "start"}),
+                json.dumps({"event": "background.complete", "task_id": "bg_x", "text": "klaar"}),
+                json.dumps({"id": 2, "ok": True, "output": "later"}),
+            ]
+        )
+        worker._drain_stdout()
+
+        responses = []
+        while True:
+            msg = worker.stdout_queue.get_nowait()
+            if msg is None:
+                break
+            responses.append(msg)
+        assert [m["id"] for m in responses] == [1, 2]
+
+        events = worker.poll_events()
+        assert events == [{"event": "background.complete", "task_id": "bg_x", "text": "klaar"}]
+        # poll_events is draining: a second call is empty
+        assert worker.poll_events() == []
+
+    def test_garbage_lines_are_skipped(self):
+        # The pre-fix behaviour: console output from the background thread hit
+        # stdout as non-JSON and was silently dropped by json.loads. It must
+        # still not corrupt the protocol queues.
+        worker = self._make_worker(["not json at all", json.dumps({"id": 1, "ok": True, "output": "x"})])
+        worker._drain_stdout()
+        assert worker.stdout_queue.get_nowait()["id"] == 1
+        assert worker.poll_events() == []
+
+
+class TestAttachWorkerEventDrain:
+    def test_drain_thread_emits_background_complete(self):
+        worker = SimpleNamespace(
+            event_queue=queue.Queue(),
+            proc=SimpleNamespace(poll=lambda: None),
+        )
+        session = {"slash_worker": worker}
+        emitted = []
+
+        with server._sessions_lock:
+            server._sessions["sid-test"] = session
+        try:
+            with patch.object(server, "_emit", lambda ev, sid, payload: emitted.append((ev, sid, payload))):
+                server._attach_worker("sid-test", session, worker)
+                worker.event_queue.put(
+                    {"event": "background.complete", "task_id": "bg_1", "text": "hallo"}
+                )
+                deadline = time.monotonic() + 5
+                while not emitted and time.monotonic() < deadline:
+                    time.sleep(0.05)
+                assert emitted == [
+                    ("background.complete", "sid-test", {"task_id": "bg_1", "text": "hallo"})
+                ]
+        finally:
+            # Detach so the daemon drain thread exits on its next poll.
+            with server._sessions_lock:
+                server._sessions.pop("sid-test", None)
+            session["slash_worker"] = None
+            time.sleep(1.1)
+
+    def test_attach_worker_closes_orphan(self):
+        closed = threading.Event()
+        worker = SimpleNamespace(close=lambda: closed.set())
+        session = {"slash_worker": None}
+        with server._sessions_lock:
+            server._sessions["sid-orphan"] = {"not": "this session"}
+        try:
+            server._attach_worker("sid-orphan", session, worker)
+            assert closed.is_set()
+        finally:
+            with server._sessions_lock:
+                server._sessions.pop("sid-orphan", None)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -331,6 +331,10 @@ class _SlashWorker:
         self._seq = 0
         self.stderr_tail: list[str] = []
         self.stdout_queue: queue.Queue[dict | None] = queue.Queue()
+        # Unsolicited event frames (e.g. background.complete) sent by the
+        # worker outside the request/response protocol. Kept separate so
+        # run() never has to skip over them while waiting for its own reply.
+        self.event_queue: queue.Queue[dict] = queue.Queue()
 
         argv = [
             sys.executable,
@@ -392,10 +396,26 @@ class _SlashWorker:
     def _drain_stdout(self):
         for line in self.proc.stdout or []:
             try:
-                self.stdout_queue.put(json.loads(line))
+                msg = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if isinstance(msg, dict) and msg.get("event"):
+                self.event_queue.put(msg)
+            else:
+                self.stdout_queue.put(msg)
         self.stdout_queue.put(None)
+
+    def poll_events(self) -> list[dict]:
+        """Drain unsolicited event frames sent by the worker (e.g. the
+        ``background.complete`` frame emitted when a ``/background`` task
+        finishes after its ``slash.exec`` response was already returned)."""
+        events: list[dict] = []
+        while True:
+            try:
+                events.append(self.event_queue.get_nowait())
+            except queue.Empty:
+                break
+        return events
 
     def _drain_stderr(self):
         for line in self.proc.stderr or []:
@@ -871,8 +891,37 @@ def _attach_worker(sid: str, session: dict, worker) -> None:
     with _sessions_lock:
         if _sessions.get(sid) is session:
             session["slash_worker"] = worker
+        else:
+            worker.close()
             return
-    worker.close()
+
+    # Forward unsolicited worker event frames (background.complete from a
+    # finished /background task) to the connected client. The task runs to
+    # completion after the slash.exec response was already returned, so no
+    # single RPC call can carry it; this drain thread bridges that gap. It
+    # exits when the worker is detached from the session or its process dies.
+    def _drain_worker_events() -> None:
+        while True:
+            try:
+                ev = worker.event_queue.get(timeout=1.0)
+            except queue.Empty:
+                if session.get("slash_worker") is not worker or worker.proc.poll() is not None:
+                    return
+                continue
+            try:
+                _emit(
+                    "background.complete",
+                    sid,
+                    {"task_id": ev.get("task_id", ""), "text": ev.get("text", "")},
+                )
+            except Exception:
+                pass
+
+    threading.Thread(
+        target=_drain_worker_events,
+        daemon=True,
+        name=f"slash-bg-events-{sid[:8]}",
+    ).start()
 
 
 def _pop_session_by_id(sid: str) -> dict | None:

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -125,6 +125,30 @@ def _run(cli: HermesCLI, command: str) -> str:
     return strip_ansi(buf.getvalue().rstrip())
 
 
+_BG_EVENT_LOCK = threading.Lock()
+
+
+def _emit_background_event(task_id: str, text: str, stream=None) -> None:
+    """Emit a ``background.complete`` JSON frame on the worker's stdout.
+
+    The worker's stdout is the JSON-lines protocol channel to the gateway.
+    A ``/background`` task finishes AFTER the ``slash.exec`` response was
+    already returned, so the only way to surface the result is an extra,
+    unsolicited event frame. The gateway splits these frames into an event
+    queue and emits ``background.complete`` to the connected client (see
+    ``tui_gateway/server.py`` SlashWorker). ``stream`` is injectable for
+    tests; it defaults to the worker's real stdout.
+    """
+    frame = json.dumps(
+        {"event": "background.complete", "task_id": task_id, "text": text},
+        ensure_ascii=False,
+    )
+    out = stream if stream is not None else sys.stdout
+    with _BG_EVENT_LOCK:
+        out.write(frame + "\n")
+        out.flush()
+
+
 def main():
     p = argparse.ArgumentParser(add_help=False)
     p.add_argument("--session-key", required=True)
@@ -142,6 +166,13 @@ def main():
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
+
+    # Deliver /background results as JSON event frames instead of the console
+    # print (which lands in a buffer nobody reads in the TUI/Desktop route).
+    # The gateway routes these into an event queue and emits them to the
+    # connected client; the classic CLI keeps the console behaviour because
+    # the hook is None there.
+    cli._background_complete_callback = _emit_background_event
 
     # Spurious stdin-EOF recovery (same O_NONBLOCK shared file-description
     # issue as the gateway entry point — any child inheriting fd 0 can flip


### PR DESCRIPTION
## Problem

In the **TUI/Desktop** route, a `/background <prompt>` task runs in a daemon thread inside the slash-worker subprocess. The `slash.exec` response is returned as soon as the thread starts, and the final response was later printed to the worker's stdout — a channel nobody renders. The user sees the "🔄 Background task started" message but **never the result**. The session itself is written to `~/.hermes/state.db` in full, so the work is done but invisible.

The **messaging gateway** (Telegram/Discord/…) already delivers correctly (`gateway/run.py` `_run_background_task_inner` sends "✅ Background task complete" via `adapter.send`). Only the Desktop/TUI route — which goes through `slash.exec → _SlashWorker → HermesCLI.process_command()` — loses the result.

## Fix

Route the result back as an **unsolicited JSON event frame** on the worker's stdout:

1. **`hermes_cli/cli_commands_mixin.py`** — `_handle_background_command` calls an optional `_background_complete_callback(task_id, text)` hook when the task finishes (success **and** error path). The classic CLI keeps `None` and the existing console print — zero behaviour change there.
2. **`tui_gateway/slash_worker.py`** — the worker sets that hook to emit `{"event": "background.complete", "task_id": …, "text": …}` on stdout (lock-guarded, injectable stream for tests).
3. **`tui_gateway/server.py`** — `SlashWorker._drain_stdout` splits event frames into a dedicated `event_queue` (so `run()` never has to skip over them); `_attach_worker` starts a daemon drain thread that emits `background.complete` to the connected client. The thread exits when the worker is detached or its process dies.
4. **`apps/desktop`** — the gateway event handler surfaces `background.complete` as a persistent system message in the transcript. It is deliberately **not** written to the backend history, so the active session's prompt cache and role alternation stay untouched (per the repo's cache/alternation invariants).

## Tests

- Python (9 new): worker frame emission (incl. unicode), `_drain_stdout` event/response split + garbage-line tolerance, `poll_events` draining, `_attach_worker` drain emit + orphan-close; CLI callback success/error/None paths.
- TS (2 new): `background.complete` renders a system message with task id + result; empty text adds nothing.
- Regression: `tests/cli/test_cli_background_busy_path.py`, `test_cli_approval_ui.py`, `test_moa_reference_emit.py`, `test_review_summary_callback.py` (34 passed) and the full `use-message-stream` suite (18 files / 81 tests passed).

## Related

Same architectural gap as #51009 (Desktop/TUI slash-command dispatch is a second-class path vs. the gateway handlers) but a **different symptom**: there the handlers are missing entirely ("unknown command"); here the handler exists but its async delivery mechanism is absent. A future consolidation of the Desktop/TUI dispatch onto the gateway handlers could close both.