### PR TITLE
fix(update): gate 'Code updated!' on HEAD actually moving (#79678)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4061,6 +4061,31 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         _invalidate_update_cache()
 
+        # Verify HEAD actually moved (issue #79678). ``merge --ff-only``
+        # succeeding only means the merge completed, not that the update
+        # applied: a checkout that is pinned to a raw SHA (detached HEAD) can
+        # report "N new commit(s)" against origin yet still sit on the old
+        # commit afterward (the branch-switch step re-detaches to the SHA).
+        # Before this guard, ``hermes update`` printed "✓ Code updated!" and
+        # reinstalled deps + rebuilt the desktop app against the stale tree —
+        # no error, no warning, ``hermes doctor`` healthy. Compare pre-pull
+        # and post-pull HEAD; if they match, surface the no-op instead of
+        # claiming success.
+        post_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
+        if pre_pull_sha and post_pull_sha == pre_pull_sha:
+            print()
+            print("✗ Code did not move — update was a no-op.")
+            print(
+                f"  HEAD is pinned to {pre_pull_sha[:10]} (detached checkout); "
+                f"origin/{branch} advanced but the working tree stayed put."
+            )
+            print(
+                "  Reattach to the branch and retry: "
+                f"git -C {_m().PROJECT_ROOT} checkout {branch} && hermes update"
+            )
+            _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
+            sys.exit(1)
+
         # Clear stale .pyc bytecode cache — prevents ImportError on gateway
         # restart when updated source references names that didn't exist in
         # the old bytecode (e.g. get_hermes_home added to hermes_constants).

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -1,0 +1,135 @@
+"""Tests for the post-pull HEAD-movement gate in ``hermes update``.
+
+Issue #79678: a detached/pinned checkout can report "N new commit(s)"
+against origin, run the ff-only merge successfully, and still sit on the
+old commit afterward (the branch-switch step re-detaches to the raw SHA).
+Before this guard ``hermes update`` printed "✓ Code updated!" and
+reinstalled deps + rebuilt the desktop app against the stale tree — no
+error, no warning. The gate compares the pre-pull and post-pull HEAD SHA
+and fails loudly when the update was a no-op.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import main as hermes_main
+
+
+def _make_head_moved_side_effect(pre_sha="abc123", post_sha="def456"):
+    """Simulate git commands where HEAD advances from pre_sha to post_sha."""
+    calls = {"n": 0}
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+
+        # git rev-parse --abbrev-ref HEAD  (get current branch)
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="main\n", stderr="")
+
+        # git rev-list HEAD..origin/main --count  (behind count)
+        if "rev-list" in joined:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+
+        # git rev-parse HEAD  — first call (pre-pull) returns pre_sha,
+        # subsequent calls (post-pull) return post_sha.
+        if joined.endswith("rev-parse HEAD"):
+            if calls["n"] == 0:
+                calls["n"] += 1
+                return SimpleNamespace(returncode=0, stdout=f"{pre_sha}\n", stderr="")
+            return SimpleNamespace(returncode=0, stdout=f"{post_sha}\n", stderr="")
+
+        # Everything else (merge, checkout, etc.) succeeds quietly.
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return side_effect
+
+
+def _make_head_pinned_side_effect(sha="abc123"):
+    """Simulate a detached checkout pinned to ``sha``: HEAD never moves."""
+
+    def side_effect(cmd, **kwargs):
+        joined = " ".join(str(c) for c in cmd)
+
+        if "rev-parse" in joined and "--abbrev-ref" in joined:
+            return SimpleNamespace(returncode=0, stdout="HEAD\n", stderr="")
+
+        if "rev-list" in joined:
+            return SimpleNamespace(returncode=0, stdout="3\n", stderr="")
+
+        if joined.endswith("rev-parse HEAD"):
+            return SimpleNamespace(returncode=0, stdout=f"{sha}\n", stderr="")
+
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return side_effect
+
+
+def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
+    """Patch the hermes_cli.main helpers ``_cmd_update_impl`` touches.
+
+    ``_m()`` in update_cmd.py lazily returns hermes_cli.main, so patching
+    attributes on that module is the canonical test surface (matches
+    tests/hermes_cli/test_cmd_update.py).
+    """
+    monkeypatch.setattr(hermes_main.subprocess, "run", run_side_effect)
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    (tmp_path / ".git").mkdir()  # pass the "is a git repo" gate
+    monkeypatch.setattr(
+        hermes_main, "_resolve_update_branch", lambda args: "main"
+    )
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        hermes_main, "_get_origin_url",
+        lambda *a, **k: "https://github.com/NousResearch/hermes-agent.git",
+    )
+    monkeypatch.setattr(hermes_main, "_is_fork", lambda *a, **k: False)
+    monkeypatch.setattr(
+        hermes_main, "_stash_local_changes_if_needed", lambda *a, **k: None
+    )
+    monkeypatch.setattr(hermes_main, "_clear_bytecode_cache", lambda *a, **k: 0)
+    monkeypatch.setattr(
+        hermes_main, "_record_bytecode_fingerprint", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        hermes_main, "_run_pre_update_backup", lambda *a, **k: None
+    )
+    monkeypatch.setattr(
+        hermes_main, "_pause_windows_gateways_for_update", lambda: None
+    )
+    monkeypatch.setattr(
+        hermes_main, "_resume_windows_gateways_after_update", lambda *a, **k: None
+    )
+    # Short-circuit the long tail: dependency install + desktop build.
+    monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
+    monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)
+    # Gateway restart path (called after a successful update).
+    monkeypatch.setattr(hermes_main, "_finish_dashboard_update_cleanup", lambda *a: None)
+
+
+def test_update_success_when_head_moves(monkeypatch, tmp_path, capsys):
+    """When the pull advances HEAD, the update proceeds normally."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+    _patch_update_deps(monkeypatch, tmp_path, _make_head_moved_side_effect())
+
+    hermes_main.cmd_update(args)  # completes normally (no SystemExit)
+
+    out = capsys.readouterr().out
+    assert "✓ Code updated!" in out
+    assert "Code did not move" not in out
+
+
+def test_update_fails_loudly_when_head_pinned(monkeypatch, tmp_path, capsys):
+    """A detached/pinned HEAD that never moves must fail loudly, not print
+    '✓ Code updated!' against the stale tree."""
+    args = SimpleNamespace(branch=None, yes=False, force=False, force_venv=False)
+    _patch_update_deps(monkeypatch, tmp_path, _make_head_pinned_side_effect())
+
+    with pytest.raises(SystemExit) as exc_info:
+        hermes_main.cmd_update(args)
+
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    assert "Code did not move" in out
+    assert "✓ Code updated!" not in out
+    assert "checkout main" in out


### PR DESCRIPTION
## Fix: gate "✓ Code updated!" on HEAD actually moving (#79678)

### What
`hermes update` on a **detached/pinned checkout** can report "N new commit(s)",
run `git merge --ff-only` successfully, and still sit on the **old commit**
afterward — the branch-switch step re-detaches to the raw SHA. Before this
fix, the updater then printed `✓ Code updated!` and reinstalled Python deps +
rebuilt the desktop app against the **stale source tree**: no error, no
warning, `hermes doctor` healthy.

This PR adds a post-pull gate: compare the pre-pull HEAD SHA against the
post-pull HEAD. If they match, the update was a no-op — print a clear
`✗ Code did not move — update was a no-op.` message with a reattach hint
(`git checkout <branch> && hermes update`) and exit non-zero instead of
claiming success.

### Why now
Issue #79678 reports the full reflog evidence: after a successful
`hermes update` from a detached install, HEAD had re-detached to the old
SHA. The core re-detach fix landed in `55879ebf1` (2026-06-04,
`fix(update): detached head update support`) — this PR closes the remaining
silent-failure gap the issue's own suggested fix #3 pointed at: the success
message must not claim an update that never applied.

### Fix
`hermes_cli/update_cmd.py` — after `_invalidate_update_cache()` (post-pull,
pre-deps-install):

```python
post_pull_sha = _capture_head_sha(git_cmd, _m().PROJECT_ROOT)
if pre_pull_sha and post_pull_sha == pre_pull_sha:
    print()
    print("✗ Code did not move — update was a no-op.")
    ...
    _m()._resume_windows_gateways_after_update(_windows_gateway_resume)
    sys.exit(1)
```

- `pre_pull_sha` is already captured at line 3957 for the rollback guard;
  the gate reuses it — no new git calls on the happy path.
- None-safe: if either SHA can't be captured, the gate is skipped
  (conservative — never blocks a legitimate update).
- `sys.exit(1)` matches the established abort idiom in this function
  (lines 3668/3690/3826), and `cmd_update`'s try/finally releases the
  update lock + finalizes output either way.

### Tests (RED-GREEN proven)
New `tests/hermes_cli/test_update_head_moved_gate.py`:
- `test_update_success_when_head_moves` — HEAD advances pre→post → full
  success path runs, `✓ Code updated!` prints.
- `test_update_fails_loudly_when_head_pinned` — detached checkout pinned to
  one SHA → the gate fires, `✗ Code did not move` prints, exit code 1,
  `✓ Code updated!` does NOT print.

RED: with the fix stashed, `test_update_fails_loudly_when_head_pinned`
FAILS (prints `✓ Code updated!` against the stale tree — the exact bug).
GREEN: with the fix, both pass.

### Validation
- `scripts/run_tests.sh tests/hermes_cli/test_update_head_moved_gate.py tests/hermes_cli/test_cmd_update.py` → 23 passed
- 145 update-related tests across the suite → all green
- E2E git simulation (real repo): the updater's exact sequence
  (checkout main → ff-only merge → re-detach to old SHA) → gate FIRES;
  healthy advance (v3→v5) → gate silent.

### Known limitations
- If `rev-parse HEAD` fails both before and after (rare), the gate is
  skipped — the pre-existing rollback guard already covers the "can't
  capture SHA" case with its own error path.
- A `hermes doctor` check for detached installs (the issue's other ask)
  is intentionally out of scope — this PR targets the silent-failure
  success claim, which is the defect.
