### PR TITLE
fix(tools): stop _resolve_path_for_task resolving ssh paths on the Hermes host

### DIFF
--- a/tests/tools/test_file_tools_cwd_resolution.py
+++ b/tests/tools/test_file_tools_cwd_resolution.py
@@ -17,11 +17,13 @@ Core invariant these tests pin:
 
 import os
 from pathlib import Path, PurePosixPath
+from unittest.mock import MagicMock
 
 import pytest
 
 import tools.file_tools as ft
 import tools.terminal_tool as terminal_tool
+from tools.environments.ssh import SSHEnvironment
 
 
 @pytest.fixture
@@ -310,3 +312,86 @@ def test_v4a_patch_applies_to_resolved_workspace_not_backend_cwd(
     assert (workspace / "target.py").read_text() == "WORKSPACE_PATCHED\n"
     # The decoy (backend cwd) was left untouched.
     assert (decoy / "target.py").read_text() == "DECOY_ORIGINAL\n"
+
+
+# ── #79663: ssh paths live on the remote host, not on the Hermes host ───────
+
+
+REMOTE_ABS_PATH = "/home/michidut/hermes-workspace/file.txt"
+
+
+def _use_backend(monkeypatch, env_type):
+    """Pin the terminal backend without touching the resolver under test."""
+    monkeypatch.setattr(terminal_tool, "_get_env_config", lambda: {"env_type": env_type})
+    monkeypatch.setattr(terminal_tool, "_active_environments", {})
+    monkeypatch.delenv("TERMINAL_ENV", raising=False)
+
+
+def _assert_left_for_the_remote(resolved, expected=REMOTE_ABS_PATH):
+    """The path must survive verbatim AND skip host resolution entirely.
+
+    ``_normalize_without_host_deref`` returns a pure ``PurePosixPath``; the
+    host branch returns a concrete ``Path`` (``WindowsPath`` / ``PosixPath``)
+    that has already been through ``resolve()``. The isinstance check is what
+    makes this test meaningful on a Linux host too, where a nonexistent
+    ``/home/...`` survives ``resolve()`` unchanged by luck rather than design.
+    """
+    assert str(resolved) == expected, f"path was rewritten on the Hermes host: {resolved}"
+    assert not isinstance(resolved, Path), (
+        f"path went through host resolution ({type(resolved).__name__}); "
+        "remote paths must not be resolved against the Hermes filesystem"
+    )
+
+
+def test_ssh_absolute_path_is_not_resolved_on_the_hermes_host(monkeypatch):
+    """An absolute ssh path must reach the remote shell byte-identical.
+
+    ``terminal`` runs the command on the remote host, so ``file`` tools must
+    agree with it. Resolving on the Hermes host rewrites the path before the
+    remote ever sees it: a macOS ``/home`` firmlink expands to
+    ``/System/Volumes/Data/home/...`` and a Windows host anchors it to the
+    ``C:`` drive, neither of which exists on the remote (#79663).
+    """
+    _use_backend(monkeypatch, "ssh")
+
+    _assert_left_for_the_remote(ft._resolve_path_for_task(REMOTE_ABS_PATH, task_id="default"))
+
+
+def test_ssh_live_environment_is_not_host_resolved(monkeypatch):
+    """The live-session path: a registered SSHEnvironment, not just config.
+
+    ``_terminal_env_type_for_task`` prefers the registered environment over
+    ``_get_env_config``, so this is the branch a real ssh session takes.
+    """
+    _use_backend(monkeypatch, "local")
+    monkeypatch.setattr(
+        terminal_tool, "_active_environments", {"default": MagicMock(spec=SSHEnvironment)}
+    )
+
+    assert ft._terminal_env_type_for_task("default") == "ssh"
+    _assert_left_for_the_remote(ft._resolve_path_for_task(REMOTE_ABS_PATH, task_id="default"))
+
+
+def test_ssh_relative_path_anchors_under_the_remote_cwd(monkeypatch):
+    """A relative ssh path must join the remote cwd with posix semantics."""
+    _use_backend(monkeypatch, "ssh")
+    monkeypatch.setattr(terminal_tool, "_session_cwd", {})
+    terminal_tool.record_session_cwd("default", "/home/michidut/hermes-workspace")
+
+    _assert_left_for_the_remote(ft._resolve_path_for_task("file.txt", task_id="default"))
+
+
+def test_ssh_stays_out_of_the_container_cwd_guard(monkeypatch):
+    """ssh takes the remote-path branch without becoming a container backend.
+
+    ``_CONTAINER_BACKENDS`` also drives the container cwd guard
+    (``_is_unusable_container_cwd``), which rejects ``/home/...`` as a working
+    directory. That is correct for ``docker run -w`` and wrong for ssh, where
+    ``/home/<user>`` is exactly where the remote session belongs, so ssh must
+    widen path resolution only.
+    """
+    _use_backend(monkeypatch, "ssh")
+
+    assert ft._uses_container_paths("default") is True
+    assert "ssh" not in terminal_tool._CONTAINER_BACKENDS
+    assert terminal_tool._is_unusable_container_cwd("/home/michidut") is True

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -164,7 +164,9 @@ def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPa
 # (gateway/run.py); the file/terminal-tool layer must do likewise so CLI
 # sessions get the same protection. See references/worktree-cwd-discipline.md.
 _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
-_CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
+_REMOTE_PATH_BACKENDS_FALLBACK = frozenset(
+    {"docker", "singularity", "modal", "daytona", "vercel_sandbox", "ssh"}
+)
 
 
 def _terminal_env_type_for_task(task_id: str = "default") -> str:
@@ -204,12 +206,20 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
 
 
 def _uses_container_paths(task_id: str = "default") -> bool:
+    """Return True when paths belong to the backend's namespace, not the host's.
+
+    True for every sandbox backend and for ``ssh``: the remote shell interprets
+    the path, so resolving it against the Hermes filesystem rewrites it before
+    the backend ever sees it. Named for the container case it was introduced
+    for; the set it consults is ``_REMOTE_PATH_BACKENDS``, which is wider than
+    ``_CONTAINER_BACKENDS`` on purpose (#79663).
+    """
     try:
-        from tools.terminal_tool import _CONTAINER_BACKENDS
-        container_backends = _CONTAINER_BACKENDS
+        from tools.terminal_tool import _REMOTE_PATH_BACKENDS
+        remote_path_backends = _REMOTE_PATH_BACKENDS
     except Exception:
-        container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+        remote_path_backends = _REMOTE_PATH_BACKENDS_FALLBACK
+    return _terminal_env_type_for_task(task_id) in remote_path_backends
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1366,6 +1366,15 @@ _HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")
 
 _CONTAINER_BACKENDS = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
+# Backends whose filesystem lives in a namespace other than the Hermes host's,
+# so file-tool paths must reach the backend unresolved (no host symlink deref,
+# no drive anchoring). Deliberately a superset of _CONTAINER_BACKENDS rather
+# than an addition to it: ssh paths are remote, but ssh is not a sandbox, so
+# container-only handling — image config, docker volumes, and the
+# _is_unusable_container_cwd guard, for which /home/<user> is a perfectly good
+# remote cwd — must keep excluding it.
+_REMOTE_PATH_BACKENDS = _CONTAINER_BACKENDS | {"ssh"}
+
 
 def _is_ssh_remote_tilde_cwd(backend: str, cwd: str) -> bool:
     """Return True when *cwd* is a tilde path that the remote SSH shell must


### PR DESCRIPTION
Fixes #79663

## What breaks

With `terminal.backend: ssh`, every file tool resolves its path against the Hermes host filesystem before the path ever reaches the remote shell. The remote path is rewritten, so the tool touches the wrong file or fails outright.

On macOS the reporter sees `/tmp/x` turn into `/private/tmp/x` (host firmlink deref). On Windows the same branch is louder, because an absolute POSIX path gets anchored to the host drive:

```
_CONTAINER_BACKENDS : ['daytona', 'docker', 'modal', 'singularity', 'vercel_sandbox']
'ssh' in set        : False

backend=docker        _uses_container_paths=True  -> /home/michidut/hermes-workspace/file.txt
backend=ssh           _uses_container_paths=False -> C:\home\michidut\hermes-workspace\file.txt

With a live SSHEnvironment registered:
  _terminal_env_type_for_task -> 'ssh'
  _uses_container_paths       -> False
  _resolve_path_for_task      -> C:\home\michidut\hermes-workspace\file.txt
```

## Who hits it and when

Anyone running `terminal.backend: ssh`, on every file tool call carrying a remote path. Registering a live `SSHEnvironment` does not save it: the backend is detected correctly as `ssh` and the path is still host-resolved.

## Why

`_uses_container_paths()` (`tools/file_tools.py:206`) is the switch that decides whether a path belongs to the backend's namespace or to the host's. It consults `_CONTAINER_BACKENDS` (`tools/terminal_tool.py:1367`), which lists the five sandbox backends and does not list `ssh`. So `ssh` falls into the host branch of `_resolve_path_for_task()` (`tools/file_tools.py:364`) and takes a local `Path.resolve()` / `ntpath.normpath()`.

The same gap is already patched one level up for the tilde case: `_is_ssh_remote_tilde_cwd()` (`tools/terminal_tool.py:1370`) exists precisely to keep ssh out of host-side cwd rewriting. This is that bug again, for ordinary paths.

## Why not simply add "ssh" to _CONTAINER_BACKENDS

That is option 1 in the issue, and it regresses live ssh sessions.

`_CONTAINER_BACKENDS` also drives the container cwd guard (`tools/terminal_tool.py:1527`, `tools/terminal_tool.py:2334`, `tools/file_tools.py:1188`), which calls `_is_unusable_container_cwd()` (`tools/terminal_tool.py:1386`). That function rejects any cwd starting with `_HOST_CWD_PREFIXES = ("/Users/", "/home/", "C:\\", "C:/")` (`tools/terminal_tool.py:1365`) and clamps it to the container default. Inside a container `/home/<user>` really is a host leak. Over ssh it is the normal remote home. Adding `ssh` to that set would silently drop every ssh session out of its working directory.

## What changes

`tools/terminal_tool.py` gains `_REMOTE_PATH_BACKENDS = _CONTAINER_BACKENDS | {"ssh"}`, used for one decision only: which namespace a path belongs to. `_uses_container_paths()` consults that set. Container-only handling (image config, docker volumes, the cwd guard above) keeps reading `_CONTAINER_BACKENDS`, unchanged.

`_uses_container_paths` keeps its name on purpose: it is monkeypatched by name in `tests/tools/test_file_tools.py`, and renaming it would widen the diff for no behavioural gain. Its docstring records the widened meaning.

## How it was verified

RED, production files reverted to main, new tests kept:

```
git checkout main -- tools/file_tools.py tools/terminal_tool.py
python -m pytest tests/tools/test_file_tools_cwd_resolution.py -k ssh
```

```
E  AssertionError: path was rewritten on the Hermes host: C:\home\michidut\hermes-workspace\file.txt
E  assert 'C:\\home\\mi...ace\\file.txt' == '/home/michid...pace/file.txt'
E    - /home/michidut/hermes-workspace/file.txt
E    + C:\home\michidut\hermes-workspace\file.txt
E  AssertionError: assert False is True
E   +  where False = <function _uses_container_paths at 0x...>('default')
4 failed
```

GREEN, with the fix: `4 passed`.

The four tests are:

- `test_ssh_absolute_path_is_not_resolved_on_the_hermes_host`
- `test_ssh_live_environment_is_not_host_resolved` (live `SSHEnvironment` in `_active_environments`)
- `test_ssh_relative_path_anchors_under_the_remote_cwd`
- `test_ssh_stays_out_of_the_container_cwd_guard`

The last one guards the regression described above: it asserts `"ssh" not in _CONTAINER_BACKENDS` and that `_is_unusable_container_cwd("/home/michidut")` still returns True, so the two sets cannot later be merged by a well-meaning edit.

The assertions do not compare strings alone. The container branch returns a `PurePosixPath`, the host branch a concrete `Path`, so `assert not isinstance(resolved, Path)` catches the wrong branch on Linux too, where a nonexistent `/home/...` happens to survive `resolve()` unchanged and a string comparison alone would pass.

That is not a theoretical claim. The same RED and GREEN pair was run on `ubuntu-latest` through GitHub Actions, and the isinstance check is exactly what fires there:

```
GREEN, with the fix
  test_ssh_absolute_path_is_not_resolved_on_the_hermes_host PASSED
  test_ssh_live_environment_is_not_host_resolved            PASSED
  test_ssh_relative_path_anchors_under_the_remote_cwd       PASSED
  test_ssh_stays_out_of_the_container_cwd_guard             PASSED
  4 passed, 11 deselected

RED, production files reverted to base
  E  AssertionError: path went through host resolution (PosixPath);
     remote paths must not be resolved against the Hermes filesystem
  E  AssertionError: assert False is True
  4 failed, 11 deselected
```

The three touched suites in full on `ubuntu-latest`, with the fix: **66 passed, 0 failed**.

Beyond those suites, the branch was put through this repository's own CI in full on a fork mirror, so the result is available without waiting for a workflow approval here. All eight `Python tests` slices, `e2e`, `ruff enforcement`, `Windows footguns`, `check-attribution`, `check-common-ancestor` and `uv lock --check` are green on `ubuntu-latest` with Python 3.11: https://github.com/cryptoyasenka/hermes-agent/actions/runs/31052297278

Counts on Windows (Python 3.13), where the bug is loudest: `tests/tools/test_file_tools_cwd_resolution.py` goes from 7 passed / 4 failed on main to 11 passed / 4 failed. Neighbouring suites `tests/tools/test_file_tools.py` and `tests/tools/test_file_tools_tilde_profile.py` give 43 passed / 8 failed both with and without the fix, so nothing regressed there either.

`ruff check` on all three touched files: all checks passed.

Those 12 Windows failures are pre-existing and unrelated to this change. The clean Linux run above is what confirms it:

```
test_file_tools_cwd_resolution.py::test_container_absolute_input_path_does_not_follow_host_symlink
test_file_tools_cwd_resolution.py::test_container_relative_path_keeps_container_cwd_symlink
test_file_tools_cwd_resolution.py::test_warning_fires_when_relative_path_escapes_workspace
test_file_tools_cwd_resolution.py::test_warning_fires_from_terminal_cwd_when_registry_empty
test_file_tools.py::TestReadFileHandler::test_exception_returns_error_json
test_file_tools.py::TestWriteFileHandler::test_writes_content
test_file_tools.py::TestPatchHandler::test_replace_mode_calls_patch_replace
test_file_tools.py::TestPatchSensitivePathExtraction::test_patch_move_to_sensitive_dst_blocked
test_file_tools.py::TestPatchSensitivePathExtraction::test_patch_update_no_space_after_asterisks_blocked
test_file_tools.py::TestSensitivePathCheck::test_system_path_still_blocked
test_file_tools.py::TestSensitivePathCheck::test_macos_private_var_carveouts
test_file_tools_tilde_profile.py::TestExpandTilde::test_tilde_expands_to_profile_home
```

@michidut you offered to test a patch against a live Ubuntu box. This branch is it. The absolute-path case is what your report describes; a relative path now anchors under the recorded remote cwd instead of the Hermes cwd. The runs above are unit level on Windows and Linux, so a confirmation against a real ssh session would still add something they cannot cover.
