### PR TITLE
fix(dashboard): scope memory admin to selected profile

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6057,25 +6057,34 @@ async def get_memory_provider_config(name: str, surface: Optional[str] = None, p
     return await asyncio.to_thread(_run)
 
 @app.post("/api/memory/providers/{name}/setup")
-async def setup_memory_provider(name: str, body: MemoryProviderSetupRequest):
+async def setup_memory_provider(
+    name: str,
+    body: MemoryProviderSetupRequest,
+    profile: Optional[str] = None,
+):
     _require_valid_memory_provider_name(name)
-    provider = _load_memory_provider(name)
-    if provider is None and not _memory_provider_manifest(name):
-        # No discoverable plugin directory → nothing whose manifest could
-        # legitimately declare setup commands. Refuse before the
-        # command-running path. (provider may be None with a manifest present
-        # when its pip deps aren't installed yet — that's the setup use case.)
-        raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
-    if provider is not None and body.values:
-        try:
-            _write_memory_provider_config_values(name, provider, body.values)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
-        except Exception:
-            _log.exception("Failed to persist memory provider setup values for %s", name)
-            raise HTTPException(status_code=500, detail="Internal server error")
-    _invalidate_plugins_hub_cache()
-    return _install_memory_provider_setup(name)
+
+    def _run():
+        with _profile_scope(profile):
+            provider = _load_memory_provider(name)
+            if provider is None and not _memory_provider_manifest(name):
+                # No discoverable plugin directory → nothing whose manifest could
+                # legitimately declare setup commands. Refuse before the
+                # command-running path. (provider may be None with a manifest present
+                # when its pip deps aren't installed yet — that's the setup use case.)
+                raise HTTPException(status_code=404, detail=f"Unknown memory provider: {name}")
+            if provider is not None and body.values:
+                try:
+                    _write_memory_provider_config_values(name, provider, body.values)
+                except ValueError as exc:
+                    raise HTTPException(status_code=400, detail=str(exc)) from exc
+                except Exception:
+                    _log.exception("Failed to persist memory provider setup values for %s", name)
+                    raise HTTPException(status_code=500, detail="Internal server error")
+            _invalidate_plugins_hub_cache()
+            return _install_memory_provider_setup(name)
+
+    return await asyncio.to_thread(_run)
 
 
 @app.put("/api/memory/providers/{name}/config")
@@ -12737,63 +12746,81 @@ async def remove_credential_pool_entry(provider: str, index: int):
 
 
 @app.get("/api/memory")
-async def get_memory_status():
-    cfg = load_config()
-    active = ""
-    mem = cfg.get("memory")
-    if isinstance(mem, dict):
-        active = _normalize_memory_provider_name(mem.get("provider"))
+async def get_memory_status(profile: Optional[str] = None):
+    def _run():
+        with _profile_scope(profile):
+            cfg = load_config()
+            active = ""
+            mem = cfg.get("memory")
+            if isinstance(mem, dict):
+                active = _normalize_memory_provider_name(mem.get("provider"))
 
-    # Built-in memory file sizes (so the UI can show what a reset would erase).
-    mem_dir = get_hermes_home() / "memories"
-    files = {}
-    for fname, key in (("MEMORY.md", "memory"), ("USER.md", "user")):
-        path = mem_dir / fname
-        files[key] = path.stat().st_size if path.exists() else 0
+            # Built-in memory file sizes (so the UI can show what a reset would erase).
+            mem_dir = get_hermes_home() / "memories"
+            files = {}
+            for fname, key in (("MEMORY.md", "memory"), ("USER.md", "user")):
+                path = mem_dir / fname
+                files[key] = path.stat().st_size if path.exists() else 0
 
-    return {
-        "active": active,
-        "providers": _discover_memory_provider_statuses(),
-        "builtin_files": files,
-    }
+            return {
+                "active": active,
+                "providers": _discover_memory_provider_statuses(),
+                "builtin_files": files,
+            }
+
+    return await asyncio.to_thread(_run)
 
 
 @app.put("/api/memory/provider")
-async def set_memory_provider(body: MemoryProviderSelect):
-    provider = _normalize_memory_provider_name(body.provider)
+async def set_memory_provider(
+    body: MemoryProviderSelect,
+    profile: Optional[str] = None,
+):
+    def _run():
+        with _profile_scope(profile):
+            provider = _normalize_memory_provider_name(body.provider)
 
-    _require_memory_provider_ready(provider)
+            _require_memory_provider_ready(provider)
 
-    cfg = load_config()
-    if not isinstance(cfg.get("memory"), dict):
-        cfg["memory"] = {}
-    cfg["memory"]["provider"] = provider
-    save_config(cfg)
-    return {"ok": True, "active": provider}
+            cfg = load_config()
+            if not isinstance(cfg.get("memory"), dict):
+                cfg["memory"] = {}
+            cfg["memory"]["provider"] = provider
+            save_config(cfg)
+            return {"ok": True, "active": provider}
+
+    return await asyncio.to_thread(_run)
 
 
 @app.post("/api/memory/reset")
-async def reset_memory(body: MemoryReset):
+async def reset_memory(
+    body: MemoryReset,
+    profile: Optional[str] = None,
+):
     target = (body.target or "all").strip().lower()
     if target not in {"all", "memory", "user"}:
         raise HTTPException(status_code=400, detail="target must be all, memory, or user")
 
-    mem_dir = get_hermes_home() / "memories"
-    deleted = []
-    targets = []
-    if target in {"all", "memory"}:
-        targets.append("MEMORY.md")
-    if target in {"all", "user"}:
-        targets.append("USER.md")
-    for fname in targets:
-        path = mem_dir / fname
-        if path.exists():
-            try:
-                path.unlink()
-                deleted.append(fname)
-            except OSError as exc:
-                raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
-    return {"ok": True, "deleted": deleted}
+    def _run():
+        with _profile_scope(profile):
+            mem_dir = get_hermes_home() / "memories"
+            deleted = []
+            targets = []
+            if target in {"all", "memory"}:
+                targets.append("MEMORY.md")
+            if target in {"all", "user"}:
+                targets.append("USER.md")
+            for fname in targets:
+                path = mem_dir / fname
+                if path.exists():
+                    try:
+                        path.unlink()
+                        deleted.append(fname)
+                    except OSError as exc:
+                        raise HTTPException(status_code=500, detail=f"Could not delete {fname}: {exc}")
+            return {"ok": True, "deleted": deleted}
+
+    return await asyncio.to_thread(_run)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6065,7 +6065,7 @@ async def setup_memory_provider(
     _require_valid_memory_provider_name(name)
 
     def _run():
-        with _profile_scope(profile):
+        with _config_profile_scope(profile):
             provider = _load_memory_provider(name)
             if provider is None and not _memory_provider_manifest(name):
                 # No discoverable plugin directory → nothing whose manifest could
@@ -12748,7 +12748,7 @@ async def remove_credential_pool_entry(provider: str, index: int):
 @app.get("/api/memory")
 async def get_memory_status(profile: Optional[str] = None):
     def _run():
-        with _profile_scope(profile):
+        with _config_profile_scope(profile):
             cfg = load_config()
             active = ""
             mem = cfg.get("memory")
@@ -12777,7 +12777,7 @@ async def set_memory_provider(
     profile: Optional[str] = None,
 ):
     def _run():
-        with _profile_scope(profile):
+        with _config_profile_scope(profile):
             provider = _normalize_memory_provider_name(body.provider)
 
             _require_memory_provider_ready(provider)
@@ -12802,7 +12802,7 @@ async def reset_memory(
         raise HTTPException(status_code=400, detail="target must be all, memory, or user")
 
     def _run():
-        with _profile_scope(profile):
+        with _config_profile_scope(profile):
             mem_dir = get_hermes_home() / "memories"
             deleted = []
             targets = []

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -124,6 +124,89 @@ class TestProfileScopedMcp:
         )
 
 
+class TestProfileScopedMemory:
+    def test_memory_status_reads_requested_profile(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        default_home = isolated_profiles["default"]
+        worker_home = isolated_profiles["worker_beta"]
+        (default_home / "config.yaml").write_text(
+            yaml.safe_dump({"memory": {"provider": "default-provider"}}),
+            encoding="utf-8",
+        )
+        (worker_home / "config.yaml").write_text(
+            yaml.safe_dump({"memory": {"provider": "worker-provider"}}),
+            encoding="utf-8",
+        )
+        (default_home / "memories").mkdir(parents=True, exist_ok=True)
+        (worker_home / "memories").mkdir(parents=True, exist_ok=True)
+        (default_home / "memories" / "USER.md").write_text(
+            "default-user", encoding="utf-8"
+        )
+        (worker_home / "memories" / "USER.md").write_text(
+            "worker", encoding="utf-8"
+        )
+        monkeypatch.setattr(web_server, "_discover_memory_provider_statuses", lambda: [])
+
+        resp = client.get("/api/memory", params={"profile": "worker_beta"})
+
+        assert resp.status_code == 200
+        assert resp.json()["active"] == "worker-provider"
+        assert resp.json()["builtin_files"]["user"] == len("worker")
+
+    def test_memory_provider_selection_writes_requested_profile_only(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        default_home = isolated_profiles["default"]
+        worker_home = isolated_profiles["worker_beta"]
+        (default_home / "config.yaml").write_text(
+            yaml.safe_dump({"memory": {"provider": "default-provider"}}),
+            encoding="utf-8",
+        )
+        (worker_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        monkeypatch.setattr(
+            web_server, "_require_memory_provider_ready", lambda name: None
+        )
+
+        resp = client.put(
+            "/api/memory/provider",
+            params={"profile": "worker_beta"},
+            json={"provider": "honcho"},
+        )
+
+        assert resp.status_code == 200
+        assert _cfg(worker_home)["memory"]["provider"] == "honcho"
+        assert _cfg(default_home)["memory"]["provider"] == "default-provider"
+
+    def test_memory_reset_deletes_requested_profile_only(self, client, isolated_profiles):
+        default_home = isolated_profiles["default"]
+        worker_home = isolated_profiles["worker_beta"]
+        for home, text in ((default_home, "default-user"), (worker_home, "worker-user")):
+            mem_dir = home / "memories"
+            mem_dir.mkdir(parents=True, exist_ok=True)
+            (mem_dir / "USER.md").write_text(text, encoding="utf-8")
+            (mem_dir / "MEMORY.md").write_text(f"{text}-memory", encoding="utf-8")
+
+        resp = client.post(
+            "/api/memory/reset",
+            params={"profile": "worker_beta"},
+            json={"target": "user"},
+        )
+
+        assert resp.status_code == 200
+        assert "USER.md" in resp.json()["deleted"]
+        assert not (worker_home / "memories" / "USER.md").exists()
+        assert (worker_home / "memories" / "MEMORY.md").exists()
+        assert (
+            (default_home / "memories" / "USER.md").read_text(encoding="utf-8")
+            == "default-user"
+        )
+
+
 
     def test_mcp_test_oauth_server_without_token_is_not_ok(
         self, client, isolated_profiles, monkeypatch

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { api, fetchJSON } from "./api";
+import { api, fetchJSON, setManagementProfile } from "./api";
 
 const reloadMocks = vi.hoisted(() => ({
   attemptDashboardTokenReloadOnce: vi.fn(() => false),
@@ -33,6 +33,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  setManagementProfile("");
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -171,5 +172,34 @@ describe("api OAuth helpers", () => {
       expect(init.credentials).toBe("include");
       expect((init.headers as Headers).has(SESSION_HEADER)).toBe(false);
     }
+  });
+});
+
+describe("api Memory helpers", () => {
+  it("scopes memory admin calls to the active management profile", async () => {
+    vi.stubGlobal("window", { __HERMES_SESSION_TOKEN__: "loopback-token" });
+    const fetchMock = jsonFetchMock({
+      active: "",
+      providers: [],
+      builtin_files: { memory: 0, user: 0 },
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    setManagementProfile("coder");
+
+    await api.getMemory();
+    await api.getMemoryProviderConfig("honcho");
+    await api.updateMemoryProviderConfig("honcho", { api_key: "secret" });
+    await api.setupMemoryProvider("honcho", { api_key: "secret" });
+    await api.setMemoryProvider("honcho");
+    await api.resetMemory("user");
+
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/memory?profile=coder",
+      "/api/memory/providers/honcho/config?profile=coder",
+      "/api/memory/providers/honcho/config?profile=coder",
+      "/api/memory/providers/honcho/setup?profile=coder",
+      "/api/memory/provider?profile=coder",
+      "/api/memory/reset?profile=coder",
+    ]);
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,7 @@ const PROFILE_SCOPED_PREFIXES = [
   "/api/tools/toolsets",
   "/api/config",
   "/api/env",
+  "/api/memory",
   "/api/mcp",
   "/api/messaging/platforms",
   "/api/messaging/telegram/onboarding",


### PR DESCRIPTION
Fixes #79655

The web dashboard Memory admin was not consistently scoped to the selected management profile.

The frontend did not append ?profile=<selected> for /api/memory calls, and several backend Memory routes resolved config and memory files from the dashboard launch profile. That meant status reads, provider selection, provider setup, and reset actions could affect the wrong profile.

This change makes the Memory admin family profile-aware end to end:

- adds /api/memory to the dashboard profile-scoped API prefixes
- accepts profile on Memory status, provider selection, setup, and reset routes
- runs those backend operations under the requested profile scope
- keeps provider config routes covered through the same frontend scoping path
- adds frontend coverage for all Memory admin helpers
- adds backend regressions proving selected-profile status, provider selection, and reset do not touch the launch profile

Validation:

uv run --extra dev pytest tests/hermes_cli/test_web_server_profile_unification.py tests/hermes_cli/test_dashboard_admin_endpoints.py -q -k 'memory or ProfileScopedMemory'
Result: 6 passed

npm test -- src/lib/api.test.ts --run
Result: 8 passed

uv run ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server_profile_unification.py
Result: passed