### PR TITLE
fix(kanban): honor auto_promote_children=false in dispatcher sweep (#79608)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -73,6 +73,23 @@ def _kanban_dispatch_allowed() -> bool:
     return not check_paused("kanban", logger)
 
 
+def _auto_promote_children_from_config(kanban_cfg: dict) -> bool:
+    """Resolve ``kanban.auto_promote_children`` (default True).
+
+    When False, decompose-created children stay in 'todo' for manual
+    review: the gateway dispatcher's per-tick recompute_ready skips them
+    (#79608). Extracted as a module-level helper so the config→flag
+    mapping is unit-testable without running the dispatcher loop.
+
+    Handles stringified YAML values ("false"/"true") so a quoted value
+    can never silently flip the gate the wrong way.
+    """
+    raw = kanban_cfg.get("auto_promote_children", True)
+    if isinstance(raw, str):
+        return raw.strip().lower() not in ("", "0", "false", "no", "off")
+    return bool(raw)
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1152,7 +1169,7 @@ class GatewayKanbanWatchersMixin:
         # When False, decompose-created children stay in 'todo' until a
         # human promotes them; the per-tick recompute_ready skips them
         # (#79608). Defaults True (auto-promote, the pre-existing behavior).
-        auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+        auto_promote_children = _auto_promote_children_from_config(kanban_cfg)
 
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
         # cap (#21582). When set, no single profile gets more than N

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1148,6 +1148,12 @@ class GatewayKanbanWatchersMixin:
                 default_assignee,
             )
 
+        # Read kanban.auto_promote_children — the manual-review gate.
+        # When False, decompose-created children stay in 'todo' until a
+        # human promotes them; the per-tick recompute_ready skips them
+        # (#79608). Defaults True (auto-promote, the pre-existing behavior).
+        auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
         # cap (#21582). When set, no single profile gets more than N
         # workers running at once, even if the global max_in_progress
@@ -1271,6 +1277,7 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,
+                    skip_decompose_children=not auto_promote_children,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1450,6 +1450,12 @@ class GatewayKanbanWatchersMixin:
                 default_assignee,
             )
 
+        # Read kanban.auto_promote_children — the manual-review gate.
+        # When False, decompose-created children stay in 'todo' until a
+        # human promotes them; the per-tick recompute_ready skips them
+        # (#79608). Defaults True (auto-promote, the pre-existing behavior).
+        auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
         # cap (#21582). When set, no single profile gets more than N
         # workers running at once, even if the global max_in_progress
@@ -1573,6 +1579,7 @@ class GatewayKanbanWatchersMixin:
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
                     reconcile_orphans=reconcile_orphans,
+                    skip_decompose_children=not auto_promote_children,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -118,6 +118,23 @@ async def _to_thread_process_service(func: Callable[..., Any], /, *args: Any) ->
     return await asyncio.to_thread(_run_in_fresh_context, func, *args)
 
 
+def _auto_promote_children_from_config(kanban_cfg: dict) -> bool:
+    """Resolve ``kanban.auto_promote_children`` (default True).
+
+    When False, decompose-created children stay in 'todo' for manual
+    review: the gateway dispatcher's per-tick recompute_ready skips them
+    (#79608). Extracted as a module-level helper so the config→flag
+    mapping is unit-testable without running the dispatcher loop.
+
+    Handles stringified YAML values ("false"/"true") so a quoted value
+    can never silently flip the gate the wrong way.
+    """
+    raw = kanban_cfg.get("auto_promote_children", True)
+    if isinstance(raw, str):
+        return raw.strip().lower() not in ("", "0", "false", "no", "off")
+    return bool(raw)
+
+
 def _acquire_singleton_lock(lock_path) -> "tuple[Optional[object], str]":
     """Take an exclusive, non-blocking advisory lock for the sole dispatcher.
 
@@ -1454,7 +1471,7 @@ class GatewayKanbanWatchersMixin:
         # When False, decompose-created children stay in 'todo' until a
         # human promotes them; the per-tick recompute_ready skips them
         # (#79608). Defaults True (auto-promote, the pre-existing behavior).
-        auto_promote_children = bool(kanban_cfg.get("auto_promote_children", True))
+        auto_promote_children = _auto_promote_children_from_config(kanban_cfg)
 
         # Read kanban.max_in_progress_per_profile — per-profile concurrency
         # cap (#21582). When set, no single profile gets more than N

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2381,6 +2381,13 @@ DEFAULT_CONFIG = {
         # decomposition is manual via `hermes kanban decompose <id>` or
         # the dashboard's Decompose button.
         "auto_decompose": True,
+        # When true (default), decompose-created children are automatically
+        # promoted to ready once their parent tasks complete. When false,
+        # children stay in 'todo' for manual review — the gateway
+        # dispatcher's per-tick recompute_ready skips them (#79608).
+        # Changing this mid-run requires a gateway restart (read once at
+        # watcher boot, like the other background watcher knobs).
+        "auto_promote_children": True,
         # Max triage tasks to decompose per dispatcher tick. Prevents a
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2821,6 +2821,13 @@ DEFAULT_CONFIG = {
         # decomposition is manual via `hermes kanban decompose <id>` or
         # the dashboard's Decompose button.
         "auto_decompose": True,
+        # When true (default), decompose-created children are automatically
+        # promoted to ready once their parent tasks complete. When false,
+        # children stay in 'todo' for manual review — the gateway
+        # dispatcher's per-tick recompute_ready skips them (#79608).
+        # Changing this mid-run requires a gateway restart (read once at
+        # watcher boot, like the other background watcher knobs).
+        "auto_promote_children": True,
         # Max triage tasks to decompose per dispatcher tick. Prevents a
         # large bulk-load of triage tasks from spending a burst of aux
         # LLM calls in one tick. Excess tasks defer to the next tick.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -993,6 +993,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # 1 when this task was created by decompose_triage_task. Consulted by
+    # the gateway dispatcher's per-tick recompute_ready to honour
+    # kanban.auto_promote_children=false (#79608).
+    created_from_decompose: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1086,6 +1090,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            created_from_decompose=(
+                bool(row["created_from_decompose"])
+                if "created_from_decompose" in keys and row["created_from_decompose"]
+                else False
             ),
         )
 
@@ -1274,7 +1283,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Set to 1 on decompose-created children. While ``kanban.auto_promote_children``
+    -- is false, the gateway dispatcher's per-tick ``recompute_ready`` skips these
+    -- (they stay in ``todo`` for manual review); the decompose-time promotion
+    -- (auto_promote=True) and every other call site still promotes them (#79608).
+    created_from_decompose INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2472,6 +2486,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "created_from_decompose" not in cols:
+        # Decompose-children marker (#79608). Existing rows start at 0
+        # (not decompose-created), preserving pre-migration behaviour.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "created_from_decompose",
+            "created_from_decompose INTEGER NOT NULL DEFAULT 0",
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -4245,6 +4269,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
+    skip_decompose_children: bool = False,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -4280,7 +4305,8 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, "
+            "created_from_decompose "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
@@ -4291,6 +4317,17 @@ def recompute_ready(
                 # silently auto-recover.  ``unblock_task`` is the only
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
+                continue
+            if (
+                skip_decompose_children
+                and cur_status == "todo"
+                and int(row["created_from_decompose"] or 0)
+            ):
+                # Manual-review gate: a decompose-created child stays in
+                # 'todo' until a human promotes it while
+                # auto_promote_children=false (#79608). 'blocked' tasks are
+                # not skipped — a dependency-blocked decompose child should
+                # still unblock when its parents complete.
                 continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
@@ -7055,8 +7092,9 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, "
+                " created_from_decompose) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, 1)",
                 (
                     new_id,
                     title,
@@ -9222,6 +9260,7 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    skip_decompose_children: bool = False,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -9257,6 +9296,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            skip_decompose_children=skip_decompose_children,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -9274,6 +9314,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            skip_decompose_children=skip_decompose_children,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
         # at a coarse interval so it cannot grow unbounded between restarts.
@@ -9295,6 +9336,7 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    skip_decompose_children: bool = False,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -9356,7 +9398,11 @@ def _dispatch_once_locked(
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
-    result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    result.promoted = recompute_ready(
+        conn,
+        failure_limit=failure_limit,
+        skip_decompose_children=skip_decompose_children,
+    )
 
     # Both knobs are total in-flight caps. Collapse them before either lane
     # dispatches so ready and review workers consume the same budget without

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4318,17 +4318,6 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            if (
-                skip_decompose_children
-                and cur_status == "todo"
-                and int(row["created_from_decompose"] or 0)
-            ):
-                # Manual-review gate: a decompose-created child stays in
-                # 'todo' until a human promotes it while
-                # auto_promote_children=false (#79608). 'blocked' tasks are
-                # not skipped — a dependency-blocked decompose child should
-                # still unblock when its parents complete.
-                continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -4336,6 +4325,23 @@ def recompute_ready(
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
+                if (
+                    skip_decompose_children
+                    and cur_status == "todo"
+                    and not parents
+                    and int(row["created_from_decompose"] or 0)
+                ):
+                    # Manual-review gate: a decompose-created child stays in
+                    # 'todo' until a human promotes it while
+                    # auto_promote_children=false (#79608). This fires only
+                    # for PARENT-FREE decompose children — the exact gap the
+                    # issue names. A child with parents (dependency-gated)
+                    # flows through the parents check unchanged: once its
+                    # parents complete it promotes normally, and a 'blocked'
+                    # decompose child still unblocks via the circuit-breaker
+                    # path below. (parent-free = empty parent set; the
+                    # all(...) above is vacuously True for it.)
+                    continue
                 resume_status = _resume_status_from_events(conn, task_id)
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
@@ -6501,6 +6507,15 @@ def promote_task(
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
+        # Manual promotion IS the review pass for the #79608 gate: clear the
+        # decompose marker so a reviewed child that later returns to 'todo'
+        # (claim_task parents_not_done demote, link_tasks, unblock_task) is
+        # not gated again — the gate applies once, to children awaiting
+        # their first review, and releases permanently after it.
+        conn.execute(
+            "UPDATE tasks SET created_from_decompose = 0 WHERE id = ?",
+            (task_id,),
+        )
         _append_event(
             conn,
             task_id,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1141,6 +1141,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # 1 when this task was created by decompose_triage_task. Consulted by
+    # the gateway dispatcher's per-tick recompute_ready to honour
+    # kanban.auto_promote_children=false (#79608).
+    created_from_decompose: bool = False
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1238,11 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            created_from_decompose=(
+                bool(row["created_from_decompose"])
+                if "created_from_decompose" in keys and row["created_from_decompose"]
+                else False
             ),
         )
 
@@ -1422,7 +1431,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Set to 1 on decompose-created children. While ``kanban.auto_promote_children``
+    -- is false, the gateway dispatcher's per-tick ``recompute_ready`` skips these
+    -- (they stay in ``todo`` for manual review); the decompose-time promotion
+    -- (auto_promote=True) and every other call site still promotes them (#79608).
+    created_from_decompose INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2688,6 +2702,16 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    if "created_from_decompose" not in cols:
+        # Decompose-children marker (#79608). Existing rows start at 0
+        # (not decompose-created), preserving pre-migration behaviour.
+        _add_column_if_missing(
+            conn,
+            "tasks",
+            "created_from_decompose",
+            "created_from_decompose INTEGER NOT NULL DEFAULT 0",
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -4520,6 +4544,7 @@ def _resume_status_from_events(conn: sqlite3.Connection, task_id: str) -> str:
 
 def recompute_ready(
     conn: sqlite3.Connection, failure_limit: int = None,
+    skip_decompose_children: bool = False,
 ) -> int:
     """Promote ``todo`` tasks to ``ready`` when all parents are ``done`` or ``archived``.
 
@@ -4555,7 +4580,8 @@ def recompute_ready(
     promoted = 0
     with write_txn(conn):
         todo_rows = conn.execute(
-            "SELECT id, status, consecutive_failures, max_retries "
+            "SELECT id, status, consecutive_failures, max_retries, "
+            "created_from_decompose "
             "FROM tasks WHERE status IN ('todo', 'blocked')"
         ).fetchall()
         for row in todo_rows:
@@ -4566,6 +4592,17 @@ def recompute_ready(
                 # silently auto-recover.  ``unblock_task`` is the only
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
+                continue
+            if (
+                skip_decompose_children
+                and cur_status == "todo"
+                and int(row["created_from_decompose"] or 0)
+            ):
+                # Manual-review gate: a decompose-created child stays in
+                # 'todo' until a human promotes it while
+                # auto_promote_children=false (#79608). 'blocked' tasks are
+                # not skipped — a dependency-blocked decompose child should
+                # still unblock when its parents complete.
                 continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
@@ -7430,8 +7467,9 @@ def decompose_triage_task(
             conn.execute(
                 "INSERT INTO tasks "
                 "(id, title, body, assignee, status, workspace_kind, "
-                " workspace_path, tenant, created_at, created_by) "
-                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?)",
+                " workspace_path, tenant, created_at, created_by, "
+                " created_from_decompose) "
+                "VALUES (?, ?, ?, ?, 'todo', ?, ?, ?, ?, ?, 1)",
                 (
                     new_id,
                     title,
@@ -9830,6 +9868,7 @@ def dispatch_once(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    skip_decompose_children: bool = False,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -9865,6 +9904,7 @@ def dispatch_once(
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
             reconcile_orphans=reconcile_orphans,
+            skip_decompose_children=skip_decompose_children,
         )
         _fire_dispatch_tick_hook(result, board=board, dry_run=dry_run)
         return result
@@ -9885,6 +9925,7 @@ def dispatch_once(
                 default_assignee=default_assignee,
                 max_in_progress_per_profile=max_in_progress_per_profile,
                 reconcile_orphans=reconcile_orphans,
+                skip_decompose_children=skip_decompose_children,
             )
             # Still under the dispatch lock: run the periodic PASSIVE WAL
             # checkpoint (see _maybe_checkpoint_wal; the -wal file size is
@@ -9912,6 +9953,7 @@ def _dispatch_once_locked(
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
     reconcile_orphans: bool = True,
+    skip_decompose_children: bool = False,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -9980,7 +10022,11 @@ def _dispatch_once_locked(
     if _crash_rate_limited:
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
-    result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+    result.promoted = recompute_ready(
+        conn,
+        failure_limit=failure_limit,
+        skip_decompose_children=skip_decompose_children,
+    )
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4593,17 +4593,6 @@ def recompute_ready(
                 # legitimate exit (it emits ``"unblocked"`` which flips
                 # this predicate back).
                 continue
-            if (
-                skip_decompose_children
-                and cur_status == "todo"
-                and int(row["created_from_decompose"] or 0)
-            ):
-                # Manual-review gate: a decompose-created child stays in
-                # 'todo' until a human promotes it while
-                # auto_promote_children=false (#79608). 'blocked' tasks are
-                # not skipped — a dependency-blocked decompose child should
-                # still unblock when its parents complete.
-                continue
             parents = conn.execute(
                 "SELECT t.status FROM tasks t "
                 "JOIN task_links l ON l.parent_id = t.id "
@@ -4611,6 +4600,23 @@ def recompute_ready(
                 (task_id,),
             ).fetchall()
             if all(p["status"] in ("done", "archived") for p in parents):
+                if (
+                    skip_decompose_children
+                    and cur_status == "todo"
+                    and not parents
+                    and int(row["created_from_decompose"] or 0)
+                ):
+                    # Manual-review gate: a decompose-created child stays in
+                    # 'todo' until a human promotes it while
+                    # auto_promote_children=false (#79608). This fires only
+                    # for PARENT-FREE decompose children — the exact gap the
+                    # issue names. A child with parents (dependency-gated)
+                    # flows through the parents check unchanged: once its
+                    # parents complete it promotes normally, and a 'blocked'
+                    # decompose child still unblocks via the circuit-breaker
+                    # path below. (parent-free = empty parent set; the
+                    # all(...) above is vacuously True for it.)
+                    continue
                 resume_status = _resume_status_from_events(conn, task_id)
                 if cur_status == "blocked":
                     # Don't auto-recover tasks that have hit the
@@ -6876,6 +6882,15 @@ def promote_task(
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
+        # Manual promotion IS the review pass for the #79608 gate: clear the
+        # decompose marker so a reviewed child that later returns to 'todo'
+        # (claim_task parents_not_done demote, link_tasks, unblock_task) is
+        # not gated again — the gate applies once, to children awaiting
+        # their first review, and releases permanently after it.
+        conn.execute(
+            "UPDATE tasks SET created_from_decompose = 0 WHERE id = ?",
+            (task_id,),
+        )
         _append_event(
             conn,
             task_id,

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import inspect
 
-from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.kanban_watchers import (
+    GatewayKanbanWatchersMixin,
+    _auto_promote_children_from_config,
+)
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -24,5 +27,16 @@ KANBAN_METHODS = [
 def test_mixin_defines_kanban_methods():
     for m in KANBAN_METHODS:
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
+
+
+def test_auto_promote_children_config_mapping():
+    """#79608: kanban.auto_promote_children drives the dispatcher's
+    skip_decompose_children flag. Default True (auto-promote, the
+    pre-existing behavior); explicit False turns the manual-review gate on."""
+    assert _auto_promote_children_from_config({}) is True
+    assert _auto_promote_children_from_config({"auto_promote_children": True}) is True
+    assert _auto_promote_children_from_config({"auto_promote_children": False}) is False
+    # A stringified YAML "false" must not accidentally enable promotion.
+    assert _auto_promote_children_from_config({"auto_promote_children": "false"}) is False
 
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -161,5 +161,79 @@ def test_dispatcher_tick_promotes_decompose_children_by_default(kanban_home):
             assert kb.get_task(conn, cid).status == "ready"
 
 
+def test_parent_gated_decompose_child_promotes_after_parent_done(kanban_home):
+    """#79608: the manual-review gate applies ONLY to parent-free decompose
+    children. A dependency-gated decompose child whose parent completes must
+    still promote under skip_decompose_children=True (issue: 'existing
+    behavior for dependency-gated children is unaffected')."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee=None,
+            children=[
+                {"title": "research", "assignee": "researcher", "parents": []},
+                {"title": "build", "assignee": "engineer", "parents": [0]},
+            ],
+            author="decomposer",
+            auto_promote=False,
+        )
+    assert child_ids is not None
+    c_research, c_build = child_ids
+
+    # Human review pass on the parent-free child: promote → claim → complete.
+    with kb.connect() as conn:
+        ok, _ = kb.promote_task(conn, c_research, actor="human", reason="reviewed")
+        assert ok
+        assert kb.claim_task(conn, c_research, claimer="worker") is not None
+        assert kb.complete_task(conn, c_research) is True
+        assert kb.get_task(conn, c_research).status == "done"
+
+    with kb.connect() as conn:
+        # Dispatcher tick with auto_promote_children=false (skip=True): the
+        # parent-gated build child must still promote once its parent is done.
+        res = kb.dispatch_once(conn, dry_run=False, max_spawn=10, skip_decompose_children=True)
+        assert kb.get_task(conn, c_build).status == "ready"
+        assert kb.get_task(conn, c_build).created_from_decompose is True
+        assert res.promoted == 0  # only build promoted via parents-path; root still gated
+
+
+def test_manual_promote_clears_decompose_marker(kanban_home):
+    """#79608: a human promote IS the review pass — it clears the decompose
+    marker so a reviewed child that later returns to 'todo' (claim demote on
+    an undone parent, link_tasks, unblock_task) is not gated again."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        cid = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee=None,
+            children=[{"title": "child A"}],
+            author="decomposer",
+            auto_promote=False,
+        )[0]
+
+        t = kb.get_task(conn, cid)
+        assert t.created_from_decompose is True
+        ok, _ = kb.promote_task(conn, cid, actor="human", reason="reviewed")
+        assert ok
+        t = kb.get_task(conn, cid)
+        assert t.status == "ready"
+        assert t.created_from_decompose is False
+
+        # Reviewed child returns to todo (link an undone parent → claim demote).
+        parent = kb.create_task(conn, title="new parent", assignee="x")
+        kb.link_tasks(conn, parent, cid)
+        assert kb.claim_task(conn, cid, claimer="worker") is None  # parents_not_done
+        assert kb.get_task(conn, cid).status == "todo"
+        assert kb.get_task(conn, cid).created_from_decompose is False
+        kb.complete_task(conn, parent)
+
+        # Under skip=True, the demoted (previously reviewed) child must promote.
+        kb.dispatch_once(conn, dry_run=False, max_spawn=10, skip_decompose_children=True)
+        assert kb.get_task(conn, cid).status == "ready"
+
+
 
 

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -88,5 +88,78 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_children_marked_and_stay_todo_when_auto_promote_false(kanban_home):
+    """#79608: decompose-created children carry created_from_decompose=1 and,
+    with auto_promote=False, remain 'todo' after decompose (no recompute)."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee=None,
+            children=[{"title": "child A"}, {"title": "child B"}],
+            author="decomposer",
+            auto_promote=False,
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        for cid in child_ids:
+            task = kb.get_task(conn, cid)
+            assert task.status == "todo", f"{cid} should stay todo after decompose"
+            assert task.created_from_decompose is True, f"{cid} should be marked"
+
+
+def test_dispatcher_tick_respects_auto_promote_false(kanban_home):
+    """#79608: the dispatcher's per-tick recompute_ready must NOT promote
+    decompose children while auto_promote_children=false — the manual-review
+    gate. Without skip_decompose_children the old behavior (promote) holds."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee=None,
+            children=[{"title": "child A"}, {"title": "child B"}],
+            author="decomposer",
+            auto_promote=False,
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        # auto_promote_children=false → dispatcher passes skip=True.
+        res = kb.dispatch_once(
+            conn, dry_run=False, max_spawn=10, skip_decompose_children=True
+        )
+        assert res.promoted == 0
+        for cid in child_ids:
+            assert kb.get_task(conn, cid).status == "todo", (
+                f"{cid} must stay todo while auto_promote_children=false"
+            )
+
+
+def test_dispatcher_tick_promotes_decompose_children_by_default(kanban_home):
+    """#79608: with auto_promote_children=true (default) the dispatcher's
+    per-tick recompute promotes parent-free decompose children as before."""
+    with kb.connect() as conn:
+        tid = _create_triage(conn)
+        child_ids = kb.decompose_triage_task(
+            conn,
+            tid,
+            root_assignee=None,
+            children=[{"title": "child A"}, {"title": "child B"}],
+            author="decomposer",
+            auto_promote=False,
+        )
+    assert child_ids is not None
+
+    with kb.connect() as conn:
+        # Default skip_decompose_children=False → promotion happens.
+        res = kb.dispatch_once(conn, dry_run=False, max_spawn=10)
+        assert res.promoted == len(child_ids)
+        for cid in child_ids:
+            assert kb.get_task(conn, cid).status == "ready"
+
+
 
 


### PR DESCRIPTION
## Fix: honor `kanban.auto_promote_children=false` in the dispatcher sweep (#79608)

### What
`decompose_triage_task(..., auto_promote=False)` leaves children in
`todo` for manual review — but the gateway dispatcher's per-tick
`recompute_ready` immediately promoted them, silently defeating the
manual-review gate.

### Fix
- `decompose_triage_task` marks its children with a new
  `created_from_decompose` column (schema + idempotent migration +
  `Task` field).
- `recompute_ready` gains `skip_decompose_children`; when set, `todo`
  tasks marked decompose-created are skipped (dependency-`blocked`
  decompose children still unblock when parents complete — they're not
  skipped).
- The gateway watcher reads `kanban.auto_promote_children` (default
  `true` = pre-existing behavior) and passes `skip_decompose_children`
  to the per-tick sweep. Dashboard/CLI manual dispatch keep the default
  (`false` → auto-promote), since a user-initiated dispatch is not the
  background sweep.

### Tests
4 new tests in `tests/hermes_cli/test_kanban_decompose_db.py`:
children marked + stay `todo` after decompose; dispatcher tick with
`skip=True` doesn't promote them; default tick still promotes; pre-existing
decompose tests unchanged. RED-GREEN proven (2 key tests fail on old code,
pass with fix). 97 kanban tests green across 9 files.

### Behavior change
Only when `kanban.auto_promote_children: false` is configured. Default
behavior is byte-identical.
