### PR TITLE
fix(installer): record the installed checkout commit

### DIFF
--- a/.github/workflows/installer-tests.yml
+++ b/.github/workflows/installer-tests.yml
@@ -29,10 +29,16 @@ jobs:
       # `irm | iex` into whatever shell the user already has, and 5.1 is what
       # ships with Windows. A construct that only parses under 7 is a broken
       # installer for most of the people hitting it.
-      - name: 8.3 short-path normalization (pwsh 7)
+      - name: PowerShell installer behavior (pwsh 7)
         shell: pwsh
-        run: pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+        run: |
+          pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-stage-protocol.ps1
 
-      - name: 8.3 short-path normalization (Windows PowerShell 5.1)
+      - name: PowerShell installer behavior (Windows PowerShell 5.1)
         shell: powershell
-        run: powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+        run: |
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-longpath.ps1
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+          powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-stage-protocol.ps1

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -261,29 +261,24 @@ pub(crate) fn hermes_is_installed(install_root: &std::path::Path) -> bool {
 }
 
 fn resolve_marker_commit(install_root: &Path, pin: &Pin) -> Option<String> {
-    if let Some(commit) = pin
-        .commit
-        .as_ref()
-        .filter(|commit| !commit.trim().is_empty())
-    {
-        return Some(commit.clone());
-    }
-
     let output = std::process::Command::new("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(install_root)
         .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
+        .ok();
+    let installed_commit = output
+        .filter(|output| output.status.success())
+        .and_then(|output| {
+            let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            (!commit.is_empty()).then_some(commit)
+        });
 
-    let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if commit.is_empty() {
-        None
-    } else {
-        Some(commit)
-    }
+    installed_commit.or_else(|| {
+        pin.commit
+            .as_ref()
+            .filter(|commit| !commit.trim().is_empty())
+            .cloned()
+    })
 }
 
 fn write_bootstrap_complete_marker(install_root: &Path, pin: &Pin) -> Result<serde_json::Value> {
@@ -1016,6 +1011,48 @@ mod tests {
             resolve_hermes_desktop_app(&root).is_none(),
             "no resolved app when nothing has been built"
         );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn bootstrap_complete_marker_records_installed_head_ahead_of_requested_pin() {
+        let root = unique_tmp_dir("marker-installed-head");
+        let run_git = |args: &[&str]| {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&root)
+                .output()
+                .expect("git should run")
+        };
+
+        assert!(run_git(&["init", "-q"]).status.success());
+        let commit = run_git(&[
+            "-c",
+            "user.name=Hermes Test",
+            "-c",
+            "user.email=hermes@example.invalid",
+            "commit",
+            "--allow-empty",
+            "-qm",
+            "installed",
+        ]);
+        assert!(
+            commit.status.success(),
+            "git commit failed: {}",
+            String::from_utf8_lossy(&commit.stderr)
+        );
+        let head = run_git(&["rev-parse", "HEAD"]);
+        assert!(head.status.success());
+        let head = String::from_utf8_lossy(&head.stdout).trim().to_string();
+
+        let pin = Pin {
+            commit: Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string()),
+            branch: Some("main".to_string()),
+        };
+        let marker =
+            write_bootstrap_complete_marker(&root, &pin).expect("marker write should succeed");
+
+        assert_eq!(marker["pinnedCommit"], head);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -131,7 +131,7 @@ test('fallback install stamps use an unpinned branch ref', () => {
   )
 })
 
-test('resolveMarkerPinnedCommit prefers real HEAD over fallback stamp zeros', () => {
+test('resolveMarkerPinnedCommit records installed HEAD ahead of the requested pin', () => {
   const realHead = 'c'.repeat(40)
   assert.equal(
     resolveMarkerPinnedCommit({ commit: ZERO_COMMIT, branch: 'main' }, '/tmp/checkout', {
@@ -143,8 +143,8 @@ test('resolveMarkerPinnedCommit prefers real HEAD over fallback stamp zeros', ()
     resolveMarkerPinnedCommit({ commit: 'd'.repeat(40), branch: 'main' }, '/tmp/checkout', {
       resolveHead: () => realHead
     }),
-    'd'.repeat(40),
-    'packaged real pin wins over checkout HEAD'
+    realHead,
+    'installed HEAD wins when rollback protection keeps a newer checkout'
   )
   assert.equal(
     resolveMarkerPinnedCommit({ commit: ZERO_COMMIT, branch: 'main' }, '/tmp/missing', {

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -101,8 +101,9 @@ function readExistingPinnedCommit(activeRoot: string | null | undefined): string
 
 /**
  * Pick the commit to store on the bootstrap-complete marker.
- * Packaged fallback stamps must NOT win (all-zero is not a real pin); after a
- * successful install the checkout's HEAD (or install.ps1's marker) does.
+ * A successful install may intentionally keep a checkout newer than the
+ * packaged pin. Record the installed checkout's HEAD when it is available,
+ * then fall back to the requested pin or install.ps1's existing marker.
  */
 function resolveMarkerPinnedCommit(
   installStamp: { commit?: string; branch?: string | null } | null | undefined,
@@ -111,14 +112,14 @@ function resolveMarkerPinnedCommit(
 ): string | null {
   const resolveHead = opts.resolveHead || resolveCheckoutHead
 
-  if (installStamp && isPinnedCommit(installStamp.commit)) {
-    return installStamp.commit
-  }
-
   const head = resolveHead(activeRoot)
 
   if (head) {
     return head
+  }
+
+  if (installStamp && isPinnedCommit(installStamp.commit)) {
+    return installStamp.commit
   }
 
   return readExistingPinnedCommit(activeRoot)

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3604,7 +3604,7 @@ function readJson(filePath) {
 // Marker schema (version 1):
 //   {
 //     schemaVersion: 1,
-//     pinnedCommit: "<40-char SHA>",       // what install.ps1 was driven against
+//     pinnedCommit: "<40-char SHA>",       // checkout HEAD after installation
 //     pinnedBranch: "<branch name>" | null,
 //     completedAt:  "<ISO 8601>",
 //     desktopVersion: "<app.getVersion()>"  // for forensics

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2697,9 +2697,9 @@ function Write-BootstrapMarker {
     #   apps/desktop/electron/main.ts lines 1199-1222
     #   BOOTSTRAP_MARKER_SCHEMA_VERSION = 1 (line 187)
     #
-    # Pinned commit/branch come from -Commit + -Branch flags (passed by
-    # Hermes-Setup.exe) or fall back to whatever git resolves in the
-    # checkout. The desktop validates schemaVersion + pinnedCommit
+    # Record the checkout that actually finished installing. Rollback
+    # protection may intentionally keep it ahead of the requested -Commit.
+    # The desktop validates schemaVersion + pinnedCommit
     # length but doesn't enforce that HEAD matches the pin (users
     # update via `hermes update` which moves HEAD legitimately).
     if (-not (Test-Path $InstallDir)) {
@@ -2707,31 +2707,27 @@ function Write-BootstrapMarker {
         return
     }
 
-    # Resolve the pinned commit: explicit -Commit wins, otherwise read
-    # the checkout's HEAD via git. If git can't run, leave commit empty
-    # and the marker will fail desktop validation (pinnedCommit.length
-    # >= 7) -- better to be invalid than wrong.
-    $pinnedCommit = $Commit
-    if (-not $pinnedCommit) {
-        # PS 5.1 doesn't support the ?. null-conditional operator, so
-        # check Get-Command's result explicitly before reading .Source.
-        $gitCmd = Get-Command git -ErrorAction SilentlyContinue
-        $gitExe = if ($gitCmd) { $gitCmd.Source } else { $null }
-        if ($gitExe) {
-            Push-Location $InstallDir
-            try {
-                $resolved = & $gitExe rev-parse HEAD 2>$null
-                if ($LASTEXITCODE -eq 0 -and $resolved) {
-                    $pinnedCommit = $resolved.Trim()
-                }
-            } catch {
-                # Ignore -- pinnedCommit stays empty, marker stays invalid,
-                # desktop falls through to its legacy bootstrap path.
-            } finally {
-                Pop-Location
+    # Prefer the installed checkout's HEAD. If git cannot inspect it, fall back
+    # to the requested commit so archive installs can still publish a marker.
+    $pinnedCommit = $null
+    # PS 5.1 doesn't support the ?. null-conditional operator, so
+    # check Get-Command's result explicitly before reading .Source.
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    $gitExe = if ($gitCmd) { $gitCmd.Source } else { $null }
+    if ($gitExe) {
+        Push-Location $InstallDir
+        try {
+            $resolved = & $gitExe rev-parse HEAD 2>$null
+            if ($LASTEXITCODE -eq 0 -and $resolved) {
+                $pinnedCommit = $resolved.Trim()
             }
+        } catch {
+            # Fall back to the requested commit below.
+        } finally {
+            Pop-Location
         }
     }
+    if (-not $pinnedCommit) { $pinnedCommit = $Commit }
 
     $pinnedBranch = $Branch
     if (-not $pinnedBranch) {
@@ -3374,41 +3370,15 @@ function Install-Desktop {
     # for some other tool, electron-builder would still try to sign.
     Write-Info "Building desktop app (this takes 1-3 minutes)..."
     $buildLog = "$env:TEMP\hermes-desktop-build-$(Get-Random).log"
-    # Seed GITHUB_SHA for write-build-stamp.mjs. The stamp prefers CI env vars
-    # over `git rev-parse`, so this covers: (1) node can't find git.exe on PATH
-    # even though this PowerShell session can, (2) ZIP/init trees that still
-    # lack a HEAD after a failed post-extract fetch. Without it the desktop
-    # pack dies with "could not determine git commit" (#50823).
-    if (-not $env:GITHUB_SHA) {
-        if ($Commit) {
-            $env:GITHUB_SHA = $Commit
-        } else {
-            Push-Location $InstallDir
-            try {
-                $global:LASTEXITCODE = 0
-                $resolvedSha = & git -c windows.appendAtomically=false rev-parse HEAD 2>$null
-                if ($LASTEXITCODE -ne 0 -or -not $resolvedSha) {
-                    # ZIP path may have FETCH_HEAD after a fetch even when HEAD is unset.
-                    $global:LASTEXITCODE = 0
-                    $resolvedSha = & git -c windows.appendAtomically=false rev-parse FETCH_HEAD 2>$null
-                }
-                if ($LASTEXITCODE -eq 0 -and $resolvedSha) {
-                    $env:GITHUB_SHA = ("$resolvedSha").Trim()
-                }
-            } catch { } finally {
-                Pop-Location
-            }
-        }
-    }
-    if (-not $env:GITHUB_REF_NAME) {
-        $env:GITHUB_REF_NAME = if ($Branch) { $Branch } else { "main" }
-    }
-    if ($env:GITHUB_SHA) {
-        $shaPreview = if ($env:GITHUB_SHA.Length -ge 12) { $env:GITHUB_SHA.Substring(0, 12) } else { $env:GITHUB_SHA }
-        Write-Info "Desktop build stamp: $shaPreview ($($env:GITHUB_REF_NAME))"
-    } else {
-        Write-Warn "Could not resolve a git commit for the desktop stamp -- write-build-stamp will use its non-git fallback"
-    }
+    # This is an installer-local build, even if the installer was launched
+    # from a CI shell. Let write-build-stamp inspect the checkout itself so it
+    # records the installed HEAD, actual branch, and tracked-file dirty state.
+    $prevGithubSha = [Environment]::GetEnvironmentVariable("GITHUB_SHA", "Process")
+    $prevGithubRefName = [Environment]::GetEnvironmentVariable("GITHUB_REF_NAME", "Process")
+    $prevGithubHeadRef = [Environment]::GetEnvironmentVariable("GITHUB_HEAD_REF", "Process")
+    Remove-Item Env:GITHUB_SHA -ErrorAction SilentlyContinue
+    Remove-Item Env:GITHUB_REF_NAME -ErrorAction SilentlyContinue
+    Remove-Item Env:GITHUB_HEAD_REF -ErrorAction SilentlyContinue
     Push-Location $desktopDir
     $prevEAP = $ErrorActionPreference
     $prevCSCAuto = $env:CSC_IDENTITY_AUTO_DISCOVERY
@@ -3470,9 +3440,12 @@ function Install-Desktop {
         Pop-Location
         throw
     } finally {
-        # Restore env to whatever the caller had -- don't leak our
-        # signing-off override into anything install.ps1 invokes later
-        # (Stage-PlatformSdks, etc.).
+        # Restore env to whatever the caller had -- don't leak our signing or
+        # build-provenance overrides into anything install.ps1 invokes later
+        # (Stage-PlatformSdks, etc.), or into the caller's `irm | iex` shell.
+        [Environment]::SetEnvironmentVariable("GITHUB_SHA", $prevGithubSha, "Process")
+        [Environment]::SetEnvironmentVariable("GITHUB_REF_NAME", $prevGithubRefName, "Process")
+        [Environment]::SetEnvironmentVariable("GITHUB_HEAD_REF", $prevGithubHeadRef, "Process")
         $env:CSC_IDENTITY_AUTO_DISCOVERY = $prevCSCAuto
         $env:WIN_CSC_LINK = $prevWinCscLink
         $env:WIN_CSC_KEY_PASSWORD = $prevWinCscKeyPassword

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2547,13 +2547,13 @@ write_bootstrap_marker() {
         return 0
     fi
 
-    # Explicit --commit wins; otherwise read HEAD from the checkout we just
-    # installed. If neither resolves, skip the marker entirely rather than
-    # write one the desktop will reject -- an absent marker is a clean
-    # "bootstrap needed", a malformed one is a confusing half-state.
-    local pinned_commit="$INSTALL_COMMIT"
+    # Record the checkout that actually finished installing. Rollback
+    # protection may intentionally keep it ahead of the requested --commit.
+    # Fall back to the request only when git cannot inspect the checkout.
+    local pinned_commit=""
+    pinned_commit=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || pinned_commit=""
     if [ -z "$pinned_commit" ]; then
-        pinned_commit=$(git -C "$INSTALL_DIR" rev-parse HEAD 2>/dev/null) || pinned_commit=""
+        pinned_commit="$INSTALL_COMMIT"
     fi
 
     if [ -z "$pinned_commit" ]; then
@@ -2833,6 +2833,9 @@ EOF
 _desktop_pack() {
     local desktop_dir="$1"
     local mirror="${2:-}"
+    # npm run pack is a local build even when install.sh was launched from a
+    # CI shell. Let write-build-stamp inspect HEAD, branch, and dirty state.
+    unset GITHUB_SHA GITHUB_REF_NAME GITHUB_HEAD_REF
     if [ -n "$mirror" ]; then
         ( cd "$desktop_dir" && ELECTRON_MIRROR="$mirror" CSC_IDENTITY_AUTO_DISCOVERY=false npm run pack )
     else

--- a/scripts/tests/test-install-ps1-stage-protocol.ps1
+++ b/scripts/tests/test-install-ps1-stage-protocol.ps1
@@ -4,13 +4,11 @@
 #
 #   powershell -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-stage-protocol.ps1
 #
-# These tests only exercise the metadata surface (-ProtocolVersion, -Manifest,
-# unknown -Stage handling).  They DO NOT actually run any install stages --
-# those have heavy side effects (winget, git clone, pip install, PATH writes)
-# and are out of scope for a unit smoke test.  All three metadata commands
-# below return without invoking Main / Invoke-AllStages.
-#
-# To exercise real install stages, drive the script from a clean VM.
+# These tests exercise the metadata surface (-ProtocolVersion, -Manifest,
+# unknown -Stage handling) plus the bounded bootstrap-marker stage against a
+# temporary Git checkout. Heavy stages with external side effects (winget,
+# clone, pip install, PATH writes) remain out of scope; drive those from a
+# clean VM.
 
 $ErrorActionPreference = "Stop"
 $repoRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path))
@@ -119,6 +117,52 @@ if ($errFrame) {
     Assert-Equal -Expected $false -Actual $errFrame.ok -Label "unknown-stage frame has ok=false"
     Assert-Equal -Expected "does-not-exist" -Actual $errFrame.stage -Label "unknown-stage frame echoes stage name"
     Assert-True ($errFrame.reason -match "unknown stage") -Label "unknown-stage frame explains why"
+}
+
+# -----------------------------------------------------------------------------
+# Test: bootstrap marker records the installed checkout, not a stale request
+# -----------------------------------------------------------------------------
+Write-Host ""
+Write-Host "-- bootstrap marker installed HEAD --"
+$markerTestRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
+    ("hermes-marker-test-" + [Guid]::NewGuid().ToString("N"))
+$markerInstallDir = Join-Path $markerTestRoot "checkout"
+$markerHermesHome = Join-Path $markerTestRoot "home"
+$currentShell = (Get-Process -Id $PID).Path
+
+try {
+    New-Item -ItemType Directory -Path $markerInstallDir, $markerHermesHome -Force | Out-Null
+    & git -C $markerInstallDir init -q
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "marker fixture git init succeeds"
+    & git -C $markerInstallDir `
+        -c user.name="Hermes Test" `
+        -c user.email="hermes@example.invalid" `
+        commit --allow-empty -qm installed
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "marker fixture git commit succeeds"
+    $installedHead = (& git -C $markerInstallDir rev-parse HEAD).Trim()
+    $requestedCommit = "a" * 40
+
+    $stageOutput = & $currentShell -NoProfile -ExecutionPolicy Bypass -File $installScript `
+        -Stage "bootstrap-marker" `
+        -InstallDir $markerInstallDir `
+        -HermesHome $markerHermesHome `
+        -Commit $requestedCommit `
+        -NonInteractive `
+        -Json
+    Assert-Equal -Expected 0 -Actual $LASTEXITCODE -Label "bootstrap-marker stage exits 0"
+
+    $markerPath = Join-Path $markerInstallDir ".hermes-bootstrap-complete"
+    Assert-True (Test-Path -LiteralPath $markerPath -PathType Leaf) `
+        -Label "bootstrap-marker stage writes the marker"
+    if (Test-Path -LiteralPath $markerPath -PathType Leaf) {
+        $marker = Get-Content -LiteralPath $markerPath -Raw | ConvertFrom-Json
+        Assert-Equal -Expected $installedHead -Actual $marker.pinnedCommit `
+            -Label "marker records installed HEAD instead of stale -Commit"
+    }
+} finally {
+    if (Test-Path -LiteralPath $markerTestRoot) {
+        Remove-Item -LiteralPath $markerTestRoot -Recurse -Force
+    }
 }
 
 # -----------------------------------------------------------------------------

--- a/tests/test_install_sh_bootstrap_marker.py
+++ b/tests/test_install_sh_bootstrap_marker.py
@@ -82,14 +82,22 @@ def test_marker_publish_leaves_no_temp_sibling(tmp_path):
     assert not (install_dir / ".hermes-bootstrap-complete.tmp").exists()
 
 
-def test_explicit_commit_pin_wins_over_head(tmp_path):
+def test_installed_head_wins_over_requested_commit(tmp_path):
     install_dir = make_checkout(tmp_path)
     pinned = "abcdef1234567890abcdef1234567890abcdef12"
+
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=install_dir,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
 
     run_write_marker(install_dir, commit=pinned)
 
     payload = json.loads((install_dir / ".hermes-bootstrap-complete").read_text())
-    assert payload["pinnedCommit"] == pinned
+    assert payload["pinnedCommit"] == head
 
 
 def test_no_marker_written_when_head_cannot_be_resolved(tmp_path):


### PR DESCRIPTION
## What does this PR do?

Hermes installers can intentionally keep a managed checkout newer than the requested pin because of rollback protection. The install still succeeds, but several completion paths recorded the stale requested commit instead of the checkout that actually finished installation. That leaves bootstrap markers and locally packaged Desktop provenance disagreeing with the installed runtime.

This PR makes the installed checkout's `HEAD` authoritative when it is available, while retaining the requested pin as the fallback for non-Git/archive installs. Installer-local Desktop builds also derive commit, branch, and dirty state from the checkout instead of inherited GitHub CI variables.

The behavior is covered with real temporary Git repositories, including the PowerShell installer stage under both PowerShell 7 and Windows PowerShell 5.1.

## Related Issue

Related: #39333

That issue asks for `.hermes-bootstrap-complete` to remain consistent with the actual managed install state. Its existing PRs #39351 and #39358 address detached-branch recovery and cancellation reporting; this PR is limited to completion/build metadata provenance and does not claim to close the issue.

No exact issue or open PR was found for a newer installed `HEAD` being overwritten in metadata by an older requested pin.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/bootstrap-installer/src-tauri/src/bootstrap.rs`: prefer the installed checkout's `HEAD` in Rust bootstrap-complete markers, then fall back to the requested pin.
- `apps/desktop/electron/bootstrap-runner.ts`: apply the same precedence in first-launch marker recovery.
- `scripts/install.ps1` and `scripts/install.sh`: record the checkout that actually completed installation in their bootstrap markers.
- For installer-local Desktop packaging, clear inherited GitHub CI provenance so `write-build-stamp.mjs` reads the real local commit, branch, and tracked-file dirty state; PowerShell restores the caller's environment afterward.
- `scripts/tests/test-install-ps1-stage-protocol.ps1`: execute the real bounded `bootstrap-marker` stage against a temporary Git checkout under both supported PowerShell runtimes.
- `.github/workflows/installer-tests.yml`: run that stage-protocol suite under PowerShell 7 and Windows PowerShell 5.1.
- Update focused Electron, Rust, and POSIX marker regressions.

## How to Test

1. Run the Desktop marker/build-stamp tests:

   ```powershell
   bunx vitest run apps/desktop/electron/bootstrap-runner.test.ts apps/desktop/scripts/write-build-stamp.test.mjs
   ```

2. Run the Rust marker tests:

   ```powershell
   cargo test --manifest-path apps/bootstrap-installer/src-tauri/Cargo.toml bootstrap_complete_marker --lib
   ```

3. Run the Windows installer stage under both shells:

   ```powershell
   pwsh -NoProfile -File scripts/tests/test-install-ps1-stage-protocol.ps1
   powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/tests/test-install-ps1-stage-protocol.ps1
   ```

4. In a temporary checkout, pass an older requested commit to each marker path while `HEAD` points to a newer commit. Verify `pinnedCommit` equals `HEAD`. Remove the checkout metadata and verify the requested commit remains the fallback.

5. Run `bash -n scripts/install.sh` and `git diff --check`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, PowerShell 7, Windows PowerShell 5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Desktop marker/build-stamp tests: 17 passed across 2 files
Rust bootstrap-marker tests: 3 passed
PowerShell 7 stage protocol: 26 assertions passed
Windows PowerShell 5.1 stage protocol: 26 assertions passed
POSIX installer syntax: passed
Real POSIX marker probe: installed HEAD recorded instead of requested pin
git diff --check: passed
```

The repository's Python wrapper did not return after its child process exited on this host, so no full-suite result is claimed.
