### PR TITLE
fix(sessions): escape LIKE wildcards in prune/archive filters and the cwd-prefix clause

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -176,6 +176,17 @@ def _delegate_from_json(col: str = "model_config") -> str:
 _MODEL_CONFIG_ROW_MISSING = object()
 
 
+def _escape_like(text: str) -> str:
+    """Escape SQL LIKE wildcards so an operator-supplied filter matches
+    literally.  Pair with ``ESCAPE '\\'`` in the clause.
+
+    ``%`` and ``_`` are wildcards to LIKE, and ``_`` in particular is common
+    in the values these filters run against (branch names, session titles).
+    A filter documented as a substring match must not silently widen.
+    """
+    return text.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
     return "(s.cwd = ? OR s.cwd LIKE ? OR s.cwd LIKE ?)", [prefix, f"{prefix}/%", f"{prefix}\\%"]
@@ -8402,8 +8413,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.source = ?")
             params.append(source)
         if title_like:
-            clauses.append("LOWER(COALESCE(s.title, '')) LIKE ?")
-            params.append(f"%{title_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.title, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(title_like.lower())}%")
         if end_reason:
             clauses.append("s.end_reason = ?")
             params.append(end_reason)
@@ -8418,8 +8429,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.message_count <= ?")
             params.append(max_messages)
         if model_like:
-            clauses.append("LOWER(COALESCE(s.model, '')) LIKE ?")
-            params.append(f"%{model_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.model, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(model_like.lower())}%")
         if provider:
             clauses.append("LOWER(COALESCE(s.billing_provider, '')) = ?")
             params.append(provider.lower())
@@ -8433,8 +8444,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             clauses.append("s.chat_type = ?")
             params.append(chat_type)
         if branch_like:
-            clauses.append("LOWER(COALESCE(s.git_branch, '')) LIKE ?")
-            params.append(f"%{branch_like.lower()}%")
+            clauses.append("LOWER(COALESCE(s.git_branch, '')) LIKE ? ESCAPE '\\'")
+            params.append(f"%{_escape_like(branch_like.lower())}%")
         if min_tokens is not None:
             clauses.append(
                 "(COALESCE(s.input_tokens, 0) + COALESCE(s.output_tokens, 0)) >= ?"

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -189,7 +189,16 @@ def _escape_like(text: str) -> str:
 
 def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     prefix = cwd_prefix.rstrip("/\\") or cwd_prefix
-    return "(s.cwd = ? OR s.cwd LIKE ? OR s.cwd LIKE ?)", [prefix, f"{prefix}/%", f"{prefix}\\%"]
+    # ``_`` and ``%`` are LIKE wildcards but ordinary characters in a path
+    # (``my_project``), so an unescaped prefix also matches sibling directories.
+    # Escape the needle and pair it with ESCAPE; the literal separator
+    # backslash in the Windows pattern needs escaping for the same reason. The
+    # ``=`` arm is an exact compare and keeps the raw prefix.
+    esc = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return (
+        "(s.cwd = ? OR s.cwd LIKE ? ESCAPE '\\' OR s.cwd LIKE ? ESCAPE '\\')",
+        [prefix, f"{esc}/%", f"{esc}\\\\%"],
+    )
 
 
 def _workspace_key_clause(key: str) -> Tuple[str, List[str]]:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -194,7 +194,7 @@ def _cwd_prefix_clause(cwd_prefix: str) -> Tuple[str, List[str]]:
     # Escape the needle and pair it with ESCAPE; the literal separator
     # backslash in the Windows pattern needs escaping for the same reason. The
     # ``=`` arm is an exact compare and keeps the raw prefix.
-    esc = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    esc = _escape_like(prefix)
     return (
         "(s.cwd = ? OR s.cwd LIKE ? ESCAPE '\\' OR s.cwd LIKE ? ESCAPE '\\')",
         [prefix, f"{esc}/%", f"{esc}\\\\%"],

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1068,6 +1068,59 @@ class TestPruneSessionFilters:
 
 
 
+    def test_title_like_underscore_is_literal_not_a_wildcard(self, db):
+        """``_`` is a single-character wildcard in SQL LIKE, so an unescaped
+        filter deletes sessions the operator never selected. The filters are
+        documented (and shown in the CLI confirmation) as substring matches.
+        """
+        self._mk(db, "target", title="user_auth refactor")
+        self._mk(db, "bystander1", title="user-auth review")
+        self._mk(db, "bystander2", title="userXauth notes")
+        self._mk(db, "bystander3", title="user auth meeting")
+
+        rows = db.list_prune_candidates(title_like="user_auth")
+        assert {r["id"] for r in rows} == {"target"}
+
+        pruned = db.prune_sessions(older_than_days=None, title_like="user_auth")
+        assert pruned == 1
+        for survivor in ("bystander1", "bystander2", "bystander3"):
+            assert db.get_session(survivor) is not None
+
+    def test_percent_in_filter_does_not_select_everything(self, db):
+        """``%`` matches any run of characters — a bare one would delete the
+        whole table."""
+        self._mk(db, "a", title="alpha")
+        self._mk(db, "b", title="beta")
+        self._mk(db, "pct", title="100% coverage run")
+
+        # Only the title that really contains a percent sign matches.
+        assert {r["id"] for r in db.list_prune_candidates(title_like="%")} == {"pct"}
+        assert {r["id"] for r in db.list_prune_candidates(title_like="100%")} == {"pct"}
+
+    def test_branch_like_underscore_is_literal(self, db):
+        """Branch names carry underscores routinely."""
+        self._mk_rich(db, "want", git_branch="fix/session_prune")
+        self._mk_rich(db, "other", git_branch="fix/session-prune")
+
+        rows = db.list_prune_candidates(branch_like="session_prune")
+        assert {r["id"] for r in rows} == {"want"}
+
+    def test_model_like_underscore_is_literal(self, db):
+        self._mk_rich(db, "want", model="vendor/model_mini")
+        self._mk_rich(db, "other", model="vendor/model-mini")
+
+        rows = db.list_prune_candidates(model_like="model_mini")
+        assert {r["id"] for r in rows} == {"want"}
+
+    def test_plain_substring_filters_still_match(self, db):
+        """Guard against over-escaping: ordinary filters keep working, and a
+        literal backslash in the needle is matched as itself."""
+        self._mk(db, "smoke", title="Codex Smoke Test")
+        self._mk_rich(db, "winpath", title=r"build C:\tmp artifacts")
+
+        assert {r["id"] for r in db.list_prune_candidates(title_like="smoke")} == {"smoke"}
+        assert {r["id"] for r in db.list_prune_candidates(title_like=r"c:\tmp")} == {"winpath"}
+
     def test_unknown_filter_rejected(self, db):
         import pytest as _pytest
         with _pytest.raises(TypeError):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1121,6 +1121,35 @@ class TestPruneSessionFilters:
         assert {r["id"] for r in db.list_prune_candidates(title_like="smoke")} == {"smoke"}
         assert {r["id"] for r in db.list_prune_candidates(title_like=r"c:\tmp")} == {"winpath"}
 
+    def test_cwd_prefix_underscore_is_literal_not_a_wildcard(self, db):
+        """``_`` is a LIKE wildcard but an ordinary character in a path, so an
+        unescaped prefix also matched a same-length sibling directory — and
+        prune_sessions deletes what it matches."""
+        self._mk(db, "target", cwd="/home/me/my_project/src")
+        self._mk(db, "sibling", cwd="/home/me/myXproject/src")
+
+        rows = db.list_prune_candidates(cwd_prefix="/home/me/my_project")
+        assert {r["id"] for r in rows} == {"target"}
+
+        pruned = db.prune_sessions(older_than_days=None, cwd_prefix="/home/me/my_project")
+        assert pruned == 1
+        assert db.get_session("sibling") is not None
+
+    def test_cwd_prefix_percent_does_not_select_everything(self, db):
+        self._mk(db, "a", cwd="/home/me/one")
+        self._mk(db, "b", cwd="/home/me/two")
+
+        assert db.list_prune_candidates(cwd_prefix="/home/me/%") == []
+
+    def test_cwd_prefix_still_matches_the_directory_and_its_children(self, db):
+        """Control: the prefix must keep matching itself and anything under it."""
+        self._mk(db, "root", cwd="/home/me/proj")
+        self._mk(db, "child", cwd="/home/me/proj/src")
+        self._mk(db, "outside", cwd="/home/me/other")
+
+        rows = db.list_prune_candidates(cwd_prefix="/home/me/proj")
+        assert {r["id"] for r in rows} == {"root", "child"}
+
     def test_unknown_filter_rejected(self, db):
         import pytest as _pytest
         with _pytest.raises(TypeError):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1150,6 +1150,17 @@ class TestPruneSessionFilters:
         rows = db.list_prune_candidates(cwd_prefix="/home/me/proj")
         assert {r["id"] for r in rows} == {"root", "child"}
 
+    def test_cwd_prefix_windows_separator_arm(self, db):
+        """The backslash child arm (``{esc}\\\\%`` in the pattern) must keep
+        matching Windows children while ``_`` stays literal — a guard against
+        'simplifying' the quadruple backslash."""
+        self._mk(db, "win_root", cwd=r"C:\Users\me\my_project")
+        self._mk(db, "win_child", cwd=r"C:\Users\me\my_project\src")
+        self._mk(db, "win_sibling", cwd=r"C:\Users\me\myXproject\src")
+
+        rows = db.list_prune_candidates(cwd_prefix=r"C:\Users\me\my_project")
+        assert {r["id"] for r in rows} == {"win_root", "win_child"}
+
     def test_unknown_filter_rejected(self, db):
         import pytest as _pytest
         with _pytest.raises(TypeError):


### PR DESCRIPTION
## Summary

`hermes sessions prune/archive` substring filters (`--title/--model/--branch`) and the cwd-prefix clause treated `_` and `%` as SQL LIKE wildcards, so a filter like `title_like='user_auth'` matched — and **deleted** — `user-auth`, `userXauth`, and `user auth` sessions too, transcripts included. Salvage of #78681 + #78927 by @Drexuxux onto current main, plus a small dedup follow-up.

## Changes

- `hermes_state.py`: new `_escape_like()` helper; `title_like` / `model_like` / `branch_like` clauses in `_prune_filter_where` now escape the needle and pair `LIKE` with `ESCAPE '\'` (#78681, cherry-picked)
- `hermes_state.py`: `_cwd_prefix_clause` escapes the prefix in both LIKE arms — covers prune AND session listing / workspace resume, which share the clause (#78927, cherry-picked)
- Follow-up (ours): `_cwd_prefix_clause` calls `_escape_like()` instead of re-inlining its body
- Follow-up (ours): test guarding the Windows backslash child arm (`{esc}\\%`) — weakening the quadruple backslash to a double now fails a test (mutation-checked)

## Validation

| | Before (main) | After |
|---|---|---|
| `title_like='user_auth'` on 4 near-miss titles | deletes 4 | deletes 1 (target only) |
| `title_like='%'` | selects whole table | selects nothing (only literal `%`) |
| `cwd_prefix='/home/me/my_project'` | also matches `/home/me/myXproject/src` | target only |
| dir named `pct%dir` / Windows `C:\Users\...` prefix | — | still matches itself + children (no over-escaping) |

- `tests/test_hermes_state.py`: 187 passed (12 new tests; mutation check: reverting `hermes_state.py` to main fails exactly the 5 new wildcard guards, controls stay green)
- Sibling suites touching `prune_sessions`/`cwd_prefix`/`session_filters`: 33 passed
- E2E with real `SessionDB` + real SQLite (isolated HERMES_HOME): main reproduces the over-delete (`pruned: 4, survivors: []`), fixed tree deletes only the target
- `EXPLAIN QUERY PLAN`: adding `ESCAPE` does not change plans for these clauses
- ruff clean; no callers rely on wildcard passthrough (CLI/docs/API all say "contains this substring")

Closes #78681
Closes #78927

## Credit

Both fixes authored by @Drexuxux; commits cherry-picked with authorship preserved. Merge with `--rebase`.
