### PR TITLE
fix(serve): make ws keepalive ping configurable (#79635)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1465,6 +1465,17 @@ DEFAULT_CONFIG = {
         # falls through to request reconstruction rather than breaking
         # the login flow.
         "public_url": "",
+        # WebSocket keepalive ping tuning (seconds). ``ws_ping_interval`` /
+        # ``ws_ping_timeout`` control uvicorn's protocol-level ping for the
+        # desktop/dashboard WS connection. The default ``"auto"`` preserves
+        # the historical behavior: ping disabled on loopback (None) so an
+        # event-loop stall can never false-disconnect, 20s/20s on public
+        # binds (Cloudflare Tunnel half-open detection). Set both keys to a
+        # number (e.g. 60 for a direct Tailscale/WireGuard mesh, which has
+        # no proxy idle window) to override; set to ``None`` explicitly to
+        # disable the keepalive ping entirely (#79635).
+        "ws_ping_interval": "auto",
+        "ws_ping_timeout": "auto",
     },
 
     # Privacy settings

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17813,6 +17813,23 @@ def start_server(
     # ping at 20/20 to detect it promptly and stay under the tunnel's idle
     # window.
     _is_loopback = host in ("127.0.0.1", "localhost", "::1")
+    # ws keepalive tuning (#79635): defaults preserve today's behavior
+    # (disabled on loopback, 20s/20s elsewhere for Cloudflare Tunnel paths),
+    # but a direct remote mesh (Tailscale, WireGuard) has no proxy idle
+    # window and benefits from a longer ping timeout. Configurable via
+    # dashboard.ws_ping_interval / dashboard.ws_ping_timeout (seconds, None
+    # disables the keepalive ping entirely).
+    try:
+        from hermes_cli.config import load_config as _load_cfg
+        _dash_cfg = (_load_cfg().get("dashboard") or {}) or {}
+        _ping_interval = _dash_cfg.get("ws_ping_interval", "unset")
+        _ping_timeout = _dash_cfg.get("ws_ping_timeout", "unset")
+    except Exception:
+        _ping_interval = _ping_timeout = "unset"
+    if _ping_interval == "unset":
+        _ping_interval = None if _is_loopback else 20.0
+    if _ping_timeout == "unset":
+        _ping_timeout = None if _is_loopback else 20.0
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees
@@ -17827,8 +17844,8 @@ def start_server(
         # disables the protocol ping (None) so an event-loop stall can never
         # trigger a false disconnect; a genuinely dead local client is still
         # reaped via the WebSocketDisconnect → disconnect/reap path.
-        ws_ping_interval=None if _is_loopback else 20.0,
-        ws_ping_timeout=None if _is_loopback else 20.0,
+        ws_ping_interval=_ping_interval,
+        ws_ping_timeout=_ping_timeout,
         ws_max_size=_DESKTOP_ATTACHMENT_WS_MAX_BYTES,
     )
     server = uvicorn.Server(config)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17822,14 +17822,30 @@ def start_server(
     try:
         from hermes_cli.config import load_config as _load_cfg
         _dash_cfg = (_load_cfg().get("dashboard") or {}) or {}
-        _ping_interval = _dash_cfg.get("ws_ping_interval", "unset")
-        _ping_timeout = _dash_cfg.get("ws_ping_timeout", "unset")
+        _ping_interval = _dash_cfg.get("ws_ping_interval", "auto")
+        _ping_timeout = _dash_cfg.get("ws_ping_timeout", "auto")
     except Exception:
-        _ping_interval = _ping_timeout = "unset"
-    if _ping_interval == "unset":
+        _ping_interval = _ping_timeout = "auto"
+
+    def _coerce_ping(value):
+        # Defensive coercion: hand-edited YAML may quote the number
+        # ("60"), which uvicorn would pass to loop.call_later as a str
+        # and crash the ping loop. Accept int/float/numeric-str; any
+        # other value (incl. explicit None) falls through untouched so
+        # "None disables ping" keeps working (#79635).
+        if isinstance(value, str) and value.strip():
+            try:
+                return float(value)
+            except ValueError:
+                return value
+        return value
+
+    if _ping_interval == "auto":
         _ping_interval = None if _is_loopback else 20.0
-    if _ping_timeout == "unset":
+    if _ping_timeout == "auto":
         _ping_timeout = None if _is_loopback else 20.0
+    _ping_interval = _coerce_ping(_ping_interval)
+    _ping_timeout = _coerce_ping(_ping_timeout)
     config = uvicorn.Config(
         app, host=host, port=port, log_level="warning",
         # proxy_headers defaults to False so _ws_client_is_allowed sees

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -180,6 +180,39 @@ def test_start_server_config_override_can_disable_ping(monkeypatch):
     assert captured["ws_ping_timeout"] is None
 
 
+def test_start_server_auto_default_preserves_historical_behavior(monkeypatch):
+    """#79635: the DEFAULT_CONFIG 'auto' sentinel keeps the historical
+    loopback-disable / public-20s behavior, so adding the keys to
+    DEFAULT_CONFIG doesn't change anything for existing users."""
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setattr(web_server, "should_require_auth", lambda *a, **k: False)
+    # Simulate the merged config with the 'auto' defaults in place.
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"dashboard": {"ws_ping_interval": "auto", "ws_ping_timeout": "auto"}},
+    )
+
+    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+    assert captured["ws_ping_interval"] == 20.0
+    assert captured["ws_ping_timeout"] == 20.0
+
+
+def test_start_server_coerces_quoted_numeric_ping(monkeypatch):
+    """#79635: hand-edited YAML with quoted numbers ("60") must not crash
+    uvicorn's ping loop — coerce numeric strings to float at the boundary."""
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setattr(web_server, "should_require_auth", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"dashboard": {"ws_ping_interval": "60", "ws_ping_timeout": "90"}},
+    )
+
+    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 60.0
+    assert captured["ws_ping_timeout"] == 90.0
+
+
 @pytest.mark.windows_only
 def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):
     """The dashboard/desktop backend must serve uvicorn on the loop *uvicorn*

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -147,6 +147,39 @@ def test_start_server_enables_ws_ping_for_half_open_detection(monkeypatch):
     assert captured["ws_ping_timeout"] >= captured["ws_ping_interval"]
 
 
+def test_start_server_honors_config_ws_ping_override(monkeypatch):
+    """#79635: dashboard.ws_ping_interval/timeout in config.yaml override the
+    hardcoded non-loopback 20s/20s (Tailscale/direct-mesh remote binds need a
+    longer window than Cloudflare-Tunnel-only 20s)."""
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setattr(web_server, "should_require_auth", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"dashboard": {"ws_ping_interval": 60.0, "ws_ping_timeout": 90.0}},
+    )
+
+    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] == 60.0
+    assert captured["ws_ping_timeout"] == 90.0
+
+
+def test_start_server_config_override_can_disable_ping(monkeypatch):
+    """#79635: an explicit None in config disables the keepalive even on a
+    non-loopback bind (user opts out of half-open detection)."""
+    captured = _stub_uvicorn(monkeypatch)
+    monkeypatch.setattr(web_server, "should_require_auth", lambda *a, **k: False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"dashboard": {"ws_ping_interval": None, "ws_ping_timeout": None}},
+    )
+
+    web_server.start_server(host="0.0.0.0", port=0, open_browser=False)
+
+    assert captured["ws_ping_interval"] is None
+    assert captured["ws_ping_timeout"] is None
+
+
 @pytest.mark.windows_only
 def test_start_server_runs_on_uvicorns_loop_factory(monkeypatch):
     """The dashboard/desktop backend must serve uvicorn on the loop *uvicorn*


### PR DESCRIPTION
## Fix: make ws keepalive ping configurable (#79635)

### What
Remote Desktop → `hermes serve` over Tailscale (direct WireGuard, no
Cloudflare Tunnel) hit hardcoded `ws_ping_interval=20.0` / `ws_ping_timeout=20.0`
on every non-loopback bind. A brief latency blip or busy client event loop
overruns the 20s timeout → uvicorn drops the socket (1006) → session detaches
and gets reaped as `ws_orphan_reap` → "session not found" on the next thread
click. No config knob existed.

### Change
`hermes_cli/web_server.py` now reads `dashboard.ws_ping_interval` /
`dashboard.ws_ping_timeout` from `config.yaml` (seconds; explicit `None`
disables the keepalive). **Defaults preserve today's behavior exactly**
(None on loopback, 20/20 on non-loopback), so nothing changes for existing
users — Tailscale/mesh users can now set e.g. 60/90.

### Proof
- `tests/test_web_server.py` — 2 new tests:
  - `test_start_server_honors_config_ws_ping_override` — **fails on old
    code** (hardcoded 20/20 ignored config), passes with the fix.
  - `test_start_server_config_override_can_disable_ping` — explicit None
    disables the keepalive on a non-loopback bind.
  - Existing loopback-disable + public-bind-enable invariants unchanged.
- Full file: 8 tests green.

### Notes
- The relaxed-default option (raise non-loopback to 60s) was deliberately
  NOT taken — changing the default for Cloudflare-Tunnel users without
  evidence would trade one failure mode for another. Config knob first.
