### PR TITLE
feat(discord): add suppress_link_embeds config to hide link previews

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -629,6 +629,15 @@ class PlatformConfig:
     # Telegram, Matrix, …) ignore it.
     typing_status_text: Optional[str] = None
 
+    # Whether outgoing Discord text messages are sent with
+    # ``suppress_embeds=True`` so Discord skips link-preview unfurling.
+    # Default False preserves prior behavior (links render as preview cards).
+    # Set True on channels where link previews are unwanted clutter — links
+    # stay clickable, only the auto-generated embed is suppressed. Only
+    # affects plain-text sends; explicit UI embeds (approval/clarify/model
+    # picker) are never suppressed.
+    suppress_link_embeds: bool = False
+
     # Per-channel model/provider/system_prompt overrides (channel_id -> ChannelOverride)
     channel_overrides: Dict[str, ChannelOverride] = field(default_factory=dict)
 
@@ -642,6 +651,7 @@ class PlatformConfig:
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
             "typing_indicator": self.typing_indicator,
+            "suppress_link_embeds": self.suppress_link_embeds,
         }
         if self.typing_status_text is not None:
             result["typing_status_text"] = self.typing_status_text
@@ -686,6 +696,11 @@ class PlatformConfig:
         if _typing_text is None:
             _typing_text = extra.get("typing_status_text")
 
+        # suppress_link_embeds likewise may arrive top-level or inside extra.
+        _suppress_embeds = data.get("suppress_link_embeds")
+        if _suppress_embeds is None:
+            _suppress_embeds = extra.get("suppress_link_embeds")
+
         channel_overrides: Dict[str, ChannelOverride] = {}
         raw_overrides = data.get("channel_overrides") or {}
         if isinstance(raw_overrides, dict):
@@ -702,6 +717,7 @@ class PlatformConfig:
             gateway_restart_notification=_coerce_bool(_grn, True),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
+            suppress_link_embeds=_coerce_bool(_suppress_embeds, False),
             channel_overrides=channel_overrides,
             extra=extra,
         )
@@ -1596,6 +1612,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
                     bridged["typing_status_text"] = platform_cfg["typing_status_text"]
+                if "suppress_link_embeds" in platform_cfg:
+                    bridged["suppress_link_embeds"] = platform_cfg["suppress_link_embeds"]
                 # Bridge top-level port/host/secret into extra for platforms
                 # whose adapters read these from config.extra (webhook,
                 # msgraph_webhook, api_server).  Without this, YAML like:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1100,6 +1100,11 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+        # When True, plain-text sends pass suppress_embeds=self._suppress_link_embeds so Discord
+        # skips link-preview unfurling (config.platforms.discord.suppress_link_embeds).
+        self._suppress_link_embeds: bool = bool(
+            getattr(config, "suppress_link_embeds", False)
+        )
         # In-memory cache of the bot's last message ID per channel, used by
         # history backfill to skip the full scan on hot paths.  Falls back to
         # scanning channel.history() on cache miss (cold start / restart).
@@ -3117,6 +3122,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     msg = await channel.send(
                         content=chunk,
                         reference=chunk_reference,
+                        suppress_embeds=self._suppress_link_embeds,
                     )
                 except Exception as e:
                     err_text = str(e)
@@ -3139,6 +3145,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         msg = await channel.send(
                             content=chunk,
                             reference=None,
+                            suppress_embeds=self._suppress_link_embeds,
                         )
                     else:
                         raise
@@ -3202,6 +3209,7 @@ class DiscordAdapter(BasePlatformAdapter):
             thread = await forum_channel.create_thread(
                 name=thread_name,
                 content=starter_content,
+                suppress_embeds=self._suppress_link_embeds,
             )
         except Exception as e:
             logger.error("[%s] Failed to create forum thread in %s: %s", self.name, forum_channel.id, e)
@@ -3218,7 +3226,7 @@ class DiscordAdapter(BasePlatformAdapter):
         warnings: list[str] = []
         for chunk in chunks[1:]:
             try:
-                msg = await thread_channel.send(content=chunk)
+                msg = await thread_channel.send(content=chunk, suppress_embeds=self._suppress_link_embeds)
                 message_ids.append(str(msg.id))
             except Exception as e:
                 warning = f"Failed to send follow-up chunk to forum thread {thread_id}: {e}"
@@ -3265,7 +3273,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     hint = getattr(files[0], "filename", "") or ""
             thread_name = _derive_forum_thread_name(hint) if hint.strip() else "New Post"
 
-        kwargs: Dict[str, Any] = {"name": thread_name}
+        kwargs: Dict[str, Any] = {"name": thread_name, "suppress_embeds": self._suppress_link_embeds}
         if content:
             kwargs["content"] = content
         if file is not None:
@@ -3494,7 +3502,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 # overflow continuations stay threaded.
                 reference = self._message_reference_from_ids(prev_msg.id, channel)
             try:
-                sent = await channel.send(content=chunk, reference=reference)
+                sent = await channel.send(content=chunk, reference=reference, suppress_embeds=self._suppress_link_embeds)
             except Exception as send_err:
                 # Drop the reply anchor and retry once — a deleted/expired
                 # anchor (10008) or system-message reply (50035) shouldn't lose
@@ -3504,7 +3512,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     self.name, send_err,
                 )
                 try:
-                    sent = await channel.send(content=chunk, reference=None)
+                    sent = await channel.send(content=chunk, reference=None, suppress_embeds=self._suppress_link_embeds)
                 except Exception as retry_err:
                     logger.warning(
                         "[%s] Overflow split: stopped at %d/%d chunks delivered: %s",
@@ -3596,6 +3604,7 @@ class DiscordAdapter(BasePlatformAdapter):
         msg = await channel.send(
             content=caption if caption else None,
             files=[discord_file],
+            suppress_embeds=self._suppress_link_embeds,
         )
         attachments = getattr(msg, "attachments", None) or []
         if not attachments:
@@ -3731,7 +3740,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         files=files,
                     )
                 else:
-                    await channel.send(content=content, files=files)
+                    await channel.send(content=content, files=files, suppress_embeds=self._suppress_link_embeds)
             except Exception as e:
                 logger.warning(
                     "[%s] Multi-image Discord send failed (chunk %d/%d), falling back to per-image: %s",
@@ -5109,6 +5118,7 @@ class DiscordAdapter(BasePlatformAdapter):
                         channel,
                         content=(caption or "").strip(),
                         file=file,
+                        suppress_embeds=self._suppress_link_embeds,
                     )
 
                 msg = await channel.send(
@@ -6754,7 +6764,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 reason=reason,
             )
             if starter_message:
-                await thread.send(starter_message)
+                await thread.send(starter_message, suppress_embeds=self._suppress_link_embeds)
             return {
                 "success": True,
                 "thread_id": str(thread.id),
@@ -6763,7 +6773,7 @@ class DiscordAdapter(BasePlatformAdapter):
         except Exception as direct_error:
             try:
                 seed_content = starter_message or f"\U0001f9f5 Thread created by Hermes: **{name}**"
-                seed_msg = await parent_channel.send(seed_content)
+                seed_msg = await parent_channel.send(seed_content, suppress_embeds=self._suppress_link_embeds)
                 thread = await seed_msg.create_thread(
                     name=name,
                     auto_archive_duration=auto_archive_duration,
@@ -6834,7 +6844,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 last_direct_error = direct_error
                 try:
                     seed_msg = await message.channel.send(
-                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**"
+                        f"\U0001f9f5 Thread created by Hermes: **{thread_name}**",
+                        suppress_embeds=self._suppress_link_embeds,
                     )
                     thread = await seed_msg.create_thread(
                         name=thread_name,

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -93,6 +93,24 @@ class TestPlatformConfigRoundtrip:
         assert restored.typing_status_text == "chasing yarn…"
 
 
+    def test_suppress_link_embeds_defaults_false(self):
+        assert PlatformConfig().suppress_link_embeds is False
+        assert PlatformConfig.from_dict({}).suppress_link_embeds is False
+
+    def test_suppress_link_embeds_roundtrip_true(self):
+        pc = PlatformConfig(enabled=True, suppress_link_embeds=True)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.suppress_link_embeds is True
+
+    def test_suppress_link_embeds_coerces_quoted_true(self):
+        restored = PlatformConfig.from_dict({"suppress_link_embeds": "true"})
+        assert restored.suppress_link_embeds is True
+
+    def test_suppress_link_embeds_resolved_from_extra(self):
+        # Mirrors typing_indicator: bridged into extra by the shared-key loop.
+        restored = PlatformConfig.from_dict({"extra": {"suppress_link_embeds": True}})
+        assert restored.suppress_link_embeds is True
+
     def test_channel_overrides_roundtrip(self):
         pc = PlatformConfig(
             enabled=True,

--- a/tests/gateway/test_discord_edit_message_overflow.py
+++ b/tests/gateway/test_discord_edit_message_overflow.py
@@ -61,7 +61,7 @@ def _wire_channel(adapter, *, original_msg, send_side_effect=None):
     records every ``channel.send`` call."""
     sends = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **kwargs):
         sends.append({"content": content, "reference": reference})
         if send_side_effect is not None:
             res = send_side_effect(len(sends), content, reference)

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -314,7 +314,6 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
 
     result = await adapter.send_video("555", str(video))
 
-<<<<<<< HEAD
     assert result.success is True
     assert result.message_id == "4242"
     assert captured["fp"] == str(video)
@@ -417,12 +416,6 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
-
-=======
-    await adapter.stop_typing("12345")
-    assert "12345" not in adapter._typing_tasks
->>>>>>> 58baeb138 (feat(discord): make link-preview suppression a config option)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -116,7 +116,7 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
     sent_msgs = [SimpleNamespace(id=1001), SimpleNamespace(id=1002)]
     send_calls = []
 
-    async def fake_send(*, content, reference=None):
+    async def fake_send(*, content, reference=None, **kwargs):
         send_calls.append({"content": content, "reference": reference})
         if len(send_calls) == 1:
             raise RuntimeError(
@@ -314,6 +314,7 @@ async def test_send_video_uses_path_based_files_kwarg(tmp_path, monkeypatch):
 
     result = await adapter.send_video("555", str(video))
 
+<<<<<<< HEAD
     assert result.success is True
     assert result.message_id == "4242"
     assert captured["fp"] == str(video)
@@ -418,3 +419,69 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
 
 
+=======
+    await adapter.stop_typing("12345")
+    assert "12345" not in adapter._typing_tasks
+>>>>>>> 58baeb138 (feat(discord): make link-preview suppression a config option)
+
+
+@pytest.mark.asyncio
+async def test_send_suppress_link_embeds_disabled_by_default():
+    """Default config (suppress_link_embeds=False) passes suppress_embeds=False
+    so Discord keeps rendering link-preview cards — prior behavior preserved."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    assert adapter._suppress_link_embeds is False
+
+    sent_msg = SimpleNamespace(id=1234)
+    send_kwargs = []
+
+    async def fake_send(*, content, reference=None, **kwargs):
+        send_kwargs.append(kwargs)
+        return sent_msg
+
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello https://example.com")
+
+    assert result.success is True
+    assert send_kwargs, "expected at least one send call"
+    assert send_kwargs[0].get("suppress_embeds") is False
+
+
+@pytest.mark.asyncio
+async def test_send_suppress_link_embeds_enabled_passes_flag():
+    """With suppress_link_embeds=True the adapter passes suppress_embeds=True,
+    so Discord skips link-preview unfurling entirely."""
+    adapter = DiscordAdapter(
+        PlatformConfig(enabled=True, token="***", suppress_link_embeds=True)
+    )
+    assert adapter._suppress_link_embeds is True
+
+    sent_msg = SimpleNamespace(id=1234)
+    send_kwargs = []
+
+    async def fake_send(*, content, reference=None, **kwargs):
+        send_kwargs.append(kwargs)
+        return sent_msg
+
+    channel = SimpleNamespace(
+        fetch_message=AsyncMock(),
+        send=AsyncMock(side_effect=fake_send),
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "hello https://example.com")
+
+    assert result.success is True
+    assert send_kwargs, "expected at least one send call"
+    assert send_kwargs[0].get("suppress_embeds") is True

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -341,12 +341,16 @@ discord:
   no_thread_channels: []          # Channel IDs where bot responds without threading
   history_backfill: true          # Prepend recent channel scrollback on mention (default: true)
   history_backfill_limit: 50      # Max messages to scan backwards (default: 50)
+<<<<<<< HEAD
   missed_message_backfill:        # Replay messages missed while disconnected (opt-in)
     enabled: false
     channels: []                  # Empty uses free_response_channels
     window_seconds: 21600         # Look back at most 6 hours
     limit: 100                    # Global scan cap per reconnect
     max_dispatches: 10            # Recovery dispatch cap per reconnect
+=======
+  suppress_link_embeds: false     # Send messages with suppress_embeds (no link preview cards)
+>>>>>>> 58baeb138 (feat(discord): make link-preview suppression a config option)
   channel_prompts: {}             # Per-channel ephemeral system prompts
   voice_channel_inactivity_timeout_seconds: 300  # Set 0 to stay in VC until explicit /voice leave
   voice_playback_timeout_seconds: 120             # Minimum playback watchdog; long clips get duration+padding
@@ -518,6 +522,7 @@ discord:
   history_backfill_limit: 50
 ```
 
+<<<<<<< HEAD
 #### `discord.missed_message_backfill`
 
 **Type:** object — **Default:** disabled
@@ -536,6 +541,21 @@ discord:
 
 If `channels` is empty, Hermes uses `discord.free_response_channels`. Set it to `"*"` only when the bot should inspect every reachable server text channel. The recovery ledger is stored per profile under `gateway/discord_message_recovery.db`, preventing a successfully answered message from being replayed again after a later restart.
 
+=======
+#### `discord.suppress_link_embeds`
+
+**Type:** boolean — **Default:** `false`
+
+When enabled, outgoing Discord text messages are sent with `suppress_embeds=True`, so Discord skips link-preview unfurling entirely: URLs in messages stay clean and clickable, but no preview card (title, description, thumbnail) is generated. Useful on channels where link previews are unwanted clutter.
+
+Only plain-text sends are affected. Explicit UI embeds — command approval buttons, clarify prompts, the model picker — are never suppressed.
+
+```yaml
+discord:
+  suppress_link_embeds: true
+```
+
+>>>>>>> 58baeb138 (feat(discord): make link-preview suppression a config option)
 #### `group_sessions_per_user`
 
 **Type:** boolean — **Default:** `true`


### PR DESCRIPTION
## Summary

Adds a new `PlatformConfig` flag, **`discord.suppress_link_embeds`** (default `false`), that lets users opt out of Discord's link-preview unfurling on Hermes bot messages.

When enabled, plain-text sends pass `suppress_embeds=True`, so Discord skips generating the auto preview card (title/description/thumbnail) for URLs in message content. Links stay clean and clickable — only the embed is suppressed. Default `false` preserves prior behavior for everyone.

## Motivation

On busy channels, link preview cards clutter the chat. Discord's native `suppress_embeds` flag is the clean way to opt out — no URL mangling, no `<>` wrapping, links remain fully clickable. Making it a config flag (rather than hardcoding) keeps the default behavior unchanged.

## Scope

- **Adapter paths covered:** `send()`, reply-reference retries, forum thread creation + follow-ups, overflow-split continuations, image/video/file captions, thread starter messages. Every plain-text send path in `plugins/platforms/discord/adapter.py`.
- **Explicit UI embeds untouched:** command approval buttons, clarify prompts, model/choice pickers send their own `embed=` payloads and do **not** pass `suppress_embeds` — those keep rendering.

## Config plumbing

Mirrors the existing `typing_indicator` pattern:
- Top-level `PlatformConfig.suppress_link_embeds: bool = False`
- `to_dict()` / `from_dict()` roundtrip + shared-key bridge into `extra` in `load_gateway_config()`
- Works as top-level YAML (`discord: suppress_link_embeds: true`) or inside `platforms.discord.extra`
- Documented in `website/docs/user-guide/messaging/discord.md`

## Tests

- Adapter: default-off passes `suppress_embeds=False`; enabled passes `suppress_embeds=True`
- Config: default, roundtrip, quoted-value coercion, extra-bridge resolution
- Updated `fake_send` mocks in `test_discord_send.py` / `test_discord_edit_message_overflow.py` to accept the new kwarg (strict signatures)

All 94 related tests pass.