### PR TITLE
fix(agent): 修复授权门卡死挂死整轮并击穿并发批次截止时间的问题

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -102,6 +102,45 @@ _DEFAULT_CONCURRENT_TOOL_TIMEOUT_S = 420.0
 # to cover slow-but-legitimate authorization (e.g. an approval round-trip),
 # short enough that one wedged dispatch cannot starve the batch forever.
 _START_ORDER_GATE_TIMEOUT_S = 120.0
+# Upper bound a concurrent worker will wait for the authorization
+# serialization lock before running its prompt unserialized. Mirrors
+# _START_ORDER_GATE_TIMEOUT_S: long enough to cover slow-but-legitimate
+# authorization, short enough that a worker wedged inside the gate (a hanging
+# pre_tool_block plugin, or an approval round-trip to a client that went away)
+# cannot starve every other worker in the batch forever. Losing serialization
+# degrades to interleaved approval prompts — the same tradeoff the start-order
+# gate accepts, and strictly better than a hung turn.
+_AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 120.0
+# Fallback ceiling (seconds) for how much wall-clock time a single open
+# authorization window may exclude from the batch deadline. The ceiling is
+# normally derived from the approval gate's own timeout (approvals.timeout,
+# default 300s) plus a margin — see _authorization_gate_max_window_seconds() —
+# and this constant is only used when that config cannot be read.
+_AUTHORIZATION_GATE_MAX_WINDOW_S = 600.0
+# Margin added on top of the configured approval timeout when deriving the
+# exclusion ceiling, so a slow-but-legitimate human round-trip (which is
+# already bounded by approvals.timeout inside the approval gate) stays
+# covered without the ceiling being so tight it truncates real approvals.
+_AUTHORIZATION_GATE_APPROVAL_MARGIN_S = 120.0
+
+
+def _authorization_gate_max_window_seconds() -> float:
+    """Resolve the ceiling on an open authorization window's deadline exclusion.
+
+    A legitimate approval round-trip is itself bounded by the approval gate's
+    timeout (``approvals.timeout``, default 300s), so the exclusion ceiling
+    tracks that bound plus a margin: slow-but-legitimate human waits stay
+    excluded from the batch deadline, while a wedged ``pre_tool_block`` plugin
+    — which has no intrinsic timeout of its own — can no longer grow the
+    exclusion 1:1 with wall clock and defeat the batch deadline forever. Falls
+    back to a fixed ceiling when the approval config cannot be read.
+    """
+    try:
+        from tools.approval import _get_approval_timeout
+
+        return float(_get_approval_timeout()) + _AUTHORIZATION_GATE_APPROVAL_MARGIN_S
+    except Exception:
+        return _AUTHORIZATION_GATE_MAX_WINDOW_S
 
 
 class _BatchAbandoned(BaseException):
@@ -356,14 +395,35 @@ class _ManagedToolResult:
 
 
 class _ConcurrentToolAuthorizationGate:
-    """Serialize policy prompts and exclude their queue from batch deadlines."""
+    """Serialize policy prompts and exclude their queue from batch deadlines.
 
-    def __init__(self) -> None:
+    Both bounds are deliberately finite so a worker that wedges inside the
+    gate (a hanging ``pre_tool_block`` plugin, or an approval round-trip to a
+    client that went away) cannot hang the turn:
+
+    - The serialization lock is acquired with a timeout; on expiry the worker
+      runs its prompt unserialized rather than blocking behind the wedged
+      holder forever (same tradeoff as the start-order gate in #79705).
+    - The open-window exclusion reported to the batch deadline is capped, so
+      a wedged window cannot grow the exclusion 1:1 with wall clock and make
+      the deadline's ``remaining`` constant — the deadline always fires.
+    """
+
+    def __init__(
+        self,
+        *,
+        lock_timeout: float = _AUTHORIZATION_GATE_LOCK_TIMEOUT_S,
+        max_window_seconds: float | None = None,
+    ) -> None:
         self._serialization_lock = threading.Lock()
         self._state_lock = threading.Lock()
         self._pending = 0
         self._window_started: float | None = None
         self._excluded_seconds = 0.0
+        self._lock_timeout = lock_timeout
+        if max_window_seconds is None:
+            max_window_seconds = _authorization_gate_max_window_seconds()
+        self._max_window_seconds = max_window_seconds
 
     def run(self, callback):
         now = time.monotonic()
@@ -372,8 +432,18 @@ class _ConcurrentToolAuthorizationGate:
                 self._window_started = now
             self._pending += 1
         try:
-            with self._serialization_lock:
+            acquired = self._serialization_lock.acquire(timeout=self._lock_timeout)
+            try:
+                if not acquired:
+                    logger.warning(
+                        "authorization gate lock timed out after %.1fs; "
+                        "running prompt unserialized",
+                        self._lock_timeout,
+                    )
                 return callback()
+            finally:
+                if acquired:
+                    self._serialization_lock.release()
         finally:
             now = time.monotonic()
             with self._state_lock:
@@ -386,12 +456,20 @@ class _ConcurrentToolAuthorizationGate:
                     self._window_started = None
 
     def excluded_seconds(self) -> float:
-        """Return completed plus currently active authorization wait time."""
+        """Return completed plus currently active authorization wait time.
+
+        The active window's contribution is capped at ``_max_window_seconds``:
+        the batch deadline loop adds this value to the deadline on every poll,
+        so an *uncapped* open window grows 1:1 with wall clock and ``remaining``
+        never decreases — the deadline never fires. Once the cap is reached the
+        exclusion stops growing and the deadline converges.
+        """
         now = time.monotonic()
         with self._state_lock:
             excluded = self._excluded_seconds
             if self._window_started is not None:
-                excluded += max(0.0, now - self._window_started)
+                open_seconds = max(0.0, now - self._window_started)
+                excluded += min(open_seconds, self._max_window_seconds)
             return excluded
 
 

--- a/tests/run_agent/test_authorization_gate.py
+++ b/tests/run_agent/test_authorization_gate.py
@@ -1,0 +1,217 @@
+"""Tests for the concurrent authorization gate (issue #79719).
+
+The gate serializes approval/pre-tool-block prompts and excludes their queue
+from the batch deadline. Before the fix, a worker wedged *inside* the gate
+(a hanging ``pre_tool_block`` plugin, or an approval round-trip to a client
+that went away) had two coupled failure modes:
+
+1. The serialization lock was an unbounded blocking acquire: every other
+   worker needing authorization blocked behind the wedged holder forever.
+2. ``excluded_seconds()`` grew 1:1 with wall clock while the window was open,
+   and the batch-deadline loop adds it to the deadline on every poll — so
+   ``remaining`` was constant and the deadline never fired.
+
+These tests drive the real ``_ConcurrentToolAuthorizationGate`` with the same
+arithmetic as the deadline loop (mirroring the issue's reproduction).
+"""
+
+import sys
+import threading
+import time
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_hermes(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    (tmp_path / ".hermes").mkdir(exist_ok=True)
+
+
+def _spawn_wedged_worker(gate, lock_held, release):
+    """Run a callback that wedges inside ``gate.run`` until released."""
+
+    def wedged_callback():
+        lock_held.set()
+        release.wait(30.0)
+        return "wedged"
+
+    t = threading.Thread(target=gate.run, args=(wedged_callback,), daemon=True)
+    t.start()
+    assert lock_held.wait(1.0), "wedged worker never entered the gate"
+    return t
+
+
+def test_wedged_lock_holder_does_not_starve_later_worker():
+    """A worker holding the serialization lock must not block later workers.
+
+    With an unbounded acquire, the contender below would block forever. The
+    bounded acquire makes it run its prompt unserialized after the lock
+    timeout — the same tradeoff the start-order gate (#79705) accepts.
+    """
+    from agent.tool_executor import _ConcurrentToolAuthorizationGate
+
+    gate = _ConcurrentToolAuthorizationGate(
+        lock_timeout=0.05, max_window_seconds=60.0
+    )
+    lock_held = threading.Event()
+    release = threading.Event()
+    holder = _spawn_wedged_worker(gate, lock_held, release)
+
+    results: list = []
+
+    def _run_fast():
+        results.append(gate.run(lambda: "ran"))
+
+    contender = threading.Thread(target=_run_fast, daemon=True)
+    started = time.monotonic()
+    contender.start()
+    contender.join(timeout=2.0)
+    elapsed = time.monotonic() - started
+
+    release.set()
+    holder.join(timeout=1.0)
+
+    assert not contender.is_alive(), (
+        "later worker starved behind the wedged lock holder"
+    )
+    assert results == ["ran"], f"unexpected result: {results}"
+    assert elapsed < 1.0, (
+        f"later worker took {elapsed:.2f}s to give up on the lock"
+    )
+
+
+def test_open_window_exclusion_is_capped():
+    """An open window must not grow the deadline exclusion 1:1 with wall clock."""
+    from agent.tool_executor import _ConcurrentToolAuthorizationGate
+
+    gate = _ConcurrentToolAuthorizationGate(
+        lock_timeout=30.0, max_window_seconds=0.1
+    )
+    lock_held = threading.Event()
+    release = threading.Event()
+    worker = _spawn_wedged_worker(gate, lock_held, release)
+
+    time.sleep(0.2)  # window open well past the 0.1s cap
+    first = gate.excluded_seconds()
+    time.sleep(0.3)
+    second = gate.excluded_seconds()
+
+    release.set()
+    worker.join(timeout=1.0)
+
+    assert second <= 0.1 + 0.05, (
+        f"exclusion grew past the cap: {second:.3f}s"
+    )
+    assert second - first < 0.05, (
+        "exclusion still grows 1:1 with wall clock: "
+        f"{first:.3f}s -> {second:.3f}s"
+    )
+
+
+def test_wedged_window_no_longer_defeats_the_batch_deadline():
+    """Mirror of the issue's repro table: the batch deadline must fire.
+
+    The deadline loop computes ``remaining = (deadline + excluded_seconds()) -
+    now`` on every poll. While the window was open, excluded_seconds() grew
+    with wall clock, so ``now`` cancelled out and ``remaining`` never reached
+    zero — the turn hung forever. With the cap, the exclusion stops growing
+    and the deadline converges.
+    """
+    from agent.tool_executor import _ConcurrentToolAuthorizationGate
+
+    gate = _ConcurrentToolAuthorizationGate(
+        lock_timeout=30.0, max_window_seconds=0.1
+    )
+    lock_held = threading.Event()
+    release = threading.Event()
+    worker = _spawn_wedged_worker(gate, lock_held, release)
+
+    deadline = time.monotonic() + 0.3
+    started = time.monotonic()
+    fired = False
+    while True:
+        remaining = (deadline + gate.excluded_seconds()) - time.monotonic()
+        if remaining <= 0:
+            fired = True
+            break
+        if time.monotonic() - started > 5.0:
+            break  # would never fire on the unbounded code — assert below
+        time.sleep(0.02)
+
+    release.set()
+    worker.join(timeout=1.0)
+
+    assert fired, (
+        "batch deadline never fired while the authorization window was open "
+        "(remaining stayed constant)"
+    )
+
+
+def test_serialization_preserved_when_lock_is_available():
+    """The bound must not break normal serialization of approval prompts."""
+    from agent.tool_executor import _ConcurrentToolAuthorizationGate
+
+    gate = _ConcurrentToolAuthorizationGate(
+        lock_timeout=5.0, max_window_seconds=60.0
+    )
+    order: list = []
+    lock_held = threading.Event()
+
+    def first_callback():
+        order.append("first:start")
+        lock_held.set()
+        time.sleep(0.1)
+        order.append("first:end")
+        return "first"
+
+    def second_callback():
+        order.append("second")
+        return "second"
+
+    t1 = threading.Thread(target=gate.run, args=(first_callback,), daemon=True)
+    t1.start()
+    assert lock_held.wait(1.0), "first worker never entered the gate"
+
+    t2 = threading.Thread(target=gate.run, args=(second_callback,), daemon=True)
+    t2.start()
+    t2.join(timeout=2.0)
+    t1.join(timeout=2.0)
+
+    assert order == ["first:start", "first:end", "second"], (
+        f"approval prompts were not serialized: {order}"
+    )
+
+
+def test_exclusion_ceiling_tracks_approval_timeout():
+    """The ceiling must cover the approval gate's own bounded human wait.
+
+    A legitimate approval round-trip is bounded by ``approvals.timeout``
+    inside the approval gate, so the exclusion ceiling (timeout + margin)
+    must sit above it: legitimate human waits stay excluded from the batch
+    deadline; only unbounded wedges (which the approval gate cannot produce)
+    hit the ceiling.
+    """
+    import agent.tool_executor as te
+
+    ceiling = te._authorization_gate_max_window_seconds()
+    try:
+        from tools.approval import _get_approval_timeout
+
+        assert ceiling > float(_get_approval_timeout()), (
+            f"ceiling {ceiling:.1f}s does not cover the approval timeout "
+            f"{_get_approval_timeout()}s"
+        )
+    except Exception:
+        assert ceiling == te._AUTHORIZATION_GATE_MAX_WINDOW_S
+
+
+def test_exclusion_ceiling_falls_back_when_config_unreadable(monkeypatch):
+    """When the approval config cannot be read, use the fixed fallback."""
+    import agent.tool_executor as te
+
+    monkeypatch.setitem(sys.modules, "tools.approval", None)
+    assert (
+        te._authorization_gate_max_window_seconds()
+        == te._AUTHORIZATION_GATE_MAX_WINDOW_S
+    )


### PR DESCRIPTION
## 背景

修复 #79719: 并发工具批次中，一个卡死在**授权门**里的工具会让整轮对话无限期挂起——与 #79705 修复的 start-order 门不同，这个路径连批次截止时间都无法触发。

## 根因分析

_ConcurrentToolAuthorizationGate（agent/tool_executor.py）存在两个耦合缺陷：

1. **无上限的阻塞式加锁**：self._serialization_lock 是无限阻塞 acquire。持有它的 worker 卡死（pre_tool_block 插件挂起、审批往返断连）时，其他所有需要授权的 worker 会永远阻塞在它后面。
2. **排除时间与墙钟 1:1 增长**：窗口打开期间 excluded_seconds() 持续增长，而批次截止时间循环每次轮询都把它加到截止时间上，于是 remaining 恒定、截止时间永远不触发。代数上：remaining = (deadline + (now - window_started)) - now = deadline - window_started，now 相互抵消。

问题 2 更严重：它位于 #79705 修复的 start-order 门**上游**——卡死在授权门的 worker 根本走不到 _begin_in_order，next_start_order 不会推进，而现在连截止时间都没有了，整轮直接挂死。

## 修复方式

- **绑定加锁等待**：用超时 acquire 替代无限阻塞（沿用 tools/daemon_pool.py / agent/conversation_compression.py 的写法），_AUTHORIZATION_GATE_LOCK_TIMEOUT_S = 120s 超时后告警并以非串行化方式运行 prompt——与 #79705 为 start-order 门接受的取舍一致，严格优于整轮挂死。
- **封顶窗口排除**：excluded_seconds() 中打开窗口的贡献按封顶值截断。封顶值由审批门自身的超时（approvals.timeout，默认 300s）+ 120s 余量推导（配置不可读时回退到 600s 固定值）。这样**等待真人审批**（本就有界）仍被有意排除在截止时间之外，而**卡死的插件窗口**（无内在超时）无法再无限期击穿截止时间——封顶后 remaining 开始随墙钟递减，截止时间必然触发。

## 验证

- [x] 新增 tests/run_agent/test_authorization_gate.py 6 个回归测试，直接驱动真实 _ConcurrentToolAuthorizationGate，复现 issue 的截止时间算术：持锁卡死不再饿死后续 worker、窗口排除封顶、卡死窗口不再使批次截止时间失效、锁可用时串行化保持不变
- [x] 变异验证：还原生产代码后 6 个测试全部失败，证明测试能捕获该 bug
- [x] tests/run_agent/ 全量通过：1397 passed, 8 skipped, 2 deselected
- [x] ruff check 通过
- [x] 遵循项目 AGENTS.md 贡献规范（无破坏性变更、无新 env var、行为契约式断言）

Closes #79719