### PR TITLE
feat(plugins): expose active parent session id

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1674,6 +1674,26 @@ class PluginContext:
             )
         return self._subagent_lifecycle
 
+    # -- parent-session awareness ------------------------------------------
+
+    @property
+    def active_parent_session_id(self) -> Optional[str]:
+        """Return the active host-owned parent session id, if available.
+
+        The task-local subagent parent is authoritative.  Interactive CLI
+        state is only a fallback while the agent is idle; non-interactive
+        contexts without a bound parent return ``None``.
+        """
+        from agent.subagent_lifecycle import get_active_subagent_parent
+
+        parent = get_active_subagent_parent()
+        if parent is not None:
+            return getattr(parent, "session_id", None)
+
+        cli = self._manager._cli_ref
+        agent = getattr(cli, "agent", None) if cli is not None else None
+        return getattr(agent, "session_id", None)
+
     # -- profile awareness --------------------------------------------------
 
     @property

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -386,6 +386,26 @@ class PluginContext:
             )
         return self._subagent_lifecycle
 
+    # -- parent-session awareness ------------------------------------------
+
+    @property
+    def active_parent_session_id(self) -> Optional[str]:
+        """Return the active host-owned parent session id, if available.
+
+        The task-local subagent parent is authoritative.  Interactive CLI
+        state is only a fallback while the agent is idle; non-interactive
+        contexts without a bound parent return ``None``.
+        """
+        from agent.subagent_lifecycle import get_active_subagent_parent
+
+        parent = get_active_subagent_parent()
+        if parent is not None:
+            return getattr(parent, "session_id", None)
+
+        cli = self._manager._cli_ref
+        agent = getattr(cli, "agent", None) if cli is not None else None
+        return getattr(agent, "session_id", None)
+
     # -- profile awareness --------------------------------------------------
 
     @property

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -2268,6 +2268,66 @@ class TestPluginDebugLogging:
             plugins_mod.logger.handlers = original_handlers
 
 
+class TestPluginContextActiveParentSessionId:
+    """ctx.active_parent_session_id resolves the current host-owned session."""
+
+    def _ctx(self, manager=None):
+        manager = manager or PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        return PluginContext(manifest, manager)
+
+    def test_bound_parent_session_id(self):
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        ctx = self._ctx()
+        parent = types.SimpleNamespace(session_id="bound-session")
+
+        with bind_subagent_parent(parent):
+            assert ctx.active_parent_session_id == "bound-session"
+
+    def test_task_local_parent_outranks_cli_fallback(self):
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        manager = PluginManager()
+        manager._cli_ref = types.SimpleNamespace(
+            agent=types.SimpleNamespace(session_id="cli-session")
+        )
+        ctx = self._ctx(manager)
+
+        with bind_subagent_parent(
+            types.SimpleNamespace(session_id="task-local-session")
+        ):
+            assert ctx.active_parent_session_id == "task-local-session"
+
+    def test_idle_cli_session_is_fallback(self):
+        manager = PluginManager()
+        manager._cli_ref = types.SimpleNamespace(
+            agent=types.SimpleNamespace(session_id="cli-session")
+        )
+
+        assert self._ctx(manager).active_parent_session_id == "cli-session"
+
+    def test_no_parent_session_returns_none(self):
+        assert self._ctx().active_parent_session_id is None
+
+    def test_copied_contexts_keep_parent_sessions_isolated(self):
+        import contextvars
+
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        ctx = self._ctx()
+        first_context = contextvars.copy_context()
+        second_context = contextvars.copy_context()
+
+        def resolve(session_id):
+            with bind_subagent_parent(types.SimpleNamespace(session_id=session_id)):
+                return ctx.active_parent_session_id
+
+        assert first_context.run(resolve, "first-session") == "first-session"
+        assert second_context.run(resolve, "second-session") == "second-session"
+        assert ctx.active_parent_session_id is None
+
+
 class TestPluginContextProfileName:
     """ctx.profile_name resolves from HERMES_HOME in every context."""
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1130,6 +1130,66 @@ class TestPluginDebugLogging:
             plugins_mod.logger.handlers = original_handlers
 
 
+class TestPluginContextActiveParentSessionId:
+    """ctx.active_parent_session_id resolves the current host-owned session."""
+
+    def _ctx(self, manager=None):
+        manager = manager or PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        return PluginContext(manifest, manager)
+
+    def test_bound_parent_session_id(self):
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        ctx = self._ctx()
+        parent = types.SimpleNamespace(session_id="bound-session")
+
+        with bind_subagent_parent(parent):
+            assert ctx.active_parent_session_id == "bound-session"
+
+    def test_task_local_parent_outranks_cli_fallback(self):
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        manager = PluginManager()
+        manager._cli_ref = types.SimpleNamespace(
+            agent=types.SimpleNamespace(session_id="cli-session")
+        )
+        ctx = self._ctx(manager)
+
+        with bind_subagent_parent(
+            types.SimpleNamespace(session_id="task-local-session")
+        ):
+            assert ctx.active_parent_session_id == "task-local-session"
+
+    def test_idle_cli_session_is_fallback(self):
+        manager = PluginManager()
+        manager._cli_ref = types.SimpleNamespace(
+            agent=types.SimpleNamespace(session_id="cli-session")
+        )
+
+        assert self._ctx(manager).active_parent_session_id == "cli-session"
+
+    def test_no_parent_session_returns_none(self):
+        assert self._ctx().active_parent_session_id is None
+
+    def test_copied_contexts_keep_parent_sessions_isolated(self):
+        import contextvars
+
+        from agent.subagent_lifecycle import bind_subagent_parent
+
+        ctx = self._ctx()
+        first_context = contextvars.copy_context()
+        second_context = contextvars.copy_context()
+
+        def resolve(session_id):
+            with bind_subagent_parent(types.SimpleNamespace(session_id=session_id)):
+                return ctx.active_parent_session_id
+
+        assert first_context.run(resolve, "first-session") == "first-session"
+        assert second_context.run(resolve, "second-session") == "second-session"
+        assert ctx.active_parent_session_id is None
+
+
 class TestPluginContextProfileName:
     """ctx.profile_name resolves from HERMES_HOME in every context."""
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -1226,10 +1226,11 @@ def register(ctx):
 
 This is the public, stable interface for tool dispatch from plugin commands. Plugins should not reach into `ctx._cli_ref.agent` or similar private state.
 
-### Act from inside a hook (profile + tools)
+### Act from inside a hook (profile + tools + parent session)
 
-`ctx._cli_ref` is only populated in an **interactive CLI** session. It is `None` in the gateway, in non-interactive `hermes chat -q` runs, and in **kanban-spawned worker sessions** — so any plugin logic that reaches through `_cli_ref` silently no-ops in exactly those contexts. Two stable, session-agnostic APIs cover what hooks actually need:
+`ctx._cli_ref` is only populated in an **interactive CLI** session. It is `None` in the gateway, in non-interactive `hermes chat -q` runs, and in **kanban-spawned worker sessions** — so any plugin logic that reaches through `_cli_ref` silently no-ops in exactly those contexts. Three stable, session-agnostic APIs cover what hooks actually need:
 
+- **`ctx.active_parent_session_id`** — the read-only active parent session id. Hermes first resolves the task-local parent bound to the current agent turn, then falls back to the interactive CLI agent while idle; it returns `None` when neither exists. Task-local bindings remain isolated across copied execution contexts, and this property never consults process environment variables.
 - **`ctx.profile_name`** — the active profile name (e.g. `"default"`, or the assignee profile in a kanban worker). Derived from `HERMES_HOME`, so it works everywhere with no `_cli_ref` dependency.
 - **`ctx.dispatch_tool(name, args)`** — invoke any registered tool (built-in or plugin), including the `kanban_*` tools, `delegate_task`, `terminal`, `read_file`, etc. Works from hook callbacks regardless of which process the hook fires in.
 

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -860,10 +860,11 @@ def register(ctx):
 
 This is the public, stable interface for tool dispatch from plugin commands. Plugins should not reach into `ctx._cli_ref.agent` or similar private state.
 
-### Act from inside a hook (profile + tools)
+### Act from inside a hook (profile + tools + parent session)
 
-`ctx._cli_ref` is only populated in an **interactive CLI** session. It is `None` in the gateway, in non-interactive `hermes chat -q` runs, and in **kanban-spawned worker sessions** — so any plugin logic that reaches through `_cli_ref` silently no-ops in exactly those contexts. Two stable, session-agnostic APIs cover what hooks actually need:
+`ctx._cli_ref` is only populated in an **interactive CLI** session. It is `None` in the gateway, in non-interactive `hermes chat -q` runs, and in **kanban-spawned worker sessions** — so any plugin logic that reaches through `_cli_ref` silently no-ops in exactly those contexts. Three stable, session-agnostic APIs cover what hooks actually need:
 
+- **`ctx.active_parent_session_id`** — the read-only active parent session id. Hermes first resolves the task-local parent bound to the current agent turn, then falls back to the interactive CLI agent while idle; it returns `None` when neither exists. Task-local bindings remain isolated across copied execution contexts, and this property never consults process environment variables.
 - **`ctx.profile_name`** — the active profile name (e.g. `"default"`, or the assignee profile in a kanban worker). Derived from `HERMES_HOME`, so it works everywhere with no `_cli_ref` dependency.
 - **`ctx.dispatch_tool(name, args)`** — invoke any registered tool (built-in or plugin), including the `kanban_*` tools, `delegate_task`, `terminal`, `read_file`, etc. Works from hook callbacks regardless of which process the hook fires in.
 


### PR DESCRIPTION
## Summary
- expose a read-only PluginContext.active_parent_session_id
- prefer exact task-local parent identity, with interactive CLI fallback
- return None when neither source exists; never consult process-global session environment
- document the plugin API

## Why
Standalone plugins such as hermes-talk need to scope asynchronous lifecycle events to the owning conversation without reading private CLI internals or process-global environment state.

## Verification
- 43 plugin tests pass on current main
- task-local precedence, CLI fallback, missing-parent, and copied-context isolation covered
- Ruff and diff checks pass