### PR TITLE
fix(backup): default output under HERMES_HOME per AGENTS.md §State files

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -611,7 +611,9 @@ def _run_backup_locked(args, hermes_root: Path) -> None:
             out_path = out_path / f"hermes-backup-{stamp}.zip"
     else:
         stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-        out_path = Path.home() / f"hermes-backup-{stamp}.zip"
+        # Per AGENTS.md §State files: persistent state under HERMES_HOME,
+        # not Path.home(). Multi-profile safe (each profile gets its own dir).
+        out_path = get_hermes_home() / "backups" / f"hermes-backup-{stamp}.zip"
 
     # Ensure the suffix is .zip
     if out_path.suffix.lower() != ".zip":


### PR DESCRIPTION
## Problem

The default `hermes backup` output path used `Path.home()`, which violates [AGENTS.md §State files](https://github.com/NousResearch/hermes-agent/blob/main/AGENTS.md):

> If a tool stores persistent state (caches, logs, checkpoints), use `get_hermes_home()` for the base directory — **never `Path.home() / ".hermes"`**. This ensures each profile gets its own state.

The current behavior also:

1. **Pollutes `$HOME`** with multi-GB files named `hermes-backup-<timestamp>.zip` (visible to Finder/Spotlight).
2. **Is not multi-profile safe** — every profile writes to the same `~/` and overwrites each other.
3. **Contradicts the official Configuration docs** which state that `pre_update_backup: full` should zip into `backups/` (under HERMES_HOME), not `~/`.

## Fix

Route the default through `get_hermes_home() / "backups"`, matching the official spec:

- **AGENTS.md §State files**: persistent state under `HERMES_HOME`
- **Configuration docs**: "full additionally zips all of `HERMES_HOME` into `backups/`"
- **Profiles docs**: "each profile gets its own ... state database"

The `--output` flag still overrides the default, preserving the existing CLI surface.

## Diff

```diff
     else:
         stamp = datetime.now().strftime("%Y-%m-%d-%H%M%S")
-        out_path = Path.home() / f"hermes-backup-{stamp}.zip"
+        # Per AGENTS.md §State files: persistent state under HERMES_HOME,
+        # not Path.home(). Multi-profile safe (each profile gets its own dir).
+        out_path = get_hermes_home() / "backups" / f"hermes-backup-{stamp}.zip"
```

## Verification

- `python -c "import hermes_cli.backup; print('import OK')"` — lint pass
- Manual path calculation with mocked `args` — confirmed output resolves to `<HERMES_HOME>/backups/hermes-backup-<ts>.zip`
- `--output` override path still works (existing CLI surface preserved)
- `get_hermes_home()` is already imported at the top of `backup.py` (line 26) — no new imports needed
