### PR TITLE
fix(cli): registered slash commands win over same-named files in file-drop detection

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3373,6 +3373,35 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
 
 
 
+def _is_registered_slash_command(token: str) -> bool:
+    """Return True when *token* names a registered slash command.
+
+    Guards :func:`_detect_file_drop` against filesystem files that collide
+    with command names — most notably WSL2's ``/init`` (the WSL init daemon
+    binary), which made ``/init <notes>`` attach the binary instead of
+    dispatching the /init command added in v0.20 (see #79765). Only bare
+    unquoted single-segment tokens are considered: quoted input is an
+    explicit file-attach intent, and a multi-slash token is a real path
+    (``/home/me/init`` must still attach).
+    """
+    if not token or not token.startswith("/"):
+        return False
+    rest = token[1:]
+    if not rest or "/" in rest:
+        return False
+    try:
+        # Lazy import: cli.py is imported very early at startup, and
+        # hermes_cli.commands pulls in the full CommandDef registry — keep
+        # it out of cli's module-import path (startup cost / cycle guard).
+        from hermes_cli.commands import resolve_command
+
+        return resolve_command(token) is not None
+    except Exception:
+        # Fail closed: if the registry is unavailable, never let a file
+        # drop hijack input that may be a command.
+        return False
+
+
 def _detect_file_drop(user_input: str) -> "dict | None":
     """Detect if *user_input* starts with a real local file path.
 
@@ -3418,6 +3447,11 @@ def _detect_file_drop(user_input: str) -> "dict | None":
 
     direct_path = _resolve_attachment_path(stripped)
     if direct_path is not None:
+        # A registered slash command wins over an existing file with the
+        # same name — on WSL2 `/init` is a real binary, so `/init` used to
+        # be attached as a file instead of dispatching the command (#79765).
+        if _is_registered_slash_command(stripped):
+            return None
         return {
             "path": direct_path,
             "is_image": direct_path.suffix.lower() in _IMAGE_EXTENSIONS,
@@ -3426,6 +3460,8 @@ def _detect_file_drop(user_input: str) -> "dict | None":
 
     first_token, remainder = _split_path_input(stripped)
     drop_path = _resolve_attachment_path(first_token)
+    if drop_path is not None and _is_registered_slash_command(first_token):
+        return None
     if drop_path is None and " " in stripped and stripped[0] not in {"'", '"'}:
         space_positions = [idx for idx, ch in enumerate(stripped) if ch == " "]
         for pos in reversed(space_positions):

--- a/tests/cli/test_cli_file_drop.py
+++ b/tests/cli/test_cli_file_drop.py
@@ -2,10 +2,12 @@
 dragged/pasted absolute paths from being mistaken for slash commands."""
 
 import os
+from pathlib import Path
 
 import pytest
 
-from cli import _detect_file_drop
+import cli
+from cli import _detect_file_drop, _is_registered_slash_command
 
 
 # ---------------------------------------------------------------------------
@@ -180,6 +182,82 @@ class TestEscapedSpaces:
 
         assert result is not None
         assert result["path"] == image
+
+
+# ---------------------------------------------------------------------------
+# Tests: registered slash command vs. existing file collision
+# ---------------------------------------------------------------------------
+
+class TestRegisteredCommandCollision:
+    """A registered slash command must never be swallowed as a file drop,
+    even when a real file with that name exists. WSL2 ships a binary at
+    /init, so `/init <notes>` used to attach the WSL init daemon instead
+    of dispatching the /init command added in v0.20 (see #79765)."""
+
+    @pytest.fixture()
+    def wsl_init_collision(self, monkeypatch):
+        """Simulate a WSL2 host where `/init` exists as a real file."""
+        real_resolve = cli._resolve_attachment_path
+        fake_init = Path("/init")
+
+        def fake_resolve(raw_path):
+            token = str(raw_path or "").strip()
+            if token in ("/init", '"/init"', "'/init'"):
+                return fake_init
+            return real_resolve(token)
+
+        monkeypatch.setattr("cli._resolve_attachment_path", fake_resolve)
+        return fake_init
+
+    def test_bare_init_dispatches_command(self, wsl_init_collision):
+        assert _detect_file_drop("/init") is None
+
+    def test_init_with_notes_dispatches_command(self, wsl_init_collision):
+        assert _detect_file_drop("/init focus on the test setup") is None
+
+    def test_init_with_trailing_text_dispatches_command(self, wsl_init_collision):
+        assert _detect_file_drop("/init 核实agent.md内容") is None
+
+    def test_quoted_init_explicitly_attaches(self, wsl_init_collision):
+        result = _detect_file_drop('"/init"')
+        assert result is not None
+        assert result["path"] == wsl_init_collision
+        assert result["remainder"] == ""
+
+    def test_other_registered_command_collision(self, monkeypatch):
+        """The guard is generic: any registered command wins over a file
+        that shares its name (e.g. /version), not just /init."""
+        fake_version = Path("/version")
+        monkeypatch.setattr(
+            "cli._resolve_attachment_path",
+            lambda p: fake_version if str(p).strip() == "/version" else None,
+        )
+        assert _detect_file_drop("/version") is None
+
+    def test_multi_component_path_named_init_still_attaches(self, tmp_path):
+        """A real multi-slash path ending in `init` is unaffected — it is
+        not a bare command token, so it still attaches."""
+        f = tmp_path / "init"
+        f.write_text("not the wsl binary\n")
+        result = _detect_file_drop(f"{f} 看看")
+        assert result is not None
+        assert result["path"] == f
+        assert result["remainder"] == "看看"
+
+
+class TestIsRegisteredSlashCommand:
+    def test_registered_command(self):
+        assert _is_registered_slash_command("/init") is True
+        assert _is_registered_slash_command("/help") is True
+
+    def test_real_path_and_quoted_tokens(self):
+        assert _is_registered_slash_command("/home/me/init") is False
+        assert _is_registered_slash_command('"/init"') is False
+        assert _is_registered_slash_command("~/init") is False
+        assert _is_registered_slash_command("") is False
+
+    def test_unregistered_single_segment(self):
+        assert _is_registered_slash_command("/nonexistentcmd") is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #79765 — on WSL2, the `/init` slash command (added in v0.20) never dispatches: the CLI's `_detect_file_drop` runs **before** slash-command routing and treats `/init` as a dragged/pasted file, because `/init` is a **real file** on WSL2 (the WSL init daemon binary at the filesystem root). The user turn becomes `[User attached file: /init] ...` and the command never fires. The same helper backs the TUI file-drop path (`tui_gateway/methods_prompt.py`), so the TUI is affected identically.

## Fix

`_detect_file_drop` now consults the command registry before treating a leading token as an attachment:

- New helper `_is_registered_slash_command(token)` — true only for bare, unquoted, single-segment tokens that resolve via `hermes_cli.commands.resolve_command` (covers every registered command **and alias**, not just `/init`).
- Guarded both the direct-path branch and the first-token branch of `_detect_file_drop`.
- Quoted input (`"/init"`) is an explicit attach intent and still attaches; multi-slash real paths (`/home/me/init`) still attach.

## Behavior

| Input | Before (WSL2) | After |
|---|---|---|
| `/init` | `[User attached file: /init]` | `/init` command dispatches |
| `/init <notes>` | attaches binary + sends notes as text | `/init` command dispatches with notes |
| `"/init"` | attaches | attaches (unchanged) |
| `/home/me/init` | attaches | attaches (unchanged) |
| `/version` (if a file of that name existed) | attached as file | dispatches as command |

## Tests

Added `TestRegisteredCommandCollision` + `TestIsRegisteredSlashCommand` to `tests/cli/test_cli_file_drop.py` (simulate the WSL2 `/init` collision via a patched `_resolve_attachment_path`, so they're deterministic on any host). All 31 tests in the file pass; full `tests/cli/` suite (935 tests) passes; `ruff check` clean; verified live on WSL2 against the real `/init` binary.