### PR TITLE
fix(qqbot): classify voice-transcribed messages as VOICE

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1325,7 +1325,7 @@ class QQAdapter(BasePlatformAdapter):
                 chat_type="dm",
             ),
             text=text,
-            message_type=self._detect_message_type(image_urls, image_media_types),
+            message_type=self._detect_message_type(image_urls, image_media_types, has_voice=bool(voice_transcripts)),
             raw_message=d,
             message_id=msg_id,
             media_urls=image_urls,
@@ -1390,7 +1390,7 @@ class QQAdapter(BasePlatformAdapter):
                 chat_type="group",
             ),
             text=text,
-            message_type=self._detect_message_type(image_urls, image_media_types),
+            message_type=self._detect_message_type(image_urls, image_media_types, has_voice=bool(voice_transcripts)),
             raw_message=d,
             message_id=msg_id,
             media_urls=image_urls,
@@ -1465,7 +1465,7 @@ class QQAdapter(BasePlatformAdapter):
                 chat_type="group",
             ),
             text=text,
-            message_type=self._detect_message_type(image_urls, image_media_types),
+            message_type=self._detect_message_type(image_urls, image_media_types, has_voice=bool(voice_transcripts)),
             raw_message=d,
             message_id=msg_id,
             media_urls=image_urls,
@@ -1535,7 +1535,7 @@ class QQAdapter(BasePlatformAdapter):
                 chat_type="dm",
             ),
             text=text,
-            message_type=self._detect_message_type(image_urls, image_media_types),
+            message_type=self._detect_message_type(image_urls, image_media_types, has_voice=bool(voice_transcripts)),
             raw_message=d,
             message_id=msg_id,
             media_urls=image_urls,
@@ -1656,8 +1656,16 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _detect_message_type(media_urls: list, media_types: list):
-        """Determine MessageType from attachment content types."""
+    def _detect_message_type(media_urls: list, media_types: list, has_voice: bool = False):
+        """Determine MessageType from attachment content types.
+
+        ``has_voice`` marks voice attachments explicitly — voice transcripts
+        are folded into the text body, so without it a pure-voice message
+        would be misclassified as TEXT and voice-reply modes
+        (voice_only/all) would never trigger.
+        """
+        if has_voice:
+            return MessageType.VOICE
         if not media_urls:
             return MessageType.TEXT
         if not media_types:


### PR DESCRIPTION
## What

QQ voice messages are transcribed via ASR and the transcript is folded into the message text body — the media attachment list contains **no audio entry** for them. `_detect_message_type()` therefore classifies a pure-voice message as `TEXT`, and the `voice_only`/`all` reply modes never trigger for QQ voice input (no auto voice reply, no voice-mode routing).

This PR passes `has_voice` (derived from the already-available `voice_transcripts`) into `_detect_message_type()` and classifies such messages as `MessageType.VOICE` — the existing consumption path (`run.py` `is_voice_input`, voice-only reply mode checks) then works unchanged.

## Why

- QQ ASR transcripts are folded into `text`, so `media_urls`/`media_types` cannot detect the voice-ness of the message.
- Same symptom as #51282 (Discord) — adapters that transcribe into the text body need an explicit voice flag.
- `MessageType.VOICE` already exists and is consumed in several places; this only fixes the classification.

## How to test

1. On QQ, send a voice message to a chat with voice mode `voice_only` (e.g. `/voice on`).
2. Before: no voice reply, message treated as text.
3. After: auto voice reply is sent (TTS), message routed as voice.

## Platforms tested

- Linux (Deepin 25), QQ adapter (voice_only / all modes).

## Notes

- `has_voice` defaults to `False` — signature stays backward compatible.
- All four call sites already have `voice_transcripts` in scope (defined at 1286/1359/1434/1505, calls at 1328/1393/1468/1538).
