### PR TITLE
fix(cli): route the remaining destructive user-file rewrites through atomic writes (salvage #79323)

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -61,6 +61,7 @@ Update semantics:
 
 from __future__ import annotations
 
+import os
 import re
 import shutil
 import subprocess
@@ -273,12 +274,26 @@ def write_manifest(profile_dir: Path, manifest: DistributionManifest) -> Path:
     # tracking and env_requires with no error surfaced anywhere.
     from utils import atomic_yaml_write
 
+    # atomic_yaml_write preserves an existing file's mode, but a file it
+    # *creates* keeps mkstemp's 0600. _materialize() reaches this line with no
+    # manifest on disk whenever a distribution declares an explicit
+    # `distribution_owned` allowlist that does not list distribution.yaml
+    # itself, so the file is never copied out of the staged tree. The manifest
+    # is a shareable descriptor rather than a secret and used to land at the
+    # umask default, so restore 0644 on the create path only.
+    existed = mf_path.exists()
+
     atomic_yaml_write(
         mf_path,
         manifest.to_dict(),
         sort_keys=False,
         default_flow_style=False,
     )
+    if not existed:
+        try:
+            os.chmod(mf_path, 0o644)
+        except OSError:
+            pass
     return mf_path
 
 

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -251,12 +251,6 @@ def _load_yaml(text: str) -> Any:
     return yaml.safe_load(text)
 
 
-def _dump_yaml(data: Any) -> str:
-    import yaml
-
-    return yaml.safe_dump(data, sort_keys=False, default_flow_style=False)
-
-
 def read_manifest(profile_dir: Path) -> Optional[DistributionManifest]:
     """Return the manifest for *profile_dir*, or None if it isn't a distribution."""
     mf_path = profile_dir / MANIFEST_FILENAME
@@ -271,7 +265,20 @@ def read_manifest(profile_dir: Path) -> Optional[DistributionManifest]:
 
 def write_manifest(profile_dir: Path, manifest: DistributionManifest) -> Path:
     mf_path = profile_dir / MANIFEST_FILENAME
-    mf_path.write_text(_dump_yaml(manifest.to_dict()), encoding="utf-8")
+    # Route through the shared atomic YAML writer (temp file + fsync + atomic
+    # replace, preserving mode/owner and symlinks). A bare write_text()
+    # truncates distribution.yaml before the dump lands, and read_manifest()
+    # treats a missing-or-unparseable manifest as "not a distribution" -- so an
+    # interrupted install/update silently demotes the profile, losing update
+    # tracking and env_requires with no error surfaced anywhere.
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(
+        mf_path,
+        manifest.to_dict(),
+        sort_keys=False,
+        default_flow_style=False,
+    )
     return mf_path
 
 

--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -61,7 +61,6 @@ Update semantics:
 
 from __future__ import annotations
 
-import os
 import re
 import shutil
 import subprocess
@@ -274,26 +273,20 @@ def write_manifest(profile_dir: Path, manifest: DistributionManifest) -> Path:
     # tracking and env_requires with no error surfaced anywhere.
     from utils import atomic_yaml_write
 
-    # atomic_yaml_write preserves an existing file's mode, but a file it
-    # *creates* keeps mkstemp's 0600. _materialize() reaches this line with no
-    # manifest on disk whenever a distribution declares an explicit
-    # `distribution_owned` allowlist that does not list distribution.yaml
-    # itself, so the file is never copied out of the staged tree. The manifest
-    # is a shareable descriptor rather than a secret and used to land at the
-    # umask default, so restore 0644 on the create path only.
-    existed = mf_path.exists()
-
+    # create_mode=0o644: _materialize() reaches this line with no manifest on
+    # disk whenever a distribution declares an explicit `distribution_owned`
+    # allowlist that does not list distribution.yaml itself, so the file is
+    # never copied out of the staged tree. The manifest is a shareable
+    # descriptor rather than a secret and used to land at the umask default,
+    # so don't leave a freshly created one at mkstemp's 0600. An existing
+    # file's mode is preserved as before.
     atomic_yaml_write(
         mf_path,
         manifest.to_dict(),
         sort_keys=False,
         default_flow_style=False,
+        create_mode=0o644,
     )
-    if not existed:
-        try:
-            os.chmod(mf_path, 0o644)
-        except OSError:
-            pass
     return mf_path
 
 

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -8,6 +8,7 @@ Provides options for:
 
 import os
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -87,7 +88,26 @@ def remove_path_from_shell_configs():
                 new_content = new_content.replace('\n\n\n', '\n\n')
             
             if new_content != original_content:
-                config_path.write_text(new_content, encoding="utf-8")
+                from utils import atomic_write_text
+
+                # This is the user's own shell rc, not a Hermes-owned file, and
+                # nothing in this function backs it up. A bare write_text()
+                # truncates it before the new content lands, so a crash or
+                # SIGINT mid-write leaves the user with an empty or truncated
+                # ~/.zshrc -- and the enclosing `except Exception` downgrades
+                # that to a warning, so the next login just starts a bare
+                # shell. atomic_replace also resolves a symlinked rc file, so a
+                # dotfiles-repo setup keeps the symlink instead of having it
+                # replaced by a regular file.
+                prior_mode = stat.S_IMODE(config_path.stat().st_mode)
+                atomic_write_text(config_path, new_content)
+                # atomic_write_text swaps in a fresh 0600 temp file; shell rc
+                # files are normally 0644 and removing Hermes' PATH block must
+                # not quietly change their permissions.
+                try:
+                    os.chmod(config_path, prior_mode)
+                except OSError:
+                    pass
                 removed_from.append(config_path)
                 
         except Exception as e:

--- a/hermes_cli/uninstall.py
+++ b/hermes_cli/uninstall.py
@@ -8,7 +8,6 @@ Provides options for:
 
 import os
 import shutil
-import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -98,16 +97,10 @@ def remove_path_from_shell_configs():
                 # that to a warning, so the next login just starts a bare
                 # shell. atomic_replace also resolves a symlinked rc file, so a
                 # dotfiles-repo setup keeps the symlink instead of having it
-                # replaced by a regular file.
-                prior_mode = stat.S_IMODE(config_path.stat().st_mode)
-                atomic_write_text(config_path, new_content)
-                # atomic_write_text swaps in a fresh 0600 temp file; shell rc
-                # files are normally 0644 and removing Hermes' PATH block must
-                # not quietly change their permissions.
-                try:
-                    os.chmod(config_path, prior_mode)
-                except OSError:
-                    pass
+                # replaced by a regular file. preserve_mode keeps the rc's
+                # permission bits (normally 0644) and owner (sudo-run
+                # uninstalls) instead of mkstemp's 0600/root.
+                atomic_write_text(config_path, new_content, preserve_mode=True)
                 removed_from.append(config_path)
                 
         except Exception as e:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -14,6 +14,8 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 
 import asyncio  # noqa: F401 — used by handlers
 import logging
+import os
+import stat
 import subprocess  # noqa: F401
 import sys  # noqa: F401
 import time  # noqa: F401
@@ -613,7 +615,28 @@ async def get_profile_soul(name: str):
 async def update_profile_soul(name: str, body: ProfileSoulUpdate):
     soul_path = _resolve_profile_dir(name) / "SOUL.md"
     try:
-        soul_path.write_text(body.content, encoding="utf-8")
+        from utils import atomic_write_text
+
+        # PUT replaces the whole persona document from the dashboard editor.
+        # A bare write_text() truncates SOUL.md before the new body lands, and
+        # the paired GET above reports an unreadable file as
+        # ``{"content": "", "exists": False}`` -- so an interrupted save shows
+        # up as "your persona was never set" and the editor's next Save
+        # persists that empty document over it.
+        try:
+            prior_mode = stat.S_IMODE(soul_path.stat().st_mode)
+        except OSError:
+            # First save for this profile -- there is no prior file to match.
+            prior_mode = None
+
+        atomic_write_text(soul_path, body.content)
+        # atomic_write_text swaps in a fresh 0600 temp file; profile SOUL.md is
+        # created 0644 and is not run through _secure_file, so re-apply.
+        if prior_mode is not None:
+            try:
+                os.chmod(soul_path, prior_mode)
+            except OSError:
+                pass
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -625,8 +625,16 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
         # persists that empty document over it.
         try:
             prior_mode = stat.S_IMODE(soul_path.stat().st_mode)
+        except FileNotFoundError:
+            # First save for this profile -- there is no prior file to match,
+            # so fall back to the mode profile creation itself produces:
+            # hermes_cli.profiles seeds SOUL.md with a bare write_text() and
+            # deliberately chmods only .env to 0600. Without this the create
+            # path keeps mkstemp's 0600 and the atomicity fix would silently
+            # tighten the persona document.
+            prior_mode = 0o644
         except OSError:
-            # First save for this profile -- there is no prior file to match.
+            # stat() failed for some other reason -- do not guess a mode.
             prior_mode = None
 
         atomic_write_text(soul_path, body.content)

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -14,8 +14,6 @@ late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 
 import asyncio  # noqa: F401 — used by handlers
 import logging
-import os
-import stat
 import subprocess  # noqa: F401
 import sys  # noqa: F401
 import time  # noqa: F401
@@ -623,28 +621,17 @@ async def update_profile_soul(name: str, body: ProfileSoulUpdate):
         # ``{"content": "", "exists": False}`` -- so an interrupted save shows
         # up as "your persona was never set" and the editor's next Save
         # persists that empty document over it.
-        try:
-            prior_mode = stat.S_IMODE(soul_path.stat().st_mode)
-        except FileNotFoundError:
-            # First save for this profile -- there is no prior file to match,
-            # so fall back to the mode profile creation itself produces:
-            # hermes_cli.profiles seeds SOUL.md with a bare write_text() and
-            # deliberately chmods only .env to 0600. Without this the create
-            # path keeps mkstemp's 0600 and the atomicity fix would silently
-            # tighten the persona document.
-            prior_mode = 0o644
-        except OSError:
-            # stat() failed for some other reason -- do not guess a mode.
-            prior_mode = None
-
-        atomic_write_text(soul_path, body.content)
-        # atomic_write_text swaps in a fresh 0600 temp file; profile SOUL.md is
-        # created 0644 and is not run through _secure_file, so re-apply.
-        if prior_mode is not None:
-            try:
-                os.chmod(soul_path, prior_mode)
-            except OSError:
-                pass
+        #
+        # preserve_mode carries an existing file's permission bits and owner
+        # across the replace. create_mode=0o644 covers the first save: named
+        # profiles seed SOUL.md at the umask default (hermes_cli.profiles
+        # chmods only .env to 0600), and SOUL.md is not a secret. (The default
+        # profile's runtime seeder does run it through _secure_file, but that
+        # seeder fires on every load_config, so the file already exists there
+        # and preserve_mode keeps whatever mode it set.)
+        atomic_write_text(
+            soul_path, body.content, preserve_mode=True, create_mode=0o644
+        )
     except OSError as e:
         _log.exception("PUT /api/profiles/%s/soul failed", name)
         raise HTTPException(status_code=500, detail=f"Could not write SOUL.md: {e}")

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -137,6 +137,9 @@ def format_issue(issue: RetirementIssue) -> str:
 # ---------------------------------------------------------------------------
 
 import datetime as _dt
+import io
+import os
+import stat
 from pathlib import Path
 import shutil
 
@@ -243,10 +246,38 @@ def apply_migration(
         shutil.copy2(config_path, backup_path)
 
     from hermes_cli.config import require_readable_config_before_write
+    from utils import atomic_write_text
 
     require_readable_config_before_write(config_path)
-    with config_path.open("w", encoding="utf-8") as fh:
-        yaml.dump(doc, fh)
+
+    # Serialize with the round-trip dumper first, then hand the finished text
+    # to the shared atomic writer (temp file + fsync + atomic replace).
+    # ``open(config_path, "w")`` truncates before the dump runs, so a crash or
+    # SIGINT mid-write leaves config.yaml empty or half-written -- and
+    # ``--no-backup`` is a documented flag, so on that path the truncated file
+    # is the only copy left. The load half above returns early when ``doc is
+    # None``, so the next `hermes migrate xai` reports nothing to migrate
+    # rather than surfacing the damage. atomic_replace also keeps a symlinked
+    # config.yaml (dotfiles repo / managed deployment) intact (GitHub #16743).
+    buf = io.StringIO()
+    yaml.dump(doc, buf)
+
+    # atomic_write_text swaps in a fresh 0600 temp file, so carry the existing
+    # permission bits across: _secure_file deliberately leaves config.yaml
+    # alone under managed (NixOS 0640) and container installs, and a migration
+    # must not silently tighten what those setups widened.
+    try:
+        prior_mode = stat.S_IMODE(config_path.stat().st_mode)
+    except OSError:
+        prior_mode = None
+
+    atomic_write_text(config_path, buf.getvalue())
+
+    if prior_mode is not None:
+        try:
+            os.chmod(config_path, prior_mode)
+        except OSError:
+            pass
 
     return ApplyResult(
         file_path=config_path,

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -138,8 +138,6 @@ def format_issue(issue: RetirementIssue) -> str:
 
 import datetime as _dt
 import io
-import os
-import stat
 from pathlib import Path
 import shutil
 
@@ -262,22 +260,11 @@ def apply_migration(
     buf = io.StringIO()
     yaml.dump(doc, buf)
 
-    # atomic_write_text swaps in a fresh 0600 temp file, so carry the existing
-    # permission bits across: _secure_file deliberately leaves config.yaml
-    # alone under managed (NixOS 0640) and container installs, and a migration
-    # must not silently tighten what those setups widened.
-    try:
-        prior_mode = stat.S_IMODE(config_path.stat().st_mode)
-    except OSError:
-        prior_mode = None
-
-    atomic_write_text(config_path, buf.getvalue())
-
-    if prior_mode is not None:
-        try:
-            os.chmod(config_path, prior_mode)
-        except OSError:
-            pass
+    # preserve_mode carries the existing permission bits AND owner across the
+    # replace: _secure_file deliberately leaves config.yaml alone under managed
+    # (NixOS 0640) and container installs, and a root-run migration on a
+    # user-owned volume must not flip ownership to root.
+    atomic_write_text(config_path, buf.getvalue(), preserve_mode=True)
 
     return ApplyResult(
         file_path=config_path,

--- a/tests/hermes_cli/test_migrate_xai.py
+++ b/tests/hermes_cli/test_migrate_xai.py
@@ -206,3 +206,89 @@ class TestUnreadableExistingConfig:
             os.chmod(trap_config, 0o644)
 
         assert trap_config.read_bytes() == original
+
+
+# ---------------------------------------------------------------------------
+# Crash durability — the rewrite must be atomic
+# ---------------------------------------------------------------------------
+
+class TestCrashDurability:
+    """apply_migration() rewrites the whole config.yaml in place.
+
+    A bare ``open(path, "w")`` truncates the file *before* the dump runs, so an
+    interruption (crash, SIGINT, ENOSPC) leaves config.yaml empty or
+    half-written.  Routing through ``utils.atomic_write_text`` means the target
+    is only ever swapped in via an atomic rename after the temp file is fully
+    written and fsynced.
+    """
+
+    def test_config_survives_an_interrupted_write(self, trap_config: Path):
+        """A failure mid-write must leave the original config.yaml untouched.
+
+        ``--no-backup`` is a documented flag, so on that path the file being
+        rewritten is the only copy in existence.
+        """
+        import os
+
+        issues = find_retired_xai_refs(_parse(trap_config))
+        assert issues  # sanity: trap_config has retired refs
+        original = trap_config.read_bytes()
+
+        def boom(fd):
+            raise OSError("simulated crash mid-write")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "fsync", boom)
+            with pytest.raises(OSError):
+                apply_migration(trap_config, issues, backup=False)
+
+        # The original bytes must survive verbatim...
+        assert trap_config.read_bytes() == original
+        # ...and the aborted write must not leave a temp file behind.
+        assert list(trap_config.parent.glob("*.tmp")) == []
+
+    def test_symlinked_config_is_replaced_in_place(self, tmp_path: Path):
+        """A config.yaml symlinked into a dotfiles repo must stay a symlink."""
+        real_dir = tmp_path / "dotfiles"
+        real_dir.mkdir()
+        real = real_dir / "hermes-config.yaml"
+        real.write_text(
+            "principal:\n"
+            "  provider: xai\n"
+            "  model: grok-3\n",
+            encoding="utf-8",
+        )
+        link = tmp_path / "config.yaml"
+        link.symlink_to(real)
+
+        issues = find_retired_xai_refs(_parse(link))
+        assert issues
+        apply_migration(link, issues, backup=False)
+
+        assert link.is_symlink(), "atomic replace detached the symlink"
+        assert real.read_text(encoding="utf-8") == link.read_text(encoding="utf-8")
+        assert "grok-4.3" in real.read_text(encoding="utf-8")
+
+    def test_existing_file_mode_is_preserved(self, trap_config: Path):
+        """Managed (NixOS 0640) and container installs widen config.yaml
+        deliberately; the migration must not silently tighten it to 0600."""
+        import os
+        import stat
+
+        os.chmod(trap_config, 0o640)
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues, backup=False)
+
+        mode = stat.S_IMODE(trap_config.stat().st_mode)
+        assert mode == 0o640, f"mode changed to {oct(mode)}"
+
+    def test_comments_survive_the_atomic_write(self, trap_config: Path):
+        """The ruamel round-trip must still run — serializing via a string
+        buffer instead of the file handle must not drop comments."""
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues, backup=False)
+
+        text = trap_config.read_text(encoding="utf-8")
+        assert "# Hermes config (sample)" in text
+        assert "# the main model" in text
+        assert "# not affected" in text

--- a/tests/hermes_cli/test_migrate_xai.py
+++ b/tests/hermes_cli/test_migrate_xai.py
@@ -1,6 +1,7 @@
 """Tests for ``hermes migrate xai`` — apply path with ruamel round-trip."""
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -269,6 +270,7 @@ class TestCrashDurability:
         assert real.read_text(encoding="utf-8") == link.read_text(encoding="utf-8")
         assert "grok-4.3" in real.read_text(encoding="utf-8")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
     def test_existing_file_mode_is_preserved(self, trap_config: Path):
         """Managed (NixOS 0640) and container installs widen config.yaml
         deliberately; the migration must not silently tighten it to 0600."""

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -737,3 +737,25 @@ class TestManifestCrashDurability:
         mode = stat.S_IMODE(mf.stat().st_mode)
         assert mode == 0o644, f"mode changed to {oct(mode)}"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX permission bits"
+    )
+    def test_created_file_mode_is_not_tightened(self, tmp_path):
+        """A manifest this function *creates* must not land owner-only.
+
+        ``atomic_yaml_write`` only re-applies a mode it captured from an
+        existing file, so a fresh distribution.yaml would otherwise keep
+        ``tempfile.mkstemp``'s 0600. ``_materialize`` hits that path whenever a
+        distribution's explicit ``distribution_owned`` allowlist omits
+        distribution.yaml, so the staged copy never lands in the profile.
+        """
+        import stat
+
+        mf = tmp_path / "distribution.yaml"
+        assert not mf.exists()
+
+        write_manifest(tmp_path, DistributionManifest(name="fresh", version="1.0.0"))
+
+        mode = stat.S_IMODE(mf.stat().st_mode)
+        assert mode == 0o644, f"new manifest created as {oct(mode)}"
+

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -672,3 +672,64 @@ class TestErrorSurfaces:
         with pytest.raises((ValueError, DistributionError)):
             plan_install(str(staged), tmp_path / "work")
 
+
+# ===========================================================================
+# Crash durability: write_manifest rewrites distribution.yaml in place
+# ===========================================================================
+
+
+class TestManifestCrashDurability:
+    """``write_manifest`` runs on every install and update of a shared profile.
+
+    ``read_manifest`` reports a missing-or-unparseable manifest as "this isn't
+    a distribution", so a truncated distribution.yaml silently demotes the
+    profile — update tracking and ``env_requires`` just stop existing, with no
+    error surfaced anywhere.
+    """
+
+    def test_previous_manifest_survives_an_interrupted_write(self, tmp_path):
+        import os
+
+        original = DistributionManifest(
+            name="keepme",
+            version="1.0.0",
+            description="the manifest already on disk",
+            env_requires=[EnvRequirement(name="FOO", description="foo")],
+        )
+        write_manifest(tmp_path, original)
+        on_disk = (tmp_path / "distribution.yaml").read_bytes()
+
+        def boom(fd):
+            raise OSError("simulated crash mid-write")
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "fsync", boom)
+            with pytest.raises(OSError):
+                write_manifest(
+                    tmp_path,
+                    DistributionManifest(name="replacement", version="2.0.0"),
+                )
+
+        # The old manifest must still be byte-identical and still parse.
+        assert (tmp_path / "distribution.yaml").read_bytes() == on_disk
+        parsed = read_manifest(tmp_path)
+        assert parsed is not None, "profile silently stopped being a distribution"
+        assert parsed.name == "keepme"
+        assert parsed.env_requires[0].name == "FOO"
+
+        # No temp file left behind next to the manifest.
+        assert list(tmp_path.glob("*.tmp")) == []
+
+    def test_existing_file_mode_is_preserved(self, tmp_path):
+        import os
+        import stat
+
+        write_manifest(tmp_path, DistributionManifest(name="modes", version="1.0.0"))
+        mf = tmp_path / "distribution.yaml"
+        os.chmod(mf, 0o644)
+
+        write_manifest(tmp_path, DistributionManifest(name="modes", version="2.0.0"))
+
+        mode = stat.S_IMODE(mf.stat().st_mode)
+        assert mode == 0o644, f"mode changed to {oct(mode)}"
+

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -10,6 +10,7 @@ mocking git would just test the mock.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
@@ -720,6 +721,9 @@ class TestManifestCrashDurability:
         # No temp file left behind next to the manifest.
         assert list(tmp_path.glob("*.tmp")) == []
 
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="POSIX permission bits"
+    )
     def test_existing_file_mode_is_preserved(self, tmp_path):
         import os
         import stat

--- a/tests/hermes_cli/test_uninstall_shell_configs.py
+++ b/tests/hermes_cli/test_uninstall_shell_configs.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -104,6 +105,7 @@ class TestCrashDurability:
         assert "# Hermes Agent" not in real.read_text(encoding="utf-8")
         assert "export EDITOR=vim" in real.read_text(encoding="utf-8")
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
     def test_existing_file_mode_is_preserved(self, fake_home: Path):
         """Shell rc files are normally 0644; uninstalling must not change that."""
         rc = fake_home / ".zshrc"

--- a/tests/hermes_cli/test_uninstall_shell_configs.py
+++ b/tests/hermes_cli/test_uninstall_shell_configs.py
@@ -1,0 +1,116 @@
+"""Tests for ``remove_path_from_shell_configs`` — the uninstaller's shell-rc rewrite.
+
+This rewrites files Hermes does not own (``~/.bashrc``, ``~/.zshrc``, ...) and
+takes no backup of them, so the rewrite has to be atomic: a bare
+``write_text()`` truncates the rc file before the new content lands, and the
+caller wraps everything in ``except Exception: log_warn(...)``, so a partial
+write is downgraded to a warning and the user's next login starts a bare shell.
+"""
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import uninstall
+
+
+ZSHRC = (
+    "export EDITOR=vim\n"
+    "alias ll='ls -la'\n"
+    "\n"
+    "# Hermes Agent\n"
+    'export PATH="$HOME/.local/bin:$PATH"\n'
+    "\n"
+    "source ~/.work-profile\n"
+)
+
+
+@pytest.fixture
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point both ``Path.home()`` and ``HERMES_HOME`` at a throwaway dir."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    monkeypatch.setenv("HERMES_HOME", str(home / ".hermes"))
+    return home
+
+
+class TestHappyPath:
+    def test_hermes_path_block_is_removed(self, fake_home: Path):
+        rc = fake_home / ".zshrc"
+        rc.write_text(ZSHRC, encoding="utf-8")
+
+        removed = uninstall.remove_path_from_shell_configs()
+
+        assert removed == [rc]
+        text = rc.read_text(encoding="utf-8")
+        assert "# Hermes Agent" not in text
+        # The user's own lines are untouched.
+        assert "export EDITOR=vim" in text
+        assert "source ~/.work-profile" in text
+
+    def test_untouched_rc_is_not_reported(self, fake_home: Path):
+        rc = fake_home / ".zshrc"
+        rc.write_text("export EDITOR=vim\n", encoding="utf-8")
+
+        assert uninstall.remove_path_from_shell_configs() == []
+        assert rc.read_text(encoding="utf-8") == "export EDITOR=vim\n"
+
+
+class TestCrashDurability:
+    def test_shell_config_survives_an_interrupted_rewrite(self, fake_home: Path):
+        """An interrupted rewrite must leave the rc file byte-identical.
+
+        There is no backup of the user's shell rc anywhere in this code path,
+        so a truncated write is unrecoverable.
+        """
+        rc = fake_home / ".zshrc"
+        rc.write_text(ZSHRC, encoding="utf-8")
+        original = rc.read_bytes()
+
+        def boom(fd):
+            raise OSError("simulated crash mid-write")
+
+        # Scoped context so restoring os.fsync doesn't also undo the
+        # Path.home()/HERMES_HOME patches the fake_home fixture installed.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "fsync", boom)
+            removed = uninstall.remove_path_from_shell_configs()
+
+        # The write failed, so the rc must not be reported as modified...
+        assert removed == []
+        # ...and it must still be exactly what the user had.
+        assert rc.read_bytes() == original
+        # The aborted write must not leave a temp file behind in $HOME.
+        assert list(fake_home.glob("*.tmp")) == []
+
+    def test_symlinked_shell_config_stays_a_symlink(self, fake_home: Path):
+        """A dotfiles-repo ``~/.zshrc`` is a symlink; replacing it with a
+        regular file silently detaches the user's dotfiles."""
+        dotfiles = fake_home / "dotfiles"
+        dotfiles.mkdir()
+        real = dotfiles / "zshrc"
+        real.write_text(ZSHRC, encoding="utf-8")
+        rc = fake_home / ".zshrc"
+        rc.symlink_to(real)
+
+        removed = uninstall.remove_path_from_shell_configs()
+
+        assert removed == [rc]
+        assert rc.is_symlink(), "the symlink was replaced by a regular file"
+        assert "# Hermes Agent" not in real.read_text(encoding="utf-8")
+        assert "export EDITOR=vim" in real.read_text(encoding="utf-8")
+
+    def test_existing_file_mode_is_preserved(self, fake_home: Path):
+        """Shell rc files are normally 0644; uninstalling must not change that."""
+        rc = fake_home / ".zshrc"
+        rc.write_text(ZSHRC, encoding="utf-8")
+        os.chmod(rc, 0o644)
+
+        uninstall.remove_path_from_shell_configs()
+
+        mode = stat.S_IMODE(rc.stat().st_mode)
+        assert mode == 0o644, f"mode changed to {oct(mode)}"

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -1,0 +1,110 @@
+"""``PUT /api/profiles/{name}/soul`` must not destroy an existing SOUL.md.
+
+The dashboard persona editor replaces the whole document on every Save. A bare
+``write_text()`` truncates SOUL.md before the new body lands, and the paired
+``GET`` reports an unreadable file as ``{"content": "", "exists": False}`` — so
+an interrupted save presents as "your persona was never set" and the editor's
+next Save persists that empty document over the original.
+
+Lives in its own module rather than ``test_web_server.py`` to keep the harness
+small and focused on this one endpoint pair.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+from fastapi.testclient import TestClient  # noqa: E402
+
+
+SOUL = "# Persona\n\nYou are a careful, terse assistant.\n"
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_DASHBOARD_SESSION_TOKEN", "soul-test-token")
+    from hermes_cli import web_server
+
+    with TestClient(web_server.app, raise_server_exceptions=False) as c:
+        c.headers["Authorization"] = "Bearer soul-test-token"
+        yield c
+
+
+@pytest.fixture()
+def profile_dir(tmp_path, monkeypatch) -> Path:
+    """Create a real profile directory under the test HERMES_HOME."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    from hermes_cli import profiles as profiles_mod
+
+    d = profiles_mod.get_profile_dir("demo")
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+class TestSoulWriteDurability:
+    def test_put_replaces_soul(self, client, profile_dir: Path):
+        """Happy path: the editor's Save still works."""
+        (profile_dir / "SOUL.md").write_text(SOUL, encoding="utf-8")
+
+        r = client.put("/api/profiles/demo/soul", json={"content": "# New\n"})
+
+        assert r.status_code == 200, r.text
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == "# New\n"
+
+    def test_put_creates_soul_when_absent(self, client, profile_dir: Path):
+        """A first save has no prior file to preserve permissions from."""
+        assert not (profile_dir / "SOUL.md").exists()
+
+        r = client.put("/api/profiles/demo/soul", json={"content": SOUL})
+
+        assert r.status_code == 200, r.text
+        assert (profile_dir / "SOUL.md").read_text(encoding="utf-8") == SOUL
+
+    def test_existing_soul_survives_an_interrupted_save(
+        self, client, profile_dir: Path
+    ):
+        soul = profile_dir / "SOUL.md"
+        soul.write_text(SOUL, encoding="utf-8")
+        original = soul.read_bytes()
+
+        def boom(fd):
+            raise OSError("simulated crash mid-write")
+
+        # Scoped context so restoring os.fsync doesn't also undo the
+        # HERMES_HOME patch the client/profile_dir fixtures installed.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(os, "fsync", boom)
+            r = client.put(
+                "/api/profiles/demo/soul", json={"content": "# clobbered\n"}
+            )
+
+        assert r.status_code == 500
+        # The persona the user already had must survive verbatim...
+        assert soul.read_bytes() == original
+        # ...and the paired GET must not report it as never-set, which is what
+        # would make the next Save persist an empty document.
+        g = client.get("/api/profiles/demo/soul")
+        assert g.status_code == 200, g.text
+        assert g.json()["exists"] is True
+        assert g.json()["content"] == SOUL
+        # No temp file left behind in the profile directory.
+        assert list(profile_dir.glob("*.tmp")) == []
+
+    def test_existing_file_mode_is_preserved(self, client, profile_dir: Path):
+        """Profile SOUL.md is created 0644 and never run through
+        ``_secure_file``; saving from the dashboard must not change that."""
+        soul = profile_dir / "SOUL.md"
+        soul.write_text(SOUL, encoding="utf-8")
+        os.chmod(soul, 0o644)
+
+        r = client.put("/api/profiles/demo/soul", json={"content": "# New\n"})
+
+        assert r.status_code == 200, r.text
+        mode = stat.S_IMODE(soul.stat().st_mode)
+        assert mode == 0o644, f"mode changed to {oct(mode)}"

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -110,3 +110,22 @@ class TestSoulWriteDurability:
         assert r.status_code == 200, r.text
         mode = stat.S_IMODE(soul.stat().st_mode)
         assert mode == 0o644, f"mode changed to {oct(mode)}"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
+    def test_created_file_mode_is_not_tightened(self, client, profile_dir: Path):
+        """The first-ever Save must not leave SOUL.md owner-only.
+
+        There is no prior file to copy permissions from, and
+        ``atomic_write_text`` swaps in a ``tempfile.mkstemp`` file (0600).
+        Profile creation seeds SOUL.md with a plain ``write_text()`` and
+        chmods only ``.env`` to 0600, so routing this endpoint through the
+        atomic writer must not tighten the persona document as a side effect.
+        """
+        soul = profile_dir / "SOUL.md"
+        assert not soul.exists()
+
+        r = client.put("/api/profiles/demo/soul", json={"content": SOUL})
+
+        assert r.status_code == 200, r.text
+        mode = stat.S_IMODE(soul.stat().st_mode)
+        assert mode == 0o644, f"first save created SOUL.md as {oct(mode)}"

--- a/tests/hermes_cli/test_web_profile_soul_writes.py
+++ b/tests/hermes_cli/test_web_profile_soul_writes.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import os
 import stat
+import sys
 from pathlib import Path
 
 import pytest
@@ -96,6 +97,7 @@ class TestSoulWriteDurability:
         # No temp file left behind in the profile directory.
         assert list(profile_dir.glob("*.tmp")) == []
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX permission bits")
     def test_existing_file_mode_is_preserved(self, client, profile_dir: Path):
         """Profile SOUL.md is created 0644 and never run through
         ``_secure_file``; saving from the dashboard must not change that."""

--- a/tests/test_atomic_write_text_metadata.py
+++ b/tests/test_atomic_write_text_metadata.py
@@ -1,0 +1,159 @@
+"""``atomic_write_text``'s opt-in metadata preservation (mode + owner).
+
+``os.replace`` swaps mkstemp's 0600 temp file (owned by the writing user)
+onto the target, so a bare atomic rewrite of an existing user-authored file
+tightens its permission bits and — for root-run callers on Docker/NAS
+volumes — flips its ownership.  ``preserve_mode=True`` carries both across
+the replace, exactly like ``atomic_yaml_write`` does unconditionally;
+``create_mode=`` sets the bits when the target does not exist yet.
+
+These guard the follow-up to PR #79323, which collapsed three hand-rolled
+stat/write/chmod blocks (xai migration, uninstaller shell-rc rewrite,
+dashboard SOUL.md editor) into these kwargs.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from utils import atomic_write_text, atomic_yaml_write
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32", reason="POSIX permission bits"
+)
+
+
+class TestPreserveMode:
+    def test_existing_mode_survives_the_rewrite(self, tmp_path: Path) -> None:
+        """A 0640 managed config must not tighten to mkstemp's 0600."""
+        target = tmp_path / "config.yaml"
+        target.write_text("old: true\n", encoding="utf-8")
+        os.chmod(target, 0o640)
+
+        atomic_write_text(target, "new: true\n", preserve_mode=True)
+
+        assert target.read_text(encoding="utf-8") == "new: true\n"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
+    def test_default_still_leaves_mkstemp_mode(self, tmp_path: Path) -> None:
+        """Without opt-in, behavior is unchanged: the file lands 0600."""
+        target = tmp_path / "notes.md"
+        target.write_text("old\n", encoding="utf-8")
+        os.chmod(target, 0o644)
+
+        atomic_write_text(target, "new\n")
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_mode_is_applied_before_the_replace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The temp fd gets fchmod'd, so the target never transits 0600."""
+        target = tmp_path / "config.yaml"
+        target.write_text("old\n", encoding="utf-8")
+        os.chmod(target, 0o640)
+
+        import utils as utils_mod
+
+        real_replace = utils_mod.atomic_replace
+        seen: list[int] = []
+
+        def spying_replace(tmp, dst):
+            seen.append(stat.S_IMODE(os.stat(tmp).st_mode))
+            return real_replace(tmp, dst)
+
+        monkeypatch.setattr(utils_mod, "atomic_replace", spying_replace)
+        atomic_write_text(target, "new\n", preserve_mode=True)
+
+        assert seen == [0o640]
+
+    def test_owner_is_restored_on_the_real_symlink_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Root-run rewrites of a user-owned file must not flip ownership.
+
+        Mirrors test_atomic_yaml_write_restores_owner_on_real_symlink_target:
+        forces a preserved uid/gid so the test does not need root.
+        """
+        real = tmp_path / "zshrc"
+        link = tmp_path / ".zshrc"
+        real.write_text("export A=1\n", encoding="utf-8")
+        link.symlink_to(real)
+
+        chown_calls: list[tuple[Path, int, int]] = []
+        monkeypatch.setattr("utils._preserve_file_owner", lambda _p: (123, 456))
+        monkeypatch.setattr(
+            "utils.os.chown",
+            lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+        )
+
+        atomic_write_text(link, "export B=2\n", preserve_mode=True)
+
+        assert chown_calls == [(real, 123, 456)]
+        assert link.is_symlink()
+        assert real.read_text(encoding="utf-8") == "export B=2\n"
+
+    def test_no_owner_calls_without_opt_in(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        target = tmp_path / "mem.md"
+        target.write_text("old\n", encoding="utf-8")
+
+        chown_calls: list[tuple] = []
+        monkeypatch.setattr("utils._preserve_file_owner", lambda _p: (123, 456))
+        monkeypatch.setattr(
+            "utils.os.chown", lambda *a: chown_calls.append(a)
+        )
+
+        atomic_write_text(target, "new\n")
+
+        assert chown_calls == []
+
+
+class TestCreateMode:
+    def test_create_mode_applies_when_target_is_new(self, tmp_path: Path) -> None:
+        target = tmp_path / "SOUL.md"
+        assert not target.exists()
+
+        atomic_write_text(
+            target, "# Persona\n", preserve_mode=True, create_mode=0o644
+        )
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+    def test_existing_mode_beats_create_mode(self, tmp_path: Path) -> None:
+        target = tmp_path / "SOUL.md"
+        target.write_text("old\n", encoding="utf-8")
+        os.chmod(target, 0o600)
+
+        atomic_write_text(
+            target, "new\n", preserve_mode=True, create_mode=0o644
+        )
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_atomic_yaml_write_create_mode(self, tmp_path: Path) -> None:
+        """write_manifest's create path: new file lands 0644, not 0600."""
+        target = tmp_path / "distribution.yaml"
+        assert not target.exists()
+
+        atomic_yaml_write(target, {"name": "t"}, create_mode=0o644)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+    def test_atomic_yaml_write_existing_mode_beats_create_mode(
+        self, tmp_path: Path
+    ) -> None:
+        target = tmp_path / "distribution.yaml"
+        target.write_text("name: old\n", encoding="utf-8")
+        os.chmod(target, 0o600)
+
+        atomic_yaml_write(target, {"name": "new"}, create_mode=0o644)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600

--- a/tests/test_atomic_write_text_metadata.py
+++ b/tests/test_atomic_write_text_metadata.py
@@ -138,6 +138,33 @@ class TestCreateMode:
 
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
 
+    def test_create_mode_never_rewrites_an_existing_file(
+        self, tmp_path: Path
+    ) -> None:
+        """create_mode without preserve_mode must not chmod an existing file."""
+        target = tmp_path / "notes.md"
+        target.write_text("old\n", encoding="utf-8")
+        os.chmod(target, 0o640)
+
+        atomic_write_text(target, "new\n", create_mode=0o644)
+
+        # The write is a plain (non-preserving) atomic rewrite: mkstemp 0600.
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+
+    def test_windows_fallback_branch_applies_mode_after_replace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without os.fchmod (Windows), the mode is applied post-replace."""
+        target = tmp_path / "config.yaml"
+        target.write_text("old\n", encoding="utf-8")
+        os.chmod(target, 0o640)
+
+        monkeypatch.delattr(os, "fchmod")
+        atomic_write_text(target, "new\n", preserve_mode=True)
+
+        assert target.read_text(encoding="utf-8") == "new\n"
+        assert stat.S_IMODE(target.stat().st_mode) == 0o640
+
     def test_atomic_yaml_write_create_mode(self, tmp_path: Path) -> None:
         """write_manifest's create path: new file lands 0644, not 0600."""
         target = tmp_path / "distribution.yaml"

--- a/utils.py
+++ b/utils.py
@@ -142,6 +142,8 @@ def atomic_write_text(
     *,
     encoding: str = "utf-8",
     tmp_prefix: str = ".tmp_",
+    preserve_mode: bool = False,
+    create_mode: "int | None" = None,
 ) -> None:
     """Write *content* to *path* via temp file + fsync + atomic rename.
 
@@ -151,18 +153,45 @@ def atomic_write_text(
 
     Used by the memory store, skill manager, and agent importer so that
     every destructive file rewrite in the codebase shares one implementation.
+
+    Args:
+        preserve_mode: When True, carry an existing target's permission bits
+            and (POSIX, best-effort) owner across the replace, like
+            ``atomic_yaml_write`` does unconditionally.  ``os.replace`` swaps
+            in mkstemp's 0600 temp file owned by the writing user, so without
+            this a root-run rewrite of a user-owned file flips its owner and
+            tightens its mode.  The mode is applied to the temp fd *before*
+            the replace, so the file never transits through 0600.  Off by
+            default: the historical callers (memory store, skill manager,
+            cron) own their 0600-is-fine files.
+        create_mode: Permission bits to apply when the target does not yet
+            exist (otherwise the new file keeps mkstemp's 0600).  Ignored
+            when ``preserve_mode`` found an existing mode to carry over.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    original_mode = _preserve_file_mode(path) if preserve_mode else None
+    original_owner = _preserve_file_owner(path) if preserve_mode else None
+    effective_mode = original_mode if original_mode is not None else create_mode
+
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent), prefix=tmp_prefix, suffix=".tmp"
     )
     try:
+        if effective_mode is not None and hasattr(os, "fchmod"):
+            # fchmod is Unix-only; on Windows the post-replace chmod below
+            # applies the final mode instead.
+            os.fchmod(fd, effective_mode)
         with os.fdopen(fd, "w", encoding=encoding) as handle:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        atomic_replace(tmp_path, path)
+        real_path = atomic_replace(tmp_path, path)
+        if preserve_mode:
+            _restore_file_owner(Path(real_path), original_owner)
+        if effective_mode is not None and not hasattr(os, "fchmod"):
+            _restore_file_mode(Path(real_path), effective_mode)
     except BaseException:
         try:
             os.unlink(tmp_path)
@@ -307,6 +336,7 @@ def atomic_yaml_write(
     default_flow_style: bool = False,
     sort_keys: bool = False,
     extra_content: str | None = None,
+    create_mode: "int | None" = None,
 ) -> None:
     """Write YAML data to a file atomically.
 
@@ -321,12 +351,17 @@ def atomic_yaml_write(
         sort_keys: Whether to sort dict keys (default False).
         extra_content: Optional string to append after the YAML dump
             (e.g. commented-out sections for user reference).
+        create_mode: Permission bits to apply when the target does not yet
+            exist (a created file otherwise keeps mkstemp's 0600).  An
+            existing file's mode is always preserved and wins over this.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
+    if original_mode is None:
+        original_mode = create_mode
 
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),

--- a/utils.py
+++ b/utils.py
@@ -165,25 +165,28 @@ def atomic_write_text(
             default: the historical callers (memory store, skill manager,
             cron) own their 0600-is-fine files.
         create_mode: Permission bits to apply when the target does not yet
-            exist (otherwise the new file keeps mkstemp's 0600).  Ignored
-            when ``preserve_mode`` found an existing mode to carry over.
+            exist (otherwise the new file keeps mkstemp's 0600).  Never
+            applied to an existing file.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     original_mode = _preserve_file_mode(path) if preserve_mode else None
     original_owner = _preserve_file_owner(path) if preserve_mode else None
-    effective_mode = original_mode if original_mode is not None else create_mode
+    effective_mode = original_mode
+    if effective_mode is None and create_mode is not None and not path.exists():
+        effective_mode = create_mode
 
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent), prefix=tmp_prefix, suffix=".tmp"
     )
     try:
-        if effective_mode is not None and hasattr(os, "fchmod"):
-            # fchmod is Unix-only; on Windows the post-replace chmod below
-            # applies the final mode instead.
-            os.fchmod(fd, effective_mode)
         with os.fdopen(fd, "w", encoding=encoding) as handle:
+            if effective_mode is not None and hasattr(os, "fchmod"):
+                # fchmod the temp fd BEFORE the replace so the target never
+                # transits through mkstemp's 0600. fchmod is Unix-only; on
+                # Windows the post-replace chmod below applies the mode.
+                os.fchmod(handle.fileno(), effective_mode)
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
@@ -352,15 +355,15 @@ def atomic_yaml_write(
         extra_content: Optional string to append after the YAML dump
             (e.g. commented-out sections for user reference).
         create_mode: Permission bits to apply when the target does not yet
-            exist (a created file otherwise keeps mkstemp's 0600).  An
-            existing file's mode is always preserved and wins over this.
+            exist (a created file otherwise keeps mkstemp's 0600).  Never
+            applied to an existing file, whose mode is always preserved.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
 
     original_mode = _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
-    if original_mode is None:
+    if original_mode is None and create_mode is not None and not path.exists():
         original_mode = create_mode
 
     fd, tmp_path = tempfile.mkstemp(
@@ -370,6 +373,12 @@ def atomic_yaml_write(
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
+            if original_mode is not None and hasattr(os, "fchmod"):
+                # Apply the mode to the temp fd BEFORE the replace so the
+                # target never transits through mkstemp's 0600 (the
+                # post-replace _restore_file_mode below then re-applies it
+                # harmlessly, and remains the sole path on Windows).
+                os.fchmod(f.fileno(), original_mode)
             # allow_unicode=True writes emoji/kaomoji (e.g. personalities, skin
             # cursors) as real UTF-8 instead of fragile escape sequences. Without
             # it, PyYAML emits astral-plane chars as `\UXXXXXXXX` (8-digit) escapes


### PR DESCRIPTION
## Salvage of #79323 — @briandevans's atomic user-file rewrites + metadata-preservation follow-up

Closes #79323

### What this does

`@briandevans`'s three commits are cherry-picked verbatim (authorship preserved). They route the last four non-atomic full-file rewrites of **existing user-authored files** through the shared atomic writers, so a crash/`SIGINT`/`ENOSPC` mid-write can no longer leave the file empty or half-written:

| # | Site | File rewritten | Why the damage was silent before |
|---|------|----------------|----------------------------------|
| 1 | `xai_retirement.apply_migration()` | the user's `config.yaml` | reload gets `doc is None` → next `hermes migrate xai` reports nothing to migrate |
| 2 | `uninstall.remove_path_from_shell_configs()` | the user's `~/.zshrc` / `~/.bashrc` | enclosing `except Exception` downgrades it to a warning; next login starts a bare shell |
| 3 | dashboard `PUT /api/profiles/{name}/soul` | a profile's `SOUL.md` | paired GET reports `{"content": "", "exists": False}`; the editor's next Save persists the empty doc |
| 4 | `profile_distribution.write_manifest()` | `distribution.yaml` | `read_manifest` returns `None`, silently demoting the profile to a non-distribution |

Each site carries a regression test that fails on `main` (verified: exactly 4 fail on a clean `upstream/main` worktree, 72 pass).

### Follow-up commit (ours)

Review of the salvaged commits found the three hand-rolled `stat → atomic_write_text → chmod` blocks shared a gap: they restored the **mode** but not the **owner**. The old in-place writes (`open(path, "w")`) kept the inode, so ownership survived root-run rewrites for free; `atomic_write_text` swaps in a new inode owned by the writing user. A root-run `hermes migrate xai` (or `sudo` uninstall) on a user-owned Docker/NAS volume would flip `config.yaml` / `~/.zshrc` ownership to root — the exact scenario `utils._restore_file_owner`'s docstring exists for, and which `atomic_yaml_write`/`atomic_json_write` already handle.

The follow-up moves the whole pattern into the shared helper:

- `atomic_write_text(preserve_mode=True)` — carries mode **and owner** across the replace, using the same `_preserve_file_mode`/`_preserve_file_owner` helpers its yaml/json siblings use. Off by default, so the existing callers (memory store, skill manager, cron, agent importer) are untouched.
- `create_mode=` on both `atomic_write_text` and `atomic_yaml_write` — first-create paths (SOUL.md first save, `write_manifest`'s `distribution_owned`-allowlist create path) land at 0644 instead of mkstemp's 0600, without the caller-side `existed`/chmod block (and its small TOCTOU).
- The mode is applied via `fchmod` on the temp fd **before** the replace (mirroring `atomic_json_write`'s `mode=` param), so the target never transits through 0600.
- Deletes the three duplicated ~12-line blocks; net production diff of the follow-up is −69/+~80 with most of the + being docstrings/tests.

### Validation

| Check | Result |
|---|---|
| PR's own 4 test files + new metadata tests | 94 passed, 1 skipped |
| Regression proof on clean `upstream/main` | 4 failed (one per production site), 72 passed |
| Adjacent suites (`test_web_server`, xai, uninstall, dashboard, memory/skill tools) | 245 + 81 passed |
| Live E2E (real imports, temp home) | symlinked 0640 `config.yaml` migrates with ruamel comments intact & stays a symlink; symlinked `.zshrc` survives uninstall at 0644; manifest create=0644 / rewrite preserves custom mode; no `.tmp` leftovers |
| Mutation checks | gutting `preserve_mode` → 4 tests fail; gutting `create_mode` in `atomic_yaml_write` → 1 test fails; restored & re-verified green |
| ruff | clean on all touched files |

### Credit

Commits 1–3 authored by @briandevans (`fix(cli): route the remaining destructive user-file rewrites through atomic writes` + Windows-skip + create-mode fix), cherry-picked with authorship preserved. The PR body's site inventory and deliberate-exclusions analysis are theirs and were verified accurate during review.
