### PR TITLE
fix(gateway): don't claim deleted head chunks as delivered in the empty-fallback recovery

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -1618,9 +1618,17 @@ class GatewayStreamConsumer:
         self._final_response_sent = True
         self._final_content_delivered = True
         # Fresh commit of the complete answer after a failed finalize (#71643).
-        # Recorder-routed so a split turn records the unsplit ledger instead of
-        # a tail-only payload the gateway would read as stale (#78541).
-        self._record_turn_final_payload(final_text)
+        #
+        # Record ``final_text`` VERBATIM -- do not route through
+        # _record_turn_final_payload here.  This recovery deleted the sealed
+        # segment previews just above, so the only thing left on screen is the
+        # message we just sent.  On a split turn the ledger holds the sealed
+        # heads too, and recording it would claim delivery for text this path
+        # just removed -- the gateway would then suppress and the user would be
+        # left with a fraction of the answer (the #78541 swallow, reintroduced).
+        self._delivered_final_text = ensure_closed_code_fences(
+            self._clean_for_display(final_text or "")
+        ).strip()
         self._last_sent_text = final_text
         self._fallback_prefix = ""
         self._fallback_preserve_partial_messages = False

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -567,3 +567,43 @@ async def test_failed_final_edit_after_split_records_visible_payload():
     assert await consumer._send_or_edit(full, finalize=True) is False
     assert consumer._final_content_delivered is True
     assert consumer.delivered_final_matches(full) is True
+
+
+@pytest.mark.asyncio
+async def test_empty_fallback_final_after_split_records_only_what_survives():
+    """A recovery that DELETES the sealed heads must not claim them as delivered.
+
+    ``_send_empty_fallback_final`` replaces the active segment: it sends the
+    completed text as a fresh message and deletes every tracked segment
+    preview -- including the sealed head chunks of an overflow split.  Only the
+    new message is left on screen, so the recorded payload must be that message
+    verbatim, NOT the stream ledger.  Recording the ledger would claim delivery
+    for text this path just removed, and the gateway would suppress its own
+    send and leave the user with a fraction of the answer (#78541).
+    """
+    adapter = _SplittingAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-split",
+        StreamConsumerConfig(
+            edit_interval=0.0, buffer_threshold=1, cursor="",
+            fresh_final_after_seconds=0.0,
+        ),
+    )
+    head = "HEAD text. " * 40
+    tail = "TAIL text. " * 6
+    complete = head + tail
+
+    # Sealed head chunk is on screen and tracked as a segment preview.
+    head_id = await consumer._send_new_chunk(head, None, final=False)
+    consumer._turn_split_delivery = True
+    consumer._stream_ledger = complete
+    assert head_id in consumer._segment_preview_message_ids
+
+    # The recovery commits only ``tail`` and deletes the sealed head.
+    assert await consumer._send_empty_fallback_final(tail) == "delivered"
+    assert head_id in adapter.deleted, "expected the recovery to delete the head"
+
+    # The head is gone from the chat, so the complete answer was NOT delivered:
+    # the gateway must be told this is a mismatch and send it.
+    assert consumer.delivered_final_matches(complete) is False


### PR DESCRIPTION
## Summary

Follow-up to #79669. That PR routed the three fallback recorder sites through `_record_turn_final_payload` so a split turn would record the unsplit ledger instead of a tail-only payload. For two of them that's right. For `_send_empty_fallback_final` it's wrong — and it reintroduces the #78541 swallow at the very site it was meant to fix.

`_send_empty_fallback_final` is a **replacement** recovery: it sends the completed text as a fresh message and deletes every tracked segment preview, which on an overflow split includes the sealed head chunks. After it runs, the only thing on screen is the message it just sent. Recording the ledger there claims delivery for text the same function just removed, so `delivered_final_matches()` returns `True`, the gateway suppresses its own send, and the user is left with a fraction of the answer.

## Context — measured, real `run()` loop

543-char reply; 475-char head sealed as its own message then deleted by the recovery; 67-char tail committed:

```
BEFORE this fix
  TRACE: _send_empty_fallback_final: payload_len=67 segment_previews=['m1','m2'] split=True ledger_len=543
  TRACE:   -> delivered; recorded_len=543
  deleted           : ['m2', 'm1']
  messages left     : [('m3', 67)]
  on-screen chars   : 67 / 543
  head text on screen?: False
  delivered_final_matches(full) -> True
  *** SWALLOW: gateway suppresses while head text is NOT on screen ***

AFTER this fix
  TRACE:   -> delivered; recorded_len=67
  on-screen chars   : 67 / 543
  delivered_final_matches(full) -> False
  --- mismatch reported: gateway re-sends the complete answer ---
```

## Changes

- `_send_empty_fallback_final` records `final_text` verbatim (same `_clean_for_display` + `ensure_closed_code_fences` normalization, no ledger substitution).
- The sibling site in `_send_fallback_final` **keeps** the recorder: its delete is gated on `continuation == final_text` and targets only the single active partial, never the sealed heads, so the ledger correctly describes what survives.

The general rule, now stated in the comment: **whether a recovery ADDS to what's on screen or REPLACES it.** Additive paths may record the ledger; replacing paths must record only what they leave behind. `_try_fresh_final` is the same shape, and #79669 handled it by refusing the route on split turns — this is the one replacing path that got the additive treatment by mistake.

## Validation

| | result |
|---|---|
| `test_stale_finalize_suppression.py` | 17 passed (16 + 1 new) |
| `tests/gateway/ -k 'stream or consumer or final or deliver or suppress or overflow or split or telegram'` | **1063 passed**, 1 skipped (pre-existing mautrix skip) |
| ruff | clean |
| 8 probes vs `main`, real `run()` loop | all shapes correct |

New test drives the real seal-then-delete sequence (`_send_new_chunk` → `_send_empty_fallback_final`) and asserts the mismatch so the gateway is required to re-send. **Mutation-checked:** restoring the `_record_turn_final_payload` call turns it red.

## How this was found

A post-merge review pass on #79669's own follow-up commit — the structured 2c/simplify angles had been run against the salvaged contributor diff but not against my own additions. Worth noting as a process gap, not just a code one: the fix commit needed the same review bar as the code it was fixing.
