### PR TITLE
fix(search): report true total_count when rg fetch truncates (#79530)

### DIFF
--- a/tests/tools/test_search_total_count.py
+++ b/tests/tools/test_search_total_count.py
@@ -1,0 +1,92 @@
+"""Regression tests for search_files total_count under-reporting (#79530).
+
+The rg search pipeline pipes match output through ``| head -n fetch_limit``
+to bound memory, but ``total_count`` was derived from the *fetched* rows
+only — so any search with more matches than the fetch ceiling reported a
+total that was too small (e.g. 5 of 1300 real matches). The fix runs a
+dedicated untruncated count query (``rg --count-matches`` /
+``rg -l | wc -l``) when the fetch hit its ceiling and uses that as
+``total_count``.
+"""
+
+import os
+import subprocess
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+def _real_shell_env(cwd):
+    """A terminal env that actually runs commands (matches test_file_operations)."""
+
+    def execute(command, **kwargs):
+        completed = subprocess.run(
+            command,
+            shell=True,
+            text=True,
+            capture_output=True,
+            cwd=kwargs.get("cwd") or cwd,
+        )
+        return {"output": completed.stdout + completed.stderr, "returncode": completed.returncode}
+
+    return type("Env", (), {"cwd": cwd, "execute": staticmethod(execute)})()
+
+
+@pytest.fixture()
+def big_dir(tmp_path):
+    """A directory with more matching files than the fetch ceiling."""
+    for i in range(1300):
+        (tmp_path / f"file_{i}.md").write_text(f"email: pessoa{i}@teste.com\n")
+    return tmp_path
+
+
+def test_content_mode_total_count_is_true_total(big_dir):
+    """Default content mode: total_count reflects all 1300 matches, page is 5."""
+    s = ShellFileOperations(_real_shell_env(str(big_dir)))
+    r = s._search_content("email", str(big_dir), None, 5, 0, "content", 0)
+
+    assert len(r.matches) == 5
+    assert r.total_count == 1300
+    assert r.truncated is True
+
+
+def test_files_only_mode_total_count_is_true_total(big_dir):
+    s = ShellFileOperations(_real_shell_env(str(big_dir)))
+    r = s._search_content("email", str(big_dir), None, 5, 0, "files_only", 0)
+
+    assert len(r.files) == 5
+    assert r.total_count == 1300
+    assert r.truncated is True
+
+
+def test_count_mode_total_count_is_true_total(big_dir):
+    s = ShellFileOperations(_real_shell_env(str(big_dir)))
+    r = s._search_content("email", str(big_dir), None, 5, 0, "count", 0)
+
+    assert r.total_count == 1300
+    assert r.truncated is True
+
+
+def test_small_dir_total_count_unchanged(tmp_path):
+    """Below the fetch ceiling, total_count is exact without a count query."""
+    for i in range(3):
+        (tmp_path / f"f{i}.txt").write_text(f"needle {i}\n")
+
+    s = ShellFileOperations(_real_shell_env(str(tmp_path)))
+    r = s._search_content("needle", str(tmp_path), None, 5, 0, "content", 0)
+
+    assert r.total_count == 3
+    assert r.truncated is False
+
+
+def test_limit_below_total_still_truncated(tmp_path):
+    """A small dir with limit < total: truncated=True, total exact."""
+    for i in range(3):
+        (tmp_path / f"f{i}.txt").write_text(f"needle {i}\n")
+
+    s = ShellFileOperations(_real_shell_env(str(tmp_path)))
+    r = s._search_content("needle", str(tmp_path), None, 2, 0, "content", 0)
+
+    assert r.total_count == 3
+    assert r.truncated is True

--- a/tests/tools/test_search_total_count.py
+++ b/tests/tools/test_search_total_count.py
@@ -21,9 +21,11 @@ def _real_shell_env(cwd):
     """A terminal env that actually runs commands (matches test_file_operations)."""
 
     def execute(command, **kwargs):
+        # The search pipeline uses `set -o pipefail`, a bash builtin — run
+        # under bash like the real terminal env (tools/environments/local.py
+        # executes via bash), not /bin/sh (dash on Debian/Ubuntu rejects it).
         completed = subprocess.run(
-            command,
-            shell=True,
+            ["/bin/bash", "-c", command],
             text=True,
             capture_output=True,
             cwd=kwargs.get("cwd") or cwd,

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2999,7 +2999,6 @@ class ShellFileOperations(FileOperations):
         # so we grab generously and filter in Python.
         fetch_limit = limit + offset + 200 if context > 0 else limit + offset
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
         # `set -o pipefail` so rg's exit status propagates through `| head`.
         # Without it the pipeline reports head's status (0), masking rg's
         # error code (2) and making the guard below unreachable. rg handles a
@@ -3033,11 +3032,18 @@ class ShellFileOperations(FileOperations):
         if output_mode == "files_only":
             all_files = [f for f in stdout.strip().split('\n') if f]
             total = len(all_files)
+            # The fetch was truncated by `| head -n fetch_limit` — the real
+            # total is larger than what we fetched. Run a dedicated count to
+            # report the true number of matching files (#79530).
+            if total >= fetch_limit and not limit_reason:
+                total = self._count_rg_files(pattern, path, file_glob)
+                if total < 0:
+                    total = len(all_files)  # count failed — keep estimate
             page = all_files[offset:offset + limit]
             return SearchResult(
                 files=page,
                 total_count=total,
-                truncated=bool(limit_reason),
+                truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
                 warning=_ml_note,
             )
@@ -3052,10 +3058,22 @@ class ShellFileOperations(FileOperations):
                             counts[parts[0]] = int(parts[1])
                         except ValueError:
                             pass
+            # Same truncation correction: count-mode output is also piped
+            # through `| head`, so when we hit the fetch ceiling the true
+            # total is under-reported.
+            if len(counts) >= fetch_limit and not limit_reason:
+                counts, total = self._count_rg_matches(
+                    pattern, path, file_glob, limit, offset
+                )
+                if total < 0:
+                    # count query failed — keep the fetched estimate
+                    total = sum(counts.values()) if counts else len(counts)
+            else:
+                total = sum(counts.values())
             return SearchResult(
                 counts=counts,
-                total_count=sum(counts.values()),
-                truncated=bool(limit_reason),
+                total_count=total,
+                truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
@@ -3095,6 +3113,16 @@ class ShellFileOperations(FileOperations):
             
             total = len(matches)
             page = matches[offset:offset + limit]
+            # Truncation correction for the default content mode (#79530):
+            # when the fetch hit the `| head` ceiling, count the true total
+            # of matches with a dedicated count query so `total_count` stops
+            # under-reporting.
+            if total >= fetch_limit and not limit_reason:
+                _counts, _total = self._count_rg_matches(
+                    pattern, path, file_glob, limit, offset
+                )
+                if _total >= 0:
+                    total = _total
             return SearchResult(
                 matches=page,
                 total_count=total,
@@ -3103,6 +3131,56 @@ class ShellFileOperations(FileOperations):
                 warning=_ml_note,
             )
     
+    def _count_rg_files(self, pattern: str, path: str, file_glob: Optional[str]) -> int:
+        """Count matching files with ripgrep (untruncated).
+
+        ``rg -l`` piped through ``head`` truncates; ``rg --files-with-matches
+        | wc -l`` counts the true total. Used to correct ``total_count`` when
+        the main fetch hit its ceiling (#79530).
+        """
+        try:
+            cmd = (
+                f"rg -l --no-messages {self._escape_shell_arg(pattern)} "
+                f"{self._escape_shell_arg(path)}"
+                + (f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else "")
+                + " | wc -l"
+            )
+            result = self._exec(cmd, timeout=60)
+            return int(result.stdout.strip() or 0)
+        except Exception:
+            return -1
+
+    def _count_rg_matches(
+        self, pattern: str, path: str, file_glob: Optional[str],
+        limit: int, offset: int,
+    ) -> tuple[dict[str, int], int]:
+        """Count per-file matches and the true total (untruncated).
+
+        ``rg --count-matches`` emits one ``file:count`` line per matching
+        file — no match content, so it is cheap and immune to the
+        ``| head`` truncation of the main fetch. Returns ``(counts, total)``
+        used to correct ``total_count`` (#79530). Falls back to ``({}, -1)``
+        so callers can detect the failure and keep the fetched estimate.
+        """
+        try:
+            cmd = (
+                f"rg --count-matches --no-messages {self._escape_shell_arg(pattern)} "
+                f"{self._escape_shell_arg(path)}"
+                + (f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else "")
+            )
+            result = self._exec(cmd, timeout=60)
+            counts: dict[str, int] = {}
+            for line in result.stdout.strip().split("\n"):
+                if ":" in line:
+                    parts = line.rsplit(":", 1)
+                    try:
+                        counts[parts[0]] = int(parts[1])
+                    except ValueError:
+                        pass
+            return counts, sum(counts.values())
+        except Exception:
+            return {}, -1
+
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2577,7 +2577,6 @@ class ShellFileOperations(FileOperations):
         # so we grab generously and filter in Python.
         fetch_limit = limit + offset + 200 if context > 0 else limit + offset
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])
-        
         # `set -o pipefail` so rg's exit status propagates through `| head`.
         # Without it the pipeline reports head's status (0), masking rg's
         # error code (2) and making the guard below unreachable. rg handles a
@@ -2611,11 +2610,18 @@ class ShellFileOperations(FileOperations):
         if output_mode == "files_only":
             all_files = [f for f in stdout.strip().split('\n') if f]
             total = len(all_files)
+            # The fetch was truncated by `| head -n fetch_limit` — the real
+            # total is larger than what we fetched. Run a dedicated count to
+            # report the true number of matching files (#79530).
+            if total >= fetch_limit and not limit_reason:
+                total = self._count_rg_files(pattern, path, file_glob)
+                if total < 0:
+                    total = len(all_files)  # count failed — keep estimate
             page = all_files[offset:offset + limit]
             return SearchResult(
                 files=page,
                 total_count=total,
-                truncated=bool(limit_reason),
+                truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
                 warning=_ml_note,
             )
@@ -2630,10 +2636,22 @@ class ShellFileOperations(FileOperations):
                             counts[parts[0]] = int(parts[1])
                         except ValueError:
                             pass
+            # Same truncation correction: count-mode output is also piped
+            # through `| head`, so when we hit the fetch ceiling the true
+            # total is under-reported.
+            if len(counts) >= fetch_limit and not limit_reason:
+                counts, total = self._count_rg_matches(
+                    pattern, path, file_glob, limit, offset
+                )
+                if total < 0:
+                    # count query failed — keep the fetched estimate
+                    total = sum(counts.values()) if counts else len(counts)
+            else:
+                total = sum(counts.values())
             return SearchResult(
                 counts=counts,
-                total_count=sum(counts.values()),
-                truncated=bool(limit_reason),
+                total_count=total,
+                truncated=total > offset + limit or bool(limit_reason),
                 limit_reason=limit_reason,
             )
         
@@ -2673,6 +2691,16 @@ class ShellFileOperations(FileOperations):
             
             total = len(matches)
             page = matches[offset:offset + limit]
+            # Truncation correction for the default content mode (#79530):
+            # when the fetch hit the `| head` ceiling, count the true total
+            # of matches with a dedicated count query so `total_count` stops
+            # under-reporting.
+            if total >= fetch_limit and not limit_reason:
+                _counts, _total = self._count_rg_matches(
+                    pattern, path, file_glob, limit, offset
+                )
+                if _total >= 0:
+                    total = _total
             return SearchResult(
                 matches=page,
                 total_count=total,
@@ -2681,6 +2709,56 @@ class ShellFileOperations(FileOperations):
                 warning=_ml_note,
             )
     
+    def _count_rg_files(self, pattern: str, path: str, file_glob: Optional[str]) -> int:
+        """Count matching files with ripgrep (untruncated).
+
+        ``rg -l`` piped through ``head`` truncates; ``rg --files-with-matches
+        | wc -l`` counts the true total. Used to correct ``total_count`` when
+        the main fetch hit its ceiling (#79530).
+        """
+        try:
+            cmd = (
+                f"rg -l --no-messages {self._escape_shell_arg(pattern)} "
+                f"{self._escape_shell_arg(path)}"
+                + (f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else "")
+                + " | wc -l"
+            )
+            result = self._exec(cmd, timeout=60)
+            return int(result.stdout.strip() or 0)
+        except Exception:
+            return -1
+
+    def _count_rg_matches(
+        self, pattern: str, path: str, file_glob: Optional[str],
+        limit: int, offset: int,
+    ) -> tuple[dict[str, int], int]:
+        """Count per-file matches and the true total (untruncated).
+
+        ``rg --count-matches`` emits one ``file:count`` line per matching
+        file — no match content, so it is cheap and immune to the
+        ``| head`` truncation of the main fetch. Returns ``(counts, total)``
+        used to correct ``total_count`` (#79530). Falls back to ``({}, -1)``
+        so callers can detect the failure and keep the fetched estimate.
+        """
+        try:
+            cmd = (
+                f"rg --count-matches --no-messages {self._escape_shell_arg(pattern)} "
+                f"{self._escape_shell_arg(path)}"
+                + (f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else "")
+            )
+            result = self._exec(cmd, timeout=60)
+            counts: dict[str, int] = {}
+            for line in result.stdout.strip().split("\n"):
+                if ":" in line:
+                    parts = line.rsplit(":", 1)
+                    try:
+                        counts[parts[0]] = int(parts[1])
+                    except ValueError:
+                        pass
+            return counts, sum(counts.values())
+        except Exception:
+            return {}, -1
+
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""


### PR DESCRIPTION
## Fix: `search_files` reports the true `total_count` when rg fetch truncates (#79530)

### What
The rg search pipeline pipes match output through `| head -n fetch_limit` to
bound memory, but `total_count` was derived from the **fetched rows only**.
Any search with more matches than the fetch ceiling under-reported:

- `search_files(pattern="email", path="/tmp/bigtest", limit=5)` on 1,300
  matching files returned `total_count: 5` (real: 1,300), with a
  nondeterministic slice of files.

### Fix
When the fetch hits its ceiling, run a **dedicated untruncated count**
(`rg --count-matches` for content/count modes, `rg -l | wc -l` for
files_only) and use it as `total_count`. All three output modes covered.
Falls back to the fetched estimate if the count query fails. Directories
below the fetch ceiling are unaffected — no extra query runs.

### RED-GREEN proof
- `tests/tools/test_search_total_count.py` (5 tests): 1,300-file fixture;
  content/files_only/count modes assert `total_count == 1300` with a 5-row
  page and `truncated=True`. On the pre-fix code, 4/5 **fail** with
  `total_count == 5`.
- E2E: verified against the issue's exact `/tmp/bigtest` repro (1,300 files):
  all three modes now report 1300; small dirs report exact totals with no
  extra query.
- Neighboring suites green (81 tests: `test_file_operations`,
  `test_search_error_guard`, `test_search_zero_match_and_multipath`,
  `test_search_auto_multiline`).

### Note
This fixes the `total_count` under-reporting (the "unreported" defect the
issue calls out). The separate symptom of *content invisible in a
specific large directory* (the `People/` case) is covered by related
issues #72047 / #18473 / #77423 — that path is a different mechanism
(ripgrep directory-scan behavior), not the `| head` truncation this PR
fixes.
