### PR TITLE
fix: preserve repairable tool-call arguments during replay

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -33,6 +33,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
+from agent.message_sanitization import _repair_tool_call_arguments
 from agent.prompt_builder import format_steer_marker
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
@@ -386,6 +387,20 @@ def sanitize_tool_call_arguments(
                 tool_call_id = _ra().AIAgent._get_tool_call_id_static(tool_call) or None
                 function_name = function.get("name", "?")
                 preview = arguments[:80]
+                repaired_arguments = _repair_tool_call_arguments(arguments, function_name)
+                if repaired_arguments != "{}":
+                    function["arguments"] = repaired_arguments
+                    log.warning(
+                        "Corrupted tool_call arguments normalized before request "
+                        "(session=%s, message_index=%s, tool_call_id=%s, function=%s, preview=%r)",
+                        session_id or "-",
+                        message_index,
+                        tool_call_id or "-",
+                        function_name,
+                        preview,
+                    )
+                    repaired += 1
+                    continue
                 log.warning(
                     "Corrupted tool_call arguments repaired before request "
                     "(session=%s, message_index=%s, tool_call_id=%s, function=%s, preview=%r)",

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -183,6 +183,45 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
     return "".join(out)
 
 
+def _repair_invalid_json_string_escapes(raw: str) -> str:
+    """Drop illegal backslash escapes inside JSON string values."""
+    out: list[str] = []
+    in_string = False
+    i = 0
+    valid_simple = {'"', "\\", "/", "b", "f", "n", "r", "t"}
+    while i < len(raw):
+        ch = raw[i]
+        if not in_string:
+            out.append(ch)
+            if ch == '"':
+                in_string = True
+            i += 1
+            continue
+        if ch == '"':
+            in_string = False
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < len(raw):
+            nxt = raw[i + 1]
+            if nxt in valid_simple:
+                out.extend((ch, nxt))
+                i += 2
+                continue
+            if nxt == "u" and i + 5 < len(raw):
+                hex_part = raw[i + 2 : i + 6]
+                if all(c in "0123456789abcdefABCDEF" for c in hex_part):
+                    out.append(raw[i : i + 6])
+                    i += 6
+                    continue
+            out.append(nxt)
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -218,6 +257,20 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 tool_name,
             )
         return reserialised
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    # Repair invalid JSON escapes inside string values, e.g. ``\'``.
+    try:
+        fixed_escapes = _repair_invalid_json_string_escapes(raw_stripped)
+        if fixed_escapes != raw_stripped:
+            parsed = json.loads(fixed_escapes, strict=False)
+            reserialised = json.dumps(parsed, separators=(",", ":"))
+            logger.warning(
+                "Repaired invalid JSON string escapes in tool_call arguments for %s",
+                tool_name,
+            )
+            return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass
 

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -6,6 +6,12 @@ from run_agent import _repair_tool_call_arguments
 
 
 class TestRepairToolCallArguments:
+    def test_invalid_backslash_apostrophe_escape_is_normalized(self):
+        raw = "{\"command\":\"printf \\'ok\\'\\n\"}"
+        result = _repair_tool_call_arguments(raw, "terminal")
+        parsed = json.loads(result)
+        assert parsed == {"command": "printf 'ok'\n"}
+
     """Verify each repair stage in the pipeline."""
 
     # -- Stage 1: empty / whitespace-only --

--- a/tests/run_agent/test_tool_call_args_sanitizer.py
+++ b/tests/run_agent/test_tool_call_args_sanitizer.py
@@ -50,6 +50,24 @@ def test_valid_arguments_unchanged():
     assert messages == original
 
 
+def test_repairable_illegal_json_escape_is_normalized_without_corruption_marker():
+    marker = AIAgent._TOOL_CALL_ARGUMENTS_CORRUPTION_MARKER
+    messages = [
+        _assistant_message(
+            _tool_call(arguments="{\"command\":\"printf \\'hello\\'\"}")
+        ),
+        _tool_message(content="existing tool output"),
+    ]
+
+    repaired = AIAgent._sanitize_tool_call_arguments(messages)
+
+    assert repaired == 1
+    assert messages[0]["tool_calls"][0]["function"]["arguments"] == (
+        '{"command":"printf \'hello\'"}'
+    )
+    assert not messages[1]["content"].startswith(marker)
+
+
 def test_truncated_arguments_replaced_with_empty_object(caplog):
     messages = [
         _assistant_message(_tool_call(arguments='{"path": "/tmp/foo')),
@@ -120,11 +138,10 @@ def test_multiple_corrupted_tool_calls_in_one_message():
     assert repaired == 2
     assert messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
     assert messages[0]["tool_calls"][1]["function"]["arguments"] == '{"path":"/tmp/bar"}'
-    assert messages[0]["tool_calls"][2]["function"]["arguments"] == "{}"
+    assert messages[0]["tool_calls"][2]["function"]["arguments"] == '{"mode":"tail"}'
     assert messages[1]["tool_call_id"] == "call_1"
     assert messages[1]["content"] == marker
-    assert messages[2]["tool_call_id"] == "call_3"
-    assert messages[2]["content"] == marker
+    assert len(messages) == 2
 
 
 def test_empty_string_arguments_treated_as_empty_object(caplog):


### PR DESCRIPTION
## Problem

`sanitize_tool_call_arguments` in `agent_runtime_helpers.py` repairs corrupted assistant tool-call argument JSON before the next model request. When `json.loads()` fails, it **unconditionally replaces the arguments with `{}`** and inserts a corruption marker — even for **repairable** malformations like `\'` (illegal JSON escape that the canonical `_repair_tool_call_arguments()` already knows how to fix).

**Reproduction:**
```python
raw = '{"command":"printf \\'hello\\'"}'
# json.loads(raw) raises → arguments replaced with "{}"
# _repair_tool_call_arguments(raw) would return {"command":"printf 'hello'"} — but it is never called
```

**Symptom:** A shell command runs correctly, but the next model request sees the previous assistant `tool_call` with `{}` arguments plus a corruption marker, making the assistant look broken and losing the actual tool context.

## Solution

Wire `_repair_tool_call_arguments()` into the replay-path sanitizer (`sanitize_tool_call_arguments`):

1. When `json.loads()` fails, first try `_repair_tool_call_arguments(arguments, function_name)`.
2. If it returns something other than `"{}"` (the unrepairable fallback), use the repaired arguments instead of replacing with `{}`.
3. Only when repair genuinely fails (returns `"{}"`) do we fall through to the existing `{}` + corruption marker path.

Additionally, add `_repair_invalid_json_string_escapes()` to `message_sanitization.py` — a new repair pass that drops illegal backslash escapes (e.g. `\'`) inside JSON string values while preserving valid escapes (`\"`, `\\`, `\n`, `\uXXXX`, etc.).

## Tests

11 tests pass:
```
tests/run_agent/test_tool_call_args_sanitizer.py  — 8 tests (including new repairable-escape regression test)
tests/run_agent/test_repair_tool_call_arguments.py — 3 tests (including new invalid-escape normalization test)
```

Updated `test_multiple_corrupted_tool_calls_in_one_message`: `{"mode":"tail"` is now correctly repaired to `{"mode":"tail"}` instead of being dropped to `{}`, so no corruption marker is inserted for call_3.

Verified: `11 passed` on current `main` (`1be70d6354`).