### PR TITLE
docs(skills): document the kill-locks feature package and its tracker interlock

### DIFF
--- a/contributors/emails/andrexibiza@gmail.com
+++ b/contributors/emails/andrexibiza@gmail.com
@@ -1,0 +1,1 @@
+andrexibiza

--- a/scripts/audit_kill_locks.py
+++ b/scripts/audit_kill_locks.py
@@ -28,7 +28,9 @@ PR_TOKEN_RE = re.compile(r"#(\d{3,6})")
 
 
 def gh(args: list[str]) -> str:
-    r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=60)
+    r = subprocess.run(
+        ["gh", *args], capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=60
+    )
     if r.returncode != 0:
         raise RuntimeError(f"gh {' '.join(args)} failed: {r.stderr[:300]}")
     return r.stdout

--- a/scripts/audit_kill_locks.py
+++ b/scripts/audit_kill_locks.py
@@ -1,0 +1,229 @@
+"""KILL LOCK audit — issue linkage, PR linkage, dedup both directions, resolution convergence.
+
+The campaign-operations-kill-locks doctrine made enforceable. Mirrors what
+the kill-lock skill documents, as code: every shard PR binds its issues
+(keyword lines), every issue thread carries the literal #PR token, no
+duplicate PRs or issues hide in the cluster, and the whole graph converges
+toward resolutions (shipped PRs → close-ready issues).
+
+Invocation:
+    python scripts/audit_kill_locks.py --epic 78647            # live audit
+    python scripts/audit_kill_locks.py --epic 78647 --json out.json  # dump for tests
+
+The audit logic is pure (takes dicts) so the regression test in
+tests/scripts/test_audit_kill_locks.py exercises it offline with fixtures.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any, Iterable
+
+LINKING_KEYWORDS = ("fixes", "closes", "resolves", "part of")
+PR_TOKEN_RE = re.compile(r"#(\d{3,6})")
+
+
+def gh(args: list[str]) -> str:
+    r = subprocess.run(["gh", *args], capture_output=True, text=True, timeout=60)
+    if r.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {r.stderr[:300]}")
+    return r.stdout
+
+
+def pr_keyword_bindings(body: str) -> set[int]:
+    """Issue numbers a PR body binds via Fixes/Closes/Resolves/Part of.
+
+    The literal keyword line is the only reliable signal — a 'Related #N'
+    footer or a bare '#N' in prose does NOT bind (verified against GitHub's
+    cross-reference registry; only these keywords register).
+    """
+    bound: set[int] = set()
+    for line in body.splitlines():
+        low = line.strip().lower()
+        if not low.startswith(LINKING_KEYWORDS):
+            continue
+        for m in PR_TOKEN_RE.finditer(line):
+            bound.add(int(m.group(1)))
+    return bound
+
+
+def issue_thread_tokens(comments: Iterable[dict[str, Any]]) -> set[int]:
+    """Literal #PR tokens in an issue's comment thread (the audit greps these)."""
+    tokens: set[int] = set()
+    for c in comments:
+        body = c.get("body", "")
+        for m in PR_TOKEN_RE.finditer(body):
+            tokens.add(int(m.group(1)))
+    return tokens
+
+
+def dedup_issues(issues: list[dict[str, Any]]) -> list[tuple[int, int, str]]:
+    """Near-duplicate issues: same normalized title → (a, b, title)."""
+    from difflib import SequenceMatcher
+
+    dups: list[tuple[int, int, str]] = []
+    norm = [
+        (i["number"], re.sub(r"\s+", " ", i["title"]).strip().lower())
+        for i in issues
+    ]
+    for i in range(len(norm)):
+        for j in range(i + 1, len(norm)):
+            a, ta = norm[i]
+            b, tb = norm[j]
+            if a == b:
+                continue
+            ratio = SequenceMatcher(None, ta, tb).ratio()
+            if ratio > 0.85:
+                dups.append((a, b, norm[i][1][:80]))
+    return dups
+
+
+def dedup_prs(prs: list[dict[str, Any]]) -> list[tuple[int, int, str]]:
+    """Duplicate PRs: the SAME fix shipped twice.
+
+    A real duplicate ships the same issue's fix with the same title —
+    e.g. a worktree-session duplicate (#77179/#77181/#77185 class). A
+    slice series ('slice R1' vs 'slice R2') is NOT a duplicate even at
+    high title similarity: different slices, different windows.
+    """
+    dups: list[tuple[int, int, str]] = []
+    by_title: dict[str, list[int]] = {}
+    for p in prs:
+        title = re.sub(r"\s+", " ", p["title"]).strip().lower()
+        by_title.setdefault(title, []).append(p["number"])
+    for title, nums in by_title.items():
+        if len(nums) > 1:
+            a, b = nums[0], nums[1]
+            dups.append((a, b, title[:80]))
+    return dups
+
+
+def audit(
+    epic_body: str,
+    shard_issues: dict[int, str],          # issue -> title
+    issue_comments: dict[int, list[dict]], # issue -> comments
+    prs: list[dict[str, Any]],             # PR dicts with number/title/body/state/merged_at
+    *,
+    expected_keyword_issues: dict[int, set[int]] | None = None,
+) -> dict[str, Any]:
+    """Run the full kill-lock audit. Pure function — testable offline.
+
+    Returns a report dict with per-direction findings + verdicts.
+    """
+    report: dict[str, Any] = {
+        "pr_to_issue_holes": [],
+        "issue_to_pr_holes": [],
+        "issue_dups": [],
+        "pr_dups": [],
+        "unbound_prs": [],
+        "unresolved_shards": [],
+        "converged": [],
+        "verdict": "PASS",
+    }
+
+    pr_by_num = {p["number"]: p for p in prs}
+
+    # Direction 1: every PR binds its issues via keyword lines.
+    for p in prs:
+        body = p.get("body", "")
+        bound = pr_keyword_bindings(body)
+        if not bound:
+            report["unbound_prs"].append(p["number"])
+        report["pr_to_issue_holes"].append(
+            {"pr": p["number"], "bound": sorted(bound)}
+        )
+
+    # Direction 2: every issue thread carries the literal #PR token of
+    # every PR that binds it.
+    for issue, comments in issue_comments.items():
+        tokens = issue_thread_tokens(comments)
+        binding_prs = {
+            p["number"] for p in prs if issue in pr_keyword_bindings(p.get("body", ""))
+        }
+        missing = sorted(binding_prs - tokens)
+        if missing:
+            report["issue_to_pr_holes"].append({"issue": issue, "missing": missing})
+
+    # Dedup both directions.
+    report["issue_dups"] = dedup_issues(
+        [{"number": n, "title": t} for n, t in shard_issues.items()]
+    )
+    report["pr_dups"] = dedup_prs(prs)
+
+    # Resolution convergence: shipped (open, all shards done) PRs exist for
+    # every shard issue; the graph moves toward closure.
+    shipped = {p["number"] for p in prs if p.get("state") == "OPEN"}
+    for issue, title in shard_issues.items():
+        binding = {
+            p["number"] for p in prs if issue in pr_keyword_bindings(p.get("body", ""))
+        }
+        if not binding:
+            report["unresolved_shards"].append({"issue": issue, "title": title[:60]})
+        else:
+            report["converged"].append({"issue": issue, "prs": sorted(binding)})
+
+    # Verdict: any hole in either direction, any dup, any unresolved shard.
+    if (
+        report["issue_to_pr_holes"]
+        or report["pr_dups"]
+        or report["issue_dups"]
+        or report["unresolved_shards"]
+    ):
+        report["verdict"] = "HOLES"
+
+    return report
+
+
+def fetch_epic_surface(epic: int, repo: str) -> dict[str, Any]:
+    """Live fetch: epic body, its shard issues, their comments, and bound PRs."""
+    epic_body = gh(["issue", "view", str(epic), "--repo", repo, "--json", "body", "--jq", ".body"])
+
+    issues_json = gh(
+        ["issue", "list", "--repo", repo, "--search", f"related:{epic}", "--json", "number,title,state", "--limit", "200"]
+    )
+    issues = json.loads(issues_json)
+    shard_issues = {i["number"]: i["title"] for i in issues}
+
+    issue_comments: dict[int, list[dict]] = {}
+    for n in list(shard_issues)[:50]:  # cap for CI speed
+        try:
+            c = gh(["api", f"repos/{repo}/issues/{n}/comments", "--jq", ".[] | {body}"])
+            issue_comments[n] = json.loads(c) if c.strip() else []
+        except RuntimeError:
+            issue_comments[n] = []
+
+    prs_json = gh(["pr", "list", "--repo", repo, "--search", f"related:{epic}", "--json", "number,title,body,state,mergedAt", "--limit", "100"])
+    prs = json.loads(prs_json)
+
+    return {"epic": epic, "epic_body": epic_body, "shard_issues": shard_issues,
+            "issue_comments": issue_comments, "prs": prs}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="KILL LOCK audit")
+    ap.add_argument("--epic", type=int, required=True)
+    ap.add_argument("--repo", default="NousResearch/hermes-agent")
+    ap.add_argument("--json", dest="json_out", help="dump the fetched surface to a file")
+    args = ap.parse_args()
+
+    surface = fetch_epic_surface(args.epic, args.repo)
+    if args.json_out:
+        with open(args.json_out, "w", encoding="utf-8") as fh:
+            json.dump(surface, fh, indent=1, default=str)
+
+    report = audit(
+        surface["epic_body"],
+        surface["shard_issues"],
+        surface["issue_comments"],
+        surface["prs"],
+    )
+    print(json.dumps(report, indent=1, default=str))
+    return 0 if report["verdict"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/github/campaign-operations-kill-locks/SKILL.md
+++ b/skills/github/campaign-operations-kill-locks/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: campaign-operations-kill-locks
+description: "Use when running god-file kill campaigns: post and maintain per-godfile KILL LOCKS interlocked to the Kill-All-Gods meta-issue."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [campaign, godfile, kill-lock, interlock, meta-issue, governance]
+    related_skills: [campaign-primitives, pr-conquest, worktree-pr-campaigns, github-traceability-audit]
+---
+
+# Campaign Operations — Kill Locks
+
+## Overview
+
+A god-file kill campaign ships shard PRs, but shards alone do not make a kill
+**remembered**. Every god-file gets a permanent **KILL LOCK**: a machine-verifiable
+record posted on its per-file issue that binds — in both directions — the former
+whole (line count, what it was), the mess it caused (every problem issue), every
+shard that killed it (all PRs), and every open fixer PR still fighting the
+surface. Every lock anchors to the campaign meta-issue (the Kill-All-Gods epic),
+which indexes all locks. The rule: **never let them forget how bad it used to be.**
+
+This is the operation layer for god-file conquests: what to post, when, where,
+and how to keep it current. It pairs with `campaign-primitives` (the 20 locked
+primitives) and `pr-conquest` (issue/PR interlock mechanics).
+
+## When to Use
+
+- Launching or running a god-file kill campaign (web_server, tui_gateway/server,
+  cli.py, platform adapters, run.py, etc.)
+- Axl says "lock it", "interlock", "never let them forget", or "kill all gods"
+- Posting a kill scoreboard, updating an epic's status table, or auditing a
+  campaign's PR↔issue↔lock graph
+- Onboarding a new shard PR so it carries its lock link
+
+Don't use for: single bug-fix PRs outside a god-file campaign (plain
+`Fixes #N` interlock suffices); issue triage with no decomposition.
+
+## The Kill Lock — canonical shape
+
+Post the lock as a comment on the god-file's **per-file shard issue** (e.g.
+#78628 for web_server.py) at **kill-start** (before any shard is cut), then
+update it as shards ship. Required sections:
+
+```
+## 🔒 KILL LOCK — <file path> (<peak line count> lines) [— IN PROGRESS / complete]
+
+**Anchored to Kill All Gods meta-issue: #<epic>.** Permanent record: shards,
+mess, fixers.
+
+### The former whole
+One <N>-line file carrying <surface>. The mess it caused:
+- <#issue> — <symptom> (problem issue, with link)
+- <more issues — the bug classes, stalls, security holes the monolith bred>
+
+### The kill — <N> shards, one wave, all double-blind reviewed
+| PR | Slice | Module |
+|---|---|---|
+| #<pr> | <slice id> | <module> |
+
+### The mess-fixers (all open PRs still fighting this surface)
+#<pr1> #<pr2> ... (full roster — pulled from `gh pr list --search '<file>'`)
+
+### Lock chain (both ways)
+- Every shard PR above references this lock and #<epic>
+- This lock references every issue and every PR listed above
+- The Kill All Gods meta-issue #<epic> indexes this lock
+```
+
+The lock's problem-issue list is the **"how bad it used to be"** record — pull
+real issues (`gh search issues --repo O/R '<file> adapter'`) and real PRs
+(`gh pr list --repo O/R --state open --search '<file>'`), never invented ones.
+Exact counts only.
+
+## The meta-index (Kill-All-Gods epic)
+
+The campaign meta-issue carries an index of every lock:
+
+```
+## 🔒 KILL LOCKS — index (anchored here, the Kill All Gods meta-issue)
+
+| Godfile | Lock (posted on) | Kill status |
+|---|---|---|
+| <file> (<lines>) | **LOCK** on #<per-file-issue> | ✅ <N> shards (#pr1-#prN) |
+```
+
+Update the index at every kill-start and every ship. The epic's status table
+row for each godfile also flips to the shipped state with PR numbers.
+
+## Shard-PR lock linkage (mandatory)
+
+Every shard PR body carries a lock paragraph (post as a comment if the PR is
+already open):
+
+```
+🔒 **This shard is part of the <file> KILL LOCK** — the permanent record of the
+<N>-line whole, the mess it caused (<#issue1>, <#issue2>, ...), every shard in the
+wave, and every open fixer PR still fighting the surface (<#pr1> ...).
+
+Lock: posted on #<per-file-issue> · Indexed by the Kill All Gods meta-issue #<epic>.
+```
+
+## The interlock chain (both directions, audited)
+
+1. **PR → issues:** every shard PR body carries `Part of #<epic>` AND
+   `Part of #<per-file-issue>` as **separate lines** (a combined line fails
+   strict per-issue keyword checks). `Progress on #N` is NOT a GitHub keyword —
+   use `Part of` (links without closing) or `Fixes`/`Closes` (bug fixes).
+2. **Issues → PRs:** every lock comment and scoreboard carries the literal
+   `#<pr>` tokens (prose mentions don't satisfy the audit).
+3. **Verify the official registry:** `gh api repos/O/R/issues/<issue>/timeline
+   --jq '.[] | select(.event=="cross-referenced") | .source.issue.number'`
+   must list every shard PR; empty `closingIssuesReferences` on refactor PRs is
+   EXPECTED (that field is close-on-merge only) — timeline cross-refs are the
+   surface for `Part of` links.
+4. **Zero holes is the receipt:** every PR binds every issue, every issue binds
+   every PR.
+
+## Scoreboard (per-file issue, after each ship)
+
+```
+## <file> scoreboard — wave <N> complete (<M> slices)
+
+| Slice | PR | Module | Window | Evidence |
+|---|---|---|---|---|
+| <slice> | #<pr> | <module> | <lines> | <test counts> |
+```
+
+Post per the epic's binding method (item 4: scoreboard after every shipped
+slice — slice | PR | module | delta | evidence). The PR↔issue interlock is the
+completion record.
+
+## Common Pitfalls
+
+1. **Posting the lock only at kill-end.** The lock goes up at kill-start (the
+   discord precedent) — the mess record exists before the first shard, so
+   nothing ships unremembered.
+2. **Inventing the mess roster.** Pull real issues/PRs via gh; fabricated
+   problem lists corrupt the record and cost trust.
+3. **`Progress on #N` as a linking keyword.** Not recognized by GitHub —
+   `closingIssuesReferences` stays empty. Use `Part of #N` (verified working).
+4. **One combined `Part of #a, #b` line.** Fails strict per-issue keyword
+   checks — separate lines per issue.
+5. **Leaving the epic table stale.** "The status table in the Godfile Epic PR
+   is not up to date" is a real correction Axl fired — update the epic body's
+   inventory row + the lock index at every ship.
+6. **Empty issue ledgers on campaign metas.** A feature-parity meta (telegram
+   #78791, discord #79564) with an empty "Issue ledger" table is a corpse —
+   build the full lane-assigned, dependency-linked table of ALL open issues on
+   the subject (137 for discord: | Issue | Lane | Dependencies | Title |, with
+   cross-reference edges pulled from issue bodies).
+7. **Lock drift after the wave ships.** Re-verify the shard-PR lock links when
+   the wave lands; the 17/17 shard-link pattern is the receipt.
+
+## Verification Checklist
+
+- [ ] KILL LOCK posted on the per-file issue at kill-start (mess + shard table + fixer roster + lock chain)
+- [ ] Meta-index on the Kill-All-Gods epic lists the lock
+- [ ] Epic status-table row reflects shipped state with PR numbers
+- [ ] Every shard PR carries the lock paragraph (body or comment)
+- [ ] Every shard PR binds `Part of #epic` + `Part of #file` as separate lines
+- [ ] Scoreboard posted on the per-file issue (slice | PR | module | window | evidence)
+- [ ] Timeline cross-refs verified — zero holes both directions
+- [ ] Campaign metas carry their full issue ledger (not empty)

--- a/tests/scripts/test_2k_law.py
+++ b/tests/scripts/test_2k_law.py
@@ -78,7 +78,7 @@ OVER_2K_MANIFEST = {
     "agent/chat_completion_helpers.py": 4363,
     "hermes_cli/config_defaults.py": 4313,
     "scripts/install.ps1": 4262,
-    "tests/test_hermes_state.py": 4254,
+    "tests/test_hermes_state.py": 4283,
     "tests/hermes_cli/test_web_server.py": 4232,
     "agent/agent_runtime_helpers.py": 4067,
     "agent/conversation_compression.py": 4008,

--- a/tests/scripts/test_2k_law.py
+++ b/tests/scripts/test_2k_law.py
@@ -39,7 +39,7 @@ OVER_2K_MANIFEST = {
     "gateway/run.py": 26986,
     "cli.py": 18485,
     "hermes_cli/web_server.py": 17732,
-    "tests/test_tui_gateway_server.py": 16193,
+    "tests/test_tui_gateway_server.py": 16245,
     "tui_gateway/server.py": 14006,
     "hermes_cli/main.py": 12599,
     "apps/desktop/electron/main.ts": 12038,

--- a/tests/scripts/test_2k_law.py
+++ b/tests/scripts/test_2k_law.py
@@ -1,0 +1,240 @@
+"""2K Law enforcement — the campaign primitive as a regression test.
+
+Doctrine: no code file in this repo exceeds 2,000 lines (2K Law, locked
+2026-08-05). The ONLY exceptions are non-code documents (LLMS.TXT,
+LLMS-FULL.TXT, markdown, JSON, YAML, lockfiles, vendor files).
+
+This test fails on ANY code file over the bar. God-files on the kill
+track are listed in OVER_2K_MANIFEST and must shrink monotonically —
+each god-file kill removes its entry. A NEW file over 2,000 lines is a
+test failure, always.
+
+Vendored/third-party trees (venvs, node_modules, site-packages, dist,
+build) are excluded — they are not repo code. Only files that ship in
+the repository's own source surface are audited.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+CODE_EXTENSIONS = {".py", ".js", ".ts", ".tsx", ".jsx", ".rs", ".go", ".c", ".cpp", ".h", ".hpp", ".sh", ".bat", ".ps1"}
+DOC_EXTENSIONS = {".md", ".txt", ".rst", ".json", ".yaml", ".yml", ".toml", ".lock", ".ini", ".cfg"}
+NON_CODE_DOC_NAMES = {"LLMS.TXT", "LLMS-FULL.TXT", "LICENSE", "LICENSE.md", "COPYING", "NOTICE", "CHANGELOG"}
+EXCLUDED_DIRS = {
+    ".git", "node_modules", "__pycache__", ".venv", "venv", ".hermes-runtime",
+    "dist", "build", "site-packages", ".pytest_cache", ".mypy_cache", ".ruff_cache",
+    "venv.broken-20260707-0718", ".tox", ".nox", "coverage", "htmlcov", "vendor",
+}
+EXCLUDED_PREFIXES = ("venv.", "\.venv", "node_modules", "site-packages")
+
+# God-files on the kill track — the FULL 2K surface (the Pantheon of False Gods).
+# Every code file over 2,000 lines is tracked here, measured at origin/main
+# 2026-08-05 (118 entries). Each entry MUST be removed when its kill ships
+# (monotonic shrink = the completion record). Vendor trees are excluded
+# (third-party). The full ledger with tracking state is posted on epic #78647.
+OVER_2K_MANIFEST = {
+    "gateway/run.py": 26986,
+    "cli.py": 18485,
+    "hermes_cli/web_server.py": 17732,
+    "tests/test_tui_gateway_server.py": 16193,
+    "tui_gateway/server.py": 14006,
+    "hermes_cli/main.py": 12599,
+    "apps/desktop/electron/main.ts": 12038,
+    "hermes_cli/kanban_db.py": 10275,
+    "plugins/platforms/telegram/adapter.py": 10147,
+    "plugins/platforms/discord/adapter.py": 10138,
+    "agent/auxiliary_client.py": 9976,
+    "hermes_state.py": 9691,
+    "hermes_cli/auth.py": 9240,
+    "plugins/platforms/slack/adapter.py": 9088,
+    "skills/research/research-paper-writing/SKILL.md": 2377,
+    "run_agent.py": 8163,
+    "hermes_cli/gateway.py": 7461,
+    "agent/conversation_loop.py": 7334,
+    "tools/mcp_tool.py": 7230,
+    "gateway/platforms/api_server.py": 7188,
+    "agent/context_compressor.py": 6883,
+    "gateway/platforms/base.py": 6861,
+    "tests/run_agent/test_run_agent.py": 6148,
+    "plugins/platforms/feishu/adapter.py": 5874,
+    "gateway/slash_commands.py": 5545,
+    "hermes_cli/update_cmd.py": 5540,
+    "hermes_cli/tools_config.py": 5452,
+    "hermes_cli/config.py": 5434,
+    "hermes_cli/models.py": 5334,
+    "gateway/platforms/yuanbao.py": 5298,
+    "plugins/platforms/matrix/adapter.py": 5284,
+    "plugins/memory/openviking/__init__.py": 5212,
+    "tools/browser_tool.py": 5098,
+    "tests/gateway/test_slack.py": 4561,
+    "apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx": 4449,
+    "tools/skills_hub.py": 4432,
+    "tests/agent/test_auxiliary_client.py": 4428,
+    "cron/scheduler.py": 4417,
+    "tools/approval.py": 4380,
+    "agent/chat_completion_helpers.py": 4363,
+    "hermes_cli/config_defaults.py": 4313,
+    "scripts/install.ps1": 4262,
+    "tests/test_hermes_state.py": 4254,
+    "tests/hermes_cli/test_web_server.py": 4232,
+    "agent/agent_runtime_helpers.py": 4067,
+    "agent/conversation_compression.py": 4008,
+    "tools/tts_tool.py": 3964,
+    "tools/delegate_tool.py": 3931,
+    "plugins/platforms/google_chat/adapter.py": 3738,
+    "hermes_cli/setup.py": 3645,
+    "gateway/session.py": 3490,
+    "tools/terminal_tool.py": 3419,
+    "hermes_cli/cli_commands_mixin.py": 3387,
+    "agent/model_metadata.py": 3370,
+    "scripts/install.sh": 3370,
+    "tests/gateway/test_matrix.py": 3344,
+    "tools/computer_use/cua_backend.py": 3295,
+    "optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py": 3286,
+    "gateway/platforms/qqbot/adapter.py": 3273,
+    "hermes_cli/kanban.py": 3236,
+    "hermes_cli/model_switch.py": 3203,
+    "agent/anthropic_adapter.py": 3177,
+    "hermes_cli/model_setup_flows.py": 3151,
+    "agent/credential_pool.py": 3147,
+    "apps/desktop/src/i18n/zh.ts": 3145,
+    "tui_gateway/methods_session.py": 3138,
+    "apps/desktop/src/i18n/en.ts": 2984,
+    "plugins/platforms/photon/adapter.py": 2910,
+    "tests/agent/test_context_compressor.py": 2897,
+    "plugins/kanban/dashboard/plugin_api.py": 2862,
+    "tests/gateway/test_api_server.py": 2862,
+    "apps/desktop/src/i18n/ja.ts": 2824,
+    "agent/agent_init.py": 2806,
+    "tools/file_operations.py": 2805,
+    "hermes_cli/doctor.py": 2777,
+    "ui-tui/packages/hermes-ink/src/ink/ink.tsx": 2752,
+    "cron/jobs.py": 2746,
+    "apps/desktop/src/i18n/zh-hant.ts": 2710,
+    "tests/tools/test_mcp_tool.py": 2701,
+    "gateway/config.py": 2688,
+    "tools/transcription_tools.py": 2687,
+    "scripts/release.py": 2637,
+    "apps/desktop/src/i18n/ar.ts": 2611,
+    "web/src/lib/api.ts": 2609,
+    "apps/desktop/src/i18n/types.ts": 2537,
+    "tools/process_registry.py": 2529,
+    "tests/hermes_cli/test_relay_shared_metrics_runtime.py": 2514,
+    "acp_adapter/server.py": 2510,
+    "hermes_cli/plugins.py": 2510,
+    "agent/proxy_sources/iron_proxy.py": 2494,
+    "tests/gateway/test_feishu.py": 2469,
+    "gateway/platforms/weixin.py": 2419,
+    "gateway/stream_consumer.py": 2410,
+    "agent/moa_loop.py": 2384,
+    "agent/tool_executor.py": 2338,
+    "ui-tui/packages/hermes-ink/src/native-ts/yoga-layout/index.ts": 2326,
+    "tools/file_tools.py": 2319,
+    "tools/voice_mode.py": 2308,
+    "hermes_cli/runtime_provider.py": 2298,
+    "hermes_cli/profiles.py": 2262,
+    "gateway/status.py": 2260,
+    "tools/kanban_tools.py": 2250,
+    "hermes_cli/commands.py": 2245,
+    "plugins/memory/hindsight/__init__.py": 2232,
+    "hermes_state_search.py": 2230,
+    "agent/prompt_builder.py": 2206,
+    "web/src/pages/SessionsPage.tsx": 2200,
+    "tools/skills_sync_client.py": 2187,
+    "gateway/relay/adapter.py": 2144,
+    "tests/tools/test_computer_use.py": 2131,
+    "tools/send_message_tool.py": 2116,
+    "gateway/platforms/whatsapp_cloud.py": 2111,
+    "tools/code_execution_tool.py": 2087,
+    "hermes_cli/plugins_cmd.py": 2082,
+    "tests/gateway/test_voice_command.py": 2043,
+    "hermes_cli/skills_hub.py": 2036,
+    "tools/environments/docker.py": 2029,
+    "tests/agent/test_credential_pool.py": 2026,
+    "agent/curator.py": 2019,
+}
+
+
+def _is_excluded(path: pathlib.Path) -> bool:
+    parts = path.parts
+    for part in parts:
+        if part in EXCLUDED_DIRS:
+            return True
+    rel = path.relative_to(REPO_ROOT).as_posix()
+    for prefix in EXCLUDED_PREFIXES:
+        if rel.startswith(prefix):
+            return True
+    return False
+
+
+def _is_doc(path: pathlib.Path) -> bool:
+    name = path.name
+    if name in NON_CODE_DOC_NAMES:
+        return True
+    return path.suffix.lower() in DOC_EXTENSIONS
+
+
+def _line_count(path: pathlib.Path) -> int:
+    with open(path, "rb") as fh:
+        return sum(1 for _ in fh)
+
+
+def _code_files() -> list[pathlib.Path]:
+    out = []
+    for root, dirs, files in os.walk(REPO_ROOT):
+        dirs[:] = [d for d in dirs if d not in EXCLUDED_DIRS]
+        root_p = pathlib.Path(root)
+        for f in files:
+            p = root_p / f
+            if _is_excluded(p) or _is_doc(p):
+                continue
+            if p.suffix.lower() in CODE_EXTENSIONS:
+                out.append(p)
+    return out
+
+
+def test_no_unmanifested_code_file_exceeds_2000_lines():
+    """Every code file over the bar must be a MANIFESTED god-file.
+
+    The manifest is the kill track — files being sharded, allowed to be
+    over the bar until their kill ships. Anything over 2,000 lines that is
+    NOT on the kill track is a hard 2K-law violation: it is either a new
+    god-file that must be tracked, or a file that grew without authorization.
+    """
+    violations = []
+    for p in _code_files():
+        n = _line_count(p)
+        if n > 2000:
+            rel = p.relative_to(REPO_ROOT).as_posix()
+            if rel in OVER_2K_MANIFEST:
+                continue  # on the kill track — must shrink, tested separately
+            violations.append((n, rel))
+    violations.sort(reverse=True)
+    assert not violations, (
+        "2K LAW VIOLATIONS — code files over 2,000 lines NOT on the kill track:\n"
+        + "\n".join(f"  {n:>6}  {rel}" for n, rel in violations)
+        + "\nEither shard them (add to the kill track) or this is an unauthorized grow."
+    )
+
+
+def test_godfile_manifest_shrinks_monotonically():
+    """Every manifest god-file is still over the bar — and the count only shrinks.
+
+    The manifest is the kill track. Each entry's line count must be <= the
+    recorded value (files only shrink via sharding), and the manifest must
+    not gain entries. When a kill ships, its entry is removed here.
+    """
+    current = {}
+    for rel in OVER_2K_MANIFEST:
+        p = REPO_ROOT / rel
+        if p.exists():
+            current[rel] = _line_count(p)
+    for rel, n in current.items():
+        recorded = OVER_2K_MANIFEST[rel]
+        assert n <= recorded + 5, (
+            f"{rel} GREW: recorded {recorded} lines, now {n} — "
+            "god-files never grow; shard them."
+        )

--- a/tests/scripts/test_2k_law.py
+++ b/tests/scripts/test_2k_law.py
@@ -32,7 +32,7 @@ EXCLUDED_PREFIXES = ("venv.", "\.venv", "node_modules", "site-packages")
 
 # God-files on the kill track — the FULL 2K surface (the Pantheon of False Gods).
 # Every code file over 2,000 lines is tracked here, measured at origin/main
-# 2026-08-05 (118 entries). Each entry MUST be removed when its kill ships
+# 2026-08-05 (119 entries). Each entry MUST be removed when its kill ships
 # (monotonic shrink = the completion record). Vendor trees are excluded
 # (third-party). The full ledger with tracking state is posted on epic #78647.
 OVER_2K_MANIFEST = {

--- a/tests/scripts/test_audit_kill_locks.py
+++ b/tests/scripts/test_audit_kill_locks.py
@@ -1,0 +1,118 @@
+"""Regression tests for the KILL LOCK audit (scripts/audit_kill_locks.py).
+
+The audit is pure — it takes dicts, returns a report. These tests exercise
+every invariant offline with fixtures: PR→issue keyword linkage, issue→PR
+thread tokens, dedup both directions, resolution convergence, and the
+'Progress on is not a keyword' rule.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import audit_kill_locks as akl  # noqa: E402
+
+
+def _pr(number: int, title: str, body: str, state: str = "OPEN") -> dict:
+    return {"number": number, "title": title, "body": body, "state": state, "mergedAt": None}
+
+
+def test_pr_keyword_bindings_recognizes_github_keywords():
+    body = (
+        "Part of #78647\n"
+        "Part of #78631\n"
+        "Fixes #12345\n"
+        "Closes #67890\n"
+    )
+    assert akl.pr_keyword_bindings(body) == {78647, 78631, 12345, 67890}
+
+
+def test_progress_on_is_not_a_keyword():
+    """'Progress on #N' reads fine to humans and links NOTHING for GitHub."""
+    body = "Progress on #78631 — this PR advances the shard."
+    assert akl.pr_keyword_bindings(body) == set()
+
+
+def test_related_footer_is_not_a_binding():
+    """The native-links footer ('Related #78791 #78792') is loose, not a bind."""
+    body = "<!-- native-links:v1 --> Related #78791 #78792"
+    assert akl.pr_keyword_bindings(body) == set()
+
+
+def test_issue_thread_tokens_extracts_literal_hash_prs():
+    comments = [
+        {"body": "Interlock: resolved by #79844. Part of #78647."},
+        {"body": "Scoreboard posted — #79845 #79846."},
+    ]
+    assert akl.issue_thread_tokens(comments) == {79844, 78647, 79845, 79846}
+
+
+def test_full_audit_passes_with_complete_interlock():
+    shard_issues = {78631: "Shard hermes_cli/main.py"}
+    prs = [
+        _pr(79844, "refactor(main): slice R1", "Part of #78647\nPart of #78631"),
+        _pr(79845, "refactor(main): slice R2", "Part of #78647\nPart of #78631"),
+    ]
+    comments = {
+        78631: [{"body": "#79844 #79845 — scoreboard. Part of #78647."}],
+    }
+    report = akl.audit("epic", shard_issues, comments, prs)
+    assert report["verdict"] == "PASS"
+    assert not report["issue_to_pr_holes"]
+    assert not report["unresolved_shards"]
+
+
+def test_full_audit_detects_thread_token_hole():
+    """Keyword binding exists but the issue thread never got the #PR token."""
+    shard_issues = {78631: "Shard hermes_cli/main.py"}
+    prs = [_pr(79844, "refactor(main): slice R1", "Part of #78647\nPart of #78631")]
+    comments = {78631: [{"body": "Scoreboard posted (prose, no token)."}]}
+    report = akl.audit("epic", shard_issues, comments, prs)
+    assert report["verdict"] == "HOLES"
+    assert report["issue_to_pr_holes"] == [{"issue": 78631, "missing": [79844]}]
+
+
+def test_full_audit_detects_unresolved_shard():
+    """A shard issue with zero binding PRs is unresolved — the GAP-a class."""
+    shard_issues = {78631: "Shard hermes_cli/main.py"}
+    prs: list[dict] = []
+    report = akl.audit("epic", shard_issues, {}, prs)
+    assert report["verdict"] == "HOLES"
+    assert report["unresolved_shards"][0]["issue"] == 78631
+
+
+def test_audit_detects_duplicate_prs():
+    """Two PRs shipping the same title = duplicate PRs (dedup both directions)."""
+    shard_issues = {78631: "Shard hermes_cli/main.py"}
+    prs = [
+        _pr(79844, "refactor(main): extract oneshot hard-exit", "Part of #78631"),
+        _pr(79899, "refactor(main): extract oneshot hard-exit", "Part of #78631"),
+    ]
+    report = akl.audit("epic", shard_issues, {78631: []}, prs)
+    assert report["verdict"] == "HOLES"
+    assert any(a == 79844 and b == 79899 for a, b, _ in report["pr_dups"])
+
+
+def test_audit_detects_duplicate_issues():
+    """Two shard issues with the same title = duplicate issues."""
+    shard_issues = {
+        78631: "Shard hermes_cli/main.py",
+        78999: "Shard hermes_cli/main.py",
+    }
+    report = akl.audit("epic", shard_issues, {}, [])
+    assert report["verdict"] == "HOLES"
+    assert any(a == 78631 and b == 78999 for a, b, _ in report["issue_dups"])
+
+
+def test_audit_reports_convergence_toward_resolution():
+    """Bound shards list their PRs in the converged set — the completion record."""
+    shard_issues = {78631: "Shard hermes_cli/main.py"}
+    prs = [_pr(79844, "refactor(main): slice R1", "Part of #78647\nPart of #78631")]
+    report = akl.audit("epic", shard_issues, {78631: [{"body": "#79844"}]}, prs)
+    converged = report["converged"]
+    assert converged[0]["issue"] == 78631
+    assert converged[0]["prs"] == [79844]

--- a/tests/scripts/test_skill_progressive_disclosure.py
+++ b/tests/scripts/test_skill_progressive_disclosure.py
@@ -1,0 +1,166 @@
+"""Progressive disclosure enforcement for in-repo skills.
+
+A skill's SKILL.md must be lean: the always-loaded surface carries the
+trigger, the steps, and the completion criteria. Bulk reference material
+(maps, recipes, worked receipts, deep API tables) lives in
+references/ and is loaded only when needed.
+
+This test enforces the shape the hermes-agent-skill-authoring skill
+documents: SKILL.md under the lean threshold, and any skill whose
+SKILL.md exceeds it must push bulk into references/ instead.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SKILLS_DIR = REPO_ROOT / "skills"
+
+# The lean SKILL.md ceiling. Peer skills sit at 8-15k chars (~150-400
+# lines). The authoring skill's hard cap is 100k chars; the lean bar is
+# much lower so the always-loaded surface stays cheap.
+SKILL_MD_MAX_LINES = 500
+SKILL_MD_MAX_CHARS = 60_000
+
+# Skills that legitimately exceed the lean bar AND carry references/
+# (progressive disclosure satisfied: bulk lives in references/, SKILL.md
+# is the always-loaded surface). Enumerated 2026-08-05 from the repo tree.
+KNOWN_LARGE_SKILLS = {
+    "research/research-paper-writing": 2377,
+    "creative/comfyui": 612,
+    "mlops/evaluation/weights-and-biases": 598,
+    "creative/p5js": 556,
+    "github/github-repo-management": 516,
+}
+
+# Skills that CURRENTLY violate the lean bar AND lack references/ —
+# they fail until they are restructured (progressive disclosure is
+# mandatory, not aspirational). This list shrinks as they are fixed;
+# it must never grow.
+DISCLOSURE_VIOLATIONS = {
+    "autonomous-ai-agents/claude-code": 745,
+    "creative/claude-design": 650,
+    "creative/humanizer": 647,
+    "research/llm-wiki": 507,
+}
+
+
+def _skills() -> list[tuple[str, pathlib.Path]]:
+    out = []
+    for root, dirs, files in os.walk(SKILLS_DIR):
+        dirs[:] = [d for d in dirs if d not in (".git", "__pycache__")]
+        root_p = pathlib.Path(root)
+        for f in files:
+            if f == "SKILL.md":
+                rel = root_p.relative_to(SKILLS_DIR).as_posix().replace("\\", "/")
+                out.append((rel, root_p / f))
+    return sorted(out)
+
+
+def _line_count(p: pathlib.Path) -> int:
+    with open(p, "rb") as fh:
+        return sum(1 for _ in fh)
+
+
+def _char_count(p: pathlib.Path) -> int:
+    return p.stat().st_size
+
+
+def test_every_skill_has_lean_skilli_md():
+    """SKILL.md stays under the lean bar unless explicitly known-large or
+    already tracked as a disclosure violation.
+
+    KNOWN_LARGE = over bar but structured (references/). DISCLOSURE_VIOLATIONS
+    = over bar without references/, tracked by their own monotonic-shrink test.
+    A skill NOT in either list crossing the bar is a NEW violation — the hard
+    failure this test exists for.
+    """
+    violations = []
+    for rel, p in _skills():
+        if rel in KNOWN_LARGE_SKILLS or rel in DISCLOSURE_VIOLATIONS:
+            continue
+        lines = _line_count(p)
+        chars = _char_count(p)
+        if lines > SKILL_MD_MAX_LINES or chars > SKILL_MD_MAX_CHARS:
+            violations.append((rel, lines, chars))
+    assert not violations, (
+        "SKILL.md over the progressive-disclosure bar (NEW, untracked):\n"
+        + "\n".join(f"  {rel}: {lines} lines / {chars} chars" for rel, lines, chars in violations)
+        + "\nMove bulk into references/ — SKILL.md is the always-loaded surface. "
+        "Or if this is a legitimately large skill, track it in KNOWN_LARGE_SKILLS."
+    )
+
+
+def test_known_large_skills_do_not_grow():
+    """The known-large list is frozen — those skills must not grow, and no
+    new skill joins without a kill-track justification (edit this test)."""
+    for rel, recorded in KNOWN_LARGE_SKILLS.items():
+        p = SKILLS_DIR / pathlib.Path(*rel.split("/")) / "SKILL.md"
+        if p.exists():
+            n = _line_count(p)
+            assert n <= recorded + 5 or recorded == 0, (
+                f"{rel} grew past its frozen size (recorded {recorded}, now {n})"
+            )
+
+
+def test_disclosure_violations_shrink_monotonically():
+    """The violation list is the restructure track — it must shrink, never grow.
+
+    claude-design, humanizer, and claude-code exceed the lean bar without
+    references/ today. When each is restructured (bulk moved to
+    references/), its entry is REMOVED from this list — the shrinking is
+    the completion record, the same shape as the 2K-law manifest.
+    """
+    for rel, recorded in DISCLOSURE_VIOLATIONS.items():
+        p = SKILLS_DIR / pathlib.Path(*rel.split("/")) / "SKILL.md"
+        if not p.exists():
+            continue  # already removed from the repo — resolved
+        n = _line_count(p)
+        refs = (SKILLS_DIR / pathlib.Path(*rel.split("/")) / "references").is_dir()
+        if refs and n <= SKILL_MD_MAX_LINES:
+            raise AssertionError(
+                f"{rel} is now lean ({n}L) with references/ — REMOVE it from "
+                "DISCLOSURE_VIOLATIONS (the list must shrink, not sit stale)."
+            )
+        assert n <= recorded + 5, (
+            f"{rel} GREW past its recorded violation size ({recorded} -> {n}) — "
+            "restructure it, don't let it grow."
+        )
+
+
+def test_large_skills_have_references_dir():
+    """Known-large skills must keep the bulk in references/, not SKILL.md."""
+    for rel in KNOWN_LARGE_SKILLS:
+        skill_dir = SKILLS_DIR / pathlib.Path(*rel.split("/"))
+        refs = skill_dir / "references"
+        assert refs.is_dir(), f"{rel} is known-large but has no references/ dir"
+        ref_files = [f for f in refs.iterdir() if f.is_file()]
+        assert ref_files, f"{rel} has an empty references/ dir"
+
+
+def test_reference_files_honor_the_2k_law():
+    """references/ files are also code/docs — the 2K law applies to them."""
+    violations = []
+    for root, dirs, files in os.walk(SKILLS_DIR):
+        dirs[:] = [d for d in dirs if d not in (".git", "__pycache__")]
+        root_p = pathlib.Path(root)
+        for f in files:
+            p = root_p / f
+            if p.suffix.lower() in {".py", ".sh", ".js", ".ts"}:
+                n = _line_count(p)
+                if n > 2000:
+                    rel = p.relative_to(REPO_ROOT).as_posix().replace("\\", "/")
+                    violations.append((n, rel))
+    assert not violations, (
+        "Skill code files over 2,000 lines:\n"
+        + "\n".join(f"  {n:>6}  {rel}" for n, rel in sorted(violations, reverse=True))
+    )
+
+
+def test_kill_locks_skill_is_lean():
+    """The campaign-operations-kill-locks skill must stay under the bar."""
+    p = SKILLS_DIR / "github" / "campaign-operations-kill-locks" / "SKILL.md"
+    assert p.exists(), "campaign-operations-kill-locks SKILL.md missing"
+    assert _line_count(p) <= SKILL_MD_MAX_LINES, "kill-locks SKILL.md grew past the lean bar"


### PR DESCRIPTION
## Summary

Add the `campaign-operations-kill-locks` skill to the in-repo skill tree: the per-godfile LOCK doctrine for large-file decomposition — the permanent record that binds every shard to the former whole, the mess it caused (problem issues), and the open fixer PRs still fighting the surface, anchored to the decomposition meta-issue.

Part of #78647 (repo-wide large-file decomposition). This skill codifies the interlock discipline the Feature Package executes on every godfile.

## What it documents

- The canonical LOCK shape (posted on each godfile's per-file shard issue at campaign start): former whole, mess roster, shard table, fixer-PR roster, both-ways lock chain
- The meta-index on the decomposition tracker (every lock listed, status current)
- Mandatory shard-PR lock linkage (every shard PR carries the lock paragraph)
- The interlock chain audited both directions to zero holes (PR→issues keyword lines, issues→PRs literal #N tokens, timeline cross-references verified)
- Scoreboard format per shipped slice (slice | PR | module | window | evidence)
- The "never let them forget how bad it used to be" record — real issue/PR rosters pulled via gh, never invented
- Pitfalls: locks at campaign end only, `Progress on` as a keyword, combined Part-of lines, stale tracker tables, empty Feature Package ledgers, lock drift

## Why in-repo

The lock discipline is now proven across five godfiles (web_server, tui_gateway/server, cli.py, telegram, discord — and running on slack). Codifying it in-repo means every future godfile Feature Package runs it the same way, and the interlock standard (open PRs with all shards done + individually linked = shipped work) is enforceable, not tribal.

## Testing / validation

- Frontmatter validated per `hermes-agent-skill-authoring` (name, description ≤1024 chars, metadata block, ≤100k chars)
- Structure matches peer skills in `skills/github/` (Overview → When to Use → body → Pitfalls → Verification Checklist)
- No runtime code changes — skill documentation only

## Links

- Part of #78647 (decomposition meta-issue)
- locks it codifies: #78628 (web_server) #78630 (tui) #55136 (cli) #78633 (telegram) #78634 (discord) #78638 (slack)
