### PR TITLE
fix(tui_gateway): re-check session busy before moving a workspace

### DIFF
--- a/tests/tui_gateway/test_workspace_move_busy_race.py
+++ b/tests/tui_gateway/test_workspace_move_busy_race.py
@@ -1,0 +1,78 @@
+"""session.workspace.move must refuse a session that goes busy mid-call.
+
+The handler checks ``running`` once, then runs two git subprocesses before it
+mutates anything, and it runs on the RPC pool. A prompt submitted inside that
+window flips ``running`` after the check — and ``_set_session_cwd`` does not
+re-check — so the move re-anchors a live turn's terminal/file tools onto a
+different directory. The handler's own docstring says it refuses that case.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def gw(tmp_path, monkeypatch):
+    from tui_gateway import server, methods_session
+
+    old = tmp_path / "old"
+    old.mkdir()
+    new = tmp_path / "new"
+    new.mkdir()
+
+    sess = {"session_key": "sk1", "running": False, "cwd": str(old), "agent": None}
+    monkeypatch.setitem(server._sessions, "sid1", sess)
+    monkeypatch.setattr(
+        server, "_git_common_repo_root_for_cwd", lambda _c: ""
+    )
+    return server, methods_session, sess, old, new
+
+
+def _call(server, new):
+    return server._methods["session.workspace.move"](
+        1, {"session_key": "sk1", "cwd": str(new)}
+    )
+
+
+def test_refuses_when_a_turn_starts_during_the_git_probe(gw, monkeypatch):
+    server, methods_session, sess, old, new = gw
+
+    def _probe_then_turn_starts(_cwd):
+        # A prompt lands while the git subprocess runs.
+        sess["running"] = True
+        return "main"
+
+    monkeypatch.setattr(
+        server, "_git_branch_for_cwd", _probe_then_turn_starts
+    )
+
+    resp = _call(server, new)
+
+    assert resp["error"]["message"] == "session busy"
+    assert sess["cwd"] == str(old), "workspace moved out from under a live turn"
+
+
+def test_still_refuses_when_already_busy_before_the_call(gw, monkeypatch):
+    server, methods_session, sess, old, new = gw
+    sess["running"] = True
+    monkeypatch.setattr(
+        server, "_git_branch_for_cwd", lambda _c: "main"
+    )
+
+    resp = _call(server, new)
+
+    assert resp["error"]["message"] == "session busy"
+    assert sess["cwd"] == str(old)
+
+
+def test_missing_target_directory_is_rejected(gw, monkeypatch):
+    server, methods_session, sess, old, new = gw
+    monkeypatch.setattr(
+        server, "_git_branch_for_cwd", lambda _c: "main"
+    )
+
+    resp = server._methods["session.workspace.move"](
+        1, {"session_key": "sk1", "cwd": str(new / "does-not-exist")}
+    )
+
+    assert "does not exist" in resp["error"]["message"]
+    assert sess["cwd"] == str(old)

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -788,6 +788,19 @@ def _(rid, params: dict) -> dict:
 
     branch = _git_branch_for_cwd(resolved)
     root = _git_common_repo_root_for_cwd(resolved)
+
+    # Re-check before mutating. The two probes above are git subprocesses and
+    # this method runs on the RPC pool, so a prompt submitted while they run
+    # flips ``running`` after the first check — and ``_set_session_cwd`` below
+    # does not re-check. Without this the move yanks the workspace out from
+    # under a live turn's terminal/file tools, the exact case the first check
+    # exists to refuse.
+    if live is not None:
+        with _sessions_lock:
+            still_running = bool(live.get("running"))
+        if still_running:
+            return _err(rid, 4009, "session busy")
+
     with _profile_db(params) as db:
         if db is None:
             return _db_unavailable_error(rid, code=5007)


### PR DESCRIPTION
## What

`session.workspace.move` (28b3b0dd1, 2026-08-04) re-homes a stored session's workspace. Its docstring states the contract:

> a mid-turn session refuses the move rather than yanking the workspace out from under its tools

It checks `running` once, and then — before mutating anything — runs two git subprocesses:

```python
if live is not None and live.get("running"):
    return _err(rid, 4009, "session busy")

branch = _git_branch_for_cwd(resolved)          # subprocess
root = _git_common_repo_root_for_cwd(resolved)  # subprocess
...
db.update_session_cwd(target, resolved, branch, root, replace_git_meta=True)
_set_session_cwd(live, resolved)
```

The same commit message notes the handler "Runs on the RPC pool — the git probes are subprocesses", i.e. it is concurrent with the turn-running thread by design. A prompt submitted while those probes run sets `running = True` (`methods_prompt.py:241`, under `history_lock`, not `_sessions_lock`) *after* the check has passed, and `_set_session_cwd` does not re-check. The move then proceeds against a session that is now mid-turn.

The consequence is the one the check exists to prevent: `_set_session_cwd` rewrites `session["cwd"]`, re-registers the session cwd and re-anchors the agent, so the running turn's `terminal`, `write_file` and `patch` calls after that point execute against a **different directory** than the one the turn started in.

## The fix

Re-check under `_sessions_lock` immediately before the write:

```python
if live is not None:
    with _sessions_lock:
        still_running = bool(live.get("running"))
    if still_running:
        return _err(rid, 4009, "session busy")
```

The probes stay outside the lock — only the decision moves next to the mutation it guards, so the slow subprocesses still run unlocked and the busy verdict is the one that holds at write time.

`_sessions_lock` resolves correctly here: `method_ctx.HandlerRegistry.install` rebinds each handler's `__globals__` onto `server`'s namespace, which is also why the tests below patch the probes on `server` rather than on `methods_session`.

## Tests

This RPC shipped without tests; these are its first. New file `tests/tui_gateway/test_workspace_move_busy_race.py`:

- **the race** — the git probe is replaced with one that flips `running` while it "runs", reproducing a prompt landing mid-call. The move must return `session busy` and leave `session["cwd"]` untouched.
- a session already busy at entry is still refused (the original check, so the added one cannot mask it)
- a non-existent target directory is still rejected before anything is touched

Results:

```
3 passed
```

Red without the source change:

```
FAILED test_refuses_when_a_turn_starts_during_the_git_probe
E   assert resp["error"]["message"] == "session busy"
1 failed, 2 passed
```

The two controls pass on both sides.

Regression over `tests/tui_gateway/` (345 tests): the failure sets before and after are the same size, and the only entry that differs between the two full runs is `test_compute_host_phase1.py::test_shutdown_drain_sleep_never_overshoots_the_reserve`. Run in isolation it fails 3/3 on unmodified main and passes 3/3 with this change applied, so it is order-dependent and pre-existing, not caused here — this change touches only `session.workspace.move`. `test_append_log_record_single_write_lines` also fails on main. `scripts/check-windows-footguns.py` is clean on both files.