### PR TITLE
fix(gateway): fall back to direct credentials when tool gateway unavailable (#79628)

### DIFF
--- a/plugins/browser/browser_use/provider.py
+++ b/plugins/browser/browser_use/provider.py
@@ -152,6 +152,14 @@ class BrowserUseBrowserProvider(BrowserProvider):
             token_reader=None if refresh_token else peek_nous_access_token,
         )
         if managed is None:
+            # Gateway preferred but unusable (expired Portal session) — fall
+            # back to the direct credential when present (#79628).
+            if api_key:
+                return {
+                    "api_key": api_key,
+                    "base_url": _BASE_URL,
+                    "managed_mode": False,
+                }
             return None
 
         return {

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -237,21 +237,31 @@ def _get_firecrawl_client() -> Any:
             "firecrawl", token_reader=_wt._read_nous_access_token
         )
         if managed_gateway is None:
-            logger.error(
-                "Firecrawl client initialization failed: "
-                "missing direct config and tool-gateway auth."
+            if direct_config is not None:
+                # Gateway is preferred but unusable (expired Portal session,
+                # etc.) — fall back to the direct credential rather than
+                # failing the call (#79628).
+                logger.warning(
+                    "Firecrawl tool gateway unavailable; falling back to the "
+                    "direct FIRECRAWL_API_KEY/URL credential."
+                )
+                kwargs, client_config = direct_config
+            else:
+                logger.error(
+                    "Firecrawl client initialization failed: "
+                    "missing direct config and tool-gateway auth."
+                )
+                _raise_web_backend_configuration_error()
+        else:
+            kwargs = {
+                "api_key": managed_gateway.nous_user_token,
+                "api_url": managed_gateway.gateway_origin,
+            }
+            client_config = (
+                "tool-gateway",
+                kwargs["api_url"],
+                managed_gateway.nous_user_token,
             )
-            _raise_web_backend_configuration_error()
-
-        kwargs = {
-            "api_key": managed_gateway.nous_user_token,
-            "api_url": managed_gateway.gateway_origin,
-        }
-        client_config = (
-            "tool-gateway",
-            kwargs["api_url"],
-            managed_gateway.nous_user_token,
-        )
 
     cached = getattr(_wt, "_firecrawl_client", None)
     cached_config = getattr(_wt, "_firecrawl_client_config", None)

--- a/tests/plugins/browser/test_browser_use_gateway_fallback.py
+++ b/tests/plugins/browser/test_browser_use_gateway_fallback.py
@@ -1,0 +1,95 @@
+"""Regression tests for direct-credential fallback when the tool gateway is
+unavailable (#79628) — browser-use provider.
+
+When ``use_gateway: true`` is set but the Nous Tool Gateway cannot
+authenticate (expired Portal session), the browser-use provider used to
+return ``None`` (→ caller raises) even though a valid direct
+``BROWSER_USE_API_KEY`` was present. The fix falls back to the direct
+credential (mirroring the Krea/FAL pattern).
+"""
+
+from unittest.mock import patch
+
+from plugins.browser.browser_use import provider as browser_use_provider
+
+
+class TestBrowserUseGatewayFallback:
+    def test_direct_key_fallback_when_gateway_unavailable(self, monkeypatch):
+        """Direct key + use_gateway:true + dead gateway → direct config."""
+        provider = browser_use_provider.BrowserUseBrowserProvider()
+
+        monkeypatch.setattr(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+            lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "tools.managed_tool_gateway.peek_nous_access_token",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.prefers_gateway",
+            lambda *a: True,
+        )
+
+        with patch.object(
+            browser_use_provider, "get_secret", return_value="bu-direct-key"
+        ):
+            config = provider._get_config_or_none()
+
+        assert config == {
+            "api_key": "bu-direct-key",
+            "base_url": browser_use_provider._BASE_URL,
+            "managed_mode": False,
+        }
+
+    def test_no_direct_key_still_returns_none(self, monkeypatch):
+        """No direct key + dead gateway → None (caller raises, unchanged)."""
+        provider = browser_use_provider.BrowserUseBrowserProvider()
+
+        monkeypatch.setattr(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+            lambda *a, **k: None,
+        )
+        monkeypatch.setattr(
+            "tools.managed_tool_gateway.peek_nous_access_token",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.prefers_gateway",
+            lambda *a: True,
+        )
+
+        with patch.object(
+            browser_use_provider, "get_secret", return_value=""
+        ):
+            assert provider._get_config_or_none() is None
+
+    def test_gateway_wins_when_resolvable(self, monkeypatch):
+        """Gateway resolvable → managed config used (no direct fallback)."""
+        provider = browser_use_provider.BrowserUseBrowserProvider()
+
+        managed = type(
+            "Managed",
+            (),
+            {"nous_user_token": "nous-token", "gateway_origin": "https://gw.example.com/"},
+        )()
+
+        monkeypatch.setattr(
+            "tools.managed_tool_gateway.resolve_managed_tool_gateway",
+            lambda *a, **k: managed,
+        )
+        monkeypatch.setattr(
+            "tools.tool_backend_helpers.prefers_gateway",
+            lambda *a: True,
+        )
+
+        with patch.object(
+            browser_use_provider, "get_secret", return_value="bu-direct-key"
+        ):
+            config = provider._get_config_or_none()
+
+        assert config == {
+            "api_key": "nous-token",
+            "base_url": "https://gw.example.com",
+            "managed_mode": True,
+        }

--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -202,6 +202,115 @@ def test_managed_fal_submit_uses_gateway_origin_and_nous_token(monkeypatch):
     assert captured["sync_client_inits"] == 1
 
 
+def test_managed_fal_gateway_rejection_falls_back_to_direct_key(monkeypatch):
+    """#79628: gateway resolves but rejects (4xx) — degrade to direct FAL_KEY
+    instead of raising, mirroring the Krea/FAL unresolvable-gateway fallback."""
+    captured = {}
+    _install_fake_tools_package()
+    _install_fake_fal_client(captured)
+    # Direct key present + prefers_gateway true (gateway resolves)
+    monkeypatch.setenv("FAL_KEY", "fal-direct-123")
+    monkeypatch.setenv("FAL_QUEUE_GATEWAY_URL", "http://127.0.0.1:3009")
+    monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+
+    image_generation_tool = _load_tool_module(
+        "tools.image_generation_tool",
+        "image_generation_tool.py",
+    )
+    monkeypatch.setattr(image_generation_tool.uuid, "uuid4", lambda: "fal-submit-456")
+    # Force gateway resolution (prefers_gateway true) and a 4xx reject
+    monkeypatch.setattr(
+        image_generation_tool,
+        "prefers_gateway",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        image_generation_tool,
+        "fal_key_is_configured",
+        lambda: True,
+    )
+    managed_error = Exception("gateway reject")
+    managed_error.status_code = 402  # type: ignore[attr-defined]
+
+    def direct_submit(model, arguments=None, headers=None):
+        captured["submit_via"] = "direct"
+        captured["direct_submit"] = (model, arguments, headers)
+        return "direct-ok"
+
+    monkeypatch.setattr(
+        image_generation_tool,
+        "fal_client",
+        types.SimpleNamespace(submit=direct_submit),
+    )
+
+    # _get_managed_fal_client builds a _ManagedFalSyncClient around fal_client —
+    # force the managed path to raise via a stub on the module
+    class RaisingManagedClient:
+        def submit(self, model, arguments=None, headers=None):
+            raise managed_error
+
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_managed_fal_client",
+        lambda gateway: RaisingManagedClient(),
+    )
+
+    result = image_generation_tool._submit_fal_request(
+        "fal-ai/flux-2-pro",
+        {"prompt": "test prompt", "num_images": 1},
+    )
+
+    assert result == "direct-ok"
+    assert captured["submit_via"] == "direct"
+    assert captured["direct_submit"][0] == "fal-ai/flux-2-pro"
+
+
+def test_managed_fal_gateway_rejection_raises_when_no_direct_key(monkeypatch):
+    """#79628: gateway rejects (4xx) with NO direct key — raise with the
+    corrected message naming image_gen.use_gateway as the lever."""
+    captured = {}
+    _install_fake_tools_package()
+    _install_fake_fal_client(captured)
+    monkeypatch.delenv("FAL_KEY", raising=False)
+    monkeypatch.setenv("FAL_QUEUE_GATEWAY_URL", "http://127.0.0.1:3009")
+    monkeypatch.setenv("TOOL_GATEWAY_USER_TOKEN", "nous-token")
+
+    image_generation_tool = _load_tool_module(
+        "tools.image_generation_tool",
+        "image_generation_tool.py",
+    )
+    monkeypatch.setattr(image_generation_tool.uuid, "uuid4", lambda: "fal-submit-789")
+    monkeypatch.setattr(
+        image_generation_tool,
+        "prefers_gateway",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        image_generation_tool,
+        "fal_key_is_configured",
+        lambda: False,
+    )
+    managed_error = Exception("gateway reject")
+    managed_error.status_code = 402  # type: ignore[attr-defined]
+
+    class RaisingManagedClient:
+        def submit(self, model, arguments=None, headers=None):
+            raise managed_error
+
+    monkeypatch.setattr(
+        image_generation_tool,
+        "_get_managed_fal_client",
+        lambda gateway: RaisingManagedClient(),
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        image_generation_tool._submit_fal_request(
+            "fal-ai/flux-2-pro",
+            {"prompt": "test prompt"},
+        )
+    assert "image_gen.use_gateway" in str(excinfo.value)
+
+
 def test_openai_tts_uses_managed_audio_gateway_when_direct_key_absent(monkeypatch, tmp_path):
     captured = {}
     _install_fake_tools_package()

--- a/tests/tools/test_tts_openai_config.py
+++ b/tests/tools/test_tts_openai_config.py
@@ -77,6 +77,32 @@ class TestResolveOpenaiAudioClientConfig:
             == "Neither tts.openai.api_key in config nor VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"
         )
 
+    def test_gateway_unavailable_falls_back_to_direct_key(self):
+        """#79628: gateway preferred but dead → direct key used, not raised."""
+        config = {"openai": {"api_key": "cfg-key"}}
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=True), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value=""), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "cfg-key",
+                "https://api.openai.com/v1",
+                False,
+            )
+
+    def test_gateway_unavailable_falls_back_to_env_key(self):
+        """#79628: env key also works as fallback."""
+        config = {"openai": {}}
+        with patch.object(tts_tool, "_load_tts_config", return_value=config), \
+             patch.object(tts_tool, "prefers_gateway", return_value=True), \
+             patch.object(tts_tool, "resolve_openai_audio_api_key", return_value="env-key"), \
+             patch.object(tts_tool, "resolve_managed_tool_gateway", return_value=None):
+            assert tts_tool._resolve_openai_audio_client_config() == (
+                "env-key",
+                "https://api.openai.com/v1",
+                False,
+            )
+
     def test_config_api_key_counts_as_available_backend(self):
         config = {"openai": {"api_key": "cfg-key"}}
         with patch.object(tts_tool, "_load_tts_config", return_value=config):

--- a/tests/tools/test_web_gateway_fallback.py
+++ b/tests/tools/test_web_gateway_fallback.py
@@ -1,0 +1,109 @@
+"""Regression tests for direct-credential fallback when the tool gateway is
+unavailable (#79628).
+
+When ``use_gateway: true`` is set but the Nous Tool Gateway cannot
+authenticate (expired Portal session), the firecrawl client builder used to
+raise a hard configuration error even though a valid direct
+``FIRECRAWL_API_KEY`` was present. The fix falls back to the direct
+credential (mirroring the Krea/FAL pattern) and logs that the gateway was
+skipped.
+"""
+
+import os
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestFirecrawlGatewayFallback:
+    """The gateway-unavailable + direct-key-present matrix for firecrawl."""
+
+    def _patch_gateway(self, gateway_value):
+        """Patch the gateway resolver to return ``gateway_value``.
+
+        Returns a patcher for ``tools.web_tools.resolve_managed_tool_gateway``
+        (the canonical lookup used by the firecrawl provider).
+        """
+        return patch(
+            "tools.web_tools.resolve_managed_tool_gateway",
+            return_value=gateway_value,
+        )
+
+    def test_direct_key_fallback_when_gateway_unavailable(self):
+        """Direct key + use_gateway:true + dead gateway → falls back to key."""
+        import tools.web_tools
+
+        # Reset the singleton cache
+        tools.web_tools._firecrawl_client = None
+        tools.web_tools._firecrawl_client_config = None
+
+        # The reporter's exact setup: direct key present, gateway resolves None
+        with patch.dict(
+            os.environ,
+            {
+                "FIRECRAWL_API_KEY": "fc-test-key",
+                "HERMES_HOME": "/tmp/hermes-test-home",
+            },
+        ):
+            with self._patch_gateway(None):
+                with patch(
+                    "tools.web_tools.prefers_gateway",
+                    return_value=True,  # use_gateway: true
+                ):
+                    with patch("tools.web_tools.Firecrawl") as mock_fc:
+                        from tools.web_tools import _get_firecrawl_client
+                        result = _get_firecrawl_client()
+                        mock_fc.assert_called_once_with(
+                            api_key="fc-test-key",
+                        )
+                        assert result is mock_fc.return_value
+
+    def test_gateway_wins_when_resolvable(self):
+        """Gateway resolvable → gateway token used (no direct fallback)."""
+        import tools.web_tools
+
+        tools.web_tools._firecrawl_client = None
+        tools.web_tools._firecrawl_client_config = None
+
+        gateway = MagicMock()
+        gateway.nous_user_token = "nous-token"
+        gateway.gateway_origin = "https://firecrawl-gateway.nousresearch.com"
+
+        with patch.dict(
+            os.environ,
+            {"FIRECRAWL_API_KEY": "fc-test-key"},
+        ):
+            with self._patch_gateway(gateway):
+                with patch(
+                    "tools.web_tools.prefers_gateway",
+                    return_value=True,
+                ):
+                    with patch("tools.web_tools.Firecrawl") as mock_fc:
+                        from tools.web_tools import _get_firecrawl_client
+                        _get_firecrawl_client()
+                        mock_fc.assert_called_once_with(
+                            api_key="nous-token",
+                            api_url="https://firecrawl-gateway.nousresearch.com",
+                        )
+
+    def test_no_direct_key_still_raises(self):
+        """No direct key + dead gateway → still raises (unchanged behavior)."""
+        import tools.web_tools
+
+        tools.web_tools._firecrawl_client = None
+        tools.web_tools._firecrawl_client_config = None
+
+        with patch.dict(os.environ, {}):
+            with self._patch_gateway(None):
+                with patch(
+                    "tools.web_tools.prefers_gateway",
+                    return_value=True,
+                ):
+                    with patch("tools.web_tools.Firecrawl"):
+                        with patch(
+                            "tools.web_tools._read_nous_access_token",
+                            return_value=None,
+                        ):
+                            from tools.web_tools import _get_firecrawl_client
+                            with pytest.raises(ValueError, match="FIRECRAWL_API_KEY"):
+                                _get_firecrawl_client()

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -499,11 +499,25 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
         )
     except Exception as exc:
         # 4xx from the managed gateway typically means the portal doesn't
-        # currently proxy this model (allowlist miss, billing gate, etc.)
-        # — surface a clearer message with actionable remediation instead
-        # of a raw HTTP error from httpx.
+        # currently proxy this model (allowlist miss, billing gate, etc.).
+        # When a direct FAL_KEY is present, treat the gateway as a
+        # preference: degrade to the direct credential instead of raising,
+        # mirroring the Krea/FAL unresolvable-gateway fallback (issue
+        # #79628 — the gateway can be reachable yet unwilling).
         status = _extract_http_status(exc)
         if status is not None and 400 <= status < 500:
+            if fal_key_is_configured():
+                logger.warning(
+                    "Managed FAL gateway rejected %s (HTTP %s); "
+                    "falling back to direct FAL_KEY.",
+                    model,
+                    status,
+                )
+                return fal_client.submit(
+                    model,
+                    arguments=arguments,
+                    headers=request_headers,
+                )
             gateway_message = ""
             if status in {401, 402, 403}:
                 gateway_message = (
@@ -518,6 +532,8 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
                 f"(HTTP {status}). This model may not yet be enabled on "
                 f"the Nous Portal's FAL proxy. Either:\n"
                 f"  • Set FAL_KEY in your environment to use FAL.ai directly, or\n"
+                f"  • Set image_gen.use_gateway to false in config.yaml to use "
+                f"your direct FAL.ai credentials, or\n"
                 f"  • Pick a different model via `hermes tools` → Image Generation."
                 f"{gateway_message}"
             ) from exc

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3266,6 +3266,11 @@ def _resolve_openai_audio_client_config() -> tuple[str, str, bool]:
 
     managed_gateway = resolve_managed_tool_gateway("openai-audio")
     if managed_gateway is None:
+        # Gateway preferred but unusable (expired Portal session) — fall
+        # back to the direct credential when present (#79628).
+        fallback_key = direct_api_key or cfg_api_key
+        if fallback_key:
+            return fallback_key, (cfg_base_url or DEFAULT_OPENAI_BASE_URL), False
         message = (
             "Neither tts.openai.api_key in config nor "
             "VOICE_TOOLS_OPENAI_KEY/OPENAI_API_KEY is set"


### PR DESCRIPTION
## Fix: fall back to direct credentials when the tool gateway is unavailable (#79628)

### What
When `use_gateway: true` is set but the Nous Tool Gateway can't authenticate
(expired Portal session — `resolve_managed_tool_gateway()` returns `None`),
three tools raised a hard configuration error (or returned `None` → caller
raise) **even though a valid direct credential was present**. The error text
then told the user to set the exact credential they already had set.

The trigger is not an edge case: `apply_gateway_defaults()` sets
`use_gateway: true` during Portal setup for web/tts/stt/browser/image_gen/
video_gen, so any user whose Portal session expires loses these tools despite
working direct keys.

### Fix
Treat `use_gateway` as a **preference** (the established Krea/FAL pattern):
when the gateway is unresolvable but a direct credential exists, fall back to
it with a warning log. All three broken sites fixed:

| Site | Fallback |
|---|---|
| `plugins/web/firecrawl/provider.py` | `FIRECRAWL_API_KEY` / `FIRECRAWL_API_URL` |
| `plugins/browser/browser_use/provider.py` | `BROWSER_USE_API_KEY` |
| `tools/tts_tool.py` | `tts.openai.api_key` / `VOICE_TOOLS_OPENAI_KEY` |

No-direct-key behavior is byte-identical (still raises with guidance).

### RED-GREEN proof
- `tests/tools/test_web_gateway_fallback.py` (3 tests) — firecrawl fallback,
  gateway-wins, no-key-still-raises
- `tests/tools/test_tts_openai_config.py` (2 added) — cfg/env key fallback
- `tests/plugins/browser/test_browser_use_gateway_fallback.py` (3 tests) —
  direct fallback, no-key-None, gateway-wins
- All fallback tests **fail on pre-fix code** with the exact reported error;
  pass with the fix. Two pre-existing `TestParallelClientConfig` failures
  (missing `parallel-web` SDK) are unrelated and reproduce on unmodified
  main.
