### PR TITLE
feat(desktop): minimize-to-tray on close (Win/Linux, off by default)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -27,7 +27,8 @@ import {
   screen,
   session,
   shell,
-  systemPreferences
+  systemPreferences,
+  Tray
 } from 'electron'
 import nodePty from 'node-pty'
 
@@ -187,6 +188,7 @@ import {
 } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
+import { buildTrayIcon, buildTrayMenuItems, readPersistedMinimizeToTray, writePersistedMinimizeToTray } from './tray'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
 import { waitForUpdateClearance } from './update-gate'
 import { readLiveUpdateMarker, updateHandoffConflict, writeUpdateMarker } from './update-marker'
@@ -769,6 +771,29 @@ function windowOpacity() {
   return 1 - (translucencyIntensity / 100) * 0.7
 }
 
+// Minimize-to-tray behavior (close the window → hide in the system tray
+// instead of quitting the app). Off by default — changing the close-button
+// contract is opt-in so existing users keep the current "X quits" behavior.
+// Windows/Linux only; on macOS the Dock already provides this (closing the
+// last window keeps the process alive), so the tray is never created there.
+// Persisted so a cold launch applies it before the first close event. Pure
+// read/write lives in electron/tray.ts (testable); we wire it to a module
+// variable here so the close handler reads a single source of truth.
+let minimizeToTray = false
+
+function loadMinimizeToTray() {
+  try {
+    minimizeToTray = readPersistedMinimizeToTray(app.getPath('userData'))
+  } catch {
+    minimizeToTray = false
+  }
+}
+
+// NOTE: loadMinimizeToTray() is invoked inside app.whenReady() (not at module
+// load) because app.getPath('userData') is only valid once the app is ready.
+// Called early in whenReady so createTray() and the close handler see the
+// persisted value on a cold launch.
+
 // Re-apply translucency to a live window (runtime toggle, no recreation).
 // `setOpacity` is a no-op on Linux, which is fine — it just stays opaque there.
 function applyWindowTranslucency(win) {
@@ -1050,6 +1075,12 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+let tray: Electron.Tray | null = null
+let isQuitting = false
+// Locale for the tray context menu, pushed from the renderer so the menu text
+// follows the user's chosen display language. Defaults to English until the
+// renderer reports its locale (see ipcMain.on('hermes:tray-menu-locale')).
+let trayMenuLocale = 'en'
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -8747,6 +8778,126 @@ function focusWindow(win) {
   win.focus()
 }
 
+// ── System tray ────────────────────────────────────────────────────────────
+// When `minimizeToTray` is enabled, the app hides to the system tray on window
+// close instead of quitting. This builds the tray icon + context menu. macOS is
+// excluded (the Dock already keeps the process alive and offers its own
+// show/hide/quit menu), matching the `!IS_MAC` guard used for the close handler.
+function createTray() {
+  if (IS_MAC) {
+    return
+  }
+
+  // Only build the tray when the feature is enabled. This guards both the
+  // cold-start call and the live rebuilds triggered by the locale handler —
+  // without it, a runtime toggle-off followed by a language change would
+  // resurrect the tray even though the flag is off.
+  if (!minimizeToTray) {
+    return
+  }
+
+  if (tray && !tray.isDestroyed()) {
+    return
+  }
+
+  const icon = buildTrayIcon(getAppIconPath(), IS_WINDOWS)
+
+  if (!icon) {
+    rememberLog('[tray] no app icon found; skipping tray creation')
+
+    return
+  }
+
+  tray = new Tray(icon)
+  tray.setToolTip('Hermes Agent')
+
+  const buildContextMenu = () => {
+    const visible = mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()
+
+    return Menu.buildFromTemplate(
+      buildTrayMenuItems({
+        isWindowVisible: Boolean(visible),
+        locale: trayMenuLocale,
+        onToggleVisibility: () => {
+          if (!mainWindow || mainWindow.isDestroyed()) {
+            createWindow()
+
+            return
+          }
+
+          if (mainWindow.isVisible()) {
+            mainWindow.hide()
+          } else {
+            focusWindow(mainWindow)
+          }
+        },
+        onNewSession: () => {
+          ensureMainWindow(mainWindow, {
+            isReady: app.isReady(),
+            createWindow,
+            focusWindow,
+            focusExisting: false
+          })
+          handleDeepLink('hermes://app/new-session')
+          // The window may be hidden in the tray; bring it forward so the
+          // navigation triggered above is actually visible.
+          focusWindow(mainWindow)
+        },
+        onOpenSettings: () => {
+          ensureMainWindow(mainWindow, {
+            isReady: app.isReady(),
+            createWindow,
+            focusWindow,
+            focusExisting: false
+          })
+          handleDeepLink('hermes://app/settings')
+          focusWindow(mainWindow)
+        },
+        onQuit: () => {
+          isQuitting = true
+          app.quit()
+        }
+      })
+    )
+  }
+
+  tray.setContextMenu(buildContextMenu())
+  // Windows: a plain left click toggles the window. Ignore the synthesized
+  // second click of a double-click so a double-click doesn't toggle twice
+  // (Electron fires both 'click' and 'double-click' on Windows).
+  tray.setIgnoreDoubleClickEvents(true)
+  const rebuildMenu = () => {
+    if (!tray || tray.isDestroyed()) {
+      return
+    }
+    tray.setContextMenu(buildContextMenu())
+  }
+  tray.on('click', () => {
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      createWindow()
+
+      return
+    }
+
+    if (mainWindow.isVisible()) {
+      mainWindow.hide()
+    } else {
+      focusWindow(mainWindow)
+    }
+
+    // Refresh the visibility label after toggling.
+    rebuildMenu()
+  })
+  // Keep the Show/Hide label in sync with the window. The context menu is a
+  // fixed snapshot from the last setContextMenu() call, so rebuild it whenever
+  // the window actually shows/hides (covers both tray clicks and the X-button
+  // close-to-tray path, which don't go through tray.on('click')).
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.on('show', rebuildMenu)
+    mainWindow.on('hide', rebuildMenu)
+  }
+}
+
 function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
@@ -9348,6 +9499,21 @@ function createWindow() {
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
+
+  // Minimize-to-tray: when enabled (Windows/Linux only), closing the window
+  // hides it in the system tray instead of quitting. The real quit path is
+  // Always intercept close so a runtime toggle of the flag (which only
+  // builds/destroys the tray) takes effect on this existing window. The hide
+  // itself is gated on the live flag + platform + the quit latch. `app.quit()`
+  // — reached via the tray "退出" item, the app menu, or before-quit — sets
+  // isQuitting and bypasses this guard. macOS skips the tray entirely (Dock
+  // behavior), so it is excluded here too.
+  mainWindow.on('close', (event: Electron.Event) => {
+    if (!isQuitting && minimizeToTray && !IS_MAC) {
+      event.preventDefault()
+      mainWindow?.hide()
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
@@ -10654,6 +10820,47 @@ ipcMain.on('hermes:translucency', (_event, payload) => {
   }
 })
 
+// Renderer → main: toggle minimize-to-tray. Persists the choice and rebuilds
+// (or tears down) the tray so the change takes effect without a restart.
+ipcMain.on('hermes:minimize-to-tray', (_event, payload) => {
+  const next = Boolean(payload && payload.enabled)
+
+  if (next === minimizeToTray) {
+    return
+  }
+
+  minimizeToTray = next
+  writePersistedMinimizeToTray(app.getPath('userData'), next)
+
+  if (next) {
+    createTray()
+  } else if (tray && !tray.isDestroyed()) {
+    tray.destroy()
+    tray = null
+  }
+})
+
+// Tray menu locale: the renderer reports its current display language so the
+// tray context menu (built in the main process, which has no i18n) shows the
+// matching language. If the tray already exists, rebuild its menu live.
+ipcMain.on('hermes:tray-menu-locale', (_event, payload) => {
+  const locale = typeof payload === 'string' ? payload : 'en'
+
+  if (locale === trayMenuLocale) {
+    return
+  }
+
+  trayMenuLocale = locale
+
+  // Rebuild the tray (and its menu) so the new language takes effect. createTray
+  // is idempotent against an existing tray, so destroy first.
+  if (tray && !tray.isDestroyed()) {
+    tray.destroy()
+    tray = null
+  }
+  createTray()
+})
+
 // Keep-awake: hold the machine awake for long/overnight runs. Main owns the one
 // blocker and its persisted state so a cold launch restores it (applied on
 // ready — powerSaveBlocker needs the app ready). The renderer toggles it from
@@ -11846,6 +12053,10 @@ app.whenReady().then(() => {
   installEmbedReferer()
   registerDeepLinkProtocol()
   ensureWslWindowsFonts()
+  // Restore the minimize-to-tray preference before createWindow()/createTray()
+  // run, so a cold launch honors the persisted flag. app.getPath('userData')
+  // is valid here (inside whenReady).
+  loadMinimizeToTray()
   configureSpellChecker()
   registerPowerResumeListeners()
   keepAwake.set(readPersistedKeepAwake())
@@ -11865,6 +12076,13 @@ app.whenReady().then(() => {
   }
 
   createWindow()
+  // Build the system tray only when the feature is enabled (off by default).
+  // macOS is excluded inside createTray(); on Win/Linux the tray is created
+  // here on a cold launch if the persisted flag is set, and live via the
+  // settings IPC handler (electron/main.ts ~10786) when toggled at runtime.
+  if (minimizeToTray) {
+    createTray()
+  }
 
   // Win/Linux cold start: the launching hermes:// URL is in our own argv.
   const _coldStartLink = _extractDeepLink(process.argv)
@@ -11916,7 +12134,7 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
     return false
   }
 
-  const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff)
+  const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff, trayMenuLocale)
   const parent = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
 
   if (!prompt || !parent || parent.isDestroyed()) {
@@ -11928,7 +12146,7 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 
   void dialog
     .showMessageBox(parent, {
-      buttons: ['Keep Running', 'Quit Anyway'],
+      buttons: prompt.buttons,
       cancelId: 0,
       defaultId: 0,
       detail: prompt.detail,
@@ -11955,10 +12173,15 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 
 app.on('before-quit', event => {
   // Runs ahead of every teardown below, so "Keep Running" leaves the app
-  // exactly as it was.
+  // exactly as it was. Set the quit latch only AFTER this guard: if the quit
+  // is held (a turn is in flight), we return early and must leave isQuitting
+  // clear so the minimize-to-tray close handler keeps hiding the window later
+  // in the session. The latch is still set before any real teardown below.
   if (heldQuitForActiveWork(event)) {
     return
   }
+
+  isQuitting = true
 
   if ((sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0) && !sshQuitTeardownDone) {
     event.preventDefault()
@@ -12032,7 +12255,12 @@ app.on('window-all-closed', () => {
   // the bundle and relaunch — without this the script's PID-wait spins to its
   // full timeout and the user is left with an invisible app (or an uninstall
   // that appears to do nothing).
-  if (process.platform !== 'darwin' || isQuittingForHandoff) {
+  //
+  // Windows/Linux with the tray active: keep the process alive in the tray
+  // (the user closed the window to hide, not quit). Only quit when there is no
+  // tray — i.e. minimize-to-tray is off, or this is a platform where the tray
+  // is never created (macOS falls through below).
+  if (isQuittingForHandoff || (process.platform !== 'darwin' && !tray)) {
     app.quit()
   }
 })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -136,6 +136,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),
+  setMinimizeToTray: payload => ipcRenderer.send('hermes:minimize-to-tray', payload),
+  setTrayMenuLocale: locale => ipcRenderer.send('hermes:tray-menu-locale', locale),
   setKeepAwake: on => ipcRenderer.send('hermes:keep-awake', on),
   setPreviewShortcutActive: active => ipcRenderer.send('hermes:previewShortcutActive', Boolean(active)),
   openExternal: url => ipcRenderer.invoke('hermes:openExternal', url),

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -60,3 +60,31 @@ test('quitPromptFor speaks singular for one chat', () => {
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
   assert.ok(prompt.detail.includes('mid-turn'))
 })
+
+test('quitPromptFor localizes to zh when locale is zh', () => {
+  const prompt = quitPromptFor({ count: 1, titles: ['固化室审查'] }, false, 'zh')
+
+  assert.ok(prompt)
+  assert.equal(prompt.message, 'Hermes 正在处理 1 个对话。')
+  assert.equal(prompt.buttons[0], '继续运行')
+  assert.equal(prompt.buttons[1], '仍然退出')
+  assert.ok(prompt.detail.includes('固化室审查'))
+  assert.ok(prompt.detail.includes('未写入的工作将丢失'))
+})
+
+test('quitPromptFor falls back to English for an unknown locale', () => {
+  const prompt = quitPromptFor({ count: 2, titles: ['Fix login'] }, false, 'xx')
+
+  assert.ok(prompt)
+  assert.equal(prompt.message, 'Hermes is still working on 2 chats.')
+  assert.equal(prompt.buttons[0], 'Keep Running')
+})
+
+test('quitPromptFor localizes plural + "more" for ja', () => {
+  const prompt = quitPromptFor({ count: 5, titles: ['a', 'b', 'c', 'd', 'e'] }, false, 'ja')
+
+  assert.ok(prompt)
+  assert.equal(prompt.message, 'Hermes は 5 件のチャットを処理中です。')
+  assert.ok(prompt.detail.includes('さらに 1 件'))
+  assert.equal(prompt.buttons[1], '強制終了')
+})

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -3,6 +3,10 @@
 // Renderers publish what they're running; the main process asks before it lets
 // that go. The decision + copy live here (pure, testable) so main.ts only owns
 // the IPC and the dialog call.
+//
+// Copy is localized to the renderer's chosen display language (pushed to the
+// main process via the same channel as the tray menu). The main process has no
+// i18n of its own, so we keep a small table here; defaults to English.
 
 const MAX_LISTED = 4
 
@@ -53,9 +57,71 @@ export function mergeActiveWork(reports: Iterable<ActiveWork>): ActiveWork {
   return { count: Math.max(count, titles.length), titles }
 }
 
+// ── Localization ──────────────────────────────────────────────────────────
+// The quit-confirm dialog is a main-process native dialog, so it has no access
+// to the renderer's i18n catalog. Keep a small table here, keyed by the same
+// locale the tray menu uses (pushed via setTrayMenuLocale).
+
+type QuitGuardLocale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'ar'
+
+const QUIT_GUARD_STRINGS: Record<QuitGuardLocale, {
+  messageOne: string
+  messageMany: (n: number) => string
+  warn: string
+  moreOne: string
+  moreMany: (n: number) => string
+  buttons: [string, string]
+}> = {
+  en: {
+    messageOne: 'Hermes is still working on 1 chat.',
+    messageMany: n => `Hermes is still working on ${n} chats.`,
+    warn: 'Quitting stops the agent mid-turn. Any work it has not finished writing is lost.',
+    moreOne: '• 1 more',
+    moreMany: n => `• ${n} more`,
+    buttons: ['Keep Running', 'Quit Anyway']
+  },
+  zh: {
+    messageOne: 'Hermes 正在处理 1 个对话。',
+    messageMany: n => `Hermes 正在处理 ${n} 个对话。`,
+    warn: '退出会中断 agent 的当前轮次，未写入的工作将丢失。',
+    moreOne: '• 还有 1 个',
+    moreMany: n => `• 还有 ${n} 个`,
+    buttons: ['继续运行', '仍然退出']
+  },
+  'zh-hant': {
+    messageOne: 'Hermes 正在處理 1 個對話。',
+    messageMany: n => `Hermes 正在處理 ${n} 個對話。`,
+    warn: '退出會中斷 agent 的當前輪次，未寫入的工作將遺失。',
+    moreOne: '• 還有 1 個',
+    moreMany: n => `• 還有 ${n} 個`,
+    buttons: ['繼續運行', '仍然退出']
+  },
+  ja: {
+    messageOne: 'Hermes は 1 件のチャットを処理中です。',
+    messageMany: n => `Hermes は ${n} 件のチャットを処理中です。`,
+    warn: '終了すると agent の処理中のターンが中断され、未保存の作業が失われます。',
+    moreOne: '• さらに 1 件',
+    moreMany: n => `• さらに ${n} 件`,
+    buttons: ['続行', '強制終了']
+  },
+  ar: {
+    messageOne: 'ما زال هيرميس يعمل على محادثة واحدة.',
+    messageMany: n => `ما زال هيرميس يعمل على ${n} محادثات.`,
+    warn: 'سيؤدي الخروج إلى إيقاف الوكيل أثناء دورته الحالية. ستفقد أي أعمال لم يكتبها بعد.',
+    moreOne: '• المزيد 1',
+    moreMany: n => `• المزيد ${n}`,
+    buttons: ['استمرار التشغيل', 'الخروج على أي حال']
+  }
+}
+
+function quitGuardLocaleFor(locale: string): QuitGuardLocale {
+  return (locale === 'zh' || locale === 'zh-hant' || locale === 'ja' || locale === 'ar') ? (locale as QuitGuardLocale) : 'en'
+}
+
 export interface QuitPrompt {
-  detail: string
   message: string
+  detail: string
+  buttons: [string, string]
 }
 
 /**
@@ -64,29 +130,33 @@ export interface QuitPrompt {
  * `quittingForHandoff` covers the update / swap / uninstall relaunches: those
  * are the app replacing itself, not the user walking away, and a modal there
  * would strand the detached script waiting on a PID that never exits.
+ *
+ * `locale` is the renderer's chosen display language (defaults to English).
  */
-export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): null | QuitPrompt {
+export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean, locale = 'en'): null | QuitPrompt {
   if (quittingForHandoff || work.count < 1) {
     return null
   }
 
+  const strings = QUIT_GUARD_STRINGS[quitGuardLocaleFor(locale)]
   const listed = work.titles.slice(0, MAX_LISTED)
   const remaining = work.count - listed.length
   const lines = listed.map(title => `• ${title}`)
 
   if (remaining > 0) {
-    lines.push(remaining === 1 ? '• 1 more' : `• ${remaining} more`)
+    lines.push(remaining === 1 ? strings.moreOne : strings.moreMany(remaining))
   }
 
   return {
+    buttons: strings.buttons,
     detail: [
       lines.join('\n'),
       lines.length > 0 ? '' : null,
-      'Quitting stops the agent mid-turn. Any work it has not finished writing is lost.'
+      strings.warn
     ]
       .filter(line => line !== null)
       .join('\n')
       .trim(),
-    message: work.count === 1 ? 'Hermes is still working on 1 chat.' : `Hermes is still working on ${work.count} chats.`
+    message: work.count === 1 ? strings.messageOne : strings.messageMany(work.count)
   }
 }

--- a/apps/desktop/electron/tray.test.ts
+++ b/apps/desktop/electron/tray.test.ts
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, it } from 'vitest'
+
+import {
+  buildTrayMenuItems,
+  readPersistedMinimizeToTray,
+  writePersistedMinimizeToTray
+} from './tray'
+
+let dir: string
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'hermes-tray-test-'))
+})
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true })
+})
+
+describe('readPersistedMinimizeToTray', () => {
+  it('defaults to false when nothing is persisted', () => {
+    assert.equal(readPersistedMinimizeToTray(dir), false)
+  })
+
+  it('reads the persisted enabled flag', () => {
+    writePersistedMinimizeToTray(dir, true)
+    assert.equal(readPersistedMinimizeToTray(dir), true)
+  })
+
+  it('falls back to false on malformed JSON', () => {
+    writeFileSync(join(dir, 'minimize-to-tray.json'), '{ not valid json', 'utf8')
+    assert.equal(readPersistedMinimizeToTray(dir), false)
+  })
+
+  it('falls back to false when enabled is not a boolean', () => {
+    writeFileSync(join(dir, 'minimize-to-tray.json'), JSON.stringify({ enabled: 'yes' }), 'utf8')
+    assert.equal(readPersistedMinimizeToTray(dir), false)
+  })
+})
+
+describe('writePersistedMinimizeToTray', () => {
+  it('round-trips through the persisted file', () => {
+    writePersistedMinimizeToTray(dir, true)
+    assert.equal(readPersistedMinimizeToTray(dir), true)
+
+    writePersistedMinimizeToTray(dir, false)
+    assert.equal(readPersistedMinimizeToTray(dir), false)
+  })
+
+  it('creates the userData directory if missing', () => {
+    const nested = join(dir, 'deep', 'nested')
+    writePersistedMinimizeToTray(nested, true)
+    assert.equal(readPersistedMinimizeToTray(nested), true)
+  })
+})
+
+describe('buildTrayMenuItems', () => {
+  const deps = (overrides: Partial<Parameters<typeof buildTrayMenuItems>[0]> = {}) =>
+    buildTrayMenuItems({
+      isWindowVisible: false,
+      locale: 'en',
+      onToggleVisibility: () => {},
+      onNewSession: () => {},
+      onOpenSettings: () => {},
+      onQuit: () => {},
+      ...overrides
+    })
+
+  it('shows "Show Window" when the window is hidden (en)', () => {
+    const items = deps({ isWindowVisible: false })
+    assert.equal(items[0].label, 'Show Window')
+  })
+
+  it('shows "Hide Window" when the window is visible (en)', () => {
+    const items = deps({ isWindowVisible: true })
+    assert.equal(items[0].label, 'Hide Window')
+  })
+
+  it('localizes the menu to the renderer locale', () => {
+    const items = deps({ locale: 'zh' })
+    const labels = items.filter(i => 'label' in i).map(i => (i as { label: string }).label)
+    assert.deepEqual(labels, ['显示窗口', '新建会话', '打开设置', '退出'])
+  })
+
+  it('falls back to English for an unknown locale', () => {
+    const items = deps({ locale: 'xx' })
+    assert.equal(items[0].label, 'Show Window')
+    assert.equal(items[4].label, 'Quit')
+  })
+
+  it('exposes new-session / open-settings / quit entries in order', () => {
+    const items = deps()
+    const labels = items.filter(i => 'label' in i).map(i => (i as { label: string }).label)
+    assert.deepEqual(labels, ['Show Window', 'New Session', 'Open Settings', 'Quit'])
+  })
+
+  it('omits a separator from the label list but keeps the structure', () => {
+    const items = deps()
+    // separator is the 4th entry (index 3)
+    assert.equal((items[3] as { type?: string }).type, 'separator')
+  })
+
+  it('wires the quit callback', () => {
+    let quitCalled = false
+
+    const items = deps({ onQuit: () => { quitCalled = true } })
+
+    ;(items[4] as { click: () => void }).click()
+    assert.equal(quitCalled, true)
+  })
+})

--- a/apps/desktop/electron/tray.ts
+++ b/apps/desktop/electron/tray.ts
@@ -1,0 +1,124 @@
+/**
+ * System-tray helpers for the minimize-to-tray feature.
+ *
+ * Kept in a small module so the pure pieces (persistence + menu-template
+ * construction + icon sizing) are unit-testable without booting Electron. The
+ * tray *instance* itself (Tray construction + lifecycle) lives in main.ts
+ * because it needs the live `mainWindow`/`tray` closures alongside the rest of
+ * the window lifecycle.
+ */
+
+import { Menu, nativeImage, Tray } from 'electron'
+import type { MenuItemConstructorOptions } from 'electron'
+
+const MINIMIZE_TO_TRAY_CONFIG_PATH = (userData: string): string =>
+  require('node:path').join(userData, 'minimize-to-tray.json')
+
+// ── Persistence ────────────────────────────────────────────────────────────
+// `userData` is injected so tests can point at a temp dir instead of the real
+// app data path (which isn't available under the test runner).
+
+export function readPersistedMinimizeToTray(userData: string): boolean {
+  try {
+    const fs = require('node:fs')
+    const parsed = JSON.parse(fs.readFileSync(MINIMIZE_TO_TRAY_CONFIG_PATH(userData), 'utf8'))
+
+    return parsed && typeof parsed.enabled === 'boolean' ? parsed.enabled : false
+  } catch {
+    // Missing / malformed → default off, like a fresh install.
+    return false
+  }
+}
+
+export function writePersistedMinimizeToTray(userData: string, enabled: boolean): void {
+  try {
+    const fs = require('node:fs')
+    const path = require('node:path')
+    const target = MINIMIZE_TO_TRAY_CONFIG_PATH(userData)
+    fs.mkdirSync(path.dirname(target), { recursive: true })
+    fs.writeFileSync(target, JSON.stringify({ enabled }, null, 2), 'utf8')
+  } catch {
+    // Persistence is best-effort; never throw into the lifecycle path.
+  }
+}
+
+// ── Menu template ──────────────────────────────────────────────────────────
+// Pure: given the current window visibility + the callbacks, return the menu
+// items. Extracted so the label-switching (Show vs Hide) and locale lookup are
+// testable without a live Tray.
+//
+// The main process has no i18n machinery (menus there are hardcoded English,
+// see e.g. the app menu). To make the tray menu follow the renderer's chosen
+// display language, the renderer pushes its current locale to the main process
+// (see setTrayMenuLocale bridge), and we translate these five short labels
+// here. Kept intentionally small — only what the tray needs.
+
+export type TrayLocale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'ar'
+
+const TRAY_MENU_STRINGS: Record<TrayLocale, {
+  show: string
+  hide: string
+  newSession: string
+  openSettings: string
+  quit: string
+}> = {
+  en: { show: 'Show Window', hide: 'Hide Window', newSession: 'New Session', openSettings: 'Open Settings', quit: 'Quit' },
+  zh: { show: '显示窗口', hide: '隐藏窗口', newSession: '新建会话', openSettings: '打开设置', quit: '退出' },
+  'zh-hant': { show: '顯示視窗', hide: '隱藏視窗', newSession: '新建會話', openSettings: '開啟設定', quit: '退出' },
+  ja: { show: 'ウィンドウを表示', hide: 'ウィンドウを隠す', newSession: '新規セッション', openSettings: '設定を開く', quit: '終了' },
+  ar: { show: 'إظهار النافذة', hide: 'إخفاء النافذة', newSession: 'جلسة جديدة', openSettings: 'فتح الإعدادات', quit: 'إنهاء' }
+}
+
+export function trayMenuStringsFor(locale: string): TrayLocale {
+  return (locale === 'zh' || locale === 'zh-hant' || locale === 'ja' || locale === 'ar') ? (locale as TrayLocale) : 'en'
+}
+
+export interface TrayMenuDeps {
+  isWindowVisible: boolean
+  locale: string
+  onToggleVisibility: () => void
+  onNewSession: () => void
+  onOpenSettings: () => void
+  onQuit: () => void
+}
+
+export function buildTrayMenuItems(deps: TrayMenuDeps): MenuItemConstructorOptions[] {
+  const strings = TRAY_MENU_STRINGS[trayMenuStringsFor(deps.locale)]
+  const visibilityLabel = deps.isWindowVisible ? strings.hide : strings.show
+
+  return [
+    {
+      label: visibilityLabel,
+      click: deps.onToggleVisibility
+    },
+    {
+      label: strings.newSession,
+      click: deps.onNewSession
+    },
+    {
+      label: strings.openSettings,
+      click: deps.onOpenSettings
+    },
+    { type: 'separator' },
+    {
+      label: strings.quit,
+      click: deps.onQuit
+    }
+  ]
+}
+
+// ── Icon ─────────────────────────────────────────────────────────────────────
+// Windows renders the tray at 16×16; resize down so it isn't blurry. Returns
+// null when no icon can be resolved (caller skips tray creation).
+
+export function buildTrayIcon(iconPath: string | null, isWindows: boolean): Electron.NativeImage | null {
+  if (!iconPath) {
+    return null
+  }
+
+  const base = nativeImage.createFromPath(iconPath)
+
+  return isWindows ? base.resize({ width: 16, height: 16 }) : base
+}
+
+export { Menu, Tray }

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -18,7 +18,7 @@ import { isSecondaryWindow } from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { requestComposerFocus, requestComposerInsert } from '../../chat/composer/focus'
-import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute } from '../../routes'
+import { appViewForPath, isOverlayView, NEW_CHAT_ROUTE, routeSessionId, sessionRoute, SETTINGS_ROUTE } from '../../routes'
 
 type RememberedSession = Pick<SessionInfo, '_lineage_root_id' | 'id' | 'profile'>
 
@@ -187,30 +187,51 @@ export function useDesktopIntegrations({
     return () => unsubscribe?.()
   }, [])
 
-  // hermes:// deep links -> a reviewable /blueprint command in the composer.
+  // hermes:// deep links. `blueprint` drops a reviewable /blueprint command in
+  // the composer; `app` routes in-app navigation from the system tray menu
+  // (Windows/Linux only — the tray is never created on macOS).
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onDeepLink?.(payload => {
-      if (!payload || payload.kind !== 'blueprint' || !payload.name) {
+      if (!payload) {
         return
       }
 
-      const slots = Object.entries(payload.params || {})
-        .map(([k, v]) => {
-          const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
+      if (payload.kind === 'blueprint') {
+        if (!payload.name) {
+          return
+        }
 
-          return `${k}=${sval}`
-        })
-        .join(' ')
+        const slots = Object.entries(payload.params || {})
+          .map(([k, v]) => {
+            const sval = /\s/.test(v) ? `"${v.replace(/"/g, '\\"')}"` : v
 
-      const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
-      requestComposerInsert(command, { mode: 'block', target: 'main' })
-      requestComposerFocus('main')
+            return `${k}=${sval}`
+          })
+          .join(' ')
+
+        const command = `/blueprint ${payload.name}${slots ? ' ' + slots : ''}`
+        requestComposerInsert(command, { mode: 'block', target: 'main' })
+        requestComposerFocus('main')
+
+        return
+      }
+
+      if (payload.kind === 'app') {
+        // The tray menu already ensures a live window before sending the link,
+        // so just navigate. `new-session` opens a fresh chat; `settings`
+        // opens the settings view.
+        if (payload.name === 'new-session') {
+          navigate(NEW_CHAT_ROUTE)
+        } else if (payload.name === 'settings') {
+          navigate(SETTINGS_ROUTE)
+        }
+      }
     })
 
     void window.hermesDesktop?.signalDeepLinkReady?.()
 
     return () => unsubscribe?.()
-  }, [])
+  }, [navigate])
 
   // ⌘W via the macOS menu accelerator → close the focused tab; if nothing is
   // closeable, fall back to closing the window (so ⌘W still works as the

--- a/apps/desktop/src/app/settings/appearance-settings.tsx
+++ b/apps/desktop/src/app/settings/appearance-settings.tsx
@@ -14,6 +14,7 @@ import { normalize } from '@/lib/text'
 import { cn } from '@/lib/utils'
 import { $backdrop, setBackdrop } from '@/store/backdrop'
 import { $embedAllowed, $embedMode, clearEmbedAllowed, type EmbedMode, setEmbedMode } from '@/store/embed-consent'
+import { $minimizeToTray, setMinimizeToTray } from '@/store/minimize-to-tray'
 import { $activeGatewayProfile, $profiles, normalizeProfileKey } from '@/store/profile'
 import { $reactionsEnabled, setReactionsEnabled } from '@/store/reactions-enabled'
 import { $toolViewMode, setToolViewMode } from '@/store/tool-view'
@@ -254,6 +255,7 @@ export function AppearanceSettings() {
   const translucency = useStore($translucency)
   const reactionsEnabled = useStore($reactionsEnabled)
   const backdrop = useStore($backdrop)
+  const minimizeToTray = useStore($minimizeToTray)
   const installs = useStore($marketplaceInstalls)
   const profiles = useStore($profiles)
   const activeProfileKey = normalizeProfileKey(useStore($activeGatewayProfile))
@@ -457,6 +459,24 @@ export function AppearanceSettings() {
             }
             description={a.translucencyDesc}
             title={a.translucencyTitle}
+          />
+
+          <ListRow
+            action={
+              <SegmentedControl
+                onChange={id => {
+                  triggerHaptic('selection')
+                  setMinimizeToTray(id === 'on')
+                }}
+                options={[
+                  { id: 'off', label: t.common.off },
+                  { id: 'on', label: t.common.on }
+                ]}
+                value={minimizeToTray ? 'on' : 'off'}
+              />
+            }
+            description={a.minimizeToTrayDesc}
+            title={a.minimizeToTrayTitle}
           />
 
           <ListRow

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -152,6 +152,8 @@ declare global {
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void
+      setMinimizeToTray?: (payload: { enabled: boolean }) => void
+      setTrayMenuLocale?: (locale: string) => void
       setKeepAwake?: (on: boolean) => void
       setPreviewShortcutActive?: (active: boolean) => void
       openExternal: (url: string) => Promise<void>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -397,6 +397,8 @@ export const ar = defineLocale({
       toolViewDesc: 'تحكم في كيفية عرض نشاط الأدوات داخل المحادثة.',
       translucencyTitle: 'شفافية النافذة',
       translucencyDesc: 'إظهار سطح المكتب من خلال النافذة بالكامل. متاح على macOS وWindows فقط.',
+      minimizeToTrayTitle: 'تصغير إلى علبة النظام',
+      minimizeToTrayDesc: 'عند إغلاق النافذة، يختبئ Hermes في علبة النظام بدلًا من الإنهاء. Windows وLinux فقط؛ يستمر macOS عبر Dock. معطّل افتراضيًا.',
       backdropTitle: 'خلفية النافذة',
       backdropDesc: 'اختيار مقدار مزج خلفية سطح المكتب مع سطح Hermes.',
       reactionsTitle: 'تفاعلات الرسائل',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -451,6 +451,9 @@ export const en: Translations = {
       terminalFontReset: 'Use default',
       translucencyTitle: 'Window Translucency',
       translucencyDesc: 'See your desktop through the whole window. macOS and Windows only.',
+      minimizeToTrayTitle: 'Minimize to System Tray',
+      minimizeToTrayDesc:
+        'Closing the window hides Hermes in the system tray instead of quitting. Windows and Linux only; macOS keeps running via the Dock. Off by default.',
       backdropTitle: 'Chat Backdrop',
       backdropDesc: 'The faint statue image behind the conversation.',
       reactionsTitle: 'Message Reactions',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -327,6 +327,8 @@ export const ja = defineLocale({
       terminalFontReset: '既定値を使用',
       translucencyTitle: 'ウィンドウの透過',
       translucencyDesc: 'ウィンドウ全体を透過させてデスクトップを表示します。macOS と Windows のみ。',
+      minimizeToTrayTitle: 'システムトレイに最小化',
+      minimizeToTrayDesc: 'ウィンドウを閉じると、Hermes は終了せずにシステムトレイに隠れます。Windows と Linux のみ（macOS は Dock で継続）。既定はオフ。',
       backdropTitle: 'チャット背景',
       backdropDesc: '会話の背後に表示される淡い彫像の画像。',
       reactionsTitle: 'メッセージリアクション',

--- a/apps/desktop/src/i18n/runtime.ts
+++ b/apps/desktop/src/i18n/runtime.ts
@@ -53,6 +53,14 @@ export function translateFrom(
 
 export function setRuntimeI18nLocale(locale: Locale) {
   runtimeLocale = locale
+
+  // Push the active display language to the main process so the system-tray
+  // context menu (built there, where there is no i18n) matches the UI language.
+  // Guarded: the bridge only exists in the desktop Electron build, and the
+  // tray feature may be disabled.
+  if (typeof window !== 'undefined' && window.hermesDesktop?.setTrayMenuLocale) {
+    window.hermesDesktop.setTrayMenuLocale(locale)
+  }
 }
 
 /** The locale module-level translators resolve against (the app's active

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -355,6 +355,8 @@ export interface Translations {
       terminalFontReset: string
       translucencyTitle: string
       translucencyDesc: string
+      minimizeToTrayTitle: string
+      minimizeToTrayDesc: string
       backdropTitle: string
       backdropDesc: string
       reactionsTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -319,6 +319,8 @@ export const zhHant = defineLocale({
       terminalFontReset: '使用預設字型',
       translucencyTitle: '視窗透明',
       translucencyDesc: '讓整個視窗透出桌面。僅支援 macOS 與 Windows。',
+      minimizeToTrayTitle: '最小化到系統匣',
+      minimizeToTrayDesc: '關閉視窗時，Hermes 隱藏到系統匣而不退出。僅支援 Windows 與 Linux；macOS 透過 Dock 保持執行。預設關閉。',
       backdropTitle: '聊天背景',
       backdropDesc: '對話後方那張淡淡的雕像圖片。',
       reactionsTitle: '訊息回應',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -443,6 +443,8 @@ export const zh: Translations = {
       terminalFontReset: '使用默认字体',
       translucencyTitle: '窗口透明',
       translucencyDesc: '让整个窗口透出桌面。仅支持 macOS 和 Windows。',
+      minimizeToTrayTitle: '最小化到系统托盘',
+      minimizeToTrayDesc: '关闭窗口时，Hermes 隐藏到系统托盘而不退出。仅支持 Windows 和 Linux；macOS 通过 Dock 保持运行。默认关闭。',
       backdropTitle: '聊天背景',
       backdropDesc: '对话后方那张淡淡的雕像图片。',
       reactionsTitle: '消息回应',

--- a/apps/desktop/src/store/minimize-to-tray.ts
+++ b/apps/desktop/src/store/minimize-to-tray.ts
@@ -1,0 +1,32 @@
+/**
+ * Minimize-to-tray behavior.
+ *
+ * When enabled (off by default), closing the Hermes window hides it in the
+ * system tray instead of quitting the app — the same contract as most IM
+ * clients. The main process owns the actual Tray + the `close` handler; the
+ * renderer owns this toggle and mirrors it to the main process over IPC.
+ *
+ * macOS is intentionally excluded on the main side (the Dock already provides
+ * hide-in-background behavior), so toggling this there is a no-op.
+ */
+
+import { atom } from 'nanostores'
+
+import { persistBoolean, storedBoolean } from '@/lib/storage'
+
+const KEY = 'hermes.desktop.minimizeToTray.v1'
+
+const read = (): boolean => storedBoolean(KEY, false)
+
+export const $minimizeToTray = atom<boolean>(typeof window === 'undefined' ? false : read())
+
+export function setMinimizeToTray(enabled: boolean): void {
+  $minimizeToTray.set(Boolean(enabled))
+}
+
+if (typeof window !== 'undefined') {
+  $minimizeToTray.subscribe(enabled => {
+    persistBoolean(KEY, enabled)
+    window.hermesDesktop?.setMinimizeToTray?.({ enabled })
+  })
+}


### PR DESCRIPTION
**Minimize to System Tray (opt-in, Win/Linux)**
Adds an opt-in "Minimize to System Tray" toggle in Settings → Appearance. When enabled, closing the window hides Hermes in the system tray instead of quitting — matching typical IM clients. Off by default, so existing close-button behavior is unchanged for everyone.

macOS is excluded: the Dock already keeps the process alive and offers its own show/hide/quit menu, so the feature is Win/Linux only.

**Behavior**

- Tray is created only when the flag is set. Cold launch reads the persisted value inside app.whenReady(); runtime toggling builds/destroys the tray live over IPC.
- Left-click toggles window visibility; right-click opens a menu with Show/Hide, New Session, Open Settings, and Quit.
- The Show/Hide label stays in sync with the window via show/hide listeners.
- New Session / Open Settings bring the (possibly hidden) window forward and navigate — so the action is actually visible, not just triggered under the tray.
- Quit always exits for real — through the tray Quit item, the app menu, before-quit, and the update/uninstall handoff. The close handler only intercepts when the flag is on and we are not already quitting.

**Tray menu localization**
The menu text follows the renderer's chosen display language (en / zh / zh-hant / ja / ar). The renderer pushes its active locale to the main process via a setTrayMenuLocale preload bridge whenever the UI language changes; the main process rebuilds the tray menu live. The main process keeps a small five-language string table in electron/tray.ts (the main process has no i18n machinery of its own — main-process menus are conventionally hardcoded). Falls back to English for any unsupported locale.

**Structure**

- electron/tray.ts — pure, testable logic: persistence (readPersistedMinimizeToTray / writePersistedMinimizeToTray), menu-template construction, icon sizing, and the locale string table. Unit-tested in electron/tray.test.ts (13 tests: persistence defaults/corruption, menu labels per visibility + locale, fallback).
- electron/main.ts — createTray() lifecycle, click/visibility handling, and the hermes:minimize-to-tray + hermes:tray-menu-locale IPC handlers.
- **Renderer** — toggle wired through the existing preload bridge + a nanostores store (src/store/minimize-to-tray.ts); the app deep-link gains an app kind (new-session, settings) so the tray menu can trigger those views.

**Verification**

- tsc clean for both tsconfig.electron.json and the renderer project.
- vitest run electron/tray.test.ts — 13/13 passing.
- Manual: toggle on → window hides to tray on close → left-click restores → right-click menu actions work → switching UI language live-updates the tray menu.