### PR TITLE
fix(cron): stamp session cwd from configured workdir (#79623)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -71,13 +71,28 @@ def _launch_cwd_for_session(source: str) -> Optional[str]:
 
     Only local CLI sessions get a recorded cwd: the directory the process was
     launched from is meaningful for ``hermes -c`` / ``--resume`` (relaunch
-    where you left off). Gateway/cron/remote-backend sessions have no stable
-    host cwd to restore, so they record nothing.
+    where you left off). Gateway/remote-backend sessions have no stable host
+    cwd to restore, so they record nothing.
+
+    Cron sessions are the exception: a job with a configured ``workdir`` runs
+    its tools in that directory, and the scheduler pins it via the
+    ``_SESSION_CWD`` contextvar. Stamping it keeps ``sessions list --workspace``
+    and resume-to-workspace working for cron runs (#79623).
 
     ``TERMINAL_ENV`` is set by the CLI's config bridge (``load_cli_config``);
     a non-"local" backend (docker/ssh/modal/...) means the host cwd is
     irrelevant to the agent's tools, so we skip it there too.
     """
+    if source == "cron":
+        # Cron workdir is pinned by the scheduler via _SESSION_CWD.
+        try:
+            from agent.runtime_cwd import _session_cwd_override
+            cron_cwd = _session_cwd_override().strip()
+            if cron_cwd and Path(cron_cwd).is_dir():
+                return cron_cwd
+        except Exception:
+            pass
+        return None
     if source != "cli":
         return None
     backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()

--- a/tests/run_agent/test_cron_session_cwd.py
+++ b/tests/run_agent/test_cron_session_cwd.py
@@ -1,0 +1,63 @@
+"""Regression tests for cron session cwd provenance (#79623).
+
+Cron jobs run with a configured ``workdir`` (pinned via the ``_SESSION_CWD``
+contextvar), but the durable ``sessions`` row left ``cwd`` NULL because
+``_launch_cwd_for_session`` only stamped local CLI sessions. This broke
+``hermes sessions list --workspace`` and resume-to-workspace for cron runs.
+"""
+
+import os
+
+import pytest
+
+import run_agent
+from agent.runtime_cwd import _SESSION_CWD, set_session_cwd
+
+
+def _with_session_cwd(cwd, fn):
+    """Run ``fn`` with the _SESSION_CWD contextvar pinned to ``cwd``."""
+    token = set_session_cwd(cwd)
+    try:
+        return fn()
+    finally:
+        _SESSION_CWD.reset(token)
+
+
+class TestCronCwdProvenance:
+    def test_cron_session_stamps_configured_workdir(self, tmp_path, monkeypatch):
+        """A cron job with a configured workdir records it as the session cwd."""
+        monkeypatch.setattr(os, "getcwd", lambda: "/unrelated/launch-dir")
+
+        def _call():
+            return run_agent._launch_cwd_for_session("cron")
+
+        result = _with_session_cwd(str(tmp_path), _call)
+        assert result == str(tmp_path)
+
+    def test_cron_without_workdir_records_none(self, monkeypatch):
+        """A cron job with no workdir records nothing (unchanged)."""
+
+        def _call():
+            return run_agent._launch_cwd_for_session("cron")
+
+        result = _with_session_cwd("", _call)
+        assert result is None
+
+    def test_cron_missing_workdir_records_none(self, tmp_path, monkeypatch):
+        """A configured workdir that no longer exists records nothing."""
+        missing = str(tmp_path / "does-not-exist")
+
+        def _call():
+            return run_agent._launch_cwd_for_session("cron")
+
+        result = _with_session_cwd(missing, _call)
+        assert result is None
+
+    def test_cli_still_records_launch_cwd(self, tmp_path, monkeypatch):
+        """CLI behavior is unchanged: records os.getcwd()."""
+        monkeypatch.setattr(os, "getcwd", lambda: str(tmp_path))
+        assert run_agent._launch_cwd_for_session("cli") == str(tmp_path)
+
+    def test_gateway_still_records_none(self, monkeypatch):
+        """Gateway behavior is unchanged: records nothing."""
+        assert run_agent._launch_cwd_for_session("telegram") is None


### PR DESCRIPTION
## Fix: stamp cron session cwd from configured workdir (#79623)

### What
Cron jobs run with a configured `workdir` (pinned via the `_SESSION_CWD`
contextvar), but the durable `sessions` row left `cwd`, `git_repo_root`, and
`git_branch` all NULL — so `hermes sessions list --workspace <repo>` returned
`No sessions found` for cron runs even though the job's terminal/read_file
calls executed in the repo.

Root cause: `run_agent.py::_launch_cwd_for_session()` deliberately stamps
`cwd` only for `source == "cli"` (gateway/remote sessions have no stable
host cwd). Cron is the exception — a job with a configured workdir DOES have
a stable, meaningful cwd: the one the scheduler pins via `_SESSION_CWD`.

### Change
`_launch_cwd_for_session("cron")` now resolves the recorded cwd from the
`_SESSION_CWD` contextvar the scheduler sets, falling back to `None` when no
workdir is configured or it no longer exists. CLI and gateway behavior
unchanged.

### Proof
- `tests/run_agent/test_cron_session_cwd.py` (5 tests): workdir test **fails
  on old code** (cron cwd None — the bug), passes with the fix; the other 4
  behavior-preservation tests pass both ways.
- Full suite: 11 tests green (incl. `tests/agent/test_runtime_cwd.py`).

### Notes
- `git_repo_root`/`git_branch` remain the CLI's responsibility (recorded at
  session-create by callers that know the repo); this fix makes cron's `cwd`
  correct, which is what `--workspace` filters on.
