### PR TITLE
fix(desktop): recover attach and /compress after stale session drop

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -157,12 +157,18 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
-    ): Promise<ComposerAttachment[]> => {
+    ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const remote = $connection.get()?.mode === 'remote'
+      let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
 
+      const onSessionRecovered = (recoveredId: string) => {
+        liveSessionId = recoveredId
+        runtimeIdRef.current = recoveredId
+      }
+
       for (const attachment of attachments) {
-        if (!attachment.path || attachment.attachedSessionId === sessionId) {
+        if (!attachment.path || attachment.attachedSessionId === liveSessionId) {
           synced.push(attachment)
 
           continue
@@ -173,7 +179,9 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
             backendCwd: readState()?.cwd,
             remote,
             requestGateway,
-            sessionId
+            sessionId: liveSessionId,
+            storedSessionId: storedIdRef.current,
+            onSessionRecovered
           })
 
           if (options.updateComposerAttachments ?? true) {
@@ -188,7 +196,7 @@ export function useSessionTileActions({ runtimeId, scope, storedSessionId }: Ses
         synced.push(attachment)
       }
 
-      return synced
+      return { attachments: synced, sessionId: liveSessionId }
     },
     [requestGateway, scope.attachments]
   )

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -2745,6 +2745,116 @@ describe('usePromptActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toEqual({ session_id: RECOVERED_SESSION_ID, text: 'message after wake' })
   })
 
+  it('resumes before attach when image.attach_bytes reports "session not found"', async () => {
+    // Attach runs *before* prompt.submit. Without recovery here, text still
+    // works after sleep but image send fails with "session not found".
+    $connection.set({ mode: 'remote' } as never)
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: {
+        readFileDataUrl: vi.fn(async () => 'data:image/png;base64,aaaa')
+      }
+    })
+
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let attachAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'image.attach_bytes') {
+        attachAttempts += 1
+
+        if (attachAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return { attached: true, path: '/remote/pic.png' } as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    const attachment: ComposerAttachment = {
+      id: 'image:pic.png',
+      kind: 'image',
+      label: 'pic.png',
+      path: '/Users/alice/Pictures/pic.png',
+      refText: '@image:`/Users/alice/Pictures/pic.png`'
+    }
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    const ok = await handle!.submitText('what is this', { attachments: [attachment] })
+
+    expect(ok).toBe(true)
+    expect(calls.map(c => c.method)).toEqual([
+      'image.attach_bytes',
+      'session.resume',
+      'image.attach_bytes',
+      'prompt.submit'
+    ])
+    expect(calls[0]?.params).toMatchObject({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[2]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
+    expect(calls[3]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
+  })
+
+  it('resumes and retries once when session.compress reports "session not found"', async () => {
+    const calls: { method: string; params?: Record<string, unknown> }[] = []
+    let compressAttempts = 0
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'session.compress') {
+        compressAttempts += 1
+
+        if (compressAttempts === 1) {
+          throw new Error('session not found')
+        }
+
+        return {
+          removed: 2,
+          summary: { headline: 'Compressed: 10 → 8 messages' }
+        } as never
+      }
+
+      if (method === 'session.resume') {
+        return { session_id: RECOVERED_SESSION_ID } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        storedSessionId={STORED_SESSION_ID}
+      />
+    )
+
+    await handle!.submitText('/compress')
+
+    expect(calls.map(c => c.method)).toEqual(['session.compress', 'session.resume', 'session.compress'])
+    expect(calls[0]?.params).toMatchObject({ session_id: RUNTIME_SESSION_ID })
+    expect(calls[2]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
+  })
+
   // #67603 (second symptom): a recovery resume must re-register on the session's
   // OWNING profile. Resuming on whichever profile is live forks the conversation
   // into the wrong profile's DB — the session then appears under both profiles.

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -69,7 +69,8 @@ import {
   isSessionNotFoundError,
   readFileDataUrlForAttach,
   readImageForRemoteAttach,
-  type SubmitTextOptions
+  type SubmitTextOptions,
+  withSessionNotFoundResume
 } from './utils'
 
 interface HandoffResult {
@@ -98,88 +99,111 @@ function attachmentPathNeedsUpload(path: string, backendCwd?: null | string): bo
  */
 export async function uploadComposerAttachment(
   attachment: ComposerAttachment,
-  opts: { backendCwd?: null | string; remote: boolean; requestGateway: GatewayRequest; sessionId: string }
+  opts: {
+    backendCwd?: null | string
+    remote: boolean
+    requestGateway: GatewayRequest
+    sessionId: string
+    /** Durable id used to re-register after sleep/wake / backend restart. */
+    storedSessionId?: null | string
+    /** Called when attach recovered onto a fresh live id (rebind the foreground). */
+    onSessionRecovered?: (sessionId: string) => void
+  }
 ): Promise<ComposerAttachment> {
-  const { backendCwd, remote, requestGateway, sessionId } = opts
+  const { backendCwd, remote, requestGateway, storedSessionId, onSessionRecovered } = opts
   const path = attachment.path ?? ''
   const label = attachment.label || pathLabel(path)
   const uploadBytes = remote || attachmentPathNeedsUpload(path, backendCwd)
 
-  if (attachment.kind === 'image') {
-    let result: ImageAttachResponse
+  // Bytes / paths are read once; only the session-scoped RPC needs recovery.
+  let imagePayload: Awaited<ReturnType<typeof readImageForRemoteAttach>> | null = null
+  let fileDataUrl: string | null = null
 
-    if (uploadBytes) {
-      let payload: Awaited<ReturnType<typeof readImageForRemoteAttach>>
-
-      try {
-        payload = await readImageForRemoteAttach(path)
-      } catch (err) {
-        throw friendlyRemoteAttachError(err, label)
-      }
-
-      if (!payload) {
-        throw new Error(`Could not read ${label}`)
-      }
-
-      result = await requestGateway<ImageAttachResponse>('image.attach_bytes', {
-        session_id: sessionId,
-        content_base64: payload.contentBase64,
-        filename: payload.filename
-      })
-    } else {
-      result = await requestGateway<ImageAttachResponse>('image.attach', {
-        path,
-        session_id: sessionId
-      })
-    }
-
-    if (!result.attached) {
-      throw new Error(result.message || `Could not attach ${label}`)
-    }
-
-    const attachedPath = result.path || path
-
-    return {
-      ...attachment,
-      attachedSessionId: sessionId,
-      label: attachedPath ? pathLabel(attachedPath) : attachment.label,
-      path: attachedPath,
-      uploadState: undefined
-    }
-  }
-
-  // Non-image file.
-  let dataUrl: string | null = null
-
-  if (uploadBytes) {
+  if (attachment.kind === 'image' && uploadBytes) {
     try {
-      dataUrl = await readFileDataUrlForAttach(path)
+      imagePayload = await readImageForRemoteAttach(path)
     } catch (err) {
       throw friendlyRemoteAttachError(err, label)
     }
 
-    if (!dataUrl) {
+    if (!imagePayload) {
+      throw new Error(`Could not read ${label}`)
+    }
+  } else if (attachment.kind !== 'image' && uploadBytes) {
+    try {
+      fileDataUrl = await readFileDataUrlForAttach(path)
+    } catch (err) {
+      throw friendlyRemoteAttachError(err, label)
+    }
+
+    if (!fileDataUrl) {
       throw new Error(`Could not read ${label}`)
     }
   }
 
-  const result = await requestGateway<FileAttachResponse>('file.attach', {
-    name: label,
-    path,
-    session_id: sessionId,
-    ...(dataUrl ? { data_url: dataUrl } : {})
-  })
+  const stageForSession = async (sessionId: string): Promise<ComposerAttachment> => {
+    if (attachment.kind === 'image') {
+      let result: ImageAttachResponse
 
-  if (!result.attached || !result.ref_text) {
-    throw new Error(result.message || `Could not attach ${label}`)
+      if (imagePayload) {
+        result = await requestGateway<ImageAttachResponse>('image.attach_bytes', {
+          session_id: sessionId,
+          content_base64: imagePayload.contentBase64,
+          filename: imagePayload.filename
+        })
+      } else {
+        result = await requestGateway<ImageAttachResponse>('image.attach', {
+          path,
+          session_id: sessionId
+        })
+      }
+
+      if (!result.attached) {
+        throw new Error(result.message || `Could not attach ${label}`)
+      }
+
+      const attachedPath = result.path || path
+
+      return {
+        ...attachment,
+        attachedSessionId: sessionId,
+        label: attachedPath ? pathLabel(attachedPath) : attachment.label,
+        path: attachedPath,
+        uploadState: undefined
+      }
+    }
+
+    const result = await requestGateway<FileAttachResponse>('file.attach', {
+      name: label,
+      path,
+      session_id: sessionId,
+      ...(fileDataUrl ? { data_url: fileDataUrl } : {})
+    })
+
+    if (!result.attached || !result.ref_text) {
+      throw new Error(result.message || `Could not attach ${label}`)
+    }
+
+    return {
+      ...attachment,
+      attachedSessionId: sessionId,
+      refText: result.ref_text,
+      uploadState: undefined
+    }
   }
 
-  return {
-    ...attachment,
-    attachedSessionId: sessionId,
-    refText: result.ref_text,
-    uploadState: undefined
+  const { result, sessionId: usedSessionId } = await withSessionNotFoundResume(
+    requestGateway,
+    storedSessionId,
+    opts.sessionId,
+    stageForSession
+  )
+
+  if (usedSessionId !== opts.sessionId) {
+    onSessionRecovered?.(usedSessionId)
   }
+
+  return result
 }
 
 interface PromptActionsOptions {
@@ -300,10 +324,17 @@ export function usePromptActions({
       sessionId: string,
       attachments: ComposerAttachment[],
       options: { updateComposerAttachments?: boolean } = {}
-    ): Promise<ComposerAttachment[]> => {
+    ): Promise<{ attachments: ComposerAttachment[]; sessionId: string }> => {
       const updateComposerAttachments = options.updateComposerAttachments ?? true
       const remote = $connection.get()?.mode === 'remote'
+      const storedSessionId = selectedStoredSessionIdRef.current
+      let liveSessionId = sessionId
       const synced: ComposerAttachment[] = []
+
+      const onSessionRecovered = (recoveredId: string) => {
+        liveSessionId = recoveredId
+        activeSessionIdRef.current = recoveredId
+      }
 
       for (const original of attachments) {
         let attachment = original
@@ -323,7 +354,9 @@ export function usePromptActions({
         // Already-synced or pathless refs (terminal, url, etc.) pass through.
         // A drop-time eager upload may already have staged this one (matching
         // attachedSessionId) — don't re-upload it.
-        if (!attachment.path || attachment.attachedSessionId === sessionId) {
+        // After a mid-loop recovery, attachedSessionId may reference the old
+        // dead runtime — treat that as needing re-stage onto liveSessionId.
+        if (!attachment.path || attachment.attachedSessionId === liveSessionId) {
           synced.push(attachment)
 
           continue
@@ -334,7 +367,9 @@ export function usePromptActions({
             backendCwd: $currentCwd.get(),
             remote,
             requestGateway,
-            sessionId
+            sessionId: liveSessionId,
+            storedSessionId,
+            onSessionRecovered
           })
 
           // Update-only: never resurrect a chip the user removed mid-upload.
@@ -350,9 +385,9 @@ export function usePromptActions({
         synced.push(attachment)
       }
 
-      return synced
+      return { attachments: synced, sessionId: liveSessionId }
     },
-    [requestGateway]
+    [activeSessionIdRef, requestGateway, selectedStoredSessionIdRef]
   )
 
   // Stage a freshly dropped file as soon as it lands (when a session already
@@ -379,7 +414,11 @@ export function usePromptActions({
             backendCwd: $currentCwd.get(),
             remote,
             requestGateway,
-            sessionId
+            sessionId,
+            storedSessionId: selectedStoredSessionIdRef.current,
+            onSessionRecovered: recoveredId => {
+              activeSessionIdRef.current = recoveredId
+            }
           })
         )
       } catch (err) {
@@ -390,7 +429,7 @@ export function usePromptActions({
         notifyError(err, copy.dropFiles)
       }
     },
-    [copy.dropFiles, requestGateway]
+    [activeSessionIdRef, copy.dropFiles, requestGateway, selectedStoredSessionIdRef]
   )
 
   const composerAttachments = useStore($composerAttachments)

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -62,7 +62,8 @@ import {
   renderCommandsCatalog,
   renderRpcResult,
   slashStatusText,
-  type SubmitTextOptions
+  type SubmitTextOptions,
+  withSessionNotFoundResume
 } from './utils'
 
 // Manual compression is LLM-bound and routinely outlives the desktop's 30s
@@ -499,7 +500,8 @@ export function useSlashCommand(deps: SlashCommandDeps) {
             return
           }
 
-          const { render: renderSlashOutput, sessionId, storedSessionId } = resolved
+          const { render: renderSlashOutput, sessionId: initialSessionId, storedSessionId } = resolved
+          let sessionId = initialSessionId
           const focusTopic = ctx.arg.trim()
           const noticeId = `session-compress:${sessionId}`
 
@@ -518,14 +520,33 @@ export function useSlashCommand(deps: SlashCommandDeps) {
           })
 
           try {
-            const result = await requestGateway<SessionCompressResponse>(
-              'session.compress',
-              {
-                session_id: sessionId,
-                ...(focusTopic ? { focus_topic: focusTopic } : {})
-              },
-              SESSION_COMPRESS_TIMEOUT_MS
+            // Same sleep/wake recovery as prompt.submit: a dead runtime id
+            // 404s session.compress while plain chat still works (submit
+            // recovers; compress used to surface "session not found").
+            const { result, sessionId: liveSessionId } = await withSessionNotFoundResume(
+              requestGateway,
+              storedSessionId,
+              sessionId,
+              sid =>
+                requestGateway<SessionCompressResponse>(
+                  'session.compress',
+                  {
+                    session_id: sid,
+                    ...(focusTopic ? { focus_topic: focusTopic } : {})
+                  },
+                  SESSION_COMPRESS_TIMEOUT_MS
+                )
             )
+
+            if (liveSessionId !== sessionId) {
+              compressInFlightRef.current.delete(sessionId)
+              compressInFlightRef.current.add(liveSessionId)
+              sessionId = liveSessionId
+
+              if (activeSessionIdRef.current === initialSessionId) {
+                activeSessionIdRef.current = liveSessionId
+              }
+            }
 
             // Replace the transcript with the post-compress history so the
             // summarized bubbles actually disappear. `messages` is the same

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -63,7 +63,7 @@ interface SubmitPromptDeps {
     sessionId: string,
     attachments: ComposerAttachment[],
     options?: { updateComposerAttachments?: boolean }
-  ) => Promise<ComposerAttachment[]>
+  ) => Promise<{ attachments: ComposerAttachment[]; sessionId: string }>
   updateSessionState: (
     sessionId: string,
     updater: (state: ClientSessionState) => ClientSessionState,
@@ -584,23 +584,36 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
       }
 
       try {
-        const syncedAttachments = await syncAttachmentsForSubmit(sessionId, attachments, {
+        // Attach runs *before* prompt.submit. On sleep/wake the runtime id is
+        // already dead, so image.attach / file.attach must recover (and rebind
+        // sessionId) here — submit's recovery never runs if attach fails first.
+        const attachResult = await syncAttachmentsForSubmit(sessionId, attachments, {
           updateComposerAttachments: usingComposerAttachments
         })
+
+        const syncedAttachments = attachResult.attachments
+        // attachResult.sessionId is always a live string; pin it so TS narrows
+        // past the outer `string | null` sessionId binding for prompt.submit.
+        const liveSessionId = attachResult.sessionId
+        sessionId = liveSessionId
+
+        if (targetIsCurrentView() && activeSessionIdRef.current !== liveSessionId) {
+          activeSessionIdRef.current = liveSessionId
+        }
 
         const attachmentsDrift = sessionDriftReason()
 
         if (attachmentsDrift) {
           console.warn('[submit-drift-abort]', attachmentsDrift, { phase: 'post-attachments' })
 
-          return abortForSessionSwitch(sessionId)
+          return abortForSessionSwitch(liveSessionId)
         }
 
         // Rewrite the optimistic message + prompt text with the synced refs so
         // the gateway receives @file: paths that resolve in its workspace.
         // (Images keep their inline base64 preview — see optimisticAttachmentRef.)
         attachmentRefs = syncedAttachments.map(optimisticAttachmentRef).filter((r): r is string => Boolean(r))
-        rewriteOptimistic(sessionId)
+        rewriteOptimistic(liveSessionId)
         const text = buildContextText(syncedAttachments)
 
         const submitParams = (targetId: string) => ({
@@ -622,7 +635,7 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
         try {
           await withSessionBusyRetry(() =>
-            requestGateway('prompt.submit', submitParams(sessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
+            requestGateway('prompt.submit', submitParams(liveSessionId), PROMPT_SUBMIT_REQUEST_TIMEOUT_MS)
           )
         } catch (firstErr) {
           const recoverStoredSessionId = targetStoredSessionId ?? selectedStoredSessionIdRef.current

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.test.ts
@@ -7,6 +7,7 @@ import {
   appendText,
   base64FromDataUrl,
   friendlyRemoteAttachError,
+  type GatewayRequest,
   imageFilenameFromPath,
   inlineErrorMessage,
   isSessionBusyError,
@@ -16,7 +17,8 @@ import {
   renderRpcResult,
   slashStatusText,
   visibleUserIndexAtOrdinal,
-  visibleUserOrdinal
+  visibleUserOrdinal,
+  withSessionNotFoundResume
 } from './utils'
 
 describe('isSessionIdCandidate', () => {
@@ -51,6 +53,63 @@ describe('session error classifiers', () => {
     expect(isSessionBusyError(new Error('session busy'))).toBe(true)
     expect(isSessionNotFoundError(new Error('other'))).toBe(false)
     expect(isSessionBusyError(new Error('other'))).toBe(false)
+  })
+})
+
+describe('withSessionNotFoundResume', () => {
+  it('returns the first-call result without resume when the RPC succeeds', async () => {
+    const requestGateway = vi.fn(async () => ({})) as unknown as GatewayRequest
+
+    const call = vi.fn(async (sid: string) => `ok:${sid}`)
+    const out = await withSessionNotFoundResume(requestGateway, 'stored-1', 'rt-stale', call)
+
+    expect(out).toEqual({ result: 'ok:rt-stale', sessionId: 'rt-stale' })
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(requestGateway).not.toHaveBeenCalled()
+  })
+
+  it('resumes the stored session and retries once on "session not found"', async () => {
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        return { session_id: 'rt-fresh' }
+      }
+
+      throw new Error(`unexpected ${method}`)
+    }) as unknown as GatewayRequest
+
+    let attempts = 0
+
+    const call = vi.fn(async (sid: string) => {
+      attempts += 1
+
+      if (attempts === 1) {
+        throw new Error('session not found')
+      }
+
+      return `ok:${sid}`
+    })
+
+    const out = await withSessionNotFoundResume(requestGateway, 'stored-1', 'rt-stale', call)
+
+    expect(out).toEqual({ result: 'ok:rt-fresh', sessionId: 'rt-fresh' })
+    expect(call.mock.calls.map(c => c[0])).toEqual(['rt-stale', 'rt-fresh'])
+    expect(requestGateway).toHaveBeenCalledWith(
+      'session.resume',
+      expect.objectContaining({ session_id: 'stored-1', source: 'desktop', omit_messages: true })
+    )
+  })
+
+  it('rethrows when no stored session id is available', async () => {
+    const requestGateway = vi.fn() as unknown as GatewayRequest
+
+    const call = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    await expect(withSessionNotFoundResume(requestGateway, null, 'rt-stale', call)).rejects.toThrow(
+      'session not found'
+    )
+    expect(requestGateway).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/utils.ts
@@ -53,6 +53,70 @@ export function isSessionNotFoundError(error: unknown): boolean {
 }
 
 /**
+ * Re-register a durable stored session after the gateway dropped its in-memory
+ * runtime id (sleep/wake, remote backend restart, long idle). Returns the fresh
+ * live id, or null when resume produces none.
+ *
+ * Same recovery class as prompt.submit after sleep — attach and /compress must
+ * use this too: those RPCs run *before* prompt.submit's recovery, so a stale
+ * runtime id surfaces "session not found" while plain text still works.
+ */
+export async function resumeStoredRuntimeSession(
+  requestGateway: GatewayRequest,
+  storedSessionId: string
+): Promise<string | null> {
+  // Lazy import keeps utils free of a hard cycle with session-actions on init.
+  const { resolveSessionProfile } = await import('../use-session-actions/utils')
+  const resumeProfile = await resolveSessionProfile(storedSessionId)
+
+  const resumed = await requestGateway<{ session_id: string }>('session.resume', {
+    session_id: storedSessionId,
+    source: 'desktop',
+    omit_messages: true,
+    ...(resumeProfile ? { profile: resumeProfile } : {})
+  })
+
+  return resumed?.session_id ?? null
+}
+
+/**
+ * Run `call(sessionId)`; on "session not found" (optionally gateway timeout),
+ * resume the stored session once and retry with the recovered live id.
+ */
+export async function withSessionNotFoundResume<T>(
+  requestGateway: GatewayRequest,
+  storedSessionId: string | null | undefined,
+  sessionId: string,
+  call: (liveSessionId: string) => Promise<T>,
+  options?: { alsoTimeout?: boolean }
+): Promise<{ result: T; sessionId: string }> {
+  try {
+    return { result: await call(sessionId), sessionId }
+  } catch (err) {
+    const recoverable =
+      isSessionNotFoundError(err) || (Boolean(options?.alsoTimeout) && isGatewayTimeoutError(err))
+
+    if (!recoverable || !storedSessionId) {
+      throw err
+    }
+
+    let recoveredId: null | string
+
+    try {
+      recoveredId = await resumeStoredRuntimeSession(requestGateway, storedSessionId)
+    } catch {
+      throw err
+    }
+
+    if (!recoveredId) {
+      throw err
+    }
+
+    return { result: await call(recoveredId), sessionId: recoveredId }
+  }
+}
+
+/**
  * Is the session a prompt is about to run against currently mid-turn?
  *
  * The foreground `busyRef` is NOT the answer. It mirrors whatever chat is on


### PR DESCRIPTION
## Summary
- After sleep/wake or remote backend restart, image attach and `/compress` failed with "session not found" while plain text still worked.
- Resume the stored session once and retry attach + `session.compress`.

## Test plan
- [x] desktop vitest for attach/compress session-not-found recovery
- [ ] Desktop remote: idle/sleep or restart backend → attach image + `/compress` works