### PR TITLE
fix(desktop): keep running-process timer in flow

### DIFF
--- a/apps/desktop/src/components/chat/disclosure-row.test.tsx
+++ b/apps/desktop/src/components/chat/disclosure-row.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { DisclosureRow } from './disclosure-row'
+
+describe('DisclosureRow', () => {
+  it('keeps trailing status content in flow so it cannot overlap the title', () => {
+    const markup = renderToStaticMarkup(
+      <DisclosureRow open={false} trailing={<span>68s</span>}>
+        <span>Running process</span>
+      </DisclosureRow>
+    )
+
+    const trailingHost = markup.match(/<span class="([^"]*)"><span>68s<\/span><\/span>/)?.[1]
+
+    expect(trailingHost).toBeDefined()
+    expect(trailingHost?.split(' ')).toContain('ml-auto')
+    expect(trailingHost?.split(' ')).not.toContain('absolute')
+  })
+})

--- a/apps/desktop/src/components/chat/disclosure-row.tsx
+++ b/apps/desktop/src/components/chat/disclosure-row.tsx
@@ -14,11 +14,10 @@ import { cn } from '@/lib/utils'
 //     title text, NOT the full row — and reaches just past the chevron with
 //     `-mx-1.5 px-1.5` so it reads as a soft hit-target rather than a slab
 //     stretching to the message edge.
-//   - `trailing` overlays the right edge (absolute) and must stay
-//     non-interactive (e.g. a duration timer) — an opacity-0-but-clickable
-//     control there steals clicks from the caret. Interactive controls go in
-//     `action`, which lays out *in flow* at the far right so it never sits on
-//     top of the caret's hit-target, no matter how long the title is.
+//   - `trailing` stays non-interactive (e.g. a duration timer) and occupies the
+//     far-right slot in flow. Keeping it in flow matters when the surrounding
+//     scaffold shrink-wraps: an absolute timer would otherwise reserve no width
+//     and paint over the title. Interactive controls go in `action`.
 export function DisclosureRow({
   action,
   children,
@@ -68,7 +67,14 @@ export function DisclosureRow({
         </span>
       )}
       {trailing && (
-        <span className="absolute right-1 top-0 flex h-(--conversation-line-height) items-center">{trailing}</span>
+        <span
+          className={cn(
+            'pointer-events-none flex h-(--conversation-line-height) shrink-0 items-center self-start pl-1.5',
+            !action && 'ml-auto'
+          )}
+        >
+          {trailing}
+        </span>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- keep running-process labels and elapsed timers as separate in-flow flex items
- reserve nonshrinking space for the elapsed timer instead of absolutely positioning it over the title
- preserve action/trailing coexistence and non-interactive trailing content

Fixes #78464

## Testing

- focused server-rendered `DisclosureRow` layout regression — 1 passed
- ESLint with `--max-warnings 0` on touched files — passed
- Prettier on touched files — passed
- `git diff --check` — passed

The shared checkout's normal Vitest setup cannot resolve its missing `@testing-library/react` installation, so the dependency-free component regression was also run with a temporary node-only Vitest config. No dependency installation was added to this patch.
