### PR TITLE
refactor(cli): extract tui-layout/kanban-goal mixins from cli.py (shard s5)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -54,6 +54,8 @@ from hermes_cli.fallback_config import get_fallback_chain
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin
+from hermes_cli.tui_layout_mixin import TUILayoutMixin
+from hermes_cli.kanban_goal_loop import _run_kanban_goal_loop_q
 from agent.interrupt_compat import request_hard_interrupt
 
 # prompt_toolkit for fixed input area TUI
@@ -4202,7 +4204,7 @@ class _VoiceInputMessage:
         return self.text
 
 
-class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
+class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin, TUILayoutMixin):
     """
     Interactive CLI for the Hermes Agent.
     
@@ -14828,81 +14830,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         self._invalidate(min_interval=0.0)
         return True
 
-    # --- Protected TUI extension hooks for wrapper CLIs ---
-
-    def _get_extra_tui_widgets(self) -> list:
-        """Return extra prompt_toolkit widgets to insert into the TUI layout.
-
-        Wrapper CLIs can override this to inject widgets (e.g. a mini-player,
-        overlay menu) into the layout without overriding ``run()``.  Widgets
-        are inserted between the spacer and the status bar.
-        """
-        return []
-
-    def _register_extra_tui_keybindings(self, kb, *, input_area) -> None:
-        """Register extra keybindings on the TUI ``KeyBindings`` object.
-
-        Wrapper CLIs can override this to add keybindings (e.g. transport
-        controls, modal shortcuts) without overriding ``run()``.
-
-        Parameters
-        ----------
-        kb : KeyBindings
-            The active keybinding registry for the prompt_toolkit application.
-        input_area : TextArea
-            The main input widget, for wrappers that need to inspect or
-            manipulate user input from a keybinding handler.
-        """
-
-    def _build_tui_layout_children(
-        self,
-        *,
-        sudo_widget,
-        secret_widget,
-        approval_widget,
-        slash_confirm_widget=None,
-        clarify_widget,
-        model_picker_widget=None,
-        spinner_widget=None,
-        spacer,
-        status_bar,
-        input_rule_top,
-        image_bar,
-        input_area,
-        input_rule_bot,
-        voice_status_bar,
-        completions_menu,
-    ) -> list:
-        """Assemble the ordered list of children for the root ``HSplit``.
-
-        Wrapper CLIs typically override ``_get_extra_tui_widgets`` instead of
-        this method.  Override this only when you need full control over widget
-        ordering.
-        """
-        return [
-            item for item in [
-                Window(height=0),
-                sudo_widget,
-                secret_widget,
-                approval_widget,
-                slash_confirm_widget,
-                clarify_widget,
-                model_picker_widget,
-                spinner_widget,
-                spacer,
-                *self._get_extra_tui_widgets(),
-                getattr(self, "_pet_widget", None),
-                getattr(self, "_stash_panel_widget", None),
-                status_bar,
-                input_rule_top,
-                image_bar,
-                input_area,
-                input_rule_bot,
-                voice_status_bar,
-                completions_menu,
-            ] if item is not None
-        ]
-
     def run(self):
         """Run the interactive CLI loop with persistent input at bottom."""
         if not self._claim_active_session("cli"):
@@ -17858,95 +17785,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 # ============================================================================
 # Main Entry Point
 # ============================================================================
-
-def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
-    """Drive a kanban goal_mode worker through the Ralph-style goal loop.
-
-    Called from the quiet single-query path AFTER the worker's first turn,
-    only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
-    goal_mode card). Wires the worker's ``run_conversation`` and the kanban
-    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
-    caller — a broken goal loop must never wedge a worker, the dispatcher's
-    claim TTL / crash detection is the backstop.
-    """
-    import os as _os
-
-    task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    if not task_id:
-        return
-
-    from hermes_cli import kanban_db as _kb
-    from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
-
-    # Resolve goal text from the card (title + body = the acceptance
-    # criteria the judge evaluates against).
-    conn = _kb.connect()
-    try:
-        task = _kb.get_task(conn, task_id)
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
-    if task is None:
-        return
-
-    goal_parts = [task.title or ""]
-    if task.body:
-        goal_parts.append(task.body)
-    goal_text = "\n\n".join(p for p in goal_parts if p).strip()
-    if not goal_text:
-        return
-
-    max_turns = task.goal_max_turns or _DEF_TURNS
-
-    def _run_turn(prompt: str) -> str:
-        result = cli.agent.run_conversation(
-            user_message=prompt,
-            conversation_history=cli.conversation_history,
-        )
-        # Keep session_id in sync if mid-run compression rotated it.
-        if (
-            getattr(cli.agent, "session_id", None)
-            and cli.agent.session_id != cli.session_id
-        ):
-            cli.session_id = cli.agent.session_id
-        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
-        if resp:
-            print(resp)
-        return resp or ""
-
-    def _task_status() -> "str | None":
-        c = _kb.connect()
-        try:
-            t = _kb.get_task(c, task_id)
-            return t.status if t is not None else None
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    def _block(reason: str) -> None:
-        c = _kb.connect()
-        try:
-            _kb.block_task(c, task_id, reason=reason)
-        finally:
-            try:
-                c.close()
-            except Exception:
-                pass
-
-    _run_loop(
-        task_id=task_id,
-        goal_text=goal_text,
-        run_turn=_run_turn,
-        task_status_fn=_task_status,
-        block_fn=_block,
-        max_turns=max_turns,
-        first_response=first_response or "",
-        log=lambda m: logger.info("%s", m),
-    )
 
 
 def main(

--- a/hermes_cli/kanban_goal_loop.py
+++ b/hermes_cli/kanban_goal_loop.py
@@ -1,0 +1,100 @@
+"""Kanban goal-loop driver for the quiet single-query CLI path.
+
+Extracted verbatim from cli.py (wave 1 godfile extraction, shard s5 cluster
+c25). ``_run_kanban_goal_loop_q`` drives a dispatcher-spawned kanban
+goal_mode worker through ``hermes_cli.goals.run_kanban_goal_loop``.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
+    """Drive a kanban goal_mode worker through the Ralph-style goal loop.
+
+    Called from the quiet single-query path AFTER the worker's first turn,
+    only when ``HERMES_KANBAN_GOAL_MODE`` is set (dispatcher-spawned
+    goal_mode card). Wires the worker's ``run_conversation`` and the kanban
+    DB into ``goals.run_kanban_goal_loop``. All errors are swallowed by the
+    caller — a broken goal loop must never wedge a worker, the dispatcher's
+    claim TTL / crash detection is the backstop.
+    """
+    import os as _os
+
+    task_id = (_os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    if not task_id:
+        return
+
+    from hermes_cli import kanban_db as _kb
+    from hermes_cli.goals import run_kanban_goal_loop as _run_loop, DEFAULT_MAX_TURNS as _DEF_TURNS
+
+    # Resolve goal text from the card (title + body = the acceptance
+    # criteria the judge evaluates against).
+    conn = _kb.connect()
+    try:
+        task = _kb.get_task(conn, task_id)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+    if task is None:
+        return
+
+    goal_parts = [task.title or ""]
+    if task.body:
+        goal_parts.append(task.body)
+    goal_text = "\n\n".join(p for p in goal_parts if p).strip()
+    if not goal_text:
+        return
+
+    max_turns = task.goal_max_turns or _DEF_TURNS
+
+    def _run_turn(prompt: str) -> str:
+        result = cli.agent.run_conversation(
+            user_message=prompt,
+            conversation_history=cli.conversation_history,
+        )
+        # Keep session_id in sync if mid-run compression rotated it.
+        if (
+            getattr(cli.agent, "session_id", None)
+            and cli.agent.session_id != cli.session_id
+        ):
+            cli.session_id = cli.agent.session_id
+        resp = result.get("final_response", "") if isinstance(result, dict) else str(result)
+        if resp:
+            print(resp)
+        return resp or ""
+
+    def _task_status() -> "str | None":
+        c = _kb.connect()
+        try:
+            t = _kb.get_task(c, task_id)
+            return t.status if t is not None else None
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    def _block(reason: str) -> None:
+        c = _kb.connect()
+        try:
+            _kb.block_task(c, task_id, reason=reason)
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
+    _run_loop(
+        task_id=task_id,
+        goal_text=goal_text,
+        run_turn=_run_turn,
+        task_status_fn=_task_status,
+        block_fn=_block,
+        max_turns=max_turns,
+        first_response=first_response or "",
+        log=lambda m: logger.info("%s", m),
+    )

--- a/hermes_cli/tui_layout_mixin.py
+++ b/hermes_cli/tui_layout_mixin.py
@@ -1,0 +1,85 @@
+"""TUILayoutMixin for HermesCLI — protected TUI extension hooks.
+
+Extracted verbatim from cli.py (wave 1 godfile extraction, shard s5 cluster
+c2). Wrapper CLIs override these hooks to inject widgets / keybindings and
+control root HSplit child ordering without overriding ``run()``.
+"""
+
+from prompt_toolkit.layout import Window
+
+
+class TUILayoutMixin:
+    # --- Protected TUI extension hooks for wrapper CLIs ---
+
+    def _get_extra_tui_widgets(self) -> list:
+        """Return extra prompt_toolkit widgets to insert into the TUI layout.
+
+        Wrapper CLIs can override this to inject widgets (e.g. a mini-player,
+        overlay menu) into the layout without overriding ``run()``.  Widgets
+        are inserted between the spacer and the status bar.
+        """
+        return []
+
+    def _register_extra_tui_keybindings(self, kb, *, input_area) -> None:
+        """Register extra keybindings on the TUI ``KeyBindings`` object.
+
+        Wrapper CLIs can override this to add keybindings (e.g. transport
+        controls, modal shortcuts) without overriding ``run()``.
+
+        Parameters
+        ----------
+        kb : KeyBindings
+            The active keybinding registry for the prompt_toolkit application.
+        input_area : TextArea
+            The main input widget, for wrappers that need to inspect or
+            manipulate user input from a keybinding handler.
+        """
+
+    def _build_tui_layout_children(
+        self,
+        *,
+        sudo_widget,
+        secret_widget,
+        approval_widget,
+        slash_confirm_widget=None,
+        clarify_widget,
+        model_picker_widget=None,
+        spinner_widget=None,
+        spacer,
+        status_bar,
+        input_rule_top,
+        image_bar,
+        input_area,
+        input_rule_bot,
+        voice_status_bar,
+        completions_menu,
+    ) -> list:
+        """Assemble the ordered list of children for the root ``HSplit``.
+
+        Wrapper CLIs typically override ``_get_extra_tui_widgets`` instead of
+        this method.  Override this only when you need full control over widget
+        ordering.
+        """
+        return [
+            item for item in [
+                Window(height=0),
+                sudo_widget,
+                secret_widget,
+                approval_widget,
+                slash_confirm_widget,
+                clarify_widget,
+                model_picker_widget,
+                spinner_widget,
+                spacer,
+                *self._get_extra_tui_widgets(),
+                getattr(self, "_pet_widget", None),
+                getattr(self, "_stash_panel_widget", None),
+                status_bar,
+                input_rule_top,
+                image_bar,
+                input_area,
+                input_rule_bot,
+                voice_status_bar,
+                completions_menu,
+            ] if item is not None
+        ]

--- a/tests/cli/test_tui_layout_mixin_regression.py
+++ b/tests/cli/test_tui_layout_mixin_regression.py
@@ -1,0 +1,141 @@
+"""Regression tests for TUILayoutMixin (extracted verbatim from cli.py).
+
+Wave 1 godfile extraction, shard s5 cluster c2 -> hermes_cli/tui_layout_mixin.py.
+These tests exercise the moved methods directly on the bare mixin (no cli.py
+import, no prompt_toolkit stubs beyond the real ``Window``) so they pin the
+extracted code itself. The existing tests/cli/test_cli_extension_hooks.py
+continues to cover the same methods via the HermesCLI MRO.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.tui_layout_mixin import TUILayoutMixin
+
+
+class TestTUILayoutMixinDefaults:
+    def test_extra_tui_widgets_default_empty(self):
+        mixin = TUILayoutMixin()
+        assert mixin._get_extra_tui_widgets() == []
+
+    def test_register_extra_tui_keybindings_default_noop(self):
+        mixin = TUILayoutMixin()
+        # Body is docstring-only: returns None and registers nothing.
+        result = mixin._register_extra_tui_keybindings(None, input_area=None)
+        assert result is None
+
+    def test_build_tui_layout_children_returns_all_widgets_in_order(self):
+        mixin = TUILayoutMixin()
+        children = mixin._build_tui_layout_children(
+            sudo_widget="sudo",
+            secret_widget="secret",
+            approval_widget="approval",
+            clarify_widget="clarify",
+            spinner_widget="spinner",
+            spacer="spacer",
+            status_bar="status",
+            input_rule_top="top-rule",
+            image_bar="image-bar",
+            input_area="input-area",
+            input_rule_bot="bottom-rule",
+            voice_status_bar="voice-status",
+            completions_menu="completions-menu",
+        )
+        # First element is the zero-height Window, rest are the named widgets.
+        assert children[1:] == [
+            "sudo", "secret", "approval", "clarify", "spinner",
+            "spacer", "status", "top-rule", "image-bar", "input-area",
+            "bottom-rule", "voice-status", "completions-menu",
+        ]
+        assert children[0].__class__.__name__ == "Window"
+
+    def test_build_tui_layout_children_omits_none_widgets(self):
+        mixin = TUILayoutMixin()
+        children = mixin._build_tui_layout_children(
+            sudo_widget=None,
+            secret_widget="secret",
+            approval_widget=None,
+            clarify_widget="clarify",
+            spacer="spacer",
+            status_bar="status",
+            input_rule_top="top-rule",
+            image_bar="image-bar",
+            input_area="input-area",
+            input_rule_bot="bottom-rule",
+            voice_status_bar="voice-status",
+            completions_menu="completions-menu",
+        )
+        assert "sudo" not in children
+        assert "approval" not in children
+        assert children[0].__class__.__name__ == "Window"
+
+
+class TestTUILayoutMixinWidgetInjection:
+    def test_extra_widgets_inserted_between_spacer_and_status_bar(self):
+        mixin = TUILayoutMixin()
+        mixin._get_extra_tui_widgets = lambda: ["radio-menu", "mini-player"]
+
+        children = mixin._build_tui_layout_children(
+            sudo_widget="sudo",
+            secret_widget="secret",
+            approval_widget="approval",
+            clarify_widget="clarify",
+            spinner_widget="spinner",
+            spacer="spacer",
+            status_bar="status",
+            input_rule_top="top-rule",
+            image_bar="image-bar",
+            input_area="input-area",
+            input_rule_bot="bottom-rule",
+            voice_status_bar="voice-status",
+            completions_menu="completions-menu",
+        )
+        spacer_idx = children.index("spacer")
+        status_idx = children.index("status")
+        assert children[spacer_idx + 1] == "radio-menu"
+        assert children[spacer_idx + 2] == "mini-player"
+        assert children[spacer_idx + 3] == "status"
+        assert status_idx == spacer_idx + 3
+
+    def test_pet_and_stash_widgets_are_getattr_guarded(self):
+        """_pet_widget / _stash_panel_widget are read via getattr so a bare
+        mixin (or a HermesCLI before run() sets them) yields None and the
+        widgets are omitted from the layout."""
+        mixin = TUILayoutMixin()
+        children = mixin._build_tui_layout_children(
+            sudo_widget="sudo",
+            secret_widget="secret",
+            approval_widget="approval",
+            clarify_widget="clarify",
+            spinner_widget="spinner",
+            spacer="spacer",
+            status_bar="status",
+            input_rule_top="top-rule",
+            image_bar="image-bar",
+            input_area="input-area",
+            input_rule_bot="bottom-rule",
+            voice_status_bar="voice-status",
+            completions_menu="completions-menu",
+        )
+        assert "pet-widget" not in children
+        assert "stash-widget" not in children
+
+        mixin._pet_widget = "pet-widget"
+        mixin._stash_panel_widget = "stash-widget"
+        children = mixin._build_tui_layout_children(
+            sudo_widget="sudo",
+            secret_widget="secret",
+            approval_widget="approval",
+            clarify_widget="clarify",
+            spinner_widget="spinner",
+            spacer="spacer",
+            status_bar="status",
+            input_rule_top="top-rule",
+            image_bar="image-bar",
+            input_area="input-area",
+            input_rule_bot="bottom-rule",
+            voice_status_bar="voice-status",
+            completions_menu="completions-menu",
+        )
+        assert children[children.index("spacer") + 1] == "pet-widget"
+        assert children[children.index("pet-widget") + 1] == "stash-widget"
+        assert children[children.index("stash-widget") + 1] == "status"

--- a/tests/hermes_cli/test_kanban_goal_loop_q.py
+++ b/tests/hermes_cli/test_kanban_goal_loop_q.py
@@ -1,0 +1,170 @@
+"""Regression tests for _run_kanban_goal_loop_q (extracted verbatim from
+cli.py -> hermes_cli/kanban_goal_loop.py).
+
+Wave 1 godfile extraction, shard s5 cluster c25. The function is a
+module-level driver for dispatcher-spawned kanban goal_mode workers; the
+tests below drive it with a fake HermesCLI-like object, fake kanban_db
+entries, and a captured goals.run_kanban_goal_loop, so no real agent or DB
+is touched.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from hermes_cli import kanban_db
+from hermes_cli import goals
+from hermes_cli.kanban_goal_loop import _run_kanban_goal_loop_q
+
+
+class _FakeConn:
+    """Stand-in for a sqlite3 connection; close() must not raise."""
+
+    def close(self):
+        pass
+
+
+class _FakeTask:
+    def __init__(self, title="Card title", body="Card body", status="in_progress",
+                 goal_max_turns=None):
+        self.title = title
+        self.body = body
+        self.status = status
+        self.goal_max_turns = goal_max_turns
+
+
+class _FakeCLI:
+    """Minimal HermesCLI-shaped object: agent + conversation_history + session_id."""
+
+    def __init__(self, response="hello from agent"):
+        self.agent = _FakeAgent(response)
+        self.conversation_history = []
+        self.session_id = "sess-1"
+
+    @property
+    def agent(self):
+        return self._agent
+
+    @agent.setter
+    def agent(self, value):
+        self._agent = value
+
+
+class _FakeAgent:
+    def __init__(self, response):
+        self.response = response
+        self.session_id = "sess-1"
+        self.calls = []
+
+    def run_conversation(self, *, user_message, conversation_history):
+        self.calls.append((user_message, conversation_history))
+        return {"final_response": self.response}
+
+
+@pytest.fixture(autouse=True)
+def _clean_goal_env(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_GOAL_MODE", raising=False)
+
+
+class TestNoOpPaths:
+    def test_no_task_env_returns_immediately_without_touching_db(self, monkeypatch):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("kanban_db must not be touched without a task id")
+
+        monkeypatch.setattr(kanban_db, "connect", _boom)
+        _run_kanban_goal_loop_q(_FakeCLI(), "first response")
+
+    def test_empty_task_env_returns_immediately(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "   ")
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("kanban_db must not be touched for a blank task id")
+
+        monkeypatch.setattr(kanban_db, "connect", _boom)
+        _run_kanban_goal_loop_q(_FakeCLI(), "first response")
+
+    def test_missing_task_returns_without_running_loop(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "42")
+        monkeypatch.setattr(kanban_db, "connect", lambda: _FakeConn())
+        monkeypatch.setattr(kanban_db, "get_task", lambda conn, tid: None)
+
+        captured = {}
+        monkeypatch.setattr(
+            goals,
+            "run_kanban_goal_loop",
+            lambda **kwargs: captured.update(kwargs),
+        )
+        _run_kanban_goal_loop_q(_FakeCLI(), "first response")
+        assert captured == {}
+
+    def test_task_without_goal_text_returns_without_running_loop(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "42")
+        monkeypatch.setattr(kanban_db, "connect", lambda: _FakeConn())
+        monkeypatch.setattr(
+            kanban_db, "get_task", lambda conn, tid: _FakeTask(title="", body="   ")
+        )
+
+        captured = {}
+        monkeypatch.setattr(
+            goals,
+            "run_kanban_goal_loop",
+            lambda **kwargs: captured.update(kwargs),
+        )
+        _run_kanban_goal_loop_q(_FakeCLI(), "first response")
+        assert captured == {}
+
+
+class TestFullLoop:
+    def test_drives_run_kanban_goal_loop_with_wired_callbacks(self, monkeypatch, capsys):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "7")
+        task = _FakeTask(title="Build widget", body="Must pass tests",
+                         status="in_progress", goal_max_turns=5)
+        monkeypatch.setattr(kanban_db, "connect", lambda: _FakeConn())
+        monkeypatch.setattr(kanban_db, "get_task", lambda conn, tid: task)
+        monkeypatch.setattr(kanban_db, "block_task",
+                            lambda conn, tid, reason=None: None)
+
+        cli = _FakeCLI(response="turn output")
+        captured = {}
+
+        def _fake_run_loop(**kwargs):
+            captured.update(kwargs)
+            # Exercise the wired callbacks inside the loop.
+            assert kwargs["run_turn"]("continue") == "turn output"
+            assert kwargs["task_status_fn"]() == "in_progress"
+            kwargs["block_fn"]("stuck")
+
+        monkeypatch.setattr(goals, "run_kanban_goal_loop", _fake_run_loop)
+
+        _run_kanban_goal_loop_q(cli, "first response")
+
+        assert captured["task_id"] == "7"
+        assert captured["goal_text"] == "Build widget\n\nMust pass tests"
+        assert captured["max_turns"] == 5
+        assert captured["first_response"] == "first response"
+        assert captured["log"]("msg") is None  # logger.info callable
+        # The worker turn went through cli.agent.run_conversation with the
+        # CLI's conversation history and the printed response hit stdout.
+        assert cli.agent.calls == [("continue", cli.conversation_history)]
+        assert "turn output" in capsys.readouterr().out
+
+    def test_goal_max_turns_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "7")
+        task = _FakeTask(title="T", body="B", status="in_progress",
+                         goal_max_turns=None)
+        monkeypatch.setattr(kanban_db, "connect", lambda: _FakeConn())
+        monkeypatch.setattr(kanban_db, "get_task", lambda conn, tid: task)
+
+        captured = {}
+        monkeypatch.setattr(
+            goals,
+            "run_kanban_goal_loop",
+            lambda **kwargs: captured.update(kwargs),
+        )
+        _run_kanban_goal_loop_q(_FakeCLI(), "")
+        assert captured["max_turns"] == goals.DEFAULT_MAX_TURNS


### PR DESCRIPTION
## Shard S5 extraction of cli.py

5×2×3 blind-witness large-file decomposition, wave-3-verified. Byte-fidelity extraction, zero behavior change.

Related #78791 #78792 #77376 #77746 #77748 #77751 #77752 #77756 #77759 #79066 #79067 #79068 #79069 #79070 #79392 #79393 #79394 #79395 #79396 #79547 #79548 #79549 #79550 #79551 #79593 #79594 #79595 #79596 #79597 #79613 #79614 #79615 #79616 #79617 #79658 #79659 #79660 #79661 #79662 #79670 #79672 #79673 #79674 #79675