### PR TITLE
fix(tests): hermetic runner strips HERMES_TEST_IMAGE — docker CI rebuilds the 5GB image it already has

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -123,6 +123,32 @@ for _win_var in USERPROFILE HOMEDRIVE HOMEPATH LOCALAPPDATA APPDATA SYSTEMROOT T
   fi
 done
 
+# ── Test-runner knobs (computed before we drop env) ────────────────────────
+# The runner's own documented environment knobs must survive the hermetic
+# `env -i` below, or they are silent no-ops for anyone invoking this script:
+#
+#   * HERMES_TEST_WORKERS / PATHS / FILE_TIMEOUT / FILE_RETRIES / SLICE are
+#     read by run_tests_parallel.py at argparse-default time — inside the
+#     stripped environment.
+#   * HERMES_TEST_IMAGE is read by tests/docker/conftest.py to skip its
+#     session-scoped `docker build`. CI's docker.yml sets it to the image
+#     the build step just loaded; stripping it made every per-file pytest
+#     subprocess rebuild the 5GB image from a cold builder cache instead
+#     (~4 min per worker per run, and the rebuilt image lacked the
+#     HERMES_GIT_SHA build-arg the workflow bakes in).
+#
+# These are test-infrastructure knobs, not credentials — same class as the
+# HERMES_RUN_SLOW_PET_TESTS / HERMES_E2E_BROWSER opt-ins already forwarded.
+# Keep this an explicit allowlist (no HERMES_TEST_* glob) so the "no
+# credential can leak" property stays auditable at a glance.
+TEST_ENV=()
+for _test_var in HERMES_TEST_IMAGE HERMES_TEST_WORKERS HERMES_TEST_PATHS \
+  HERMES_TEST_FILE_TIMEOUT HERMES_TEST_FILE_RETRIES HERMES_TEST_SLICE; do
+  if [ -n "${!_test_var:-}" ]; then
+    TEST_ENV+=("$_test_var=${!_test_var}")
+  fi
+done
+
 # ── Run in hermetic env ──────────────────────────────────────────────────────
 # env -i: start with empty environment, opt-in only what we need.
 # No credential var can leak — you'd have to explicitly add it here.
@@ -144,6 +170,7 @@ exec env -i \
   PATH="$PATH" \
   HOME="$HOME" \
   ${WIN_ENV[@]+"${WIN_ENV[@]}"} \
+  ${TEST_ENV[@]+"${TEST_ENV[@]}"} \
   TZ=UTC \
   LANG=C.UTF-8 \
   LC_ALL=C.UTF-8 \


### PR DESCRIPTION
## What this does, concretely

`scripts/run_tests.sh` runs the suite under `env -i` with an explicit
allowlist — and the runner's own documented `HERMES_TEST_*` knobs were never
on it. Every one of them (`WORKERS`, `PATHS`, `FILE_TIMEOUT`, `FILE_RETRIES`,
`SLICE`, and `HERMES_TEST_IMAGE`) has been a **silent no-op** through the
canonical wrapper. This forwards them, compute-before-drop, exactly the way
the Windows location vars are forwarded (66c4c9c0b).

## Who was paying for this

**CI's docker jobs, ~4 wasted minutes per job, on both arches, since June.**

`docker.yml` sets `HERMES_TEST_IMAGE` to the image the build step just loaded
so `tests/docker/conftest.py` skips its session-scoped `docker build`. The
wrapper strips it, so every per-file pytest subprocess fell back to building
`hermes-agent-harness:latest` itself. The job log (run 30966912726, amd64)
shows it plainly:

```
✓ tests/docker/test_config_migration.py            (1✓, 248.0s)
✓ tests/docker/test_dump_build_sha.py              (1✓, 256.6s)  <- ONE `docker run --entrypoint cat`
✓ tests/docker/test_home_override_scripts.py       (3✓, 270.8s)
✓ tests/docker/test_docker_exec_privilege_drop.py  (3✓, 272.3s)
✓ tests/docker/test_container_restart.py           (2✓, 287.5s)
✓ tests/docker/test_dashboard.py                   (3✓, 292.1s)
✓ tests/docker/test_gateway_bootstrap_state.py     (4✓, 295.6s)
✓ tests/docker/test_gateway_run_supervised.py      (3✓, 297.5s)
...everything dispatched after these 8: 4-38s
```

The 8 files at 248-297s are exactly the first 8 the LPT scheduler dispatches
(one per worker): they're waiting out the concurrent initial `docker build` on
a cold local builder, then each subsequent file rides the layer cache. That
build is pure waste — the workflow **already built and loaded** the image.

Worse than slow: the tests exercised a locally-rebuilt image **without the
`HERMES_GIT_SHA` build-arg** the workflow bakes in — not the artifact being
shipped. `test_dump_build_sha.py` has a "when present" branch, so it passed
without ever validating the baked SHA on CI.

Local devs using `HERMES_TEST_IMAGE` for the documented "faster local
iteration" path, or `HERMES_TEST_WORKERS` to tame load, hit the same silent
strip (the docstring of `run_tests_parallel.py` advertises these knobs; the
wrapper ate them).

## Why an explicit allowlist (not a `HERMES_TEST_*` glob)

The hermetic runner's core property is "no credential can leak — you'd have to
explicitly add it here." A glob would be shorter but makes that property
non-auditable at a glance. Six named vars, each forwarded only when set, so
runs without them are byte-for-byte unchanged.

## Verification (probe test through the wrapper)

```
before: HERMES_TEST_IMAGE=None inside the test subprocess
after:  HERMES_TEST_IMAGE='sentinel-image'
        HERMES_TEST_FILE_TIMEOUT='123'
        HERMES_TEST_WORKERS=3  -> "(3 workers)" in the runner summary
        SOME_SECRET=None       -> hermeticity intact
```

`bash -n` clean; shellcheck reports no new findings (the SC2046 on the
pre-existing `compileall` line predates this change).

Expected effect on the next main-push docker run: the 8 heavy-file outliers
collapse to their true cost, the "Run docker integration tests" step drops
from ~320s to roughly a minute, and the suite tests the actual built image
(baked SHA now really asserted). The docker build job's `if:` gate skips fork
PRs, so the proof run happens post-merge / on a branch in this repo —
reviewers can compare the per-file durations in the first docker job after
this lands against the numbers above.
