### PR TITLE
fix(lifecycle-guard): close NUL-byte bypass in referenced-script scanning

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -329,6 +329,17 @@ def _contains_unsafe_gateway_action(
         script_text, unsafe = _read_referenced_script(script_path)
         if unsafe:
             return True
+        if script_text is None and "\x00" in str(script_path):
+            # ``_read_referenced_script`` correctly refuses to open a path with
+            # an embedded NUL, but returning "nothing to scan" is exploitable
+            # here: a POSIX shell DROPS NUL bytes from a word, so the command
+            # ``bash danger\x00.sh`` actually executes ``danger.sh``. Scan the
+            # path the shell would resolve instead of skipping the reference.
+            stripped = Path(str(script_path).replace("\x00", ""))
+            if str(stripped):
+                script_text, unsafe = _read_referenced_script(stripped)
+                if unsafe:
+                    return True
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))

--- a/tests/cron/test_lifecycle_guard_nul_path_bypass.py
+++ b/tests/cron/test_lifecycle_guard_nul_path_bypass.py
@@ -1,0 +1,88 @@
+"""The lifecycle guard must not be bypassable with an embedded NUL byte.
+
+``_read_referenced_script`` refuses to ``os.open()`` a path containing a NUL and
+reports "nothing to scan". That refusal is correct, but treating it as "nothing
+to scan" is exploitable at the call site: a POSIX shell *drops* NUL bytes from a
+word, so ``bash danger\\x00.sh`` really executes ``danger.sh``.
+
+The guard therefore has to scan the path the shell would resolve, not the raw
+token it was handed.
+
+These tests drive the public entry point, which is the actual attack surface,
+and pass the script by name with ``cwd=`` so the command line stays free of
+backslashes (``shlex`` treats those as escapes, which would silently mangle a
+Windows absolute path and make the assertions meaningless).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from cron.lifecycle_guard import (  # noqa: E402
+    contains_gateway_lifecycle_command_or_referenced_script as guard,
+)
+
+
+# Assembled rather than written literally so this module's own source does not
+# read as a lifecycle command to tools that scan test files.
+UNSAFE_BODY = "#!/usr/bin/env bash\n" + "hermes" + " gateway " + "restart" + "\n"
+SAFE_BODY = "#!/usr/bin/env bash\necho hello\n"
+
+
+def _write(tmp_path: Path, name: str, body: str) -> Path:
+    script = tmp_path / name
+    script.write_text(body, encoding="utf-8")
+    return script
+
+
+def test_nul_in_path_does_not_bypass_the_guard(tmp_path: Path) -> None:
+    """``danger\\x00.sh`` must be detected, because the shell runs ``danger.sh``."""
+    _write(tmp_path, "danger.sh", UNSAFE_BODY)
+
+    assert guard("bash danger\x00.sh", cwd=str(tmp_path)) is True
+
+
+def test_plain_unsafe_script_is_still_detected(tmp_path: Path) -> None:
+    """Baseline: detection of an ordinary unsafe reference is unchanged."""
+    _write(tmp_path, "danger.sh", UNSAFE_BODY)
+
+    assert guard("bash danger.sh", cwd=str(tmp_path)) is True
+
+
+def test_safe_script_with_nul_is_not_flagged(tmp_path: Path) -> None:
+    """Stripping the NUL must not turn a harmless script into a false positive."""
+    _write(tmp_path, "safe.sh", SAFE_BODY)
+
+    assert guard("bash safe\x00.sh", cwd=str(tmp_path)) is False
+
+
+def test_nul_path_with_no_real_file_is_not_flagged(tmp_path: Path) -> None:
+    """A NUL path whose stripped form does not exist stays 'nothing to scan'."""
+    assert guard("bash missing\x00.sh", cwd=str(tmp_path)) is False
+
+
+def test_all_nul_word_does_not_crash(tmp_path: Path) -> None:
+    """A word that is only NULs strips to empty and must not raise."""
+    assert guard("bash \x00\x00", cwd=str(tmp_path)) is False
+
+
+def test_nul_in_source_directive_is_also_covered(tmp_path: Path) -> None:
+    """The same smuggling through ``source`` must not bypass the guard either."""
+    _write(tmp_path, "danger.sh", UNSAFE_BODY)
+
+    assert guard("source danger\x00.sh", cwd=str(tmp_path)) is True
+
+
+def test_guard_never_raises_on_nul_path(tmp_path: Path) -> None:
+    """The guard must return a verdict, never propagate ValueError.
+
+    Upstream already stopped ``os.open`` from crashing the guard; this asserts
+    the NUL-stripping retry did not reintroduce an unguarded path operation.
+    """
+    _write(tmp_path, "danger.sh", UNSAFE_BODY)
+
+    # Would raise ValueError("embedded null byte") if a path op were unguarded.
+    assert guard("bash danger\x00.sh", cwd=str(tmp_path)) is True


### PR DESCRIPTION
## What does this PR do?

Closes a bypass in the lifecycle guard: **a single NUL byte in a script path
makes the guard skip scanning a script that the shell will still execute.**

`_read_referenced_script()` refuses to `os.open()` a path containing an embedded
NUL and reports "nothing to scan". That refusal is correct and was hardened
recently (#76762, #77703, and 9a9cf6a). But treating it as "nothing to scan" at
the *call site* is exploitable, because a POSIX shell **drops** NUL bytes from a
word:

```
bash danger\x00.sh      # guard sees an unopenable token -> skipped
                        # shell actually executes danger.sh
```

So any script the guard is meant to catch can be smuggled past it by inserting
one NUL byte into the path. This is the exploitable half of the same NUL class:
upstream fixed "the guard must not crash", this fixes "the guard must not be
silently bypassed".

### Why this approach

When a referenced path cannot be read **and** contains a NUL, rescan the path the
shell would actually resolve (NUL bytes removed) before falling through to the
remote reader. The guard should inspect what will really run, not a token the
shell never uses verbatim.

The change is deliberately narrow to avoid new false positives:

- it only triggers when the read **already failed** and a NUL is present, so the
  common path is completely untouched;
- an all-NUL word strips to empty and is skipped rather than probing the cwd;
- a stripped path that does not exist stays "nothing to scan";
- the remote-reader fallback, `visited` set, and recursion depth limits are
  unchanged.

Stripping NULs earlier (in `_iter_referenced_shell_scripts`) was the alternative,
but that would silently rewrite tokens for every consumer of that iterator.
Handling it at the point of the failed read keeps the blast radius to exactly the
case that is currently exploitable.

## Related Issue

Same class as #76762 / #77703, which addressed the crash. This addresses the
bypass that remains once the guard stops crashing:

- 9a9cf6a `fix(cron): tolerate NUL bytes in referenced-script paths at os.open`
  added the `ValueError` catch. I confirmed on current `main` that no
  NUL-stripping rescan exists, so the bypass is still open.

I'm treating this as security-relevant, so I've kept the reproduction in the
tests rather than writing an exploit into the issue tracker. Happy to move the
discussion wherever maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `cron/lifecycle_guard.py`
  - In `_contains_unsafe_gateway_action()`, when `_read_referenced_script()`
    returns no text **and** the path contains a NUL, retry the read against the
    NUL-stripped path (the form the shell resolves) and honour an `unsafe`
    verdict from it.
- `tests/cron/test_lifecycle_guard_nul_path_bypass.py` — new, 7 tests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(lifecycle-guard):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit)
- [x] I've run the relevant suite and all tests pass (see below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

```
tests/cron/test_lifecycle_guard_nul_path_bypass.py    7 passed, 0 failed
```

| Test | Asserts |
|---|---|
| `test_nul_in_path_does_not_bypass_the_guard` | the smuggled `bash danger\x00.sh` form is detected |
| `test_nul_in_source_directive_is_also_covered` | same smuggling through `source` is detected |
| `test_plain_unsafe_script_is_still_detected` | ordinary detection is unchanged |
| `test_safe_script_with_nul_is_not_flagged` | no false positive from stripping |
| `test_nul_path_with_no_real_file_is_not_flagged` | nonexistent stripped path stays unscanned |
| `test_all_nul_word_does_not_crash` | all-NUL word strips to empty safely |
| `test_guard_never_raises_on_nul_path` | the guard returns a verdict, never propagates `ValueError` |

**I verified the fix is load-bearing**: reverting the rescan turns exactly the
three security assertions red (`nul_in_path`, `nul_in_source`,
`never_raises`), while the false-positive guards stay green.

### A note on the test style

The scripts are passed by **name with `cwd=`** rather than as absolute paths.
`shlex` treats backslashes as escapes, so a Windows absolute path is silently
mangled (`C:\Users\...` → `C:Users...`) and the resulting candidate never
resolves — which would make the assertions pass for the wrong reason. I hit this
while writing the tests; flagging it in case it's worth a note for other
Windows contributors.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (rationale is an inline comment
      at the fix site)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the bypass is POSIX-shell
      semantics; the fix is pure string/path logic with no platform branches
- [x] I've updated tool descriptions/schemas — N/A (guard verdicts unchanged for
      all non-NUL input)
