### PR TITLE
fix(compression): stop fresh-tail context overflow retry loops

### DIFF
--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -346,6 +346,27 @@ class ContextEngine(ABC):
         """
         return False
 
+    # -- Optional: mid-turn request-pressure hook --------------------------
+
+    def should_compress_request_pressure(
+        self, messages: List[Dict[str, Any]], prompt_tokens: int
+    ) -> bool:
+        """Return True when a pre-API pressure check should compact now.
+
+        This hook is distinct from :meth:`should_compress_preflight`: preflight
+        is a turn-prologue/deferred-maintenance signal, while request pressure
+        fires immediately before an API call after tools, injected context, and
+        API-only overhead have been assembled.  The default delegates to the
+        legacy token-only :meth:`should_compress` so the built-in compressor and
+        older engines keep their existing behavior.
+
+        Context engines with protected/fresh-tail semantics should override this
+        to inspect ``messages`` and return False when the over-threshold request
+        has no eligible material to compact.  That prevents no-op compression
+        retries that cannot shrink the protected tail.
+        """
+        return self.should_compress(prompt_tokens)
+
     def get_automatic_compaction_status_message(
         self,
         *,

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -367,6 +367,16 @@ class ContextEngine(ABC):
         """
         return self.should_compress(prompt_tokens)
 
+    def overflow_recovery_failed(self) -> bool:
+        """Return True when the last forced overflow recovery still exceeded budget.
+
+        Most engines never run a distinct forced-overflow assembly path, so the
+        default is False.  Engines that can prove their protected/fresh tail
+        remains too large should override this so the host can stop retry loops
+        without depending on engine-private attributes.
+        """
+        return False
+
     def get_automatic_compaction_status_message(
         self,
         *,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -35,7 +35,7 @@ from agent.conversation_compression import (
     compression_skipped_due_to_lock,
     conversation_history_after_compression,
 )
-from agent.context_engine import automatic_compaction_status_message
+from agent.context_engine import ContextEngine, automatic_compaction_status_message
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.turn_context import (
@@ -990,11 +990,19 @@ def _context_engine_overflow_recovery_failed(agent) -> bool:
     _compressor = getattr(agent, "context_compressor", None)
     _checker = getattr(_compressor, "overflow_recovery_failed", None)
     if callable(_checker):
-        try:
-            return bool(_checker())
-        except Exception:
-            logger.exception("context engine overflow_recovery_failed hook failed")
-            return False
+        _class_checker = getattr(type(_compressor), "overflow_recovery_failed", None)
+        _instance_checker = getattr(_compressor, "__dict__", {}).get(
+            "overflow_recovery_failed"
+        )
+        if (
+            _instance_checker is not None
+            or _class_checker is not ContextEngine.overflow_recovery_failed
+        ):
+            try:
+                return bool(_checker())
+            except Exception:
+                logger.exception("context engine overflow_recovery_failed hook failed")
+                return False
     # Compatibility for older plugin engines that predate the public hook.
     return getattr(_compressor, "_last_overflow_recovery_failed", False) is True
 
@@ -2060,43 +2068,46 @@ def run_conversation(
                 f"{_previous_preflight_pressure:,}",
                 f"{request_pressure_tokens:,}",
             )
-        _defer_preflight = getattr(
-            _compressor, "should_defer_preflight_to_real_usage", lambda _t: False
-        )
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
-        _preflight_deferred = _defer_preflight(request_pressure_tokens)
+        _preflight_deferred = False
         _can_run_pre_api_compression = (
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
             and not _preflight_compression_blocked
-            and not _preflight_deferred
             and not _compression_cooldown
         )
+        if _can_run_pre_api_compression:
+            _defer_preflight = getattr(
+                _compressor, "should_defer_preflight_to_real_usage", lambda _t: False
+            )
+            _preflight_deferred = bool(_defer_preflight(request_pressure_tokens))
+            if _preflight_deferred:
+                _can_run_pre_api_compression = False
         _request_pressure_eligible = False
         if _can_run_pre_api_compression:
             _request_pressure_hook = getattr(
                 _compressor, "should_compress_request_pressure", None
             )
+            _request_pressure_decision = None
             if callable(_request_pressure_hook):
                 try:
-                    _request_pressure_eligible = bool(_request_pressure_hook(
+                    _request_pressure_decision = _request_pressure_hook(
                         messages,
                         request_pressure_tokens,
-                    ))
+                    )
                 except Exception:
                     logger.exception(
                         "context engine should_compress_request_pressure failed; falling back to should_compress"
                     )
-                    _request_pressure_eligible = _compressor.should_compress(
-                        request_pressure_tokens
-                    )
-            else:
+            if _request_pressure_decision is None:
                 _request_pressure_eligible = _compressor.should_compress(
                     request_pressure_tokens
                 )
+            else:
+                _request_pressure_eligible = bool(_request_pressure_decision)
         if _can_run_pre_api_compression and _request_pressure_eligible:
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -89,7 +89,9 @@ from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
+from tools.budget_config import budget_for_context_window
 from tools.skill_provenance import set_current_write_origin
+from tools.tool_result_storage import enforce_recent_tool_tail_budget
 from utils import base_url_host_matches, env_var_enabled
 
 logger = logging.getLogger(__name__)
@@ -2040,6 +2042,42 @@ def run_conversation(
         _preflight_threshold = int(
             getattr(_compressor, "threshold_tokens", 0) or 0
         )
+        if (
+            len(messages) > 1
+            and _preflight_threshold > 0
+            and request_pressure_tokens >= _preflight_threshold
+        ):
+            _context_length = int(getattr(_compressor, "context_length", 0) or 0)
+            _tail_budget_config = budget_for_context_window(_context_length)
+            try:
+                from tools.terminal_tool import get_active_env
+                _tail_budget_env = get_active_env(effective_task_id)
+            except Exception:
+                _tail_budget_env = None
+            try:
+                _tool_tail_reduced = enforce_recent_tool_tail_budget(
+                    messages,
+                    env=_tail_budget_env,
+                    config=_tail_budget_config,
+                )
+            except Exception:
+                logger.exception("recent tool-tail budget enforcement failed")
+                _tool_tail_reduced = False
+            if _tool_tail_reduced:
+                logger.info(
+                    "Pre-API tool-tail budget enforcement reduced recent tool output before provider call: ~%s request tokens >= %s threshold",
+                    f"{request_pressure_tokens:,}",
+                    f"{_preflight_threshold:,}",
+                )
+                pending_moa_prepared_request = None
+                _last_preflight_pressure = None
+                api_call_count -= 1
+                agent._api_call_count = api_call_count
+                try:
+                    agent.iteration_budget.refund()
+                except Exception:
+                    pass
+                continue
         # A previous mid-turn preflight pass deliberately continued the loop so
         # API-only context and all sanitization could be rebuilt. Compare that
         # fully assembled request with the fully assembled request that caused

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1007,7 +1007,10 @@ def _context_engine_overflow_recovery_failed(agent) -> bool:
         )
         if (
             _instance_checker is not None
-            or _class_checker is not ContextEngine.overflow_recovery_failed
+            or (
+                _class_checker is not None
+                and _class_checker is not ContextEngine.overflow_recovery_failed
+            )
         ):
             try:
                 return bool(_checker())

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -89,7 +89,7 @@ from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
-from tools.budget_config import budget_for_context_window
+from tools.budget_config import DEFAULT_BUDGET, budget_for_context_window
 from tools.skill_provenance import set_current_write_origin
 from tools.tool_result_storage import enforce_recent_tool_tail_budget
 from utils import base_url_host_matches, env_var_enabled
@@ -119,6 +119,15 @@ _LOCAL_PROCESSING_MODULES = frozenset({
 _API_CALL_MODULES = frozenset({
     "chat_completion_helpers",
 })
+
+
+def _budget_for_context_compressor(compressor: Any):
+    """Resolve tool-result budgets from a context compressor, with fallback."""
+    try:
+        context_length = getattr(compressor, "context_length", None)
+        return budget_for_context_window(int(context_length)) if context_length else DEFAULT_BUDGET
+    except Exception:
+        return DEFAULT_BUDGET
 
 
 def _apply_active_turn_redirect(agent: Any, messages: List[Dict[str, Any]], text: str) -> None:
@@ -2047,8 +2056,7 @@ def run_conversation(
             and _preflight_threshold > 0
             and request_pressure_tokens >= _preflight_threshold
         ):
-            _context_length = int(getattr(_compressor, "context_length", 0) or 0)
-            _tail_budget_config = budget_for_context_window(_context_length)
+            _tail_budget_config = _budget_for_context_compressor(_compressor)
             try:
                 from tools.terminal_tool import get_active_env
                 _tail_budget_env = get_active_env(effective_task_id)
@@ -2069,7 +2077,7 @@ def run_conversation(
                     f"{request_pressure_tokens:,}",
                     f"{_preflight_threshold:,}",
                 )
-                pending_moa_prepared_request = None
+                pending_moa_prepared_request = _moa_prepared_request
                 _last_preflight_pressure = None
                 api_call_count -= 1
                 agent._api_call_count = api_call_count

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -985,6 +985,39 @@ def _fresh_tail_context_exhausted_result(
     }
 
 
+def _context_engine_overflow_recovery_failed(agent) -> bool:
+    """Return whether the active context engine reports failed overflow recovery."""
+    _compressor = getattr(agent, "context_compressor", None)
+    _checker = getattr(_compressor, "overflow_recovery_failed", None)
+    if callable(_checker):
+        try:
+            return bool(_checker())
+        except Exception:
+            logger.exception("context engine overflow_recovery_failed hook failed")
+            return False
+    # Compatibility for older plugin engines that predate the public hook.
+    return getattr(_compressor, "_last_overflow_recovery_failed", False) is True
+
+
+def _fresh_tail_context_exhausted_result_if_needed(
+    agent,
+    messages: List[Dict],
+    conversation_history: Optional[List[Dict]],
+    api_call_count: int,
+    *,
+    attempted_tokens: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    if not _context_engine_overflow_recovery_failed(agent):
+        return None
+    return _fresh_tail_context_exhausted_result(
+        agent,
+        messages,
+        conversation_history,
+        api_call_count,
+        attempted_tokens=attempted_tokens,
+    )
+
+
 def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
     """Rewrite a cache-decorated system message in place, keeping its blocks.
 
@@ -2033,33 +2066,38 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
-        _request_pressure_eligible = None
-        _request_pressure_hook = getattr(
-            _compressor, "should_compress_request_pressure", None
-        )
-        if callable(_request_pressure_hook):
-            try:
-                _request_pressure_eligible = _request_pressure_hook(
-                    messages,
-                    request_pressure_tokens,
-                )
-            except Exception:
-                logger.exception(
-                    "context engine should_compress_request_pressure failed; falling back to should_compress"
-                )
-        if _request_pressure_eligible is None:
-            _request_pressure_eligible = _compressor.should_compress(
-                request_pressure_tokens
-            )
-        if (
+        _preflight_deferred = _defer_preflight(request_pressure_tokens)
+        _can_run_pre_api_compression = (
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
             and not _preflight_compression_blocked
-            and not _defer_preflight(request_pressure_tokens)
+            and not _preflight_deferred
             and not _compression_cooldown
-            and _request_pressure_eligible
-        ):
+        )
+        _request_pressure_eligible = False
+        if _can_run_pre_api_compression:
+            _request_pressure_hook = getattr(
+                _compressor, "should_compress_request_pressure", None
+            )
+            if callable(_request_pressure_hook):
+                try:
+                    _request_pressure_eligible = bool(_request_pressure_hook(
+                        messages,
+                        request_pressure_tokens,
+                    ))
+                except Exception:
+                    logger.exception(
+                        "context engine should_compress_request_pressure failed; falling back to should_compress"
+                    )
+                    _request_pressure_eligible = _compressor.should_compress(
+                        request_pressure_tokens
+                    )
+            else:
+                _request_pressure_eligible = _compressor.should_compress(
+                    request_pressure_tokens
+                )
+        if _can_run_pre_api_compression and _request_pressure_eligible:
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request
             compression_attempts += 1
@@ -2124,14 +2162,15 @@ def run_conversation(
                 if pending_moa_prepared_request is _moa_prepared_request:
                     pending_moa_prepared_request = None
             else:
-                if getattr(_compressor, "_last_overflow_recovery_failed", False) is True:
-                    return _fresh_tail_context_exhausted_result(
-                        agent,
-                        messages,
-                        conversation_history,
-                        api_call_count,
-                        attempted_tokens=request_pressure_tokens,
-                    )
+                _tail_exhausted = _fresh_tail_context_exhausted_result_if_needed(
+                    agent,
+                    messages,
+                    conversation_history,
+                    api_call_count,
+                    attempted_tokens=request_pressure_tokens,
+                )
+                if _tail_exhausted is not None:
+                    return _tail_exhausted
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
                 # counters from the pre-compaction history.
@@ -2160,7 +2199,7 @@ def run_conversation(
             agent.compression_enabled
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
-            and not _defer_preflight(request_pressure_tokens)
+            and not _preflight_deferred
             and _compression_cooldown
         ):
             # Blocked by the summary-LLM cooldown. Surface a deduped warning
@@ -4757,16 +4796,17 @@ def run_conversation(
                         return _compression_deferred_result(
                             agent, messages, api_call_count
                         )
-                    if getattr(agent.context_compressor, "_last_overflow_recovery_failed", False) is True:
-                        return _fresh_tail_context_exhausted_result(
-                            agent,
-                            messages,
-                            conversation_history,
-                            api_call_count,
-                            attempted_tokens=estimate_request_tokens_rough(
-                                api_messages, tools=agent.tools or None
-                            ),
-                        )
+                    _tail_exhausted = _fresh_tail_context_exhausted_result_if_needed(
+                        agent,
+                        messages,
+                        conversation_history,
+                        api_call_count,
+                        attempted_tokens=estimate_request_tokens_rough(
+                            api_messages, tools=agent.tools or None
+                        ),
+                    )
+                    if _tail_exhausted is not None:
+                        return _tail_exhausted
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -5068,16 +5108,17 @@ def run_conversation(
                         return _compression_deferred_result(
                             agent, messages, api_call_count
                         )
-                    if getattr(agent.context_compressor, "_last_overflow_recovery_failed", False) is True:
-                        return _fresh_tail_context_exhausted_result(
-                            agent,
-                            messages,
-                            conversation_history,
-                            api_call_count,
-                            attempted_tokens=estimate_request_tokens_rough(
-                                api_messages, tools=agent.tools or None
-                            ),
-                        )
+                    _tail_exhausted = _fresh_tail_context_exhausted_result_if_needed(
+                        agent,
+                        messages,
+                        conversation_history,
+                        api_call_count,
+                        attempted_tokens=estimate_request_tokens_rough(
+                            api_messages, tools=agent.tools or None
+                        ),
+                    )
+                    if _tail_exhausted is not None:
+                        return _tail_exhausted
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -931,6 +931,60 @@ def _compression_deferred_result(
     }
 
 
+def _fresh_tail_context_exhausted_result(
+    agent,
+    messages: List[Dict],
+    conversation_history: Optional[List[Dict]],
+    api_call_count: int,
+    *,
+    attempted_tokens: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a terminal result when protected recent context cannot fit.
+
+    Context engines such as LCM may preserve a fresh tail verbatim.  When the
+    engine reports that even forced overflow recovery is still over its assembly
+    cap, retrying the same request only burns compression attempts and repeats
+    the provider overflow.  Stop immediately with a handoff/new-session hint.
+    """
+    try:
+        agent._flush_status_buffer()
+    except Exception:
+        pass
+    token_hint = f" (~{attempted_tokens:,} tokens)" if attempted_tokens else ""
+    agent._vprint(
+        f"{agent.log_prefix}❌ Protected recent context is still too large after forced compression{token_hint}.",
+        force=True,
+    )
+    agent._vprint(
+        f"{agent.log_prefix}   💡 Start a fresh session or create a concise handoff; older details remain recoverable through context tools.",
+        force=True,
+    )
+    logger.error(
+        "%sContext overflow recovery failed because the protected fresh tail still exceeds the safe assembly budget%s.",
+        agent.log_prefix,
+        token_hint,
+    )
+    agent._persist_session(messages, conversation_history)
+    _final = (
+        "Context recovery failed: the protected recent context/tool-output tail "
+        "is still too large to fit safely after compression. Start a fresh "
+        "session or ask for a concise handoff before continuing."
+    )
+    return {
+        "final_response": _final,
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": _final,
+        "partial": True,
+        "failed": True,
+        "compression_exhausted": True,
+        "context_handoff_required": True,
+        "fresh_tail_exhausted": True,
+        "session_id": agent.session_id,
+    }
+
+
 def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
     """Rewrite a cache-decorated system message in place, keeping its blocks.
 
@@ -1933,9 +1987,13 @@ def run_conversation(
         # relative to a recent real provider prompt that fit under threshold
         # (schema overhead / post-compaction over-count, #36718); (2) skip
         # while a same-session compression-failure cooldown is active; (3) then
-        # should_compress() — reusing the canonical threshold_tokens (output
-        # room already reserved by _compute_threshold_tokens) and its summary-
-        # LLM cooldown + anti-thrash guards (#11529). compression_attempts is a
+        # should_compress_request_pressure() — reusing the canonical
+        # threshold_tokens (output room already reserved by
+        # _compute_threshold_tokens) and its summary-LLM cooldown + anti-thrash
+        # guards (#11529) via the default delegate.  The message-aware hook lets
+        # alternative engines combine host pressure with their own
+        # eligible-backlog/protected-tail rules, preventing no-op retries when
+        # the engine has no material it can compact. compression_attempts is a
         # hard per-turn backstop shared with the overflow error handlers.
         _compressor = agent.context_compressor
         _preflight_threshold = int(
@@ -1975,6 +2033,24 @@ def run_conversation(
         _compression_cooldown = getattr(
             _compressor, "get_active_compression_failure_cooldown", lambda: None
         )()
+        _request_pressure_eligible = None
+        _request_pressure_hook = getattr(
+            _compressor, "should_compress_request_pressure", None
+        )
+        if callable(_request_pressure_hook):
+            try:
+                _request_pressure_eligible = _request_pressure_hook(
+                    messages,
+                    request_pressure_tokens,
+                )
+            except Exception:
+                logger.exception(
+                    "context engine should_compress_request_pressure failed; falling back to should_compress"
+                )
+        if _request_pressure_eligible is None:
+            _request_pressure_eligible = _compressor.should_compress(
+                request_pressure_tokens
+            )
         if (
             agent.compression_enabled
             and len(messages) > 1
@@ -1982,7 +2058,7 @@ def run_conversation(
             and not _preflight_compression_blocked
             and not _defer_preflight(request_pressure_tokens)
             and not _compression_cooldown
-            and _compressor.should_compress(request_pressure_tokens)
+            and _request_pressure_eligible
         ):
             if _moa_prepared_request is not None:
                 pending_moa_prepared_request = _moa_prepared_request
@@ -2048,6 +2124,14 @@ def run_conversation(
                 if pending_moa_prepared_request is _moa_prepared_request:
                     pending_moa_prepared_request = None
             else:
+                if getattr(_compressor, "_last_overflow_recovery_failed", False) is True:
+                    return _fresh_tail_context_exhausted_result(
+                        agent,
+                        messages,
+                        conversation_history,
+                        api_call_count,
+                        attempted_tokens=request_pressure_tokens,
+                    )
                 # Reset retry/empty-response state so the compacted request
                 # gets a fresh chance instead of inheriting stale recovery
                 # counters from the pre-compaction history.
@@ -4673,6 +4757,16 @@ def run_conversation(
                         return _compression_deferred_result(
                             agent, messages, api_call_count
                         )
+                    if getattr(agent.context_compressor, "_last_overflow_recovery_failed", False) is True:
+                        return _fresh_tail_context_exhausted_result(
+                            agent,
+                            messages,
+                            conversation_history,
+                            api_call_count,
+                            attempted_tokens=estimate_request_tokens_rough(
+                                api_messages, tools=agent.tools or None
+                            ),
+                        )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history
                     )
@@ -4973,6 +5067,16 @@ def run_conversation(
                         agent._persist_session(messages, conversation_history)
                         return _compression_deferred_result(
                             agent, messages, api_call_count
+                        )
+                    if getattr(agent.context_compressor, "_last_overflow_recovery_failed", False) is True:
+                        return _fresh_tail_context_exhausted_result(
+                            agent,
+                            messages,
+                            conversation_history,
+                            api_call_count,
+                            attempted_tokens=estimate_request_tokens_rough(
+                                api_messages, tools=agent.tools or None
+                            ),
                         )
                     conversation_history = conversation_history_after_compression(
                         agent, messages, conversation_history

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5478,6 +5478,8 @@ class TurnRunner:
                 "error": result.get("error"),
                 "compression_exhausted": result.get("compression_exhausted", False),
                 "compression_deferred": result.get("compression_deferred", False),
+                "context_handoff_required": result.get("context_handoff_required", False),
+                "fresh_tail_exhausted": result.get("fresh_tail_exhausted", False),
                 "tools": ctx.tools_holder[0] or [],
                 "history_offset": _effective_history_offset,
                 "compacted_in_place": _compacted_in_place,
@@ -5615,6 +5617,18 @@ class TurnRunner:
             # session that a concurrent compressor is about to shrink.
             "compression_deferred": (
                 ctx.result_holder[0].get("compression_deferred", False)
+                if ctx.result_holder[0] else False
+            ),
+            "compression_exhausted": (
+                ctx.result_holder[0].get("compression_exhausted", False)
+                if ctx.result_holder[0] else False
+            ),
+            "context_handoff_required": (
+                ctx.result_holder[0].get("context_handoff_required", False)
+                if ctx.result_holder[0] else False
+            ),
+            "fresh_tail_exhausted": (
+                ctx.result_holder[0].get("fresh_tail_exhausted", False)
                 if ctx.result_holder[0] else False
             ),
             "tools": ctx.tools_holder[0] or [],

--- a/tests/gateway/test_compression_deferred_soft_result.py
+++ b/tests/gateway/test_compression_deferred_soft_result.py
@@ -62,6 +62,22 @@ def _find_deferred_guarded_reset_chain() -> ast.If:
     )
 
 
+def _return_dict_keysets_containing(required_key: str) -> list[set[str]]:
+    tree = ast.parse(inspect.getsource(gateway_run))
+    keysets: list[set[str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Dict):
+            continue
+        keys = {
+            key.value
+            for key in node.value.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        }
+        if required_key in keys:
+            keysets.append(keys)
+    return keysets
+
+
 class TestCompressionDeferredIsSoft:
     def test_deferred_branch_guards_the_auto_reset(self):
         """The auto-reset (``reset_session``) must be unreachable when
@@ -84,5 +100,26 @@ class TestCompressionDeferredIsSoft:
             f"defer is transient — the session must stay intact so the next "
             f"message retries against the freshly compressed context "
             f"(#49874, #69870)."
+        )
+
+    def test_compression_terminal_flags_survive_gateway_result_returns(self):
+        """Every gateway result carrying defer must also carry exhaustion flags.
+
+        Fresh-tail exhaustion returns a non-empty user-facing response, so the
+        non-empty response path must preserve ``compression_exhausted`` for the
+        auto-reset consumer just like the empty-response path does.
+        """
+        keysets = _return_dict_keysets_containing("compression_deferred")
+        assert keysets, "No gateway return dict carries compression_deferred"
+
+        required = {
+            "compression_exhausted",
+            "context_handoff_required",
+            "fresh_tail_exhausted",
+        }
+        missing_by_return = [required - keys for keys in keysets if not required <= keys]
+        assert not missing_by_return, (
+            "Gateway return dicts that carry compression_deferred must also "
+            f"preserve {required}; missing={missing_by_return}"
         )
 

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -634,7 +634,7 @@ class TestPreflightCompression:
 
         history = [
             {"role": "user", "content": "live task"},
-            {"role": "tool", "content": "fresh protected tool output"},
+            {"role": "assistant", "content": "fresh protected assistant output"},
         ]
         ok_resp = _mock_response(content="No proactive no-op compression", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [ok_resp]
@@ -658,6 +658,37 @@ class TestPreflightCompression:
         mock_compress.assert_not_called()
         agent.context_compressor.should_compress.assert_not_called()
 
+    def test_pre_api_pressure_hook_skipped_when_cheap_guards_block(self, agent):
+        """Avoid side-effectful engine hooks when pre-API compression cannot run."""
+        agent.compression_enabled = False
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+        pressure_hook = MagicMock(return_value=True)
+        agent.context_compressor.should_compress_request_pressure = pressure_hook
+
+        ok_resp = _mock_response(content="Compression disabled", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=140_000,
+            ),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=[{"role": "user", "content": "live task"}],
+            )
+
+        assert result["completed"] is True
+        pressure_hook.assert_not_called()
+        mock_compress.assert_not_called()
+
     def test_context_overflow_stops_when_engine_reports_fresh_tail_exhausted(self, agent):
         """Do not retry provider overflow after LCM says the protected tail cannot fit."""
         err_400 = Exception(
@@ -667,7 +698,7 @@ class TestPreflightCompression:
         )
         err_400.status_code = 400  # type: ignore[attr-defined]
         agent.client.chat.completions.create.side_effect = [err_400]
-        agent.context_compressor._last_overflow_recovery_failed = False
+        agent.context_compressor.overflow_recovery_failed = MagicMock(return_value=False)
 
         history = [
             {"role": "user", "content": "live task"},
@@ -675,7 +706,7 @@ class TestPreflightCompression:
         ]
 
         def _compress_reports_tail_exhausted(msgs, *_args, **_kwargs):
-            agent.context_compressor._last_overflow_recovery_failed = True
+            agent.context_compressor.overflow_recovery_failed.return_value = True
             return msgs, "compressed prompt"
 
         with (

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -625,6 +625,48 @@ class TestPreflightCompression:
             "Pre-API compression" in msg for _ev, msg in status_messages
         )
 
+    def test_pre_api_pressure_spills_recent_tool_tail_before_compressing(self, agent):
+        """High request pressure first externalizes cumulative fresh-tail tool output.
+
+        This is the guard for the WebUI/LCM incident shape: when the same user
+        turn accumulates too much recent tool output, shrink that tail and
+        rebuild the request before spending a compression attempt.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        ok_resp = _mock_response(content="After tail spill", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                side_effect=[140_000, 10_000],
+            ),
+            patch(
+                "agent.conversation_loop.enforce_recent_tool_tail_budget",
+                return_value=True,
+            ) as tail_budget,
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=[
+                    {"role": "user", "content": "earlier"},
+                    {"role": "assistant", "content": "earlier answer"},
+                ],
+            )
+
+        assert result["completed"] is True
+        tail_budget.assert_called_once()
+        mock_compress.assert_not_called()
+        agent.client.chat.completions.create.assert_called_once()
+
     def test_pre_api_pressure_uses_context_engine_message_aware_hook(self, agent):
         """Engines can decline no-op pressure compaction for protected tails."""
         agent.compression_enabled = True

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -667,6 +667,51 @@ class TestPreflightCompression:
         mock_compress.assert_not_called()
         agent.client.chat.completions.create.assert_called_once()
 
+    def test_tool_tail_spill_rebases_prepared_moa_request(self, agent):
+        """Tail spilling must not rerun MoA advisors on the rebuilt request."""
+        agent.provider = "moa"
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+
+        completions = agent.client.chat.completions
+        prepared_request = {"messages": [{"role": "user", "content": "prepared"}]}
+        rebased_request = {"messages": [{"role": "user", "content": "rebased"}]}
+        completions.prepare = MagicMock(return_value=prepared_request)
+        completions.rebase_prepared_request = MagicMock(return_value=rebased_request)
+        completions.create.side_effect = [
+            _mock_response(content="After rebased tail spill", finish_reason="stop")
+        ]
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                side_effect=[140_000, 10_000],
+            ),
+            patch(
+                "agent.conversation_loop.enforce_recent_tool_tail_budget",
+                return_value=True,
+            ),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=[
+                    {"role": "user", "content": "earlier"},
+                    {"role": "assistant", "content": "earlier answer"},
+                ],
+            )
+
+        assert result["completed"] is True
+        completions.prepare.assert_called_once()
+        assert completions.rebase_prepared_request.call_count >= 1
+        assert completions.rebase_prepared_request.call_args_list[0].args[0] is prepared_request
+        mock_compress.assert_not_called()
+
     def test_pre_api_pressure_uses_context_engine_message_aware_hook(self, agent):
         """Engines can decline no-op pressure compaction for protected tails."""
         agent.compression_enabled = True

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -15,8 +15,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
+from agent.context_engine import ContextEngine
 from agent.context_compressor import SUMMARY_PREFIX
 from agent.conversation_compression import COMPACTION_DONE_STATUS, COMPACTION_STATUS
+from agent.conversation_loop import _context_engine_overflow_recovery_failed
 from run_agent import AIAgent
 import run_agent
 
@@ -658,6 +660,50 @@ class TestPreflightCompression:
         mock_compress.assert_not_called()
         agent.context_compressor.should_compress.assert_not_called()
 
+    def test_pre_api_pressure_none_hook_falls_back_to_should_compress(self, agent):
+        """A None hook result preserves the legacy token-only fallback."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+        agent.context_compressor.should_compress = MagicMock(return_value=True)
+        pressure_hook = MagicMock(return_value=None)
+        agent.context_compressor.should_compress_request_pressure = pressure_hook
+
+        history = [
+            {"role": "user", "content": "live task"},
+            {"role": "assistant", "content": "fresh protected assistant output"},
+        ]
+        ok_resp = _mock_response(content="Fallback compressed", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        compressed_messages = [
+            {"role": "user", "content": "compressed history"},
+            {"role": "assistant", "content": "ready"},
+            {"role": "user", "content": "continue"},
+        ]
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=140_000,
+            ),
+            patch.object(
+                agent,
+                "_compress_context",
+                return_value=(compressed_messages, "compressed prompt"),
+            ) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue", conversation_history=history)
+
+        assert result["completed"] is True
+        pressure_hook.assert_called_once()
+        agent.context_compressor.should_compress.assert_called_once()
+        mock_compress.assert_called_once()
+
     def test_pre_api_pressure_hook_skipped_when_cheap_guards_block(self, agent):
         """Avoid side-effectful engine hooks when pre-API compression cannot run."""
         agent.compression_enabled = False
@@ -665,6 +711,8 @@ class TestPreflightCompression:
         agent.context_compressor.threshold_tokens = 100_000
         pressure_hook = MagicMock(return_value=True)
         agent.context_compressor.should_compress_request_pressure = pressure_hook
+        defer_hook = MagicMock(return_value=False)
+        agent.context_compressor.should_defer_preflight_to_real_usage = defer_hook
 
         ok_resp = _mock_response(content="Compression disabled", finish_reason="stop")
         agent.client.chat.completions.create.side_effect = [ok_resp]
@@ -687,7 +735,38 @@ class TestPreflightCompression:
 
         assert result["completed"] is True
         pressure_hook.assert_not_called()
+        defer_hook.assert_not_called()
         mock_compress.assert_not_called()
+
+    def test_inherited_overflow_hook_falls_back_to_legacy_private_flag(self):
+        """Default ContextEngine hook must not mask older engine state."""
+
+        class LegacyEngine(ContextEngine):
+            @property
+            def name(self) -> str:
+                return "legacy"
+
+            def update_from_response(self, usage):
+                return None
+
+            def should_compress(self, prompt_tokens=None):
+                return False
+
+            def compress(
+                self,
+                messages,
+                current_tokens=None,
+                focus_topic=None,
+                force=False,
+                memory_context="",
+            ):
+                return messages
+
+        engine = LegacyEngine()
+        engine._last_overflow_recovery_failed = True
+        assert _context_engine_overflow_recovery_failed(
+            SimpleNamespace(context_compressor=engine)
+        ) is True
 
     def test_context_overflow_stops_when_engine_reports_fresh_tail_exhausted(self, agent):
         """Do not retry provider overflow after LCM says the protected tail cannot fit."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -623,6 +623,85 @@ class TestPreflightCompression:
             "Pre-API compression" in msg for _ev, msg in status_messages
         )
 
+    def test_pre_api_pressure_uses_context_engine_message_aware_hook(self, agent):
+        """Engines can decline no-op pressure compaction for protected tails."""
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 200_000
+        agent.context_compressor.threshold_tokens = 100_000
+        agent.context_compressor.should_compress = MagicMock(return_value=True)
+        pressure_hook = MagicMock(return_value=False)
+        agent.context_compressor.should_compress_request_pressure = pressure_hook
+
+        history = [
+            {"role": "user", "content": "live task"},
+            {"role": "tool", "content": "fresh protected tool output"},
+        ]
+        ok_resp = _mock_response(content="No proactive no-op compression", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [ok_resp]
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=140_000,
+            ),
+            patch.object(agent, "_compress_context") as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue", conversation_history=history)
+
+        assert result["completed"] is True
+        pressure_hook.assert_called_once()
+        assert pressure_hook.call_args.args[1] >= 140_000
+        mock_compress.assert_not_called()
+        agent.context_compressor.should_compress.assert_not_called()
+
+    def test_context_overflow_stops_when_engine_reports_fresh_tail_exhausted(self, agent):
+        """Do not retry provider overflow after LCM says the protected tail cannot fit."""
+        err_400 = Exception(
+            "Error code: 400 - {'error': {'message': "
+            "\"This endpoint's maximum context length is 272000 tokens. "
+            "However, you requested about 286232 tokens.\", 'code': 400}}"
+        )
+        err_400.status_code = 400  # type: ignore[attr-defined]
+        agent.client.chat.completions.create.side_effect = [err_400]
+        agent.context_compressor._last_overflow_recovery_failed = False
+
+        history = [
+            {"role": "user", "content": "live task"},
+            {"role": "tool", "content": "oversized protected output"},
+        ]
+
+        def _compress_reports_tail_exhausted(msgs, *_args, **_kwargs):
+            agent.context_compressor._last_overflow_recovery_failed = True
+            return msgs, "compressed prompt"
+
+        with (
+            patch("agent.turn_context.estimate_request_tokens_rough", return_value=10_000),
+            patch(
+                "agent.conversation_loop.estimate_messages_tokens_rough",
+                return_value=10_000,
+            ),
+            patch(
+                "agent.conversation_loop.estimate_request_tokens_rough",
+                return_value=286_232,
+            ),
+            patch.object(agent, "_compress_context", side_effect=_compress_reports_tail_exhausted) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("continue", conversation_history=history)
+
+        mock_compress.assert_called_once()
+        assert agent.client.chat.completions.create.call_count == 1
+        assert result["failed"] is True
+        assert result["context_handoff_required"] is True
+        assert result["fresh_tail_exhausted"] is True
+        assert "protected recent context" in result["final_response"]
+
 
     def test_preflight_compresses_oversized_history(self, agent):
         """When loaded history exceeds the model's context threshold, compress before API call."""

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -855,6 +855,16 @@ class TestPreflightCompression:
             SimpleNamespace(context_compressor=engine)
         ) is True
 
+    def test_magicmock_compressor_does_not_invent_overflow_hook(self):
+        """Dynamically-created MagicMock attributes are not engine contracts."""
+        compressor = MagicMock()
+        compressor._last_overflow_recovery_failed = False
+
+        assert _context_engine_overflow_recovery_failed(
+            SimpleNamespace(context_compressor=compressor)
+        ) is False
+        compressor.overflow_recovery_failed.assert_not_called()
+
     def test_context_overflow_stops_when_engine_reports_fresh_tail_exhausted(self, agent):
         """Do not retry provider overflow after LCM says the protected tail cannot fit."""
         err_400 = Exception(

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -10,6 +10,7 @@ sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
 sys.modules.setdefault("fal_client", types.SimpleNamespace())
 
 import run_agent
+from agent import conversation_loop as conversation_loop_module
 
 
 @pytest.fixture(autouse=True)
@@ -1321,6 +1322,11 @@ def test_run_conversation_compresses_mid_turn_before_output_budget_exhaustion(mo
     agent = _build_agent(monkeypatch)
     agent.context_compressor.context_length = 20_000
     agent.context_compressor.threshold_tokens = 20_000
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "enforce_recent_tool_tail_budget",
+        lambda *_args, **_kwargs: False,
+    )
 
     responses = [
         _codex_tool_call_response(),
@@ -1387,6 +1393,11 @@ def test_mid_turn_compaction_does_not_double_persist_in_place_rows(monkeypatch, 
 
     agent.context_compressor.context_length = 20_000
     agent.context_compressor.threshold_tokens = 20_000
+    monkeypatch.setattr(
+        conversation_loop_module,
+        "enforce_recent_tool_tail_budget",
+        lambda *_args, **_kwargs: False,
+    )
 
     agent._session_db = SessionDB()
     agent._ensure_db_session()

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -347,6 +347,50 @@ class TestEnforceRecentToolTailBudget:
         assert changed is False
         assert all(PERSISTED_OUTPUT_TAG not in m.get("content", "") for m in messages)
 
+    def test_ignores_synthetic_user_scaffolding_when_selecting_tail(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "current task"},
+            {"role": "tool", "tool_call_id": "t1", "content": "a" * 70_000},
+            {
+                "role": "user",
+                "content": "[Your active task list was preserved across context compression]",
+                "_todo_snapshot_synthetic": True,
+            },
+            {"role": "tool", "tool_call_id": "t2", "content": "b" * 65_000},
+        ]
+
+        changed = enforce_recent_tool_tail_budget(
+            messages,
+            env=env,
+            config=BudgetConfig(turn_budget=120_000),
+        )
+
+        assert changed is True
+        assert sum(PERSISTED_OUTPUT_TAG in m.get("content", "") for m in messages) == 1
+
+    def test_does_not_accept_non_reducing_no_env_replacements(self):
+        messages = [
+            {"role": "user", "content": "current task"},
+            {"role": "tool", "tool_call_id": "t1", "content": "a" * 100},
+            {"role": "tool", "tool_call_id": "t2", "content": "b" * 100},
+            {"role": "tool", "tool_call_id": "t3", "content": "c" * 100},
+        ]
+        before = sum(len(m["content"]) for m in messages if m.get("role") == "tool")
+
+        changed = enforce_recent_tool_tail_budget(
+            messages,
+            env=None,
+            config=BudgetConfig(turn_budget=150),
+        )
+
+        after = sum(len(m["content"]) for m in messages if m.get("role") == "tool")
+        assert changed is False
+        assert after == before
+        assert all(PERSISTED_OUTPUT_TAG not in m.get("content", "") for m in messages)
+
 
 # ── Per-tool threshold integration ────────────────────────────────────
 

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -18,6 +18,7 @@ from tools.tool_result_storage import (
     _resolve_storage_dir,
     _safe_result_filename,
     _write_to_sandbox,
+    enforce_recent_tool_tail_budget,
     enforce_turn_budget,
     generate_preview,
     maybe_persist_tool_result,
@@ -287,6 +288,64 @@ class TestEnforceTurnBudget:
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))
         assert result == []
+
+
+class TestEnforceRecentToolTailBudget:
+    def test_spills_cumulative_tool_tail_since_latest_user(self):
+        """Many medium same-user-turn tool outputs must not stay inline forever.
+
+        Each result is below the normal per-result threshold, but together they
+        recreate the incident shape: a protected fresh tail dominated by tool
+        output that LCM cannot compact without losing the latest user anchor.
+        """
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "older task"},
+            {"role": "tool", "tool_call_id": "older", "content": "o" * 90_000},
+            {"role": "user", "content": "current task"},
+            {"role": "tool", "tool_call_id": "t1", "content": "a" * 70_000},
+            {"role": "assistant", "content": "thinking"},
+            {"role": "tool", "tool_call_id": "t2", "content": "b" * 65_000},
+            {"role": "tool", "tool_call_id": "t3", "content": "c" * 55_000},
+        ]
+
+        changed = enforce_recent_tool_tail_budget(
+            messages,
+            env=env,
+            config=BudgetConfig(turn_budget=120_000),
+        )
+
+        assert changed is True
+        # Older history is outside the latest-user protected tail and is left to
+        # the context engine rather than rewritten here.
+        assert messages[2]["content"] == "o" * 90_000
+        latest_tail_tool_chars = sum(
+            len(m["content"])
+            for m in messages[4:]
+            if m.get("role") == "tool"
+        )
+        assert latest_tail_tool_chars <= 120_000
+        assert sum(PERSISTED_OUTPUT_TAG in m.get("content", "") for m in messages[4:]) >= 1
+        env.execute.assert_called()
+
+    def test_returns_false_when_tail_under_budget(self):
+        messages = [
+            {"role": "system", "content": "system"},
+            {"role": "user", "content": "current task"},
+            {"role": "tool", "tool_call_id": "t1", "content": "a" * 20_000},
+            {"role": "tool", "tool_call_id": "t2", "content": "b" * 20_000},
+        ]
+
+        changed = enforce_recent_tool_tail_budget(
+            messages,
+            env=None,
+            config=BudgetConfig(turn_budget=120_000),
+        )
+
+        assert changed is False
+        assert all(PERSISTED_OUTPUT_TAG not in m.get("content", "") for m in messages)
 
 
 # ── Per-tool threshold integration ────────────────────────────────────

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -200,6 +200,86 @@ def maybe_persist_tool_result(
     )
 
 
+def enforce_recent_tool_tail_budget(
+    messages: list[dict],
+    env=None,
+    config: BudgetConfig = DEFAULT_BUDGET,
+) -> bool:
+    """Enforce a cumulative tool-output budget after the latest user message.
+
+    LCM and other compressors must protect the latest user request.  In long
+    same-user turns, many individually acceptable medium tool outputs can pile
+    up after that anchor, leaving no compressible backlog and causing provider
+    context overflow.  This guard rewrites the largest non-persisted tool
+    results in that protected tail to persisted-output references until the
+    tail's aggregate tool content fits the configured budget.
+
+    Older tool messages before the latest user are intentionally left untouched;
+    they are the context engine's normal compaction territory.
+    """
+    if not messages:
+        return False
+
+    tail_start = 0
+    for idx in range(len(messages) - 1, -1, -1):
+        msg = messages[idx]
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and not content.strip():
+            continue
+        if content:
+            tail_start = idx + 1
+            break
+
+    candidates: list[tuple[int, int]] = []
+    total_size = 0
+    for idx, msg in enumerate(messages[tail_start:], start=tail_start):
+        if msg.get("role") != "tool":
+            continue
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content:
+            continue
+        size = len(content)
+        total_size += size
+        if PERSISTED_OUTPUT_TAG not in content:
+            candidates.append((idx, size))
+
+    if total_size <= config.turn_budget:
+        return False
+
+    changed = False
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    for idx, size in candidates:
+        if total_size <= config.turn_budget:
+            break
+        msg = messages[idx]
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content:
+            continue
+        tool_use_id = msg.get("tool_call_id", f"tail_budget_{idx}")
+        replacement = maybe_persist_tool_result(
+            content=content,
+            tool_name=_BUDGET_TOOL_NAME,
+            tool_use_id=tool_use_id,
+            env=env,
+            config=config,
+            threshold=0,
+        )
+        if replacement != content:
+            msg["content"] = replacement
+            total_size -= size
+            total_size += len(replacement)
+            changed = True
+            logger.info(
+                "Recent tool-tail budget enforcement: persisted tool result %s (%d chars)",
+                tool_use_id,
+                size,
+            )
+
+    return changed
+
+
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -43,6 +43,47 @@ HEREDOC_MARKER = "HERMES_PERSIST_EOF"
 _BUDGET_TOOL_NAME = "__budget_enforcement__"
 _UNSAFE_RESULT_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]+")
 _MAX_RESULT_FILENAME_STEM = 120
+_SYNTHETIC_TAIL_USER_FLAGS = (
+    "_todo_snapshot_synthetic",
+    "_empty_recovery_synthetic",
+    "_verification_stop_synthetic",
+    "_pre_verify_synthetic",
+    "_dropped_toolcall_nudge",
+)
+_SYNTHETIC_TAIL_USER_PREFIXES = (
+    "[System: Your previous response was truncated",
+    "[System: The previous response was cut off",
+    "[System: Your previous tool call",
+    "[Your active task list was preserved across context compression]",
+    "[IMPORTANT: Background process ",
+    "[CONTEXT COMPACTION",
+    "[CONTEXT SUMMARY]",
+)
+
+
+def _message_text(message: dict) -> str:
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(part.get("text") or part.get("content") or "")
+            for part in content
+            if isinstance(part, dict)
+        )
+    return ""
+
+
+def _is_tail_user_anchor(message: dict) -> bool:
+    """Return True for user messages that can anchor a protected tool tail."""
+    if message.get("role") != "user":
+        return False
+    if any(message.get(flag) for flag in _SYNTHETIC_TAIL_USER_FLAGS):
+        return False
+    text = _message_text(message).strip()
+    if not text:
+        return False
+    return not text.startswith(_SYNTHETIC_TAIL_USER_PREFIXES)
 
 
 def _resolve_storage_dir(env) -> str:
@@ -200,6 +241,76 @@ def maybe_persist_tool_result(
     )
 
 
+def _enforce_tool_subset_budget(
+    messages: list[dict],
+    indices: list[int],
+    *,
+    env=None,
+    config: BudgetConfig = DEFAULT_BUDGET,
+    fallback_id_prefix: str,
+    log_label: str,
+) -> bool:
+    """Persist largest indexed tool-result messages until under budget."""
+    candidates: list[tuple[int, int]] = []
+    total_size = 0
+    for idx in indices:
+        msg = messages[idx]
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content:
+            continue
+        size = len(content)
+        total_size += size
+        if PERSISTED_OUTPUT_TAG not in content:
+            candidates.append((idx, size))
+
+    if total_size <= config.turn_budget:
+        return False
+
+    changed = False
+    candidates.sort(key=lambda item: item[1], reverse=True)
+    for idx, size in candidates:
+        if total_size <= config.turn_budget:
+            break
+        msg = messages[idx]
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content:
+            continue
+        tool_use_id = msg.get("tool_call_id", f"{fallback_id_prefix}_{idx}")
+        if env is None and size <= config.preview_size:
+            continue
+        replacement = maybe_persist_tool_result(
+            content=content,
+            tool_name=_BUDGET_TOOL_NAME,
+            tool_use_id=tool_use_id,
+            env=env,
+            config=config,
+            threshold=0,
+        )
+        if replacement == content:
+            continue
+        if len(replacement) >= size:
+            logger.info(
+                "%s skipped non-reducing replacement for %s (%d -> %d chars)",
+                log_label,
+                tool_use_id,
+                size,
+                len(replacement),
+            )
+            continue
+        msg["content"] = replacement
+        total_size -= size
+        total_size += len(replacement)
+        changed = True
+        logger.info(
+            "%s: persisted tool result %s (%d chars)",
+            log_label,
+            tool_use_id,
+            size,
+        )
+
+    return changed
+
+
 def enforce_recent_tool_tail_budget(
     messages: list[dict],
     env=None,
@@ -222,62 +333,23 @@ def enforce_recent_tool_tail_budget(
 
     tail_start = 0
     for idx in range(len(messages) - 1, -1, -1):
-        msg = messages[idx]
-        if msg.get("role") != "user":
-            continue
-        content = msg.get("content")
-        if isinstance(content, str) and not content.strip():
-            continue
-        if content:
+        if _is_tail_user_anchor(messages[idx]):
             tail_start = idx + 1
             break
 
-    candidates: list[tuple[int, int]] = []
-    total_size = 0
+    tool_indices: list[int] = []
     for idx, msg in enumerate(messages[tail_start:], start=tail_start):
-        if msg.get("role") != "tool":
-            continue
-        content = msg.get("content", "")
-        if not isinstance(content, str) or not content:
-            continue
-        size = len(content)
-        total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
-            candidates.append((idx, size))
+        if msg.get("role") == "tool":
+            tool_indices.append(idx)
 
-    if total_size <= config.turn_budget:
-        return False
-
-    changed = False
-    candidates.sort(key=lambda item: item[1], reverse=True)
-    for idx, size in candidates:
-        if total_size <= config.turn_budget:
-            break
-        msg = messages[idx]
-        content = msg.get("content", "")
-        if not isinstance(content, str) or not content:
-            continue
-        tool_use_id = msg.get("tool_call_id", f"tail_budget_{idx}")
-        replacement = maybe_persist_tool_result(
-            content=content,
-            tool_name=_BUDGET_TOOL_NAME,
-            tool_use_id=tool_use_id,
-            env=env,
-            config=config,
-            threshold=0,
-        )
-        if replacement != content:
-            msg["content"] = replacement
-            total_size -= size
-            total_size += len(replacement)
-            changed = True
-            logger.info(
-                "Recent tool-tail budget enforcement: persisted tool result %s (%d chars)",
-                tool_use_id,
-                size,
-            )
-
-    return changed
+    return _enforce_tool_subset_budget(
+        messages,
+        tool_indices,
+        env=env,
+        config=config,
+        fallback_id_prefix="tail_budget",
+        log_label="Recent tool-tail budget enforcement",
+    )
 
 
 def enforce_turn_budget(
@@ -293,42 +365,13 @@ def enforce_turn_budget(
 
     Mutates the list in-place and returns it.
     """
-    candidates = []
-    total_size = 0
-    for i, msg in enumerate(tool_messages):
-        content = msg.get("content", "")
-        size = len(content)
-        total_size += size
-        if PERSISTED_OUTPUT_TAG not in content:
-            candidates.append((i, size))
-
-    if total_size <= config.turn_budget:
-        return tool_messages
-
-    candidates.sort(key=lambda x: x[1], reverse=True)
-
-    for idx, size in candidates:
-        if total_size <= config.turn_budget:
-            break
-        msg = tool_messages[idx]
-        content = msg["content"]
-        tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
-
-        replacement = maybe_persist_tool_result(
-            content=content,
-            tool_name=_BUDGET_TOOL_NAME,
-            tool_use_id=tool_use_id,
-            env=env,
-            config=config,
-            threshold=0,
-        )
-        if replacement != content:
-            total_size -= size
-            total_size += len(replacement)
-            tool_messages[idx]["content"] = replacement
-            logger.info(
-                "Budget enforcement: persisted tool result %s (%d chars)",
-                tool_use_id, size,
-            )
+    _enforce_tool_subset_budget(
+        tool_messages,
+        list(range(len(tool_messages))),
+        env=env,
+        config=config,
+        fallback_id_prefix="budget",
+        log_label="Budget enforcement",
+    )
 
     return tool_messages


### PR DESCRIPTION
## Summary

Fixes the fresh-tail context overflow failure class where compression repeatedly runs but cannot shrink protected recent messages/tool results enough to fit the provider context window.

This is the failure mode behind #64382: pre-API request pressure can exceed the model limit while the active context engine has no compactable material left. Token-only retry loops then burn `compression.max_attempts` and still fail.

## What changed

- Add a message-aware context-engine hook: `ContextEngine.should_compress_request_pressure(messages, prompt_tokens)`.
  - Default behavior delegates to legacy token-only `should_compress()`.
  - Engines with protected-tail semantics can decline no-op compression when nothing eligible remains.
- Add an overflow-exhaustion contract: `ContextEngine.overflow_recovery_failed()`.
  - The conversation loop stops repeated same-cycle overflow compression when the engine reports terminal fresh-tail exhaustion.
  - Result flags include `compression_exhausted`, `context_handoff_required`, and `fresh_tail_exhausted`.
- Preserve those terminal compression flags through gateway wrapping, including non-empty user-facing error paths.
- Add cumulative recent tool-tail budget enforcement before provider calls under request pressure.
  - Large recent tool outputs after the latest real user anchor can be persisted/spilled before they become an unrecoverable protected tail.
  - This complements existing per-result/per-turn caps by bounding cumulative recent tool output.
- Add focused regression coverage for request-pressure hook use, terminal fresh-tail exhaustion, gateway flag propagation, and recent tool-tail spilling.

## Relation to existing PRs/issues

- Fixes #64382 / overlaps #64401 by making pre-API pressure context-engine aware.
- Related to #76151 / #76313, but this PR does **not** add a preflight opt-out. The failure fixed here is not only maintenance preflight: it is provider-call request pressure plus protected-tail incompressibility.
- This PR is intentionally scoped to Hermes Agent core. LCM plugin default assembly reserve / protected-tail-specific behavior lives in the separate `hermes-lcm` plugin repo and will be handled separately because that repo's `origin/main` has diverged substantially.

## Test plan

Clean branch based on current `origin/main` (`a88b76bf7` at time of branch creation):

```bash
HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/run_agent/test_413_compression.py tests/gateway/test_compression_deferred_soft_result.py -q
```

Result: 35 tests passed, 0 failed.

```bash
HERMES_PYTHON=/usr/bin/python3 scripts/run_tests.sh tests/tools/test_tool_result_storage.py tests/run_agent/test_413_compression.py tests/gateway/test_compression_deferred_soft_result.py -q
```

Result: 65 tests passed, 0 failed.

```bash
git diff --check origin/main..HEAD
```

Result: clean.
