### PR TITLE
feat(cron): enforce required skills via cron.required_skills

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4537,6 +4537,77 @@ def cron_model_drift_guard_enabled(
     return cron_config.get("model_drift_guard", True) is not False
 
 
+def cron_required_skills(
+    config: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    """Return the skills every agent-driven cron job must load.
+
+    Read from ``cron.required_skills``. A single comma-separated string is
+    tolerated alongside the list form. Missing or malformed values yield an
+    empty list, which disables enforcement. When *config* is omitted, load
+    the active merged configuration.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return []
+    if not isinstance(config, dict):
+        return []
+    cron_config = config.get("cron")
+    if not isinstance(cron_config, dict):
+        return []
+    value = cron_config.get("required_skills")
+    if isinstance(value, str):
+        return [s.strip() for s in value.split(",") if s.strip()]
+    if isinstance(value, (list, tuple)):
+        return [s for s in value if isinstance(s, str) and s.strip()]
+    return []
+
+
+def cron_required_skills_enforce(
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return whether a required-skills violation hard-rejects the operation.
+
+    Only the literal YAML boolean ``false`` downgrades enforcement to a
+    warning log. Missing, malformed, or non-boolean values stay enforced.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return True
+    if not isinstance(config, dict):
+        return True
+    cron_config = config.get("cron")
+    if not isinstance(cron_config, dict):
+        return True
+    return cron_config.get("required_skills_enforce", True) is not False
+
+
+def cron_required_skills_agent_only(
+    config: Optional[Dict[str, Any]] = None,
+) -> bool:
+    """Return whether ``cron.required_skills`` applies only to agent jobs.
+
+    Default True: a no_agent job owns its stdout via a script, so loading a
+    presentation skill there is meaningless. Only the literal YAML boolean
+    ``false`` extends the check to no_agent jobs.
+    """
+    if config is None:
+        try:
+            config = load_config()
+        except Exception:
+            return True
+    if not isinstance(config, dict):
+        return True
+    cron_config = config.get("cron")
+    if not isinstance(cron_config, dict):
+        return True
+    return cron_config.get("required_skills_agent_only", True) is not False
+
+
 def _cron_fleet_default_covers_axis(
     axis: str,
     config: Optional[Dict[str, Any]] = None,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2297,6 +2297,19 @@ DEFAULT_CONFIG = {
         # wedges the job's dispatch guard forever. Also overridable via
         # HERMES_CRON_SESSION_DB_TIMEOUT env var. 0 = unlimited (skip the bound).
         "session_db_timeout_seconds": 10,
+        # Skills every agent-driven cron job must load, enforced at create and
+        # update time (issue #79797). A job whose skills[] misses an entry
+        # here is rejected (or warned — see required_skills_enforce). Empty
+        # list = no enforcement, current behaviour preserved.
+        "required_skills": [],
+        # Apply required_skills only to agent-driven (no_agent=False) jobs.
+        # A no_agent job owns its stdout via a script, not a skill, so loading
+        # a presentation skill there is meaningless. Set to false to check
+        # no_agent jobs too.
+        "required_skills_agent_only": True,
+        # true = reject create/update that violates required_skills; false =
+        # downgrade to a warning log and allow the operation.
+        "required_skills_enforce": True,
     },
 
     # Kanban multi-agent coordination — controls the dispatcher loop that

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -360,6 +360,7 @@ def cron_create(args):
         no_agent=getattr(args, "no_agent", False) or None,
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        force=getattr(args, "force", False),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -431,6 +432,7 @@ def cron_edit(args):
         no_agent=getattr(args, "no_agent", None),
         monitor_script=getattr(args, "monitor_script", None),
         monitor_url=getattr(args, "monitor_url", None),
+        force=getattr(args, "force", False),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -105,6 +105,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         dest="model_provider",
         help="Inference provider paired with --model (e.g. 'openrouter', 'nous').",
     )
+    cron_create.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Bypass the cron.required_skills gate for this one job. Human-only: "
+            "the agent's cronjob tool cannot pass this flag."
+        ),
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -196,6 +204,14 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         "--provider",
         dest="model_provider",
         help="Inference provider paired with --model. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--force",
+        action="store_true",
+        help=(
+            "Bypass the cron.required_skills gate for this one edit. Human-only: "
+            "the agent's cronjob tool cannot pass this flag."
+        ),
     )
 
     # lifecycle actions

--- a/tests/tools/test_cron_required_skills.py
+++ b/tests/tools/test_cron_required_skills.py
@@ -1,0 +1,196 @@
+"""Tests for cron.required_skills config enforcement (issue #79797).
+
+Covers the create/update gate in tools/cronjob_tools.py: the agent tool and
+the hermes cron CLI both route through cronjob(), so these tests exercise the
+unified tool surface with cron.* config patched via load_config().
+"""
+
+import json
+
+import pytest
+
+from tools.cronjob_tools import cronjob
+
+
+def _config(required_skills=None, enforce=True, agent_only=True):
+    cfg = {"cron": {}}
+    if required_skills is not None:
+        cfg["cron"]["required_skills"] = required_skills
+    cfg["cron"]["required_skills_enforce"] = enforce
+    cfg["cron"]["required_skills_agent_only"] = agent_only
+    return cfg
+
+
+class TestCronRequiredSkills:
+    @pytest.fixture(autouse=True)
+    def _isolate_cron_store(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+        monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+        monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+        # Point the script-path validator at the temp dir so no_agent jobs can
+        # reference a real (relative) script without touching the real home.
+        import hermes_constants
+
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "watch.sh").write_text("echo hi\n")
+
+    def _set_required_skills(self, monkeypatch, **kwargs):
+        import hermes_cli.config as hcfg
+
+        monkeypatch.setattr(hcfg, "load_config", lambda: _config(**kwargs))
+
+    def _create(self, **kwargs):
+        return json.loads(cronjob(action="create", schedule="every 1h", **kwargs))
+
+    def test_create_rejected_when_missing_required_skill(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = self._create(prompt="send me the daily brief")
+        assert result["success"] is False
+        assert "cron.required_skills" in result["error"]
+        assert "cron-output" in result["error"]
+
+    def test_create_ok_when_required_skill_present(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = self._create(prompt="brief", skills=["cron-output"])
+        assert result["success"] is True
+
+    def test_create_ok_when_no_required_skills_configured(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=[])
+        result = self._create(prompt="brief")
+        assert result["success"] is True
+
+    def test_create_no_agent_exempt_by_default(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = self._create(prompt=None, script="watch.sh", no_agent=True)
+        assert result["success"] is True
+
+    def test_create_no_agent_checked_when_agent_only_false(self, monkeypatch):
+        self._set_required_skills(
+            monkeypatch, required_skills=["cron-output"], agent_only=False
+        )
+        result = self._create(prompt=None, script="watch.sh", no_agent=True)
+        assert result["success"] is False
+        assert "cron-output" in result["error"]
+
+    def test_update_clear_skills_rejected(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        created = self._create(prompt="brief", skills=["cron-output"])
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], skills=[])
+        )
+        assert result["success"] is False
+        assert "cron-output" in result["error"]
+
+    def test_update_replacing_skills_with_missing_required_rejected(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        created = self._create(prompt="brief", skills=["cron-output"])
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                skills=["other-skill"],
+            )
+        )
+        assert result["success"] is False
+        assert "cron-output" in result["error"]
+
+    def test_update_adding_required_skill_ok(self, monkeypatch):
+        # Job created before the policy existed (nothing required at the time).
+        self._set_required_skills(monkeypatch, required_skills=[])
+        created = self._create(prompt="brief")
+        # Policy lands later; an update that adds the skill satisfies it.
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                skills=["cron-output"],
+            )
+        )
+        assert result["success"] is True
+
+    def test_update_unrelated_field_allowed_on_noncompliant_job(self, monkeypatch):
+        # A legacy job created before the policy is not trapped: updates that
+        # leave the skills axis untouched still go through, so it can be
+        # remediated field-by-field.
+        self._set_required_skills(monkeypatch, required_skills=[])
+        created = self._create(prompt="brief")
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], name="renamed")
+        )
+        assert result["success"] is True
+        assert result["job"]["name"] == "renamed"
+
+    def test_update_flip_no_agent_off_checked(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        created = self._create(prompt=None, script="watch.sh", no_agent=True)
+        # Flipping to agent mode without the required skill is rejected.
+        result = json.loads(
+            cronjob(action="update", job_id=created["job_id"], no_agent=False)
+        )
+        assert result["success"] is False
+        assert "cron-output" in result["error"]
+
+    def test_enforce_false_allows_with_warning(self, monkeypatch):
+        self._set_required_skills(
+            monkeypatch, required_skills=["cron-output"], enforce=False
+        )
+        result = self._create(prompt="brief")
+        assert result["success"] is True
+
+    def test_force_bypasses_gate(self, monkeypatch):
+        self._set_required_skills(monkeypatch, required_skills=["cron-output"])
+        result = self._create(prompt="brief", force=True)
+        assert result["success"] is True
+
+
+class TestConfigAccessors:
+    def test_string_form_split(self):
+        from hermes_cli.config import cron_required_skills
+
+        assert cron_required_skills(
+            {"cron": {"required_skills": "cron-output, plain-english"}}
+        ) == ["cron-output", "plain-english"]
+
+    def test_list_form(self):
+        from hermes_cli.config import cron_required_skills
+
+        assert cron_required_skills(
+            {"cron": {"required_skills": ["cron-output"]}}
+        ) == ["cron-output"]
+
+    def test_garbage_yields_empty(self):
+        from hermes_cli.config import cron_required_skills
+
+        assert cron_required_skills({"cron": {"required_skills": 42}}) == []
+        assert cron_required_skills({"cron": {}}) == []
+        assert cron_required_skills({}) == []
+
+    def test_only_literal_false_disables(self):
+        from hermes_cli.config import (
+            cron_required_skills_agent_only,
+            cron_required_skills_enforce,
+        )
+
+        assert (
+            cron_required_skills_enforce(
+                {"cron": {"required_skills_enforce": False}}
+            )
+            is False
+        )
+        assert (
+            cron_required_skills_enforce(
+                {"cron": {"required_skills_enforce": "false"}}
+            )
+            is True
+        )
+        assert (
+            cron_required_skills_agent_only(
+                {"cron": {"required_skills_agent_only": False}}
+            )
+            is False
+        )
+        assert cron_required_skills_agent_only({"cron": {}}) is True

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -277,6 +277,52 @@ def _scan_cron_prompt(prompt: str) -> str:
     return ""
 
 
+def _required_skills_violation(
+    skills: Any,
+    no_agent: bool,
+    *,
+    force: bool = False,
+) -> str:
+    """Return an error string when a job violates ``cron.required_skills``.
+
+    Reads ``cron.required_skills``, ``cron.required_skills_agent_only``, and
+    ``cron.required_skills_enforce`` from the merged config (issue #79797).
+    Returns an empty string when the job is compliant, when the check is
+    disabled, or when *force* is set (the CLI-only escape hatch). When
+    enforcement is downgraded to warning mode (``required_skills_enforce:
+    false``), the violation is logged and the operation proceeds.
+    """
+    if force:
+        return ""
+    from hermes_cli.config import (
+        cron_required_skills,
+        cron_required_skills_agent_only,
+        cron_required_skills_enforce,
+    )
+
+    if no_agent and cron_required_skills_agent_only():
+        return ""
+    required = cron_required_skills()
+    if not required:
+        return ""
+    present = {s.strip().lower() for s in (skills or []) if isinstance(s, str)}
+    missing = [r for r in required if r.strip().lower() not in present]
+    if not missing:
+        return ""
+    if not cron_required_skills_enforce():
+        logger.warning(
+            "Cron job is missing required skill(s) %s from cron.required_skills; "
+            "enforcement disabled (cron.required_skills_enforce=false), allowing.",
+            ", ".join(missing),
+        )
+        return ""
+    return (
+        "Blocked: job missing required skill(s) configured in cron.required_skills: "
+        + ", ".join(missing)
+        + ". Add them (agent tool: skills=[...]; CLI: --skill) or use --force on the CLI."
+    )
+
+
 def _scan_cron_skill_assembled(assembled: str) -> tuple[str, str]:
     """Scan an ASSEMBLED cron prompt that includes loaded skill content.
 
@@ -1049,6 +1095,7 @@ def cronjob(
     attach_to_session: Optional[bool] = None,
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
+    force: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1081,6 +1128,16 @@ def cronjob(
                 scan_error = _scan_cron_prompt(prompt)
                 if scan_error:
                     return tool_error(scan_error, success=False)
+
+            # Config-enforced required skills (cron.required_skills, #79797).
+            # Agent tool + CLI both land here via cronjob(); the dashboard API
+            # writes through cron.jobs directly and is intentionally out of
+            # scope for this first pass.
+            required_skills_error = _required_skills_violation(
+                canonical_skills, _no_agent, force=bool(force)
+            )
+            if required_skills_error:
+                return tool_error(required_skills_error, success=False)
 
             # Validate script path before storing
             if script:
@@ -1423,6 +1480,33 @@ def cronjob(
                 if job.get("state") != "paused":
                     updates["state"] = "scheduled"
                     updates["enabled"] = True
+            # Config-enforced required skills (#79797): gate updates that
+            # change the skills axis (skills/skill) or the agent mode
+            # (no_agent). The check runs against the EFFECTIVE post-update
+            # state — stored skills merged with this update's changes — so a
+            # --clear-skills / skills=[] that strips a required skill is
+            # rejected, while updates that leave the skills axis untouched
+            # (name, schedule, deliver, ...) stay allowed even on a legacy
+            # noncompliant job, so it can still be remediated field-by-field.
+            if "skills" in updates or "no_agent" in updates:
+                effective_skills = (
+                    updates["skills"]
+                    if "skills" in updates
+                    else list(
+                        job.get("skills")
+                        or ([] if not job.get("skill") else [job.get("skill")])
+                    )
+                )
+                effective_no_agent = (
+                    updates["no_agent"]
+                    if "no_agent" in updates
+                    else bool(job.get("no_agent"))
+                )
+                required_skills_error = _required_skills_violation(
+                    effective_skills, effective_no_agent, force=bool(force)
+                )
+                if required_skills_error:
+                    return tool_error(required_skills_error, success=False)
             if not updates:
                 return tool_error("No updates provided.", success=False)
             updated = update_job(job_id, updates)

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -121,6 +121,41 @@ global defaults. A switch to a paid provider or model can therefore spend money
 on every scheduled run.
 :::
 
+## Enforcing required skills on cron jobs
+
+Some skills are load-bearing for cron output: presentation skills that format
+briefs, `[SILENT]` rules, character limits, or language enforcement. If an
+agent-driven job forgets to load them, the job still runs — it just produces
+unstructured or mis-formatted output.
+
+Set `cron.required_skills` to the list of skills every agent-driven job must
+load. Jobs created or updated without them are rejected:
+
+```yaml
+# ~/.hermes/config.yaml
+cron:
+  required_skills:
+    - cron-output
+```
+
+Behavior:
+
+- The check runs at create and update time, on both the agent's `cronjob`
+  tool and the `hermes cron create` / `hermes cron edit` CLI.
+- Updates that change the job's skills (including `--clear-skills`) or toggle
+  `no_agent` are checked against the effective post-update state. Updating an
+  unrelated field (name, schedule, deliver) on an already-noncompliant job is
+  still allowed, so it can be fixed field-by-field.
+- `no_agent` jobs are exempt by default — a script owns their stdout, not a
+  skill. Set `cron.required_skills_agent_only: false` to apply the check to
+  them too.
+- `cron.required_skills_enforce: false` downgrades the hard reject to a
+  warning log, for a nudge without a block.
+- `hermes cron create --force` / `hermes cron edit --force` bypasses the check
+  for a one-off job that legitimately does not need the skill. The flag is
+  human-only: the agent's `cronjob` tool cannot pass it.
+- An empty list (the default) disables enforcement entirely.
+
 ## Skill-backed cron jobs
 
 A cron job can load one or more skills before it runs the prompt.


### PR DESCRIPTION
## Summary

Cron jobs can be created or updated without the skills their output depends on, and nothing in the framework enforces otherwise. Output quality is left to whichever agent session or model happens to create the job — when it forgets a presentation skill, the job still ships, just as an unstructured dump missing `[SILENT]` rules, char limits, or language enforcement. The issue documents 9 of ~46 live jobs with exactly this failure after a full audit.

This PR adds a config-enforced gate: `cron.required_skills`. Jobs created or updated without every entry are rejected at create/update time, on both the agent's `cronjob` tool and the `hermes cron create` / `hermes cron edit` CLI — both paths already funnel through `cronjob()` in `tools/cronjob_tools.py`, so the check lives next to the existing `_scan_cron_prompt` create/update interception, exactly where the prompt-injection gate already runs.

## Changes

- `hermes_cli/config_defaults.py`: new `cron.required_skills` (empty list default = no enforcement), `cron.required_skills_agent_only` (default true), `cron.required_skills_enforce` (default true).
- `hermes_cli/config.py`: `cron_required_skills()` / `cron_required_skills_enforce()` / `cron_required_skills_agent_only()` accessors following the `cron_model_drift_guard_enabled` pattern — only the literal YAML `false` disables a guard; malformed values stay fail-closed.
- `tools/cronjob_tools.py`: `_required_skills_violation()` gate called at create and at update when the update changes the skills axis or toggles `no_agent`. The update check runs against the effective post-update state (stored skills merged with the update's changes), so `--clear-skills` that strips a required skill is rejected, while a name/schedule-only edit on a legacy noncompliant job still goes through and can be remediated field-by-field.
- `hermes_cli/cron.py` + `hermes_cli/subcommands/cron.py`: `--force` on `hermes cron create/edit` as a per-command escape hatch. It is deliberately not wired into the tool's registry schema, so the agent cannot bypass its own gate — same pattern as `model`/`provider` being user-owned.
- `website/docs/user-guide/features/cron.md`: new section documenting the three keys, the update semantics, and `--force`.
- `tests/tools/test_cron_required_skills.py`: behavior tests through the unified tool surface (create reject/allow, no_agent exemption, agent_only=false, clear-skills reject, legacy-job remediation, enforce=false warning mode, force bypass) plus accessor unit tests.

## Behavior notes

- `no_agent` jobs are exempt by default — a script owns their stdout, not a skill. `cron.required_skills_agent_only: false` extends the check to them.
- `cron.required_skills_enforce: false` downgrades the hard reject to a warning log.
- Scope: the dashboard API path (`hermes_cli/web_server.py` `_create_cron_job_sync` / `_update_cron_job_sync`) writes through `cron.jobs.*` directly and does not pass through `cronjob()`, so it is not covered by this first pass. Flagged in a code comment; a follow-up can move or mirror the gate at the `cron.jobs` layer if dashboard coverage is wanted.

## Validation

- `pytest tests/tools/test_cron_required_skills.py tests/tools/test_cronjob_tools.py` — 84 passed
- `pytest tests/cron/ tests/tools/test_cron_prompt_injection.py tests/tools/test_cronjob_run_immediate.py` — 426 passed (1 pre-existing env failure: `test_desktop_ticker_calls_tick_then_stops` exits because fastapi is not installed in this venv; unrelated to this diff)
- CLI parser smoke: `--force` accepted on create and edit; defaults load as `required_skills=[]`, `enforce=True`, `agent_only=True`

Closes #79797
