### PR TITLE
fix(runtime): rebuild primary transport before retry

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1247,30 +1247,30 @@ def recover_with_credential_pool(
 
 def try_recover_primary_transport(
     agent, api_error: Exception, *, retry_count: int, max_retries: int,
-) -> bool:
+) -> Optional[bool]:
     """Attempt one extra primary-provider recovery cycle for transient transport failures.
 
-    After ``max_retries`` exhaust, rebuild the primary client (clearing
-    stale connection pools) and give it one more attempt before falling
-    back.  This is most useful for direct endpoints (custom, Z.AI,
-    Anthropic, OpenAI, local models) where a TCP-level hiccup does not
-    mean the provider is down.
+    On the first transient transport failure, rebuild the primary client
+    (clearing stale connection pools) before the next retry. A successful
+    rebuild starts one fresh, bounded retry cycle before fallback. This is most
+    useful for direct endpoints (custom, Z.AI, Anthropic, OpenAI, local models)
+    where a TCP-level hiccup does not mean the provider is down.
 
     Skipped for proxy/aggregator providers (OpenRouter, Nous) which
     already manage connection pools and retries server-side — if our
     retries through them are exhausted, one more rebuilt client won't help.
     """
     if agent._fallback_activated:
-        return False
+        return None
 
     # Only for transient transport errors
     error_type = type(api_error).__name__
     if error_type not in _TRANSIENT_TRANSPORT_ERRORS:
-        return False
+        return None
 
     # Skip for aggregator providers — they manage their own retry infra
     if agent._is_openrouter_url():
-        return False
+        return None
     provider_lower = (agent.provider or "").strip().lower()
     # Portal OpenAI-wire traffic still rides aggregator retry infra, so one
     # more rebuilt OpenAI client won't help. Portal Claude on the native
@@ -1281,7 +1281,7 @@ def try_recover_primary_transport(
         provider_lower in {"nous", "nous-portal", "nousresearch"}
         and getattr(agent, "api_mode", None) != "anthropic_messages"
     ):
-        return False
+        return None
 
     try:
         # Retire the existing client to release stale connections. #70773:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1350,6 +1350,10 @@ def run_conversation(
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
+    # One transport rebuild at most for the entire user turn, including every
+    # tool-loop model iteration. A failed rebuild consumes the same one-shot
+    # budget; repeatedly rebuilding a broken client is not recovery.
+    primary_transport_recovery_attempted = False
     final_response = None
     interrupted = False
     failed = False
@@ -2165,7 +2169,6 @@ def run_conversation(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
                             compression_attempts = 0
-                            _retry.primary_recovery_attempted = False
                             continue
                         # No fallback available — surface buffered context
                         # so user sees the rate-limit message that led here.
@@ -2607,7 +2610,6 @@ def run_conversation(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
                         compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
                         continue
 
                     # Check for error field in response (some providers include this)
@@ -2680,7 +2682,6 @@ def run_conversation(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
                             compression_attempts = 0
-                            _retry.primary_recovery_attempted = False
                             continue
                         # Terminal — flush buffered retry trace so user sees what happened.
                         agent._flush_status_buffer()
@@ -2857,7 +2858,6 @@ def run_conversation(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
                         compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
                         continue
 
                     agent._flush_status_buffer()
@@ -3033,7 +3033,6 @@ def run_conversation(
                                 truncated_response_parts = []
                                 retry_count = 0
                                 compression_attempts = 0
-                                _retry.primary_recovery_attempted = False
                                 _retry.restart_with_rebuilt_messages = True
                                 break
                             # No fallback available — fall through to normal
@@ -4488,7 +4487,6 @@ def run_conversation(
                                 agent, api_messages, active_system_prompt)
                             retry_count = 0
                             compression_attempts = 0
-                            _retry.primary_recovery_attempted = False
                             continue
 
                 # ── Auth-failure provider failover ───────────────────────
@@ -4521,7 +4519,6 @@ def run_conversation(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
                         compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
                         continue
 
                 # ── Nous Portal: record rate limit & skip retries ─────
@@ -5128,7 +5125,6 @@ def run_conversation(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
                         compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
                         continue
                     if api_kwargs is not None:
                         agent._dump_api_request_debug(
@@ -5325,24 +5321,32 @@ def run_conversation(
                         "error": _nonretryable_summary,
                     }
 
-                if retry_count >= max_retries:
-                    # Before falling back, try rebuilding the primary
-                    # client once for transient transport errors (stale
-                    # connection pool, TCP reset).  Only attempted once
-                    # per API call block.
-                    if not _retry.primary_recovery_attempted and agent._try_recover_primary_transport(
+                # Rebuild the primary client before the next retry rather than
+                # repeating a stale pooled connection until the budget is
+                # exhausted. Recovery remains one-shot and starts the same
+                # bounded fresh attempt cycle that the previous terminal-budget
+                # path provided.
+                if not primary_transport_recovery_attempted:
+                    recovery_result = agent._try_recover_primary_transport(
                         api_error, retry_count=retry_count, max_retries=max_retries,
-                    ):
-                        _retry.primary_recovery_attempted = True
-                        retry_count = 0
-                        # Primary transport recovery starts a fresh attempt
-                        # cycle. Re-open fallback state so a follow-on 429 can
-                        # still activate fallback_providers after stale
-                        # pre-recovery fallback/credential-pool bookkeeping.
-                        _retry.has_retried_429 = False
-                        agent._fallback_index = 0
-                        agent._fallback_activated = False
-                        continue
+                    )
+                    # None means the error/provider was ineligible and did not
+                    # consume the turn-scoped recovery budget. True/False both
+                    # mean a rebuild was attempted; failure remains one-shot.
+                    if recovery_result is not None:
+                        primary_transport_recovery_attempted = True
+                        if recovery_result:
+                            retry_count = 0
+                            # Primary transport recovery starts a fresh attempt
+                            # cycle. Re-open fallback state so a follow-on 429 can
+                            # still activate fallback_providers after stale
+                            # pre-recovery fallback/credential-pool bookkeeping.
+                            _retry.has_retried_429 = False
+                            agent._fallback_index = 0
+                            agent._fallback_activated = False
+                            continue
+
+                if retry_count >= max_retries:
                     # Try fallback before giving up entirely
                     if agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
@@ -5351,7 +5355,6 @@ def run_conversation(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
                         compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
                         continue
                     # Terminal — flush buffered retry/fallback trace.
                     agent._flush_status_buffer()

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -64,7 +64,6 @@ class TurnRetryState:
     llama_cpp_grammar_retry_attempted: bool = False
 
     # ── Transport / rate-limit recovery ──────────────────────────────────
-    primary_recovery_attempted: bool = False
     has_retried_429: bool = False
 
     # ── Auth-failure provider failover ───────────────────────────────────

--- a/run_agent.py
+++ b/run_agent.py
@@ -6451,7 +6451,7 @@ class AIAgent:
 
     def _try_recover_primary_transport(
         self, api_error: Exception, *, retry_count: int, max_retries: int,
-    ) -> bool:
+    ) -> Optional[bool]:
         """Forwarder — see ``agent.agent_runtime_helpers.try_recover_primary_transport``."""
         from agent.agent_runtime_helpers import try_recover_primary_transport
         return try_recover_primary_transport(self, api_error, retry_count=retry_count, max_retries=max_retries)

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -27,7 +27,6 @@ EXPECTED_FIELDS = {
     "multimodal_tool_content_retry_attempted",
     "oauth_1m_beta_retry_attempted",
     "llama_cpp_grammar_retry_attempted",
-    "primary_recovery_attempted",
     "has_retried_429",
     "auth_failover_attempted",
     "restart_with_compressed_messages",

--- a/tests/run_agent/test_32646_fallback_429_after_timeout.py
+++ b/tests/run_agent/test_32646_fallback_429_after_timeout.py
@@ -206,18 +206,21 @@ class TestFallbackChainResetOnTransportRecovery:
         # Retry-state semantics: simulate the conversation loop body.
         retry_state = TurnRetryState()
         retry_state.has_retried_429 = True  # set by a pre-recovery 429 path
+        # Transport recovery is scoped to the full run_conversation call, not
+        # the per-API-block TurnRetryState that is rebuilt between tool turns.
+        primary_transport_recovery_attempted = False
 
         # The fix block:
         recovered = True  # _try_recover_primary_transport() returned True
-        if recovered and not retry_state.primary_recovery_attempted:
-            retry_state.primary_recovery_attempted = True
+        if recovered and not primary_transport_recovery_attempted:
+            primary_transport_recovery_attempted = True
             retry_state.has_retried_429 = False  # the documented reset
 
         assert retry_state.has_retried_429 is False, (
             "post-recovery cycle must reset has_retried_429 so the "
             "credential-pool path treats the next 429 as a fresh first-hit"
         )
-        assert retry_state.primary_recovery_attempted is True
+        assert primary_transport_recovery_attempted is True
 
     def test_run_conversation_fallbacks_on_429_after_timeout_recovery(self):
         """Full loop regression for #32646.

--- a/tests/run_agent/test_primary_runtime_restore.py
+++ b/tests/run_agent/test_primary_runtime_restore.py
@@ -10,6 +10,7 @@ Verifies that:
 """
 
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -380,6 +381,49 @@ def _make_transport_error(error_type="ReadTimeout"):
 
 class TestTryRecoverPrimaryTransport:
 
+    def test_run_conversation_rebuilds_before_first_transport_retry(self):
+        """A stale pooled connection must be rebuilt before retrying it.
+
+        Waiting until the retry budget is exhausted only repeats the same
+        broken transport. Recovery is still one-shot, but its successful
+        rebuild must happen between the first timeout and the next API call.
+        """
+        agent = _make_agent(provider="custom")
+        setattr(agent, "_api_max_retries", 3)
+        calls = 0
+
+        def fake_api_call(_api_kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise _make_transport_error("ReadTimeout")
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        finish_reason="stop",
+                        message=SimpleNamespace(content="Recovered", tool_calls=None),
+                    )
+                ],
+                model="primary/model",
+                usage=None,
+            )
+
+        with (
+            patch.object(agent, "_interruptible_api_call", side_effect=fake_api_call),
+            patch.object(agent, "_try_recover_primary_transport", return_value=True) as recover,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered"
+        assert calls == 2
+        recover.assert_called_once()
+        assert recover.call_args.kwargs == {"retry_count": 1, "max_retries": 3}
+
     def test_recovers_on_read_timeout(self):
         agent = _make_agent(provider="custom")
         error = _make_transport_error("ReadTimeout")
@@ -404,7 +448,7 @@ class TestTryRecoverPrimaryTransport:
         result = agent._try_recover_primary_transport(
             error, retry_count=3, max_retries=3,
         )
-        assert result is False
+        assert result is None
 
 
 
@@ -481,6 +525,29 @@ class TestTryRecoverPrimaryTransport:
             )
 
         assert result is False
+
+    def test_failed_rebuild_consumes_turn_recovery_budget(self):
+        """A broken rebuild must not be retried after every transport error."""
+        agent = _make_agent(provider="custom")
+        setattr(agent, "_api_max_retries", 3)
+
+        with (
+            patch.object(
+                agent,
+                "_interruptible_api_call",
+                side_effect=_make_transport_error("ReadTimeout"),
+            ),
+            patch.object(agent, "_try_recover_primary_transport", return_value=False) as recover,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch("agent.model_metadata.get_model_context_length", return_value=200000),
+            patch("agent.conversation_loop.time.sleep"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is False
+        recover.assert_called_once()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- rebuild the primary provider client before retrying the first eligible transient transport failure
- replace the stale connection pool before the next request
- allow at most one actual rebuild attempt across the complete conversation run, including tool-loop model iterations
- make a failed rebuild consume that one-shot budget while ineligible errors leave it available
- preserve bounded retry and fallback behavior

Fixes #78406

## Testing

- primary recovery, retry-state contract, and post-recovery fallback suites — 34 passed
- Ruff on touched files — passed
- `git diff --check` — passed

## Checklist

- [x] Recovery occurs before the next retry
- [x] Successful and failed rebuilds are bounded once per run
- [x] Fallback/retry state remains bounded
- [x] No new dependency or configuration key
- [x] Focused diff with no unrelated changes
