### PR TITLE
fix(agent): adopt live compression child on flush

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1472,6 +1472,7 @@ def run_conversation(
     # A configured SessionDB append failure halts only the affected turn. A
     # cached gateway agent must recover on the next message if storage did.
     agent._incremental_persistence_failed = False
+    agent._persistence_failure_reason = None
 
     # Main conversation loop counters (pure locals consumed by the loop below).
     api_call_count = 0
@@ -6517,7 +6518,9 @@ def run_conversation(
                     # run side-effecting tools from state that exists only in
                     # this process. Breaking also avoids retrying the same
                     # unpersisted turn until the iteration budget is exhausted.
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = getattr(
+                        agent, "_persistence_failure_reason", None
+                    ) or "session_persistence_failed"
                     final_response = ""
                     failed = True
                     break
@@ -6546,7 +6549,9 @@ def run_conversation(
                     # A tool result could not be made canonical. Do not send
                     # the in-memory result back to the model or project any
                     # later events from this turn.
-                    _turn_exit_reason = "session_persistence_failed"
+                    _turn_exit_reason = getattr(
+                        agent, "_persistence_failure_reason", None
+                    ) or "session_persistence_failed"
                     final_response = ""
                     failed = True
                     break

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -676,10 +676,19 @@ def finalize_turn(
     # Persistence failures already set failed=True + an explanation in
     # final_response; also stamp `error` so gateway surfaces status="error"
     # (and desktop can toast disk-full) instead of a quiet complete frame.
-    if failed and str(_turn_exit_reason) == "session_persistence_failed":
-        result["error"] = final_response or (
-            "session storage could not be written — free disk space and try again"
-        )
+    if failed and str(_turn_exit_reason) in (
+        "session_persistence_failed",
+        "compression_session_closed",
+    ):
+        if str(_turn_exit_reason) == "compression_session_closed":
+            result["error"] = final_response or (
+                "the previous session was compressed, but its live continuation "
+                "could not be selected safely — send your message again"
+            )
+        else:
+            result["error"] = final_response or (
+                "session storage could not be written — free disk space and try again"
+            )
     # Surface any post-loop cleanup failures so the caller can distinguish a
     # clean turn from one whose trajectory/session/resource teardown raised
     # (the response is still returned either way — #8049).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6755,6 +6755,34 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
 
+    def _append_messages_batch_in_transaction(
+        self,
+        conn,
+        *,
+        session_id: str,
+        messages: List[Dict[str, Any]],
+        compression_lock_holder: Optional[str] = None,
+    ) -> int:
+        """Append one transcript batch using the caller's write transaction."""
+        self._check_transcript_write_guards(
+            conn, session_id, compression_lock_holder
+        )
+        inserted, tool_calls_total = self._insert_message_rows(
+            conn, session_id, messages
+        )
+        if tool_calls_total > 0:
+            conn.execute(
+                """UPDATE sessions SET message_count = message_count + ?,
+                   tool_call_count = tool_call_count + ? WHERE id = ?""",
+                (inserted, tool_calls_total, session_id),
+            )
+        else:
+            conn.execute(
+                "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
+                (inserted, session_id),
+            )
+        return inserted
+
     def append_messages_batch(
         self,
         session_id: str,
@@ -6803,27 +6831,75 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return inserted_total
 
         def _do(conn):
-            self._check_transcript_write_guards(
-                conn, session_id, compression_lock_holder
+            return self._append_messages_batch_in_transaction(
+                conn,
+                session_id=session_id,
+                messages=messages,
+                compression_lock_holder=compression_lock_holder,
             )
-            inserted, tool_calls_total = self._insert_message_rows(
-                conn, session_id, messages
-            )
-            # One aggregated counter update for the whole batch.
-            if tool_calls_total > 0:
-                conn.execute(
-                    """UPDATE sessions SET message_count = message_count + ?,
-                       tool_call_count = tool_call_count + ? WHERE id = ?""",
-                    (inserted, tool_calls_total, session_id),
-                )
-            else:
-                conn.execute(
-                    "UPDATE sessions SET message_count = message_count + ? WHERE id = ?",
-                    (inserted, session_id),
-                )
-            return inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
+    def append_messages_batch_to_live_compression_child(
+        self,
+        parent_session_id: str,
+        messages: List[Dict[str, Any]],
+        compression_lock_holder: Optional[str] = None,
+    ) -> str:
+        """Atomically resolve one live compression child and append a batch.
+
+        The unique-child check and transcript insert share one ``BEGIN
+        IMMEDIATE`` transaction. A concurrent compression publisher therefore
+        cannot create another child between selection and commit. Missing or
+        ambiguous continuations fail closed with the same exception as a direct
+        write to the compression-ended parent.
+
+        Returns the child session id after the transcript batch commits.
+        """
+        if not messages:
+            raise ValueError("messages must not be empty")
+
+        def _do(conn):
+            parent = conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                (parent_session_id,),
+            ).fetchone()
+            if (
+                parent is None
+                or parent["ended_at"] is None
+                or parent["end_reason"] != "compression"
+            ):
+                raise CompressionSessionClosedError(parent_session_id)
+
+            rows = conn.execute(
+                """
+                SELECT s.id
+                FROM sessions s
+                WHERE s.parent_session_id = ?
+                  AND s.ended_at IS NULL
+                  AND json_extract(COALESCE(s.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(s.source, '') != 'tool'
+                ORDER BY s.started_at ASC
+                LIMIT 2
+                """,
+                (parent_session_id,),
+            ).fetchall()
+            if len(rows) != 1:
+                raise CompressionSessionClosedError(parent_session_id)
+
+            child_session_id = str(rows[0]["id"])
+            self._append_messages_batch_in_transaction(
+                conn,
+                session_id=child_session_id,
+                messages=messages,
+                compression_lock_holder=compression_lock_holder,
+            )
+            return child_session_id
+
         return self._execute_write(
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -2280,13 +2280,79 @@ class AIAgent:
             # re-writes the whole tail (same recovery contract as before,
             # minus the partial-prefix case that could double-pay counters).
             if _batch_rows:
-                self._session_db.append_messages_batch(
-                    session_id=self.session_id,
-                    messages=_batch_rows,
-                    compression_lock_holder=getattr(
-                        self, "_active_compression_lock_holder", None
-                    ),
+                _compression_lock_holder = getattr(
+                    self, "_active_compression_lock_holder", None
                 )
+                try:
+                    self._session_db.append_messages_batch(
+                        session_id=self.session_id,
+                        messages=_batch_rows,
+                        compression_lock_holder=_compression_lock_holder,
+                    )
+                except Exception as _append_exc:
+                    from hermes_state import CompressionSessionClosedError
+
+                    if not isinstance(_append_exc, CompressionSessionClosedError):
+                        raise
+                    _parent_session_id = self.session_id
+                    _atomic_reroute = getattr(
+                        type(self._session_db),
+                        "append_messages_batch_to_live_compression_child",
+                        None,
+                    )
+                    if not callable(_atomic_reroute):
+                        self._persistence_failure_reason = (
+                            "compression_session_closed"
+                        )
+                        raise
+                    # Resolve and append under one BEGIN IMMEDIATE transaction,
+                    # then mutate the live binding only after commit. A second
+                    # publisher cannot create an ambiguous child between the
+                    # uniqueness check and transcript insert.
+                    try:
+                        _child_session_id = str(
+                            _atomic_reroute(
+                                self._session_db,
+                                parent_session_id=_parent_session_id,
+                                messages=_batch_rows,
+                                compression_lock_holder=_compression_lock_holder,
+                            )
+                        )
+                    except CompressionSessionClosedError:
+                        self._persistence_failure_reason = (
+                            "compression_session_closed"
+                        )
+                        raise
+                    self.session_id = _child_session_id
+                    self._session_db_created = True
+                    self._flushed_db_message_session_id = _child_session_id
+                    self._persistence_failure_reason = None
+                    try:
+                        from gateway.session_context import set_current_session_id
+
+                        set_current_session_id(_child_session_id)
+                    except Exception as _context_exc:
+                        os.environ["HERMES_SESSION_ID"] = _child_session_id
+                        logger.warning(
+                            "Failed to update gateway session context after "
+                            "compression-child adoption: %s",
+                            _context_exc,
+                        )
+                    try:
+                        from hermes_logging import set_session_context
+
+                        set_session_context(_child_session_id)
+                    except Exception as _logging_exc:
+                        logger.warning(
+                            "Failed to update logging session context after "
+                            "compression-child adoption: %s",
+                            _logging_exc,
+                        )
+                    logger.info(
+                        "Session DB flush adopted compression continuation: %s -> %s",
+                        _parent_session_id,
+                        _child_session_id,
+                    )
                 for _written in _batch_msgs:
                     _written[_DB_PERSISTED_MARKER] = True
             # The intrinsic markers are now the sole source of truth. Reset the
@@ -3674,6 +3740,14 @@ class AIAgent:
                 "written (the transcript would have been lost on restart). "
                 "This is often a full disk — free some space (or fix state.db "
                 "permissions), then send your message again."
+            )
+        if reason == "compression_session_closed":
+            return (
+                prefix
+                + "the turn was stopped because the previous session was "
+                "compressed and its live compression continuation could not "
+                "be selected safely. Send your message again to continue on "
+                "the current session."
             )
         # Unknown/diagnostic-only reasons (e.g. "unknown", guardrail_halt
         # which already surfaces its own message) — don't second-guess.

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -165,6 +165,41 @@ class TestAppendMessagesBatch:
         with pytest.raises(CompressionSessionClosedError):
             db.append_messages_batch("sess-batch", _turn_messages())
 
+    def test_atomic_reroute_appends_to_unique_live_compression_child(self, db):
+        db.end_session("sess-batch", "compression")
+        db.create_session(
+            "sess-child",
+            source="cli",
+            parent_session_id="sess-batch",
+        )
+
+        child_id = db.append_messages_batch_to_live_compression_child(
+            "sess-batch",
+            _turn_messages(),
+        )
+
+        assert child_id == "sess-child"
+        assert len(db.get_messages("sess-child")) == 4
+        assert db.get_messages("sess-batch") == []
+
+    def test_atomic_reroute_rejects_ambiguous_live_children(self, db):
+        db.end_session("sess-batch", "compression")
+        for child_id in ("sess-child-a", "sess-child-b"):
+            db.create_session(
+                child_id,
+                source="cli",
+                parent_session_id="sess-batch",
+            )
+
+        with pytest.raises(CompressionSessionClosedError):
+            db.append_messages_batch_to_live_compression_child(
+                "sess-batch",
+                _turn_messages(),
+            )
+
+        assert db.get_messages("sess-child-a") == []
+        assert db.get_messages("sess-child-b") == []
+
     def test_multimodal_content_encoded(self, db):
         msgs = [
             {

--- a/tests/run_agent/test_compression_closed_flush_reroute.py
+++ b/tests/run_agent/test_compression_closed_flush_reroute.py
@@ -1,0 +1,125 @@
+"""Regression coverage for agent flushes that lose a compression race."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from hermes_state import SessionDB
+
+
+def _make_agent(db: SessionDB, session_id: str):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._ensure_db_session()
+    return agent
+
+
+def test_flush_adopts_unique_live_child_when_parent_was_compressed(tmp_path) -> None:
+    """A stale turn must persist to the winner's child instead of stopping."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_id = "parent"
+    child_id = "child"
+    agent = _make_agent(db, parent_id)
+
+    old_message = {"role": "user", "content": "already persisted"}
+    db.append_message(
+        parent_id,
+        role=old_message["role"],
+        content=old_message["content"],
+    )
+    db.end_session(parent_id, "compression")
+    db.create_session(child_id, source="test", parent_session_id=parent_id)
+    db.replace_messages(
+        child_id,
+        [{"role": "user", "content": "[CONTEXT COMPACTION] summary"}],
+    )
+
+    current_user = {"role": "user", "content": "arrived during compression"}
+    current_reply = {"role": "assistant", "content": "completed safely"}
+    messages = [old_message, current_user, current_reply]
+
+    with patch.object(
+        SessionDB,
+        "find_live_compression_child",
+        side_effect=AssertionError("reroute must resolve and append in one transaction"),
+    ):
+        assert agent._flush_messages_to_session_db(
+            messages,
+            conversation_history=[old_message],
+        ) is True
+    assert getattr(agent, "session_id", None) == child_id
+    assert agent._flushed_db_message_session_id == child_id
+    assert [row["content"] for row in db.get_messages(child_id)] == [
+        "[CONTEXT COMPACTION] summary",
+        "arrived during compression",
+        "completed safely",
+    ]
+    assert all(message.get("_db_persisted") is True for message in messages)
+    assert agent._flush_messages_to_session_db(
+        messages,
+        conversation_history=[old_message],
+    ) is True
+    assert [row["content"] for row in db.get_messages(child_id)] == [
+        "[CONTEXT COMPACTION] summary",
+        "arrived during compression",
+        "completed safely",
+    ]
+    db.close()
+
+
+def test_flush_classifies_ambiguous_compression_continuation(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_id = "parent"
+    db.create_session(parent_id, "slack")
+    db.end_session(parent_id, "compression")
+
+    for child_id in ("child-a", "child-b"):
+        db.create_session(
+            child_id,
+            "slack",
+            parent_session_id=parent_id,
+        )
+        db.replace_messages(
+            child_id,
+            [{"role": "user", "content": f"Summary for {child_id}"}],
+        )
+
+    agent = _make_agent(db, parent_id)
+    current_user = {"role": "user", "content": "Continue the task"}
+    assistant = {"role": "assistant", "content": "Current answer"}
+    messages = [current_user, assistant]
+
+    persisted = agent._flush_messages_to_session_db(
+        messages,
+        conversation_history=[],
+    )
+
+    assert persisted is False
+    assert agent.session_id == parent_id
+    assert getattr(agent, "_persistence_failure_reason", None) == (
+        "compression_session_closed"
+    )
+    assert all(message.get("_db_persisted") is not True for message in messages)
+    for child_id in ("child-a", "child-b"):
+        assert [row["content"] for row in db.get_messages(child_id)] == [
+            f"Summary for {child_id}"
+        ]
+
+    explanation = agent._format_turn_completion_explanation(
+        "compression_session_closed"
+    )
+    assert "compression continuation" in explanation.lower()
+    assert "disk" not in explanation.lower()
+    db.close()

--- a/tests/run_agent/test_tool_call_incremental_persistence.py
+++ b/tests/run_agent/test_tool_call_incremental_persistence.py
@@ -243,6 +243,34 @@ def test_failed_assistant_persist_blocks_ui_projection_and_tool_side_effects():
     assert result["turn_exit_reason"] == "session_persistence_failed"
 
 
+def test_closed_compression_session_surfaces_specific_failure_reason():
+    agent = _make_agent()
+    tool_call = _mock_tool_call(call_id="must-not-run")
+    assert agent.client is not None
+    agent.client.chat.completions.create.return_value = _mock_response(
+        content="I'll inspect the repository now.",
+        finish_reason="tool_calls",
+        tool_calls=[tool_call],
+    )
+
+    def _closed_session_flush(*_args, **_kwargs):
+        agent._persistence_failure_reason = "compression_session_closed"
+        return False
+
+    agent._flush_messages_to_session_db = MagicMock(
+        side_effect=_closed_session_flush
+    )
+    agent._execute_tool_calls = MagicMock()
+
+    result = agent.run_conversation("inspect the repository")
+
+    agent._execute_tool_calls.assert_not_called()
+    assert result["failed"] is True
+    assert result["turn_exit_reason"] == "compression_session_closed"
+    assert "compression continuation" in result["error"].lower()
+    assert "disk" not in result["error"].lower()
+
+
 # ---------------------------------------------------------------------------
 # Contract 2: the SEQUENTIAL path flushes each tool result immediately, BEFORE
 # the next tool dispatches.  Dispatch goes through run_agent.handle_function_call


### PR DESCRIPTION
## Summary

A transcript flush that loses a context-compression race now follows the session's unique live continuation instead of aborting the turn against the closed parent.

If Hermes cannot select exactly one live continuation, it still fails closed, preserves the unpersisted markers for a safe retry, and reports a compression-lineage failure rather than suggesting that the disk is full.

## Problem

`SessionDB.append_messages_batch()` correctly rejects writes to sessions closed by compression. `AIAgent._flush_messages_to_session_db_unlocked()` treated that specific rejection like any other persistence failure, so an otherwise healthy turn could stop after another compression path rotated the session.

The resulting `session_persistence_failed` message pointed operators toward disk capacity or `state.db` permissions even when both were healthy.

## Changes

- Catch `CompressionSessionClosedError` at the agent's atomic batch-flush boundary.
- Resolve exactly one live compression child and append the unchanged batch inside one `BEGIN IMMEDIATE` transaction, preventing a second publisher from making the lineage ambiguous between selection and commit.
- Update the agent/session logging binding only after the atomic reroute commits.
- Preserve fail-closed behavior when the child is missing or ambiguous.
- Propagate unresolved cases as `compression_session_closed` with actionable, non-disk guidance.
- Add regression coverage for successful adoption, idempotent repeat flushes, ambiguous-child refusal, and turn-finalizer classification.

## Relationship to existing work

This is distinct from #77386 / #77410 / #77799, which address writers waiting on a compression lock, and from #57895 / #79322, which route queued gateway follow-ups after a completed turn. This patch handles the lower-level agent transcript flush after the parent has already been closed and a continuation published.

## Validation

- `pytest tests/run_agent/test_compression_closed_flush_reroute.py tests/run_agent/test_860_dedup.py tests/run_agent/test_tool_call_incremental_persistence.py tests/run_agent/test_turn_completion_explainer.py -q -o addopts=` — 25 passed
- `pytest tests/agent/test_compression_concurrent_fork.py tests/test_hermes_state_compression_busy_retry.py tests/hermes_state/test_append_messages_batch.py tests/hermes_state -q -o addopts=` — 99 passed
- `pytest tests/gateway/test_session.py tests/agent/test_turn_finalizer_final_response_persistence.py -q -o addopts=` — 64 passed
- `ruff check hermes_state.py run_agent.py agent/conversation_loop.py agent/turn_finalizer.py tests/run_agent/test_compression_closed_flush_reroute.py tests/run_agent/test_tool_call_incremental_persistence.py tests/hermes_state/test_append_messages_batch.py`
- `git diff --cached --check`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched existing PRs for overlap
- [x] The PR contains only changes related to this fix
- [x] Tests cover the new behavior
- [x] Tested on Linux

### Documentation & Housekeeping

- [x] Documentation update is not required for this internal persistence behavior
- [x] No configuration keys or tool schemas changed
- [x] Cross-platform behavior was considered; the change is SQLite/session logic only

## Agent Disclosure

Created with Hermes Agent under direct human instruction and reviewed before submission.
