### PR TITLE
fix(agent): bound synchronous Relay execution — cooperative ceiling + hard thread-abandon (salvage #79570)

### DIFF
--- a/agent/relay_await.py
+++ b/agent/relay_await.py
@@ -30,6 +30,11 @@ Two layers, because one is not enough:
    executor's ``shutdown(wait=False)`` policy for hung workers, and
    ``TimeoutError`` is raised so the turn can continue.
 
+The same abandon policy applies to ``KeyboardInterrupt``: Ctrl-C interrupts
+the calling thread's wait promptly, but the worker (and the tool it is
+running) is abandoned rather than cancelled and may complete detached —
+matching how the concurrent executor treats its workers on interrupt.
+
 The worker is wrapped with ``tools.thread_context.propagate_context_to_thread``
 so the turn's ContextVars and the thread-local approval/sudo callbacks reach
 the tool callback despite the thread shift (same audited mechanism the

--- a/agent/relay_await.py
+++ b/agent/relay_await.py
@@ -1,0 +1,165 @@
+"""Bounded synchronous execution of Relay awaitables.
+
+The Relay adapters (``agent.relay_tools``, ``agent.relay_llm``) drive async
+Relay operations from synchronous call sites via ``asyncio.run``. A bare
+``asyncio.run(value)`` has no deadline: an awaitable that never resolves parks
+the conversation-turn thread in the event-loop selector forever with no log
+output (#79568 — observed in production with a wedged ``skill_view``; the
+session's ``ended_at``/``end_reason`` stay NULL and the client spins on
+"ruminating…" indefinitely). The concurrent tool path is already bounded by
+``HERMES_CONCURRENT_TOOL_TIMEOUT_S``; this module gives the synchronous funnel
+an equivalent backstop.
+
+Two layers, because one is not enough:
+
+1. **Cooperative ceiling** — ``asyncio.wait_for(value, ceiling)``. Cleanly
+   cancels a wedge that is parked at an ``await`` (the observed production
+   class): ``finally`` blocks run, the loop closes, nothing leaks. The timer
+   can only fire while the loop is idle, so a tool that *legitimately* blocks
+   the loop synchronously past the ceiling (terminal foreground commands run
+   up to 600s; an approval prompt adds up to 300s) is NOT interrupted
+   mid-execution — the overdue timer fires at the next await point, and the
+   adapters' post-dispatch recovery (``execute()``'s ``except BaseException``
+   fallback) returns the already-computed tool result.
+2. **Hard abandon** — the awaitable runs on a daemon worker thread, and the
+   calling thread waits at most ``ceiling * _HARD_ABANDON_MULTIPLIER``. A
+   wedge that swallows ``CancelledError`` or blocks the loop synchronously
+   forever defeats layer 1 (``wait_for`` joins the cancellation, so it hangs
+   exactly like the bare ``asyncio.run``). When the hard deadline expires the
+   worker thread is abandoned — never joined — mirroring the concurrent
+   executor's ``shutdown(wait=False)`` policy for hung workers, and
+   ``TimeoutError`` is raised so the turn can continue.
+
+The worker is wrapped with ``tools.thread_context.propagate_context_to_thread``
+so the turn's ContextVars and the thread-local approval/sudo callbacks reach
+the tool callback despite the thread shift (same audited mechanism the
+concurrent executor uses).
+
+``HERMES_TOOL_EXECUTION_CEILING_S`` tunes the cooperative ceiling (default
+420s, matching ``HERMES_CONCURRENT_TOOL_TIMEOUT_S``); any value <= 0 disables
+both layers. This is an internal operator knob like its concurrent sibling —
+not user-facing configuration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOOL_EXECUTION_CEILING_S = 420.0
+
+# The hard-abandon deadline is a multiple of the cooperative ceiling because
+# layer 1's timer is starved while a tool blocks the loop synchronously: a
+# legitimate slow tool must be allowed to finish before the runner gives up on
+# the thread and its result is lost. Stock worst case is a 300s approval
+# prompt followed by a 600s foreground terminal command = 900s; 3x the 420s
+# default gives 1260s of headroom above that.
+_HARD_ABANDON_MULTIPLIER = 3.0
+
+# Floor for the managed-LLM twin: a single codex call may legitimately run up
+# to HERMES_CODEX_HARD_TIMEOUT_SECONDS (1500s) inside the synchronous provider
+# callback, which would outlive the tool path's 1260s hard deadline.
+LLM_HARD_DEADLINE_FLOOR_S = 1800.0
+
+
+def tool_execution_ceiling_seconds() -> float | None:
+    """Cooperative upper bound for one synchronous Relay execution, or None.
+
+    Reads ``HERMES_TOOL_EXECUTION_CEILING_S``. Empty/unset -> the 420s
+    default; non-numeric -> warn and use the default; any value that is not
+    strictly positive (including negatives and NaN) -> None (disabled),
+    matching ``_resolve_concurrent_tool_timeout``'s contract.
+    """
+    raw = os.getenv("HERMES_TOOL_EXECUTION_CEILING_S", "").strip()
+    if not raw:
+        return _DEFAULT_TOOL_EXECUTION_CEILING_S
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning(
+            "invalid HERMES_TOOL_EXECUTION_CEILING_S=%r; using %.0fs",
+            raw,
+            _DEFAULT_TOOL_EXECUTION_CEILING_S,
+        )
+        return _DEFAULT_TOOL_EXECUTION_CEILING_S
+    if not value > 0:
+        return None
+    return value
+
+
+def run_awaitable(
+    value: Any,
+    *,
+    on_loop_error: str,
+    hard_deadline_floor: float = 0.0,
+) -> Any:
+    """Run *value* to completion off any event loop, bounded by the ceiling.
+
+    Non-awaitables pass through unchanged. Raises ``RuntimeError`` with
+    *on_loop_error* when called from an event-loop thread (unchanged adapter
+    behavior). ``hard_deadline_floor`` raises the layer-2 abandon deadline for
+    call sites whose synchronous callbacks legitimately run longer than the
+    tool path's stock worst case (the managed-LLM twin).
+    """
+    if not inspect.isawaitable(value):
+        return value
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError(on_loop_error)
+
+    ceiling = tool_execution_ceiling_seconds()
+    if ceiling is None:
+        return asyncio.run(value)
+    hard_deadline = max(ceiling * _HARD_ABANDON_MULTIPLIER, hard_deadline_floor)
+    return _run_bounded(value, ceiling, hard_deadline)
+
+
+def _run_bounded(value: Any, ceiling: float, hard_deadline: float) -> Any:
+    # Lazy import: thread_context lazily imports tools.terminal_tool, which is
+    # heavy; keep this module a cheap leaf until a bounded run actually happens.
+    from tools.thread_context import propagate_context_to_thread
+
+    outcome: dict[str, Any] = {}
+    done = threading.Event()
+
+    def _worker() -> None:
+        try:
+            outcome["result"] = asyncio.run(asyncio.wait_for(value, timeout=ceiling))
+        except BaseException as exc:  # re-raised on the calling thread below
+            outcome["error"] = exc
+        finally:
+            done.set()
+
+    thread = threading.Thread(
+        target=propagate_context_to_thread(_worker),
+        name="hermes-relay-bounded-await",
+        daemon=True,
+    )
+    thread.start()
+    if not done.wait(hard_deadline):
+        # Layer 1 failed: the awaitable swallows CancelledError or blocks the
+        # loop synchronously, so wait_for is parked joining a cancellation
+        # that will never finish. Abandon the daemon thread — joining a hung
+        # worker is exactly the forever-wedge this module exists to prevent.
+        logger.warning(
+            "Relay awaitable ignored the %.0fs execution ceiling; "
+            "abandoning its worker thread after %.0fs",
+            ceiling,
+            hard_deadline,
+        )
+        raise TimeoutError(
+            f"execution exceeded the {ceiling:.0f}s ceiling and did not honor "
+            f"cancellation within {hard_deadline:.0f}s; worker thread abandoned"
+        )
+    if "error" in outcome:
+        raise outcome["error"]
+    return outcome["result"]

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterator
 from types import SimpleNamespace
 from typing import Any
 
-from agent import relay_runtime
+from agent import relay_await, relay_runtime
 
 logger = logging.getLogger(__name__)
 
@@ -1228,12 +1228,10 @@ def _json_equal(left: Any, right: Any) -> bool:
 
 
 def _run_awaitable(value: Any) -> Any:
-    if not inspect.isawaitable(value):
-        return value
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(value)
-    raise RuntimeError(
-        "Synchronous Relay LLM execution cannot run on an event-loop thread"
+    return relay_await.run_awaitable(
+        value,
+        on_loop_error=(
+            "Synchronous Relay LLM execution cannot run on an event-loop thread"
+        ),
+        hard_deadline_floor=relay_await.LLM_HARD_DEADLINE_FLOOR_S,
     )

--- a/agent/relay_llm.py
+++ b/agent/relay_llm.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
-import inspect
 import json
 import logging
 from collections.abc import Callable, Iterator

--- a/agent/relay_tools.py
+++ b/agent/relay_tools.py
@@ -7,6 +7,7 @@ import contextvars
 import inspect
 import json
 import logging
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -111,12 +112,39 @@ def _json_equal(left: Any, right: Any) -> bool:
         return left == right
 
 
+def _tool_execution_ceiling_seconds() -> float:
+    """Upper bound for one synchronous tool execution, in seconds.
+
+    The concurrent tool path is bounded by HERMES_CONCURRENT_TOOL_TIMEOUT_S,
+    but the sequential path has no deadline at all: a tool whose awaitable
+    never resolves wedges the conversation turn forever with no log output
+    (observed in production with a stuck skill_view; the turn thread parks in
+    the event-loop selector and the session's ended_at/end_reason stay NULL).
+    The default sits above every stock per-tool budget (web_extract 360s,
+    typical terminal timeouts) so it only fires on genuinely wedged tools.
+    Set HERMES_TOOL_EXECUTION_CEILING_S=0 to disable.
+    """
+    raw = os.getenv("HERMES_TOOL_EXECUTION_CEILING_S", "").strip()
+    if not raw:
+        return 420.0
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "invalid HERMES_TOOL_EXECUTION_CEILING_S=%r; using 420s", raw
+        )
+        return 420.0
+
+
 def _run_awaitable(value: Any) -> Any:
     if not inspect.isawaitable(value):
         return value
     try:
         asyncio.get_running_loop()
     except RuntimeError:
+        ceiling = _tool_execution_ceiling_seconds()
+        if ceiling > 0:
+            return asyncio.run(asyncio.wait_for(value, timeout=ceiling))
         return asyncio.run(value)
     raise RuntimeError(
         "Synchronous Hermes Relay tool execution cannot run on an active event-loop thread"

--- a/agent/relay_tools.py
+++ b/agent/relay_tools.py
@@ -2,16 +2,13 @@
 
 from __future__ import annotations
 
-import asyncio
 import contextvars
-import inspect
 import json
 import logging
-import os
 from collections.abc import Callable
 from typing import Any
 
-from agent import relay_runtime
+from agent import relay_await, relay_runtime
 
 logger = logging.getLogger(__name__)
 
@@ -112,40 +109,10 @@ def _json_equal(left: Any, right: Any) -> bool:
         return left == right
 
 
-def _tool_execution_ceiling_seconds() -> float:
-    """Upper bound for one synchronous tool execution, in seconds.
-
-    The concurrent tool path is bounded by HERMES_CONCURRENT_TOOL_TIMEOUT_S,
-    but the sequential path has no deadline at all: a tool whose awaitable
-    never resolves wedges the conversation turn forever with no log output
-    (observed in production with a stuck skill_view; the turn thread parks in
-    the event-loop selector and the session's ended_at/end_reason stay NULL).
-    The default sits above every stock per-tool budget (web_extract 360s,
-    typical terminal timeouts) so it only fires on genuinely wedged tools.
-    Set HERMES_TOOL_EXECUTION_CEILING_S=0 to disable.
-    """
-    raw = os.getenv("HERMES_TOOL_EXECUTION_CEILING_S", "").strip()
-    if not raw:
-        return 420.0
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning(
-            "invalid HERMES_TOOL_EXECUTION_CEILING_S=%r; using 420s", raw
-        )
-        return 420.0
-
-
 def _run_awaitable(value: Any) -> Any:
-    if not inspect.isawaitable(value):
-        return value
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        ceiling = _tool_execution_ceiling_seconds()
-        if ceiling > 0:
-            return asyncio.run(asyncio.wait_for(value, timeout=ceiling))
-        return asyncio.run(value)
-    raise RuntimeError(
-        "Synchronous Hermes Relay tool execution cannot run on an active event-loop thread"
+    return relay_await.run_awaitable(
+        value,
+        on_loop_error=(
+            "Synchronous Hermes Relay tool execution cannot run on an active event-loop thread"
+        ),
     )

--- a/tests/agent/test_relay_run_awaitable_ceiling.py
+++ b/tests/agent/test_relay_run_awaitable_ceiling.py
@@ -1,0 +1,53 @@
+"""Tests for the synchronous tool-execution ceiling in relay_tools._run_awaitable.
+
+The sequential tool path has no batch deadline (unlike the concurrent path's
+HERMES_CONCURRENT_TOOL_TIMEOUT_S), so a tool whose awaitable never resolves
+used to wedge the conversation turn forever. _run_awaitable now bounds every
+synchronous execution with a configurable ceiling.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent import relay_tools
+
+
+def test_completed_awaitable_returns_value(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_EXECUTION_CEILING_S", raising=False)
+
+    async def _quick():
+        return "done"
+
+    assert relay_tools._run_awaitable(_quick()) == "done"
+
+
+def test_non_awaitable_passes_through():
+    assert relay_tools._run_awaitable("plain") == "plain"
+
+
+def test_wedged_awaitable_raises_timeout(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _never():
+        await asyncio.Event().wait()
+
+    with pytest.raises(TimeoutError):
+        relay_tools._run_awaitable(_never())
+
+
+def test_ceiling_zero_disables_bound(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0")
+
+    async def _quick():
+        return 42
+
+    # With the ceiling disabled the awaitable still runs to completion.
+    assert relay_tools._run_awaitable(_quick()) == 42
+
+
+def test_invalid_ceiling_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "not-a-number")
+    assert relay_tools._tool_execution_ceiling_seconds() == 420.0

--- a/tests/agent/test_relay_run_awaitable_ceiling.py
+++ b/tests/agent/test_relay_run_awaitable_ceiling.py
@@ -1,18 +1,54 @@
-"""Tests for the synchronous tool-execution ceiling in relay_tools._run_awaitable.
+"""Tests for the bounded synchronous Relay execution (agent.relay_await).
 
 The sequential tool path has no batch deadline (unlike the concurrent path's
 HERMES_CONCURRENT_TOOL_TIMEOUT_S), so a tool whose awaitable never resolves
-used to wedge the conversation turn forever. _run_awaitable now bounds every
-synchronous execution with a configurable ceiling.
+used to wedge the conversation turn forever (#79568). ``relay_await`` now
+bounds every synchronous Relay execution with a configurable cooperative
+ceiling plus a hard thread-abandon deadline, and both Relay adapters
+(``relay_tools`` for tools, ``relay_llm`` for managed LLM calls) route their
+``_run_awaitable`` through it.
 """
 
 from __future__ import annotations
 
 import asyncio
+import time
 
 import pytest
 
-from agent import relay_tools
+from agent import relay_await, relay_llm, relay_tools
+
+
+# ---------------------------------------------------------------------------
+# tool_execution_ceiling_seconds
+# ---------------------------------------------------------------------------
+
+
+def test_default_ceiling(monkeypatch):
+    monkeypatch.delenv("HERMES_TOOL_EXECUTION_CEILING_S", raising=False)
+    assert (
+        relay_await.tool_execution_ceiling_seconds()
+        == relay_await._DEFAULT_TOOL_EXECUTION_CEILING_S
+    )
+
+
+def test_invalid_ceiling_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "not-a-number")
+    assert (
+        relay_await.tool_execution_ceiling_seconds()
+        == relay_await._DEFAULT_TOOL_EXECUTION_CEILING_S
+    )
+
+
+@pytest.mark.parametrize("raw", ["0", "-1", "-0.5", "nan"])
+def test_non_positive_and_nan_disable(monkeypatch, raw):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", raw)
+    assert relay_await.tool_execution_ceiling_seconds() is None
+
+
+# ---------------------------------------------------------------------------
+# run_awaitable — cooperative ceiling (layer 1)
+# ---------------------------------------------------------------------------
 
 
 def test_completed_awaitable_returns_value(monkeypatch):
@@ -34,20 +70,200 @@ def test_wedged_awaitable_raises_timeout(monkeypatch):
     async def _never():
         await asyncio.Event().wait()
 
+    start = time.monotonic()
     with pytest.raises(TimeoutError):
         relay_tools._run_awaitable(_never())
+    # Cooperative wedge is cancelled at the ceiling, well before the 3x
+    # hard-abandon deadline.
+    assert time.monotonic() - start < 0.5
 
 
 def test_ceiling_zero_disables_bound(monkeypatch):
     monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0")
 
+    def _no_wait_for(*args, **kwargs):  # pragma: no cover - failure path
+        pytest.fail("wait_for must not be used when the ceiling is disabled")
+
+    monkeypatch.setattr(relay_await.asyncio, "wait_for", _no_wait_for)
+
     async def _quick():
         return 42
 
-    # With the ceiling disabled the awaitable still runs to completion.
     assert relay_tools._run_awaitable(_quick()) == 42
 
 
-def test_invalid_ceiling_falls_back_to_default(monkeypatch):
-    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "not-a-number")
-    assert relay_tools._tool_execution_ceiling_seconds() == 420.0
+def test_raises_on_event_loop_thread():
+    async def _driver():
+        async def _payload():
+            return "unused"
+
+        payload = _payload()
+        try:
+            with pytest.raises(RuntimeError, match="event-loop thread"):
+                relay_tools._run_awaitable(payload)
+        finally:
+            payload.close()
+
+    asyncio.run(_driver())
+
+
+def test_slow_sync_block_past_ceiling_still_returns_result(monkeypatch):
+    """A tool that synchronously blocks past the ceiling must NOT be killed.
+
+    The cooperative timer is starved while the loop is blocked; the worker is
+    only abandoned at the hard deadline (3x ceiling). A legitimately slow
+    synchronous tool that finishes within that window keeps its result.
+    """
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _sync_block():
+        time.sleep(0.4)  # blocks the worker's loop well past the 0.2s ceiling
+        return "slow-but-done"
+
+    assert relay_tools._run_awaitable(_sync_block()) == "slow-but-done"
+
+
+# ---------------------------------------------------------------------------
+# run_awaitable — hard abandon (layer 2)
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_swallowing_wedge_is_abandoned(monkeypatch):
+    """A wedge that swallows CancelledError defeats wait_for (it joins the
+    cancellation); the hard deadline must abandon the worker thread and raise.
+    """
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _swallows_cancel():
+        while True:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                continue  # refuses to die
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError, match="worker thread abandoned"):
+        relay_tools._run_awaitable(_swallows_cancel())
+    elapsed = time.monotonic() - start
+    # Fired at the hard deadline (0.6s = 0.2 * 3), not never.
+    assert 0.5 < elapsed < 2.0
+
+
+def test_exception_from_awaitable_propagates(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "1")
+
+    async def _boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        relay_tools._run_awaitable(_boom())
+
+
+# ---------------------------------------------------------------------------
+# relay_tools.execute — TimeoutError interaction with the dispatch fallback
+# ---------------------------------------------------------------------------
+
+
+class _FakeRuntime:
+    """Minimal managed-execution runtime driving execute()'s real code path."""
+
+    def __init__(self, coro_factory):
+        self._coro_factory = coro_factory
+        # execute() dereferences runtime.relay.tools.execute before dispatch.
+        tools_ns = type("_ToolsNS", (), {"execute": staticmethod(lambda *a, **k: None)})
+        self.relay = type("_RelayNS", (), {"tools": tools_ns})
+
+    def managed_execution_enabled(self):
+        return True
+
+    def run_in_session_async(self, session, relay_execute, tool_name, args, invoke,
+                             **kwargs):
+        return self._coro_factory(invoke, args)
+
+
+class _FakeSession:
+    handle = object()
+
+
+def _patch_context(monkeypatch, runtime):
+    monkeypatch.setattr(
+        relay_tools.relay_runtime,
+        "resolve_execution_context",
+        lambda session_id: (runtime, _FakeSession(), None),
+    )
+
+
+def test_execute_post_dispatch_timeout_returns_tool_result(monkeypatch):
+    """The safety contract for slow-but-successful tools: once the callback
+    has produced a result, a late TimeoutError from relay post-processing is
+    absorbed and the real tool result is returned (never discarded).
+    """
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _dispatch_then_wedge(invoke, args):
+        invoke(args)  # tool runs and populates raw_result
+        await asyncio.Event().wait()  # relay post-processing wedges
+
+    _patch_context(monkeypatch, _FakeRuntime(_dispatch_then_wedge))
+
+    result, final_args = relay_tools.execute(
+        "mytool", {"a": 1}, lambda args: {"ok": True, "args": args},
+        session_id="s1",
+    )
+    assert result == {"ok": True, "args": {"a": 1}}
+    assert final_args == {"a": 1}
+
+
+def test_execute_pre_dispatch_timeout_propagates(monkeypatch):
+    """A wedge before the tool ever ran has no result to salvage — the
+    TimeoutError must surface instead of hanging the turn forever."""
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+
+    async def _wedge_before_dispatch(invoke, args):
+        await asyncio.Event().wait()
+
+    _patch_context(monkeypatch, _FakeRuntime(_wedge_before_dispatch))
+
+    with pytest.raises(TimeoutError):
+        relay_tools.execute(
+            "mytool", {"a": 1}, lambda args: {"ok": True}, session_id="s1"
+        )
+
+
+# ---------------------------------------------------------------------------
+# relay_llm sibling — same funnel, same bound
+# ---------------------------------------------------------------------------
+
+
+def test_relay_llm_run_awaitable_is_bounded(monkeypatch):
+    monkeypatch.setenv("HERMES_TOOL_EXECUTION_CEILING_S", "0.2")
+    # Neutralize the LLM floor so the test doesn't wait 1800s.
+    monkeypatch.setattr(relay_await, "LLM_HARD_DEADLINE_FLOOR_S", 0.0)
+
+    async def _never():
+        await asyncio.Event().wait()
+
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        relay_llm._run_awaitable(_never())
+    assert time.monotonic() - start < 0.5
+
+
+def test_relay_llm_hard_deadline_floor_applied(monkeypatch):
+    """The LLM twin's hard deadline honors the floor for legitimately long
+    synchronous provider callbacks (codex hard timeout is 1500s)."""
+    captured = {}
+
+    def _fake_run_bounded(value, ceiling, hard_deadline):
+        captured["hard_deadline"] = hard_deadline
+        value.close()
+        return "ok"
+
+    monkeypatch.delenv("HERMES_TOOL_EXECUTION_CEILING_S", raising=False)
+    monkeypatch.setattr(relay_await, "_run_bounded", _fake_run_bounded)
+
+    async def _quick():
+        return "unused"
+
+    assert relay_llm._run_awaitable(_quick()) == "ok"
+    assert captured["hard_deadline"] == relay_await.LLM_HARD_DEADLINE_FLOOR_S


### PR DESCRIPTION
## Summary

A tool whose awaitable never resolves on the sequential path no longer wedges the conversation turn forever — synchronous Relay execution is now bounded by a cooperative ceiling plus a hard thread-abandon deadline, on both the tool and managed-LLM funnels.

Salvage of #79570 by @sylbae (authorship preserved via cherry-pick), fixes #79568.

## Context

The concurrent tool path got a wall-clock deadline in c1784e909 (`HERMES_CONCURRENT_TOOL_TIMEOUT_S`, 420s). The sequential path (`execute_tool_calls_sequential` → `_run_agent_tool_execution_middleware` → `relay_tools.execute`) had none: its final funnel, `relay_tools._run_awaitable`, was a bare `asyncio.run(value)`. @sylbae captured the failure live in production — the turn thread parked in the event-loop selector forever, no log line, `ended_at`/`end_reason` NULL, client spinning on "ruminating…" — and contributed the `asyncio.wait_for` ceiling with 5 tests, validated in production (`tool skill_view failed (420.11s)` → turn continued to `finish_reason=stop`).

This path only engages when NeMo Relay managed execution is active (`relay_tools.execute` early-returns the plain callback otherwise), so default installs see no behavior change.

## Changes

- **Commit 1 (@sylbae, cherry-picked):** the original #79570 — `HERMES_TOOL_EXECUTION_CEILING_S` ceiling (default 420s, `0` disables) wrapping `asyncio.run(asyncio.wait_for(...))` in `agent/relay_tools._run_awaitable` + 5 tests.
- **Commit 2 (follow-up):** hardening the review surfaced:
  - `agent/relay_await.py` — shared bounded runner. Layer 1: the cooperative `wait_for` ceiling. Layer 2: the awaitable runs on a daemon worker thread abandoned after 3× the ceiling, because `wait_for` *joins* cancellation — a wedge that swallows `CancelledError` or blocks the loop synchronously defeats layer 1 entirely (empirically verified: bare `wait_for` hangs forever on both classes). Same abandon-never-join policy as the concurrent executor. The worker is wrapped with `tools.thread_context.propagate_context_to_thread` so approval/sudo callbacks and turn ContextVars survive the thread shift.
  - `agent/relay_llm.py` — its byte-identical unbounded `_run_awaitable` twin (managed LLM calls, same wedge class) now routes through the shared runner, with an 1800s hard-deadline floor above the 1500s codex hard timeout.
  - Disable semantics normalized to the concurrent sibling's contract (`<= 0`/NaN → disabled), named default constant, docstring's "sits above every stock per-tool budget" corrected (terminal foreground max is 600s > 420s).

## Why a legitimately slow tool is never discarded

The cooperative timer only fires while the loop is idle, so a terminal command legitimately blocking for 500s (max 600s) is not interrupted mid-execution; the overdue timer fires at the next await point, *after* the tool completed, and `execute()`'s post-dispatch `except BaseException` fallback returns the already-computed real tool result (verified end-to-end by `test_execute_post_dispatch_timeout_returns_tool_result` and a live smoke probe). The hard-abandon deadline (3× ceiling = 1260s stock) sits above the worst legitimate synchronous stack (300s approval prompt + 600s terminal).

## Validation

| Check | Result |
|---|---|
| New suite (`test_relay_run_awaitable_ceiling.py`) | 18/18 passed |
| `tests/agent -k relay` | 49 passed |
| guardrail runtime + batch segmentation + relay shared metrics | 85 passed, 1 skipped |
| Wedged awaitable (parked await), ceiling 0.2s | TimeoutError in 0.20s, both twins |
| Cancel-swallowing wedge | abandoned at hard deadline (0.6s), was: hangs forever |
| Sync block past ceiling | result preserved, not killed |
| Post-dispatch late timeout | real tool result returned (never discarded) |
| Mutation checks | neutering hard-abandon → its guard test fails; removing `wait_for` → wedge test fails; both restored green |
| ruff on touched files | clean (ty errors on relay_llm are pre-existing on main) |

## Credit

Original diagnosis (faulthandler dump pinpointing `relay_tools.py:120`), fix, and production validation by @sylbae in #79570 — cherry-picked with authorship preserved. Closes #79570. Fixes #79568.
