### PR TITLE
fix(buzz): propagate community auth tag to CLI

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -275,12 +275,46 @@ def _resolve_private_key(extra: Optional[dict] = None) -> str:
     return ""
 
 
+def _resolve_auth_tag(extra: Optional[dict] = None) -> str:
+    """Resolve the optional community owner-attestation auth tag.
+
+    Hosted Buzz communities can require this tag in addition to the Nostr
+    private key. Keep the same precedence and credentials-file behavior as
+    :func:`_resolve_private_key` so scoped secrets and systemd credential
+    files work for both values.
+    """
+    auth_tag = _get_scoped_secret("BUZZ_AUTH_TAG", "").strip()
+    if auth_tag:
+        return auth_tag
+    configured = os.getenv("BUZZ_CREDENTIALS_FILE", "").strip() or (extra or {}).get("credentials_file", "")
+    if configured:
+        candidates = [Path(configured).expanduser()]
+    else:
+        try:
+            candidates = sorted(_DEFAULT_CREDENTIALS_DIR.glob("*credentials*.json"))
+        except OSError:
+            candidates = []
+    for path in candidates:
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        for field in ("BUZZ_AUTH_TAG", "auth_tag"):
+            value = data.get(field)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
 async def _exec_buzz(
     cli_path: str,
     args: List[str],
     *,
     relay_url: str,
     private_key: str,
+    auth_tag: str = "",
     input_text: Optional[str] = None,
     timeout: float = _CLI_TIMEOUT,
 ) -> Tuple[int, str, str]:
@@ -293,6 +327,11 @@ async def _exec_buzz(
     env = os.environ.copy()
     env["BUZZ_RELAY_URL"] = relay_url
     env["BUZZ_PRIVATE_KEY"] = private_key
+    # Do not let another profile's ambient community attestation bleed into
+    # this subprocess. Only the value resolved for this adapter may pass.
+    env.pop("BUZZ_AUTH_TAG", None)
+    if auth_tag:
+        env["BUZZ_AUTH_TAG"] = auth_tag
     proc = await asyncio.create_subprocess_exec(
         cli_path,
         *args,
@@ -451,6 +490,7 @@ class BuzzAdapter(BasePlatformAdapter):
             args,
             relay_url=self.relay_url,
             private_key=self._private_key,
+            auth_tag=_resolve_auth_tag(self._extra),
             input_text=input_text,
         )
 
@@ -1392,7 +1432,12 @@ async def _standalone_send(
         args += ["--file", str(path)]
     try:
         code, out, err = await _exec_buzz(
-            cli_path, args, relay_url=relay, private_key=private_key, input_text=message
+            cli_path,
+            args,
+            relay_url=relay,
+            private_key=private_key,
+            auth_tag=_resolve_auth_tag(extra),
+            input_text=message,
         )
     except asyncio.CancelledError:
         raise

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -19,6 +19,8 @@ npub_to_hex = _buzz_mod.npub_to_hex
 _normalize_user_ref = _buzz_mod._normalize_user_ref
 _cli_error_message = _buzz_mod._cli_error_message
 _resolve_private_key = _buzz_mod._resolve_private_key
+_resolve_auth_tag = _buzz_mod._resolve_auth_tag
+_exec_buzz = _buzz_mod._exec_buzz
 check_requirements = _buzz_mod.check_requirements
 validate_config = _buzz_mod.validate_config
 register = _buzz_mod.register
@@ -38,6 +40,7 @@ DM_CHANNEL = "6468cc16-a114-4f23-8b8c-02c1655cbf6b"
 _ENV_VARS = (
     "BUZZ_RELAY_URL",
     "BUZZ_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
     "BUZZ_CHANNELS",
     "BUZZ_HOME_CHANNEL",
     "BUZZ_ALLOWED_USERS",
@@ -481,6 +484,71 @@ class TestCredentialResolution:
         monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
         assert _resolve_private_key() == "nsec1fromfile"
 
+    def test_auth_tag_env_wins(self, monkeypatch):
+        monkeypatch.setenv("BUZZ_AUTH_TAG", "owner-attestation")
+        assert _resolve_auth_tag() == "owner-attestation"
+
+    def test_auth_tag_credentials_file_fallback(self, monkeypatch, tmp_path):
+        creds = tmp_path / "agent_credentials.json"
+        creds.write_text(
+            json.dumps({"nsec": "nsec1fromfile", "BUZZ_AUTH_TAG": "owner-attestation"}),
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("BUZZ_CREDENTIALS_FILE", str(creds))
+        assert _resolve_auth_tag() == "owner-attestation"
+
+    @pytest.mark.asyncio
+    async def test_exec_buzz_passes_auth_tag_only_in_subprocess_env(self, monkeypatch):
+        captured = {}
+        monkeypatch.setenv("BUZZ_AUTH_TAG", "wrong-profile-attestation")
+
+        class FakeProcess:
+            returncode = 0
+
+            async def communicate(self, _input):
+                return b"{}", b""
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            captured.update(args=args, kwargs=kwargs)
+            return FakeProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+        await _exec_buzz(
+            "/usr/bin/buzz",
+            ["users", "get"],
+            relay_url="wss://relay.example",
+            private_key="nsec1secret",
+            auth_tag="owner-attestation",
+        )
+
+        assert "owner-attestation" not in captured["args"]
+        assert captured["kwargs"]["env"]["BUZZ_AUTH_TAG"] == "owner-attestation"
+
+    @pytest.mark.asyncio
+    async def test_exec_buzz_removes_unresolved_ambient_auth_tag(self, monkeypatch):
+        captured = {}
+        monkeypatch.setenv("BUZZ_AUTH_TAG", "wrong-profile-attestation")
+
+        class FakeProcess:
+            returncode = 0
+
+            async def communicate(self, _input):
+                return b"{}", b""
+
+        async def fake_create_subprocess_exec(*args, **kwargs):
+            captured.update(args=args, kwargs=kwargs)
+            return FakeProcess()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+        await _exec_buzz(
+            "/usr/bin/buzz",
+            ["users", "get"],
+            relay_url="wss://relay.example",
+            private_key="nsec1secret",
+        )
+
+        assert "BUZZ_AUTH_TAG" not in captured["kwargs"]["env"]
+
 
 # ── Env enablement / registration / standalone send ──────────────────────
 
@@ -524,8 +592,16 @@ class TestStandaloneSend:
 
         captured = {}
 
-        async def fake_exec(cli_path, args, *, relay_url, private_key, input_text=None, timeout=30.0):
-            captured.update(cli_path=cli_path, args=args, relay_url=relay_url, input_text=input_text)
+        async def fake_exec(
+            cli_path, args, *, relay_url, private_key, auth_tag="", input_text=None, timeout=30.0
+        ):
+            captured.update(
+                cli_path=cli_path,
+                args=args,
+                relay_url=relay_url,
+                auth_tag=auth_tag,
+                input_text=input_text,
+            )
             return 0, json.dumps({"accepted": True, "event_id": "evt-cron", "message": ""}), ""
 
         monkeypatch.setattr(_buzz_mod, "_exec_buzz", fake_exec)
@@ -534,6 +610,7 @@ class TestStandaloneSend:
         assert result == {"success": True, "message_id": "evt-cron"}
         assert captured["args"][:2] == ["messages", "send"]
         assert captured["input_text"] == "cron says hi"
+        assert captured["auth_tag"] == ""
         # The private key must never be part of argv
         assert all("nsec1x" not in str(a) for a in captured["args"])
 


### PR DESCRIPTION
## Summary
- resolve optional `BUZZ_AUTH_TAG` from scoped secrets or the existing Buzz credentials JSON
- pass the tag to `buzz` only through the subprocess environment, never argv or logs
- cover both live gateway calls and standalone cron delivery
- remove unresolved ambient tags to prevent cross-profile credential bleed

## Verification
- `python -m pytest tests/gateway/test_buzz_adapter.py -o addopts= -q`: 27 passed
- Ruff passes for the adapter and its tests
- rebased on current `origin/main`

Hosted Buzz communities can require this owner-attestation tag in addition to the Nostr private key. Without propagation, cron delivery fails with `403 relay_membership_required` even when the credentials JSON is otherwise valid.