### PR TITLE
fix(desktop): diagnose Linux singleton lock failures

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -175,6 +175,7 @@ import {
   SESSION_WINDOW_MIN_HEIGHT,
   SESSION_WINDOW_MIN_WIDTH
 } from './session-windows'
+import { requestSingleInstanceLockWithDiagnostic } from './single-instance-lock'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
@@ -11795,7 +11796,7 @@ function registerDeepLinkProtocol() {
 // Single-instance lock: deep links on a running app (Win/Linux) arrive as a
 // second-instance argv. Without the lock a second `hermes://` launch spawns a
 // whole new app instead of routing into the running one.
-const _gotSingleInstanceLock = app.requestSingleInstanceLock()
+const _gotSingleInstanceLock = requestSingleInstanceLockWithDiagnostic(app)
 
 if (!_gotSingleInstanceLock) {
   app.quit()

--- a/apps/desktop/electron/single-instance-lock.test.ts
+++ b/apps/desktop/electron/single-instance-lock.test.ts
@@ -1,0 +1,139 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, test, vi } from 'vitest'
+
+import { requestSingleInstanceLockWithDiagnostic } from './single-instance-lock'
+
+const temporaryRoots: string[] = []
+
+afterEach(() => {
+  vi.restoreAllMocks()
+
+  for (const root of temporaryRoots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+function singletonFixture(): {
+  cookiePath: string
+  lockPath: string
+  socketPath: string
+  userData: string
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-singleton-lock-'))
+  const userData = path.join(root, 'user-data')
+  const lockPath = path.join(userData, 'SingletonLock')
+  const cookiePath = path.join(userData, 'SingletonCookie')
+  const socketPath = path.join(userData, 'SingletonSocket')
+
+  temporaryRoots.push(root)
+  fs.mkdirSync(userData)
+  fs.symlinkSync('desktop-host-4242', lockPath)
+  fs.writeFileSync(cookiePath, 'cookie-sentinel')
+  fs.symlinkSync('/tmp/hermes-live-socket-sentinel', socketPath)
+
+  return { cookiePath, lockPath, socketPath, userData }
+}
+
+test('fails closed without retrying or modifying singleton artifacts', () => {
+  const { cookiePath, lockPath, socketPath, userData } = singletonFixture()
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  let attempts = 0
+
+  const acquired = requestSingleInstanceLockWithDiagnostic({
+    getPath: name => {
+      assert.equal(name, 'userData')
+
+      return userData
+    },
+    requestSingleInstanceLock: () => {
+      attempts += 1
+
+      return false
+    }
+  })
+
+  assert.equal(acquired, false)
+  assert.equal(attempts, 1)
+  assert.equal(fs.readlinkSync(lockPath), 'desktop-host-4242')
+  assert.equal(fs.readFileSync(cookiePath, 'utf8'), 'cookie-sentinel')
+  assert.equal(fs.readlinkSync(socketPath), '/tmp/hermes-live-socket-sentinel')
+  assert.equal(errorSpy.mock.calls.length, 1)
+})
+
+test('logs an actionable diagnostic when the lock cannot be acquired', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-singleton-lock-'))
+  const userData = path.join(root, 'user-data')
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+
+  temporaryRoots.push(root)
+  fs.mkdirSync(userData)
+
+  const acquired = requestSingleInstanceLockWithDiagnostic({
+    getPath: () => userData,
+    requestSingleInstanceLock: () => false
+  })
+
+  assert.equal(acquired, false)
+  assert.equal(errorSpy.mock.calls.length, 1)
+
+  const message = String(errorSpy.mock.calls[0]?.[0])
+
+  assert.match(message, /single-instance lock/i)
+  assert.match(message, /another Hermes Desktop instance may be running/i)
+  assert.match(message, /SingletonLock/)
+  assert.match(message, /SingletonCookie/)
+  assert.match(message, /SingletonSocket/)
+  assert.match(message, new RegExp(userData.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+})
+
+test('keeps the ordinary successful acquisition path silent', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  let attempts = 0
+
+  const acquired = requestSingleInstanceLockWithDiagnostic({
+    getPath: () => assert.fail('userData is not needed after acquiring the lock'),
+    requestSingleInstanceLock: () => {
+      attempts += 1
+
+      return true
+    }
+  })
+
+  assert.equal(acquired, true)
+  assert.equal(attempts, 1)
+  assert.equal(errorSpy.mock.calls.length, 0)
+})
+
+test('preserves failed lock behavior without a diagnostic on non-Linux platforms', () => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+  const acquired = requestSingleInstanceLockWithDiagnostic({
+    getPath: () => assert.fail('the Linux diagnostic path must not run'),
+    requestSingleInstanceLock: () => false
+  })
+
+  assert.equal(acquired, false)
+  assert.equal(errorSpy.mock.calls.length, 0)
+})
+
+test('preserves the failed lock decision if diagnostic logging throws', () => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('linux')
+  vi.spyOn(console, 'error').mockImplementation(() => {
+    throw new Error('log sink unavailable')
+  })
+
+  const acquired = requestSingleInstanceLockWithDiagnostic({
+    getPath: () => '/tmp/hermes-user-data',
+    requestSingleInstanceLock: () => false
+  })
+
+  assert.equal(acquired, false)
+})

--- a/apps/desktop/electron/single-instance-lock.ts
+++ b/apps/desktop/electron/single-instance-lock.ts
@@ -1,0 +1,35 @@
+interface SingleInstanceApp {
+  getPath(name: 'userData'): string
+  requestSingleInstanceLock(): boolean
+}
+
+function singleInstanceLockDiagnostic(app: SingleInstanceApp): string {
+  let userData = 'the Electron user-data directory'
+
+  try {
+    userData = app.getPath('userData')
+  } catch {
+    // The lock decision is authoritative even if its diagnostic path is unavailable.
+  }
+
+  return (
+    '[hermes] Unable to acquire the Electron single-instance lock. ' +
+    'Another Hermes Desktop instance may be running. If no instance is running, ' +
+    `inspect SingletonLock, SingletonCookie, and SingletonSocket under ${userData}; ` +
+    'Hermes will not remove these artifacts automatically because it cannot safely prove ownership.'
+  )
+}
+
+export function requestSingleInstanceLockWithDiagnostic(app: SingleInstanceApp): boolean {
+  const acquired = app.requestSingleInstanceLock()
+
+  if (!acquired && process.platform === 'linux') {
+    try {
+      console.error(singleInstanceLockDiagnostic(app))
+    } catch {
+      // Logging must never change Electron's authoritative lock decision.
+    }
+  }
+
+  return acquired
+}


### PR DESCRIPTION
## Summary

- keep Electron's single authoritative `requestSingleInstanceLock()` attempt and never inspect, rename, delete, or otherwise mutate Chromium singleton artifacts
- on Linux lock failure, log the resolved user-data directory and the `SingletonLock`, `SingletonCookie`, and `SingletonSocket` artifacts operators should inspect
- preserve successful startup, non-Linux failure behavior, second-instance routing, and existing startup ordering
- fail closed if diagnostic path lookup or logging itself fails

Fixes #78101

## Testing

- focused singleton diagnostic suite — 5 passed
- desktop TypeScript projects — passed
- desktop ESLint — 0 errors (88 pre-existing warnings)
- complete Electron/platform suite — 79 files passed and 1 skipped; 943 tests passed and 2 skipped
- production desktop build and `assert-dist-built` — passed
- five-candidate integration: typecheck, lint, 3,490 UI tests, 943 Electron/platform tests, and production build passed
- `git diff --check` — passed

## Safety

- [x] no automatic stale-lock cleanup or retry
- [x] no PID, hostname, procfs, symlink, or pathname ownership inference
- [x] Linux-only diagnostic; non-Linux behavior unchanged
- [x] no new dependency or configuration key
- [x] focused three-file diff
