### PR TITLE
fix(commands): preserve symlinked skill categories in gateway menus

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -849,6 +849,35 @@ _clamp_telegram_names = _clamp_command_names
 # Shared skill/plugin collection for gateway platforms
 # ---------------------------------------------------------------------------
 
+def _gateway_path_relative_to_root(path, root):
+    """Return *path* relative to *root* through lexical or resolved aliases.
+
+    Skill scanners normally preserve the configured path spelling.  Compare
+    that spelling first so a category symlink inside a local skills tree keeps
+    its category even when its target lives elsewhere.  The resolved fallback
+    handles a symlinked HERMES_HOME and macOS aliases such as /var -> /private/var.
+    ``Path.relative_to`` supplies component-aware containment on every platform.
+    """
+    from pathlib import Path
+
+    lexical_path = Path(path).expanduser().absolute()
+    lexical_root = Path(root).expanduser().absolute()
+    try:
+        return lexical_path.relative_to(lexical_root)
+    except ValueError:
+        pass
+
+    try:
+        resolved_path = lexical_path.resolve()
+        resolved_root = lexical_root.resolve()
+    except (OSError, RuntimeError):
+        return None
+    try:
+        return resolved_path.relative_to(resolved_root)
+    except ValueError:
+        return None
+
+
 def _collect_gateway_skill_entries(
     platform: str,
     max_slots: int,
@@ -921,34 +950,27 @@ def _collect_gateway_skill_entries(
         from agent.skill_commands import get_skill_commands
         from tools.skills_tool import SKILLS_DIR
         from agent.skill_utils import get_external_skills_dirs
-        _skills_dir = str(SKILLS_DIR.resolve())
-        _hub_dir = str((SKILLS_DIR / ".hub").resolve()).rstrip("/") + "/"
-        # Build set of allowed directory prefixes: local skills dir + any
-        # user-configured ``skills.external_dirs``. Ensure each prefix ends
-        # with ``/`` so ``/my-skills`` does not also match ``/my-skills-extra``.
+        _skills_dir = SKILLS_DIR
+        _hub_dir = SKILLS_DIR / ".hub"
+        # Build allowed roots: local skills dir + any user-configured
+        # ``skills.external_dirs``. Component-aware relative paths keep a
+        # sibling such as ``/my-skills-extra`` outside ``/my-skills``.
         # Without this widening, external skills are visible in
         # ``hermes skills list`` and the agent's ``/skill-name`` dispatch but
         # silently excluded from gateway slash menus (#8110).
-        _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
-        _allowed_prefixes.extend(
-            os.path.realpath(str(d)).rstrip("/") + "/"
-            for d in get_external_skills_dirs()
-        )
+        _allowed_roots = [_skills_dir, *get_external_skills_dirs()]
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
             info = skill_cmds[cmd_key]
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            # The skill scanner builds paths from the un-resolved SKILLS_DIR,
-            # while the prefixes above are resolved.  When $HERMES_HOME sits
-            # behind a symlink (~/.hermes -> /Volumes/...), the two never
-            # match and every skill is dropped from gateway menus.  Normalize
-            # both sides to the real path (also covers macOS /var->/private/var).
-            skill_path = os.path.realpath(skill_path)
-            if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
+            if not any(
+                _gateway_path_relative_to_root(skill_path, root) is not None
+                for root in _allowed_roots
+            ):
                 continue
-            if skill_path.startswith(_hub_dir):
+            if _gateway_path_relative_to_root(skill_path, _hub_dir) is not None:
                 continue
             skill_name = info.get("name", "")
             if skill_name in _platform_disabled:
@@ -1110,16 +1132,15 @@ def discord_skill_commands_by_category(
         from agent.skill_utils import get_external_skills_dirs
         from tools.skills_tool import SKILLS_DIR
 
-        _skills_dir = SKILLS_DIR.resolve()
-        _hub_dir = (SKILLS_DIR / ".hub").resolve()
-        # Build list of (resolved_root, is_local) tuples. Each external dir
-        # becomes its own scan root for category derivation — a skill at
+        _skills_dir = SKILLS_DIR
+        _hub_dir = SKILLS_DIR / ".hub"
+        # Each external dir becomes its own scan root for category derivation — a skill at
         # ``<external>/mlops/foo/SKILL.md`` is still categorized as "mlops".
-        _scan_roots: list[_P] = [_skills_dir]
+        _scan_roots = [_skills_dir]
         try:
             for ext in get_external_skills_dirs():
                 try:
-                    _scan_roots.append(_P(ext).resolve())
+                    _scan_roots.append(ext)
                 except Exception:
                     continue
         except Exception:
@@ -1131,22 +1152,19 @@ def discord_skill_commands_by_category(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
-            sp = _P(skill_path).resolve()
+            sp = _P(skill_path)
             # Hub skills are loaded via the skill hub, not surfaced as
             # slash commands.
-            if str(sp).startswith(str(_hub_dir)):
+            if _gateway_path_relative_to_root(sp, _hub_dir) is not None:
                 continue
             # Accept skill if it lives under any scan root; record the
             # matching root so we can derive the category correctly.
-            matched_root: _P | None = None
+            matched_relative = None
             for root in _scan_roots:
-                try:
-                    sp.relative_to(root)
-                except ValueError:
-                    continue
-                matched_root = root
-                break
-            if matched_root is None:
+                matched_relative = _gateway_path_relative_to_root(sp.parent, root)
+                if matched_relative is not None:
+                    break
+            if matched_relative is None:
                 continue
 
             skill_name = info.get("name", "")
@@ -1197,8 +1215,7 @@ def discord_skill_commands_by_category(
 
             # Determine category from the relative path within the matched
             # scan root. e.g. creative/ascii-art/SKILL.md → ("creative", ...)
-            rel = sp.parent.relative_to(matched_root)
-            parts = rel.parts
+            parts = matched_relative.parts
             if len(parts) >= 2:
                 cat = parts[0]
                 categories.setdefault(cat, []).append((discord_name, desc, cmd_key))

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -931,7 +931,8 @@ def _collect_gateway_skill_entries(
         # silently excluded from gateway slash menus (#8110).
         _allowed_prefixes = [_skills_dir.rstrip("/") + "/"]
         _allowed_prefixes.extend(
-            str(d).rstrip("/") + "/" for d in get_external_skills_dirs()
+            os.path.realpath(str(d)).rstrip("/") + "/"
+            for d in get_external_skills_dirs()
         )
         skill_cmds = get_skill_commands()
         for cmd_key in sorted(skill_cmds):
@@ -939,6 +940,12 @@ def _collect_gateway_skill_entries(
             skill_path = info.get("skill_md_path", "")
             if not skill_path:
                 continue
+            # The skill scanner builds paths from the un-resolved SKILLS_DIR,
+            # while the prefixes above are resolved.  When $HERMES_HOME sits
+            # behind a symlink (~/.hermes -> /Volumes/...), the two never
+            # match and every skill is dropped from gateway menus.  Normalize
+            # both sides to the real path (also covers macOS /var->/private/var).
+            skill_path = os.path.realpath(skill_path)
             if not any(skill_path.startswith(prefix) for prefix in _allowed_prefixes):
                 continue
             if skill_path.startswith(_hub_dir):

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -1,5 +1,6 @@
 """Tests for the central command registry and autocomplete."""
 
+import pytest
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
 
@@ -748,6 +749,55 @@ class TestTelegramMenuCommands:
         menu_names = {n for n, _ in menu}
         assert "apple_notes" in menu_names
         assert "hub_skill" not in menu_names  # hub stays excluded under symlink
+
+    def test_symlinked_category_keeps_menu_category_and_hub_exclusion(self, tmp_path):
+        """A local category symlink is trusted, but one targeting .hub is not."""
+        import sys
+        from unittest.mock import patch
+        from hermes_cli.commands import discord_skill_commands_by_category
+
+        if sys.platform == "win32":
+            pytest.skip("symlinks need elevated privileges on Windows")
+
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        external_category = tmp_path / "external-creative"
+        (external_category / "diagram").mkdir(parents=True)
+        (skills_dir / "creative").symlink_to(external_category, target_is_directory=True)
+
+        hub_category = skills_dir / ".hub" / "hidden-category"
+        (hub_category / "hidden").mkdir(parents=True)
+        (skills_dir / "linked-hub").symlink_to(hub_category, target_is_directory=True)
+
+        fake_cmds = {
+            "/diagram": {
+                "name": "diagram",
+                "description": "Diagram skill",
+                "skill_md_path": str(skills_dir / "creative" / "diagram" / "SKILL.md"),
+            },
+            "/hidden": {
+                "name": "hidden",
+                "description": "Hub skill through a local symlink",
+                "skill_md_path": str(skills_dir / "linked-hub" / "hidden" / "SKILL.md"),
+            },
+        }
+
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+            patch("agent.skill_utils.get_disabled_skill_names", return_value=set()),
+            patch("tools.skills_tool.SKILLS_DIR", skills_dir),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+            categories, uncategorized, hidden = discord_skill_commands_by_category(set())
+
+        assert "diagram" in {name for name, _ in menu}
+        assert [entry[0] for entry in categories["creative"]] == ["diagram"]
+        assert uncategorized == []
+        assert hidden == 0
+        assert "hidden" not in {
+            entry[0] for entries in categories.values() for entry in entries
+        }
 
     def test_special_chars_in_skill_names_sanitized(self, tmp_path, monkeypatch):
         """Skills with +, /, or other special chars produce valid Telegram names."""

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -703,6 +703,52 @@ class TestTelegramMenuCommands:
             "prefix-match sibling directories must not be admitted"
         )
 
+    def test_symlinked_skills_dir_included_in_telegram_menu(self, tmp_path, monkeypatch):
+        """Skills under a symlinked $HERMES_HOME must appear in gateway menus.
+
+        Regression test for symlinked HERMES_HOME: with ~/.hermes a symlink to
+        the real HERMES_HOME (e.g. an external drive), get_skill_commands()
+        returns paths built from the un-resolved SKILLS_DIR while the menu
+        filter compares against SKILLS_DIR.resolve(), so every skill failed the
+        prefix check and gateway menus showed zero skills. Hub skills must also
+        stay excluded under symlink.
+        """
+        import sys
+        from unittest.mock import patch
+
+        if sys.platform == "win32":
+            pytest.skip("symlinks need elevated privileges on Windows")
+
+        real_dir = tmp_path / "real-skills"
+        real_dir.mkdir()
+        link_dir = tmp_path / "skills-link"
+        link_dir.symlink_to(real_dir, target_is_directory=True)
+
+        fake_cmds = {
+            "/apple-notes": {
+                "name": "apple-notes",
+                "description": "Notes",
+                "skill_md_path": f"{link_dir}/apple-notes/SKILL.md",
+                "skill_dir": f"{link_dir}/apple-notes",
+            },
+            "/hub-skill": {
+                "name": "hub-skill",
+                "description": "Hub installed",
+                "skill_md_path": f"{link_dir}/.hub/hub-skill/SKILL.md",
+                "skill_dir": f"{link_dir}/.hub/hub-skill",
+            },
+        }
+        with (
+            patch("agent.skill_commands.get_skill_commands", return_value=fake_cmds),
+            patch("tools.skills_tool.SKILLS_DIR", link_dir),
+            patch("agent.skill_utils.get_external_skills_dirs", return_value=[]),
+        ):
+            menu, _ = telegram_menu_commands(max_commands=100)
+
+        menu_names = {n for n, _ in menu}
+        assert "apple_notes" in menu_names
+        assert "hub_skill" not in menu_names  # hub stays excluded under symlink
+
     def test_special_chars_in_skill_names_sanitized(self, tmp_path, monkeypatch):
         """Skills with +, /, or other special chars produce valid Telegram names."""
         from unittest.mock import patch


### PR DESCRIPTION
## Summary

- preserve skill categories when `HERMES_HOME`, a local category, or an external root is reached through a symlink
- use component-aware lexical and resolved containment instead of string-prefix checks
- keep `.hub` skills and prefix-sibling directories excluded
- keep menu category derivation fail-closed when path resolution raises
- preserve the issue author's test-first commits and authorship

Fixes #78144

## Testing

- `scripts/run_tests.sh -j 1 tests/hermes_cli/test_commands.py -q` — 54 passed
- `ruff check hermes_cli/commands.py tests/hermes_cli/test_commands.py` — passed
- `git diff --check` — passed

## Checklist

- [x] Local, external, symlink, `.hub`, and prefix-sibling paths covered
- [x] No new dependency or configuration key
- [x] External contributor authorship preserved
- [x] Focused diff with no unrelated changes
