### PR TITLE
fix(search): use extended regex in grep fallback for alternation support

### DIFF
--- a/tests/tools/test_file_operations_edge_cases.py
+++ b/tests/tools/test_file_operations_edge_cases.py
@@ -253,6 +253,32 @@ class TestPaginationBounds:
 
 
 class TestSearchContextParsing:
+    def test_search_with_grep_uses_extended_regex(self):
+        env = MagicMock()
+        env.cwd = "/tmp"
+        ops = ShellFileOperations(env)
+
+        with patch.object(ops, "_exec") as mock_exec:
+            mock_exec.return_value = MagicMock(
+                exit_code=0,
+                stdout="./first.txt:1:foo\n./second.txt:1:bar\n",
+            )
+            result = ops._search_with_grep(
+                "foo|bar",
+                path=".",
+                file_glob=None,
+                limit=10,
+                offset=0,
+                output_mode="content",
+                context=0,
+            )
+
+        cmd_arg = mock_exec.call_args[0][0]
+        assert cmd_arg.startswith("set -o pipefail; grep -rnHE ")
+        assert result.error is None
+        assert result.total_count == 2
+        assert [match.content for match in result.matches] == ["foo", "bar"]
+
     def test_parse_search_context_line_prefers_rightmost_numeric_separator(self):
         parsed = _parse_search_context_line("dir/file-12-name.py-8-context here")
 

--- a/tests/tools/test_search_hidden_dirs.py
+++ b/tests/tools/test_search_hidden_dirs.py
@@ -69,7 +69,7 @@ class TestGrepExcludesHiddenDirs:
     def test_grep_skips_hub_cache(self, searchable_tree):
         """grep --exclude-dir should skip .hub/ directory."""
         cmd = (
-            f"grep -rnH --exclude-dir='.*' 'ignore' {searchable_tree}"
+            f"grep -rnHE --exclude-dir='.*' 'ignore' {searchable_tree}"
         )
         result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
         # Should NOT find the injection text in .hub/index-cache/catalog.json
@@ -79,7 +79,7 @@ class TestGrepExcludesHiddenDirs:
     def test_grep_still_finds_visible_content(self, searchable_tree):
         """grep should still find content in visible directories."""
         cmd = (
-            f"grep -rnH --exclude-dir='.*' 'real skill' {searchable_tree}"
+            f"grep -rnHE --exclude-dir='.*' 'real skill' {searchable_tree}"
         )
         result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
         assert "SKILL.md" in result.stdout

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2684,7 +2684,7 @@ class ShellFileOperations(FileOperations):
     def _search_with_grep(self, pattern: str, path: str, file_glob: Optional[str],
                           limit: int, offset: int, output_mode: str, context: int) -> SearchResult:
         """Fallback search using grep."""
-        cmd_parts = ["grep", "-rnH"]  # -H forces filename even for single-file searches
+        cmd_parts = ["grep", "-rnHE"]  # -H forces filenames; -E matches rg regex behavior
         
         # Exclude hidden directories (matching ripgrep's default behavior).
         # This prevents searching inside .hub/index-cache/, .git/, etc.


### PR DESCRIPTION
## Summary

Salvage of #39922 (@yinkev) onto current `main`. The grep fallback in `search_files(target="content")` now uses extended regex (`grep -rnHE`), so alternation (`|`), `+`, `?`, `()`, and `{n,m}` behave like the ripgrep path instead of silently returning zero matches on hosts without ripgrep.

Fixes #39294 (reported by @ishouldbedany).

## Context

Before: on a grep-only host, `search_files(pattern="foo|bar", target="content")` returned `{"total_count": 0}` silently — BRE treats `|` as a literal pipe. Worse, the zero-match steering hint (`_zero_match_probe`) requires rg, so grep-only users got no guidance at all: a total dead end that made agents conclude "no matches exist."

After: `foo|bar` returns real matches across all three output modes (content / files_only / count), matching ripgrep's dialect. Verified E2E with real `ShellFileOperations` + `LocalEnvironment` (rg disabled): pre-fix → 0/0/0, post-fix → correct matches in all modes; plain patterns unchanged; escaped `\|` / `\+` behave per ERE exactly as rg does.

## Changes

- `tools/file_operations.py`: `["grep", "-rnH"]` → `["grep", "-rnHE"]` in `_search_with_grep()` (cherry-picked from #39922, authorship preserved)
- `tests/tools/test_file_operations_edge_cases.py`: regression test pinning the exact command prefix (`set -o pipefail; grep -rnHE `) and exercising match parsing on the fallback path (from #39922)
- `tests/tools/test_search_hidden_dirs.py`: follow-up — updated the two hardcoded `grep -rnH` subprocess mirrors to `-rnHE` so they stay faithful to the production command they document

## Credit

Two contributors fixed this independently:
- @liuhao1024 submitted #39298 first — same production fix, working regression test
- @yinkev's #39922 had the tighter test (exact command-prefix pin + parse coverage), so its commit is the one cherry-picked here

Both PRs are correct; thanks to both. Closes #39298, closes #39922.

## Validation

| Check | Result |
|---|---|
| E2E grep-fallback (rg disabled), `foo\|bar` content/files_only/count | 0/0/0 before → 2/2/2 after |
| Mutation check (revert `-E`, run new test) | fails as expected |
| `tests/tools/test_file_operations_edge_cases.py` + `test_search_hidden_dirs.py` + `test_search_error_guard.py` | 39 passed |
| Sibling-site sweep | line 2687 is the only production grep content-search; no findstr path |
| BSD (macOS) + GNU grep portability of `-rnHE` | verified (`-E` is POSIX) |
| ruff on touched files | clean |
