### PR TITLE
fix(slack): ack free-response channel messages

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5640,6 +5640,7 @@ class SlackAdapter(BasePlatformAdapter):
                 if allow_bots == "mentions" and not is_mentioned:
                     return
 
+        is_free_response_routing = False
         if not is_one_to_one_dm and bot_uid:
             # Check allowed channels — if set, only respond in these channels (whitelist)
             allowed_channels = self._slack_allowed_channels()
@@ -5666,15 +5667,17 @@ class SlackAdapter(BasePlatformAdapter):
                 )
                 return
 
-            if force_process:
-                pass  # Explicit internal routing path (reaction trigger).
-            elif (
+            is_free_response_routing = (
                 channel_id not in self._slack_require_mention_channels()
                 and (
                     channel_id in self._slack_free_response_channels()
                     or not self._slack_require_mention()
                 )
-            ):
+            )
+
+            if force_process:
+                pass  # Explicit internal routing path (reaction trigger).
+            elif is_free_response_routing:
                 # Free-response channel, or mention requirement disabled
                 # globally — unless the channel is force-mention-gated via
                 # require_mention_channels, which overrides both.
@@ -6298,11 +6301,13 @@ class SlackAdapter(BasePlatformAdapter):
             },
         )
 
-        # Only react when bot is directly addressed (1:1 DM or @mention).
-        # MPIMs are shared surfaces: reacting to every group-DM message (even
-        # when unmentioned) is visible noise to the whole group, so they must
-        # be @mentioned to earn a reaction — same as any channel.
-        _should_react = (is_one_to_one_dm or is_mentioned) and self._reactions_enabled()
+        # React when the bot is directly addressed (1:1 DM or @mention), or
+        # when the routing decision above accepted an unmentioned message.
+        # Reusing that decision keeps forced-mention and global mention
+        # settings consistent with the reaction lifecycle.
+        _should_react = (
+            is_one_to_one_dm or is_mentioned or is_free_response_routing
+        ) and self._reactions_enabled()
         if _should_react:
             self._reacting_message_ids.add(
                 self._workspace_message_marker(team_id, ts)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -2623,6 +2623,53 @@ class TestReactions:
         # Message ID should be cleaned up
         assert "1234567890.000001" not in adapter._reacting_message_ids
 
+    @pytest.mark.asyncio
+    async def test_reactions_registered_for_free_response_channel(self, adapter):
+        """Processed free-response channel messages should get ack reactions."""
+        adapter.config.extra["free_response_channels"] = "C123"
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+            "ts": "1234567890.000002",
+        }
+        await adapter._handle_slack_message(event)
+
+        marker = adapter._workspace_message_marker(
+            "T_TEAM", "1234567890.000002"
+        )
+        assert marker in adapter._reacting_message_ids
+
+    @pytest.mark.asyncio
+    async def test_reactions_not_registered_when_require_mention_overrides_free_response(
+        self, adapter
+    ):
+        """Forced mention gating should suppress free-response reactions."""
+        adapter.config.extra["free_response_channels"] = "C123"
+        adapter.config.extra["require_mention_channels"] = "C123"
+        adapter._app.client.users_info = AsyncMock(
+            return_value={"user": {"profile": {"display_name": "Tyler"}}}
+        )
+
+        event = {
+            "text": "hello",
+            "user": "U_USER",
+            "channel": "C123",
+            "channel_type": "channel",
+            "team": "T_TEAM",
+            "ts": "1234567890.000003",
+        }
+        await adapter._handle_slack_message(event)
+
+        assert adapter._reacting_message_ids == set()
+        adapter.handle_message.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # TestThreadReplyHandling


### PR DESCRIPTION
## Summary

- reuse the Slack routing decision when enrolling messages in the reaction lifecycle
- add processing acknowledgements for configured free-response channels and globally mention-free routing
- preserve forced-mention channel behavior

## Regression

Slack accepted and processed messages from `free_response_channels`, but `_should_react` only enrolled one-to-one DMs and explicit mentions. Those messages therefore received no in-progress acknowledgement.

## Tests

- `pytest tests/gateway/test_slack.py::TestReactions tests/gateway/test_slack_require_mention_channels.py tests/test_slack_thread_require_mention.py -o addopts= -q` — 13 passed
- `ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack.py` — passed
- `git diff --check` — passed