### PR TITLE
fix(tui): force redraw when terminal ignores DECRQM probe

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/app-mouse-watchdog.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/app-mouse-watchdog.test.ts
@@ -7,7 +7,7 @@ import StdinContext from './components/StdinContext.js'
 import Text from './components/Text.js'
 import Ink from './ink.js'
 import instances from './instances.js'
-import { csi } from './termio/csi.js'
+import { csi, CURSOR_HOME, ERASE_SCREEN } from './termio/csi.js'
 import { DEC, DISABLE_MOUSE_TRACKING, enableMouseTrackingFor } from './termio/dec.js'
 
 // DECRQM request for mode 1000 (what the watchdog writes).
@@ -211,6 +211,31 @@ describe('App mouse-mode watchdog', () => {
     await h.tickWatchdog()
     await h.tickWatchdog()
     expect(h.stdout.chunks.join('')).not.toContain(DECRQM_1000)
+
+    h.ink.unmount()
+  })
+
+  it('force-redraws the screen when the terminal ignores DECRQM (scrubs echoed query byte)', async () => {
+    const h = await mount('all')
+
+    await h.tickWatchdog()
+    expect(h.stdout.chunks.join('')).toContain(DECRQM_1000)
+    h.stdout.chunks = []
+
+    // Terminal answers only the DA1 sentinel — DECRQM unsupported. The
+    // DA1 reply proves the terminal already processed the query bytes, so
+    // any echo (Apple Terminal prints the trailing 'p' of CSI ? 1000 $ p)
+    // has landed. The watchdog must erase + repaint to scrub it — the
+    // diff engine never rewrites cells it believes unchanged.
+    await h.answer(DA1_REPLY)
+
+    const out = h.stdout.chunks.join('')
+
+    // forceRedraw: erase screen + cursor home, then a full repaint of the
+    // rendered cell even though the model didn't change.
+    expect(out).toContain(ERASE_SCREEN)
+    expect(out).toContain(CURSOR_HOME)
+    expect(out).toContain('x')
 
     h.ink.unmount()
   })

--- a/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/components/App.tsx
@@ -477,6 +477,15 @@ export default class App extends PureComponent<Props, State> {
           this.mouseWatchdogUnsupported = true
           logForDebugging('mouse watchdog: DECRQM unsupported, disabling')
 
+          // The DA1 reply proves the terminal already processed our query
+          // bytes. Terminals that ignore DECRQM may have echoed the query's
+          // final byte as a printable char (Apple Terminal echoes the 'p'
+          // of CSI ? 1000 $ p) — the diff engine never repaints cells it
+          // believes unchanged, so the stray char would persist until a
+          // resize. forceRedraw() is the recovery path for exactly this
+          // divergence: erase + full repaint from the model. One-shot.
+          instances.get(this.props.stdout)?.forceRedraw()
+
           return
         }
 


### PR DESCRIPTION
## Description

The TUI's mouse-mode watchdog probes DEC mode 1000 with DECRQM (`CSI ? 1000 $ p`) every 2s. **Apple Terminal doesn't implement DECRQM** and echoes the trailing `p` of the query as a printable character at the cursor. The cursor is parked at the composer's padding cell (column 0, left of the `❯` prompt), so a stray `p` appears there.

Ink's diff engine never repaints cells it believes unchanged — the model says "blank", the terminal says "p" — so the artifact persists until a window resize. A resize also latches the watchdog off (the terminal never answered DECRQM → `mouseWatchdogUnsupported`), which is why the `p` "temporarily goes away when you resize."

## Fix

When the DA1 sentinel proves the terminal ignored DECRQM, call `forceRedraw()` — the existing recovery path for physical-screen/model divergence (same mechanism as the macOS Cmd+K case): erase screen + full repaint from the model. This scrubs the echoed byte. It fires at most once per session (probing stays disabled afterward), and only on terminals that ignore DECRQM — conforming terminals (iTerm2, kitty, WezTerm, xterm) never hit it.

## Reproduction

1. Run the Hermes TUI in Apple Terminal (macOS)
2. Wait ~2s — the first watchdog tick writes the DECRQM probe
3. A `p` appears at the left edge of the composer line, before `❯`
4. Resize the window — the `p` disappears and stays gone (latch fires)

## Verification

Confirmed live on Apple Terminal (macOS): with this fix, the stray `p` no longer appears at startup — the force-redraw scrubs it within ~2s of the first probe, before it's visible. Also reproduced the original artifact on Linux (SSH'd into a Fedora box from the same Apple Terminal emulator), confirming the bug is terminal-emulator-side, not platform-side, and that the fix clears it there too.

## Test Plan

- New test: `app-mouse-watchdog.test.ts` — "force-redraws the screen when the terminal ignores DECRQM" asserts `ERASE_SCREEN` + `CURSOR_HOME` + full repaint after the DA1-only reply
- All 6 watchdog tests pass; full `hermes-ink` suite passes (1 pre-existing flake in `ink-backpressure.test.ts` unrelated to this change, reproduced on clean main)
- `tsc --noEmit` and `eslint` clean
