### PR TITLE
fix(a2a): record late-finishing task results instead of discarding them

### DIFF
--- a/plugins/platforms/a2a/README.md
+++ b/plugins/platforms/a2a/README.md
@@ -84,6 +84,7 @@ via `tasks/get`.
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity. |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20). |
 | `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply. |
+| `A2A_LATE_RESULT_GRACE` | `1800` | Extra seconds a task may keep running after the reply window; the caller gets a `working` task and the outcome stays retrievable via `GetTask`/resubscribe/push. `0` fails tasks at the deadline (legacy). |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push signing. |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict skills on the Agent Card. |
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -74,6 +74,19 @@ def _reply_timeout() -> float:
         return 300.0
 
 
+def _late_result_grace() -> float:
+    """Seconds a task may keep running after its reply window expires.
+
+    While the grace runs the task stays WORKING and the eventual outcome is
+    recorded (visible to tasks/get, resubscribe watchers, and push
+    notifications) instead of being discarded. 0 restores the legacy
+    behavior: fail the task at the reply deadline and drop a late result."""
+    try:
+        return max(0.0, float(os.getenv("A2A_LATE_RESULT_GRACE", "1800")))
+    except (ValueError, TypeError):
+        return 1800.0
+
+
 def _default_agent_name() -> str:
     name = os.getenv("A2A_AGENT_NAME", "").strip()
     if name:
@@ -471,7 +484,9 @@ class A2AAdapter(BasePlatformAdapter):
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
+                with self._pending_lock:
+                    live = set(self._pending)
+                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT, skip=live):
                     logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
                     protocol.metrics.tasks_failed += 1
             except Exception:
@@ -931,6 +946,10 @@ class A2AAdapter(BasePlatformAdapter):
         ``keepalive`` is an optional zero-arg callable invoked every
         _SSE_KEEPALIVE seconds while waiting (used by the SSE paths); if it
         raises, the client is gone and we stop waiting.
+
+        May return a non-terminal (STATE_WORKING, note) when the waiter gives
+        up while the agent is still running — the caller must not finalize
+        the task in that case (see _deadline_outcome).
         """
         fut: Future = pending["future"]
         deadline = pending["started"] + _reply_timeout()
@@ -939,14 +958,64 @@ class A2AAdapter(BasePlatformAdapter):
                 return fut.result(timeout=_SSE_KEEPALIVE if keepalive else max(0.0, deadline - time.time()))
             except FuturesTimeout:
                 if time.time() >= deadline:
-                    return (protocol.STATE_FAILED, "[agent did not reply in time]")
+                    return self._deadline_outcome(pending)
                 if keepalive:
                     try:
                         keepalive()
                     except Exception:
-                        return (protocol.STATE_FAILED, "[client disconnected]")
+                        return self._deadline_outcome(pending, "[client disconnected]")
             except Exception:
                 return (protocol.STATE_FAILED, "[agent did not reply in time]")
+
+    def _deadline_outcome(self, pending: dict, reason: str = "[agent did not reply in time]") -> tuple[str, str]:
+        """Decide the waiter's answer when it gives up (reply window expired
+        or the streaming client disconnected) while the agent may still be
+        running.
+
+        With late results enabled the task is detached rather than failed: it
+        stays WORKING and _finalize_late() records the eventual outcome, so
+        tasks/get, resubscribe watchers, and push notifications observe the
+        real result instead of a synthetic failure."""
+        fut: Future = pending["future"]
+        if _late_result_grace() <= 0:
+            return (protocol.STATE_FAILED, reason)
+        # _resolve_task() sets results under _pending_lock, so between this
+        # done() check and the waiter thread starting no resolution can slip
+        # through unobserved.
+        with self._pending_lock:
+            if fut.done():
+                try:
+                    return fut.result(timeout=0)
+                except Exception:
+                    return (protocol.STATE_FAILED, reason)
+            waiter = threading.Thread(
+                target=self._finalize_late, args=(pending,), daemon=True,
+                name=f"a2a-late-{pending['task_id'][:12]}",
+            )
+        waiter.start()
+        return (protocol.STATE_WORKING, (
+            "[still working: the reply window expired but the task continues. "
+            f"Fetch the outcome later via tasks/get (id {pending['task_id']}), "
+            "tasks/resubscribe, or a registered push notification.]"
+        ))
+
+    def _finalize_late(self, pending: dict) -> None:
+        """Waiter thread for a detached task: block until the agent finishes
+        (bounded by the grace window) and record the real outcome."""
+        fut: Future = pending["future"]
+        try:
+            state, reply = fut.result(timeout=_late_result_grace())
+        except FuturesTimeout:
+            state, reply = protocol.STATE_FAILED, "[agent did not finish within the late-result grace window]"
+        except Exception:
+            state, reply = protocol.STATE_FAILED, "[agent did not reply in time]"
+        try:
+            state, reply = self._finalize_task(pending, state, reply)
+            if state in (protocol.STATE_COMPLETED, protocol.STATE_INPUT_REQUIRED):
+                protocol.metrics.tasks_late_results += 1
+                logger.info("A2A: recorded late result for task %s", pending["task_id"])
+        except Exception:
+            logger.exception("A2A: failed to record late result for task %s", pending["task_id"])
 
     def _rpc_message_send(self, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None, v1_response: bool = False) -> dict:
         terminal, pending = self._prepare_task(params, peer, agent=agent)
@@ -954,7 +1023,8 @@ class A2AAdapter(BasePlatformAdapter):
             result = protocol.send_message_response(terminal) if v1_response else terminal
             return protocol.jsonrpc_result(req_id, result)
         state, reply = self._await_reply(pending)
-        state, reply = self._finalize_task(pending, state, reply)
+        if state != protocol.STATE_WORKING:
+            state, reply = self._finalize_task(pending, state, reply)
         task = protocol.build_task(
             pending["task_id"], pending["context_id"], state, reply,
             created_at=pending["created_iso"],
@@ -1021,7 +1091,8 @@ class A2AAdapter(BasePlatformAdapter):
 
             state, reply = self._await_reply(
                 pending, keepalive=lambda: self._sse_write(handler, ": keepalive\n\n"))
-            state, reply = self._finalize_task(pending, state, reply)
+            if state != protocol.STATE_WORKING:
+                state, reply = self._finalize_task(pending, state, reply)
             self._emit_terminal(handler, task_id, context_id, state, reply, req_id=req_id)
         except (BrokenPipeError, ConnectionResetError):
             logger.debug("A2A: stream client disconnected")

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -536,6 +536,7 @@ class Metrics:
         self.push_failed = 0
         self.tasks_completed = 0
         self.tasks_failed = 0
+        self.tasks_late_results = 0
         self.anti_loop_triggers = 0
         self.rate_limit_triggers = 0
         self._start_time = time.time()
@@ -561,6 +562,7 @@ class Metrics:
             "push_failed": self.push_failed,
             "tasks_completed": self.tasks_completed,
             "tasks_failed": self.tasks_failed,
+            "tasks_late_results": self.tasks_late_results,
             "anti_loop_triggers": self.anti_loop_triggers,
             "rate_limit_triggers": self.rate_limit_triggers,
             "avg_latency_ms": round(self.avg_latency() * 1000, 1),
@@ -748,12 +750,17 @@ class TaskStore:
             return page, next_offset, total
         return page, next_offset
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(self, timeout_seconds: int = 300, skip: Optional[set[str]] = None) -> list[str]:
+        """Fail non-terminal tasks older than ``timeout_seconds``. ``skip``
+        holds ids that still have a live waiter (including detached
+        late-result tasks) and must be left running."""
+        skip = skip or set()
         with self._lock:
             now = time.time()
             stale = [
                 tid for tid, rec in self._tasks.items()
                 if rec["state"] not in TERMINAL_STATES
+                and tid not in skip
                 and now - rec["created_at"] > timeout_seconds
             ]
         failed = []

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -299,6 +299,12 @@ def a2a_call(args: dict, **_: Any) -> str:
             "\n\n(The peer needs more input — answer by calling a2a_call again "
             f"with context_id '{reply_ctx}'.)"
         )
+    elif state == protocol.STATE_WORKING:
+        body += (
+            "\n\n(The peer is still working: its reply window closed but the "
+            "task keeps running server-side. Call a2a_call again later with "
+            f"context_id '{reply_ctx}' to pick up the outcome.)"
+        )
     return f"{header}\n{body}"
 
 

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -16,6 +16,7 @@ import json
 import os
 import socket
 import threading
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import Future
@@ -689,6 +690,111 @@ class TestReplyCapture:
             adapter._pop_pending("task-ok")
 
 
+class TestLateResults:
+    """Reply-window expiry must not discard work that is still running
+    (#78007 point 3): the task detaches, stays WORKING, and the eventual
+    outcome is recorded instead of dropped."""
+
+    @staticmethod
+    def _pending_for(adapter, task_id, context_id, started_ago=10_000.0):
+        rec = adapter.tasks.create(task_id, context_id, "peer-late", "", "")
+        adapter.tasks.set_state(task_id, protocol.STATE_WORKING)
+        fut = adapter._add_pending(task_id, context_id)
+        return {
+            "task_id": task_id,
+            "context_id": context_id,
+            "peer": "peer-late",
+            "future": fut,
+            "created_iso": rec["created_iso"],
+            "started": time.time() - started_ago,
+        }
+
+    @staticmethod
+    def _wait_for(predicate, timeout=3.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if predicate():
+                return True
+            time.sleep(0.02)
+        return False
+
+    def test_expired_window_detaches_instead_of_failing(self, monkeypatch):
+        monkeypatch.delenv("A2A_LATE_RESULT_GRACE", raising=False)
+        adapter = _bare_adapter()
+        pending = self._pending_for(adapter, "task-late-detach", "ctx-late-detach")
+        try:
+            state, note = adapter._await_reply(pending)
+            assert state == protocol.STATE_WORKING
+            assert "task-late-detach" in note
+            assert adapter.tasks.get("task-late-detach")["state"] == protocol.STATE_WORKING
+            assert "task-late-detach" in adapter._pending
+        finally:
+            adapter._resolve_task("task-late-detach", protocol.STATE_CANCELED, "")
+            self._wait_for(
+                lambda: adapter.tasks.get("task-late-detach")["state"] in protocol.TERMINAL_STATES)
+
+    def test_late_reply_is_recorded_not_dropped(self, monkeypatch):
+        monkeypatch.delenv("A2A_LATE_RESULT_GRACE", raising=False)
+        adapter = _bare_adapter()
+        pending = self._pending_for(adapter, "task-late-reply", "ctx-late-reply")
+        before = protocol.metrics.tasks_late_results
+
+        state, _ = adapter._await_reply(pending)
+        assert state == protocol.STATE_WORKING
+
+        asyncio.run(adapter.send(
+            "ctx-late-reply", "LATE_RESULT_PAYLOAD", metadata={"notify": True}))
+
+        assert self._wait_for(
+            lambda: adapter.tasks.get("task-late-reply")["state"] == protocol.STATE_COMPLETED)
+        rec = adapter.tasks.get("task-late-reply")
+        assert rec["reply"] == "LATE_RESULT_PAYLOAD"
+        assert protocol.metrics.tasks_late_results == before + 1
+        assert "task-late-reply" not in adapter._pending
+
+    def test_grace_zero_restores_legacy_failure(self, monkeypatch):
+        monkeypatch.setenv("A2A_LATE_RESULT_GRACE", "0")
+        adapter = _bare_adapter()
+        pending = self._pending_for(adapter, "task-late-legacy", "ctx-late-legacy")
+        try:
+            state, msg = adapter._await_reply(pending)
+            assert state == protocol.STATE_FAILED
+            assert msg == "[agent did not reply in time]"
+        finally:
+            adapter._pop_pending("task-late-legacy")
+
+    def test_grace_expiry_fails_the_task(self, monkeypatch):
+        monkeypatch.setenv("A2A_LATE_RESULT_GRACE", "0.2")
+        adapter = _bare_adapter()
+        pending = self._pending_for(adapter, "task-late-grace", "ctx-late-grace")
+        state, _ = adapter._await_reply(pending)
+        assert state == protocol.STATE_WORKING
+        assert self._wait_for(
+            lambda: adapter.tasks.get("task-late-grace")["state"] == protocol.STATE_FAILED)
+        assert "grace window" in adapter.tasks.get("task-late-grace")["reply"]
+        assert "task-late-grace" not in adapter._pending
+
+    def test_boundary_result_beats_detach(self, monkeypatch):
+        monkeypatch.delenv("A2A_LATE_RESULT_GRACE", raising=False)
+        adapter = _bare_adapter()
+        pending = self._pending_for(adapter, "task-late-boundary", "ctx-late-boundary")
+        adapter._resolve_task("task-late-boundary", protocol.STATE_COMPLETED, "just in time")
+        try:
+            state, reply = adapter._await_reply(pending)
+            assert (state, reply) == (protocol.STATE_COMPLETED, "just in time")
+        finally:
+            adapter._pop_pending("task-late-boundary")
+
+    def test_watchdog_skips_live_pending_tasks(self):
+        adapter = _bare_adapter()
+        adapter.tasks.create("task-late-live", "ctx-late-live", "peer-late", "", "")
+        adapter.tasks.set_state("task-late-live", protocol.STATE_WORKING)
+        adapter.tasks._tasks["task-late-live"]["created_at"] -= 9_999
+        assert adapter.tasks.fail_orphans(300, skip={"task-late-live"}) == []
+        assert adapter.tasks.get("task-late-live")["state"] == protocol.STATE_WORKING
+        assert "task-late-live" in adapter.tasks.fail_orphans(300)
+
+
 # --------------------------------------------------------------------------
 # Adapter RPC handlers (driven directly, no HTTP)
 # --------------------------------------------------------------------------
@@ -1123,12 +1229,14 @@ class TestInboundRoundTrip:
 
         asyncio.run(run())
 
-    def test_timeout_returns_failed_not_completed(self, monkeypatch):
-        """When the agent never replies, the task must FAIL (and count as a
-        failure), not report success."""
+    def test_timeout_returns_working_then_failed(self, monkeypatch):
+        """When the agent never replies, the caller gets a WORKING task at the
+        reply deadline (never a synthetic success) and the task fails once the
+        late-result grace expires."""
         monkeypatch.delenv("A2A_BEARER_TOKEN", raising=False)
         monkeypatch.delenv("A2A_PEER_TOKENS", raising=False)
         monkeypatch.setenv("A2A_REPLY_TIMEOUT", "1")
+        monkeypatch.setenv("A2A_LATE_RESULT_GRACE", "0.5")
         adapter, base = _make_live_adapter(monkeypatch, reply_fn=lambda e: None)
 
         async def run():
@@ -1137,12 +1245,15 @@ class TestInboundRoundTrip:
             completed_before = protocol.metrics.tasks_completed
             resp = await asyncio.to_thread(_post_json, base + "/", _send_body("are you there"))
             task = resp["result"]
-            assert task["status"]["state"] == "TASK_STATE_FAILED"
+            assert task["status"]["state"] == "TASK_STATE_WORKING"
+            deadline = time.time() + 3.0
+            rec = adapter.tasks.get(task["id"])
+            while time.time() < deadline and rec["state"] not in protocol.TERMINAL_STATES:
+                await asyncio.sleep(0.05)
+                rec = adapter.tasks.get(task["id"])
+            assert rec["state"] == "TASK_STATE_FAILED"
             assert protocol.metrics.tasks_failed == failed_before + 1
             assert protocol.metrics.tasks_completed == completed_before
-            # The task store agrees.
-            rec = adapter.tasks.get(task["id"])
-            assert rec["state"] == "TASK_STATE_FAILED"
             await adapter.disconnect()
 
         asyncio.run(run())

--- a/website/docs/user-guide/messaging/a2a.md
+++ b/website/docs/user-guide/messaging/a2a.md
@@ -95,6 +95,7 @@ Secure by default; every widening step is explicit:
 | `A2A_RATE_LIMIT` | `60` | Requests/minute per identity |
 | `A2A_MAX_PINGPONG_TURNS` | `5` | Anti-loop turn cap per context (max 20) |
 | `A2A_REPLY_TIMEOUT` | `300` | Seconds to wait for the agent's reply |
+| `A2A_LATE_RESULT_GRACE` | `1800` | Extra seconds a task may keep running after the reply window; the caller gets a `working` task and the outcome stays retrievable via `GetTask`/resubscribe/push. `0` fails tasks at the deadline (legacy) |
 | `A2A_PUSH_SECRET` | bearer token | HMAC secret for push-notification signing |
 | `A2A_ADVERTISED_TOOLSETS` | all registered | Restrict which skills appear on the Agent Card |
 
@@ -119,4 +120,4 @@ curl -X POST http://your-host:9900/ \
 - **Peers can't reach the card URL** — the card was advertising your bind address; set `A2A_PUBLIC_URL` to the externally routable URL.
 - **`401 Unauthorized`** — token mismatch; check `A2A_PEER_TOKENS`/`A2A_BEARER_TOKEN` on the server and the peer's `auth:` block.
 - **Server won't bind non-localhost** — by design: set a bearer token first, then `A2A_HOST=0.0.0.0`.
-- **Replies time out on long tasks** — raise `A2A_REPLY_TIMEOUT`, or have the caller register a push-notification config and poll `GetTask`.
+- **Replies time out on long tasks** — raise `A2A_REPLY_TIMEOUT`, or have the caller register a push-notification config and poll `GetTask`. When the window does expire, the task now keeps running for `A2A_LATE_RESULT_GRACE` seconds and the caller receives a `working` task instead of a failure; the result lands in `GetTask` when the agent finishes.


### PR DESCRIPTION
## Summary
Follow-up to #78357 — point 3 of #78007. The server failed tasks at the `A2A_REPLY_TIMEOUT` deadline even when the dispatched agent run was still going. The eventual reply then found no pending waiter and was dropped, and since terminal task states are sticky the result could never be recorded afterwards. Long tasks did real work the caller could never see.

Now an expired reply window detaches the task instead of failing it: the caller gets a non-terminal `working` task with guidance, the task stays WORKING, and a bounded waiter records the real outcome when the agent finishes — visible to `tasks/get`, `tasks/resubscribe` watchers, and push notifications.

## Changes
- `adapter.py`: `_deadline_outcome()` + `_finalize_late()` — on reply-window expiry (or SSE client disconnect) the task detaches instead of failing; a per-task waiter bounded by `A2A_LATE_RESULT_GRACE` (default 1800s, `0` = legacy fail-at-deadline) records the eventual result. `message/send` and `message/stream` return the `working` task instead of a synthetic failure. The orphan watchdog now skips tasks that still have a live waiter, so it can no longer fail a legitimately long run at the 300s mark.
- `protocol.py`: `fail_orphans(skip=...)`; new `tasks_late_results` metric.
- `tools.py`: `a2a_call` explains a `working` reply and how to pick up the outcome.
- docs: `A2A_LATE_RESULT_GRACE` in both env tables + troubleshooting note.

## Race/deadlock notes
`_resolve_task()` sets results under `_pending_lock` and detach decides under the same lock, so a result cannot slip between the deadline check and the waiter starting. The late path finalizes from its own thread (never from a future done-callback), so it cannot deadlock against `_pending_lock`.

## Validation
| | Before | After |
|---|---|---|
| Agent finishes after reply window | task FAILED, result dropped | task completes late; result in `tasks/get`, watchers resolve, push fires |
| Agent never finishes | FAILED at deadline | FAILED after the grace window (bounded) |
| Watchdog vs long-running task | could fail a live task at 300s | skips tasks with a live waiter |
| Caller UX at deadline | "[agent did not reply in time]" | `working` task + how to fetch the outcome |

Tests: `tests/plugins/test_a2a_plugin.py` — 122 pass with `-m ""` (7 new late-result regressions; the old `test_timeout_returns_failed_not_completed` is updated to the new contract as `test_timeout_returns_working_then_failed`). ruff clean.

`A2A_LATE_RESULT_GRACE=0` is the escape hatch anywhere the old semantics are wanted.