### PR TITLE
fix(buzz): preserve opening messages at membership boundary

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -790,9 +790,29 @@ class BuzzAdapter(BasePlatformAdapter):
                 detail = response[-1] if len(response) > 1 else "authentication failed"
                 raise ConnectionError(f"Buzz WebSocket AUTH failed: {detail}")
 
-    async def _send_channel_subscription(self, websocket, subscription_id: str, channel_id: str) -> None:
+    async def _send_channel_subscription(
+        self,
+        websocket,
+        subscription_id: str,
+        channel_id: str,
+        *,
+        initial_since: Optional[int] = None,
+    ) -> None:
         state = self._channel_state.get(channel_id) or {}
-        since = max(int(state.get("last_ts") or time.time()) - 1, 0)
+        # A membership event is the only reliable lower bound for a brand-new
+        # conversation. Keep that bound in channel state until the first chat
+        # event advances last_ts; otherwise a WebSocket reconnect between the
+        # membership notification and the opening message resubscribes from
+        # "now" and can lose that first message (#78429).
+        if initial_since is not None and not state.get("last_ts"):
+            previous = state.get("bootstrap_since")
+            state["bootstrap_since"] = (
+                min(int(previous), int(initial_since))
+                if previous is not None
+                else int(initial_since)
+            )
+        anchor = state.get("last_ts") or state.get("bootstrap_since") or time.time()
+        since = max(int(anchor) - 1, 0)
         request = [
             "REQ",
             subscription_id,
@@ -825,7 +845,11 @@ class BuzzAdapter(BasePlatformAdapter):
     async def _handle_membership_event(self, websocket, subscriptions: Dict[str, Optional[str]], event: dict) -> None:
         """A membership event p-tagged to us: rediscover conversations and
         subscribe to any new ones (fresh DMs dispatch from their beginning)."""
-        self._membership_since = max(self._membership_since, int(event.get("created_at") or 0))
+        try:
+            membership_created_at = max(int(event.get("created_at") or 0), 0)
+        except (TypeError, ValueError):
+            membership_created_at = 0
+        self._membership_since = max(self._membership_since, membership_created_at)
         before = set(self._channel_state)
         await self._discover_dms(seed=False)
         for channel_id in self._channel_state:
@@ -833,7 +857,12 @@ class BuzzAdapter(BasePlatformAdapter):
                 continue
             subscription_id = f"hermes-buzz-dm-{len(subscriptions)}"
             subscriptions[subscription_id] = channel_id
-            await self._send_channel_subscription(websocket, subscription_id, channel_id)
+            await self._send_channel_subscription(
+                websocket,
+                subscription_id,
+                channel_id,
+                initial_since=membership_created_at or None,
+            )
             logger.info("Buzz: subscribed to new conversation %s", channel_id)
 
     async def _websocket_loop(self) -> None:
@@ -1013,6 +1042,8 @@ class BuzzAdapter(BasePlatformAdapter):
             return
         state["seen"][event_id] = None
         state["last_ts"] = max(state["last_ts"], created_at)
+        if state["last_ts"]:
+            state.pop("bootstrap_since", None)
 
         if int(event.get("kind") or 0) != _CHAT_KIND:
             return

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -119,3 +119,67 @@ async def test_websocket_auth_raises_on_rejection():
         await adapter._authenticate_websocket(RejectingWs())
 
 
+@pytest.mark.asyncio
+async def test_new_conversation_subscription_starts_before_membership_event(monkeypatch):
+    adapter = _make_adapter()
+    websocket = _FakeWebSocket()
+    subscriptions = {}
+    membership_created_at = 1_700_000_000
+
+    async def discover_new_dm(*, seed):
+        assert seed is False
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+
+    adapter._discover_dms = discover_new_dm
+    monkeypatch.setattr(_buzz_mod.time, "time", lambda: membership_created_at + 30)
+
+    await adapter._handle_membership_event(
+        websocket,
+        subscriptions,
+        {"created_at": membership_created_at},
+    )
+
+    request = websocket.sent[-1]
+    assert request[0] == "REQ"
+    assert request[2]["#h"] == [CHANNEL]
+    assert request[2]["since"] == membership_created_at - 1
+
+
+@pytest.mark.asyncio
+async def test_new_dm_keeps_membership_anchor_across_websocket_reconnect(monkeypatch):
+    """A reconnect before the opening message must not move `since` to now."""
+    adapter = _make_adapter()
+    first_websocket = _FakeWebSocket()
+    subscriptions = {}
+    membership_created_at = 1_700_000_000
+
+    async def discover_new_dm(*, seed):
+        assert seed is False
+        adapter._channel_state[CHANNEL] = {
+            "chat_type": "dm",
+            "last_ts": 0,
+            "seen": {},
+        }
+
+    adapter._discover_dms = discover_new_dm
+    monkeypatch.setattr(_buzz_mod.time, "time", lambda: membership_created_at + 300)
+
+    await adapter._handle_membership_event(
+        first_websocket,
+        subscriptions,
+        {"created_at": membership_created_at},
+    )
+
+    reconnect_websocket = _FakeWebSocket()
+    await adapter._subscribe_websocket(reconnect_websocket)
+
+    request = reconnect_websocket.sent[0]
+    assert request[0] == "REQ"
+    assert request[2]["#h"] == [CHANNEL]
+    assert request[2]["since"] == membership_created_at - 1
+
+


### PR DESCRIPTION
## Summary

- retain the Buzz discovery membership timestamp as durable bootstrap state
- subscribe from one second before the membership boundary
- include an opening message whose timestamp exactly matches membership creation
- keep event and subscription timestamps monotonic across reconnects

Fixes #78429

## Testing

- Buzz websocket and adapter suites — 29 passed
- Ruff on touched files — passed
- `git diff --check` — passed
