### PR TITLE
fix(kanban): add bounded proactive supervisor recovery

### DIFF
--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -84,6 +84,15 @@ def is_protected_gate(reason: str) -> bool:
     return bool(_PROTECTED_GATE_RE.search(reason or ""))
 
 
+def is_supervisor_gate_reply(
+    reply_to_text: Optional[str], *, reply_to_is_own_message: bool
+) -> bool:
+    """Return whether an authenticated reply targets a supervisor gate prompt."""
+    return bool(
+        reply_to_is_own_message and _REPLY_MARKER_RE.search(reply_to_text or "")
+    )
+
+
 def _event_payload(raw: Any) -> dict[str, Any]:
     if isinstance(raw, dict):
         return raw
@@ -220,9 +229,13 @@ def reconcile_board(
         event_kind = str(row["event_kind"])
         block_kind = str(payload.get("kind") or row.get("block_kind") or "")
 
-        protected = (
-            block_kind in {"needs_input", "capability"} or not block_kind
-        ) and is_protected_gate(reason)
+        # Legacy/untyped blocks predate the explicit block-kind contract and
+        # historically represent human blockers. Fail closed: only explicitly
+        # typed non-human failure kinds are eligible for automatic recovery.
+        protected = not block_kind or (
+            block_kind in {"needs_input", "capability"}
+            and is_protected_gate(reason)
+        )
         if protected:
             if _ensure_supervisor_subscription(
                 conn,
@@ -306,7 +319,10 @@ def render_supervisor_event(
 
     mode = str(metadata.get("_kanban_supervisor_mode") or "")
     if mode == "protected_gate":
-        if block_kind not in {"needs_input", "capability"} or not is_protected_gate(reason):
+        if block_kind and (
+            block_kind not in {"needs_input", "capability"}
+            or not is_protected_gate(reason)
+        ):
             return ""
         token = str(metadata.get("_kanban_supervisor_gate_token") or "")
         if not re.fullmatch(r"[a-f0-9]{32}", token):

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -213,10 +213,14 @@ def reconcile_board(
         event_kind = str(row["event_kind"])
         block_kind = str(payload.get("kind") or row.get("block_kind") or "")
 
-        # Legacy/untyped blocks predate the explicit block-kind contract and
-        # historically represent human blockers. Fail closed: only explicitly
-        # typed non-human failure kinds are eligible for automatic recovery.
-        protected = not block_kind or block_kind in {"needs_input", "capability"}
+        # Recovery is allowlisted, not inferred. Legacy, malformed, plugin, and
+        # future block kinds remain human gates until they opt into the typed
+        # transient contract. A block-loop event is always deliberate triage,
+        # even when the repeated underlying blocker was transient.
+        recoverable = (
+            block_kind == "transient" and event_kind in {"blocked", "gave_up"}
+        )
+        protected = not recoverable
         if protected:
             if _ensure_supervisor_subscription(
                 conn,
@@ -279,7 +283,6 @@ def render_supervisor_event(
     ).strip()
     task_id = str(getattr(task, "id", "") or "")
     title = str(getattr(task, "title", task_id) or task_id)
-    block_kind = str(payload.get("kind") or getattr(task, "block_kind", "") or "")
     metadata = delivery_metadata if isinstance(delivery_metadata, Mapping) else {}
     try:
         bound_event_id = int(metadata.get("_kanban_supervisor_event_id", -1))
@@ -300,8 +303,6 @@ def render_supervisor_event(
 
     mode = str(metadata.get("_kanban_supervisor_mode") or "")
     if mode == "protected_gate":
-        if block_kind and block_kind not in {"needs_input", "capability"}:
-            return ""
         token = str(metadata.get("_kanban_supervisor_gate_token") or "")
         if not re.fullmatch(r"[a-f0-9]{32}", token):
             return ""

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -1,0 +1,282 @@
+"""Native Kanban exception supervision for gateway-owned delivery.
+
+This module turns otherwise-unsubscribed blocking events into profile-owned
+notifications and performs one bounded recovery for agent-owned failures. It
+contains no platform sends; the existing Kanban notifier keeps ownership of
+retry, cursor, and adapter-routing semantics.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from typing import Any, Mapping, Optional
+
+from hermes_cli import kanban_db as kb
+
+_MATERIAL_EVENT_KINDS = ("blocked", "gave_up", "block_loop_detected")
+_PROTECTED_GATE_RE = re.compile(
+    r"\b(?:"
+    r"product (?:decision|judg(?:e)?ment)|business (?:decision|judg(?:e)?ment)|"
+    r"credential|credentials|secret|api key|token|password|permission|access grant|"
+    r"billing|payment|spend|spending|purchase|destructive|data[- ]loss|"
+    r"delete production|production data (?:deletion|migration)|migration risk|"
+    r"force[- ]push|history rewrite|irreversible infrastructure|"
+    r"infrastructure removal|live trad(?:e|ing)|risk decision|legal|compliance"
+    r")\b",
+    re.IGNORECASE,
+)
+_REPLY_MARKER_RE = re.compile(
+    r"\[kanban-supervisor:([a-z0-9][a-z0-9_-]{0,63}):(t_[a-zA-Z0-9]+)\]"
+)
+
+
+@dataclass(frozen=True)
+class ProactiveSupervisorConfig:
+    enabled: bool = False
+    platform: str = ""
+    chat_id: str = ""
+    thread_id: str = ""
+    chat_type: str = ""
+    recovery_limit: int = 1
+
+    @classmethod
+    def from_mapping(cls, raw: Optional[Mapping[str, Any]]) -> "ProactiveSupervisorConfig":
+        data = raw if isinstance(raw, Mapping) else {}
+        try:
+            recovery_limit = max(0, int(data.get("recovery_limit", 1)))
+        except (TypeError, ValueError):
+            recovery_limit = 1
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            platform=str(data.get("platform") or "").strip().lower(),
+            chat_id=str(data.get("chat_id") or "").strip(),
+            thread_id=str(data.get("thread_id") or "").strip(),
+            chat_type=str(data.get("chat_type") or "").strip(),
+            recovery_limit=recovery_limit,
+        )
+
+    @property
+    def usable(self) -> bool:
+        return self.enabled and bool(self.platform and self.chat_id)
+
+
+@dataclass
+class ReconcileResult:
+    protected_gates: list[str] = field(default_factory=list)
+    recovered: list[str] = field(default_factory=list)
+    recovery_exhausted: list[str] = field(default_factory=list)
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.protected_gates or self.recovered or self.recovery_exhausted)
+
+
+@dataclass(frozen=True)
+class SupervisorReplyResult:
+    board: str
+    task_id: str
+    resumed: bool
+    status: str
+
+
+def is_protected_gate(reason: str) -> bool:
+    """Return whether a blocker belongs to an explicit human-only category."""
+    return bool(_PROTECTED_GATE_RE.search(reason or ""))
+
+
+def _event_payload(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    try:
+        value = json.loads(raw or "{}")
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _active_blocking_events(conn) -> list[dict[str, Any]]:
+    placeholders = ",".join("?" for _ in _MATERIAL_EVENT_KINDS)
+    rows = conn.execute(
+        f"""
+        SELECT t.id AS task_id, t.title, t.status, t.block_kind,
+               t.last_failure_error, e.id AS event_id, e.kind AS event_kind,
+               e.payload AS event_payload
+          FROM tasks t
+          JOIN task_events e ON e.id = (
+              SELECT MAX(e2.id)
+                FROM task_events e2
+               WHERE e2.task_id = t.id
+                 AND e2.kind IN ({placeholders})
+          )
+         WHERE t.status IN ('blocked', 'triage')
+         ORDER BY e.id
+        """,
+        _MATERIAL_EVENT_KINDS,
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _ensure_supervisor_subscription(
+    conn,
+    *,
+    board: str,
+    task_id: str,
+    event_id: int,
+    config: ProactiveSupervisorConfig,
+    notifier_profile: str,
+) -> bool:
+    existing = next(
+        (
+            sub
+            for sub in kb.list_notify_subs(conn, task_id)
+            if str(sub.get("platform") or "").lower() == config.platform
+            and str(sub.get("chat_id") or "") == config.chat_id
+            and str(sub.get("thread_id") or "") == config.thread_id
+        ),
+        None,
+    )
+    metadata = dict(existing.get("delivery_metadata") or {}) if existing else {}
+    metadata["_kanban_proactive_supervisor"] = True
+    metadata["_kanban_supervisor_board"] = board
+    if config.thread_id:
+        metadata.setdefault("thread_id", config.thread_id)
+    if config.chat_type:
+        metadata.setdefault("chat_type", config.chat_type)
+    kb.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform=config.platform,
+        chat_id=config.chat_id,
+        chat_type=config.chat_type or None,
+        thread_id=config.thread_id or None,
+        notifier_profile=notifier_profile,
+        delivery_metadata=metadata,
+        start_event_id=max(0, int(event_id) - 1),
+    )
+    return existing is None
+
+
+def reconcile_board(
+    conn,
+    *,
+    board: str,
+    config: ProactiveSupervisorConfig,
+    notifier_profile: str,
+) -> ReconcileResult:
+    """Reconcile active blocking outcomes on one board.
+
+    Protected gates gain a notifier subscription in the configured command
+    channel. Agent-owned failures consume a durable per-task recovery budget;
+    only an exhausted failure is surfaced, and its message is status-only.
+    """
+    result = ReconcileResult()
+    if not config.usable:
+        return result
+
+    for row in _active_blocking_events(conn):
+        payload = _event_payload(row.get("event_payload"))
+        reason = str(
+            payload.get("reason")
+            or payload.get("error")
+            or row.get("last_failure_error")
+            or ""
+        ).strip()
+        task_id = str(row["task_id"])
+        event_id = int(row["event_id"])
+        event_kind = str(row["event_kind"])
+        block_kind = str(payload.get("kind") or row.get("block_kind") or "")
+
+        protected = block_kind in {"needs_input", "capability"} and is_protected_gate(reason)
+        if protected:
+            if _ensure_supervisor_subscription(
+                conn,
+                board=board,
+                task_id=task_id,
+                event_id=event_id,
+                config=config,
+                notifier_profile=notifier_profile,
+            ):
+                result.protected_gates.append(task_id)
+            continue
+
+        recovered, state = kb.supervisor_recover_task(
+            conn,
+            task_id,
+            source_event_id=event_id,
+            source_kind=event_kind,
+            reason=reason or f"agent-owned {event_kind}",
+            recovery_limit=config.recovery_limit,
+        )
+        if recovered:
+            result.recovered.append(task_id)
+            continue
+        if state == "budget_exhausted":
+            if _ensure_supervisor_subscription(
+                conn,
+                board=board,
+                task_id=task_id,
+                event_id=event_id,
+                config=config,
+                notifier_profile=notifier_profile,
+            ):
+                result.recovery_exhausted.append(task_id)
+
+    return result
+
+
+def render_supervisor_event(*, board: str, task, event) -> Optional[str]:
+    """Render a concise gate prompt or exhausted-recovery status message."""
+    payload = _event_payload(getattr(event, "payload", None))
+    reason = str(
+        payload.get("reason")
+        or payload.get("error")
+        or getattr(task, "last_failure_error", "")
+        or ""
+    ).strip()
+    task_id = str(getattr(task, "id", "") or "")
+    title = str(getattr(task, "title", task_id) or task_id)
+    block_kind = str(payload.get("kind") or getattr(task, "block_kind", "") or "")
+    if block_kind in {"needs_input", "capability"} and is_protected_gate(reason):
+        return (
+            f"Hermes needs one decision to continue {title}:\n{reason[:700]}\n\n"
+            "Reply to this message with the decision. Hermes will attach it to "
+            "the existing task and resume the same work graph.\n"
+            f"[kanban-supervisor:{board}:{task_id}]"
+        )
+    return (
+        f"Hermes could not recover {title} after the bounded retry. "
+        "The task remains paused for engineering follow-up; no decision is requested.\n"
+        f"[kanban-supervisor-status:{board}:{task_id}]"
+    )
+
+
+def consume_supervisor_reply(
+    *,
+    reply_to_text: Optional[str],
+    answer: str,
+    author: str,
+) -> Optional[SupervisorReplyResult]:
+    """Consume a direct reply to a native gate prompt and resume that task."""
+    match = _REPLY_MARKER_RE.search(reply_to_text or "")
+    if match is None:
+        return None
+    if not answer or not answer.strip():
+        return None
+    board, task_id = match.groups()
+    conn = kb.connect(board=board)
+    try:
+        resumed, status = kb.resume_supervisor_gate(
+            conn,
+            task_id,
+            answer=answer,
+            author=author or "user",
+        )
+        return SupervisorReplyResult(
+            board=board,
+            task_id=task_id,
+            resumed=resumed,
+            status=status,
+        )
+    finally:
+        conn.close()

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -330,9 +330,79 @@ def render_supervisor_event(
     )
 
 
+def record_supervisor_delivery_message(
+    *,
+    board: str,
+    task_id: str,
+    platform: str,
+    chat_id: str,
+    thread_id: str,
+    notifier_profile: str,
+    expected_event_id: int,
+    expected_token: str,
+    message_id: str,
+) -> bool:
+    """Bind a protected gate generation to the exact delivered bot message."""
+    if not message_id:
+        return False
+    conn = kb.connect(board=board)
+    try:
+        with kb.write_txn(conn):
+            row = conn.execute(
+                "SELECT notifier_profile, delivery_metadata "
+                "FROM kanban_notify_subs WHERE task_id = ? AND platform = ? "
+                "AND chat_id = ? AND thread_id = ?",
+                (task_id, platform, chat_id, thread_id or ""),
+            ).fetchone()
+            if row is None:
+                return False
+            owner = str(row["notifier_profile"] or "")
+            if notifier_profile and owner and owner != notifier_profile:
+                return False
+            metadata = _event_payload(row["delivery_metadata"])
+            if metadata.get("_kanban_supervisor_mode") != "protected_gate":
+                return False
+            if metadata.get("_kanban_supervisor_gate_token") != expected_token:
+                return False
+            try:
+                raw_event_id = metadata.get("_kanban_supervisor_event_id")
+                bound_event_id = int(str(raw_event_id))
+            except (TypeError, ValueError):
+                return False
+            if bound_event_id != int(expected_event_id):
+                return False
+            placeholders = ",".join("?" for _ in kb.SUPERVISOR_STATE_EVENT_KINDS)
+            current = conn.execute(
+                f"SELECT id FROM task_events WHERE task_id = ? "
+                f"AND kind IN ({placeholders}) ORDER BY id DESC LIMIT 1",
+                (task_id, *kb.SUPERVISOR_STATE_EVENT_KINDS),
+            ).fetchone()
+            if current is None or int(current["id"]) != int(expected_event_id):
+                return False
+            metadata["_kanban_supervisor_message_id"] = str(message_id)
+            encoded = json.dumps(metadata, separators=(",", ":"), sort_keys=True)
+            updated = conn.execute(
+                "UPDATE kanban_notify_subs SET delivery_metadata = ? "
+                "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ? "
+                "AND delivery_metadata = ?",
+                (
+                    encoded,
+                    task_id,
+                    platform,
+                    chat_id,
+                    thread_id or "",
+                    row["delivery_metadata"],
+                ),
+            )
+            return updated.rowcount == 1
+    finally:
+        conn.close()
+
+
 def consume_supervisor_reply(
     *,
     reply_to_text: Optional[str],
+    reply_to_message_id: Optional[str],
     answer: str,
     author: str,
     platform: str,
@@ -369,6 +439,13 @@ def consume_supervisor_reply(
                 if metadata.get("_kanban_supervisor_gate_token") != token:
                     continue
                 if metadata.get("_kanban_supervisor_mode") != "protected_gate":
+                    continue
+                delivered_message_id = str(
+                    metadata.get("_kanban_supervisor_message_id") or ""
+                )
+                if not delivered_message_id or delivered_message_id != str(
+                    reply_to_message_id or ""
+                ):
                     continue
                 if str(sub.get("platform") or "").lower() != str(platform).lower():
                     continue

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -138,6 +138,13 @@ def _ensure_supervisor_subscription(
         ),
         None,
     )
+    if existing:
+        existing_profile = str(existing.get("notifier_profile") or "").strip()
+        if existing_profile and existing_profile != notifier_profile:
+            # The route key is unique without profile in the DB schema. Never
+            # repurpose another profile's subscription: doing so would make its
+            # bot deliver a gate configured and consumed by this profile.
+            return False
     metadata = dict(existing.get("delivery_metadata") or {}) if existing else {}
     if (
         metadata.get("_kanban_supervisor_event_id") == int(event_id)
@@ -213,7 +220,9 @@ def reconcile_board(
         event_kind = str(row["event_kind"])
         block_kind = str(payload.get("kind") or row.get("block_kind") or "")
 
-        protected = block_kind in {"needs_input", "capability"} and is_protected_gate(reason)
+        protected = (
+            block_kind in {"needs_input", "capability"} or not block_kind
+        ) and is_protected_gate(reason)
         if protected:
             if _ensure_supervisor_subscription(
                 conn,

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -16,17 +16,6 @@ from typing import Any, Mapping, Optional
 from hermes_cli import kanban_db as kb
 
 _MATERIAL_EVENT_KINDS = ("blocked", "gave_up", "block_loop_detected")
-_PROTECTED_GATE_RE = re.compile(
-    r"\b(?:"
-    r"product (?:decision|judg(?:e)?ment)|business (?:decision|judg(?:e)?ment)|"
-    r"credential|credentials|secret|api key|token|password|permission|access grant|"
-    r"billing|payment|spend|spending|purchase|destructive|data[- ]loss|"
-    r"delete production|production data (?:deletion|migration)|migration risk|"
-    r"force[- ]push|history rewrite|irreversible infrastructure|"
-    r"infrastructure removal|live trad(?:e|ing)|risk decision|legal|compliance"
-    r")\b",
-    re.IGNORECASE,
-)
 _REPLY_MARKER_RE = re.compile(r"\[kanban-gate:([a-f0-9]{32})\]", re.IGNORECASE)
 
 
@@ -77,11 +66,6 @@ class SupervisorReplyResult:
     task_id: str
     resumed: bool
     status: str
-
-
-def is_protected_gate(reason: str) -> bool:
-    """Return whether a blocker belongs to an explicit human-only category."""
-    return bool(_PROTECTED_GATE_RE.search(reason or ""))
 
 
 def is_supervisor_gate_reply(
@@ -232,10 +216,7 @@ def reconcile_board(
         # Legacy/untyped blocks predate the explicit block-kind contract and
         # historically represent human blockers. Fail closed: only explicitly
         # typed non-human failure kinds are eligible for automatic recovery.
-        protected = not block_kind or (
-            block_kind in {"needs_input", "capability"}
-            and is_protected_gate(reason)
-        )
+        protected = not block_kind or block_kind in {"needs_input", "capability"}
         if protected:
             if _ensure_supervisor_subscription(
                 conn,
@@ -319,10 +300,7 @@ def render_supervisor_event(
 
     mode = str(metadata.get("_kanban_supervisor_mode") or "")
     if mode == "protected_gate":
-        if block_kind and (
-            block_kind not in {"needs_input", "capability"}
-            or not is_protected_gate(reason)
-        ):
+        if block_kind and block_kind not in {"needs_input", "capability"}:
             return ""
         token = str(metadata.get("_kanban_supervisor_gate_token") or "")
         if not re.fullmatch(r"[a-f0-9]{32}", token):

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+import secrets
 from dataclasses import dataclass, field
 from typing import Any, Mapping, Optional
 
@@ -26,9 +27,7 @@ _PROTECTED_GATE_RE = re.compile(
     r")\b",
     re.IGNORECASE,
 )
-_REPLY_MARKER_RE = re.compile(
-    r"\[kanban-supervisor:([a-z0-9][a-z0-9_-]{0,63}):(t_[a-zA-Z0-9]+)\]"
-)
+_REPLY_MARKER_RE = re.compile(r"\[kanban-gate:([a-f0-9]{32})\]", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -96,7 +95,8 @@ def _event_payload(raw: Any) -> dict[str, Any]:
 
 
 def _active_blocking_events(conn) -> list[dict[str, Any]]:
-    placeholders = ",".join("?" for _ in _MATERIAL_EVENT_KINDS)
+    state_placeholders = ",".join("?" for _ in kb.SUPERVISOR_STATE_EVENT_KINDS)
+    material_placeholders = ",".join("?" for _ in _MATERIAL_EVENT_KINDS)
     rows = conn.execute(
         f"""
         SELECT t.id AS task_id, t.title, t.status, t.block_kind,
@@ -107,12 +107,13 @@ def _active_blocking_events(conn) -> list[dict[str, Any]]:
               SELECT MAX(e2.id)
                 FROM task_events e2
                WHERE e2.task_id = t.id
-                 AND e2.kind IN ({placeholders})
+                 AND e2.kind IN ({state_placeholders})
           )
          WHERE t.status IN ('blocked', 'triage')
+           AND e.kind IN ({material_placeholders})
          ORDER BY e.id
         """,
-        _MATERIAL_EVENT_KINDS,
+        (*kb.SUPERVISOR_STATE_EVENT_KINDS, *_MATERIAL_EVENT_KINDS),
     ).fetchall()
     return [dict(row) for row in rows]
 
@@ -125,6 +126,7 @@ def _ensure_supervisor_subscription(
     event_id: int,
     config: ProactiveSupervisorConfig,
     notifier_profile: str,
+    mode: str,
 ) -> bool:
     existing = next(
         (
@@ -137,8 +139,21 @@ def _ensure_supervisor_subscription(
         None,
     )
     metadata = dict(existing.get("delivery_metadata") or {}) if existing else {}
+    if (
+        metadata.get("_kanban_supervisor_event_id") == int(event_id)
+        and metadata.get("_kanban_supervisor_mode") == mode
+    ):
+        return False
+    token = secrets.token_hex(16)
     metadata["_kanban_proactive_supervisor"] = True
     metadata["_kanban_supervisor_board"] = board
+    metadata["_kanban_supervisor_task"] = task_id
+    metadata["_kanban_supervisor_event_id"] = int(event_id)
+    metadata["_kanban_supervisor_gate_token"] = token
+    metadata["_kanban_supervisor_mode"] = mode
+    metadata["_kanban_supervisor_owned_subscription"] = bool(
+        metadata.get("_kanban_supervisor_owned_subscription", existing is None)
+    )
     if config.thread_id:
         metadata.setdefault("thread_id", config.thread_id)
     if config.chat_type:
@@ -154,7 +169,18 @@ def _ensure_supervisor_subscription(
         delivery_metadata=metadata,
         start_event_id=max(0, int(event_id) - 1),
     )
-    return existing is None
+    # A pre-existing ordinary subscription may already have claimed this event
+    # before supervision was enabled. Rewind only to the still-current event.
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE kanban_notify_subs SET last_event_id = MIN(last_event_id, ?) "
+            "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
+            (
+                max(0, int(event_id) - 1), task_id, config.platform,
+                config.chat_id, config.thread_id,
+            ),
+        )
+    return True
 
 
 def reconcile_board(
@@ -196,6 +222,7 @@ def reconcile_board(
                 event_id=event_id,
                 config=config,
                 notifier_profile=notifier_profile,
+                mode="protected_gate",
             ):
                 result.protected_gates.append(task_id)
             continue
@@ -219,14 +246,27 @@ def reconcile_board(
                 event_id=event_id,
                 config=config,
                 notifier_profile=notifier_profile,
+                mode="recovery_exhausted",
             ):
                 result.recovery_exhausted.append(task_id)
 
     return result
 
 
-def render_supervisor_event(*, board: str, task, event) -> Optional[str]:
-    """Render a concise gate prompt or exhausted-recovery status message."""
+def render_supervisor_event(
+    *,
+    board: str,
+    task,
+    event,
+    delivery_metadata: Optional[Mapping[str, Any]] = None,
+    current_event_id: Optional[int] = None,
+) -> Optional[str]:
+    """Render one event-bound supervisor message.
+
+    An empty string means the event belongs to a supervisor-owned subscription
+    but is stale and must be silent. ``None`` leaves an unrelated event to the
+    ordinary notifier renderer when a pre-existing subscription was reused.
+    """
     payload = _event_payload(getattr(event, "payload", None))
     reason = str(
         payload.get("reason")
@@ -237,17 +277,42 @@ def render_supervisor_event(*, board: str, task, event) -> Optional[str]:
     task_id = str(getattr(task, "id", "") or "")
     title = str(getattr(task, "title", task_id) or task_id)
     block_kind = str(payload.get("kind") or getattr(task, "block_kind", "") or "")
-    if block_kind in {"needs_input", "capability"} and is_protected_gate(reason):
+    metadata = delivery_metadata if isinstance(delivery_metadata, Mapping) else {}
+    try:
+        bound_event_id = int(metadata.get("_kanban_supervisor_event_id", -1))
+    except (TypeError, ValueError):
+        bound_event_id = -1
+    event_id = int(getattr(event, "id", -2))
+    owned = bool(metadata.get("_kanban_supervisor_owned_subscription"))
+    # State truth outranks subscription ownership. A reused ordinary
+    # subscription must not fall back to its generic "blocked" renderer after
+    # the supervisor already recovered this event (or another actor resolved
+    # it); that would report a task as paused when it is actually ready.
+    if current_event_id != event_id or getattr(task, "status", None) not in {
+        "blocked", "triage"
+    }:
+        return ""
+    if bound_event_id != event_id:
+        return "" if owned else None
+
+    mode = str(metadata.get("_kanban_supervisor_mode") or "")
+    if mode == "protected_gate":
+        if block_kind not in {"needs_input", "capability"} or not is_protected_gate(reason):
+            return ""
+        token = str(metadata.get("_kanban_supervisor_gate_token") or "")
+        if not re.fullmatch(r"[a-f0-9]{32}", token):
+            return ""
         return (
             f"Hermes needs one decision to continue {title}:\n{reason[:700]}\n\n"
             "Reply to this message with the decision. Hermes will attach it to "
             "the existing task and resume the same work graph.\n"
-            f"[kanban-supervisor:{board}:{task_id}]"
+            f"[kanban-gate:{token}]"
         )
+    if mode != "recovery_exhausted":
+        return ""
     return (
         f"Hermes could not recover {title} after the bounded retry. "
-        "The task remains paused for engineering follow-up; no decision is requested.\n"
-        f"[kanban-supervisor-status:{board}:{task_id}]"
+        "The task remains paused for engineering follow-up; no decision is requested."
     )
 
 
@@ -256,27 +321,69 @@ def consume_supervisor_reply(
     reply_to_text: Optional[str],
     answer: str,
     author: str,
+    platform: str,
+    chat_id: str,
+    thread_id: str = "",
+    notifier_profile: str = "",
+    reply_to_is_own_message: bool = False,
 ) -> Optional[SupervisorReplyResult]:
     """Consume a direct reply to a native gate prompt and resume that task."""
     match = _REPLY_MARKER_RE.search(reply_to_text or "")
     if match is None:
         return None
-    if not answer or not answer.strip():
+    if not answer or not answer.strip() or not reply_to_is_own_message:
         return None
-    board, task_id = match.groups()
-    conn = kb.connect(board=board)
+    token = match.group(1)
+    boards = [kb.read_board_metadata(kb.DEFAULT_BOARD)]
     try:
-        resumed, status = kb.resume_supervisor_gate(
-            conn,
-            task_id,
-            answer=answer,
-            author=author or "user",
-        )
-        return SupervisorReplyResult(
-            board=board,
-            task_id=task_id,
-            resumed=resumed,
-            status=status,
-        )
-    finally:
-        conn.close()
+        boards.extend(kb.list_boards(include_archived=False))
+    except Exception:
+        pass
+    seen_paths: set[str] = set()
+    for board_meta in boards:
+        board = str(board_meta.get("slug") or kb.DEFAULT_BOARD)
+        db_path = str(kb.kanban_db_path(board).resolve())
+        if db_path in seen_paths:
+            continue
+        seen_paths.add(db_path)
+        conn = kb.connect(board=board)
+        try:
+            for sub in kb.list_notify_subs(conn):
+                metadata = sub.get("delivery_metadata")
+                if not isinstance(metadata, dict):
+                    continue
+                if metadata.get("_kanban_supervisor_gate_token") != token:
+                    continue
+                if metadata.get("_kanban_supervisor_mode") != "protected_gate":
+                    continue
+                if str(sub.get("platform") or "").lower() != str(platform).lower():
+                    continue
+                if str(sub.get("chat_id") or "") != str(chat_id):
+                    continue
+                if str(sub.get("thread_id") or "") != str(thread_id or ""):
+                    continue
+                owner = str(sub.get("notifier_profile") or "")
+                if notifier_profile and owner and owner != notifier_profile:
+                    continue
+                task_id = str(metadata.get("_kanban_supervisor_task") or "")
+                try:
+                    raw_event_id = metadata.get("_kanban_supervisor_event_id")
+                    event_id = int(str(raw_event_id))
+                except (TypeError, ValueError):
+                    return None
+                resumed, status = kb.resume_supervisor_gate(
+                    conn,
+                    task_id,
+                    expected_event_id=event_id,
+                    answer=answer,
+                    author=author or "user",
+                )
+                return SupervisorReplyResult(
+                    board=board,
+                    task_id=task_id,
+                    resumed=resumed,
+                    status=status,
+                )
+        finally:
+            conn.close()
+    return None

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -151,6 +151,7 @@ def _ensure_supervisor_subscription(
     metadata["_kanban_supervisor_event_id"] = int(event_id)
     metadata["_kanban_supervisor_gate_token"] = token
     metadata["_kanban_supervisor_mode"] = mode
+    metadata["_kanban_supervisor_recovery_limit"] = config.recovery_limit
     metadata["_kanban_supervisor_owned_subscription"] = bool(
         metadata.get("_kanban_supervisor_owned_subscription", existing is None)
     )
@@ -314,6 +315,15 @@ def render_supervisor_event(
         )
     if mode != "recovery_exhausted":
         return ""
+    try:
+        recovery_limit = int(metadata.get("_kanban_supervisor_recovery_limit", 1))
+    except (TypeError, ValueError):
+        recovery_limit = 1
+    if recovery_limit <= 0:
+        return (
+            f"Hermes did not retry {title} because its recovery budget is zero. "
+            "The task remains paused for engineering follow-up; no decision is requested."
+        )
     return (
         f"Hermes could not recover {title} after the bounded retry. "
         "The task remains paused for engineering follow-up; no decision is requested."

--- a/gateway/kanban_proactive_supervisor.py
+++ b/gateway/kanban_proactive_supervisor.py
@@ -18,6 +18,24 @@ from hermes_cli import kanban_db as kb
 _MATERIAL_EVENT_KINDS = ("blocked", "gave_up", "block_loop_detected")
 _REPLY_MARKER_RE = re.compile(r"\[kanban-gate:([a-f0-9]{32})\]", re.IGNORECASE)
 
+# Only an explicit human-input contract may page Kevin for a decision. Other
+# block kinds are operational state and belong in the ops channel. Legacy
+# untyped cards remain compatible only when their reason names a protected
+# decision class rather than using generic words such as "approval".
+_LEGACY_PROTECTED_GATE_RE = re.compile(
+    r"(?:"
+    r"(?:product|business)\s+(?:decision|judg(?:e)?ment)|"
+    r"(?:spend|billing|purchase|payment)\s+(?:approval|authorization)|"
+    r"(?:secret|credential|api[- ]?key|password)\s+(?:needed|required|from kevin)|"
+    r"(?:destructive|data[- ]?loss|production data (?:deletion|migration))|"
+    r"(?:delete|remove)\s+(?:all\s+|the\s+)?(?:customer\s+)?(?:records|production database)|"
+    r"decision.{0,40}\bship\b|"
+    r"force[- ]?push|history rewrite|live trad(?:e|ing)|"
+    r"irreversible infrastructure removal|legal|compliance"
+    r")",
+    re.IGNORECASE,
+)
+
 
 @dataclass(frozen=True)
 class ProactiveSupervisorConfig:
@@ -52,12 +70,27 @@ class ProactiveSupervisorConfig:
 @dataclass
 class ReconcileResult:
     protected_gates: list[str] = field(default_factory=list)
+    engineering_followups: list[str] = field(default_factory=list)
     recovered: list[str] = field(default_factory=list)
     recovery_exhausted: list[str] = field(default_factory=list)
 
     @property
     def changed(self) -> bool:
-        return bool(self.protected_gates or self.recovered or self.recovery_exhausted)
+        return bool(
+            self.protected_gates
+            or self.engineering_followups
+            or self.recovered
+            or self.recovery_exhausted
+        )
+
+
+def _is_protected_gate(*, block_kind: str, reason: str) -> bool:
+    """Return whether this blocker is allowed to request a Kevin decision."""
+    if block_kind == "needs_input":
+        return True
+    if block_kind:
+        return False
+    return bool(_LEGACY_PROTECTED_GATE_RE.search(reason))
 
 
 @dataclass(frozen=True)
@@ -214,14 +247,13 @@ def reconcile_board(
         event_kind = str(row["event_kind"])
         block_kind = str(payload.get("kind") or row.get("block_kind") or "")
 
-        # Recovery is allowlisted, not inferred. Legacy, malformed, plugin, and
-        # future block kinds remain human gates until they opt into the typed
-        # transient contract. A block-loop event is always deliberate triage,
-        # even when the repeated underlying blocker was transient.
+        # Recovery is allowlisted, not inferred. A block-loop event is always
+        # deliberate engineering triage even when its underlying block was
+        # transient; it must not become a vague approval page.
         recoverable = (
             block_kind == "transient" and event_kind in {"blocked", "gave_up"}
         )
-        protected = not recoverable
+        protected = _is_protected_gate(block_kind=block_kind, reason=reason)
         if protected:
             if _ensure_supervisor_subscription(
                 conn,
@@ -233,6 +265,19 @@ def reconcile_board(
                 mode="protected_gate",
             ):
                 result.protected_gates.append(task_id)
+            continue
+
+        if not recoverable:
+            if _ensure_supervisor_subscription(
+                conn,
+                board=board,
+                task_id=task_id,
+                event_id=event_id,
+                config=config,
+                notifier_profile=notifier_profile,
+                mode="engineering_followup",
+            ):
+                result.engineering_followups.append(task_id)
             continue
 
         recovered, state = kb.supervisor_recover_task(
@@ -312,6 +357,12 @@ def render_supervisor_event(
             "Reply to this message with the decision. Hermes will attach it to "
             "the existing task and resume the same work graph.\n"
             f"[kanban-gate:{token}]"
+        )
+    if mode == "engineering_followup":
+        return (
+            f"Hermes paused {title}: {reason[:700]}\n\n"
+            "Engineering follow-up is required in the ops workstream. "
+            "No Kevin decision is requested."
         )
     if mode != "recovery_exhausted":
         return ""

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -369,6 +369,14 @@ class GatewayKanbanWatchersMixin:
                                     if not events:
                                         continue
                                     task = _kb.get_task(conn, sub["task_id"])
+                                    _state_kinds = _kb.SUPERVISOR_STATE_EVENT_KINDS
+                                    _state_placeholders = ",".join("?" for _ in _state_kinds)
+                                    _current_state_event = conn.execute(
+                                        f"SELECT id FROM task_events WHERE task_id = ? "
+                                        f"AND kind IN ({_state_placeholders}) "
+                                        "ORDER BY id DESC LIMIT 1",
+                                        (sub["task_id"], *_state_kinds),
+                                    ).fetchone()
                                     logger.debug(
                                         "kanban notifier: claimed %d event(s) for %s on board %s cursor %s→%s",
                                         len(events), sub["task_id"], slug, old_cursor, cursor,
@@ -379,6 +387,10 @@ class GatewayKanbanWatchersMixin:
                                         "cursor": cursor,
                                         "events": events,
                                         "task": task,
+                                        "current_state_event_id": (
+                                            int(_current_state_event["id"])
+                                            if _current_state_event is not None else None
+                                        ),
                                         "board": slug,
                                     })
                                 except Exception as sub_exc:
@@ -442,6 +454,7 @@ class GatewayKanbanWatchersMixin:
                         sub["task_id"], sub["platform"],
                         sub["chat_id"], sub.get("thread_id") or "",
                     )
+                    _supervisor_suppressed_event_ids: set[int] = set()
                     for ev in d["events"]:
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
@@ -464,8 +477,13 @@ class GatewayKanbanWatchersMixin:
                                 board=board_slug or _kb.DEFAULT_BOARD,
                                 task=task,
                                 event=ev,
+                                delivery_metadata=delivery_metadata,
+                                current_event_id=d.get("current_state_event_id"),
                             )
-                        if _supervisor_msg:
+                        if _supervisor_msg == "":
+                            _supervisor_suppressed_event_ids.add(int(ev.id))
+                            continue
+                        if _supervisor_msg is not None:
                             msg = _supervisor_msg
                         elif kind == "completed":
                             # Prefer the run's summary (the worker's
@@ -557,6 +575,11 @@ class GatewayKanbanWatchersMixin:
                         # not platform delivery options.
                         metadata.pop("_kanban_proactive_supervisor", None)
                         metadata.pop("_kanban_supervisor_board", None)
+                        metadata.pop("_kanban_supervisor_task", None)
+                        metadata.pop("_kanban_supervisor_event_id", None)
+                        metadata.pop("_kanban_supervisor_gate_token", None)
+                        metadata.pop("_kanban_supervisor_mode", None)
+                        metadata.pop("_kanban_supervisor_owned_subscription", None)
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         # Adapters with no push channel (the API server —
@@ -679,7 +702,12 @@ class GatewayKanbanWatchersMixin:
                         #   next tick retries.
                         task_terminal = task and task.status in {"done", "archived"}
                         _WAKE_KINDS = ("completed", "gave_up", "crashed", "timed_out", "blocked")
-                        _wake_kinds = {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                        _wake_kinds = {
+                            ev.kind
+                            for ev in d["events"]
+                            if ev.kind in _WAKE_KINDS
+                            and int(ev.id) not in _supervisor_suppressed_event_ids
+                        }
                         from gateway.wake import adapter_supports_push as _adapter_push_ok
 
                         _is_push_adapter = _adapter_push_ok(adapter)

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -473,12 +473,33 @@ class GatewayKanbanWatchersMixin:
                             and render_supervisor_event is not None
                             and kind in {"blocked", "gave_up", "block_loop_detected"}
                         ):
+                            # Collection claims the cursor before platform I/O.
+                            # Re-read the subscription and task generation at
+                            # the final delivery boundary so a concurrent
+                            # dashboard transition, recovery, or replacement
+                            # gate cannot emit stale supervisor copy.
+                            _fresh_supervisor_state = await asyncio.to_thread(
+                                self._kanban_supervisor_delivery_state,
+                                sub,
+                                board_slug,
+                            )
+                            if _fresh_supervisor_state is None:
+                                _supervisor_suppressed_event_ids.add(int(ev.id))
+                                continue
+                            _fresh_sub, task, _fresh_state_event_id = _fresh_supervisor_state
+                            if (
+                                str(_fresh_sub.get("notifier_profile") or "")
+                                != str(sub.get("notifier_profile") or "")
+                            ):
+                                _supervisor_suppressed_event_ids.add(int(ev.id))
+                                continue
+                            delivery_metadata = _fresh_sub.get("delivery_metadata")
                             _supervisor_msg = render_supervisor_event(
                                 board=board_slug or _kb.DEFAULT_BOARD,
                                 task=task,
                                 event=ev,
                                 delivery_metadata=delivery_metadata,
-                                current_event_id=d.get("current_state_event_id"),
+                                current_event_id=_fresh_state_event_id,
                             )
                         if _supervisor_msg == "":
                             _supervisor_suppressed_event_ids.add(int(ev.id))
@@ -889,6 +910,41 @@ class GatewayKanbanWatchersMixin:
                 thread_id=sub.get("thread_id") or "",
                 new_cursor=cursor,
             )
+        finally:
+            conn.close()
+
+    def _kanban_supervisor_delivery_state(
+        self, sub: dict, board: Optional[str] = None,
+    ) -> Optional[tuple[dict, Any, Optional[int]]]:
+        """Re-read a supervisor subscription and its current task generation."""
+        from hermes_cli import kanban_db as _kb
+
+        conn = _kb.connect(board=board)
+        try:
+            current_sub = next(
+                (
+                    candidate
+                    for candidate in _kb.list_notify_subs(conn, sub["task_id"])
+                    if candidate.get("platform") == sub.get("platform")
+                    and candidate.get("chat_id") == sub.get("chat_id")
+                    and (candidate.get("thread_id") or "")
+                    == (sub.get("thread_id") or "")
+                ),
+                None,
+            )
+            if current_sub is None:
+                return None
+            task = _kb.get_task(conn, sub["task_id"])
+            if task is None:
+                return None
+            state_kinds = _kb.SUPERVISOR_STATE_EVENT_KINDS
+            placeholders = ",".join("?" for _ in state_kinds)
+            row = conn.execute(
+                f"SELECT id FROM task_events WHERE task_id = ? "
+                f"AND kind IN ({placeholders}) ORDER BY id DESC LIMIT 1",
+                (sub["task_id"], *state_kinds),
+            ).fetchone()
+            return current_sub, task, int(row["id"]) if row is not None else None
         finally:
             conn.close()
 

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -152,6 +152,27 @@ class GatewayKanbanWatchersMixin:
         except Exception:
             logger.warning("kanban notifier: kanban_db not importable; notifier disabled")
             return
+        _reconcile_supervisor_board = None
+        render_supervisor_event = None
+        try:
+            from gateway.kanban_proactive_supervisor import (
+                ProactiveSupervisorConfig,
+                reconcile_board as _reconcile_supervisor_board,
+                render_supervisor_event,
+            )
+            from hermes_cli.config import load_config as _load_hermes_config
+
+            _full_config = _load_hermes_config()
+            _kanban_config = _full_config.get("kanban", {})
+            supervisor_config = ProactiveSupervisorConfig.from_mapping(
+                _kanban_config.get("proactive_supervisor", {})
+            )
+        except Exception as exc:
+            logger.warning(
+                "kanban notifier: proactive supervisor config unavailable; disabled: %s",
+                exc,
+            )
+            supervisor_config = None
 
         # "status" covers dashboard drag-drop and `_set_status_direct()`
         # writes — surface those transitions to subscribers too.
@@ -260,7 +281,7 @@ class GatewayKanbanWatchersMixin:
                         # checkpoint traffic) is exactly the per-tick cost
                         # this skip avoids.
                         try:
-                            if _kb.count_notify_subs(
+                            if (not supervisor_config or not supervisor_config.usable) and _kb.count_notify_subs(
                                 board=slug,
                                 notifier_profiles=notifier_profiles,
                                 include_unowned=include_unowned,
@@ -294,6 +315,24 @@ class GatewayKanbanWatchersMixin:
                             # a legacy DB. `_add_column_if_missing` now
                             # tolerates that race, but we still skip the
                             # redundant call to avoid the wasted work.
+                            if (
+                                supervisor_config
+                                and supervisor_config.usable
+                                and _reconcile_supervisor_board is not None
+                            ):
+                                try:
+                                    _reconcile_supervisor_board(
+                                        conn,
+                                        board=slug,
+                                        config=supervisor_config,
+                                        notifier_profile=notifier_profile,
+                                    )
+                                except Exception as exc:
+                                    logger.warning(
+                                        "kanban proactive supervisor failed for board %s: %s",
+                                        slug,
+                                        exc,
+                                    )
                             subs = _kb.list_notify_subs(
                                 conn,
                                 notifier_profiles=notifier_profiles,
@@ -410,7 +449,25 @@ class GatewayKanbanWatchersMixin:
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
-                        if kind == "completed":
+                        delivery_metadata = sub.get("delivery_metadata")
+                        _supervisor_delivery = bool(
+                            isinstance(delivery_metadata, dict)
+                            and delivery_metadata.get("_kanban_proactive_supervisor")
+                        )
+                        _supervisor_msg = None
+                        if (
+                            _supervisor_delivery
+                            and render_supervisor_event is not None
+                            and kind in {"blocked", "gave_up", "block_loop_detected"}
+                        ):
+                            _supervisor_msg = render_supervisor_event(
+                                board=board_slug or _kb.DEFAULT_BOARD,
+                                task=task,
+                                event=ev,
+                            )
+                        if _supervisor_msg:
+                            msg = _supervisor_msg
+                        elif kind == "completed":
                             # Prefer the run's summary (the worker's
                             # intentional human-facing handoff, carried
                             # in the event payload), then fall back to
@@ -491,12 +548,15 @@ class GatewayKanbanWatchersMixin:
                             # internal transition. They are also excluded from
                             # _WAKE_KINDS below, so they never wake the creator.
                             continue
-                        delivery_metadata = sub.get("delivery_metadata")
                         metadata: dict[str, Any] = (
                             dict(delivery_metadata)
                             if isinstance(delivery_metadata, dict)
                             else {}
                         )
+                        # Supervisor markers are gateway-internal routing state,
+                        # not platform delivery options.
+                        metadata.pop("_kanban_proactive_supervisor", None)
+                        metadata.pop("_kanban_supervisor_board", None)
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
                         # Adapters with no push channel (the API server —

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -463,21 +463,14 @@ class GatewayKanbanWatchersMixin:
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
                         delivery_metadata = sub.get("delivery_metadata")
-                        _supervisor_delivery = bool(
-                            isinstance(delivery_metadata, dict)
-                            and delivery_metadata.get("_kanban_proactive_supervisor")
-                        )
                         _supervisor_msg = None
-                        if (
-                            _supervisor_delivery
-                            and render_supervisor_event is not None
-                            and kind in {"blocked", "gave_up", "block_loop_detected"}
-                        ):
+                        if kind in {"blocked", "gave_up", "block_loop_detected"}:
                             # Collection claims the cursor before platform I/O.
-                            # Re-read the subscription and task generation at
-                            # the final delivery boundary so a concurrent
-                            # dashboard transition, recovery, or replacement
-                            # gate cannot emit stale supervisor copy.
+                            # Re-read every blocking event at the final delivery
+                            # boundary, including ordinary subscriptions. A
+                            # successful supervisor recovery must not fall back
+                            # to generic "blocked" copy or a creator wake merely
+                            # because the subscription predates supervision.
                             _fresh_supervisor_state = await asyncio.to_thread(
                                 self._kanban_supervisor_delivery_state,
                                 sub,
@@ -494,13 +487,26 @@ class GatewayKanbanWatchersMixin:
                                 _supervisor_suppressed_event_ids.add(int(ev.id))
                                 continue
                             delivery_metadata = _fresh_sub.get("delivery_metadata")
-                            _supervisor_msg = render_supervisor_event(
-                                board=board_slug or _kb.DEFAULT_BOARD,
-                                task=task,
-                                event=ev,
-                                delivery_metadata=delivery_metadata,
-                                current_event_id=_fresh_state_event_id,
+                            if _fresh_state_event_id != int(ev.id):
+                                _supervisor_suppressed_event_ids.add(int(ev.id))
+                                continue
+                            _supervisor_delivery = bool(
+                                isinstance(delivery_metadata, dict)
+                                and delivery_metadata.get(
+                                    "_kanban_proactive_supervisor"
+                                )
                             )
+                            if (
+                                _supervisor_delivery
+                                and render_supervisor_event is not None
+                            ):
+                                _supervisor_msg = render_supervisor_event(
+                                    board=board_slug or _kb.DEFAULT_BOARD,
+                                    task=task,
+                                    event=ev,
+                                    delivery_metadata=delivery_metadata,
+                                    current_event_id=_fresh_state_event_id,
+                                )
                         if _supervisor_msg == "":
                             _supervisor_suppressed_event_ids.add(int(ev.id))
                             continue

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -464,6 +464,7 @@ class GatewayKanbanWatchersMixin:
                         tag = f"@{who} " if who else ""
                         delivery_metadata = sub.get("delivery_metadata")
                         _supervisor_msg = None
+                        _supervisor_delivery = False
                         if kind in {"blocked", "gave_up", "block_loop_detected"}:
                             # Collection claims the cursor before platform I/O.
                             # Re-read every blocking event at the final delivery
@@ -652,6 +653,48 @@ class GatewayKanbanWatchersMixin:
                                     "adapter send() reported failure: "
                                     f"{getattr(_send_res, 'error', None) or 'unknown error'}"
                                 )
+                            if (
+                                _supervisor_delivery
+                                and isinstance(delivery_metadata, dict)
+                                and delivery_metadata.get("_kanban_supervisor_mode")
+                                == "protected_gate"
+                            ):
+                                delivered_message_id = str(
+                                    getattr(_send_res, "message_id", None) or ""
+                                )
+                                if not delivered_message_id:
+                                    raise RuntimeError(
+                                        "protected gate delivery did not return a message id"
+                                    )
+                                from gateway.kanban_proactive_supervisor import (
+                                    record_supervisor_delivery_message,
+                                )
+
+                                bound = await asyncio.to_thread(
+                                    record_supervisor_delivery_message,
+                                    board=board_slug or _kb.DEFAULT_BOARD,
+                                    task_id=sub["task_id"],
+                                    platform=platform_str,
+                                    chat_id=sub["chat_id"],
+                                    thread_id=sub.get("thread_id") or "",
+                                    notifier_profile=str(
+                                        sub.get("notifier_profile") or ""
+                                    ),
+                                    expected_event_id=int(ev.id),
+                                    expected_token=str(
+                                        delivery_metadata.get(
+                                            "_kanban_supervisor_gate_token"
+                                        )
+                                        or ""
+                                    ),
+                                    message_id=delivered_message_id,
+                                )
+                                if not bound:
+                                    logger.info(
+                                        "kanban notifier: gate %s changed before "
+                                        "message-id binding; delivered prompt is stale",
+                                        sub["task_id"],
+                                    )
                             logger.debug(
                                 "kanban notifier: delivered %s event for %s to %s/%s on board %s",
                                 kind, sub["task_id"], platform_str, sub["chat_id"], board_slug,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5652,6 +5652,55 @@ class BasePlatformAdapter(ABC):
                     logger.error("[%s] Command '/%s' dispatch failed: %s", self.name, cmd, e, exc_info=True)
                 return
 
+            # Authenticated replies to native Kanban supervisor prompts are
+            # control-plane answers, not follow-up agent turns. Preserve the
+            # quoted gate marker/provenance and dispatch them directly while
+            # the original worker remains active. Queueing or merging them
+            # would erase the capability binding and can deadlock the graph.
+            if not cmd:
+                from gateway.kanban_proactive_supervisor import (
+                    is_supervisor_gate_reply,
+                )
+
+                _is_supervisor_gate = is_supervisor_gate_reply(
+                    event.reply_to_text,
+                    reply_to_is_own_message=event.reply_to_is_own_message,
+                )
+
+                if _is_supervisor_gate:
+                    logger.debug(
+                        "[%s] Routing authenticated supervisor reply for %s",
+                        self.name,
+                        session_key,
+                    )
+                    try:
+                        _thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        response = await self._message_handler(event)
+                        _text, _eph_ttl = self._unwrap_ephemeral(response)
+                        if _text:
+                            _r = await self._send_with_retry(
+                                chat_id=event.source.chat_id,
+                                content=_text,
+                                reply_to=_reply_anchor_for_event(event),
+                                metadata=_mark_notify_metadata(_thread_meta),
+                            )
+                            if _eph_ttl > 0 and _r.success and _r.message_id:
+                                self._schedule_ephemeral_delete(
+                                    chat_id=event.source.chat_id,
+                                    message_id=_r.message_id,
+                                    ttl_seconds=_eph_ttl,
+                                )
+                    except Exception as e:
+                        logger.error(
+                            "[%s] Supervisor reply dispatch failed: %s",
+                            self.name,
+                            e,
+                            exc_info=True,
+                        )
+                    return
+
             # Clarify reply bypass: if the agent is blocked on a
             # clarify_tool call, the next non-command message in this
             # session MUST reach the runner so typed numeric choices,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14452,6 +14452,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     pairing_store._record_rate_limit(platform_name, source.user_id)
             return None
         
+        # A reply to a native Kanban gate prompt belongs to that existing task
+        # graph. Attach the answer and resume the blocked card before creating
+        # or mutating a conversational session. Slash commands still follow
+        # the normal control path.
+        if not is_internal and not event.get_command():
+            try:
+                from gateway.kanban_proactive_supervisor import (
+                    consume_supervisor_reply,
+                )
+
+                _gate_reply = consume_supervisor_reply(
+                    reply_to_text=getattr(event, "reply_to_text", None),
+                    answer=event.text or "",
+                    author=source.user_name or source.user_id or "user",
+                )
+            except Exception as exc:
+                logger.warning("Kanban supervisor reply handling failed: %s", exc)
+                _gate_reply = None
+            if _gate_reply is not None:
+                if _gate_reply.resumed:
+                    return (
+                        f"Resumed Kanban {_gate_reply.task_id} on "
+                        f"{_gate_reply.board} with your decision attached."
+                    )
+                return (
+                    f"Kanban {_gate_reply.task_id} is no longer waiting for "
+                    "that decision."
+                )
+
         # Intercept messages that are responses to a pending /update prompt.
         # The update process (detached) wrote .update_prompt.json; the watcher
         # forwarded it to the user; now the user's reply goes back via

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14457,11 +14457,19 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # or mutating a conversational session. Slash commands still follow
         # the normal control path.
         if not is_internal and not event.get_command():
+            _gate_reply_candidate = False
             try:
                 from gateway.kanban_proactive_supervisor import (
                     consume_supervisor_reply,
+                    is_supervisor_gate_reply,
                 )
 
+                _gate_reply_candidate = is_supervisor_gate_reply(
+                    getattr(event, "reply_to_text", None),
+                    reply_to_is_own_message=bool(
+                        getattr(event, "reply_to_is_own_message", False)
+                    ),
+                )
                 _gate_reply = consume_supervisor_reply(
                     reply_to_text=getattr(event, "reply_to_text", None),
                     answer=event.text or "",
@@ -14476,6 +14484,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
             except Exception as exc:
                 logger.warning("Kanban supervisor reply handling failed: %s", exc)
+                if _gate_reply_candidate:
+                    return (
+                        "Could not process that Kanban decision, so no action "
+                        "was taken. Please retry your reply."
+                    )
                 _gate_reply = None
             if _gate_reply is not None:
                 if _gate_reply.resumed:
@@ -14486,6 +14499,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return (
                     f"Kanban {_gate_reply.task_id} is no longer waiting for "
                     "that decision."
+                )
+            if _gate_reply_candidate:
+                return (
+                    "That Kanban gate is no longer active or could not be "
+                    "matched. No action was taken."
                 )
 
         # Intercept messages that are responses to a pending /update prompt.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14478,7 +14478,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     platform=getattr(source.platform, "value", str(source.platform)),
                     chat_id=source.chat_id,
                     thread_id=source.thread_id or "",
-                    notifier_profile=source.profile or self._active_profile_name(),
+                    notifier_profile=(
+                        self._adapter_profile_for_source(source)
+                        or self._active_profile_name()
+                    ),
                     reply_to_is_own_message=bool(
                         getattr(event, "reply_to_is_own_message", False)
                     ),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14472,6 +14472,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
                 _gate_reply = consume_supervisor_reply(
                     reply_to_text=getattr(event, "reply_to_text", None),
+                    reply_to_message_id=getattr(event, "reply_to_message_id", None),
                     answer=event.text or "",
                     author=source.user_name or source.user_id or "user",
                     platform=getattr(source.platform, "value", str(source.platform)),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14466,6 +14466,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     reply_to_text=getattr(event, "reply_to_text", None),
                     answer=event.text or "",
                     author=source.user_name or source.user_id or "user",
+                    platform=getattr(source.platform, "value", str(source.platform)),
+                    chat_id=source.chat_id,
+                    thread_id=source.thread_id or "",
+                    notifier_profile=source.profile or self._active_profile_name(),
+                    reply_to_is_own_message=bool(
+                        getattr(event, "reply_to_is_own_message", False)
+                    ),
                 )
             except Exception as exc:
                 logger.warning("Kanban supervisor reply handling failed: %s", exc)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2257,6 +2257,17 @@ DEFAULT_CONFIG = {
         # behaviour — e.g. for a profile that prefers explicit
         # ``kanban_notify-subscribe`` calls per task.
         "auto_subscribe_on_create": True,
+        # Gateway-native exception supervision. Disabled until an owning
+        # profile selects its command channel; this prevents cross-profile bot
+        # fallback and keeps normal installs silent by default.
+        "proactive_supervisor": {
+            "enabled": False,
+            "platform": "",
+            "chat_id": "",
+            "thread_id": "",
+            "chat_type": "",
+            "recovery_limit": 1,
+        },
         # Run the dispatcher inside the gateway process. On by default —
         # the cost is ~300µs every `dispatch_interval_seconds` when idle,
         # and gateway is the supervisor users already have. Set to false

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -134,6 +134,16 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
+# Events that establish a new durable task-state generation for native
+# supervision. Informational events such as comments and heartbeats do not
+# invalidate a still-current block.
+SUPERVISOR_STATE_EVENT_KINDS = (
+    "created", "promoted", "claimed", "reclaimed", "completed", "archived",
+    "scheduled", "dependency_wait", "blocked", "gave_up",
+    "block_loop_detected", "status", "unblocked", "specified",
+    "supervisor_recovery", "supervisor_answered",
+)
+
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
@@ -5989,6 +5999,24 @@ def supervisor_recover_task(
         if task is None:
             return False, "missing"
 
+        # The source event is a generation token, not just audit context. A
+        # dashboard move, manual unblock, later block, or successful recovery
+        # permanently invalidates an older blocking event.
+        state_placeholders = ",".join("?" for _ in SUPERVISOR_STATE_EVENT_KINDS)
+        current = conn.execute(
+            f"SELECT id, kind FROM task_events WHERE task_id = ? "
+            f"AND kind IN ({state_placeholders}) ORDER BY id DESC LIMIT 1",
+            (task_id, *SUPERVISOR_STATE_EVENT_KINDS),
+        ).fetchone()
+        if (
+            current is None
+            or int(current["id"]) != int(source_event_id)
+            or str(current["kind"]) != str(source_kind)
+        ):
+            return False, "stale_event"
+        if task["status"] not in {"blocked", "triage"}:
+            return False, "not_blocked"
+
         prior_rows = conn.execute(
             "SELECT payload FROM task_events "
             "WHERE task_id = ? AND kind = 'supervisor_recovery'",
@@ -6005,8 +6033,6 @@ def supervisor_recover_task(
             return False, "already_recovered"
         if len(prior_rows) >= limit:
             return False, "budget_exhausted"
-        if task["status"] not in {"blocked", "triage"}:
-            return False, "not_blocked"
 
         undone_parent = conn.execute(
             "SELECT 1 FROM task_links l "
@@ -6052,6 +6078,7 @@ def resume_supervisor_gate(
     conn: sqlite3.Connection,
     task_id: str,
     *,
+    expected_event_id: int,
     answer: str,
     author: str,
 ) -> tuple[bool, str]:
@@ -6069,6 +6096,20 @@ def resume_supervisor_gate(
             return False, "missing"
         if task["status"] not in {"blocked", "triage"}:
             return False, "not_waiting"
+        state_placeholders = ",".join("?" for _ in SUPERVISOR_STATE_EVENT_KINDS)
+        current = conn.execute(
+            f"SELECT id, kind FROM task_events WHERE task_id = ? "
+            f"AND kind IN ({state_placeholders}) ORDER BY id DESC LIMIT 1",
+            (task_id, *SUPERVISOR_STATE_EVENT_KINDS),
+        ).fetchone()
+        if (
+            current is None
+            or int(current["id"]) != int(expected_event_id)
+            or str(current["kind"]) not in {
+                "blocked", "gave_up", "block_loop_detected"
+            }
+        ):
+            return False, "stale_gate"
         undone_parent = conn.execute(
             "SELECT 1 FROM task_links l "
             "JOIN tasks p ON p.id = l.parent_id "
@@ -6094,7 +6135,11 @@ def resume_supervisor_gate(
             conn,
             task_id,
             "supervisor_answered",
-            {"author": author.strip(), "status": new_status},
+            {
+                "author": author.strip(),
+                "status": new_status,
+                "source_event_id": int(expected_event_id),
+            },
         )
         return True, new_status
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8051,7 +8051,8 @@ def _record_task_failure(
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', claim_lock = NULL, "
                     "claim_expires = NULL, worker_pid = NULL, "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "block_kind = 'transient' "
                     "WHERE id = ? AND status IN ('running', 'ready')",
                     (failures, error[:500], task_id),
                 )
@@ -8061,7 +8062,8 @@ def _record_task_failure(
                 # counter fields.
                 conn.execute(
                     "UPDATE tasks SET status = 'blocked', "
-                    "consecutive_failures = ?, last_failure_error = ? "
+                    "consecutive_failures = ?, last_failure_error = ?, "
+                    "block_kind = 'transient' "
                     "WHERE id = ? AND status IN ('ready', 'running')",
                     (failures, error[:500], task_id),
                 )
@@ -8080,6 +8082,7 @@ def _record_task_failure(
                     },
                 )
             payload = {
+                "kind": "transient",
                 "failures": failures,
                 "effective_limit": effective_limit,
                 "limit_source": limit_source,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -5964,6 +5964,141 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
         return True
 
 
+def supervisor_recover_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    source_event_id: int,
+    source_kind: str,
+    reason: str,
+    recovery_limit: int,
+) -> tuple[bool, str]:
+    """Schedule one bounded, durable recovery for an agent-owned exception.
+
+    The recovery marker and status transition share one transaction. Replaying
+    the same supervisor tick after a crash therefore cannot spend the budget
+    twice or create an unblock loop. The budget is per task and survives
+    gateway restarts because it is counted from ``supervisor_recovery`` events.
+    """
+    limit = max(0, int(recovery_limit))
+    now = int(time.time())
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if task is None:
+            return False, "missing"
+
+        prior_rows = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'supervisor_recovery'",
+            (task_id,),
+        ).fetchall()
+        prior_source_ids: set[int] = set()
+        for row in prior_rows:
+            try:
+                payload = json.loads(row["payload"] or "{}")
+                prior_source_ids.add(int(payload.get("source_event_id", -1)))
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+        if int(source_event_id) in prior_source_ids:
+            return False, "already_recovered"
+        if len(prior_rows) >= limit:
+            return False, "budget_exhausted"
+        if task["status"] not in {"blocked", "triage"}:
+            return False, "not_blocked"
+
+        undone_parent = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        new_status = "todo" if undone_parent else "ready"
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "consecutive_failures = 0, last_failure_error = NULL "
+            "WHERE id = ? AND status IN ('blocked', 'triage')",
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False, "status_changed"
+        comment = (
+            "Native Kanban supervisor scheduled a bounded recovery after "
+            f"{source_kind}: {reason[:500]}"
+        )
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, 'kanban-supervisor', ?, ?)",
+            (task_id, comment, now),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "supervisor_recovery",
+            {
+                "source_event_id": int(source_event_id),
+                "source_kind": source_kind,
+                "status": new_status,
+                "attempt": len(prior_rows) + 1,
+                "limit": limit,
+            },
+        )
+        return True, new_status
+
+
+def resume_supervisor_gate(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    answer: str,
+    author: str,
+) -> tuple[bool, str]:
+    """Attach a human gate answer and resume that same task graph atomically."""
+    if not answer or not answer.strip():
+        raise ValueError("answer is required")
+    if not author or not author.strip():
+        raise ValueError("author is required")
+    now = int(time.time())
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if task is None:
+            return False, "missing"
+        if task["status"] not in {"blocked", "triage"}:
+            return False, "not_waiting"
+        undone_parent = conn.execute(
+            "SELECT 1 FROM task_links l "
+            "JOIN tasks p ON p.id = l.parent_id "
+            "WHERE l.child_id = ? AND p.status != 'done' LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        new_status = "todo" if undone_parent else "ready"
+        conn.execute(
+            "INSERT INTO task_comments (task_id, author, body, created_at) "
+            "VALUES (?, ?, ?, ?)",
+            (task_id, author.strip(), answer.strip(), now),
+        )
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, current_run_id = NULL, "
+            "claim_lock = NULL, claim_expires = NULL, worker_pid = NULL, "
+            "consecutive_failures = 0, last_failure_error = NULL "
+            "WHERE id = ? AND status IN ('blocked', 'triage')",
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False, "status_changed"
+        _append_event(
+            conn,
+            task_id,
+            "supervisor_answered",
+            {"author": author.strip(), "status": new_status},
+        )
+        return True, new_status
+
+
 def specify_triage_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -9623,13 +9758,17 @@ def add_notify_sub(
     user_id: Optional[str] = None,
     notifier_profile: Optional[str] = None,
     delivery_metadata: Optional[Mapping[str, Any]] = None,
+    start_event_id: Optional[int] = None,
 ) -> None:
     """Register a gateway source that wants terminal-state notifications
     for ``task_id``. Idempotent on (task, platform, chat, thread).
 
     New subscriptions start "caught up": ``last_event_id`` snaps to the
-    task's current ``MAX(task_events.id)`` at creation instead of the
-    schema default 0. A cursor of 0 on an already-active task made the
+    task's current ``MAX(task_events.id)`` at creation unless
+    ``start_event_id`` explicitly selects an earlier cursor. The latter is
+    reserved for native discovery of an already-written blocking event.
+    The normal snapshot replaces the schema default 0. A cursor of 0 on an
+    already-active task made the
     gateway notifier replay every historical terminal event on its next
     tick — and with many stale subs, a single boot-time burst of 100+
     messages (issue #29905). Subscribers only want events that occur
@@ -9645,7 +9784,10 @@ def add_notify_sub(
                 (task_id, platform, chat_id, chat_type, thread_id, user_id,
                  notifier_profile, delivery_metadata, created_at, last_event_id)
             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
-                    COALESCE((SELECT MAX(id) FROM task_events WHERE task_id = ?), 0))
+                    CASE WHEN ? IS NULL
+                         THEN COALESCE((SELECT MAX(id) FROM task_events WHERE task_id = ?), 0)
+                         ELSE MAX(0, ?)
+                    END)
             """,
             (
                 task_id,
@@ -9657,7 +9799,9 @@ def add_notify_sub(
                 notifier_profile,
                 metadata_json,
                 now,
+                start_event_id,
                 task_id,
+                start_event_id,
             ),
         )
         if chat_type:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8099,10 +8099,19 @@ class DiscordAdapter(BasePlatformAdapter):
 
         reply_to_id = None
         reply_to_text = None
+        reply_to_is_own = False
         if message.reference:
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
-                reply_to_text = getattr(message.reference.resolved, "content", None) or None
+                resolved = message.reference.resolved
+                reply_to_text = getattr(resolved, "content", None) or None
+                resolved_author_id = getattr(getattr(resolved, "author", None), "id", None)
+                own_user_id = getattr(getattr(self._client, "user", None), "id", None)
+                reply_to_is_own = bool(
+                    resolved_author_id is not None
+                    and own_user_id is not None
+                    and resolved_author_id == own_user_id
+                )
 
         event = MessageEvent(
             text=event_text,
@@ -8114,6 +8123,7 @@ class DiscordAdapter(BasePlatformAdapter):
             media_types=media_types,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own,
             timestamp=message.created_at,
             auto_skill=_skills,
             channel_prompt=_channel_prompt,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8138,12 +8138,16 @@ class DiscordAdapter(BasePlatformAdapter):
         # Only live plain text messages use split-message batching. Recovery
         # candidates are already complete historical messages; coalescing them
         # would lose constituent IDs and make later restarts replay them.
+        is_supervisor_gate = self._is_supervisor_gate_event(event)
         if (
             not recovered
             and msg_type == MessageType.TEXT
             and self._text_batch_delay_seconds > 0
+            and not is_supervisor_gate
         ):
             self._enqueue_text_event(event)
+        elif is_supervisor_gate:
+            await self._dispatch_supervisor_gate_event(event)
         else:
             await self.handle_message(event)
         return True
@@ -8168,6 +8172,27 @@ class DiscordAdapter(BasePlatformAdapter):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
             profile=event.source.profile,
         )
+
+    @staticmethod
+    def _is_supervisor_gate_event(event: MessageEvent) -> bool:
+        from gateway.kanban_proactive_supervisor import is_supervisor_gate_reply
+
+        return is_supervisor_gate_reply(
+            event.reply_to_text,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+        )
+
+    async def _dispatch_supervisor_gate_event(self, event: MessageEvent) -> None:
+        """Dispatch a gate reply without allowing batching to erase its identity."""
+        key = self._text_batch_key(event)
+        prior_task = self._pending_text_batch_tasks.pop(key, None)
+        pending = self._pending_text_batches.pop(key, None)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+            await asyncio.gather(prior_task, return_exceptions=True)
+        if pending is not None:
+            await self.handle_message(pending)
+        await self.handle_message(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9762,14 +9762,29 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             quote = getattr(message, "quote", None)
             quote_text = getattr(quote, "text", None) if quote is not None else None
+            full_reply_text = (
+                message.reply_to_message.text
+                or message.reply_to_message.caption
+                or None
+            )
             if quote_text:
                 reply_to_text = quote_text
-            else:
-                reply_to_text = (
-                    message.reply_to_message.text
-                    or message.reply_to_message.caption
-                    or None
+                # Partial quotes are the right general context behavior, but
+                # the supervisor token is an authenticated control-plane
+                # capability. Preserve the full bot-authored prompt when the
+                # selected quote omits that token so the decision cannot fall
+                # through into an ordinary agent turn.
+                from gateway.kanban_proactive_supervisor import (
+                    is_supervisor_gate_reply,
                 )
+
+                if is_supervisor_gate_reply(
+                    full_reply_text,
+                    reply_to_is_own_message=reply_to_is_own_message,
+                ):
+                    reply_to_text = full_reply_text
+            else:
+                reply_to_text = full_reply_text
                 if not reply_to_text:
                     # Prefer Telegram's native rich-message echo when present;
                     # keep the local send-time index only as a fallback for

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8811,7 +8811,10 @@ class TelegramAdapter(BasePlatformAdapter):
         event.text = self._clean_bot_trigger_text(event.text)
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
-        self._enqueue_text_event(event)
+        if self._is_supervisor_gate_event(event):
+            await self._dispatch_supervisor_gate_event(event)
+        else:
+            self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming command messages."""
@@ -8913,6 +8916,27 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
             profile=event.source.profile,
         )
+
+    @staticmethod
+    def _is_supervisor_gate_event(event: MessageEvent) -> bool:
+        from gateway.kanban_proactive_supervisor import is_supervisor_gate_reply
+
+        return is_supervisor_gate_reply(
+            event.reply_to_text,
+            reply_to_is_own_message=event.reply_to_is_own_message,
+        )
+
+    async def _dispatch_supervisor_gate_event(self, event: MessageEvent) -> None:
+        """Dispatch a gate reply without allowing batching to erase its identity."""
+        key = self._text_batch_key(event)
+        prior_task = self._pending_text_batch_tasks.pop(key, None)
+        pending = self._pending_text_batches.pop(key, None)
+        if prior_task and not prior_task.done():
+            prior_task.cancel()
+            await asyncio.gather(prior_task, return_exceptions=True)
+        if pending is not None:
+            await self.handle_message(pending)
+        await self.handle_message(event)
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9749,8 +9749,17 @@ class TelegramAdapter(BasePlatformAdapter):
         # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
+        reply_to_is_own_message = False
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
+            replied_user = getattr(message.reply_to_message, "from_user", None)
+            replied_user_id = getattr(replied_user, "id", None)
+            current_bot_id = getattr(self._bot, "id", None)
+            reply_to_is_own_message = bool(
+                replied_user_id is not None
+                and current_bot_id is not None
+                and str(replied_user_id) == str(current_bot_id)
+            )
             quote = getattr(message, "quote", None)
             quote_text = getattr(quote, "text", None) if quote is not None else None
             if quote_text:
@@ -9793,6 +9802,7 @@ class TelegramAdapter(BasePlatformAdapter):
             platform_update_id=update_id,
             reply_to_message_id=reply_to_id,
             reply_to_text=reply_to_text,
+            reply_to_is_own_message=reply_to_is_own_message,
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9778,7 +9778,7 @@ class TelegramAdapter(BasePlatformAdapter):
             reply_to_id = str(message.reply_to_message.message_id)
             replied_user = getattr(message.reply_to_message, "from_user", None)
             replied_user_id = getattr(replied_user, "id", None)
-            current_bot_id = getattr(self._bot, "id", None)
+            current_bot_id = getattr(getattr(self, "_bot", None), "id", None)
             reply_to_is_own_message = bool(
                 replied_user_id is not None
                 and current_bot_id is not None

--- a/scripts/migrate_kanban_notification_route.py
+++ b/scripts/migrate_kanban_notification_route.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Re-route existing Hermes Kanban notification subscriptions safely.
+
+Dry-run is the default. ``--apply`` creates integrity-checked online SQLite
+backups before updating subscriptions. Collisions keep the destination row,
+advance its cursor to the newest consumed event, then remove the source row.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import pathlib
+import sqlite3
+from typing import Any
+
+
+def board_databases(home: pathlib.Path) -> list[pathlib.Path]:
+    candidates = [home / "kanban" / "kanban.db"]
+    candidates.extend(sorted((home / "kanban" / "boards").glob("*/kanban.db")))
+    return [path for path in candidates if path.is_file()]
+
+
+def online_backup(source: pathlib.Path, target: pathlib.Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(source)
+    dst = sqlite3.connect(target)
+    try:
+        src.backup(dst)
+        check = dst.execute("PRAGMA integrity_check").fetchone()[0]
+        if check != "ok":
+            raise RuntimeError(f"backup integrity_check={check}")
+    finally:
+        dst.close()
+        src.close()
+
+
+def migrate_database(
+    path: pathlib.Path,
+    *,
+    platform: str,
+    source_chat: str,
+    destination_chat: str,
+    apply: bool,
+    backup_root: pathlib.Path,
+) -> dict[str, Any]:
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    try:
+        rows = conn.execute(
+            "SELECT * FROM kanban_notify_subs WHERE platform=? AND chat_id=? "
+            "ORDER BY task_id,thread_id",
+            (platform, source_chat),
+        ).fetchall()
+        result: dict[str, Any] = {
+            "database": str(path),
+            "matched": len(rows),
+            "moved": 0,
+            "merged": 0,
+        }
+        if not apply or not rows:
+            return result
+
+        backup_name = "default.db" if path.parent.name == "kanban" else f"{path.parent.name}.db"
+        online_backup(path, backup_root / backup_name)
+
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            for row in rows:
+                existing = conn.execute(
+                    "SELECT * FROM kanban_notify_subs WHERE task_id=? AND platform=? "
+                    "AND chat_id=? AND thread_id=?",
+                    (row["task_id"], platform, destination_chat, row["thread_id"] or ""),
+                ).fetchone()
+                if existing is None:
+                    conn.execute(
+                        "UPDATE kanban_notify_subs SET chat_id=? WHERE task_id=? "
+                        "AND platform=? AND chat_id=? AND thread_id=?",
+                        (
+                            destination_chat,
+                            row["task_id"],
+                            platform,
+                            source_chat,
+                            row["thread_id"] or "",
+                        ),
+                    )
+                    result["moved"] += 1
+                    continue
+
+                conn.execute(
+                    "UPDATE kanban_notify_subs SET last_event_id=MAX(last_event_id,?), "
+                    "failure_count=MIN(failure_count,?) WHERE task_id=? AND platform=? "
+                    "AND chat_id=? AND thread_id=?",
+                    (
+                        int(row["last_event_id"] or 0),
+                        int(row["failure_count"] or 0),
+                        row["task_id"],
+                        platform,
+                        destination_chat,
+                        row["thread_id"] or "",
+                    ),
+                )
+                conn.execute(
+                    "DELETE FROM kanban_notify_subs WHERE task_id=? AND platform=? "
+                    "AND chat_id=? AND thread_id=?",
+                    (row["task_id"], platform, source_chat, row["thread_id"] or ""),
+                )
+                result["merged"] += 1
+            check = conn.execute("PRAGMA integrity_check").fetchone()[0]
+            if check != "ok":
+                raise RuntimeError(f"post-migration integrity_check={check}")
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        return result
+    finally:
+        conn.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--home", type=pathlib.Path, default=pathlib.Path.home() / ".hermes")
+    parser.add_argument("--platform", default="discord")
+    parser.add_argument("--source-chat", required=True)
+    parser.add_argument("--destination-chat", required=True)
+    parser.add_argument("--apply", action="store_true")
+    args = parser.parse_args()
+    if args.source_chat == args.destination_chat:
+        parser.error("source and destination chats must differ")
+
+    stamp = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_root = args.home / "backups" / "kanban-notify-route" / stamp
+    results = [
+        migrate_database(
+            path,
+            platform=args.platform,
+            source_chat=args.source_chat,
+            destination_chat=args.destination_chat,
+            apply=args.apply,
+            backup_root=backup_root,
+        )
+        for path in board_databases(args.home)
+    ]
+    print(json.dumps({
+        "apply": args.apply,
+        "backup_root": str(backup_root) if args.apply else None,
+        "matched": sum(item["matched"] for item in results),
+        "moved": sum(item["moved"] for item in results),
+        "merged": sum(item["merged"] for item in results),
+        "databases": results,
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -42,10 +42,10 @@ class _StubAdapter(BasePlatformAdapter):
         return {}
 
 
-def _make_adapter():
+def _make_adapter(platform=Platform.TELEGRAM):
     """Create a minimal adapter for testing the active-session guard."""
     config = PlatformConfig(enabled=True, token="test-token")
-    adapter = _StubAdapter(config, Platform.TELEGRAM)
+    adapter = _StubAdapter(config, platform)
     adapter._busy_text_mode = ""
     adapter.sent_responses = []
 
@@ -62,16 +62,29 @@ def _make_adapter():
     return adapter
 
 
-def _make_event(text="/stop", chat_id="12345"):
+def _make_event(
+    text="/stop",
+    chat_id="12345",
+    *,
+    platform=Platform.TELEGRAM,
+    reply_to_text=None,
+    reply_to_is_own_message=False,
+):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+        platform=platform, chat_id=chat_id, chat_type="dm"
     )
-    return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        reply_to_text=reply_to_text,
+        reply_to_is_own_message=reply_to_is_own_message,
+    )
 
 
-def _session_key(chat_id="12345"):
+def _session_key(chat_id="12345", *, platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+        platform=platform, chat_id=chat_id, chat_type="dm"
     )
     return build_session_key(source)
 
@@ -83,6 +96,29 @@ def _session_key(chat_id="12345"):
 
 class TestCommandBypassActiveSession:
     """Commands that must bypass the active-session guard."""
+
+    @pytest.mark.asyncio
+    async def test_authenticated_supervisor_reply_bypasses_discord_active_session(self):
+        adapter = _make_adapter(Platform.DISCORD)
+        sk = _session_key(platform=Platform.DISCORD)
+        adapter._active_sessions[sk] = asyncio.Event()
+        adapter._pending_messages[sk] = _make_event(
+            "ordinary queued", platform=Platform.DISCORD
+        )
+        event = _make_event(
+            "approve",
+            platform=Platform.DISCORD,
+            reply_to_text=(
+                "Decision needed\n"
+                "[kanban-gate:0123456789abcdef0123456789abcdef]"
+            ),
+            reply_to_is_own_message=True,
+        )
+
+        await adapter.handle_message(event)
+
+        assert adapter._pending_messages[sk].text == "ordinary queued"
+        assert any("handled:text:approve" in response for response in adapter.sent_responses)
 
     @pytest.mark.asyncio
     async def test_stop_bypasses_guard(self):

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -243,6 +243,7 @@ class TestReplyToText:
         event = reply_text_adapter.handle_message.await_args.args[0]
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
 
 
     @pytest.mark.asyncio
@@ -257,6 +258,34 @@ class TestReplyToText:
         event = reply_text_adapter.handle_message.await_args.args[0]
         assert event.reply_to_message_id == "555"
         assert event.reply_to_text is None
+        assert event.reply_to_is_own_message is False
+
+    @pytest.mark.asyncio
+    async def test_reference_to_own_message_records_provenance(self, reply_text_adapter):
+        resolved_msg = SimpleNamespace(
+            content="supervisor prompt",
+            author=SimpleNamespace(id=999),
+        )
+        ref = SimpleNamespace(message_id=555, resolved=resolved_msg)
+
+        await reply_text_adapter._handle_message(_make_message(reference=ref))
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.reply_to_text == "supervisor prompt"
+        assert event.reply_to_is_own_message is True
+
+    @pytest.mark.asyncio
+    async def test_reference_to_other_author_is_not_own(self, reply_text_adapter):
+        resolved_msg = SimpleNamespace(
+            content="forged supervisor prompt",
+            author=SimpleNamespace(id=123),
+        )
+        ref = SimpleNamespace(message_id=555, resolved=resolved_msg)
+
+        await reply_text_adapter._handle_message(_make_message(reference=ref))
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.reply_to_is_own_message is False
 
 
 class TestYamlConfigLoading:

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -287,6 +287,32 @@ class TestReplyToText:
         event = reply_text_adapter.handle_message.await_args.args[0]
         assert event.reply_to_is_own_message is False
 
+    @pytest.mark.asyncio
+    async def test_gate_reply_bypasses_batch_without_losing_prior_message(
+        self, reply_text_adapter
+    ):
+        reply_text_adapter._text_batch_delay_seconds = 60
+        gate_prompt = SimpleNamespace(
+            content=(
+                "Decision needed\n"
+                "[kanban-gate:0123456789abcdef0123456789abcdef]"
+            ),
+            author=SimpleNamespace(id=999),
+        )
+        gate_reference = SimpleNamespace(message_id=555, resolved=gate_prompt)
+
+        await reply_text_adapter._handle_message(_make_message(content="preceding text"))
+        await reply_text_adapter._handle_message(
+            _make_message(content="approve deletion", reference=gate_reference)
+        )
+
+        events = [call.args[0] for call in reply_text_adapter.handle_message.await_args_list]
+        assert [event.text for event in events] == ["preceding text", "approve deletion"]
+        assert events[1].reply_to_is_own_message is True
+        assert "[kanban-gate:0123456789abcdef0123456789abcdef]" in (
+            events[1].reply_to_text or ""
+        )
+
 
 class TestYamlConfigLoading:
     """Tests for reply_to_mode loaded from config.yaml discord section."""

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -455,6 +455,47 @@ def test_recovery_budget_is_durable_and_exhaustion_is_status_only(tmp_path, monk
         conn.close()
 
 
+def test_zero_recovery_budget_reports_that_no_retry_occurred(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Manual recovery only", assignee="forge")
+        assert kb.block_task(conn, task_id, reason="temporary backend failure", kind="transient")
+
+        result = reconcile_board(
+            conn,
+            board="default",
+            config=_config(recovery_limit=0),
+            notifier_profile="default",
+        )
+
+        assert result.recovered == []
+        assert result.recovery_exhausted == [task_id]
+        recovery_events = conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ? "
+            "AND kind = 'supervisor_recovery'",
+            (task_id,),
+        ).fetchone()[0]
+        assert recovery_events == 0
+        blocked = _latest_event(conn, task_id, "blocked")
+        task = kb.get_task(conn, task_id)
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        message = render_supervisor_event(
+            board="default",
+            task=task,
+            event=SimpleNamespace(id=blocked["id"], payload=blocked["payload"]),
+            delivery_metadata=sub["delivery_metadata"],
+            current_event_id=blocked["id"],
+        )
+        assert message == (
+            "Hermes did not retry Manual recovery only because its recovery budget is zero. "
+            "The task remains paused for engineering follow-up; no decision is requested."
+        )
+    finally:
+        conn.close()
+
+
 def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch):
     db_path = tmp_path / "kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -891,6 +891,77 @@ def test_recovered_followup_on_persistent_supervisor_sub_is_silent(
     assert adapter.received == []
 
 
+def test_first_transient_recovery_on_ordinary_subscription_is_silent(
+    tmp_path, monkeypatch
+):
+    """A recovered first failure must not fall through generic notifier copy."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Ordinary subscriber recovery",
+            assignee="forge",
+            session_id="creator-session",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="hermes-command-channel",
+            notifier_profile="default",
+            delivery_metadata={"ordinary": True},
+        )
+        assert kb.block_task(
+            conn, task_id, reason="temporary backend failure", kind="transient"
+        )
+        recovered = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert recovered.recovered == [task_id]
+        assert task.status == "ready"
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        assert sub["delivery_metadata"] == {"ordinary": True}
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"proactive_supervisor": {
+            "enabled": True,
+            "platform": "discord",
+            "chat_id": "hermes-command-channel",
+            "chat_type": "channel",
+            "recovery_limit": 1,
+        }}},
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert adapter.sent == []
+    assert adapter.received == []
+
+
 def test_gate_resolved_after_collection_before_send_is_silent(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
     kb.init_db()

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -8,11 +8,12 @@ from types import SimpleNamespace
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import MessageEvent, MessageType, SendResult
 from gateway.kanban_proactive_supervisor import (
     ProactiveSupervisorConfig,
     consume_supervisor_reply,
     reconcile_board,
+    record_supervisor_delivery_message,
     render_supervisor_event,
 )
 from gateway.run import GatewayRunner
@@ -49,6 +50,23 @@ def _gate_token(conn, task_id: str) -> str:
     token = metadata["_kanban_supervisor_gate_token"]
     assert re.fullmatch(r"[a-f0-9]{32}", token)
     return token
+
+
+def _set_gate_message_id(conn, task_id: str, message_id: str) -> str:
+    sub = kb.list_notify_subs(conn, task_id)[0]
+    metadata = sub["delivery_metadata"]
+    assert record_supervisor_delivery_message(
+        board="default",
+        task_id=task_id,
+        platform=sub["platform"],
+        chat_id=sub["chat_id"],
+        thread_id=sub.get("thread_id") or "",
+        notifier_profile=str(sub.get("notifier_profile") or ""),
+        expected_event_id=int(metadata["_kanban_supervisor_event_id"]),
+        expected_token=str(metadata["_kanban_supervisor_gate_token"]),
+        message_id=message_id,
+    )
+    return message_id
 
 
 def test_cli_created_protected_gate_gets_profile_owned_subscription(tmp_path, monkeypatch):
@@ -516,6 +534,7 @@ def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch
             notifier_profile="default",
         )
         token = _gate_token(conn, task_id)
+        delivered_message_id = _set_gate_message_id(conn, task_id, "gate-message-1")
     finally:
         conn.close()
 
@@ -526,6 +545,7 @@ def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch
     )
     result = consume_supervisor_reply(
         reply_to_text=quoted,
+        reply_to_message_id=delivered_message_id,
         answer="Yes, release to current customers only.",
         author="Kevin",
         platform="discord",
@@ -548,6 +568,7 @@ def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch
 
         duplicate = consume_supervisor_reply(
             reply_to_text=quoted,
+            reply_to_message_id=delivered_message_id,
             answer="duplicate",
             author="Kevin",
             platform="discord",
@@ -576,6 +597,7 @@ def test_stale_prompt_cannot_resume_a_different_block_generation(tmp_path, monke
         )
         reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
         token = _gate_token(conn, task_id)
+        delivered_message_id = _set_gate_message_id(conn, task_id, "gate-message-a")
         assert kb.unblock_task(conn, task_id)
         assert kb.block_task(
             conn, task_id,
@@ -588,6 +610,7 @@ def test_stale_prompt_cannot_resume_a_different_block_generation(tmp_path, monke
 
     result = consume_supervisor_reply(
         reply_to_text=f"[kanban-gate:{token}]",
+        reply_to_message_id=delivered_message_id,
         answer="approve old gate A",
         author="Kevin",
         platform="discord",
@@ -619,6 +642,7 @@ def test_stale_prompt_cannot_resume_a_later_protected_gate(tmp_path, monkeypatch
         )
         reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
         stale_token = _gate_token(conn, task_id)
+        stale_message_id = _set_gate_message_id(conn, task_id, "gate-message-a")
         assert kb.unblock_task(conn, task_id)
         assert kb.block_task(
             conn, task_id,
@@ -633,6 +657,7 @@ def test_stale_prompt_cannot_resume_a_later_protected_gate(tmp_path, monkeypatch
 
     assert consume_supervisor_reply(
         reply_to_text=f"[kanban-gate:{stale_token}]",
+        reply_to_message_id=stale_message_id,
         answer="approve old gate A",
         author="Kevin",
         platform="discord",
@@ -659,6 +684,7 @@ def test_forged_or_cross_route_prompt_marker_is_ignored(tmp_path, monkeypatch):
         )
         reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
         token = _gate_token(conn, task_id)
+        delivered_message_id = _set_gate_message_id(conn, task_id, "gate-message-1")
     finally:
         conn.close()
 
@@ -670,10 +696,22 @@ def test_forged_or_cross_route_prompt_marker_is_ignored(tmp_path, monkeypatch):
         "notifier_profile": "default",
     }
     assert consume_supervisor_reply(
-        **common, chat_id="hermes-command-channel", reply_to_is_own_message=False
+        **common,
+        chat_id="hermes-command-channel",
+        reply_to_message_id=delivered_message_id,
+        reply_to_is_own_message=False,
     ) is None
     assert consume_supervisor_reply(
-        **common, chat_id="different-channel", reply_to_is_own_message=True
+        **common,
+        chat_id="different-channel",
+        reply_to_message_id=delivered_message_id,
+        reply_to_is_own_message=True,
+    ) is None
+    assert consume_supervisor_reply(
+        **common,
+        chat_id="hermes-command-channel",
+        reply_to_message_id="different-bot-message",
+        reply_to_is_own_message=True,
     ) is None
     conn = kb.connect()
     try:
@@ -799,10 +837,64 @@ class _RecordingAdapter:
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+        return SendResult(success=True, message_id=f"sent-{len(self.sent)}")
 
     async def handle_message(self, event):
         self.received.append(event)
         return None
+
+
+def test_notifier_binds_gate_to_exact_delivered_message(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Delivered gate", assignee="forge")
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's decision", kind="needs_input"
+        )
+        reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"proactive_supervisor": {
+            "enabled": True,
+            "platform": "discord",
+            "chat_id": "hermes-command-channel",
+            "chat_type": "channel",
+            "recovery_limit": 1,
+        }}},
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert len(adapter.sent) == 1
+    conn = kb.connect()
+    try:
+        metadata = kb.list_notify_subs(conn, task_id)[0]["delivery_metadata"]
+        assert metadata["_kanban_supervisor_message_id"] == "sent-1"
+    finally:
+        conn.close()
 
 
 def test_gate_resolved_before_delivery_is_silent(tmp_path, monkeypatch):

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -7,12 +7,14 @@ import re
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
 from gateway.kanban_proactive_supervisor import (
     ProactiveSupervisorConfig,
     consume_supervisor_reply,
     reconcile_board,
 )
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 from hermes_cli import kanban_db as kb
 from hermes_cli import config as hermes_config
 from plugins.kanban.dashboard.plugin_api import _set_status_direct
@@ -135,13 +137,24 @@ def test_preexisting_subscription_is_upgraded_and_rewound_to_current_gate(
         conn.close()
 
 
-def test_untyped_legacy_protected_gate_is_not_auto_recovered(tmp_path, monkeypatch):
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "Need API key from Kevin",
+        "Need approval to delete all customer records",
+        "Need a decision on whether to ship this behavior",
+        "Need authorization to remove the production database",
+    ],
+)
+def test_untyped_legacy_protected_gate_is_not_auto_recovered(
+    tmp_path, monkeypatch, reason
+):
     monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
     kb.init_db()
     conn = kb.connect()
     try:
         task_id = kb.create_task(conn, title="Legacy credential gate", assignee="forge")
-        assert kb.block_task(conn, task_id, reason="Need API key from Kevin")
+        assert kb.block_task(conn, task_id, reason=reason)
 
         result = reconcile_board(
             conn, board="default", config=_config(), notifier_profile="default"
@@ -152,6 +165,40 @@ def test_untyped_legacy_protected_gate_is_not_auto_recovered(tmp_path, monkeypat
         assert kb.get_task(conn, task_id).status == "blocked"
     finally:
         conn.close()
+
+
+def test_authenticated_gate_reply_failure_does_not_fall_through_to_agent(monkeypatch):
+    from gateway import kanban_proactive_supervisor as supervisor
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner._active_profile_name = lambda: "default"
+    event = MessageEvent(
+        text="approve deletion",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="hermes-command-channel",
+            chat_type="channel",
+            user_id="kevin",
+            user_name="Kevin",
+            profile="default",
+        ),
+        reply_to_text="Decision needed\n[kanban-gate:0123456789abcdef0123456789abcdef]",
+        reply_to_is_own_message=True,
+    )
+
+    def fail_gate_lookup(**_kwargs):
+        raise OSError("temporary database failure")
+
+    monkeypatch.setattr(supervisor, "consume_supervisor_reply", fail_gate_lookup)
+
+    response = asyncio.run(runner._handle_message(event))
+
+    assert response is not None
+    assert "could not process" in response.lower()
+    assert "no action" in response.lower()
 
 
 def test_supervisor_does_not_take_over_subscription_owned_by_another_profile(

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -359,6 +359,44 @@ def test_authenticated_gate_reply_failure_does_not_fall_through_to_agent(monkeyp
     assert "no action" in response.lower()
 
 
+def test_gate_reply_uses_transport_owner_not_routed_runtime_profile(monkeypatch):
+    from gateway import kanban_proactive_supervisor as supervisor
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._scale_to_zero_note_real_inbound = lambda: None
+    runner._is_user_authorized = lambda source: True
+    runner._adapter_profile_for_source = lambda source: None
+    runner._active_profile_name = lambda: "default"
+    event = MessageEvent(
+        text="approved",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.DISCORD,
+            chat_id="routed-channel",
+            chat_type="channel",
+            user_id="kevin",
+            user_name="Kevin",
+            profile="ops",
+        ),
+        reply_to_message_id="gate-message-1",
+        reply_to_text="[kanban-gate:0123456789abcdef0123456789abcdef]",
+        reply_to_is_own_message=True,
+    )
+    captured = {}
+
+    def capture_owner(**kwargs):
+        captured.update(kwargs)
+        return None
+
+    monkeypatch.setattr(supervisor, "consume_supervisor_reply", capture_owner)
+
+    response = asyncio.run(runner._handle_message(event))
+
+    assert captured["notifier_profile"] == "default"
+    assert response is not None
+    assert "no action" in response.lower()
+
+
 def test_supervisor_does_not_take_over_subscription_owned_by_another_profile(
     tmp_path, monkeypatch
 ):

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -135,6 +135,57 @@ def test_preexisting_subscription_is_upgraded_and_rewound_to_current_gate(
         conn.close()
 
 
+def test_untyped_legacy_protected_gate_is_not_auto_recovered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Legacy credential gate", assignee="forge")
+        assert kb.block_task(conn, task_id, reason="Need API key from Kevin")
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.protected_gates == [task_id]
+        assert result.recovered == []
+        assert kb.get_task(conn, task_id).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_supervisor_does_not_take_over_subscription_owned_by_another_profile(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Profile-isolated gate", assignee="forge")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="hermes-command-channel",
+            notifier_profile="other-profile",
+            delivery_metadata={"ordinary": True},
+        )
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's product decision", kind="needs_input"
+        )
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+        sub = kb.list_notify_subs(conn, task_id)[0]
+
+        assert result.protected_gates == []
+        assert sub["notifier_profile"] == "other-profile"
+        assert sub["delivery_metadata"] == {"ordinary": True}
+    finally:
+        conn.close()
+
+
 def test_agent_owned_block_is_recovered_once_and_never_asks(tmp_path, monkeypatch):
     db_path = tmp_path / "kanban.db"
     monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
@@ -641,6 +692,68 @@ def test_recovered_followup_on_persistent_supervisor_sub_is_silent(
 
     assert adapter.sent == []
     assert adapter.received == []
+
+
+def test_gate_resolved_after_collection_before_send_is_silent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Racing approval", assignee="forge")
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's product decision", kind="needs_input"
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"proactive_supervisor": {
+            "enabled": True,
+            "platform": "discord",
+            "chat_id": "hermes-command-channel",
+            "chat_type": "channel",
+            "recovery_limit": 1,
+        }}},
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+
+    real_authorization_adapter = runner._authorization_adapter
+    resolved = False
+
+    def resolve_after_collection(platform, profile=None):
+        nonlocal resolved
+        if not resolved:
+            resolved = True
+            race_conn = kb.connect()
+            try:
+                assert kb.unblock_task(race_conn, task_id)
+            finally:
+                race_conn.close()
+        return real_authorization_adapter(platform, profile)
+
+    runner._authorization_adapter = resolve_after_collection
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert resolved is True
+    assert adapter.sent == []
 
 
 def test_gateway_tick_discovers_unsubscribed_gate_and_sends_replyable_prompt(

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +13,7 @@ from gateway.kanban_proactive_supervisor import (
     ProactiveSupervisorConfig,
     consume_supervisor_reply,
     reconcile_board,
+    render_supervisor_event,
 )
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource
@@ -230,6 +232,81 @@ def test_dispatcher_gave_up_is_typed_transient_and_recovered(
         conn.close()
 
 
+def test_unknown_typed_block_fails_closed_and_renders_gate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Future blocker", assignee="forge")
+        assert kb.block_task(conn, task_id, reason="Requires operator approval")
+        blocked = _latest_event(conn, task_id, "blocked")
+        payload = json.loads(blocked["payload"])
+        payload["kind"] = "approval_required"
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET block_kind = 'approval_required' WHERE id = ?",
+                (task_id,),
+            )
+            conn.execute(
+                "UPDATE task_events SET payload = ? WHERE id = ?",
+                (json.dumps(payload), blocked["id"]),
+            )
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        metadata = kb.list_notify_subs(conn, task_id)[0]["delivery_metadata"]
+        rendered = render_supervisor_event(
+            board="default",
+            task=task,
+            event=SimpleNamespace(id=blocked["id"], payload=json.dumps(payload)),
+            delivery_metadata=metadata,
+            current_event_id=blocked["id"],
+        )
+        assert result.protected_gates == [task_id]
+        assert result.recovered == []
+        assert task.status == "blocked"
+        assert rendered and "Reply to this message" in rendered
+    finally:
+        conn.close()
+
+
+def test_current_block_loop_triage_is_never_auto_recovered(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Repeated transient", assignee="forge")
+        assert kb.block_task(
+            conn, task_id, reason="temporary backend failure", kind="transient"
+        )
+        assert kb.unblock_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id, reason="temporary backend failure", kind="transient"
+        )
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "triage"
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.protected_gates == [task_id]
+        assert result.recovered == []
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "triage"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ? "
+            "AND kind = 'supervisor_recovery'",
+            (task_id,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
 def test_authenticated_gate_reply_failure_does_not_fall_through_to_agent(monkeypatch):
     from gateway import kanban_proactive_supervisor as supervisor
 
@@ -349,11 +426,21 @@ def test_recovery_budget_is_durable_and_exhaustion_is_status_only(tmp_path, monk
         first = reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
         assert first.recovered == [task_id]
 
-        assert kb.block_task(conn, task_id, reason="temporary backend failure", kind="transient")
+        assert kb._record_task_failure(
+            conn,
+            task_id,
+            "worker executable unavailable",
+            outcome="spawn_failed",
+            failure_limit=1,
+            force_trip=True,
+            release_claim=False,
+            end_run=False,
+        )
         exhausted = reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
 
         assert exhausted.recovery_exhausted == [task_id]
-        assert kb.get_task(conn, task_id).status == "triage"
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "blocked"
         exhausted_event = conn.execute(
             "SELECT * FROM task_events WHERE task_id = ? "
             "AND kind IN ('blocked', 'gave_up', 'block_loop_detected') "

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
+
+import pytest
 
 from gateway.config import Platform
 from gateway.kanban_proactive_supervisor import (
@@ -12,6 +15,7 @@ from gateway.kanban_proactive_supervisor import (
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 from hermes_cli import config as hermes_config
+from plugins.kanban.dashboard.plugin_api import _set_status_direct
 
 
 def _config(**overrides) -> ProactiveSupervisorConfig:
@@ -34,6 +38,13 @@ def _latest_event(conn, task_id: str, kind: str):
     ).fetchone()
     assert row is not None
     return row
+
+
+def _gate_token(conn, task_id: str) -> str:
+    metadata = kb.list_notify_subs(conn, task_id)[0]["delivery_metadata"]
+    token = metadata["_kanban_supervisor_gate_token"]
+    assert re.fullmatch(r"[a-f0-9]{32}", token)
+    return token
 
 
 def test_cli_created_protected_gate_gets_profile_owned_subscription(tmp_path, monkeypatch):
@@ -62,6 +73,64 @@ def test_cli_created_protected_gate_gets_profile_owned_subscription(tmp_path, mo
         assert sub["notifier_profile"] == "default"
         assert sub["last_event_id"] == blocked["id"] - 1
         assert sub["delivery_metadata"]["_kanban_proactive_supervisor"] is True
+        assert sub["delivery_metadata"]["_kanban_supervisor_event_id"] == blocked["id"]
+        assert sub["delivery_metadata"]["_kanban_supervisor_mode"] == "protected_gate"
+        assert sub["delivery_metadata"]["_kanban_supervisor_owned_subscription"] is True
+    finally:
+        conn.close()
+
+
+def test_preexisting_subscription_is_upgraded_and_rewound_to_current_gate(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Existing subscriber", assignee="forge")
+        created = _latest_event(conn, task_id, "created")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="hermes-command-channel",
+            notifier_profile="default",
+            delivery_metadata={"ordinary": True},
+            start_event_id=created["id"],
+        )
+        assert kb.block_task(
+            conn, task_id,
+            reason="Need Kevin's product decision",
+            kind="needs_input",
+        )
+        blocked = _latest_event(conn, task_id, "blocked")
+        _, cursor, claimed = kb.claim_unseen_events_for_sub(
+            conn,
+            task_id=task_id,
+            platform="discord",
+            chat_id="hermes-command-channel",
+        )
+        assert [event.id for event in claimed] == [blocked["id"]]
+        assert cursor == blocked["id"]
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+        sub = kb.list_notify_subs(conn, task_id)[0]
+
+        assert result.protected_gates == [task_id]
+        assert sub["last_event_id"] == blocked["id"] - 1
+        assert sub["delivery_metadata"]["ordinary"] is True
+        assert sub["delivery_metadata"]["_kanban_supervisor_owned_subscription"] is False
+    finally:
+        conn.close()
+
+    # Reopen to prove the rewind was committed, not visible only in one
+    # connection's uncommitted transaction.
+    conn = kb.connect()
+    try:
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        assert sub["last_event_id"] == blocked["id"] - 1
     finally:
         conn.close()
 
@@ -151,18 +220,29 @@ def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch
             reason="Need Kevin's business decision: release to the current customers?",
             kind="needs_input",
         )
+        reconcile_board(
+            conn,
+            board="default",
+            config=_config(),
+            notifier_profile="default",
+        )
+        token = _gate_token(conn, task_id)
     finally:
         conn.close()
 
     quoted = (
         "Hermes needs one decision to continue Choose release path.\n"
         "Reply to this message with the decision.\n"
-        f"[kanban-supervisor:default:{task_id}]"
+        f"[kanban-gate:{token}]"
     )
     result = consume_supervisor_reply(
         reply_to_text=quoted,
         answer="Yes, release to current customers only.",
         author="Kevin",
+        platform="discord",
+        chat_id="hermes-command-channel",
+        notifier_profile="default",
+        reply_to_is_own_message=True,
     )
 
     assert result is not None
@@ -176,6 +256,223 @@ def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch
         comments = kb.list_comments(conn, task_id)
         assert comments[-1].author == "Kevin"
         assert comments[-1].body == "Yes, release to current customers only."
+
+        duplicate = consume_supervisor_reply(
+            reply_to_text=quoted,
+            answer="duplicate",
+            author="Kevin",
+            platform="discord",
+            chat_id="hermes-command-channel",
+            notifier_profile="default",
+            reply_to_is_own_message=True,
+        )
+        assert duplicate is not None
+        assert duplicate.resumed is False
+        assert duplicate.status == "not_waiting"
+        assert len(kb.list_comments(conn, task_id)) == 1
+    finally:
+        conn.close()
+
+
+def test_stale_prompt_cannot_resume_a_different_block_generation(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Two gates", assignee="forge")
+        assert kb.block_task(
+            conn, task_id,
+            reason="Need Kevin's product decision for gate A",
+            kind="needs_input",
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        token = _gate_token(conn, task_id)
+        assert kb.unblock_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id,
+            reason="temporary backend failure for gate B",
+            kind="transient",
+        )
+        comments_before = len(kb.list_comments(conn, task_id))
+    finally:
+        conn.close()
+
+    result = consume_supervisor_reply(
+        reply_to_text=f"[kanban-gate:{token}]",
+        answer="approve old gate A",
+        author="Kevin",
+        platform="discord",
+        chat_id="hermes-command-channel",
+        notifier_profile="default",
+        reply_to_is_own_message=True,
+    )
+    assert result is not None
+    assert result.resumed is False
+    assert result.status == "stale_gate"
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert len(kb.list_comments(conn, task_id)) == comments_before
+    finally:
+        conn.close()
+
+
+def test_stale_prompt_cannot_resume_a_later_protected_gate(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Two protected gates", assignee="forge")
+        assert kb.block_task(
+            conn, task_id,
+            reason="Need Kevin's product decision for gate A",
+            kind="needs_input",
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        stale_token = _gate_token(conn, task_id)
+        assert kb.unblock_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id,
+            reason="Need Kevin's credential for gate B",
+            kind="needs_input",
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        assert _gate_token(conn, task_id) != stale_token
+        comments_before = len(kb.list_comments(conn, task_id))
+    finally:
+        conn.close()
+
+    assert consume_supervisor_reply(
+        reply_to_text=f"[kanban-gate:{stale_token}]",
+        answer="approve old gate A",
+        author="Kevin",
+        platform="discord",
+        chat_id="hermes-command-channel",
+        notifier_profile="default",
+        reply_to_is_own_message=True,
+    ) is None
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, task_id).status == "triage"
+        assert len(kb.list_comments(conn, task_id)) == comments_before
+    finally:
+        conn.close()
+
+
+def test_forged_or_cross_route_prompt_marker_is_ignored(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Protected", assignee="forge")
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's credential", kind="needs_input"
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        token = _gate_token(conn, task_id)
+    finally:
+        conn.close()
+
+    common = {
+        "reply_to_text": f"[kanban-gate:{token}]",
+        "answer": "yes",
+        "author": "Kevin",
+        "platform": "discord",
+        "notifier_profile": "default",
+    }
+    assert consume_supervisor_reply(
+        **common, chat_id="hermes-command-channel", reply_to_is_own_message=False
+    ) is None
+    assert consume_supervisor_reply(
+        **common, chat_id="different-channel", reply_to_is_own_message=True
+    ) is None
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.list_comments(conn, task_id) == []
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("historical_kind", ["blocked", "gave_up", "block_loop_detected"])
+def test_historical_failure_cannot_promote_deliberate_manual_triage(
+    tmp_path, monkeypatch, historical_kind
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Sticky triage", assignee="forge")
+        if historical_kind == "blocked":
+            assert kb.block_task(
+                conn, task_id, reason="temporary backend failure", kind="transient"
+            )
+        elif historical_kind == "gave_up":
+            assert kb._record_task_failure(
+                conn,
+                task_id,
+                "temporary worker failure",
+                outcome="spawn_failed",
+                failure_limit=1,
+                force_trip=True,
+                release_claim=False,
+                end_run=False,
+            )
+        else:
+            assert kb.block_task(
+                conn, task_id, reason="temporary backend failure", kind="transient"
+            )
+            assert kb.unblock_task(conn, task_id)
+            assert kb.block_task(
+                conn, task_id, reason="temporary backend failure", kind="transient"
+            )
+            assert kb.get_task(conn, task_id).status == "triage"
+
+        # Deliberate dashboard moves create a newer state generation. The old
+        # failure event must never become current again merely because the task
+        # is now in a supervisable status.
+        assert _set_status_direct(conn, task_id, "ready")
+        assert _set_status_direct(conn, task_id, "triage")
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.changed is False
+        assert kb.get_task(conn, task_id).status == "triage"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id = ? "
+            "AND kind = 'supervisor_recovery'", (task_id,),
+        ).fetchone()[0] == 0
+    finally:
+        conn.close()
+
+
+def test_recovery_compare_and_swap_rejects_stale_source_event(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Racing transition", assignee="forge")
+        assert kb.block_task(
+            conn, task_id, reason="temporary backend failure", kind="transient"
+        )
+        blocked = _latest_event(conn, task_id, "blocked")
+        assert kb.unblock_task(conn, task_id)
+        assert _set_status_direct(conn, task_id, "triage")
+
+        recovered, status = kb.supervisor_recover_task(
+            conn,
+            task_id,
+            source_event_id=blocked["id"],
+            source_kind="blocked",
+            reason="temporary backend failure",
+            recovery_limit=1,
+        )
+
+        assert recovered is False
+        assert status == "stale_event"
+        assert kb.get_task(conn, task_id).status == "triage"
     finally:
         conn.close()
 
@@ -209,12 +506,141 @@ def test_disabled_supervisor_is_a_noop(tmp_path, monkeypatch):
 class _RecordingAdapter:
     def __init__(self):
         self.sent = []
+        self.received = []
 
     async def send(self, chat_id, text, metadata=None):
         self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
 
     async def handle_message(self, event):
+        self.received.append(event)
         return None
+
+
+def test_gate_resolved_before_delivery_is_silent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Already approved",
+            assignee="forge",
+            session_id="creator-session",
+        )
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's product decision", kind="needs_input"
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        assert kb.unblock_task(conn, task_id)
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"proactive_supervisor": {
+            "enabled": True,
+            "platform": "discord",
+            "chat_id": "hermes-command-channel",
+            "chat_type": "channel",
+            "recovery_limit": 1,
+        }}},
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert adapter.sent == []
+    assert adapter.received == []
+
+
+@pytest.mark.parametrize("reuse_ordinary_subscription", [False, True])
+def test_recovered_followup_on_persistent_supervisor_sub_is_silent(
+    tmp_path, monkeypatch, reuse_ordinary_subscription
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="Recover followup",
+            assignee="forge",
+            session_id="creator-session",
+        )
+        if reuse_ordinary_subscription:
+            kb.add_notify_sub(
+                conn,
+                task_id=task_id,
+                platform="discord",
+                chat_id="hermes-command-channel",
+                notifier_profile="default",
+                delivery_metadata={"ordinary": True},
+            )
+        assert kb.block_task(
+            conn, task_id, reason="Need Kevin's product decision for gate A",
+            kind="needs_input",
+        )
+        reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        assert kb.unblock_task(conn, task_id)
+        assert kb.block_task(
+            conn, task_id, reason="temporary followup failure", kind="transient"
+        )
+        recovered = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+        assert recovered.recovered == [task_id]
+        assert kb.get_task(conn, task_id).status == "ready"
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {"kanban": {"proactive_supervisor": {
+            "enabled": True,
+            "platform": "discord",
+            "chat_id": "hermes-command-channel",
+            "chat_type": "channel",
+            "recovery_limit": 1,
+        }}},
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert adapter.sent == []
+    assert adapter.received == []
 
 
 def test_gateway_tick_discovers_unsubscribed_gate_and_sends_replyable_prompt(
@@ -273,5 +699,5 @@ def test_gateway_tick_discovers_unsubscribed_gate_and_sends_replyable_prompt(
     delivery = adapter.sent[0]
     assert delivery["chat_id"] == "hermes-command-channel"
     assert "needs one decision" in delivery["text"]
-    assert f"[kanban-supervisor:default:{task_id}]" in delivery["text"]
+    assert re.search(r"\[kanban-gate:[a-f0-9]{32}\]", delivery["text"])
     assert "_kanban_proactive_supervisor" not in delivery["metadata"]

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -167,6 +167,69 @@ def test_untyped_legacy_protected_gate_is_not_auto_recovered(
         conn.close()
 
 
+@pytest.mark.parametrize("kind", ["needs_input", "capability"])
+def test_typed_human_gate_is_protected_regardless_of_wording(
+    tmp_path, monkeypatch, kind
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Typed human gate", assignee="forge")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="Which option should I choose?",
+            kind=kind,
+        )
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.protected_gates == [task_id]
+        assert result.recovered == []
+        assert kb.get_task(conn, task_id).status == "blocked"
+    finally:
+        conn.close()
+
+
+@pytest.mark.parametrize("release_claim", [False, True])
+def test_dispatcher_gave_up_is_typed_transient_and_recovered(
+    tmp_path, monkeypatch, release_claim
+):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Dispatcher failure", assignee="forge")
+        assert kb._record_task_failure(
+            conn,
+            task_id,
+            "worker executable unavailable",
+            outcome="spawn_failed",
+            failure_limit=1,
+            force_trip=True,
+            release_claim=release_claim,
+            end_run=False,
+        )
+        gave_up = _latest_event(conn, task_id, "gave_up")
+
+        task = kb.get_task(conn, task_id)
+        assert task.block_kind == "transient"
+        assert json.loads(gave_up["payload"])["kind"] == "transient"
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.recovered == [task_id]
+        assert result.protected_gates == []
+        assert kb.get_task(conn, task_id).status == "ready"
+    finally:
+        conn.close()
+
+
 def test_authenticated_gate_reply_failure_does_not_fall_through_to_agent(monkeypatch):
     from gateway import kanban_proactive_supervisor as supervisor
 

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+import json
+
+from gateway.config import Platform
+from gateway.kanban_proactive_supervisor import (
+    ProactiveSupervisorConfig,
+    consume_supervisor_reply,
+    reconcile_board,
+)
+from gateway.run import GatewayRunner
+from hermes_cli import kanban_db as kb
+from hermes_cli import config as hermes_config
+
+
+def _config(**overrides) -> ProactiveSupervisorConfig:
+    values = {
+        "enabled": True,
+        "platform": "discord",
+        "chat_id": "hermes-command-channel",
+        "thread_id": "",
+        "chat_type": "channel",
+        "recovery_limit": 1,
+    }
+    values.update(overrides)
+    return ProactiveSupervisorConfig.from_mapping(values)
+
+
+def _latest_event(conn, task_id: str, kind: str):
+    row = conn.execute(
+        "SELECT * FROM task_events WHERE task_id = ? AND kind = ? ORDER BY id DESC LIMIT 1",
+        (task_id, kind),
+    ).fetchone()
+    assert row is not None
+    return row
+
+
+def test_cli_created_protected_gate_gets_profile_owned_subscription(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Publish release", assignee="forge")
+        assert kb.list_notify_subs(conn, task_id) == []
+        reason = "Need Kevin's product decision: ship the alternate navigation now?"
+        assert kb.block_task(conn, task_id, reason=reason, kind="needs_input")
+        blocked = _latest_event(conn, task_id, "blocked")
+
+        result = reconcile_board(
+            conn,
+            board="default",
+            config=_config(),
+            notifier_profile="default",
+        )
+
+        assert result.protected_gates == [task_id]
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        assert sub["platform"] == "discord"
+        assert sub["chat_id"] == "hermes-command-channel"
+        assert sub["notifier_profile"] == "default"
+        assert sub["last_event_id"] == blocked["id"] - 1
+        assert sub["delivery_metadata"]["_kanban_proactive_supervisor"] is True
+    finally:
+        conn.close()
+
+
+def test_agent_owned_block_is_recovered_once_and_never_asks(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Run tests", assignee="forge")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="pytest worker lost its temporary directory",
+            kind="transient",
+        )
+
+        first = reconcile_board(
+            conn,
+            board="default",
+            config=_config(),
+            notifier_profile="default",
+        )
+        second = reconcile_board(
+            conn,
+            board="default",
+            config=_config(),
+            notifier_profile="default",
+        )
+
+        assert first.recovered == [task_id]
+        assert second.recovered == []
+        assert kb.get_task(conn, task_id).status == "ready"
+        recovery_events = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'supervisor_recovery'",
+            (task_id,),
+        ).fetchall()
+        assert len(recovery_events) == 1
+        payload = json.loads(recovery_events[0]["payload"])
+        assert payload["source_kind"] == "blocked"
+        assert kb.list_notify_subs(conn, task_id) == []
+    finally:
+        conn.close()
+
+
+def test_recovery_budget_is_durable_and_exhaustion_is_status_only(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Flaky operation", assignee="forge")
+        assert kb.block_task(conn, task_id, reason="temporary backend failure", kind="transient")
+        first = reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+        assert first.recovered == [task_id]
+
+        assert kb.block_task(conn, task_id, reason="temporary backend failure", kind="transient")
+        exhausted = reconcile_board(conn, board="default", config=_config(), notifier_profile="default")
+
+        assert exhausted.recovery_exhausted == [task_id]
+        assert kb.get_task(conn, task_id).status == "triage"
+        exhausted_event = conn.execute(
+            "SELECT * FROM task_events WHERE task_id = ? "
+            "AND kind IN ('blocked', 'gave_up', 'block_loop_detected') "
+            "ORDER BY id DESC LIMIT 1",
+            (task_id,),
+        ).fetchone()
+        assert exhausted_event is not None
+        sub = kb.list_notify_subs(conn, task_id)[0]
+        assert sub["last_event_id"] == exhausted_event["id"] - 1
+        assert sub["delivery_metadata"]["_kanban_proactive_supervisor"] is True
+    finally:
+        conn.close()
+
+
+def test_reply_to_protected_prompt_resumes_same_task_graph(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Choose release path", assignee="forge")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="Need Kevin's business decision: release to the current customers?",
+            kind="needs_input",
+        )
+    finally:
+        conn.close()
+
+    quoted = (
+        "Hermes needs one decision to continue Choose release path.\n"
+        "Reply to this message with the decision.\n"
+        f"[kanban-supervisor:default:{task_id}]"
+    )
+    result = consume_supervisor_reply(
+        reply_to_text=quoted,
+        answer="Yes, release to current customers only.",
+        author="Kevin",
+    )
+
+    assert result is not None
+    assert result.task_id == task_id
+    assert result.board == "default"
+    assert result.resumed is True
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        comments = kb.list_comments(conn, task_id)
+        assert comments[-1].author == "Kevin"
+        assert comments[-1].body == "Yes, release to current customers only."
+    finally:
+        conn.close()
+
+
+def test_disabled_supervisor_is_a_noop(tmp_path, monkeypatch):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="No supervisor", assignee="forge")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="Need Kevin's product decision",
+            kind="needs_input",
+        )
+        result = reconcile_board(
+            conn,
+            board="default",
+            config=_config(enabled=False),
+            notifier_profile="default",
+        )
+        assert result.changed is False
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.list_notify_subs(conn, task_id) == []
+    finally:
+        conn.close()
+
+
+class _RecordingAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, chat_id, text, metadata=None):
+        self.sent.append({"chat_id": chat_id, "text": text, "metadata": metadata or {}})
+
+    async def handle_message(self, event):
+        return None
+
+
+def test_gateway_tick_discovers_unsubscribed_gate_and_sends_replyable_prompt(
+    tmp_path, monkeypatch
+):
+    db_path = tmp_path / "kanban.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Approve deployment", assignee="forge")
+        assert kb.block_task(
+            conn,
+            task_id,
+            reason="Need Kevin's business decision before production deployment",
+            kind="needs_input",
+        )
+    finally:
+        conn.close()
+
+    monkeypatch.setattr(
+        hermes_config,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "proactive_supervisor": {
+                    "enabled": True,
+                    "platform": "telegram",
+                    "chat_id": "hermes-command-channel",
+                    "chat_type": "dm",
+                    "recovery_limit": 1,
+                }
+            }
+        },
+    )
+    adapter = _RecordingAdapter()
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._kanban_sub_fail_counts = {}
+    runner._kanban_dispatcher_lock_handle = object()
+    runner._active_profile_name = lambda: "default"
+
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay):
+        if delay == 5:
+            return None
+        runner._running = False
+        await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert len(adapter.sent) == 1
+    delivery = adapter.sent[0]
+    assert delivery["chat_id"] == "hermes-command-channel"
+    assert "needs one decision" in delivery["text"]
+    assert f"[kanban-supervisor:default:{task_id}]" in delivery["text"]
+    assert "_kanban_proactive_supervisor" not in delivery["metadata"]

--- a/tests/gateway/test_kanban_proactive_supervisor.py
+++ b/tests/gateway/test_kanban_proactive_supervisor.py
@@ -187,10 +187,7 @@ def test_untyped_legacy_protected_gate_is_not_auto_recovered(
         conn.close()
 
 
-@pytest.mark.parametrize("kind", ["needs_input", "capability"])
-def test_typed_human_gate_is_protected_regardless_of_wording(
-    tmp_path, monkeypatch, kind
-):
+def test_typed_human_gate_is_protected_regardless_of_wording(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
     kb.init_db()
     conn = kb.connect()
@@ -200,7 +197,7 @@ def test_typed_human_gate_is_protected_regardless_of_wording(
             conn,
             task_id,
             reason="Which option should I choose?",
-            kind=kind,
+            kind="needs_input",
         )
 
         result = reconcile_board(
@@ -210,6 +207,40 @@ def test_typed_human_gate_is_protected_regardless_of_wording(
         assert result.protected_gates == [task_id]
         assert result.recovered == []
         assert kb.get_task(conn, task_id).status == "blocked"
+    finally:
+        conn.close()
+
+
+def test_capability_block_is_engineering_followup_not_approval(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="Public Lands release", assignee="forge")
+        reason = (
+            "Exact head pushed and verified; production unchanged; GitHub auth invalid; "
+            "continuation will retry"
+        )
+        assert kb.block_task(conn, task_id, reason=reason, kind="capability")
+        blocked = _latest_event(conn, task_id, "blocked")
+
+        result = reconcile_board(
+            conn, board="default", config=_config(), notifier_profile="default"
+        )
+
+        assert result.protected_gates == []
+        assert result.engineering_followups == [task_id]
+        metadata = kb.list_notify_subs(conn, task_id)[0]["delivery_metadata"]
+        assert metadata["_kanban_supervisor_mode"] == "engineering_followup"
+        rendered = render_supervisor_event(
+            board="default",
+            task=kb.get_task(conn, task_id),
+            event=SimpleNamespace(id=blocked["id"], payload=blocked["payload"]),
+            delivery_metadata=metadata,
+            current_event_id=blocked["id"],
+        )
+        assert rendered and "No Kevin decision is requested" in rendered
+        assert "Reply to this message" not in rendered
     finally:
         conn.close()
 
@@ -250,7 +281,7 @@ def test_dispatcher_gave_up_is_typed_transient_and_recovered(
         conn.close()
 
 
-def test_unknown_typed_block_fails_closed_and_renders_gate(tmp_path, monkeypatch):
+def test_unknown_typed_block_fails_closed_as_engineering_followup(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
     kb.init_db()
     conn = kb.connect()
@@ -284,10 +315,12 @@ def test_unknown_typed_block_fails_closed_and_renders_gate(tmp_path, monkeypatch
             delivery_metadata=metadata,
             current_event_id=blocked["id"],
         )
-        assert result.protected_gates == [task_id]
+        assert result.protected_gates == []
+        assert result.engineering_followups == [task_id]
         assert result.recovered == []
         assert task.status == "blocked"
-        assert rendered and "Reply to this message" in rendered
+        assert rendered and "No Kevin decision is requested" in rendered
+        assert "Reply to this message" not in rendered
     finally:
         conn.close()
 
@@ -312,7 +345,8 @@ def test_current_block_loop_triage_is_never_auto_recovered(tmp_path, monkeypatch
             conn, board="default", config=_config(), notifier_profile="default"
         )
 
-        assert result.protected_gates == [task_id]
+        assert result.protected_gates == []
+        assert result.engineering_followups == [task_id]
         assert result.recovered == []
         task = kb.get_task(conn, task_id)
         assert task is not None and task.status == "triage"

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -152,6 +152,22 @@ def test_message_event_authenticates_reply_to_current_bot_identity():
     assert other_reply.reply_to_is_own_message is False
 
 
+def test_partial_quote_preserves_authenticated_supervisor_gate_marker():
+    adapter = _make_adapter()
+    message = _group_message("approve", reply_to_bot=True)
+    message.reply_to_message.text = (
+        "Decision needed\n[kanban-gate:0123456789abcdef0123456789abcdef]"
+    )
+    message.quote = SimpleNamespace(text="Decision needed")
+
+    event = adapter._build_message_event(message, MessageType.TEXT)
+
+    assert event.reply_to_is_own_message is True
+    assert "[kanban-gate:0123456789abcdef0123456789abcdef]" in (
+        event.reply_to_text or ""
+    )
+
+
 def _mention_entities(text, mentions):
     return [_mention_entity(text, mention) for mention in mentions]
 

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -138,6 +138,20 @@ def _mention_entity(text, mention="@hermes_bot"):
     return SimpleNamespace(type="mention", offset=offset, length=len(mention))
 
 
+def test_message_event_authenticates_reply_to_current_bot_identity():
+    adapter = _make_adapter()
+
+    own_reply = adapter._build_message_event(
+        _group_message("approve", reply_to_bot=True), MessageType.TEXT
+    )
+    other_message = _group_message("approve", reply_to_bot=True)
+    other_message.reply_to_message.from_user.id = 123
+    other_reply = adapter._build_message_event(other_message, MessageType.TEXT)
+
+    assert own_reply.reply_to_is_own_message is True
+    assert other_reply.reply_to_is_own_message is False
+
+
 def _mention_entities(text, mentions):
     return [_mention_entity(text, mention) for mention in mentions]
 

--- a/tests/gateway/test_telegram_text_batching.py
+++ b/tests/gateway/test_telegram_text_batching.py
@@ -7,7 +7,7 @@ from the same session and aggregate them before dispatching.
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -50,11 +50,19 @@ def _make_adapter():
     return adapter
 
 
-def _make_event(text: str, chat_id: str = "12345") -> MessageEvent:
+def _make_event(
+    text: str,
+    chat_id: str = "12345",
+    *,
+    reply_to_text: str | None = None,
+    reply_to_is_own_message: bool = False,
+) -> MessageEvent:
     return MessageEvent(
         text=text,
         message_type=MessageType.TEXT,
         source=SessionSource(platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"),
+        reply_to_text=reply_to_text,
+        reply_to_is_own_message=reply_to_is_own_message,
     )
 
 
@@ -114,6 +122,61 @@ class TestTextBatching:
         assert "chunk 1" in text
         assert "chunk 2" in text
         assert "chunk 3" in text
+
+    @pytest.mark.asyncio
+    async def test_supervisor_gate_flushes_ordinary_batch_without_merging_identity(self):
+        adapter = _make_adapter()
+        handle_message = AsyncMock()
+        adapter.handle_message = handle_message
+        ordinary = _make_event("ordinary pending text")
+        gate = _make_event(
+            "approve release",
+            reply_to_text=(
+                "Decision needed\n"
+                "[kanban-gate:0123456789abcdef0123456789abcdef]"
+            ),
+            reply_to_is_own_message=True,
+        )
+        adapter._enqueue_text_event(ordinary)
+
+        await adapter._dispatch_supervisor_gate_event(gate)
+
+        assert handle_message.await_count == 2
+        dispatched = [call.args[0] for call in handle_message.await_args_list]
+        assert dispatched == [ordinary, gate]
+        assert dispatched[0].reply_to_text is None
+        assert dispatched[0].reply_to_is_own_message is False
+        assert dispatched[1].reply_to_text == gate.reply_to_text
+        assert dispatched[1].reply_to_is_own_message is True
+        assert adapter._pending_text_batches == {}
+        assert adapter._pending_text_batch_tasks == {}
+
+    @pytest.mark.asyncio
+    async def test_text_handler_routes_supervisor_gate_around_batching(self):
+        adapter = _make_adapter()
+        gate = _make_event(
+            "approve release",
+            reply_to_text="[kanban-gate:0123456789abcdef0123456789abcdef]",
+            reply_to_is_own_message=True,
+        )
+        msg = SimpleNamespace(text="approve release")
+        update = SimpleNamespace(effective_message=msg, message=msg, update_id=7)
+        adapter._is_user_authorized_from_message = Mock(return_value=True)
+        adapter._should_process_message = Mock(return_value=True)
+        adapter._ensure_forum_commands = AsyncMock()
+        adapter._build_message_event = Mock(return_value=gate)
+        adapter._clean_bot_trigger_text = Mock(side_effect=lambda text: text)
+        adapter._cache_replied_media = AsyncMock()
+        adapter._apply_telegram_group_observe_attribution = Mock(
+            side_effect=lambda event: event
+        )
+        adapter._dispatch_supervisor_gate_event = AsyncMock()
+        adapter._enqueue_text_event = Mock()
+
+        await adapter._handle_text_message(update, None)
+
+        adapter._dispatch_supervisor_gate_event.assert_awaited_once_with(gate)
+        adapter._enqueue_text_event.assert_not_called()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -34,6 +34,16 @@ def _make_event(
     )
 
 
+async def _wait_until(predicate, timeout: float = 2.0) -> None:
+    """Wait for an async batching condition without a brittle wall-clock race."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() >= deadline:
+            raise AssertionError("timed out waiting for batching condition")
+        await asyncio.sleep(0.01)
+
+
 # =====================================================================
 # Discord text batching
 # =====================================================================
@@ -69,7 +79,7 @@ class TestDiscordTextBatching:
         adapter.handle_message.assert_not_called()
 
         # Wait for flush
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         dispatched = adapter.handle_message.call_args[0][0]
@@ -86,7 +96,7 @@ class TestDiscordTextBatching:
 
         adapter.handle_message.assert_not_called()
 
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         text = adapter.handle_message.call_args[0][0].text
@@ -126,7 +136,7 @@ class TestMatrixTextBatching:
         adapter._enqueue_text_event(event)
 
         adapter.handle_message.assert_not_called()
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         assert adapter.handle_message.call_args[0][0].text == "hello world"
@@ -140,7 +150,7 @@ class TestMatrixTextBatching:
         adapter._enqueue_text_event(_make_event("second part", Platform.MATRIX))
 
         adapter.handle_message.assert_not_called()
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         text = adapter.handle_message.call_args[0][0].text
@@ -180,7 +190,7 @@ class TestWeComTextBatching:
         adapter._enqueue_text_event(event)
 
         adapter.handle_message.assert_not_called()
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         assert adapter.handle_message.call_args[0][0].text == "hello world"
@@ -194,7 +204,7 @@ class TestWeComTextBatching:
         adapter._enqueue_text_event(_make_event("second part", Platform.WECOM))
 
         adapter.handle_message.assert_not_called()
-        await asyncio.sleep(0.2)
+        await _wait_until(lambda: getattr(adapter.handle_message, "call_count", 0) == 1)
 
         adapter.handle_message.assert_called_once()
         text = adapter.handle_message.call_args[0][0].text

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -839,6 +839,36 @@ def test_create_respects_auto_subscribe_on_create_false(monkeypatch, worker_env,
     assert _list_subs_for_task(d["task_id"]) == []
 
 
+def test_create_reroutes_quiet_channel_notifications_to_ops(monkeypatch, worker_env, tmp_path):
+    home = tmp_path / "route-home" / ".hermes"
+    home.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        "kanban:\n"
+        "  notification_route:\n"
+        "    platform: discord\n"
+        "    chat_id: ops-channel\n"
+        "    chat_type: channel\n"
+        "    quiet_chat_ids:\n"
+        "      - hermes-conversation\n"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "discord")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_ID", "hermes-conversation")
+    monkeypatch.setenv("HERMES_SESSION_CHAT_TYPE", "channel")
+
+    from tools import kanban_tools as kt
+    out = kt._handle_create({"title": "routed task", "assignee": "peer"})
+    created = json.loads(out)
+
+    assert created["ok"] is True
+    assert created["subscribed"] is True
+    subs = _sub_index(_list_subs_for_task(created["task_id"]))
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "discord"
+    assert subs[0]["chat_id"] == "ops-channel"
+    assert subs[0]["delivery_metadata"]["_kanban_rerouted_from_chat_id"] == "hermes-conversation"
+
+
 def test_maybe_auto_subscribe_swallows_add_notify_sub_failure(monkeypatch, worker_env):
     """If add_notify_sub itself raises (e.g. DB locked, schema drift),
     _maybe_auto_subscribe must NOT bubble that up and fail the parent

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -1388,6 +1388,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
     We never want a notification bookkeeping failure to fail the
     kanban_create that the agent is mid-conversation about.
     """
+    cfg: dict[str, Any] = {}
     try:
         cfg = load_config()
         if not cfg_get(cfg, "kanban", "auto_subscribe_on_create", default=True):
@@ -1429,6 +1430,27 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
         chat_type = get_session_env("HERMES_SESSION_CHAT_TYPE", "") or None
         message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "") or ""
+        rerouted_from_chat_id = ""
+        route = cfg_get(cfg, "kanban", "notification_route", default={}) or {}
+        if isinstance(route, dict):
+            route_platform = str(route.get("platform") or "").strip().lower()
+            route_chat_id = str(route.get("chat_id") or "").strip()
+            quiet_chat_ids = {
+                str(value).strip()
+                for value in (route.get("quiet_chat_ids") or [])
+                if str(value).strip()
+            }
+            if (
+                route_platform
+                and route_chat_id
+                and platform.lower() == route_platform
+                and chat_id in quiet_chat_ids
+            ):
+                rerouted_from_chat_id = chat_id
+                chat_id = route_chat_id
+                thread_id = str(route.get("thread_id") or "").strip() or None
+                chat_type = str(route.get("chat_type") or "channel").strip() or "channel"
+                user_id = None
         notifier_profile = (
             get_session_env("HERMES_SESSION_PROFILE", "")
             or os.environ.get("HERMES_PROFILE")
@@ -1440,6 +1462,8 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
             except Exception:
                 notifier_profile = "default"
         delivery_metadata: dict[str, Any] = {}
+        if rerouted_from_chat_id:
+            delivery_metadata["_kanban_rerouted_from_chat_id"] = rerouted_from_chat_id
         if thread_id:
             delivery_metadata["thread_id"] = thread_id
         if chat_type:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -242,6 +242,33 @@ the old standalone daemon alive for one release cycle, but running both
 a gateway-embedded dispatcher AND a standalone daemon against the same
 `kanban.db` causes claim races and is not supported.
 
+### Proactive exception supervision
+
+The gateway can watch every board for blocking outcomes, including tasks
+created from the CLI, dashboard, plugins, or child workers that have no
+origin-session subscription. Agent-owned failures receive one durable,
+idempotent recovery attempt by default. Only blockers that name a protected
+human gate (for example a product decision, credentials, spending, destructive
+data action, or force-push) send a decision prompt. Reply directly to that
+prompt to attach the answer to the existing task and resume its graph.
+
+The feature is disabled until one profile explicitly owns the destination.
+This keeps ordinary installs silent and prevents a secondary profile's alert
+from falling back to another bot:
+
+```yaml
+kanban:
+  proactive_supervisor:
+    enabled: true
+    platform: discord
+    chat_id: "123456789012345678"
+    chat_type: channel
+    thread_id: ""        # optional
+    recovery_limit: 1
+```
+
+Run this only on the gateway profile whose adapter owns that destination.
+
 ### Idempotent create (for automation / webhooks)
 
 ```bash
@@ -584,6 +611,8 @@ Config knobs (all under `kanban:` in `~/.hermes/config.yaml`):
 | `orchestrator_profile` | `""` | Profile assigned to the root/orchestration task after decomposition. Empty = fall back to active default profile. |
 | `default_assignee` | `""` | Where a child task lands when the LLM picks an unknown profile. Empty = fall back to active default. |
 | `auto_subscribe_on_create` | `true` | When a worker calls `kanban_create` from inside a session with a persistent delivery channel (messaging gateway or TUI), the originating session is auto-subscribed to the new task's completion/block events. The dispatcher still drives the delivery — this only changes whether the caller's chat/key shows up in the notify-sub table. Set to `false` to require explicit `kanban_notify-subscribe` calls per task. |
+| `proactive_supervisor.enabled` | `false` | Watch all boards for otherwise-unsubscribed blocking outcomes. Requires `platform` and `chat_id`; notifications are owned by the active gateway profile. |
+| `proactive_supervisor.recovery_limit` | `1` | Durable per-task recovery budget for agent-owned blockers. Exhaustion produces a status notification, not a decision request. |
 
 And the two auxiliary LLM slots:
 


### PR DESCRIPTION
## Summary
- classify Kanban blocking outcomes into automatic transient recovery vs protected human gates
- bind quoted gate decisions to bot-authored, exact delivered messages and current event generations
- preserve gate identity across Telegram/Discord batching and active-session bypasses
- enforce durable bounded retries, duplicate silence, profile/route ownership, and truthful zero-attempt wording

## Verification
- `scripts/run_tests.sh tests/gateway/test_kanban_proactive_supervisor.py tests/gateway/test_command_bypass_active_session.py tests/gateway/test_discord_reply_mode.py tests/gateway/test_telegram_group_gating.py tests/gateway/test_telegram_text_batching.py tests/gateway/test_text_batching.py tests/gateway/test_telegram_thread_fallback.py --file-retries 0` — 145 passed
- broader POL-75 floor before final rebase — 230 passed
- `git diff --check origin/main...HEAD` — clean
- independent immutable exact-head review of `26a145c17a575a4ce3cafa1395389c76189bfade` vs `01a1037d1e6d7b6eb96a786ef282c3aea4818194` — APPROVE, no blockers