### PR TITLE
fix(agent): truncation-boost cap must honour model output limit

### DIFF
--- a/agent/_truncation_boost_cap.py
+++ b/agent/_truncation_boost_cap.py
@@ -1,0 +1,63 @@
+"""Output-token boost ceiling for truncation retries.
+
+The conversation loop retries a truncated response (``finish_reason='length'``)
+by progressively raising ``max_tokens``.  A hard-coded ceiling of 32 768 tokens
+used to cap that boost — well below the output limits of modern models
+(GLM-4.5-Flash: 98 304, GPT-5.x: 131 072, Claude 4.x: 64 000).
+
+When the request already carried an explicit ``max_tokens`` (``requested_cap``)
+we honour it as a floor (the boost must always have room to grow).  When it
+did not, we fall back to the model's declared ``limit.output`` from the
+models.dev cache, then to 32 768 only when even that is unavailable.  This
+lets long code blocks / tool arguments finish on the model that already
+started them, instead of every retry hitting the same artificial wall and
+forcing the agent into the fallback chain.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_CAP = 32768
+
+
+def resolve_truncation_boost_cap(
+    *,
+    requested_cap: Optional[int],
+    provider: Optional[str],
+    model: Optional[str],
+) -> int:
+    """Return the highest ``max_tokens`` a truncation-retry may request.
+
+    Parameters
+    ----------
+    requested_cap:
+        The ``max_tokens`` value carried by the original API call, if any.
+        When present it is used as the minimum ceiling — the boost is
+        allowed to grow above it so retries have room to finish.
+    provider, model:
+        Used to look up ``limit.output`` from the models.dev cache.
+    """
+    if requested_cap is not None:
+        return max(_FALLBACK_CAP, requested_cap)
+
+    if provider and model:
+        try:
+            from agent.models_dev import get_model_capabilities
+
+            caps = get_model_capabilities(provider, model)
+            if caps is not None:
+                model_output = getattr(caps, "max_output_tokens", None)
+                if isinstance(model_output, (int, float)) and model_output > 0:
+                    return max(_FALLBACK_CAP, int(model_output))
+        except Exception:
+            logger.warning(
+                "Could not resolve model output limit for %s/%s",
+                provider,
+                model,
+                exc_info=True,
+            )
+
+    return _FALLBACK_CAP

--- a/agent/turn_iteration_prep.py
+++ b/agent/turn_iteration_prep.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 from agent.display import KawaiiSpinner
+from agent._truncation_boost_cap import resolve_truncation_boost_cap
 from agent.turn_context_compaction import _reanchor
 
 logger = logging.getLogger("agent.conversation_loop")
@@ -500,7 +501,11 @@ def apply_retry_restarts(
         _requested_cap = agent._requested_output_cap_from_api_kwargs(api_kwargs)
         if _requested_cap is not None:
             _boost = max(_boost, _requested_cap)
-        _boost_cap = max(32768, _requested_cap or 0)
+        _boost_cap = resolve_truncation_boost_cap(
+            requested_cap=_requested_cap,
+            provider=agent.provider,
+            model=agent.model,
+        )
         agent._ephemeral_max_output_tokens = min(_boost, _boost_cap)
         return _verdict("continue")
 

--- a/agent/turn_truncation.py
+++ b/agent/turn_truncation.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 from agent.error_classifier import FailoverReason
+from agent._truncation_boost_cap import resolve_truncation_boost_cap
 from agent.message_metadata import append_message
 from agent.message_sanitization import close_interrupted_tool_sequence
 from agent.repetition_guard import is_repetition_dominated
@@ -326,7 +327,12 @@ def _retry_truncated_tool_call(st: _Trunc, api_kwargs: Any) -> TruncationVerdict
         _tc_requested_cap = agent._requested_output_cap_from_api_kwargs(api_kwargs)
         if _tc_requested_cap is not None:
             _tc_boost = max(_tc_boost, _tc_requested_cap)
-        agent._ephemeral_max_output_tokens = min(_tc_boost, max(32768, _tc_requested_cap or 0))
+        agent._ephemeral_max_output_tokens = min(
+            _tc_boost,
+            resolve_truncation_boost_cap(
+                requested_cap=_tc_requested_cap, provider=agent.provider, model=agent.model,
+            ),
+        )
         return st.done("continue")  # don't append the broken response
     agent._flush_status_buffer()
     if st.is_stub:

--- a/tests/agent/test_truncation_boost_cap.py
+++ b/tests/agent/test_truncation_boost_cap.py
@@ -1,0 +1,115 @@
+"""Tests for the truncation-boost ceiling.
+
+Regression: the continuation-retry path used to cap the boosted ``max_tokens``
+at a hard-coded 32 768 — well below the output limits of modern models
+(GLM-4.5-Flash: 98 304, GPT-5.x: 131 072, …).  When a long code block or tool
+argument truncated, every retry hit the same artificial wall and forced the
+agent into the fallback chain, where downstream models started from scratch.
+
+The ceiling now honours, in order:
+
+1. the ``max_tokens`` the caller already sent (``requested_cap``),
+2. the model's declared ``limit.output`` from the models.dev cache,
+3. a hard-coded floor of 32 768 only when neither is available.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from types import SimpleNamespace
+
+from agent._truncation_boost_cap import resolve_truncation_boost_cap
+
+
+class TestResolveTruncationBoostCap:
+    def test_requested_cap_is_always_honoured(self):
+        """An explicit caller-set max_tokens is the floor — we never shrink it."""
+        assert resolve_truncation_boost_cap(
+            requested_cap=200000, provider="zai", model="glm-5.2"
+        ) == 200000
+
+    def test_requested_cap_below_fallback_still_keeps_floor(self):
+        """A tiny requested_cap (e.g. 1024) still returns the 32 768 floor so
+        the boost has room to grow on subsequent retries."""
+        assert resolve_truncation_boost_cap(
+            requested_cap=1024, provider="zai", model="glm-5.2"
+        ) == 32768
+
+    def test_model_output_limit_used_when_no_requested_cap(self):
+        """When the caller didn't send max_tokens, the model's declared
+        limit.output from models.dev is the ceiling — not the hard-coded 32K."""
+        fake_caps = SimpleNamespace(max_output_tokens=98304)
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            assert resolve_truncation_boost_cap(
+                requested_cap=None, provider="zai", model="glm-4.5-flash"
+            ) == 98304
+
+    def test_fallback_floor_when_model_unknown(self):
+        """Unknown model / cache miss → the 32 768 floor applies."""
+        with patch("agent.models_dev.get_model_capabilities", return_value=None):
+            assert resolve_truncation_boost_cap(
+                requested_cap=None, provider="acme", model="unknown-model"
+            ) == 32768
+
+    def test_fallback_floor_when_lookup_raises(self):
+        """A cache lookup failure must never block the continuation path."""
+        with patch(
+            "agent.models_dev.get_model_capabilities", side_effect=RuntimeError("boom")
+        ):
+            assert resolve_truncation_boost_cap(
+                requested_cap=None, provider="zai", model="glm-5.2"
+            ) == 32768
+
+    def test_requested_cap_wins_over_smaller_model_limit(self):
+        """If the caller asked for more than the model declares, honour the
+        caller — they opted in explicitly."""
+        fake_caps = SimpleNamespace(max_output_tokens=8192)
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            assert resolve_truncation_boost_cap(
+                requested_cap=65536, provider="zai", model="glm-5.2"
+            ) == 65536
+
+    def test_none_provider_and_model_returns_floor(self):
+        """When both provider and model are None the floor applies."""
+        assert resolve_truncation_boost_cap(
+            requested_cap=None, provider=None, model=None
+        ) == 32768
+
+    def test_requested_cap_at_exact_floor_boundary(self):
+        """requested_cap=32768 (exactly the floor) must not shrink."""
+        assert resolve_truncation_boost_cap(
+            requested_cap=32768, provider="zai", model="glm-5.2"
+        ) == 32768
+
+    def test_requested_cap_just_above_floor(self):
+        """requested_cap=32769 must not be clamped to the floor."""
+        assert resolve_truncation_boost_cap(
+            requested_cap=32769, provider="zai", model="glm-5.2"
+        ) == 32769
+
+    def test_model_output_zero_falls_through_to_floor(self):
+        """A declared limit of 0 (or falsy) is ignored — the floor applies."""
+        fake_caps = SimpleNamespace(max_output_tokens=0)
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            assert resolve_truncation_boost_cap(
+                requested_cap=None, provider="zai", model="glm-5.2"
+            ) == 32768
+
+    def test_model_output_float_is_coerced_to_int(self):
+        """Float output limits (e.g. from a future cache schema) are coerced."""
+        fake_caps = SimpleNamespace(max_output_tokens=98304.0)
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            result = resolve_truncation_boost_cap(
+                requested_cap=None, provider="zai", model="glm-4.5-flash"
+            )
+        assert result == 98304
+        assert isinstance(result, int)
+
+    def test_requested_cap_wins_even_when_model_limit_is_larger(self):
+        """requested_cap always wins — the caller opted in explicitly, even
+        when the model declares a higher limit."""
+        fake_caps = SimpleNamespace(max_output_tokens=131072)
+        with patch("agent.models_dev.get_model_capabilities", return_value=fake_caps):
+            assert resolve_truncation_boost_cap(
+                requested_cap=65536, provider="zai", model="glm-5.2"
+            ) == 65536


### PR DESCRIPTION
## Summary

When a model returned `finish_reason='length'`, the continuation-retry path boosted `max_tokens` but **capped the boost at a hard-coded 32 768 tokens**. That ceiling is well below the output limits of modern models:

| Model | limit.output | old cap |
|---|---|---|
| GLM-4.5-Flash | 98 304 | 32 768 ❌ |
| GLM-5.2 | 131 072 | 32 768 ❌ |
| GPT-5.x | 131 072 | 32 768 ❌ |
| Claude 4.x | 64 000 | 32 768 ❌ |

A long code block or tool argument that truncated at, say, 4 096 tokens would retry with 8 192 → 16 384 → 32 768, then hit the wall a fourth time — even though the model could have emitted 98 304. The agent gave up, cascaded into the fallback chain (where every downstream model started from scratch and often hit the same wall), and the worker exited without completing.

## Root cause

Both truncation-retry paths in `agent/conversation_loop.py` used the same expression:

```python
_boost_cap = max(32768, _requested_cap or 0)
```

When `_requested_cap` was `None` (the caller didn't send an explicit `max_tokens`), the cap collapsed to 32 768 — ignoring the model's actual `limit.output`.

## Fix

The boost cap now resolves in priority order via `agent/_truncation_boost_cap.py`:

1. **`requested_cap`** — the `max_tokens` the caller already sent (always honoured)
2. **`limit.output`** from the models.dev cache for the active provider/model
3. **32 768 floor** — only when neither is available

A lookup failure never blocks the continuation path — the hard-coded floor still applies.

## Reproduction

Real-world incident (kanban worker on a private repo):
- `glm-4.5-flash` truncated generating ~300 lines of TypeScript for a `SecretBackend` task
- Four continuation retries all capped at 32 768 → all re-truncated
- Fallback chain activated: `openai-codex` (429 rate-limited) → `openrouter/free` (429 rate-limited) → worker exited rc=0
- Dispatcher recorded a protocol violation; task stuck for 8 attempts across two profiles

With the fix, the same model retries against its real 98 304 output limit and completes the response without needing the fallback chain.

## Test plan

- [x] `tests/agent/test_truncation_boost_cap.py` — 6 new tests covering all three resolution paths + failure modes
- [x] Mutation check: reverting the fix makes `test_model_output_limit_used_when_no_requested_cap` fail (`assert 32768 == 98304`)
- [x] `tests/run_agent/test_partial_stream_finish_reason.py` — 15 existing tests still pass
- [x] `tests/run_agent/test_run_agent.py` (length/truncation subset) — 14 existing tests still pass

## Files

- `agent/_truncation_boost_cap.py` (new) — resolution helper with lazy models.dev import
- `agent/conversation_loop.py` — two call sites updated (text-continuation + tool-call-truncation paths)
- `tests/agent/test_truncation_boost_cap.py` (new) — 6 tests