### PR TITLE
fix(auxiliary): never send a model name to a foreign endpoint

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3588,6 +3588,92 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
         identity = normalized.get(identity_field)
         if isinstance(identity, str):
             normalized[identity_field] = identity.lower()
+    # Read provenance from the RAW snapshot: ``model_endpoint`` is a tuple, so
+    # the string-only field loop above would silently drop it, and it must NOT
+    # join _MAIN_RUNTIME_CONTEXT_FIELDS because those fields feed the client
+    # cache key discriminator.
+    return _enforce_runtime_endpoint_model_coherence(
+        normalized, main_runtime.get("model_endpoint"),
+    )
+
+
+# Endpoint/model provenance guard for auxiliary runtime snapshots.
+#
+# ``_normalize_main_runtime`` copies fields individually and skips empty ones.
+# That per-field merge is what makes a cross-provider fallback able to leave an
+# INCOHERENT snapshot behind: the fallback swap rewrites ``provider`` and
+# ``base_url`` (e.g. → nvidia / integrate.api.nvidia.com) while a stale
+# ``model`` from the previous runtime survives untouched. Auxiliary tasks then
+# resolve a client for the NEW endpoint and send the OLD model name to it:
+#
+#   base_url=https://integrate.api.nvidia.com/v1/  model=claude-opus-5
+#   → 400 "The supported API model names are deepseek-v4-pro or
+#          deepseek-v4-flash, but you passed claude-opus-5."
+#
+# Failure mode matters: compression is the main consumer, and a failed summary
+# is SILENT — it only logs, then inserts a degraded placeholder marker instead
+# of a real handoff. The session keeps its tokens, so the threshold re-trips
+# immediately and compaction spins.
+#
+# A model name is only meaningful for the endpoint it was resolved against, so
+# an endpoint change invalidates a model carried over from another endpoint.
+# Drop the orphaned model rather than mixing the two: downstream resolution
+# already treats a missing model as "use this provider's default", which is
+# correct-by-construction, whereas a mismatched pair is guaranteed to fail.
+_RUNTIME_ENDPOINT_IDENTITY_FIELDS = ("provider", "base_url")
+
+
+def _runtime_endpoint_identity(runtime: Dict[str, Any]) -> Tuple[str, str]:
+    """Return the (provider, base_url) identity a model name is scoped to."""
+    provider = str(runtime.get("provider") or "").strip().lower()
+    base_url = str(runtime.get("base_url") or "").strip().rstrip("/").lower()
+    return provider, base_url
+
+
+def _enforce_runtime_endpoint_model_coherence(
+    normalized: Dict[str, Any],
+    recorded: Any = None,
+) -> Dict[str, Any]:
+    """Drop a model that belongs to a different endpoint than the snapshot's.
+
+    ``model_endpoint`` records which (provider, base_url) pair the model name
+    was resolved against. When the recorded pair no longer matches the
+    snapshot's own endpoint, the model is a leftover from a superseded runtime
+    (cross-provider fallback, /model switch, restore) and must not be sent.
+    Snapshots without provenance are left alone — absence of evidence is not
+    evidence of a mismatch, and stripping models from every legacy caller
+    would regress correct single-endpoint routing.
+    """
+    # Defensive: also honour provenance that reached ``normalized`` directly,
+    # so a future caller adding the field to the copied set still gets checked.
+    if recorded is None:
+        recorded = normalized.pop("model_endpoint", None)
+    else:
+        normalized.pop("model_endpoint", None)
+    model = normalized.get("model")
+    if not model or not isinstance(recorded, (tuple, list)) or len(recorded) != 2:
+        return normalized
+    recorded_identity = (
+        str(recorded[0] or "").strip().lower(),
+        str(recorded[1] or "").strip().rstrip("/").lower(),
+    )
+    current_identity = _runtime_endpoint_identity(normalized)
+    # Only an endpoint we can actually compare counts as a mismatch: an empty
+    # recorded identity means the producer did not know its endpoint yet.
+    if not any(recorded_identity) or recorded_identity == current_identity:
+        return normalized
+    logger.warning(
+        "Auxiliary runtime dropped a stale model name: model=%r was resolved "
+        "for provider=%r base_url=%r but this runtime is provider=%r "
+        "base_url=%r. Using the endpoint's default model instead of sending a "
+        "mismatched pair.",
+        model,
+        recorded_identity[0] or "(unset)",
+        recorded_identity[1] or "(unset)",
+        current_identity[0] or "(unset)",
+        current_identity[1] or "(unset)",
+    )
+    normalized.pop("model", None)
     return normalized
 
 
@@ -5442,7 +5528,40 @@ def _resolve_auto(
     # cheap provider-side default.  Explicit per-task overrides set via
     # config.yaml (auxiliary.<task>.provider) still win over this.
     main_provider = str(runtime_provider or _read_main_provider() or "")
-    main_model = str(runtime_model or _read_main_model() or "")
+    # ``_read_main_model()`` is config.yaml's ``model.default`` — a
+    # name that is only valid on the CONFIGURED provider. When the live runtime
+    # has been swapped to a different provider by a cross-provider fallback,
+    # falling back to the configured model name pairs a foreign model with the
+    # fallback endpoint and the request 400s:
+    #
+    #   provider=nvidia base_url=integrate.api.nvidia.com model=claude-opus-5
+    #   → "The supported API model names are deepseek-v4-pro or
+    #      deepseek-v4-flash, but you passed claude-opus-5."
+    #
+    # Only inherit the configured model when the runtime provider still IS the
+    # configured provider. Otherwise leave it empty so the resolution below
+    # asks the actual endpoint for its own default — a provider's own default
+    # is always valid on that provider, a borrowed name is not.
+    _config_main_model = str(_read_main_model() or "")
+    if runtime_model:
+        main_model = str(runtime_model)
+    elif runtime_provider and _config_main_model:
+        _configured_provider = str(_read_main_provider() or "").strip().lower()
+        _live_provider = str(runtime_provider).strip().lower()
+        if _live_provider == _configured_provider:
+            main_model = _config_main_model
+        else:
+            logger.warning(
+                "Auxiliary auto-resolution declined to reuse the configured "
+                "model %r: the live runtime provider is %r but %r is configured "
+                "for %r. Falling through to the endpoint's own default model "
+                "instead of sending a cross-endpoint pair.",
+                _config_main_model, _live_provider,
+                _config_main_model, _configured_provider or "(unset)",
+            )
+            main_model = ""
+    else:
+        main_model = _config_main_model
 
     # MoA virtual provider: the "model" is a preset name (e.g. "opus-gpt") and
     # there is no real "moa" HTTP endpoint, so resolving an aux client against
@@ -5713,6 +5832,15 @@ def resolve_provider_client(
         (client, resolved_model) or (None, None) if auth is unavailable.
     """
     _validate_proxy_env_urls()
+    # This router backfills a missing model from
+    # ``main_runtime.get("model")`` in a dozen provider branches below. If the
+    # snapshot is incoherent (endpoint swapped by a cross-provider fallback,
+    # stale model name left behind), every one of those branches would send the
+    # foreign model to the new endpoint. Normalizing here strips an
+    # endpoint-orphaned model once, at the single chokepoint, instead of
+    # auditing each backfill site.
+    if main_runtime is not None:
+        main_runtime = _normalize_main_runtime(main_runtime)
     # Preserve the original provider name before alias normalization so a
     # user-declared ``custom_providers`` entry whose name coincidentally
     # matches a built-in alias (e.g. user names their custom provider "kimi"

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3864,6 +3864,15 @@ This compaction should PRIORITISE preserving all information related to the focu
                     "base_url": self.base_url,
                     "api_key": self.api_key,
                     "api_mode": self.api_mode,
+                    # Stamp which endpoint self.model was resolved
+                    # against. update_model() keeps these three in lockstep, so
+                    # a mismatch downstream means the snapshot was merged with a
+                    # superseded runtime (cross-provider fallback leaving a
+                    # stale model name). The auxiliary layer drops the orphaned
+                    # model instead of sending it to a foreign endpoint, which
+                    # previously produced a silent 400 and a degraded
+                    # placeholder summary that never reduced tokens.
+                    "model_endpoint": (self.provider, self.base_url),
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 # NO max_tokens: the output cap must never truncate a summary.
@@ -5489,6 +5498,8 @@ This compaction should PRIORITISE preserving all information related to the focu
                 "base_url": self.base_url or "",
                 "api_key": self.api_key or "",
                 "api_mode": getattr(self, "api_mode", "") or "",
+                # Same endpoint provenance stamp as _generate_summary.
+                "model_endpoint": (self.provider or "", self.base_url or ""),
             })
 
         try:

--- a/tests/agent/test_aux_runtime_endpoint_model_coherence.py
+++ b/tests/agent/test_aux_runtime_endpoint_model_coherence.py
@@ -1,0 +1,141 @@
+"""Regression: auxiliary runtime must never pair a model name with a
+foreign endpoint.
+
+Root cause recap
+----------------
+A cross-provider fallback rewrites the live runtime's ``provider`` +
+``base_url`` but the model name reaching the auxiliary layer could still be the
+PRIMARY model, from either of two independent sources:
+
+1. ``_normalize_main_runtime`` merges fields individually and skips empty ones,
+   so a snapshot could carry a new endpoint with a stale ``model``.
+2. ``_resolve_auto`` backfilled a missing model from config.yaml's
+   ``model.default`` — valid only on the *configured* provider — without
+   checking that the live runtime still IS that provider.
+
+Either path produced a request like::
+
+    base_url=https://integrate.api.nvidia.com/v1/  model=claude-opus-5
+    → 400 "The supported API model names are deepseek-v4-pro or
+           deepseek-v4-flash, but you passed claude-opus-5."
+
+Why it mattered beyond one failed call: compression is the main consumer and a
+failed summary is SILENT. It logs, then inserts a degraded placeholder marker
+instead of a real handoff, so the session never sheds tokens and the
+compression threshold re-trips on the very next turn.
+
+These tests assert the invariant (a model is only ever sent to the endpoint it
+was resolved for), not the current model catalog, so they stay valid as
+providers change.
+"""
+
+from agent.auxiliary_client import _normalize_main_runtime
+
+NVIDIA_BASE = "https://integrate.api.nvidia.com/v1/"
+PRIMARY_BASE = "https://aicodelink.top/v1"
+
+
+def test_stale_model_dropped_when_endpoint_was_swapped():
+    """The exact 400 shape: fallback endpoint + model from the old endpoint."""
+    runtime = _normalize_main_runtime({
+        "model": "claude-opus-5",
+        "provider": "nvidia",
+        "base_url": NVIDIA_BASE,
+        "api_key": "k",
+        "api_mode": "chat_completions",
+        "model_endpoint": ("aicodelink-claude", PRIMARY_BASE),
+    })
+    # The orphaned model must be gone: downstream treats a missing model as
+    # "use this endpoint's default", which is always valid on that endpoint.
+    assert "model" not in runtime
+    # ...while the endpoint and its credentials survive untouched.
+    assert runtime["base_url"] == NVIDIA_BASE
+    assert runtime["provider"] == "nvidia"
+    assert runtime["api_key"] == "k"
+
+
+def test_coherent_runtime_keeps_its_model():
+    """A model matching its own endpoint must never be stripped."""
+    runtime = _normalize_main_runtime({
+        "model": "claude-opus-5",
+        "provider": "aicodelink-claude",
+        "base_url": PRIMARY_BASE,
+        "api_key": "k",
+        "model_endpoint": ("aicodelink-claude", PRIMARY_BASE),
+    })
+    assert runtime["model"] == "claude-opus-5"
+
+
+def test_trailing_slash_and_case_are_not_a_mismatch():
+    """Endpoint identity is compared normalized — no false positives."""
+    runtime = _normalize_main_runtime({
+        "model": "claude-opus-5",
+        "provider": "AICodeLink-Claude",
+        "base_url": PRIMARY_BASE + "/",
+        "model_endpoint": ("aicodelink-claude", PRIMARY_BASE),
+    })
+    assert runtime["model"] == "claude-opus-5"
+
+
+def test_snapshot_without_provenance_is_left_alone():
+    """Absence of evidence is not evidence of mismatch (back-compat).
+
+    Legacy callers that don't stamp ``model_endpoint`` must keep working:
+    stripping models from every unstamped snapshot would break correct
+    single-endpoint routing everywhere.
+    """
+    runtime = _normalize_main_runtime({
+        "model": "claude-opus-5",
+        "provider": "nvidia",
+        "base_url": NVIDIA_BASE,
+    })
+    assert runtime["model"] == "claude-opus-5"
+
+
+def test_empty_provenance_is_not_treated_as_mismatch():
+    """A producer that didn't know its endpoint yet must not trigger a strip."""
+    runtime = _normalize_main_runtime({
+        "model": "some-model",
+        "provider": "p",
+        "base_url": "https://example.invalid/v1",
+        "model_endpoint": ("", ""),
+    })
+    assert runtime["model"] == "some-model"
+
+
+def test_provenance_field_never_leaks_downstream():
+    """``model_endpoint`` is internal: it must not reach provider kwargs.
+
+    It is also deliberately kept out of _MAIN_RUNTIME_CONTEXT_FIELDS because
+    those fields feed the auxiliary client cache-key discriminator.
+    """
+    for snapshot in (
+        {
+            "model": "claude-opus-5",
+            "provider": "nvidia",
+            "base_url": NVIDIA_BASE,
+            "model_endpoint": ("aicodelink-claude", PRIMARY_BASE),
+        },
+        {
+            "model": "claude-opus-5",
+            "provider": "aicodelink-claude",
+            "base_url": PRIMARY_BASE,
+            "model_endpoint": ("aicodelink-claude", PRIMARY_BASE),
+        },
+    ):
+        assert "model_endpoint" not in _normalize_main_runtime(snapshot)
+
+
+def test_compressor_stamps_endpoint_provenance():
+    """The guard is only meaningful if the producer actually stamps it.
+
+    Without this the field is always absent, every snapshot takes the
+    back-compat path, and the guard silently checks nothing.
+    """
+    import inspect
+
+    from agent import context_compressor
+
+    source = inspect.getsource(context_compressor)
+    # Both auxiliary call sites in the compressor must carry the stamp.
+    assert source.count('"model_endpoint"') >= 2


### PR DESCRIPTION
## What does this PR do?

Auxiliary tasks (compression, title generation, vision, …) could send the
**primary** model name to a **different** provider's endpoint after a
cross-provider fallback, producing a request that is guaranteed to fail:

```
provider=nvidia base_url=https://integrate.api.nvidia.com/v1/ model=claude-opus-5
→ 400 "The supported API model names are deepseek-v4-pro or deepseek-v4-flash,
       but you passed claude-opus-5."
```

The impact is disproportionate to one failed call because **compression is the
main consumer and its failure is silent**: `context_compressor` logs the error,
then inserts a degraded placeholder marker instead of a real summary. The session
therefore never sheds tokens, so the compression threshold re-trips on the very
next turn. From the user's side this looks like "compression keeps running for no
reason", with no error surfaced anywhere in the UI.

### Reproduction

Requires `fallback_providers` configured with a provider whose model names differ
from the primary's (i.e. any non-aggregator fallback).

1. Primary provider starts returning 5xx.
2. `agent/conversation_loop.py` falls back to the secondary provider, rewriting
   the live runtime's `provider` + `base_url`.
3. The next auxiliary call resolves a client for the **new** endpoint but ends up
   carrying the **old** endpoint's model name.

Observed in the wild, 20s apart in one session:

```
21:27:00 WARNING agent.conversation_loop: API call failed (attempt 2/3)
         provider=nvidia base_url=https://integrate.api.nvidia.com/v1/
21:27:20 WARNING agent.context_compressor: Failed to generate context summary:
         Error code: 400 - 'The supported API model names are deepseek-v4-pro
         or deepseek-v4-flash, but you passed claude-opus-5.'
```

### Root cause

Two **independent** paths produce the incoherent (endpoint, model) pair. Fixing
only the first is insufficient — the model name flows back in through the second,
which is what initially made this look like a one-line fix:

**1. `_normalize_main_runtime()`** merges runtime fields individually and skips
empty values, so a snapshot can carry a *new* endpoint alongside a *stale* model
name inherited from the previous endpoint.

**2. `_resolve_auto()`** backfilled a missing model from config's `model.default`:

```python
main_model = str(runtime_model or _read_main_model() or "")
```

`model.default` is only valid on the **configured** provider. When the live
runtime has been swapped by a fallback, this pairs a foreign model name with the
fallback endpoint.

### Why this approach

A model name is only meaningful on the endpoint it was resolved for. So the fix
stamps provenance — `(provider, base_url)` — on the runtime snapshot, and when
the endpoint no longer matches, **drops the orphaned model name** instead of
sending it. Resolution then asks the actual endpoint for its own default, which
is always valid there, whereas a borrowed name can never be.

`resolve_provider_client()` was chosen as the single sanitization point because
it backfills a missing model from `main_runtime` in a dozen provider branches; one
choke point is more robust than auditing each branch separately. Happy to
restructure to per-branch handling if reviewers prefer.

**Backwards compatibility:** absence of provenance is *not* treated as a
mismatch, so callers that don't stamp it keep their exact current behaviour.
Stripping models from every unstamped snapshot would break correct
single-endpoint routing everywhere. There is a dedicated test for this.

## Related Issue

No existing issue — I searched open issues/PRs and found no report of this
behaviour. The closest neighbours are different layers of "wrong thing reaches
wrong endpoint" and do not overlap:

- #68240 `fix(delegation): keep credential pools endpoint-coherent` — credential
  pool leasing, not model naming.
- #54882 `fix(auxiliary): skip invalid api-key fallbacks` — key validity, not
  endpoint/model coherence.

Happy to open a tracking issue first if maintainers prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py`
  - Add `_runtime_endpoint_identity()` — normalizes `(provider, base_url)` for
    comparison (case- and trailing-slash-tolerant, so no false positives).
  - Add `_enforce_runtime_endpoint_model_coherence()` — drops an orphaned model
    name when the stamped endpoint no longer matches the runtime's endpoint, and
    logs a `WARNING` naming what was dropped and why.
  - Call it from `_normalize_main_runtime()`, reading provenance from the **raw**
    snapshot. Provenance is deliberately kept out of
    `_MAIN_RUNTIME_CONTEXT_FIELDS`, because those fields feed the auxiliary
    client cache-key discriminator and adding it there would fragment the cache.
  - Sanitize once at the entry of `resolve_provider_client()`.
  - `_resolve_auto()` now only inherits `model.default` when the live provider
    still equals the configured provider.
- `agent/context_compressor.py`
  - Stamp `model_endpoint` provenance at both auxiliary call sites, so the guard
    has something to compare against (without this the field would always be
    absent and the guard would silently check nothing).
- `tests/agent/test_aux_runtime_endpoint_model_coherence.py` — new, 7 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(auxiliary):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit on top of a clean upstream base)
- [x] I've run the relevant suites and all tests pass (see below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

Suite results on a clean checkout of the base commit:

```
tests/agent/test_aux_runtime_endpoint_model_coherence.py     7 passed
tests/agent/test_context_compressor.py                     108 passed
tests/agent/test_auxiliary_client.py                       169 passed
=== 284 passed, 0 failed ===
```

Test coverage:

| Test | Asserts |
|---|---|
| `test_stale_model_dropped_when_endpoint_was_swapped` | the reproduced 400 shape is prevented; endpoint + credentials survive |
| `test_coherent_runtime_keeps_its_model` | a model matching its own endpoint is never stripped |
| `test_trailing_slash_and_case_are_not_a_mismatch` | normalization tolerance, no false positives |
| `test_snapshot_without_provenance_is_left_alone` | back-compat for unstamped callers |
| `test_empty_provenance_is_not_treated_as_mismatch` | empty stamp is not a mismatch |
| `test_provenance_field_never_leaks_downstream` | internal field never reaches provider kwargs |
| `test_compressor_stamps_endpoint_provenance` | the producer actually stamps it, so the guard is not a no-op |

The tests assert the *invariant* (a model is only ever sent to the endpoint it was
resolved for) rather than any specific model catalog, so they stay valid as
provider catalogs change.

**I verified the tests actually fail when the guard is reverted** — reverting the
coherence call turns the suite red, confirming these assertions are not vacuous.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on both new functions explaining the failure mode) — partial: no user-facing docs needed, this is internal routing
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python string/dict logic, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (live log, primary had fallen back to a provider with a different model catalog):

```
21:27:00 WARNING [<session>] agent.conversation_loop: API call failed (attempt 2/3)
         provider=nvidia base_url=https://integrate.api.nvidia.com/v1/
21:27:20 WARNING [<session>] agent.context_compressor: Failed to generate context
         summary: Error code: 400 - 'The supported API model names are
         deepseek-v4-pro or deepseek-v4-flash, but you passed claude-opus-5.'
         Falling back to a truncated handoff marker.
```

After, the incoherent pair is caught before the request is built and the reason is
explicit instead of silent:

```
WARNING agent.auxiliary_client: Auxiliary runtime dropped a stale model name:
        model='claude-opus-5' was resolved for provider='aicodelink-claude'
        base_url='https://aicodelink.top/v1' but this runtime is
        provider='nvidia' base_url='https://integrate.api.nvidia.com/v1'.
        Using the endpoint's default model instead of sending a mismatched pair.
```
