### PR TITLE
fix(desktop): reveal active clarify prompts

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import { clearClarifyRequest } from '@/store/clarify'
+import { onScrollToBottomRequest } from '@/store/thread-scroll'
 import type { RpcEvent } from '@/types/hermes'
 
 import { useMessageStream } from './index'
@@ -19,6 +20,9 @@ const SID = 'session-1'
 
 let handleEvent: ((event: RpcEvent) => void) | null = null
 let stateRef: MutableRefObject<Map<string, ClientSessionState>> | null = null
+let stopScrollListener: (() => void) | null = null
+
+const scrollToBottom = vi.fn()
 
 function Harness() {
   const activeSessionIdRef = useRef<string | null>(SID)
@@ -71,11 +75,15 @@ describe('clarify.request stream hydration', () => {
     handleEvent = null
     stateRef = null
     clearClarifyRequest()
+    scrollToBottom.mockClear()
+    stopScrollListener = onScrollToBottomRequest(scrollToBottom)
   })
 
   afterEach(() => {
     cleanup()
     clearClarifyRequest()
+    stopScrollListener?.()
+    stopScrollListener = null
     vi.restoreAllMocks()
   })
 
@@ -91,6 +99,28 @@ describe('clarify.request stream hydration', () => {
       choices: ['yes', 'no'],
       question: 'Ship it?'
     })
+  })
+
+  it('reveals a clarify prompt raised by the active session', async () => {
+    await mountStream()
+
+    clarifyRequest({ choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-reveal' })
+
+    expect(scrollToBottom).toHaveBeenCalledOnce()
+  })
+
+  it('does not move the active thread for a background session clarify', async () => {
+    await mountStream()
+
+    act(() =>
+      handleEvent!({
+        payload: { choices: ['yes', 'no'], question: 'Ship it?', request_id: 'req-background' },
+        session_id: 'session-background',
+        type: 'clarify.request'
+      })
+    )
+
+    expect(scrollToBottom).not.toHaveBeenCalled()
   })
 
   it('merges with the real tool.start row even though its id differs from the request id', async () => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -62,6 +62,7 @@ import {
 } from '@/store/session'
 import { dropSessionState } from '@/store/session-states'
 import { pruneDelegateFallbackSubagents, pruneFinishedSessionSubagents, upsertSubagent } from '@/store/subagents'
+import { requestScrollToBottom } from '@/store/thread-scroll'
 import { clearActiveSessionTodos } from '@/store/todos'
 import { recordToolDiff } from '@/store/tool-diffs'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
@@ -905,6 +906,10 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
             // "needs input" indicator on its row — works for the active session
             // too, and survives alt-tab / window blur (unlike a toast).
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))
+
+            if (sessionId === activeSessionIdRef.current) {
+              requestScrollToBottom()
+            }
           }
 
           dispatchNativeNotification({


### PR DESCRIPTION
## Summary

- reveal a blocking `clarify.request` raised by the active Desktop session through the existing thread bottom-scroll bridge
- preserve background-session isolation so a prompt in another chat cannot move the active viewport
- add regression coverage through the real cross-component scroll bridge

## Problem

A live macOS Desktop session received a valid `clarify.request`, hydrated the inline question row and marked the session as needing input, but did not reveal the new card. The user could not see the question. Sending a normal follow-up then moved the transcript, exposed the card as **Skipped**, and returned an empty `user_response`.

Current main already makes clarify rows durable across reconnect and hydration via `d21165c2f0`. The remaining gap is visibility: the `clarify.request` handler inserts the row but does not re-arm bottom-follow for the active thread.

## Fix

After hydrating the prompt row and setting `needsInput`, call the existing `requestScrollToBottom()` bridge only when the event session matches `activeSessionIdRef.current`.

The viewport's registered `scrollToBottom()` re-locks immediately and reads the updated target on the next animation frame, after React has committed the prompt row. Background clarifies keep their existing sidebar needs-input indication without hijacking the current chat.

Refs #53666.

## Verification

TDD regression evidence:

- active-session test failed before the fix because the scroll bridge received 0 calls
- naive unconditional reveal failed the background-isolation test because the bridge received 1 call
- guarded implementation passes both cases

Final gates:

- `npx vitest run --project ui src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx src/app/chat/scroll-to-bottom-button.test.tsx src/components/assistant-ui/clarify-tool.test.tsx`: 24/24 passed
- full Desktop UI suite: 3,491/3,491 passed
- `npm run typecheck`: passed
- Desktop ESLint: 0 errors; repository baseline warnings only
- Prettier and `git diff --check`: passed
- production Desktop build: passed
- independent pre-commit review: passed with no security or logic concerns
