### PR TITLE
fix(teams): lazy-install SDK when gateway starts Teams

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -642,11 +642,11 @@ async def _standalone_send(
 
 
 # Keep the old name as an alias so existing test imports don't break.
-# NOTE: ``check_requirements`` is the PASSIVE probe (used as the registry
-# ``check_fn`` and by ``gateway status``) — it must never trigger a pip
-# install. ``check_teams_requirements`` is the ACTIVE lazy-installer called
-# from ``connect()``; it installs ``platform.teams`` on demand and rebinds the
-# SDK globals, mirroring ``check_slack_requirements`` in gateway/platforms/slack.py.
+# NOTE: ``check_requirements`` is the PASSIVE probe (status / unit tests) —
+# it must never trigger a pip install. ``check_teams_requirements`` is the
+# ACTIVE lazy-installer and is the registry ``check_fn`` — same contract as
+# Discord/Slack/Telegram. ``create_adapter()`` gates on ``check_fn`` before
+# the adapter exists, so install MUST run there; ``connect()`` re-checks.
 @contextmanager
 def _suppress_third_party_dotenv() -> Iterator[None]:
     """No-op ``dotenv.load_dotenv`` while importing the Teams SDK (#62935).
@@ -1467,11 +1467,17 @@ def register(ctx) -> None:
         name="teams",
         label="Microsoft Teams",
         adapter_factory=lambda cfg: TeamsAdapter(cfg),
-        check_fn=check_requirements,
+        # Active lazy-installer — NOT the passive ``check_requirements``.
+        # Registry create_adapter() returns None when check_fn is False, so a
+        # passive probe permanently blocks connect() and the deps never install.
+        check_fn=check_teams_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
-        install_hint="pip install microsoft-teams-apps aiohttp",
+        install_hint=(
+            "Teams SDK missing — restart the gateway to auto-install, or run: "
+            "~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'"
+        ),
         setup_fn=interactive_setup,
         # Env-driven auto-configuration — seeds PlatformConfig.extra with
         # client_id/secret/tenant + port + home_channel so env-only setups

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -299,6 +299,15 @@ class TestTeamsPluginRegistration:
         kwargs = ctx.register_platform.call_args[1]
         assert kwargs["name"] == "teams"
 
+    def test_register_check_fn_is_active_lazy_installer(self):
+        # create_adapter() gates on check_fn before connect() exists.
+        # Passive check_requirements would permanently block lazy install.
+        ctx = MagicMock()
+        register(ctx)
+        kwargs = ctx.register_platform.call_args[1]
+        assert kwargs["check_fn"] is check_teams_requirements
+        assert kwargs["check_fn"] is not check_requirements
+
     def test_register_auth_env_vars(self):
         ctx = MagicMock()
         register(ctx)

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -104,15 +104,35 @@ TEAMS_ALLOWED_USERS=<your-aad-object-id>
 
 ## Step 5: Start the Gateway
 
+**Docker** (must run from the directory that contains `docker-compose.yml` — usually your cloned `hermes-agent` repo, not `~`):
+
 ```bash
+cd /path/to/hermes-agent
 HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d gateway
 ```
 
-This starts the gateway. The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
+**Native / systemd install** (typical `hermes` one-liner installer under `~/.hermes/hermes-agent`):
+
+```bash
+hermes gateway restart
+# or foreground: hermes gateway run
+```
+
+The Teams SDK is optional; when Teams is enabled, the gateway lazy-installs it into Hermes' own venv on first start (do **not** use system `pip install` on Ubuntu 24.04 — that hits PEP 668 `externally-managed-environment`). To install manually into the Hermes venv:
+
+```bash
+~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'
+# or from a clone of the agent: uv sync --extra teams
+```
+
+The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
 
 ```bash
 curl http://localhost:3978/health   # should return: ok
+# Docker:
 docker logs -f hermes
+# Native:
+hermes gateway status -l
 ```
 
 Look for:
@@ -234,13 +254,15 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 
 | Problem | Solution |
 |---------|----------|
+| `Can't find a suitable configuration file` from `docker compose` | You are not in the repo that has `docker-compose.yml`, or you are on a native install — use `hermes gateway restart` instead, or `cd` into the clone first |
+| `requirements not met (pip install microsoft-teams-apps …)` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |
 | Bot receives messages but ignores them | Your AAD object ID may not be in `TEAMS_ALLOWED_USERS`. Run `teams status --verbose` to find it |
 | Tunnel URL changes on restart | devtunnel URLs are persistent if you use a named tunnel (`devtunnel create hermes-bot`). ngrok and cloudflared generate a new URL each run unless you have a paid plan — update the bot endpoint with `teams app update` when it changes |
-| Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` for tracebacks |
+| Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` / `hermes gateway status -l` for tracebacks |
 | `[teams] Failed to connect` in logs | The SDK failed to authenticate. Double-check your credentials and that the tenant ID matches the account you used in `teams login` |
 
 ---


### PR DESCRIPTION
## Summary
- Teams used a passive dependency probe as the registry `check_fn`, so `create_adapter()` returned `None` before `connect()` and the existing lazy-install path never ran.
- Wire registry `check_fn` to `check_teams_requirements` (same contract as Discord/Slack/Telegram) so enabled Teams installs its SDK into the Hermes venv on gateway start.
- Docs: Step 5 covers native/systemd (`hermes gateway restart`) vs Docker compose cwd, plus Hermes-venv install (avoids Ubuntu PEP 668 system `pip`).

## Test plan
- [x] `scripts/run_tests.sh tests/gateway/test_teams.py -q`
- [ ] Clean install without Teams SDK: enable Teams, `hermes gateway restart`,firm adapter starts
- [ ] Teams disabled / no credentials: no eager Teams SDK install on `load_gateway_config`