### PR TITLE
perf(ci): 12 test slices — cut the merge-gate critical path ~33%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     if: needs.detect.outputs.python == 'true'
     uses: ./.github/workflows/tests.yml
     with:
-      slice_count: 8
+      slice_count: 12
 
   lint:
     name: Python lints


### PR DESCRIPTION
## What this does, concretely

On every python PR, the merge gate (`all-checks-pass`) waits for the 8 test
slices — they finish at ~200-230s while every other required job is done by
~90s. This bumps the slice count to 12, cutting the per-slice workload by a
third and pulling the whole merge gate down with it. Anyone waiting on CI to
merge a PR gets their green check ~50-70s sooner, on every python PR.

## Context / measurements (from the last 8 successful PR runs on main)

Critical path today:

```
detect (12s) -> Generate slices (+14s) -> 8 x test slice (141-187s) -> gate @ ~210-230s
lint / e2e / supply-chain / OSV / uv-lock / history: all done by ~90s
```

Per-slice fixed overhead is only ~10s now that the uv cache is warm (#42838):
checkout 3s, ripgrep 1s, uv install + python + `uv sync` ~5s. So slicing wider
is nearly free.

LPT simulation, run with the repo's own `_compute_lpt_slices` against the live
`test-durations` cache (2622 files, all with real measured durations, merged
from the latest run's `test-durations-slice-*` artifacts):

```
n= 8  makespan= 968.3s  min= 967.9s
n=12  makespan= 645.7s  min= 645.3s   <- this PR
n=16  makespan= 484.3s  min= 483.7s
```

Balance stays perfect (makespan == min within 1s), so wall time tracks the
makespan down.

## Why 12 and not 16

- The LPT floor is the slowest single test file (`tests/test_hermes_state.py`,
  46.7s); as slices get thinner the per-slice 8-worker parallelism has less
  work to overlap, so the marginal wall-time gain past 12 shrinks.
- Peak concurrent jobs in a run rises 23 -> 27 (16 slices would push it to 31).
  Observed queue delay at today's 23 is 2-10s, so 27 has headroom; going wider
  starts gambling on org-level runner contention when several PRs run at once.
- Splitting the 3 slowest test files (46.7s / 45.5s / 35.3s) would lower the
  floor and make 16 pay off — that's a separate test-file change, kept out of
  this one-line workflow PR.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` — parses
- `actionlint .github/workflows/ci.yml` — clean
- `python3 scripts/run_tests_parallel.py --generate-slices 12` — emits 12
  balanced, non-empty slices covering all 2622 test files
- No other consumer of `tests.yml` passes `slice_count` (grep: only ci.yml),
  and `save-durations` / the durations cache are slice-count-agnostic (keyed
  per file, merged per run).

## What CI itself will show

This PR touches a workflow file, so `detect-changes` fails open / flags
`ci_review` — the run on this PR itself validates the 12-way slicing
end-to-end, and the `ci-timings` report will show the before/after gantt
against the main baseline.
