### PR TITLE
fix(desktop): refresh Windows backend PATH

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -186,6 +186,24 @@ test('Windows PATH casing and delimiter are preserved without POSIX sane entries
   assert.equal(env.Path.includes('/opt/homebrew/bin'), false)
 })
 
+test('Windows backend PATH keeps live host entries ahead of stale process extras', () => {
+  const env = buildDesktopBackendEnv({
+    hermesHome: 'C:\\Users\\test\\AppData\\Local\\hermes',
+    venvRoot: 'C:\\Users\\test\\AppData\\Local\\hermes\\hermes-agent\\venv',
+    currentEnv: {
+      Path: 'C:\\Stale\\Desktop\\bin;C:\\Windows\\System32'
+    },
+    hostPath: 'C:\\Windows\\System32;C:\\Host\\GitHubCLI;C:\\Host\\Git\\bin',
+    platform: 'win32',
+    pathModule: path.win32
+  })
+
+  const entries = env.Path.split(';')
+  assert.ok(entries.indexOf('C:\\Host\\GitHubCLI') >= 0)
+  assert.ok(entries.indexOf('C:\\Host\\GitHubCLI') < entries.indexOf('C:\\Stale\\Desktop\\bin'))
+  assert.equal(entries.filter(entry => entry.toLowerCase() === 'c:\\windows\\system32').length, 1)
+})
+
 test('appendUniquePathEntries drops empty entries and keeps first occurrence', () => {
   assert.equal(appendUniquePathEntries([':/a::/b', ['/a', '/c']], { delimiter: ':' }), '/a:/b:/c')
 })

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -36,7 +36,7 @@ function currentPathValue(env = process.env, platform = process.platform) {
   return env?.[key] || ''
 }
 
-function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
+function appendUniquePathEntries(entries, { delimiter = path.delimiter, caseInsensitive = false }: any = {}) {
   const seen = new Set()
   const ordered = []
 
@@ -48,11 +48,13 @@ function appendUniquePathEntries(entries, { delimiter = path.delimiter } = {}) {
     const parts = Array.isArray(entry) ? entry : String(entry).split(delimiter)
 
     for (const part of parts) {
-      if (!part || seen.has(part)) {
+      const comparisonKey = caseInsensitive ? part.toLowerCase() : part
+
+      if (!part || seen.has(comparisonKey)) {
         continue
       }
 
-      seen.add(part)
+      seen.add(comparisonKey)
       ordered.push(part)
     }
   }
@@ -92,6 +94,7 @@ function buildDesktopBackendPath({
   hermesHome,
   venvRoot,
   currentPath = '',
+  hostPath = '',
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
 }: any = {}) {
@@ -100,7 +103,10 @@ function buildDesktopBackendPath({
   const venvBin = venvRoot ? pathModule.join(venvRoot, platform === 'win32' ? 'Scripts' : 'bin') : null
   const saneEntries = platform === 'win32' ? [] : POSIX_SANE_PATH_ENTRIES
 
-  return appendUniquePathEntries([hermesNodeDirs, venvBin, currentPath, saneEntries], { delimiter })
+  return appendUniquePathEntries([hermesNodeDirs, venvBin, hostPath, currentPath, saneEntries], {
+    delimiter,
+    caseInsensitive: platform === 'win32'
+  })
 }
 
 function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatform(process.platform) }: any = {}) {
@@ -122,6 +128,7 @@ function buildDesktopBackendEnv({
   hermesHome,
   pythonPathEntries = [],
   venvRoot,
+  hostPath = '',
   currentEnv = process.env,
   platform = process.platform,
   pathModule = pathModuleForPlatform(platform)
@@ -142,6 +149,7 @@ function buildDesktopBackendEnv({
     [key]: buildDesktopBackendPath({
       hermesHome,
       venvRoot,
+      hostPath,
       currentPath: currentPathValue(currentEnv, platform),
       platform,
       pathModule

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -244,7 +244,7 @@ import {
   writeSandboxMarker
 } from './windows-sandbox-fallback'
 import { installWindowsSystemCaTrust } from './windows-system-ca'
-import { readWindowsUserEnvVar } from './windows-user-env'
+import { readWindowsHostPath, readWindowsUserEnvVar } from './windows-user-env'
 import { isPackagedInstallPath as isPackagedInstallPathUnderRoots } from './workspace-cwd'
 import { readWslWindowsClipboardImage } from './wsl-clipboard-image'
 import { resolvePickerDefaultPath } from './wsl-path-bridge'
@@ -577,6 +577,27 @@ function resolveHermesHome() {
 }
 
 const HERMES_HOME = resolveHermesHome()
+
+let windowsHostPath: string | undefined
+
+// Resolve once, only when a local backend needs an environment. Explorer-launched
+// apps can retain a login-time PATH after the registry changes.
+function getWindowsHostPath() {
+  if (windowsHostPath === undefined) {
+    windowsHostPath = IS_WINDOWS ? readWindowsHostPath() || '' : ''
+  }
+
+  return windowsHostPath
+}
+
+function buildDesktopBackendEnvironment(options) {
+  return buildDesktopBackendEnv({
+    ...options,
+    // Keep live host entries ahead of stale process extras, while
+    // buildDesktopBackendEnv still prepends Hermes-managed paths.
+    hostPath: getWindowsHostPath()
+  })
+}
 
 function pathWithHermesManagedNode(...entries) {
   const managed = hermesManagedNodePathEntries(HERMES_HOME).filter(directoryExists)
@@ -1869,7 +1890,7 @@ function unwrapWindowsVenvHermesCommand(command, backendArgs) {
     canImportHermesCli,
     getVenvPython,
     getVenvSitePackagesEntries,
-    buildDesktopBackendEnv,
+    buildDesktopBackendEnv: buildDesktopBackendEnvironment,
     hermesHome: HERMES_HOME,
     resolvePath: (...segments) => path.resolve(...segments),
     dirname: p => path.dirname(p),
@@ -3838,7 +3859,7 @@ function createPythonBackend(root, label, backendArgs, options: any = {}) {
     label,
     command,
     args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
+    env: buildDesktopBackendEnvironment({
       hermesHome: HERMES_HOME,
       pythonPathEntries: [root, ...getVenvSitePackagesEntries(venvRoot)],
       venvRoot
@@ -3862,7 +3883,7 @@ function createActiveBackend(backendArgs) {
     label: `Hermes at ${ACTIVE_HERMES_ROOT}`,
     command,
     args: ['-m', 'hermes_cli.main', ...backendArgs],
-    env: buildDesktopBackendEnv({
+    env: buildDesktopBackendEnvironment({
       hermesHome: HERMES_HOME,
       pythonPathEntries: [ACTIVE_HERMES_ROOT, ...getVenvSitePackagesEntries(VENV_ROOT)],
       venvRoot: VENV_ROOT

--- a/apps/desktop/electron/windows-user-env.test.ts
+++ b/apps/desktop/electron/windows-user-env.test.ts
@@ -2,7 +2,12 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar } from './windows-user-env'
+import {
+  expandWindowsEnvRefs,
+  parseRegQueryValue,
+  readWindowsHostPath,
+  readWindowsUserEnvVar
+} from './windows-user-env'
 
 // ── parseRegQueryValue ─────────────────────────────────────────────────────
 
@@ -84,4 +89,71 @@ test('readWindowsUserEnvVar returns null when reg exits non-zero (value missing)
 test('readWindowsUserEnvVar returns null for an empty value', () => {
   const exec = () => '    HERMES_HOME    REG_SZ    \r\n'
   assert.equal(readWindowsUserEnvVar('HERMES_HOME', { platform: 'win32', exec }), null)
+})
+
+test('readWindowsHostPath combines live machine and user PATH in Windows order', () => {
+  const calls = []
+
+  const exec = (cmd, args) => {
+    calls.push([cmd, args])
+
+    if (args[1].startsWith('HKLM\\')) {
+      return (
+        'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\r\n' +
+        '    Path    REG_EXPAND_SZ    %SystemRoot%\\system32;C:\\Host\\System\r\n'
+      )
+    }
+
+    return 'HKEY_CURRENT_USER\\Environment\r\n' + '    Path    REG_SZ    C:\\Host\\User;C:\\Host\\GitHubCLI\r\n'
+  }
+
+  const path = readWindowsHostPath({
+    platform: 'win32',
+    env: { SystemRoot: 'C:\\Windows' },
+    exec
+  })
+
+  assert.equal(path, 'C:\\Windows\\system32;C:\\Host\\System;C:\\Host\\User;C:\\Host\\GitHubCLI')
+  assert.deepEqual(calls, [
+    ['reg', ['query', 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment', '/v', 'Path']],
+    ['reg', ['query', 'HKCU\\Environment', '/v', 'Path']]
+  ])
+})
+
+test('readWindowsHostPath ignores a user PATH when the machine PATH is unavailable', () => {
+  const exec = (_cmd, args) => {
+    if (args[1].startsWith('HKLM\\')) {
+      throw new Error('machine environment unavailable')
+    }
+
+    return 'HKEY_CURRENT_USER\\Environment\r\n    Path    REG_SZ    C:\\Host\\User\r\n'
+  }
+
+  assert.equal(readWindowsHostPath({ platform: 'win32', exec }), null)
+})
+
+test('readWindowsHostPath keeps the machine PATH when the user PATH is unavailable', () => {
+  const exec = (_cmd, args) => {
+    if (args[1].startsWith('HKCU\\')) {
+      throw new Error('user environment unavailable')
+    }
+
+    return (
+      'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment\r\n' +
+      '    Path    REG_SZ    C:\\Windows\\System32;C:\\Host\\System\r\n'
+    )
+  }
+
+  assert.equal(readWindowsHostPath({ platform: 'win32', exec }), 'C:\\Windows\\System32;C:\\Host\\System')
+})
+
+test('readWindowsHostPath is a no-op off Windows', () => {
+  let spawned = false
+  const exec = () => {
+    spawned = true
+    return ''
+  }
+
+  assert.equal(readWindowsHostPath({ platform: 'linux', exec }), null)
+  assert.equal(spawned, false)
 })

--- a/apps/desktop/electron/windows-user-env.ts
+++ b/apps/desktop/electron/windows-user-env.ts
@@ -1,18 +1,17 @@
 // windows-user-env.ts
 //
-// Read a User-scoped environment variable straight from the Windows registry
-// (HKCU\Environment).
+// Read environment variables straight from the live Windows registry.
 //
 // A GUI app launched from Explorer inherits the environment block captured at
 // login, so a variable set via `setx` AFTER login is invisible in process.env
 // even though a fresh shell — and the Hermes CLI — sees it immediately. The
-// desktop's HERMES_HOME resolution relies on process.env, so that stale-snapshot
-// gap silently sends the backend to the default %LOCALAPPDATA%\hermes. Reading
-// the live registry value closes the gap. See #45471.
+// Desktop process resolution relies on process.env, so that stale snapshot can
+// hide a custom HERMES_HOME or PATH entries written after launch. Expansion
+// still uses the inherited environment. See #45471.
 
 import { execFileSync } from 'node:child_process'
 
-// Parse the output of `reg query HKCU\Environment /v <name>`, which looks like:
+// Parse the output of `reg query <key> /v <name>`, which looks like:
 //
 //   HKEY_CURRENT_USER\Environment
 //       HERMES_HOME    REG_SZ    F:\Hermes\data
@@ -53,20 +52,16 @@ function expandWindowsEnvRefs(value, env = process.env) {
   })
 }
 
-// Read a User-scoped env var from HKCU\Environment. Windows-only: returns null
-// off-Windows (without spawning), on any spawn error, when `reg` exits non-zero
-// (the value doesn't exist), or when the value is empty.
-function readWindowsUserEnvVar(
+type WindowsEnvReadOptions = {
+  platform?: NodeJS.Platform
+  env?: NodeJS.ProcessEnv
+  exec?: typeof execFileSync | ((file?: string, args?: any) => string)
+}
+
+function readWindowsRegistryEnvVar(
+  keyPath: string,
   name,
-  {
-    platform = process.platform,
-    env = process.env,
-    exec = execFileSync
-  }: {
-    platform?: NodeJS.Platform
-    env?: NodeJS.ProcessEnv
-    exec?: typeof execFileSync | ((file?: string, args?: any) => string)
-  } = {}
+  { platform = process.platform, env = process.env, exec = execFileSync }: WindowsEnvReadOptions = {}
 ) {
   if (platform !== 'win32' || !name) {
     return null
@@ -75,13 +70,12 @@ function readWindowsUserEnvVar(
   let stdout
 
   try {
-    stdout = exec('reg', ['query', 'HKCU\\Environment', '/v', name], {
+    stdout = exec('reg', ['query', keyPath, '/v', name], {
       encoding: 'utf8',
       windowsHide: true,
       timeout: 5000
     })
   } catch {
-    // `reg` missing, or value absent (reg exits 1) — caller falls back.
     return null
   }
 
@@ -96,4 +90,37 @@ function readWindowsUserEnvVar(
   return expanded || null
 }
 
-export { expandWindowsEnvRefs, parseRegQueryValue, readWindowsUserEnvVar }
+// Read a User-scoped env var from HKCU\Environment. Windows-only: returns null
+// off-Windows (without spawning), on any spawn error, when `reg` exits non-zero
+// (the value doesn't exist), or when the value is empty.
+function readWindowsUserEnvVar(name, options: WindowsEnvReadOptions = {}) {
+  return readWindowsRegistryEnvVar('HKCU\\Environment', name, options)
+}
+
+const WINDOWS_MACHINE_ENV_KEY = 'HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment'
+
+// Return the live effective Windows PATH rather than the environment snapshot
+// inherited by an Explorer-launched Electron process. Windows composes the
+// machine PATH before the user PATH; keeping that order preserves normal
+// command-resolution precedence while exposing newly added literal PATH
+// entries without relying on the stale process snapshot.
+function readWindowsHostPath({
+  platform = process.platform,
+  env = process.env,
+  exec = execFileSync
+}: WindowsEnvReadOptions = {}) {
+  if (platform !== 'win32') {
+    return null
+  }
+
+  const machinePath = readWindowsRegistryEnvVar(WINDOWS_MACHINE_ENV_KEY, 'Path', { platform, env, exec })
+  if (!machinePath) {
+    return null
+  }
+
+  const userPath = readWindowsRegistryEnvVar('HKCU\\Environment', 'Path', { platform, env, exec })
+
+  return userPath ? `${machinePath};${userPath}` : machinePath
+}
+
+export { expandWindowsEnvRefs, parseRegQueryValue, readWindowsHostPath, readWindowsUserEnvVar }


### PR DESCRIPTION
## What does this PR do?

Windows GUI applications can retain the environment snapshot inherited when Explorer started. After a user installs a command or changes `PATH`, a fresh shell can resolve it while a newly opened Hermes Desktop backend still inherits the stale Electron snapshot.

This PR reads the current Machine and User `PATH` values once, when the local Desktop backend is first constructed, while preserving Hermes-managed runtime precedence. A reproduced failure had the command's shim directory in the live User registry value and in a fresh shell, but not in the Desktop backend environment; applying the live overlay made the same backend resolve the command.

The final scope is Desktop-only. Python terminal environment construction and explicit `PATH` override semantics are unchanged.

## Related Issue

Supersedes the closed draft #76815.

Related, but does not close: #45435 and #70411. Those reports also include Git/Git-Bash resolver behavior outside this live `PATH` refresh.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/windows-user-env.ts`: read live HKLM and HKCU `Path` values and merge them in Windows precedence order with case-insensitive de-duplication.
- `apps/desktop/electron/backend-env.ts`: preserve Hermes-managed Node and virtualenv entries ahead of the live host `PATH`.
- `apps/desktop/electron/main.ts`: use one lazy, cached backend-environment wrapper for all local backend construction paths.
- Fall back safely when either registry read fails:
  - both succeed: live Machine -> live User -> inherited extras;
  - Machine fails: retain the inherited snapshot rather than risk reversing precedence;
  - User fails: live Machine -> inherited snapshot.
- Add focused ordering, de-duplication, platform, and partial-failure tests.

## How to Test

1. On Windows, change the User `PATH` after Explorer/Electron has inherited its environment, then start a local Hermes Desktop backend. Verify the new directory is present without displacing Hermes-managed Node or virtualenv entries.

2. Run the focused Desktop platform tests:

   ```powershell
   npm run --workspace apps/desktop test:desktop:platforms -- electron/windows-user-env.test.ts electron/backend-env.test.ts
   ```

3. Run the formatter check:

   ```powershell
   npx.cmd --yes prettier@3.9.5 --check apps/desktop/electron/backend-env.test.ts apps/desktop/electron/backend-env.ts apps/desktop/electron/main.ts apps/desktop/electron/windows-user-env.test.ts apps/desktop/electron/windows-user-env.ts
   ```

4. Simulate failed Machine and User registry reads and verify the inherited `PATH` remains usable with the precedence described above.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
Focused Desktop platform tests: 25 passed across 2 files
Prettier 3.9.5: passed for all 5 changed files
git diff --check: passed
Thermos bug/security re-review: clean
Thermos code-quality re-review: clean
```

`REG_EXPAND_SZ` references are expanded against Electron's inherited environment. A newly created variable that Electron has never seen remains literal; this PR is scoped to literal entries and references already known to the process.
