### PR TITLE
fix(mcp): support --json in `hermes mcp list` for a machine-readable inventory

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -9,6 +9,7 @@ configuration in ~/.hermes/config.yaml under the ``mcp_servers`` key.
 """
 
 import asyncio
+import json
 import logging
 import os
 import re
@@ -651,9 +652,75 @@ def cmd_mcp_remove(args):
 
 # ─── hermes mcp list ──────────────────────────────────────────────────────────
 
+def _mcp_server_json_payload(name: str, cfg: dict) -> dict:
+    """One server entry for `hermes mcp list --json`.
+
+    Tool detail comes from the on-disk schema cache (fingerprint-checked, the
+    same source lazy startup trusts), so a fresh CLI process reports real tool
+    names without spawning servers. No cache entry means ``tools_known: false``
+    — an honest "no tool detail", never a lying empty list.
+    """
+    payload: Dict[str, Any] = {"name": name}
+    enabled = cfg.get("enabled", True)
+    if isinstance(enabled, str):
+        payload["enabled"] = enabled.lower() in {"true", "1", "yes"}
+    else:
+        payload["enabled"] = bool(enabled)
+    if "url" in cfg:
+        payload["url"] = cfg["url"]
+    if "command" in cfg:
+        payload["command"] = cfg["command"]
+        args = cfg.get("args")
+        if isinstance(args, list):
+            payload["args"] = args
+    if cfg.get("auth"):
+        payload["auth"] = cfg["auth"]
+    tools = _cached_tool_list(name, cfg)
+    if tools is None:
+        payload["tools_known"] = False
+        payload["tools"] = []
+    else:
+        payload["tools_known"] = True
+        payload["tools"] = tools
+    return payload
+
+
+def _cached_tool_list(name: str, cfg: dict) -> Optional[List[dict]]:
+    """``[{name, description}]`` from the schema cache, or None when unknown."""
+    try:
+        from tools.mcp_schema_cache import config_fingerprint, get_cached_entry
+    except Exception:
+        return None
+    entry = get_cached_entry(name, config_fingerprint(cfg))
+    if entry is None:
+        return None
+    tools = entry.get("tools")
+    if not isinstance(tools, list):
+        return None
+    return [
+        {"name": tool["name"], "description": tool.get("description", "")}
+        for tool in tools
+        if isinstance(tool, dict) and tool.get("name")
+    ]
+
+
+def _print_mcp_servers_json(servers: dict) -> None:
+    """Print the server inventory as one JSON document on stdout."""
+    payload = {
+        "servers": [
+            _mcp_server_json_payload(name, cfg) for name, cfg in servers.items()
+        ]
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
 def cmd_mcp_list(args=None):
     """List all configured MCP servers."""
     servers = _get_mcp_servers()
+
+    if args is not None and getattr(args, "json", False):
+        _print_mcp_servers_json(servers)
+        return
 
     if not servers:
         print()

--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -661,18 +661,25 @@ def _mcp_server_json_payload(name: str, cfg: dict) -> dict:
     — an honest "no tool detail", never a lying empty list.
     """
     payload: Dict[str, Any] = {"name": name}
+    if not isinstance(cfg, dict):
+        # A hand-edited non-dict entry must not nuke the whole document:
+        # report it honestly as a server with no known detail.
+        payload["enabled"] = True
+        payload["tools_known"] = False
+        payload["tools"] = []
+        return payload
     enabled = cfg.get("enabled", True)
     if isinstance(enabled, str):
         payload["enabled"] = enabled.lower() in {"true", "1", "yes"}
     else:
         payload["enabled"] = bool(enabled)
+    # Transport mirrors the text path's preference: url wins over command.
     if "url" in cfg:
         payload["url"] = cfg["url"]
-    if "command" in cfg:
+    elif "command" in cfg:
         payload["command"] = cfg["command"]
         args = cfg.get("args")
-        if isinstance(args, list):
-            payload["args"] = args
+        payload["args"] = args if isinstance(args, list) else []
     if cfg.get("auth"):
         payload["auth"] = cfg["auth"]
     tools = _cached_tool_list(name, cfg)
@@ -697,11 +704,16 @@ def _cached_tool_list(name: str, cfg: dict) -> Optional[List[dict]]:
     tools = entry.get("tools")
     if not isinstance(tools, list):
         return None
-    return [
+    known = [
         {"name": tool["name"], "description": tool.get("description", "")}
         for tool in tools
         if isinstance(tool, dict) and tool.get("name")
     ]
+    # A fingerprint-matching entry with tools but no usable names is a
+    # corrupted cache, not evidence of an empty server: report unknown.
+    if tools and not known:
+        return None
+    return known
 
 
 def _print_mcp_servers_json(servers: dict) -> None:

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -79,7 +79,8 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_list_p.add_argument(
         "--json",
         action="store_true",
-        help="Emit the server inventory as JSON (tool detail from the schema cache)",
+        help="Emit the server inventory as JSON (tool detail from the schema cache; "
+             "transport values are printed untruncated)",
     )
 
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")

--- a/hermes_cli/subcommands/mcp.py
+++ b/hermes_cli/subcommands/mcp.py
@@ -75,7 +75,12 @@ def build_mcp_parser(subparsers, *, cmd_mcp: Callable) -> None:
     mcp_rm_p = mcp_sub.add_parser("remove", aliases=["rm"], help="Remove an MCP server")
     mcp_rm_p.add_argument("name", help="Server name to remove")
 
-    mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_list_p = mcp_sub.add_parser("list", aliases=["ls"], help="List configured MCP servers")
+    mcp_list_p.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the server inventory as JSON (tool detail from the schema cache)",
+    )
 
     mcp_test_p = mcp_sub.add_parser("test", help="Test MCP server connection")
     mcp_test_p.add_argument("name", help="Server name to test")

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -239,6 +239,104 @@ class TestMcpListJson:
         assert "ink" in out
         assert "enabled" in out
 
+    def test_list_json_non_dict_entry_does_not_kill_the_doc(self, tmp_path, capsys):
+        """One hand-edited non-dict server must not nuke the whole JSON doc."""
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "broken": "just a string",
+            "good": {"url": "https://example.com/mcp"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        servers = {s["name"]: s for s in doc["servers"]}
+        assert servers["broken"]["tools_known"] is False
+        assert servers["broken"]["tools"] == []
+        assert servers["good"]["url"] == "https://example.com/mcp"
+
+    def test_list_json_string_enabled_values(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "yes_server": {"url": "https://a.example/mcp", "enabled": "yes"},
+            "zero_server": {"url": "https://b.example/mcp", "enabled": "0"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        servers = {s["name"]: s for s in doc["servers"]}
+        assert servers["yes_server"]["enabled"] is True
+        assert servers["zero_server"]["enabled"] is False
+
+    def test_list_json_command_with_string_args_emits_empty_list(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "odd": {"command": "npx", "args": "npx -y @pkg"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        server = doc["servers"][0]
+        assert server["command"] == "npx"
+        assert server["args"] == []
+
+    def test_list_json_url_wins_over_command(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "both": {"url": "https://example.com/mcp", "command": "npx"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        server = doc["servers"][0]
+        assert server["url"] == "https://example.com/mcp"
+        assert "command" not in server
+
+    def test_list_json_corrupt_cache_without_names_is_unknown(self, tmp_path, capsys):
+        """Fingerprint-matching entry whose tools carry no names must read unknown."""
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "odd": {"url": "https://example.com/mcp"},
+        })
+        from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
+
+        write_cache_entry(
+            "odd",
+            config_fingerprint({"url": "https://example.com/mcp"}),
+            tools=[{"description": "nameless", "inputSchema": {}}],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        server = doc["servers"][0]
+        assert server["tools_known"] is False
+        assert server["tools"] == []
+
+    def test_list_json_parser_exposes_the_flag(self):
+        """The argparse wiring itself is under test: --json must parse on `mcp list`."""
+        import argparse
+
+        from hermes_cli.subcommands.mcp import build_mcp_parser
+
+        parser = argparse.ArgumentParser()
+        subparsers = parser.add_subparsers(dest="command")
+        build_mcp_parser(subparsers, cmd_mcp=lambda args: None)
+        ns = parser.parse_args(["mcp", "list", "--json"])
+        assert ns.mcp_action == "list"
+        assert ns.json is True
+        # The alias carries the flag too.
+        ns_alias = parser.parse_args(["mcp", "ls", "--json"])
+        assert ns_alias.json is True
+
 
 # ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove

--- a/tests/hermes_cli/test_mcp_config.py
+++ b/tests/hermes_cli/test_mcp_config.py
@@ -124,6 +124,123 @@ class TestMcpList:
 
 
 # ---------------------------------------------------------------------------
+# Tests: cmd_mcp_list --json
+# ---------------------------------------------------------------------------
+
+class TestMcpListJson:
+    def test_list_json_empty_config(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {})
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        out = capsys.readouterr().out
+        doc = jsonlib.loads(out)
+        assert doc == {"servers": []}
+
+    def test_list_json_server_fields(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "ink": {
+                "url": "https://mcp.ml.ink/mcp",
+                "auth": "oauth",
+                "enabled": True,
+            },
+            "github": {
+                "command": "npx",
+                "args": ["@mcp/github"],
+                "enabled": False,
+            },
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        servers = {s["name"]: s for s in doc["servers"]}
+        assert servers["ink"]["url"] == "https://mcp.ml.ink/mcp"
+        assert servers["ink"]["auth"] == "oauth"
+        assert servers["ink"]["enabled"] is True
+        assert servers["github"]["command"] == "npx"
+        assert servers["github"]["args"] == ["@mcp/github"]
+        assert servers["github"]["enabled"] is False
+
+    def test_list_json_tools_from_schema_cache(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "glider": {"url": "http://127.0.0.1:64342/stream"},
+        })
+        from tools.mcp_schema_cache import config_fingerprint, write_cache_entry
+
+        write_cache_entry(
+            "glider",
+            config_fingerprint({"url": "http://127.0.0.1:64342/stream"}),
+            tools=[
+                {"name": "find_callers", "description": "Trace callers of a symbol",
+                 "inputSchema": {}},
+                {"name": "get_type_info", "description": "Type details", "inputSchema": {}},
+            ],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        glider = doc["servers"][0]
+        assert glider["tools_known"] is True
+        names = [t["name"] for t in glider["tools"]]
+        assert names == ["find_callers", "get_type_info"]
+        assert glider["tools"][0]["description"] == "Trace callers of a symbol"
+
+    def test_list_json_tools_unknown_without_cache(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "fresh": {"url": "https://example.com/mcp"},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        server = doc["servers"][0]
+        assert server["tools_known"] is False
+        assert server["tools"] == []
+
+    def test_list_json_stale_cache_fingerprint(self, tmp_path, capsys):
+        import json as jsonlib
+
+        _seed_config(tmp_path, {
+            "changing": {"url": "https://example.com/mcp", "tools": {"exclude": ["x"]}},
+        })
+        from tools.mcp_schema_cache import write_cache_entry
+
+        write_cache_entry(
+            "changing",
+            "deadbeefdeadbeef",
+            tools=[{"name": "old_tool", "description": "", "inputSchema": {}}],
+        )
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list(_make_args(json=True))
+        doc = jsonlib.loads(capsys.readouterr().out)
+        server = doc["servers"][0]
+        assert server["tools_known"] is False
+        assert server["tools"] == []
+
+    def test_list_json_does_not_break_text_path(self, tmp_path, capsys):
+        _seed_config(tmp_path, {
+            "ink": {"url": "https://mcp.ml.ink/mcp", "enabled": True},
+        })
+        from hermes_cli.mcp_config import cmd_mcp_list
+
+        cmd_mcp_list()
+        out = capsys.readouterr().out
+        assert "ink" in out
+        assert "enabled" in out
+
+
+# ---------------------------------------------------------------------------
 # Tests: cmd_mcp_remove
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

`hermes mcp list` gains a `--json` flag that emits the configured MCP server inventory as one machine-readable JSON document, including per-server tool names and descriptions.

## Why

`hermes mcp list --json` has been failing with `error: unrecognized arguments: --json` (measured 2026-07 and again 2026-08-05), which silently removed the only machine-consumable MCP inventory surface hermes had. Downstream tooling (e.g. the ai-badger `mcp-index` skill, which built its hermes host listing on this exact command — ai-badger issue #188) must fall back to `claude mcp list` (~14s of health checks per run) or the text table, whose Tools column only ever reads "all" / "N selected" from config — never the real tool names.

The text table remains unchanged for humans.

## How

- `hermes_cli/subcommands/mcp.py`: `--json` flag on the `list` parser.
- `hermes_cli/mcp_config.py::cmd_mcp_list`: when `--json`, print `{"servers": [...]}` with:
  - `name`, `enabled` (normalized to bool), transport (`url` | `command`+`args`), `auth`
  - `tools`: real registered tool names + descriptions from the on-disk schema cache (`tools/mcp_schema_cache.py`, fingerprint-checked — the same source lazy startup trusts, so a fresh CLI process reports tools without spawning any server)
  - `tools_known: false` + `tools: []` when there is no cache entry — an honest "no tool detail", so a consumer never misreads an empty list as "this server exposes nothing" (that semantic is the `tools_known` contract the consumer already implements)

## Test plan

- New tests in `tests/hermes_cli/test_mcp_config.py::TestMcpListJson` (6): empty config, server fields (HTTP + stdio, enabled/disabled), tools from schema cache, `tools_known: false` without cache, stale fingerprint → `tools_known: false`, text path unaffected. Written first (RED), then implementation (GREEN).
- Existing MCP suites: `test_mcp_config.py`, `test_mcp_add_command_dest.py`, `test_mcp_startup.py` — 40 passed.
- `ruff check` clean on the three changed files.
- Manual: `hermes mcp list --json` on a machine with 10 configured servers → 10 entries, tool detail present for cached servers, `tools_known: false` for the disabled uncached one; `hermes mcp list` output byte-identical to before.

## Platforms tested

macOS (aarch64), Python 3.11 (hermes venv).

## Related

- ai-badger issue #188 (the consumer-side workaround that this root-cause fix supersedes)
