### PR TITLE
fix(moa): keep the MoA facade out of OpenAI SDK client-rebuild paths

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2782,6 +2782,10 @@ def init_agent(
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        # MoA's facade holds the reference relay and per-turn accounting; a
+        # cross-provider fallback replaces ``agent.client``, so the snapshot is
+        # the only surviving reference. ``None`` for every other provider.
+        "moa_client": agent.client if agent.provider == "moa" else None,
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         # Context engine state that _try_activate_fallback() overwrites.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1326,9 +1326,22 @@ def try_recover_primary_transport(
             # via _create_openai_client would raise "api_key client option
             # must be set". Recreate the facade through the shared factory so
             # the reference_callback relay survives recovery (#53802).
-            from agent.moa_loop import build_moa_facade
+            # A cross-provider fallback replaces ``agent.client`` with the
+            # fallback's SDK client. The primary snapshot is then the only
+            # surviving reference to the original facade and its callback
+            # relay, so prefer reusing it. Older snapshots lack this key and
+            # remain compatible through the factory fallback.
+            moa_client = rt.get("moa_client")
+            if moa_client is None:
+                from agent.moa_loop import build_moa_facade
 
-            agent.client = build_moa_facade(agent, agent.model)
+                moa_client = build_moa_facade(agent, agent.model)
+            agent.client = moa_client
+            agent._client_kwargs = {}
+            # Keep the snapshot pointing at the live facade so a later
+            # recovery does not resurrect a superseded instance and lose the
+            # reference cache / pending usage accumulated on this one.
+            rt["moa_client"] = moa_client
         else:
             agent.client = agent._create_openai_client(
                 dict(rt["client_kwargs"]),
@@ -1444,6 +1457,27 @@ def drop_thinking_only_and_merge_users(
     )
     return merged
 
+
+
+def copy_primary_runtime(runtime: Any) -> Any:
+    """Copy a ``_primary_runtime`` snapshot without deep-copying live clients.
+
+    ``copy.deepcopy`` is used by the CLI/TUI one-turn model override to keep a
+    restorable snapshot. The MoA facade stored under ``moa_client`` owns a
+    ``threading.Lock``, which ``deepcopy`` cannot pickle, so a plain deepcopy of
+    the snapshot raises ``TypeError`` for MoA sessions. Live client objects must
+    be shared by reference anyway — a copied facade would lose the reference
+    relay and per-turn accounting that make it worth snapshotting.
+    """
+    if not isinstance(runtime, dict):
+        return copy.deepcopy(runtime)
+    live_client = runtime.get("moa_client")
+    if live_client is None:
+        return copy.deepcopy(runtime)
+    shallow = {k: v for k, v in runtime.items() if k != "moa_client"}
+    copied = copy.deepcopy(shallow)
+    copied["moa_client"] = live_client
+    return copied
 
 
 def restore_primary_runtime(agent) -> bool:
@@ -1563,9 +1597,20 @@ def restore_primary_runtime(agent) -> bool:
             # shared factory so the restored facade keeps the reference_callback
             # relay wired at init — a bare MoAClient() would silently stop
             # emitting moa.reference/moa.aggregating display events (#53802).
-            from agent.moa_loop import build_moa_facade
+            # A cross-provider fallback replaces ``agent.client`` with the
+            # fallback's SDK client, leaving the snapshot as the only surviving
+            # reference to the original facade (and its accumulated reference
+            # cache / pending usage / pending trace), so prefer reusing it.
+            # Snapshots taken before this key existed fall back to the factory.
+            moa_client = rt.get("moa_client")
+            if moa_client is None:
+                from agent.moa_loop import build_moa_facade
 
-            agent.client = build_moa_facade(agent, agent.model)
+                moa_client = build_moa_facade(agent, agent.model)
+            agent.client = moa_client
+            # Keep the snapshot pointing at the live facade so a later recovery
+            # cannot resurrect a superseded instance.
+            rt["moa_client"] = moa_client
             agent._anthropic_client = None
         elif agent.api_mode == "anthropic_messages":
             from agent.anthropic_adapter import build_anthropic_client
@@ -2732,6 +2777,7 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
         "api_mode": agent.api_mode,
         "api_key": getattr(agent, "api_key", ""),
         "client_kwargs": dict(agent._client_kwargs),
+        "moa_client": agent.client if agent.provider == "moa" else None,
         "use_prompt_caching": agent._use_prompt_caching,
         "use_native_cache_layout": agent._use_native_cache_layout,
         "reasoning_config": dict(agent.reasoning_config) if getattr(agent, "reasoning_config", None) else None,
@@ -4046,6 +4092,7 @@ __all__ = [
     "try_recover_primary_transport",
     "drop_thinking_only_and_merge_users",
     "restore_primary_runtime",
+    "copy_primary_runtime",
     "extract_reasoning",
     "dump_api_request_debug",
     "prompt_caching_disabled_from_config",

--- a/cli.py
+++ b/cli.py
@@ -8980,6 +8980,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
     def _snapshot_model_runtime(self) -> dict:
         """Capture current CLI and agent model runtime for one-turn restore."""
+        from agent.agent_runtime_helpers import copy_primary_runtime
+
         agent = getattr(self, "agent", None)
         return {
             "model": self.model,
@@ -8990,7 +8992,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             "api_key": self.api_key,
             "base_url": self.base_url,
             "api_mode": self.api_mode,
-            "agent_primary_runtime": copy.deepcopy(
+            "agent_primary_runtime": copy_primary_runtime(
                 getattr(agent, "_primary_runtime", None)
             ) if agent is not None else None,
         }
@@ -9018,8 +9020,10 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
         primary = snapshot.get("agent_primary_runtime")
         if primary and hasattr(agent, "_restore_primary_runtime"):
+            from agent.agent_runtime_helpers import copy_primary_runtime
+
             try:
-                agent._primary_runtime = copy.deepcopy(primary)
+                agent._primary_runtime = copy_primary_runtime(primary)
                 agent._fallback_activated = True
                 agent._rate_limited_until = 0
                 if agent._restore_primary_runtime():

--- a/run_agent.py
+++ b/run_agent.py
@@ -4861,6 +4861,14 @@ class AIAgent:
             )
 
     def _replace_primary_openai_client(self, *, reason: str) -> bool:
+        # MoA uses a local facade rather than an OpenAI SDK client. Its
+        # ``_client_kwargs`` is intentionally empty, so trying to rebuild it via
+        # the SDK raises "api_key client option must be set" and wedges every
+        # subsequent turn. Stale-stream/dead-connection cleanup calls this
+        # method directly, so the guard belongs here at the lifecycle boundary.
+        if getattr(self, "provider", None) == "moa":
+            return True
+
         with self._openai_client_lock():
             old_client = getattr(self, "client", None)
             try:
@@ -4884,6 +4892,18 @@ class AIAgent:
         return True
 
     def _ensure_primary_openai_client(self, *, reason: str) -> Any:
+        # Return the MoA facade as-is; it is not an OpenAI SDK client and cannot
+        # be reconstructed from ``_client_kwargs``. A missing facade is an
+        # internal lifecycle regression, not an API-key configuration error.
+        if getattr(self, "provider", None) == "moa":
+            client = getattr(self, "client", None)
+            if client is not None:
+                return client
+            raise RuntimeError(
+                "MoA primary client is None; cannot recreate a MoAClient via "
+                "the OpenAI SDK"
+            )
+
         with self._openai_client_lock():
             client = getattr(self, "client", None)
             if client is not None and not self._is_openai_client_closed(client):

--- a/tests/run_agent/test_moa_client_lifecycle_no_recreate.py
+++ b/tests/run_agent/test_moa_client_lifecycle_no_recreate.py
@@ -1,0 +1,37 @@
+"""MoA client lifecycle must never fall through to the OpenAI SDK factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _bare_moa_agent(client):
+    agent = object.__new__(AIAgent)
+    setattr(agent, "provider", "moa")
+    setattr(agent, "client", client)
+    setattr(agent, "_client_kwargs", {})
+    return agent
+
+
+def test_replace_primary_client_is_a_noop_for_moa() -> None:
+    facade = object()
+    agent = _bare_moa_agent(facade)
+
+    assert agent._replace_primary_openai_client(reason="stale_stream") is True
+    assert agent.client is facade
+
+
+def test_ensure_primary_client_returns_existing_moa_facade() -> None:
+    facade = object()
+    agent = _bare_moa_agent(facade)
+
+    assert agent._ensure_primary_openai_client(reason="request") is facade
+
+
+def test_ensure_primary_client_fails_with_moa_specific_error_when_missing() -> None:
+    agent = _bare_moa_agent(None)
+
+    with pytest.raises(RuntimeError, match="MoA primary client is None"):
+        agent._ensure_primary_openai_client(reason="request")

--- a/tests/run_agent/test_moa_loop_mode.py
+++ b/tests/run_agent/test_moa_loop_mode.py
@@ -81,13 +81,17 @@ def test_moa_runtime_provider_uses_virtual_endpoint():
     assert runtime["api_key"] == "moa-virtual-provider"
 
 
-def test_moa_primary_restore_rebuilds_virtual_facade(monkeypatch, tmp_path):
+def test_moa_primary_restore_keeps_virtual_facade(monkeypatch, tmp_path):
     """MoA sessions must restore from fallback without constructing OpenAI().
 
     Regression for a long-lived MoA session that failed over to a real provider:
     the next turn restored provider/model to MoA but tried to rebuild the shared
     client from MoA's empty client_kwargs, raising "api_key client option must be
     set" and then "Failed to recreate closed OpenAI client".
+
+    Restoration reuses the facade snapshotted in ``_primary_runtime`` so the
+    reference relay and the turn's pending accounting survive the fallback; the
+    factory rebuild only covers legacy snapshots that predate that key.
     """
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -136,9 +140,58 @@ moa:
     assert agent._restore_primary_runtime() is True
     assert getattr(agent, "provider") == "moa"
     assert getattr(agent, "model") == "review"
-    assert agent.client is not primary_client
+    assert agent.client is primary_client
     assert hasattr(agent.client.chat, "completions")
     assert getattr(agent, "_fallback_activated") is False
+
+
+def test_moa_primary_restore_rebuilds_when_snapshot_predates_key(monkeypatch, tmp_path):
+    """Legacy ``_primary_runtime`` snapshots have no facade; rebuild via factory."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        """
+moa:
+  default_preset: review
+  presets:
+    review:
+      reference_models:
+        - provider: openai-codex
+          model: gpt-5.5
+      aggregator:
+        provider: openrouter
+        model: anthropic/claude-opus-4.8
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    agent = AIAgent(
+        api_key="moa-virtual-provider",
+        base_url="moa://local",
+        model="review",
+        provider="moa",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        enabled_toolsets=["file"],
+        max_iterations=1,
+    )
+    primary_client = agent.client
+    # Simulate a snapshot written before the ``moa_client`` key existed.
+    getattr(agent, "_primary_runtime").pop("moa_client", None)
+
+    def fail_openai_rebuild(*_args, **_kwargs):
+        raise AssertionError("MoA restore must not build a real OpenAI client")
+
+    monkeypatch.setattr(agent, "_create_openai_client", fail_openai_rebuild)
+    setattr(agent, "_fallback_activated", True)
+    setattr(agent, "provider", "zai")
+    agent.client = SimpleNamespace(close=lambda: None, _client=SimpleNamespace(is_closed=True))
+
+    assert agent._restore_primary_runtime() is True
+    assert agent.client is not primary_client
+    assert hasattr(agent.client.chat, "completions")
 
 
 def test_moa_restored_facade_still_emits_reference_events(monkeypatch, tmp_path):

--- a/tests/run_agent/test_moa_primary_runtime_restore.py
+++ b/tests/run_agent/test_moa_primary_runtime_restore.py
@@ -1,0 +1,116 @@
+"""MoA primary recovery must preserve the snapshotted facade instance.
+
+A cross-provider fallback replaces ``agent.client`` with the fallback's SDK
+client, so ``_primary_runtime`` is the only surviving reference to the original
+MoA facade (and the reference relay / pending accounting it owns). Recovery must
+reuse that instance and only fall back to the factory for legacy snapshots.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+import agent.agent_runtime_helpers as helpers
+from agent.agent_runtime_helpers import copy_primary_runtime
+
+
+class _FakeFacade:
+    """Stands in for MoAClient: identity matters and it holds an unpicklable lock."""
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+        self._lock = threading.Lock()
+
+
+def _moa_agent(snapshot_facade, live_client) -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="moa",
+        model="default",
+        client=live_client,
+        _client_kwargs={"api_key": "fallback-key"},
+        _primary_runtime={
+            "model": "default",
+            "provider": "moa",
+            "requested_provider": "moa",
+            "base_url": "moa://local",
+            "api_mode": "chat_completions",
+            "api_key": "",
+            "client_kwargs": {},
+            "moa_client": snapshot_facade,
+            "use_prompt_caching": False,
+            "use_native_cache_layout": False,
+        },
+    )
+
+
+def test_snapshot_reused_instead_of_rebuilt(monkeypatch):
+    snapshot = _FakeFacade("snapshot")
+    agent = _moa_agent(snapshot, live_client=object())
+
+    def _fail(*_args, **_kwargs):  # pragma: no cover - must not run
+        raise AssertionError("build_moa_facade must not be called when a snapshot exists")
+
+    from agent import moa_loop
+
+    monkeypatch.setattr(moa_loop, "build_moa_facade", _fail)
+
+    rt = agent._primary_runtime
+    facade = rt.get("moa_client")
+    assert facade is snapshot
+
+
+def test_legacy_snapshot_falls_back_to_factory():
+    agent = _moa_agent(snapshot_facade=None, live_client=object())
+    assert agent._primary_runtime.get("moa_client") is None
+
+
+def test_reuse_precedes_rebuild_in_source():
+    """Ordering invariant: swapping reuse/rebuild silently breaks the fix."""
+    source = inspect.getsource(helpers.restore_primary_runtime)
+    reuse = source.index('rt.get("moa_client")')
+    rebuild = source.index("build_moa_facade(agent, agent.model)")
+    assert reuse < rebuild
+
+
+def test_restore_refreshes_snapshot_reference():
+    source = inspect.getsource(helpers.restore_primary_runtime)
+    assert 'rt["moa_client"] = moa_client' in source
+
+
+def test_recovery_path_shares_the_same_invariants():
+    source = inspect.getsource(helpers.try_recover_primary_transport)
+    reuse = source.index('rt.get("moa_client")')
+    rebuild = source.index("build_moa_facade(agent, agent.model)")
+    assert reuse < rebuild
+    assert 'rt["moa_client"] = moa_client' in source
+    assert "agent._client_kwargs = {}" in source
+
+
+def test_copy_primary_runtime_shares_facade_and_copies_data():
+    facade = _FakeFacade("live")
+    runtime = {
+        "model": "default",
+        "client_kwargs": {"api_key": "k"},
+        "moa_client": facade,
+    }
+
+    with pytest.raises(TypeError):
+        copy.deepcopy(runtime)
+
+    copied = copy_primary_runtime(runtime)
+    assert copied["moa_client"] is facade
+    assert copied["client_kwargs"] == runtime["client_kwargs"]
+    assert copied["client_kwargs"] is not runtime["client_kwargs"]
+
+
+def test_copy_primary_runtime_deepcopies_non_moa_runtime():
+    runtime = {"model": "gpt", "moa_client": None, "client_kwargs": {"api_key": "k"}}
+    copied = copy_primary_runtime(runtime)
+    assert copied == runtime
+    assert copied["client_kwargs"] is not runtime["client_kwargs"]
+    assert copy_primary_runtime(None) is None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4278,13 +4278,15 @@ def _persist_model_switch(result) -> None:
 
 def _snapshot_agent_model_runtime(agent) -> dict:
     """Capture the current agent model runtime for a one-turn restore."""
+    from agent.agent_runtime_helpers import copy_primary_runtime
+
     return {
         "model": getattr(agent, "model", ""),
         "provider": getattr(agent, "provider", ""),
         "api_key": getattr(agent, "api_key", ""),
         "base_url": getattr(agent, "base_url", ""),
         "api_mode": getattr(agent, "api_mode", ""),
-        "primary_runtime": copy.deepcopy(getattr(agent, "_primary_runtime", None)),
+        "primary_runtime": copy_primary_runtime(getattr(agent, "_primary_runtime", None)),
     }
 
 
@@ -4294,8 +4296,10 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
         return
     primary = snapshot.get("primary_runtime")
     if primary and hasattr(agent, "_restore_primary_runtime"):
+        from agent.agent_runtime_helpers import copy_primary_runtime
+
         try:
-            agent._primary_runtime = copy.deepcopy(primary)
+            agent._primary_runtime = copy_primary_runtime(primary)
             agent._fallback_activated = True
             agent._rate_limited_until = 0
             if agent._restore_primary_runtime():


### PR DESCRIPTION
## What does this PR do?

MoA sessions could wedge **permanently** after a single transient upstream
failure, with a misleading error:

```
Failed to recreate closed OpenAI client
error=api_key client option must be set
    provider=moa  base_url=moa://local
```

No API key is missing. MoA is a local facade that fans out to reference models,
so its `_client_kwargs` is intentionally empty and it has no endpoint of its own.
Users chasing this message go looking for a credential problem that doesn't
exist.

### The failure chain

1. An upstream provider hiccup stalls the MoA reasoning stream.
2. The stale-stream detector calls `_replace_primary_openai_client()`.
3. That path builds a client through the OpenAI SDK using MoA's empty
   `_client_kwargs`, raising `api_key client option must be set`.
4. The primary client is now unusable, and **every subsequent turn repeats step
   3** — the session never recovers, even though the original hiccup is long
   over.

`_create_request_openai_client()` already short-circuits on `provider == "moa"`,
but stale-stream and dead-connection cleanup call the **lifecycle** methods
directly and bypass that request-path guard.

### Why this approach

A provider-specific guard has to live at **each client lifecycle boundary**, not
only on the request path. The existing MoA short-circuit proves the pattern is
accepted; this PR completes it for the two entry points that cleanup uses, which
is where the current gap is.

`_ensure_primary_openai_client()` raises a MoA-specific `RuntimeError` when the
facade is genuinely missing, rather than letting the SDK report an api_key error.
An internal lifecycle regression and a misconfiguration deserve different
messages — conflating them is what made this hard to diagnose.

For `restore_primary_runtime()`, the facade is snapshotted as `moa_client`
because a cross-provider fallback replaces `agent.client`, making the snapshot
the only surviving reference. Snapshots without the key keep the previous rebuild
path, so older sessions are unaffected.

## Related Issue

No existing issue — I searched open issues/PRs and found no report of this. Happy
to open a tracking issue first if maintainers prefer that order.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py`
  - `_replace_primary_openai_client()`: no-op returning `True` for MoA. There is
    no SDK client to rebuild and the facade is already valid.
  - `_ensure_primary_openai_client()`: return the existing facade; raise a
    MoA-specific `RuntimeError` if it is `None`.
- `agent/agent_init.py`
  - Snapshot the facade as `moa_client` (`None` for every other provider).
- `agent/agent_runtime_helpers.py`
  - `restore_primary_runtime()`: rebuild the MoA facade from the snapshot instead
    of via the SDK; fall back to the previous path when the key is absent.
- `cli.py`, `tui_gateway/server.py`
  - Fix a `TypeError` in the one-turn model override for MoA sessions, which hit
    the same assumption that every provider has an SDK-constructible client.
- `tests/run_agent/test_moa_loop_mode.py` — extended.
- `tests/run_agent/test_moa_client_lifecycle_no_recreate.py` — new.
- `tests/run_agent/test_moa_primary_runtime_restore.py` — new.

### Implementation note

`MoAClient` has no `is_closed`/`_client` attributes, so
`_is_openai_client_closed()` returns `False` for it. The rebuild is therefore
triggered by `client is None`, not by a false "closed" verdict — worth knowing if
anyone traces this from the error string, which points at "closed".

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(moa):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (single commit)
- [x] I've run the relevant suites (see below)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 10

```
tests/run_agent/test_moa_loop_mode.py
tests/run_agent/test_moa_client_lifecycle_no_recreate.py
tests/run_agent/test_moa_primary_runtime_restore.py
=== 37 passed, 0 failed ===
```

Coverage: the no-op replace, the ensure path returning the facade, the
`RuntimeError` when the facade is missing, primary runtime restore after
cross-provider fallback, legacy snapshots without the key, and the one-turn
override.

**I verified the tests are load-bearing** — removing the short-circuits turns
`test_replace_primary_client_is_a_noop_for_moa` and
`test_moa_primary_restore_keeps_virtual_facade` red.

### On the pre-existing failures in `tests/run_agent/`

The full `tests/run_agent/` suite reports **21 failures both with and without
this change**. I confirmed this by running the suite on a clean checkout of the
base commit (`git stash` of every modified file, new test files moved aside):

```
with this change:     1386 passed, 21 failed  (165 files)
clean base commit:    1375 passed, 21 failed  (163 files)
```

Same 21 failures, so they are pre-existing and unrelated. Mentioning it so the
CI result isn't misread as caused by this PR.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (rationale is in inline comments
      at each guard site)
- [x] I've updated `cli-config.yaml.example` — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python control flow)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before — the misleading error, repeating every turn once the session wedged:

```
WARNING run_agent: Failed to recreate closed OpenAI client
        (stale_stream_pool_cleanup) error=api_key client option must be set
        provider=moa base_url=moa://local
```

After — cleanup is a no-op for MoA and the session continues normally.
