### PR TITLE
fix(plugins): coerce string plugins.enabled instead of silently disabling all plugins

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -266,6 +266,51 @@ def _get_enabled_plugins() -> Optional[set]:
         if "enabled" not in plugins_cfg:
             return None
         enabled = plugins_cfg.get("enabled")
+        if isinstance(enabled, str):
+            # A JSON/YAML-ish string instead of a list (e.g.
+            # ``enabled: '["web/rotating-search"]'``) — written by hand or by
+            # a tool that quoted the value. Silently returning None here
+            # disables EVERY plugin, which is indistinguishable from "not
+            # configured yet" and sends capability-providing plugins (web
+            # search/extract backends) into their paid fallbacks without a
+            # word. Coerce what we can and warn loudly.
+            text = enabled.strip()
+            parsed: Optional[list] = None
+            if text:
+                try:
+                    import json
+
+                    candidate = json.loads(text)
+                    if isinstance(candidate, list):
+                        parsed = candidate
+                except Exception:
+                    # Only treat a bracketed/comma-joined value as a list;
+                    # a bare scalar like ``enabled: 'true'`` is a config
+                    # error, not a one-element allow-list.
+                    if text.startswith("[") or "," in text:
+                        parsed = [
+                            part.strip().strip("\"'")
+                            for part in text.strip("[]").split(",")
+                            if part.strip().strip("\"'")
+                        ] or None
+                    else:
+                        parsed = None
+            if parsed is None:
+                logger.warning(
+                    "plugins.enabled in config.yaml is a string that could not "
+                    "be parsed as a list (%r); treating as unset, so NO plugins "
+                    "will load. Fix it with `hermes plugins enable <name>`.",
+                    enabled[:120],
+                )
+                return None
+            logger.warning(
+                "plugins.enabled in config.yaml is a quoted string, not a YAML "
+                "list; recovered %d entries. Re-save it as a list (e.g. run "
+                "`hermes plugins enable <name>`) — otherwise plugin loading "
+                "depends on this fallback.",
+                len(parsed),
+            )
+            return set(parsed)
         if not isinstance(enabled, list):
             return None
         return set(enabled)

--- a/tests/test_plugins_enabled_coercion.py
+++ b/tests/test_plugins_enabled_coercion.py
@@ -1,0 +1,60 @@
+"""Regression tests for ``plugins.enabled`` type handling.
+
+A quoted-string ``plugins.enabled`` (e.g. ``enabled: '["web/x"]'``) used to
+make ``_get_enabled_plugins()`` return ``None``, which is the same signal as
+"not configured yet" and therefore silently disabled EVERY plugin. For
+capability-providing plugins (web search/extract backends) that meant a
+silent fall-through to the paid default backend — a billing leak with no
+error message anywhere.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+
+def _enabled_for(tmp_path, monkeypatch, value: str):
+    (tmp_path / "config.yaml").write_text(f"plugins:\n  enabled: {value}\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.config as config_mod
+    import hermes_cli.plugins as plugins_mod
+
+    importlib.reload(config_mod)
+    importlib.reload(plugins_mod)
+    return plugins_mod._get_enabled_plugins()
+
+
+def test_proper_yaml_list_is_read(tmp_path, monkeypatch):
+    got = _enabled_for(tmp_path, monkeypatch, "\n    - web/local-extract\n    - web/rotating-search")
+    assert got == {"web/local-extract", "web/rotating-search"}
+
+
+def test_quoted_json_string_is_coerced_not_dropped(tmp_path, monkeypatch):
+    """The regression: a quoted list must not disable every plugin."""
+    got = _enabled_for(tmp_path, monkeypatch, "'[\"profanity-relay\",\"web/rotating-search\"]'")
+    assert got == {"profanity-relay", "web/rotating-search"}
+
+
+def test_comma_joined_string_is_coerced(tmp_path, monkeypatch):
+    got = _enabled_for(tmp_path, monkeypatch, "'web/local-extract, web/rotating-search'")
+    assert got == {"web/local-extract", "web/rotating-search"}
+
+
+def test_explicit_empty_list_disables_everything(tmp_path, monkeypatch):
+    assert _enabled_for(tmp_path, monkeypatch, "[]") == set()
+
+
+def test_bare_scalar_is_not_mistaken_for_a_plugin_name(tmp_path, monkeypatch):
+    """A scalar is a config error; it must not become a 1-element allow-list."""
+    assert _enabled_for(tmp_path, monkeypatch, "'true'") is None
+
+
+def test_missing_key_returns_none(tmp_path, monkeypatch):
+    (tmp_path / "config.yaml").write_text("plugins:\n  disabled: []\n")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.config as config_mod
+    import hermes_cli.plugins as plugins_mod
+
+    importlib.reload(config_mod)
+    importlib.reload(plugins_mod)
+    assert plugins_mod._get_enabled_plugins() is None


### PR DESCRIPTION
## Symptom

A quoted-string `plugins.enabled` silently disables **every** plugin, with no error, warning, or log line:

```yaml
# config.yaml — written by hand, or by a tool that quoted the value
plugins:
  enabled: '["profanity-relay","web/local-extract","web/rotating-search"]'
```

## Root cause

`hermes_cli/plugins.py::_get_enabled_plugins()` fails the `isinstance(enabled, list)` check and returns `None`. Per its own docstring, `None` means *"the key is missing or malformed → treat as the opt-in default (nothing enabled)"*. A malformed value is therefore indistinguishable from an unconfigured one, and `discover_and_load()` skips every manifest.

## Why this costs money

For capability-providing plugins the failure is silent **and** billed. With a fully free web stack configured:

```yaml
web:
  search_backend: rotating-search
  extract_backend: local-extract
```

the providers never register → `_is_backend_available()` is `False` → `tools/web_tools.py::_get_backend()` falls through to its backward-compat `return "firecrawl"`. The config *looks* free while every `web_search` / `web_extract` call hits a paid backend.

Observed in the wild: **79 Firecrawl 402s** on an install configured entirely for free backends. The user's only symptom was "web extract blocked again" — nothing pointed at `plugins.enabled`. The malformed value also **recurred** after being hand-fixed once, so a one-time repair isn't sufficient.

## Fix

Coerce a JSON or comma-joined string into the allow-list and `logger.warning` loudly so the misconfiguration is visible and repairable (`hermes plugins enable <name>` rewrites it as a real list).

A bare scalar (`enabled: 'true'`) still returns `None` rather than becoming a bogus one-element allow-list — that would mask a typo'd plugin name.

## Behavior

| `plugins.enabled` | before | after |
|---|---|---|
| `- a` / `- b` (list) | `{a, b}` | `{a, b}` unchanged |
| `'["a","b"]'` | **`None` → all plugins off** | `{a, b}` + warning |
| `'a, b'` | **`None` → all plugins off** | `{a, b}` + warning |
| `[]` | `set()` | `set()` unchanged |
| `'true'` (scalar) | `None` | `None` + warning |
| key missing | `None` | `None` unchanged |

## Tests

Adds `tests/test_plugins_enabled_coercion.py` — 6 cases covering the table above.

```
tests/test_plugins_enabled_coercion.py ......    6 passed in 0.23s
```

Full plugin suite unchanged vs `main` — `59 failed, 1252 passed` both before and after this patch (the 59 are pre-existing failures on `main`: photon sidecar, discord gate, a2a, xai video_gen; unrelated to this change and verified identical via `git stash`).
