### PR TITLE
perf(tests): cut test_hermes_state.py 52s -> 10s (the suite's LPT floor) — dead sleeps, not work

### DIFF
--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -78,6 +78,24 @@ def db(tmp_path):
     session_db.close()
 
 
+@pytest.fixture(autouse=True)
+def _no_fts_rebuild_throttle(monkeypatch):
+    """Zero the FTS-rebuild inter-chunk throttle for every test in this file.
+
+    ``optimize_fts_storage`` sleeps ``max(_FTS_REBUILD_MIN_PAUSE,
+    chunk_cost * _FTS_REBUILD_DUTY_FACTOR)`` between chunks so a LIVE
+    gateway/CLI sharing the DB isn't starved of the write lock. Tests run
+    against a private tmp-path DB with no concurrent process — the sleep
+    protects nobody and was pure dead time (measured: 4.1s of a 4.6s
+    migration test was time.sleep; ~20s across the file, whose total was
+    ~52s). The duty-cycle POLICY (sleep >= 4x chunk cost) stays covered by
+    the production constants themselves; no test asserts on wall-clock
+    pacing.
+    """
+    monkeypatch.setattr(SessionDB, "_FTS_REBUILD_MIN_PAUSE", 0.0)
+    monkeypatch.setattr(SessionDB, "_FTS_REBUILD_DUTY_FACTOR", 0.0)
+
+
 # =========================================================================
 # Connection lifecycle
 # =========================================================================
@@ -3564,8 +3582,19 @@ class TestGetMessagesPagination:
 
     def _seed(self, db, n=10):
         db.create_session(session_id="s1", source="cli")
-        for i in range(n):
-            db.append_message("s1", "user" if i % 2 == 0 else "assistant", f"msg-{i}")
+        # One write transaction for the whole seed: per-row append_message
+        # pays a commit (and, off WAL, an fsync) per message, which at
+        # n=3000 was ~10s of pure seeding before the query under test ran.
+        db.append_messages_batch(
+            "s1",
+            [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"msg-{i}",
+                }
+                for i in range(n)
+            ],
+        )
 
     def test_default_returns_all_messages(self, db):
         self._seed(db)


### PR DESCRIPTION
## What this does, concretely

`tests/test_hermes_state.py` is the slowest file in the suite (46.7s in CI's durations cache). Because the per-file runner's isolation unit is the file, it sets the floor for test-slice balancing: no slice can finish faster than this file, which caps how far slicing wider (#79735) can cut the merge-gate critical path. This PR drops it to ~10s **without touching production code or weakening any assertion** — and lowers the whole suite's LPT floor to the next-slowest file.

## Where the 42s actually went (profiled, not guessed)

**1. `time.sleep` — ~20s.** cProfile on one 4.6s migration test: 4.1s inside `optimize_fts_storage`'s inter-chunk throttle (`_pause` -> `time.sleep`). The throttle exists so a LIVE gateway/CLI sharing the DB isn't starved of the write lock (sleep >= 4x chunk cost). Tests run against a private tmp-path DB with no concurrent process — the sleep protects nobody. New autouse fixture zeroes `_FTS_REBUILD_MIN_PAUSE` / `_FTS_REBUILD_DUTY_FACTOR` for this file. No test asserts on wall-clock pacing, so nothing weakens.

**2. Per-row seeding — ~10s.** `TestGetMessagesPagination._seed` appended 3000 messages one `append_message` at a time = one commit (and off WAL, one fsync) per row, before the query under test even ran. Switched to `append_messages_batch` — one write transaction; the API whose own docstring exists for exactly this shape.

## The perf contract still discriminates

The n=3000 seed feeds `test_window_query_bounded_work`, a behavior-contract test (progress-handler VM steps, threshold 300). Re-measured after batch seeding:

```
indexed path:  11 steps   (was ~12 in the docstring's calibration)
forced scan:  855 steps   (index dropped)
threshold:    300         (unchanged — >25x headroom, ~3x below scan)
```

## Measured

```
before: 187 passed in 51.8s
after:  187 passed in 9.1-16.1s  (3 runs + canonical scripts/run_tests.sh: 14.9s)
```

Zero production code touched; 187 tests before and after; test count and every assertion unchanged.

## Relation to other PRs

Follow-up to #79735 (12 slices): with this floor gone, 16 slices becomes worth revisiting once the durations cache refreshes. Independent of #79745.