### PR TITLE
docs(web): correct Brave Search API pricing in brave-free provider

### DIFF
--- a/plugins/web/brave_free/__init__.py
+++ b/plugins/web/brave_free/__init__.py
@@ -1,4 +1,4 @@
-"""Brave Search (free tier) plugin — bundled, auto-loaded.
+"""Brave Search plugin — bundled, auto-loaded.
 
 Mirrors the ``plugins/image_gen/openai/`` layout: ``provider.py`` holds the
 provider class, ``__init__.py::register(ctx)`` registers an instance.
@@ -10,5 +10,5 @@ from plugins.web.brave_free.provider import BraveFreeWebSearchProvider
 
 
 def register(ctx) -> None:
-    """Register the Brave-free provider with the plugin context."""
+    """Register the Brave provider with the plugin context."""
     ctx.register_web_search_provider(BraveFreeWebSearchProvider())

--- a/plugins/web/brave_free/plugin.yaml
+++ b/plugins/web/brave_free/plugin.yaml
@@ -1,6 +1,6 @@
 name: web-brave-free
 version: 1.0.0
-description: "Brave Search (free tier) — web search via Brave's Data-for-Search API. Requires BRAVE_SEARCH_API_KEY (free signup at https://brave.com/search/api/, 2k queries/month)."
+description: "Brave Search — web search via Brave's Data-for-Search API. Paid usage-based API (USD $5 per 1,000 requests) with a small monthly credit trial that requires a credit card. Signup: https://brave.com/search/api/. Search only."
 author: NousResearch
 kind: backend
 provides_web_providers:

--- a/plugins/web/brave_free/provider.py
+++ b/plugins/web/brave_free/provider.py
@@ -1,4 +1,4 @@
-"""Brave Search (free tier) — plugin form.
+"""Brave Search — plugin form.
 
 Subclasses :class:`agent.web_search_provider.WebSearchProvider` (the
 plugin-facing ABC). The legacy in-tree module
@@ -14,7 +14,7 @@ Config keys this provider responds to::
 
 Auth env var::
 
-    BRAVE_SEARCH_API_KEY=...    # https://brave.com/search/api/ (free tier)
+    BRAVE_SEARCH_API_KEY=...    # https://brave.com/search/api/ (paid API, card required)
 """
 
 from __future__ import annotations
@@ -31,10 +31,11 @@ _BRAVE_ENDPOINT = "https://api.search.brave.com/res/v1/web/search"
 
 
 class BraveFreeWebSearchProvider(WebSearchProvider):
-    """Search-only Brave provider using the free-tier Data-for-Search API.
+    """Search-only Brave provider using Brave's Data-for-Search API.
 
-    Free tier is 2,000 queries/month (1 qps). No content-extraction capability —
-    users pair this with Firecrawl/Tavily/Exa for ``web_extract``.
+    Brave's API is paid (USD $5 per 1,000 requests; the provider id
+    ``brave-free`` is legacy). No content-extraction capability — users
+    pair this with Firecrawl/Tavily/Exa for ``web_extract``.
     """
 
     @property
@@ -45,7 +46,7 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
 
     @property
     def display_name(self) -> str:
-        return "Brave Search (Free)"
+        return "Brave Search"
 
     def is_available(self) -> bool:
         """Return True when ``BRAVE_SEARCH_API_KEY`` is set to a non-empty value."""
@@ -128,13 +129,13 @@ class BraveFreeWebSearchProvider(WebSearchProvider):
 
     def get_setup_schema(self) -> Dict[str, Any]:
         return {
-            "name": "Brave Search (Free)",
-            "badge": "free",
-            "tag": "Free-tier API key — 2k queries/mo, search only.",
+            "name": "Brave Search",
+            "badge": "paid",
+            "tag": "Paid API — USD $5 per 1,000 requests; credit card required at signup. Search only.",
             "env_vars": [
                 {
                     "key": "BRAVE_SEARCH_API_KEY",
-                    "prompt": "Brave Search API key (free tier)",
+                    "prompt": "Brave Search API key",
                     "url": "https://brave.com/search/api/",
                 },
             ],

--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -1,4 +1,4 @@
-"""Tests for the Brave Search (free tier) web search provider.
+"""Tests for the Brave Search web search provider.
 
 Covers:
 - BraveFreeWebSearchProvider.is_available() env var gating


### PR DESCRIPTION
## What

The bundled `brave-free` web search provider still describes a free tier that no longer exists: plugin manifest ("free signup at https://brave.com/search/api/, 2k queries/month"), module/class docstrings ("Free tier is 2,000 queries/month"), display name "Brave Search (Free)", and the `hermes tools` picker schema (`badge: free`, "Free-tier API key").

Brave's Data-for-Search API is now paid: **USD $5 per 1,000 requests**, with a $5 monthly credit trial that **requires a credit card at signup** (confirmed on the live pricing page, 2026-08-05 — their FAQ even addresses "Why is a credit card required to subscribe to a free plan?").

## Why

Users setting up search get told a free tier exists, sign up expecting it, and either hit a card wall or a surprise invoice after the credit trial. The docs actively mislead; this fixes the whole class of stale "free tier" claims in the plugin (manifest + docstrings + display name + setup schema).

## Scope

- `plugins/web/brave_free/plugin.yaml` — description
- `plugins/web/brave_free/provider.py` — module docstring, auth-var comment, class docstring, `display_name`, `get_setup_schema` (name/badge/tag/prompt)
- `plugins/web/brave_free/__init__.py` — module + register docstrings
- `tests/tools/test_web_providers_brave_free.py` — module docstring

**Backward compatibility preserved:** the provider id `brave-free` and the class name `BraveFreeWebSearchProvider` are unchanged (existing `web.search_backend: "brave-free"` configs keep working). This is a docs/UX fix only — no behavior change.

## Verification

- `grep` for stale terms across the plugin: clean.
- `py_compile` on both modules: OK.
- Adjacent test suites: `tests/tools/test_web_providers_brave_free.py` + `tests/tools/test_web_tools_config.py` → 46 passed, 2 pre-existing failures in `TestParallelClientConfig` (missing Parallel SDK in the local venv — unrelated `ImportError`).
