### PR TITLE
refactor(slack): extract markdown table helpers into markdown_table_helpers (adapter.py god-file slice R1)

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -16,7 +16,6 @@ import logging
 import os
 import re
 import time
-import unicodedata
 from dataclasses import dataclass, field
 from typing import Callable, ClassVar, Dict, Optional, Any, Tuple, List
 
@@ -139,117 +138,6 @@ def _slack_file_marker(file_obj: Dict[str, Any]) -> str:
     return f"[file: {name} ({mimetype})]" if mimetype else f"[file: {name}]"
 
 
-# ── GFM markdown table preprocessing ──────────────────────────────────────
-# Slack mrkdwn does not render GFM-style pipe tables — they appear as literal
-# pipes. Wrapping in ``` fences makes them render as monospace preformatted
-# text, and padding cells to per-column max display width (with East-Asian
-# Wide / CJK awareness) keeps the columns aligned for the reader.
-
-_TABLE_SEPARATOR_RE = re.compile(
-    r"^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$"
-)
-
-
-def _is_table_row(line: str) -> bool:
-    """Return True if *line* could plausibly be a table data row."""
-    stripped = line.strip()
-    return bool(stripped) and "|" in stripped
-
-
-def _disp_width(s: str) -> int:
-    """Monospace display width: East-Asian Wide / Full-width chars count as 2."""
-    return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in s)
-
-
-def _pad(cell: str, width: int) -> str:
-    """Right-pad *cell* with spaces until its display width equals *width*."""
-    delta = width - _disp_width(cell)
-    return cell + (" " * delta if delta > 0 else "")
-
-
-def _split_table_row(line: str) -> List[str]:
-    """Split a ``| a | b | c |`` row into trimmed cells (outer pipes optional)."""
-    s = line.strip()
-    if s.startswith("|"):
-        s = s[1:]
-    if s.endswith("|"):
-        s = s[:-1]
-    return [c.strip() for c in s.split("|")]
-
-
-def _align_table(rows: List[str]) -> List[str]:
-    """Re-emit a markdown table with cells padded to per-column max display width.
-
-    *rows[0]* is the header, *rows[1]* is the GFM separator (regenerated to
-    match new column widths), and *rows[2:]* are data rows. Cells are
-    normalized to a uniform column count (missing cells filled with empty
-    strings) before width calculation.
-    """
-    if len(rows) < 2:
-        return rows
-    parsed = [_split_table_row(r) for r in rows]
-    n_cols = max(len(r) for r in parsed)
-    for r in parsed:
-        while len(r) < n_cols:
-            r.append("")
-    sep_idx = 1
-    parsed[sep_idx] = ["---"] * n_cols  # placeholder; regenerated below
-    widths = [max(_disp_width(r[c]) for r in parsed) for c in range(n_cols)]
-    out: List[str] = []
-    for idx, row in enumerate(parsed):
-        if idx == sep_idx:
-            cells = ["-" * widths[c] for c in range(n_cols)]
-        else:
-            cells = [_pad(row[c], widths[c]) for c in range(n_cols)]
-        out.append("| " + " | ".join(cells) + " |")
-    return out
-
-
-def _wrap_markdown_tables(text: str) -> str:
-    """Wrap GFM pipe tables in ``` fences and align column widths.
-
-    Detected by a row containing ``|`` immediately followed by a delimiter row
-    matching :data:`_TABLE_SEPARATOR_RE`. Subsequent pipe-containing non-blank
-    lines are consumed as the table body. Tables already inside fenced code
-    blocks are left alone.
-    """
-    if not text or "|" not in text or "-" not in text:
-        return text
-
-    lines = text.split("\n")
-    out: List[str] = []
-    in_fence = False
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        stripped = line.lstrip()
-        if stripped.startswith("```"):
-            in_fence = not in_fence
-            out.append(line)
-            i += 1
-            continue
-        if in_fence:
-            out.append(line)
-            i += 1
-            continue
-        if (
-            "|" in line
-            and i + 1 < len(lines)
-            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
-        ):
-            block = [line, lines[i + 1]]
-            j = i + 2
-            while j < len(lines) and _is_table_row(lines[j]):
-                block.append(lines[j])
-                j += 1
-            out.append("```")
-            out.extend(_align_table(block))
-            out.append("```")
-            i = j
-            continue
-        out.append(line)
-        i += 1
-    return "\n".join(out)
 
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
@@ -9086,3 +8974,10 @@ def register(ctx) -> None:
         emoji="💼",
         allow_update_command=True,
     )
+# Re-export markdown-table helpers moved to markdown_table_helpers.py
+# (adapter god-file slice R1). Keeps R2 format_message and
+# tests/gateway/test_slack.py::TestWrapMarkdownTables green unchanged.
+from .markdown_table_helpers import (  # noqa: E402,F401
+    _TABLE_SEPARATOR_RE, _is_table_row, _disp_width, _pad,
+    _split_table_row, _align_table, _wrap_markdown_tables,
+)

--- a/plugins/platforms/slack/markdown_table_helpers.py
+++ b/plugins/platforms/slack/markdown_table_helpers.py
@@ -1,0 +1,124 @@
+"""GFM pipe-table preprocessing helpers for Slack mrkdwn.
+
+Extracted verbatim from ``plugins/platforms/slack/adapter.py`` (adapter
+god-file slice R1, consensus window 142-252). Slack mrkdwn does not render
+GFM-style pipe tables; these helpers wrap them in ``` fences and pad cells
+to per-column max display width with East-Asian Wide / CJK awareness, so
+monospace code-block rendering shows readable, aligned columns.
+"""
+
+import re
+import unicodedata
+from typing import List
+
+# ── GFM markdown table preprocessing ──────────────────────────────────────
+# Slack mrkdwn does not render GFM-style pipe tables — they appear as literal
+# pipes. Wrapping in ``` fences makes them render as monospace preformatted
+# text, and padding cells to per-column max display width (with East-Asian
+# Wide / CJK awareness) keeps the columns aligned for the reader.
+
+_TABLE_SEPARATOR_RE = re.compile(
+    r"^\s*\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*){1,}\|?\s*$"
+)
+
+
+def _is_table_row(line: str) -> bool:
+    """Return True if *line* could plausibly be a table data row."""
+    stripped = line.strip()
+    return bool(stripped) and "|" in stripped
+
+
+def _disp_width(s: str) -> int:
+    """Monospace display width: East-Asian Wide / Full-width chars count as 2."""
+    return sum(2 if unicodedata.east_asian_width(c) in "WF" else 1 for c in s)
+
+
+def _pad(cell: str, width: int) -> str:
+    """Right-pad *cell* with spaces until its display width equals *width*."""
+    delta = width - _disp_width(cell)
+    return cell + (" " * delta if delta > 0 else "")
+
+
+def _split_table_row(line: str) -> List[str]:
+    """Split a ``| a | b | c |`` row into trimmed cells (outer pipes optional)."""
+    s = line.strip()
+    if s.startswith("|"):
+        s = s[1:]
+    if s.endswith("|"):
+        s = s[:-1]
+    return [c.strip() for c in s.split("|")]
+
+
+def _align_table(rows: List[str]) -> List[str]:
+    """Re-emit a markdown table with cells padded to per-column max display width.
+
+    *rows[0]* is the header, *rows[1]* is the GFM separator (regenerated to
+    match new column widths), and *rows[2:]* are data rows. Cells are
+    normalized to a uniform column count (missing cells filled with empty
+    strings) before width calculation.
+    """
+    if len(rows) < 2:
+        return rows
+    parsed = [_split_table_row(r) for r in rows]
+    n_cols = max(len(r) for r in parsed)
+    for r in parsed:
+        while len(r) < n_cols:
+            r.append("")
+    sep_idx = 1
+    parsed[sep_idx] = ["---"] * n_cols  # placeholder; regenerated below
+    widths = [max(_disp_width(r[c]) for r in parsed) for c in range(n_cols)]
+    out: List[str] = []
+    for idx, row in enumerate(parsed):
+        if idx == sep_idx:
+            cells = ["-" * widths[c] for c in range(n_cols)]
+        else:
+            cells = [_pad(row[c], widths[c]) for c in range(n_cols)]
+        out.append("| " + " | ".join(cells) + " |")
+    return out
+
+
+def _wrap_markdown_tables(text: str) -> str:
+    """Wrap GFM pipe tables in ``` fences and align column widths.
+
+    Detected by a row containing ``|`` immediately followed by a delimiter row
+    matching :data:`_TABLE_SEPARATOR_RE`. Subsequent pipe-containing non-blank
+    lines are consumed as the table body. Tables already inside fenced code
+    blocks are left alone.
+    """
+    if not text or "|" not in text or "-" not in text:
+        return text
+
+    lines = text.split("\n")
+    out: List[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if in_fence:
+            out.append(line)
+            i += 1
+            continue
+        if (
+            "|" in line
+            and i + 1 < len(lines)
+            and _TABLE_SEPARATOR_RE.match(lines[i + 1])
+        ):
+            block = [line, lines[i + 1]]
+            j = i + 2
+            while j < len(lines) and _is_table_row(lines[j]):
+                block.append(lines[j])
+                j += 1
+            out.append("```")
+            out.extend(_align_table(block))
+            out.append("```")
+            i = j
+            continue
+        out.append(line)
+        i += 1
+    return "\n".join(out)

--- a/tests/plugins/platforms/test_markdown_table_helpers_seam.py
+++ b/tests/plugins/platforms/test_markdown_table_helpers_seam.py
@@ -1,0 +1,121 @@
+"""Seam tests for the slack adapter markdown-table-helper extraction (slice R1).
+
+adapter.py god-file slice R1 moved the GFM pipe-table preprocessing helpers
+(window 142-252) into ``plugins.platforms.slack.markdown_table_helpers``.
+adapter.py now re-exports all seven names from the bottom of the module so
+``format_message`` (R2) and ``tests/gateway/test_slack.py::TestWrapMarkdownTables``
+keep resolving them without change.
+
+These tests pin the seam:
+
+1. **Identity** — every re-exported name in the adapter IS the same object
+   as the definition in ``markdown_table_helpers`` (not a copy/shadow).
+2. **Behavior** — the moved helpers still behave exactly as before on
+   aggressive inputs: table wrap, CJK alignment, edge inputs.
+"""
+
+import plugins.platforms.slack.adapter as _adapter
+import plugins.platforms.slack.markdown_table_helpers as _helpers
+
+MOVED_NAMES = (
+    "_TABLE_SEPARATOR_RE",
+    "_is_table_row",
+    "_disp_width",
+    "_pad",
+    "_split_table_row",
+    "_align_table",
+    "_wrap_markdown_tables",
+)
+
+
+def test_reexport_identity_all_seven_names():
+    """adapter re-exports the very same objects defined in the new module."""
+    for name in MOVED_NAMES:
+        assert getattr(_adapter, name) is getattr(_helpers, name), name
+        assert callable(getattr(_helpers, name)) or name == "_TABLE_SEPARATOR_RE", name
+
+
+def test_adapter_has_no_local_definitions():
+    """The moved bodies live only in markdown_table_helpers, not in adapter."""
+    import inspect
+
+    for name in MOVED_NAMES:
+        fn = getattr(_helpers, name)
+        # The adapter attribute must not be a locally-defined function.
+        if callable(fn):
+            assert inspect.getmodule(fn).__name__ == (
+                "plugins.platforms.slack.markdown_table_helpers"
+            ), name
+
+
+def test_helpers_module_is_stdlib_only():
+    """markdown_table_helpers imports nothing but stdlib / typing."""
+    import importlib
+
+    # Every module object reachable as a module-level attribute must be one
+    # of the three allowed stdlib modules (re, unicodedata, typing).
+    for value in vars(_helpers).values():
+        if isinstance(value, type(importlib)):
+            assert value.__name__ in ("re", "unicodedata", "typing"), value.__name__
+    # And no adapter/slack module may appear in the module's globals.
+    assert "_adapter" not in vars(_helpers)
+    assert not any(
+        getattr(value, "__name__", "").startswith("plugins.platforms.slack.")
+        for value in vars(_helpers).values()
+    )
+
+
+def test_table_wrapped_and_aligned_with_cjk():
+    """Aggressive: CJK cell widths + ragged input still align after wrap."""
+    text = (
+        "| 名称 | status |\n"
+        "|---|---|\n"
+        "| ci | running |\n"
+        "| 部署流水线 | ok |\n"
+        "| x | |\n"
+    )
+    out = _helpers._wrap_markdown_tables(text)
+    assert out.count("```") == 2
+    body = [ln for ln in out.split("\n") if ln.startswith("|")]
+    assert len(body) == 5  # header + separator + 3 data rows
+    # Display widths (not raw char counts) must be uniform across rows.
+    widths = {_helpers._disp_width(ln) for ln in body}
+    assert len(widths) == 1, f"display widths drift: {widths}"
+
+
+def test_align_table_normalizes_ragged_columns():
+    """Aggressive: header/separator/data rows with mismatched cell counts."""
+    rows = [
+        "| a | b |",
+        "|---|---|",
+        "| 1 |",
+        "| 2 | 3 | extra |",
+    ]
+    out = _helpers._align_table(rows)
+    pipe_counts = {ln.count("|") for ln in out}
+    assert len(pipe_counts) == 1, f"pipe counts drift: {pipe_counts}"
+    assert "extra" in out[-1]
+    # Separator regenerated from dashes only, padded to the new widths.
+    sep_cells = [c.strip() for c in out[1].strip("|").split("|")]
+    assert all(set(c) == {"-"} for c in sep_cells), out[1]
+
+
+def test_edge_inputs():
+    """Aggressive: empty, no-table, fence-guarded, and degenerate rows."""
+    assert _helpers._wrap_markdown_tables("") == ""
+    plain = "Just text, no | pipes."
+    assert _helpers._wrap_markdown_tables(plain) == plain
+    # A single pipe with no delimiter row must NOT be wrapped.
+    lone = "a | b"
+    assert _helpers._wrap_markdown_tables(lone) == lone
+    # Already-fenced code containing pipe lines must be left untouched.
+    fenced = "```\n| a | b |\n|---|---|\n| 1 | 2 |\n```\n"
+    assert _helpers._wrap_markdown_tables(fenced) == fenced
+    # Degenerate: header only, no separator.
+    assert _helpers._wrap_markdown_tables("| a | b |") == "| a | b |"
+
+
+def test_split_table_row_outer_pipes_optional():
+    assert _helpers._split_table_row("| a | b |") == ["a", "b"]
+    assert _helpers._split_table_row("a | b") == ["a", "b"]
+    assert _helpers._split_table_row("|   spaced   | x |") == ["spaced", "x"]


### PR DESCRIPTION
## Summary

slack adapter.py god-file slice **R1**: extract the markdown-table helpers from `plugins/platforms/slack/adapter.py` (9,088 lines) into `plugins/platforms/slack/markdown_table_helpers.py`. Part of the repo-wide large-file decomposition (tracker #78647).

## What changed and why

- Markdown-table helpers (window 142–252, 111 lines, 7 names: `_TABLE_SEPARATOR_RE`, `_is_table_row`, `_disp_width`, `_pad`, `_split_table_row`, `_align_table`, `_wrap_markdown_tables`) moved byte-verbatim (golden sha `b2c71c1e…` exact match)
- **Pure stdlib leaf**: zero `self`, closed call subgraph, sole external user is R2's `format_message` @3566
- adapter.py re-exports the 7 names identity-preserving (`TestWrapMarkdownTables` @test_slack.py:4437 stays green via re-export)
- Also dropped the dead `unicodedata` import (used only in the moved window)
- **Double-blind**: 2 analysts → consensus (pass B's leaf pick won over pass A's SocketMode mixin on all 5 criteria) → implementer → 2 blind re-reviewers (both APPROVED, mutation-control verified)

## Testing

- **232 passed, 0 failed** (7 seam + 161 test_slack incl. TestWrapMarkdownTables + 64 relay/registry)
- 7/7 re-export identity asserted (`getattr(adapter, n) is getattr(markdown_table_helpers, n)`)
- ruff clean · git diff --check clean · LF-only · DCO signed

## Coordination / interlock

- **Epic:** Part of #78647 · **Target:** Part of #78638
- **KILL LOCK:** part of the slack adapter kill record (posted on #78638) — mess (#71827 reactions, #70518 child timestamps, #13126 TTS, #77805 streaming, #51623 SocketMode) + 31 fixer PRs; indexed by large-file decomposition meta-issue #78647
- **Sibling PRs:** slack gate-mixin + reaction-hooks (same wave) — disjoint windows
- **Dedup:** no existing PR extracts the helpers (open-PR sweep clean)

Part of #78647
Part of #78638

Part of #79772
