### PR TITLE
fix(bluebubbles): isolate standalone sends from gateway lifecycle

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -299,7 +299,6 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             return False
 
         if not start_webhook_listener:
-            self._mark_connected()
             return True
 
         from aiohttp import web
@@ -334,7 +333,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         # Outbound-only connections never own a webhook registration.
-        if self._runner:
+        owns_gateway_lifecycle = self._runner is not None
+        if owns_gateway_lifecycle:
             await self._unregister_webhook()
 
         if self.client:
@@ -343,7 +343,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if self._runner:
             await self._runner.cleanup()
             self._runner = None
-        self._mark_disconnected()
+        # A temporary standalone sender must not overwrite the running
+        # gateway's persisted PID/status record in the shared HERMES_HOME.
+        if owns_gateway_lifecycle:
+            self._mark_disconnected()
 
     @property
     def _webhook_url(self) -> str:

--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -261,13 +261,18 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     # Lifecycle
     # ------------------------------------------------------------------
 
-    async def connect(self, *, is_reconnect: bool = False) -> bool:
+    async def connect(
+        self,
+        *,
+        is_reconnect: bool = False,
+        start_webhook_listener: bool = True,
+    ) -> bool:
+        """Validate REST access and optionally start the inbound webhook."""
         if not self.server_url or not self.password:
             logger.error(
                 "[bluebubbles] BLUEBUBBLES_SERVER_URL and BLUEBUBBLES_PASSWORD are required"
             )
             return False
-        from aiohttp import web
 
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
@@ -292,6 +297,12 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 await self.client.aclose()
                 self.client = None
             return False
+
+        if not start_webhook_listener:
+            self._mark_connected()
+            return True
+
+        from aiohttp import web
 
         # Explicit body cap: BlueBubbles webhook events are small JSON (or
         # form-encoded) payloads. client_max_size makes aiohttp enforce the
@@ -322,8 +333,9 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
-        # Unregister webhook before cleaning up
-        await self._unregister_webhook()
+        # Outbound-only connections never own a webhook registration.
+        if self._runner:
+            await self._unregister_webhook()
 
         if self.client:
             await self.client.aclose()

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -92,6 +92,42 @@ class TestBlueBubblesHelpers:
         assert api_get_paths == ["/api/v1/ping", "/api/v1/server/info"]
         assert api_post_paths == ["/api/v1/message/text"]
 
+    @pytest.mark.asyncio
+    async def test_send_reuses_live_gateway_adapter(self, monkeypatch):
+        from types import SimpleNamespace
+        from gateway.platforms.base import SendResult
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+        from tools.send_message_tool import _send_bluebubbles
+
+        calls = []
+
+        class LiveAdapter:
+            async def send(self, chat_id, message):
+                calls.append((chat_id, message))
+                return SendResult(success=True, message_id="live-message")
+
+        runner = SimpleNamespace(adapters={Platform.BLUEBUBBLES: LiveAdapter()})
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        async def fail_if_second_adapter_connects(self, *, start_webhook_listener=True):
+            raise AssertionError("standalone adapter must not start when a live adapter exists")
+
+        monkeypatch.setattr(BlueBubblesAdapter, "connect", fail_if_second_adapter_connects)
+
+        result = await _send_bluebubbles(
+            {"server_url": "http://localhost:1234", "password": "secret"},
+            "iMessage;-;user@example.com",
+            "hello live adapter",
+        )
+
+        assert result == {
+            "success": True,
+            "platform": "bluebubbles",
+            "chat_id": "iMessage;-;user@example.com",
+            "message_id": "live-message",
+        }
+        assert calls == [("iMessage;-;user@example.com", "hello live adapter")]
+
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         text = "Use /api_v2 with FEATURE_FLAG_NAME and config_file.json"

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -52,6 +52,45 @@ class TestBlueBubblesHelpers:
 
         assert check_bluebubbles_requirements() is True
 
+    @pytest.mark.asyncio
+    async def test_standalone_send_does_not_start_webhook_listener(self, monkeypatch):
+        """Outbound-only sends must work while the gateway owns the webhook port."""
+        from aiohttp import web
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+        from tools.send_message_tool import _send_bluebubbles
+
+        api_get_paths = []
+        api_post_paths = []
+        listener_starts = []
+
+        async def fake_api_get(self, path):
+            api_get_paths.append(path)
+            if path == "/api/v1/server/info":
+                return {"data": {"private_api": True, "helper_connected": True}}
+            return {"status": 200}
+
+        async def fake_api_post(self, path, payload):
+            api_post_paths.append(path)
+            return {"status": 200, "data": {"guid": "message-guid"}}
+
+        async def fail_if_listener_starts(self):
+            listener_starts.append((self._host, self._port))
+            raise OSError("webhook port already in use")
+
+        monkeypatch.setattr(BlueBubblesAdapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(BlueBubblesAdapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(web.TCPSite, "start", fail_if_listener_starts)
+
+        result = await _send_bluebubbles(
+            {"server_url": "http://localhost:1234", "password": "secret"},
+            "iMessage;-;user@example.com",
+            "hello",
+        )
+
+        assert result["success"] is True
+        assert listener_starts == []
+        assert api_get_paths == ["/api/v1/ping", "/api/v1/server/info"]
+        assert api_post_paths == ["/api/v1/message/text"]
 
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
@@ -71,6 +110,70 @@ class TestBlueBubblesHelpers:
     def test_server_url_normalized(self, monkeypatch):
         adapter = _make_adapter(monkeypatch, server_url="http://localhost:1234/")
         assert adapter.server_url == "http://localhost:1234"
+
+
+class TestBlueBubblesLifecycle:
+    @pytest.mark.asyncio
+    async def test_outbound_only_connect_still_requires_credentials(self, monkeypatch):
+        monkeypatch.delenv("BLUEBUBBLES_SERVER_URL", raising=False)
+        monkeypatch.delenv("BLUEBUBBLES_PASSWORD", raising=False)
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+        adapter = BlueBubblesAdapter(PlatformConfig(enabled=True, extra={}))
+
+        assert await adapter.connect(start_webhook_listener=False) is False
+        assert adapter.client is None
+        assert adapter._runner is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.filterwarnings("ignore:Bare functions are deprecated:DeprecationWarning")
+    async def test_default_connect_starts_and_registers_webhook_listener(self, monkeypatch):
+        from aiohttp import web
+        from gateway.platforms.bluebubbles import BlueBubblesAdapter
+
+        adapter = _make_adapter(monkeypatch)
+        listener_starts = []
+        registrations = []
+        unregistrations = []
+
+        async def fake_api_get(self, path):
+            if path == "/api/v1/server/info":
+                return {"data": {"private_api": True, "helper_connected": True}}
+            return {"status": 200}
+
+        async def fake_register(self):
+            registrations.append(self._webhook_url)
+            return True
+
+        async def fake_unregister(self):
+            unregistrations.append(self._webhook_url)
+            return True
+
+        class FakeTCPSite:
+            def __init__(self, runner, host, port):
+                self.runner = runner
+                self.host = host
+                self.port = port
+
+            async def start(self):
+                listener_starts.append((self.host, self.port))
+
+        monkeypatch.setattr(BlueBubblesAdapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(BlueBubblesAdapter, "_register_webhook", fake_register)
+        monkeypatch.setattr(BlueBubblesAdapter, "_unregister_webhook", fake_unregister)
+        monkeypatch.setattr(web, "TCPSite", FakeTCPSite)
+
+        assert await adapter.connect() is True
+        try:
+            assert listener_starts == [(adapter.webhook_host, adapter.webhook_port)]
+            assert registrations == [adapter._webhook_url]
+            assert adapter._runner is not None
+        finally:
+            await adapter.disconnect()
+
+        assert unregistrations == [adapter._webhook_url]
+        assert adapter.client is None
+        assert adapter._runner is None
 
 
 class _FakeBlueBubblesRequest:

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -93,40 +93,45 @@ class TestBlueBubblesHelpers:
         assert api_post_paths == ["/api/v1/message/text"]
 
     @pytest.mark.asyncio
-    async def test_send_reuses_live_gateway_adapter(self, monkeypatch):
-        from types import SimpleNamespace
-        from gateway.platforms.base import SendResult
+    async def test_standalone_send_does_not_write_gateway_status(self, monkeypatch):
         from gateway.platforms.bluebubbles import BlueBubblesAdapter
         from tools.send_message_tool import _send_bluebubbles
 
-        calls = []
+        async def fake_api_get(self, path):
+            if path == "/api/v1/server/info":
+                return {"data": {"private_api": True, "helper_connected": True}}
+            return {"status": 200}
 
-        class LiveAdapter:
-            async def send(self, chat_id, message):
-                calls.append((chat_id, message))
-                return SendResult(success=True, message_id="live-message")
+        async def fake_api_post(self, path, payload):
+            return {"status": 200, "data": {"guid": "standalone-message"}}
 
-        runner = SimpleNamespace(adapters={Platform.BLUEBUBBLES: LiveAdapter()})
-        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
-
-        async def fail_if_second_adapter_connects(self, *, start_webhook_listener=True):
-            raise AssertionError("standalone adapter must not start when a live adapter exists")
-
-        monkeypatch.setattr(BlueBubblesAdapter, "connect", fail_if_second_adapter_connects)
+        status_writes = []
+        monkeypatch.setattr(BlueBubblesAdapter, "_api_get", fake_api_get)
+        monkeypatch.setattr(BlueBubblesAdapter, "_api_post", fake_api_post)
+        monkeypatch.setattr(
+            BlueBubblesAdapter,
+            "_mark_connected",
+            lambda self: status_writes.append("connected"),
+        )
+        monkeypatch.setattr(
+            BlueBubblesAdapter,
+            "_mark_disconnected",
+            lambda self: status_writes.append("disconnected"),
+        )
 
         result = await _send_bluebubbles(
             {"server_url": "http://localhost:1234", "password": "secret"},
             "iMessage;-;user@example.com",
-            "hello live adapter",
+            "hello standalone adapter",
         )
 
         assert result == {
             "success": True,
             "platform": "bluebubbles",
             "chat_id": "iMessage;-;user@example.com",
-            "message_id": "live-message",
+            "message_id": "standalone-message",
         }
-        assert calls == [("iMessage;-;user@example.com", "hello live adapter")]
+        assert status_writes == []
 
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1937,34 +1937,13 @@ async def _send_weixin(pconfig, chat_id, message, media_files=None):
 
 
 async def _send_bluebubbles(extra, chat_id, message):
-    """Send via BlueBubbles iMessage server using the adapter's REST API."""
-    live_adapter = None
-    try:
-        from gateway.config import Platform
-        from gateway.run import _gateway_runner_ref
+    """Send through an outbound-only BlueBubbles adapter.
 
-        runner = _gateway_runner_ref()
-        if runner is not None:
-            live_adapter = runner.adapters.get(Platform.BLUEBUBBLES)
-    except Exception:
-        live_adapter = None
-
-    if live_adapter is not None:
-        try:
-            result = await live_adapter.send(chat_id, message)
-            if not result.success:
-                return _error(f"BlueBubbles send failed: {result.error}")
-            return {
-                "success": True,
-                "platform": "bluebubbles",
-                "chat_id": chat_id,
-                "message_id": result.message_id,
-            }
-        except Exception as e:
-            # Never fall through to a second adapter after a live send attempt:
-            # the remote request may have succeeded before the exception.
-            return _error(f"BlueBubbles live send failed: {e}")
-
+    Callers such as cron already attempt their live gateway transport before
+    entering this standalone fallback. Looking up that live adapter again here
+    can duplicate a possibly-delivered request and can cross asyncio loop
+    ownership, so this function deliberately stays standalone-only.
+    """
     try:
         from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
         if not check_bluebubbles_requirements():

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1938,6 +1938,33 @@ async def _send_weixin(pconfig, chat_id, message, media_files=None):
 
 async def _send_bluebubbles(extra, chat_id, message):
     """Send via BlueBubbles iMessage server using the adapter's REST API."""
+    live_adapter = None
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        if runner is not None:
+            live_adapter = runner.adapters.get(Platform.BLUEBUBBLES)
+    except Exception:
+        live_adapter = None
+
+    if live_adapter is not None:
+        try:
+            result = await live_adapter.send(chat_id, message)
+            if not result.success:
+                return _error(f"BlueBubbles send failed: {result.error}")
+            return {
+                "success": True,
+                "platform": "bluebubbles",
+                "chat_id": chat_id,
+                "message_id": result.message_id,
+            }
+        except Exception as e:
+            # Never fall through to a second adapter after a live send attempt:
+            # the remote request may have succeeded before the exception.
+            return _error(f"BlueBubbles live send failed: {e}")
+
     try:
         from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
         if not check_bluebubbles_requirements():
@@ -1956,7 +1983,12 @@ async def _send_bluebubbles(extra, chat_id, message):
             result = await adapter.send(chat_id, message)
             if not result.success:
                 return _error(f"BlueBubbles send failed: {result.error}")
-            return {"success": True, "platform": "bluebubbles", "chat_id": chat_id, "message_id": result.message_id}
+            return {
+                "success": True,
+                "platform": "bluebubbles",
+                "chat_id": chat_id,
+                "message_id": result.message_id,
+            }
         finally:
             await adapter.disconnect()
     except Exception as e:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1949,7 +1949,7 @@ async def _send_bluebubbles(extra, chat_id, message):
         from gateway.config import PlatformConfig
         pconfig = PlatformConfig(extra=extra)
         adapter = BlueBubblesAdapter(pconfig)
-        connected = await adapter.connect()
+        connected = await adapter.connect(start_webhook_listener=False)
         if not connected:
             return _error("BlueBubbles: failed to connect to server")
         try:


### PR DESCRIPTION
## Summary

- connect temporary BlueBubbles senders in outbound-only mode without binding or unregistering the inbound webhook
- keep standalone sender connect/disconnect from mutating the live gateway's persisted PID/status record
- keep standalone fallback independent of the live adapter, avoiding duplicate and cross-event-loop retries after callers already attempted live delivery
- preserve normal gateway listener, webhook registration, and lifecycle behavior

Fixes #78424

## Testing

- `scripts/run_tests.sh -j 1 tests/gateway/test_bluebubbles.py -q` — 22 passed
- `ruff check gateway/platforms/bluebubbles.py tools/send_message_tool.py tests/gateway/test_bluebubbles.py` — passed
- `git diff --check` — passed

## Checklist

- [x] Focused behavior-level regression coverage
- [x] No new dependency or configuration key
- [x] Normal inbound gateway lifecycle remains the default
- [x] Focused diff with no unrelated changes
