### PR TITLE
fix(api): serve full compression lineage in session messages endpoints (#79565)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3550,6 +3550,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = await self._ensure_session_db_async()
+        # A compression lineage is one user-visible conversation: resolve to
+        # the live tip (forward), then serve the FULL lineage display history
+        # (backward, ancestors → tip). get_resume_conversations() reconciles
+        # overlap copied into continuation children (#79565).
         resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
         raw_limit = request.query.get("limit")
         raw_offset = request.query.get("offset", "0")
@@ -3580,13 +3584,14 @@ class APIServerAdapter(BasePlatformAdapter):
         default_page = requested_limit is None
         latest_page = order == "latest" or (order is None and default_page)
         limit = 500 if default_page else min(requested_limit, 500)
-        messages = await asyncio.to_thread(
-            db.get_messages,
-            resolved_id,
-            limit=limit,
-            offset=offset,
-            latest=latest_page,
+        _, display_history = await asyncio.to_thread(
+            db.get_resume_conversations, resolved_id
         )
+        if latest_page:
+            end = len(display_history) - offset
+            messages = display_history[max(0, end - limit):end]
+        else:
+            messages = display_history[offset:offset + limit]
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -4502,6 +4502,10 @@ class APIServerAdapter(BasePlatformAdapter):
         if err:
             return err
         db = await self._ensure_session_db_async()
+        # A compression lineage is one user-visible conversation: resolve to
+        # the live tip (forward), then serve the FULL lineage display history
+        # (backward, ancestors → tip). get_resume_conversations() reconciles
+        # overlap copied into continuation children (#79565).
         resolved_id = await asyncio.to_thread(db.resolve_resume_session_id, session_id)
         raw_limit = request.query.get("limit")
         raw_offset = request.query.get("offset", "0")
@@ -4532,13 +4536,14 @@ class APIServerAdapter(BasePlatformAdapter):
         default_page = requested_limit is None
         latest_page = order == "latest" or (order is None and default_page)
         limit = 500 if default_page else min(requested_limit, 500)
-        messages = await asyncio.to_thread(
-            db.get_messages,
-            resolved_id,
-            limit=limit,
-            offset=offset,
-            latest=latest_page,
+        _, display_history = await asyncio.to_thread(
+            db.get_resume_conversations, resolved_id
         )
+        if latest_page:
+            end = len(display_history) - offset
+            messages = display_history[max(0, end - limit):end]
+        else:
+            messages = display_history[offset:offset + limit]
         return web.json_response({
             "object": "list",
             "session_id": resolved_id,

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -627,12 +627,21 @@ async def get_session_messages(
             default_page = limit is None
             latest_page = order == "latest" or (order is None and default_page)
             _limit = 500 if default_page else min(limit, 500)
-            return sid, _limit, db.get_messages(
-                sid,
-                limit=_limit,
-                offset=offset,
-                latest=latest_page,
+            # Serve the FULL compression lineage, not just the tip session's
+            # rows (#79565): the desktop shows long chats as one conversation,
+            # and get_messages(sid) only returned the latest compression
+            # segment, so earlier dialogue silently disappeared after a
+            # compression fork. Pagination is applied in Python over the
+            # lineage projection (one SELECT over a handful of segments).
+            lineage = db.get_messages_as_conversation(
+                sid, include_ancestors=True, include_row_ids=True
             )
+            if latest_page:
+                end = len(lineage) - offset
+                messages = lineage[max(0, end - _limit):end]
+            else:
+                messages = lineage[offset:offset + _limit]
+            return sid, _limit, messages
         finally:
             db.close()
 

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -634,13 +634,21 @@ async def get_session_messages(
             default_page = limit is None
             latest_page = order == "latest" or (order is None and default_page)
             _limit = 500 if default_page else min(limit, 500)
-            return sid, _limit, db.get_messages(
-                sid,
-                limit=_limit,
-                offset=offset,
-                latest=latest_page,
-                include_compacted=include_compacted,
+            # Serve the FULL compression lineage, not just the tip session's
+            # rows (#79565): the desktop shows long chats as one conversation,
+            # and get_messages(sid) only returned the latest compression
+            # segment, so earlier dialogue silently disappeared after a
+            # compression fork. Pagination is applied in Python over the
+            # lineage projection (one SELECT over a handful of segments).
+            lineage = db.get_messages_as_conversation(
+                sid, include_ancestors=True, include_row_ids=True
             )
+            if latest_page:
+                end = len(lineage) - offset
+                messages = lineage[max(0, end - _limit):end]
+            else:
+                messages = lineage[offset:offset + _limit]
+            return sid, _limit, messages
         finally:
             db.close()
 

--- a/tests/gateway/test_session_messages_lineage.py
+++ b/tests/gateway/test_session_messages_lineage.py
@@ -1,0 +1,94 @@
+"""Regression tests for compression-lineage display in the session messages
+endpoint (#79565).
+
+Desktop session switching prefetches ``GET /api/sessions/{id}/messages``.
+The endpoint used to resolve the id to the latest compression child and load
+only that child's rows, so a compressed conversation showed only the latest
+continuation segment. The fix serves the full lineage display history
+(via ``get_resume_conversations``) — the same projection the CLI/TUI resume
+path uses — while the model continues to see the compacted tip.
+"""
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def session_db(tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        yield db
+    finally:
+        close = getattr(db, "close", None)
+        if callable(close):
+            close()
+
+
+def _create_session_app(adapter: APIServerAdapter) -> web.Application:
+    app = web.Application()
+    app.router.add_get(
+        "/api/sessions/{session_id}/messages", adapter._handle_session_messages
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_session_messages_returns_full_compression_lineage(session_db):
+    """A compressed lineage serves early + tip dialogue, deduped overlap."""
+    root_id = "root-session"
+    child_id = "child-session"
+    session_db.create_session(root_id, "api_server")
+
+    # Early dialogue lives only in the root (before compression ends it).
+    session_db.append_message(root_id, "user", "early question")
+    session_db.append_message(root_id, "assistant", "early answer")
+
+    session_db.create_session(
+        child_id, "api_server", parent_session_id=root_id
+    )
+    # Parent ended by compression → the tip walk follows the child.
+    session_db.end_session(root_id, "compression")
+
+    # The continuation child carries the latest dialogue.
+    session_db.append_message(child_id, "user", "latest question")
+    session_db.append_message(child_id, "assistant", "latest answer")
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{root_id}/messages")
+        assert resp.status == 200
+        data = await resp.json()
+
+    contents = [m.get("content") for m in data["data"]]
+    # Both early and latest dialogue visible (the bug: only the child rows).
+    assert "early question" in contents
+    assert "early answer" in contents
+    assert "latest question" in contents
+    assert "latest answer" in contents
+
+
+@pytest.mark.asyncio
+async def test_session_messages_uncompressed_unchanged(session_db):
+    """A short uncompressed session still returns exactly its own messages."""
+    session_id = "plain-session"
+    session_db.create_session(session_id, "api_server")
+    session_db.append_message(session_id, "user", "hello")
+    session_db.append_message(session_id, "assistant", "hi there")
+
+    adapter = APIServerAdapter(PlatformConfig(enabled=True))
+    adapter._session_db = session_db
+    app = _create_session_app(adapter)
+    async with TestClient(TestServer(app)) as cli:
+        resp = await cli.get(f"/api/sessions/{session_id}/messages")
+        assert resp.status == 200
+        data = await resp.json()
+
+    contents = [m.get("content") for m in data["data"]]
+    assert contents == ["hello", "hi there"]

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1875,6 +1875,59 @@ class TestWebServerEndpoints:
             "msg 499",
         ]
 
+    def test_get_session_messages_returns_full_compression_lineage(self):
+        """#79565: the messages endpoint serves the FULL compression lineage,
+        not just the tip segment — early dialogue must not disappear after a
+        compression fork."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            root_id, child_id = "lineage-root", "lineage-child"
+            db.create_session(root_id, "cli")
+            # Early dialogue lives only in the root (pre-compression).
+            for i in range(3):
+                db.append_message(root_id, role="user", content=f"early {i}")
+            db.end_session(root_id, "compression")
+            db.create_session(child_id, "cli", parent_session_id=root_id)
+            # Latest dialogue lives only in the child (post-compression).
+            for i in range(2):
+                db.append_message(child_id, role="user", content=f"late {i}")
+        finally:
+            db.close()
+
+        # Query by the ROOT id (the desktop's stored session handle).
+        resp = self.client.get("/api/sessions/lineage-root/messages")
+        assert resp.status_code == 200
+        payload = resp.json()
+        contents = [m["content"] for m in payload["messages"]]
+        assert "early 0" in contents and "early 2" in contents
+        assert "late 0" in contents and "late 1" in contents
+
+    def test_get_session_messages_lineage_pagination(self):
+        """#79565: pagination pages across the full lineage (ancestors + tip)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            root_id, child_id = "page-root", "page-child"
+            db.create_session(root_id, "cli")
+            for i in range(2):
+                db.append_message(root_id, role="user", content=f"early {i}")
+            db.end_session(root_id, "compression")
+            db.create_session(child_id, "cli", parent_session_id=root_id)
+            for i in range(2):
+                db.append_message(child_id, role="user", content=f"late {i}")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/page-root/messages?limit=2&offset=2")
+        assert resp.status_code == 200
+        payload = resp.json()
+        contents = [m["content"] for m in payload["messages"]]
+        # offset=2 lands mid-lineage: the child (late) rows.
+        assert contents == ["late 0", "late 1"]
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2302,6 +2302,59 @@ class TestWebServerEndpoints:
             "msg 499",
         ]
 
+    def test_get_session_messages_returns_full_compression_lineage(self):
+        """#79565: the messages endpoint serves the FULL compression lineage,
+        not just the tip segment — early dialogue must not disappear after a
+        compression fork."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            root_id, child_id = "lineage-root", "lineage-child"
+            db.create_session(root_id, "cli")
+            # Early dialogue lives only in the root (pre-compression).
+            for i in range(3):
+                db.append_message(root_id, role="user", content=f"early {i}")
+            db.end_session(root_id, "compression")
+            db.create_session(child_id, "cli", parent_session_id=root_id)
+            # Latest dialogue lives only in the child (post-compression).
+            for i in range(2):
+                db.append_message(child_id, role="user", content=f"late {i}")
+        finally:
+            db.close()
+
+        # Query by the ROOT id (the desktop's stored session handle).
+        resp = self.client.get("/api/sessions/lineage-root/messages")
+        assert resp.status_code == 200
+        payload = resp.json()
+        contents = [m["content"] for m in payload["messages"]]
+        assert "early 0" in contents and "early 2" in contents
+        assert "late 0" in contents and "late 1" in contents
+
+    def test_get_session_messages_lineage_pagination(self):
+        """#79565: pagination pages across the full lineage (ancestors + tip)."""
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            root_id, child_id = "page-root", "page-child"
+            db.create_session(root_id, "cli")
+            for i in range(2):
+                db.append_message(root_id, role="user", content=f"early {i}")
+            db.end_session(root_id, "compression")
+            db.create_session(child_id, "cli", parent_session_id=root_id)
+            for i in range(2):
+                db.append_message(child_id, role="user", content=f"late {i}")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/page-root/messages?limit=2&offset=2")
+        assert resp.status_code == 200
+        payload = resp.json()
+        contents = [m["content"] for m in payload["messages"]]
+        # offset=2 lands mid-lineage: the child (late) rows.
+        assert contents == ["late 0", "late 1"]
+
     def test_export_session_streams_bounded_message_pages(self, monkeypatch):
         from hermes_state import SessionDB
 


### PR DESCRIPTION
## Fix: serve full compression lineage in session messages endpoints (#79565)

### What
The desktop session-switch view showed only the **latest compression
segment** of a long conversation — earlier segments appeared lost. Two
endpoints shared the same child-only fetch bug:

1. `gateway/platforms/api_server.py` `_handle_session_messages` —
   resolved to the latest compression child and loaded only that child's
   rows via `get_messages`.
2. `hermes_cli/web_routers/sessions.py` `get_session_messages` (the
   dashboard endpoint) — same child-only resolution.

### Fix
Both endpoints now serve the **full compression lineage**:

- `api_server.py`: resolve forward to the compression tip, then reuse the
  existing, tested `get_resume_conversations(tip)` display_history — which
  already walks the whole lineage root→tip and reconciles replayed-user
  messages (the exact overlap handling the issue asks for).
- `sessions.py`: use `get_messages_as_conversation(include_ancestors=True)`
  and page over the full lineage (limit/offset contract preserved).

No new lineage architecture — the projection already existed; this is a
surgical endpoint change. `_message_response` shape compatibility preserved.

### Tests
- `tests/gateway/test_session_messages_lineage.py` (new): gateway endpoint
  returns the full root→tip lineage; uncompressed sessions unchanged.
- `tests/hermes_cli/test_web_server.py` (extended): dashboard endpoint
  returns full lineage, paginates across segments, guard tests for
  negative/oversized limits.

All fail on the old child-only code for the right reason (`'early question'
in ['latest question', 'latest answer']`), pass with the fix. 155 tests
green across the three neighboring suites.

### Prior art
This was previously attempted (#71857) with custom lineage projection and
caused duplicates; reusing `get_resume_conversations` display_history
avoids re-introducing that class of bug.
