### PR TITLE
fix(auth): keep Codex refreshes in owning store

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1197,16 +1197,22 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
     try:
         refreshed = refresh_anthropic_oauth_pure(refresh_token, use_json=False)
-        _write_claude_code_credentials(
+        write_result = _write_claude_code_credentials(
             refreshed["access_token"],
             refreshed["refresh_token"],
             refreshed["expires_at_ms"],
         )
+        if write_result is False:
+            return None
         logger.debug("Successfully refreshed Claude Code OAuth token")
         return refreshed["access_token"]
     except Exception as e:
         logger.debug("Failed to refresh Claude Code token: %s", e)
         return None
+
+
+def _claude_code_credentials_path() -> Path:
+    return Path.home() / ".claude" / ".credentials.json"
 
 
 def _write_claude_code_credentials(
@@ -1215,7 +1221,7 @@ def _write_claude_code_credentials(
     expires_at_ms: int,
     *,
     scopes: Optional[list] = None,
-) -> None:
+) -> bool:
     """Write refreshed credentials back to ~/.claude/.credentials.json.
 
     The optional *scopes* list (e.g. ``["user:inference", "user:profile", ...]``)
@@ -1223,7 +1229,7 @@ def _write_claude_code_credentials(
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
-    cred_path = Path.home() / ".claude" / ".credentials.json"
+    cred_path = _claude_code_credentials_path()
     try:
         # Read existing file to preserve other fields
         existing = {}
@@ -1273,8 +1279,10 @@ def _write_claude_code_credentials(
             except OSError:
                 pass
             raise
+        return True
     except (OSError, IOError) as e:
         logger.debug("Failed to write refreshed credentials: %s", e)
+        return False
 
 
 def _resolve_claude_code_token_from_credentials(creds: Optional[Dict[str, Any]] = None) -> Optional[str]:

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -18,6 +18,7 @@ import platform
 import secrets
 import stat
 import subprocess
+from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -1170,42 +1171,44 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     has already produced a valid token, adopt it and skip the POST entirely.
     Only fall back to refreshing ourselves when no fresh credential is found.
     """
-    # Claude Code may have already refreshed — adopt its token rather than
-    # racing it with our (possibly already-rotated) refresh token. Only adopt
-    # when the live re-read produced a DIFFERENT token with a real future
-    # expiry: re-adopting the same credential we were just handed would be a
-    # no-op, and a 0/absent ``expiresAt`` means "managed key / unknown expiry"
-    # (see is_claude_code_token_valid) which must NOT be treated as a fresh
-    # refresh here.
-    current = read_claude_code_credentials()
-    if current:
-        current_token = current.get("accessToken", "")
-        current_exp = current.get("expiresAt", 0) or 0
-        if (
-            current_token
-            and current_token != creds.get("accessToken", "")
-            and current_exp > 0
-            and is_claude_code_token_valid(current)
-        ):
-            logger.debug("Adopted Claude Code's already-refreshed OAuth token")
-            return current_token
-
-    refresh_token = (current or {}).get("refreshToken", "") or creds.get("refreshToken", "")
-    if not refresh_token:
-        logger.debug("No refresh token available — cannot refresh")
-        return None
-
     try:
-        refreshed = refresh_anthropic_oauth_pure(refresh_token, use_json=False)
-        write_result = _write_claude_code_credentials(
-            refreshed["access_token"],
-            refreshed["refresh_token"],
-            refreshed["expires_at_ms"],
-        )
-        if write_result is False:
-            return None
-        logger.debug("Successfully refreshed Claude Code OAuth token")
-        return refreshed["access_token"]
+        with claude_code_credentials_transaction() as (_source_path, current):
+            authoritative = current or creds
+            current_token = authoritative.get("accessToken", "")
+            current_exp = authoritative.get("expiresAt", 0) or 0
+            if (
+                current is not None
+                and current_token
+                and current_token != creds.get("accessToken", "")
+                and current_exp > 0
+                and is_claude_code_token_valid(authoritative)
+            ):
+                logger.debug("Adopted Claude Code's already-refreshed OAuth token")
+                return current_token
+
+            refresh_token = authoritative.get("refreshToken", "")
+            if not refresh_token:
+                logger.debug("No refresh token available — cannot refresh")
+                return None
+            refreshed = refresh_anthropic_oauth_pure(
+                refresh_token,
+                use_json=False,
+            )
+            try:
+                _write_claude_code_credentials_locked(
+                    refreshed["access_token"],
+                    refreshed["refresh_token"],
+                    refreshed["expires_at_ms"],
+                    expected_refresh_token=refresh_token,
+                    allow_missing=current is None,
+                )
+            except _claude_lineage_changed_type():
+                winner = _read_claude_code_credentials_from_file()
+                if winner and is_claude_code_token_valid(winner):
+                    return str(winner.get("accessToken", "") or "") or None
+                return None
+            logger.debug("Successfully refreshed Claude Code OAuth token")
+            return refreshed["access_token"]
     except Exception as e:
         logger.debug("Failed to refresh Claude Code token: %s", e)
         return None
@@ -1213,6 +1216,137 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
 
 def _claude_code_credentials_path() -> Path:
     return Path.home() / ".claude" / ".credentials.json"
+
+
+def _claude_lineage_changed_type():
+    from hermes_cli.auth import SourceCredentialLineageChanged
+
+    return SourceCredentialLineageChanged
+
+
+@contextmanager
+def claude_code_credentials_transaction(timeout_seconds: float = 30.0):
+    """Lock and read the exact Claude Code credentials-file source."""
+    from hermes_cli.auth import _auth_store_lock
+
+    source_path = _claude_code_credentials_path()
+    with _auth_store_lock(
+        timeout_seconds=timeout_seconds,
+        target_path=source_path,
+    ):
+        yield source_path, _read_claude_code_credentials_from_file()
+
+
+_EXPECTED_CLAUDE_REFRESH_UNSET = object()
+
+
+def _write_claude_code_credentials_file(
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+    *,
+    scopes: Optional[list] = None,
+    expected_refresh_token: Any = _EXPECTED_CLAUDE_REFRESH_UNSET,
+    allow_missing: bool = False,
+) -> None:
+    """Write the credentials file without acquiring or swallowing errors."""
+    cred_path = _claude_code_credentials_path()
+    existing = {}
+    if cred_path.exists():
+        existing = json.loads(cred_path.read_text(encoding="utf-8"))
+    raw_current = existing.get("claudeAiOauth")
+    current = raw_current if isinstance(raw_current, dict) else None
+    if expected_refresh_token is not _EXPECTED_CLAUDE_REFRESH_UNSET:
+        current_refresh = str((current or {}).get("refreshToken", "") or "")
+        if current_refresh != expected_refresh_token and not (
+            allow_missing and current is None
+        ):
+            from hermes_cli.auth import SourceCredentialLineageChanged
+
+            raise SourceCredentialLineageChanged("anthropic")
+
+    oauth_data: Dict[str, Any] = {
+        "accessToken": access_token,
+        "refreshToken": refresh_token,
+        "expiresAt": expires_at_ms,
+    }
+    if scopes is not None:
+        oauth_data["scopes"] = scopes
+    elif "claudeAiOauth" in existing and "scopes" in existing["claudeAiOauth"]:
+        oauth_data["scopes"] = existing["claudeAiOauth"]["scopes"]
+
+    existing["claudeAiOauth"] = oauth_data
+    cred_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_cred = cred_path.with_suffix(
+        f".tmp.{os.getpid()}.{secrets.token_hex(4)}"
+    )
+    try:
+        fd = os.open(
+            str(tmp_cred),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(existing, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(tmp_cred, cred_path)
+    except OSError:
+        try:
+            tmp_cred.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def _write_claude_code_credentials_locked(
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+    *,
+    expected_refresh_token: str,
+    allow_missing: bool = False,
+    scopes: Optional[list] = None,
+) -> None:
+    """Conditionally write while ``claude_code_credentials_transaction`` is held."""
+    from hermes_cli.auth import (
+        SourceCredentialLineageChanged,
+        SourceCredentialPersistenceError,
+    )
+
+    current = _read_claude_code_credentials_from_file()
+    if current is None:
+        if not allow_missing:
+            raise SourceCredentialLineageChanged("anthropic")
+    elif current.get("refreshToken", "") != expected_refresh_token:
+        raise SourceCredentialLineageChanged("anthropic")
+    try:
+        _write_claude_code_credentials_file(
+            access_token,
+            refresh_token,
+            expires_at_ms,
+            scopes=scopes,
+            expected_refresh_token=expected_refresh_token,
+            allow_missing=allow_missing,
+        )
+    except OSError as exc:
+        raise SourceCredentialPersistenceError(
+            "anthropic",
+            source_path=_claude_code_credentials_path(),
+            consumed_refresh_token=expected_refresh_token,
+        ) from exc
+
+    persisted = _read_claude_code_credentials_from_file()
+    if (
+        persisted is None
+        or persisted.get("accessToken", "") != access_token
+        or persisted.get("refreshToken", "") != refresh_token
+    ):
+        raise SourceCredentialPersistenceError(
+            "anthropic",
+            source_path=_claude_code_credentials_path(),
+            consumed_refresh_token=expected_refresh_token,
+        )
 
 
 def _write_claude_code_credentials(
@@ -1229,56 +1363,13 @@ def _write_claude_code_credentials(
     as valid.  Claude Code >=2.1.81 gates on the presence of ``"user:inference"``
     in the stored scopes before it will use the token.
     """
-    cred_path = _claude_code_credentials_path()
     try:
-        # Read existing file to preserve other fields
-        existing = {}
-        if cred_path.exists():
-            existing = json.loads(cred_path.read_text(encoding="utf-8"))
-
-        oauth_data: Dict[str, Any] = {
-            "accessToken": access_token,
-            "refreshToken": refresh_token,
-            "expiresAt": expires_at_ms,
-        }
-        if scopes is not None:
-            oauth_data["scopes"] = scopes
-        elif "claudeAiOauth" in existing and "scopes" in existing["claudeAiOauth"]:
-            # Preserve previously-stored scopes when the refresh response
-            # does not include a scope field.
-            oauth_data["scopes"] = existing["claudeAiOauth"]["scopes"]
-
-        existing["claudeAiOauth"] = oauth_data
-
-        cred_path.parent.mkdir(parents=True, exist_ok=True)
-        # Per-process random suffix avoids collisions between concurrent
-        # writers and stale leftovers from a prior crashed write.
-        _tmp_cred = cred_path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
-        try:
-            # Create the temp file atomically at 0o600. The previous
-            # write_text + post-replace chmod opened a TOCTOU window where
-            # both the temp file and the destination briefly inherited the
-            # process umask (commonly 0o644 = world-readable), exposing
-            # Claude Code OAuth tokens to other local users between create
-            # and chmod. Mirrors agent/google_oauth.py (#19673) and
-            # tools/mcp_oauth.py (#21148). Parent dir (~/.claude/) is
-            # owned by Claude Code itself, so we leave its mode alone.
-            fd = os.open(
-                str(_tmp_cred),
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                stat.S_IRUSR | stat.S_IWUSR,
-            )
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump(existing, fh, indent=2)
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(_tmp_cred, cred_path)
-        except OSError:
-            try:
-                _tmp_cred.unlink(missing_ok=True)
-            except OSError:
-                pass
-            raise
+        _write_claude_code_credentials_file(
+            access_token,
+            refresh_token,
+            expires_at_ms,
+            scopes=scopes,
+        )
         return True
     except (OSError, IOError) as e:
         logger.debug("Failed to write refreshed credentials: %s", e)

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -11,6 +11,7 @@ Auth supports:
 """
 
 import copy
+import hashlib
 import json
 import logging
 import os
@@ -1172,43 +1173,10 @@ def _refresh_oauth_token(creds: Dict[str, Any]) -> Optional[str]:
     Only fall back to refreshing ourselves when no fresh credential is found.
     """
     try:
-        with claude_code_credentials_transaction() as (_source_path, current):
-            authoritative = current or creds
-            current_token = authoritative.get("accessToken", "")
-            current_exp = authoritative.get("expiresAt", 0) or 0
-            if (
-                current is not None
-                and current_token
-                and current_token != creds.get("accessToken", "")
-                and current_exp > 0
-                and is_claude_code_token_valid(authoritative)
-            ):
-                logger.debug("Adopted Claude Code's already-refreshed OAuth token")
-                return current_token
-
-            refresh_token = authoritative.get("refreshToken", "")
-            if not refresh_token:
-                logger.debug("No refresh token available — cannot refresh")
-                return None
-            refreshed = refresh_anthropic_oauth_pure(
-                refresh_token,
-                use_json=False,
-            )
-            try:
-                _write_claude_code_credentials_locked(
-                    refreshed["access_token"],
-                    refreshed["refresh_token"],
-                    refreshed["expires_at_ms"],
-                    expected_refresh_token=refresh_token,
-                    allow_missing=current is None,
-                )
-            except _claude_lineage_changed_type():
-                winner = _read_claude_code_credentials_from_file()
-                if winner and is_claude_code_token_valid(winner):
-                    return str(winner.get("accessToken", "") or "") or None
-                return None
-            logger.debug("Successfully refreshed Claude Code OAuth token")
-            return refreshed["access_token"]
+        refreshed = _refresh_claude_code_source_credentials(creds)
+        if refreshed:
+            return str(refreshed.get("accessToken", "") or "") or None
+        return None
     except Exception as e:
         logger.debug("Failed to refresh Claude Code token: %s", e)
         return None
@@ -1235,6 +1203,317 @@ def claude_code_credentials_transaction(timeout_seconds: float = 30.0):
         target_path=source_path,
     ):
         yield source_path, _read_claude_code_credentials_from_file()
+
+
+_CLAUDE_RESERVATION_KEY = "_oauth_refresh_reservation"
+_claude_reservation_commit_hook = None
+
+
+def _claude_source_generation(path: Path) -> tuple[int, int, int, int]:
+    source_stat = path.stat()
+    return (
+        source_stat.st_dev,
+        source_stat.st_ino,
+        source_stat.st_size,
+        source_stat.st_mtime_ns,
+    )
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        dir_fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _restore_claude_source_claim(claim_path: Path, source_path: Path) -> None:
+    """Restore a claimed external winner without overwriting a newer writer."""
+    try:
+        os.link(claim_path, source_path)
+    except FileExistsError:
+        pass
+    except OSError:
+        try:
+            fd = os.open(
+                str(source_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+        except FileExistsError:
+            pass
+        else:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(claim_path.read_bytes())
+                handle.flush()
+                os.fsync(handle.fileno())
+    finally:
+        try:
+            claim_path.unlink()
+        except FileNotFoundError:
+            pass
+    _fsync_directory(source_path.parent)
+
+
+def _install_claude_payload_if_absent(
+    temp_path: Path,
+    source_path: Path,
+    payload: bytes,
+) -> None:
+    """Install a prepared payload without replacing a non-cooperating writer."""
+    try:
+        os.link(temp_path, source_path)
+        return
+    except FileExistsError as exc:
+        raise _claude_lineage_changed_type()("anthropic") from exc
+    except OSError:
+        # Some filesystems do not permit hard links. O_EXCL retains the same
+        # no-overwrite ownership property; a partial crash state is malformed
+        # and therefore fail-closed to the existing loader.
+        try:
+            fd = os.open(
+                str(source_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+        except FileExistsError as exc:
+            raise _claude_lineage_changed_type()("anthropic") from exc
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+        except Exception:
+            try:
+                source_path.unlink()
+            except FileNotFoundError:
+                pass
+            raise
+
+
+def _conditional_claude_source_replace(
+    source_path: Path,
+    payload: Dict[str, Any],
+    *,
+    expected_bytes: bytes,
+    expected_generation: tuple[int, int, int, int],
+    run_commit_hook: bool = False,
+) -> None:
+    """Replace one exact source generation without overwriting another writer."""
+    encoded = json.dumps(payload, indent=2).encode("utf-8") + b"\n"
+    source_path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = source_path.with_suffix(f".tmp.{secrets.token_hex(8)}")
+    claim_path = source_path.with_suffix(f".claim.{secrets.token_hex(8)}")
+    fd = os.open(
+        str(temp_path),
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+
+        if run_commit_hook and _claude_reservation_commit_hook is not None:
+            _claude_reservation_commit_hook()
+
+        try:
+            os.replace(source_path, claim_path)
+        except FileNotFoundError as exc:
+            raise _claude_lineage_changed_type()("anthropic") from exc
+
+        try:
+            claimed_bytes = claim_path.read_bytes()
+            claimed_generation = _claude_source_generation(claim_path)
+            if (
+                claimed_bytes != expected_bytes
+                or claimed_generation != expected_generation
+            ):
+                _restore_claude_source_claim(claim_path, source_path)
+                raise _claude_lineage_changed_type()("anthropic")
+
+            try:
+                _install_claude_payload_if_absent(
+                    temp_path,
+                    source_path,
+                    encoded,
+                )
+            except Exception:
+                _restore_claude_source_claim(claim_path, source_path)
+                raise
+            claim_path.unlink()
+            _fsync_directory(source_path.parent)
+        except Exception:
+            if claim_path.exists():
+                _restore_claude_source_claim(claim_path, source_path)
+            raise
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _reserve_claude_code_credentials_locked(
+    source_path: Path,
+    expected_refresh_token: str,
+):
+    from hermes_cli import auth as auth_mod
+
+    raw = source_path.read_bytes()
+    generation = _claude_source_generation(source_path)
+    payload = json.loads(raw)
+    oauth = payload.get("claudeAiOauth")
+    if not isinstance(oauth, dict):
+        raise auth_mod.SourceCredentialLineageChanged("anthropic")
+    current_refresh = str(oauth.get("refreshToken", "") or "")
+    if (
+        auth_mod._refresh_lineage_fingerprint(current_refresh)
+        != auth_mod._refresh_lineage_fingerprint(expected_refresh_token)
+    ):
+        raise auth_mod.SourceCredentialLineageChanged("anthropic")
+
+    reservation = auth_mod.SourceRefreshReservation(
+        provider="anthropic",
+        source_path=source_path,
+        owner_fingerprint=auth_mod._source_owner_fingerprint(
+            "anthropic",
+            source_path,
+        ),
+        nonce=secrets.token_hex(16),
+        refresh_fingerprint=(
+            auth_mod._refresh_lineage_fingerprint(expected_refresh_token) or ""
+        ),
+    )
+    reserved_oauth: Dict[str, Any] = {
+        _CLAUDE_RESERVATION_KEY: reservation.metadata(),
+    }
+    if "scopes" in oauth:
+        reserved_oauth["scopes"] = copy.deepcopy(oauth["scopes"])
+    reserved_payload = copy.deepcopy(payload)
+    reserved_payload["claudeAiOauth"] = reserved_oauth
+    _conditional_claude_source_replace(
+        source_path,
+        reserved_payload,
+        expected_bytes=raw,
+        expected_generation=generation,
+    )
+    return reservation
+
+
+def _finalize_claude_code_reservation_locked(
+    reservation,
+    refreshed: Dict[str, Any],
+) -> Dict[str, Any]:
+    from hermes_cli import auth as auth_mod
+
+    source_path = Path(reservation.source_path)
+    raw = source_path.read_bytes()
+    generation = _claude_source_generation(source_path)
+    payload = json.loads(raw)
+    oauth = payload.get("claudeAiOauth")
+    metadata = oauth.get(_CLAUDE_RESERVATION_KEY) if isinstance(oauth, dict) else None
+    if not isinstance(metadata, dict) or metadata != reservation.metadata():
+        raise auth_mod.SourceCredentialLineageChanged("anthropic")
+
+    finalized_oauth: Dict[str, Any] = {
+        "accessToken": refreshed["access_token"],
+        "refreshToken": refreshed["refresh_token"],
+        "expiresAt": refreshed["expires_at_ms"],
+    }
+    if "scopes" in oauth:
+        finalized_oauth["scopes"] = copy.deepcopy(oauth["scopes"])
+    finalized_payload = copy.deepcopy(payload)
+    finalized_payload["claudeAiOauth"] = finalized_oauth
+    _conditional_claude_source_replace(
+        source_path,
+        finalized_payload,
+        expected_bytes=raw,
+        expected_generation=generation,
+        run_commit_hook=True,
+    )
+    winner = _read_claude_code_credentials_from_file()
+    if (
+        not winner
+        or auth_mod._refresh_lineage_fingerprint(winner.get("refreshToken"))
+        != auth_mod._refresh_lineage_fingerprint(refreshed["refresh_token"])
+    ):
+        raise auth_mod.SourceCredentialLineageChanged("anthropic")
+    return winner
+
+
+def _refresh_claude_code_source_credentials(
+    observed: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Refresh one concrete writable Claude source through a reservation."""
+    from hermes_cli import auth as auth_mod
+
+    observed_source = str(
+        observed.get("source") or "claude_code_credentials_file"
+    )
+    if observed_source != "claude_code_credentials_file":
+        logger.debug("Selected Claude credential owner is not writable by Hermes")
+        return None
+    observed_refresh = str(observed.get("refreshToken", "") or "")
+    if not observed_refresh:
+        return None
+
+    source_path = _claude_code_credentials_path()
+    with auth_mod._auth_store_lock(target_path=source_path):
+        authoritative = read_claude_code_credentials()
+        if not authoritative:
+            return None
+        authoritative_source = str(authoritative.get("source") or "")
+        authoritative_refresh = str(
+            authoritative.get("refreshToken", "") or ""
+        )
+        if authoritative_source != "claude_code_credentials_file":
+            if (
+                auth_mod._refresh_lineage_fingerprint(authoritative_refresh)
+                != auth_mod._refresh_lineage_fingerprint(observed_refresh)
+                and is_claude_code_token_valid(authoritative)
+            ):
+                return authoritative
+            return None
+        if (
+            auth_mod._refresh_lineage_fingerprint(authoritative_refresh)
+            != auth_mod._refresh_lineage_fingerprint(observed_refresh)
+        ):
+            if is_claude_code_token_valid(authoritative):
+                return authoritative
+
+        reservation = _reserve_claude_code_credentials_locked(
+            source_path,
+            authoritative_refresh,
+        )
+        try:
+            refreshed = refresh_anthropic_oauth_pure(
+                authoritative_refresh,
+                use_json=False,
+            )
+        except Exception:
+            # The reservation is already the durable fail-closed state.
+            raise
+        try:
+            return _finalize_claude_code_reservation_locked(
+                reservation,
+                refreshed,
+            )
+        except auth_mod.SourceCredentialLineageChanged:
+            winner = read_claude_code_credentials()
+            if winner and is_claude_code_token_valid(winner):
+                return winner
+            return None
+        except OSError as exc:
+            raise auth_mod.SourceCredentialPersistenceError(
+                "anthropic",
+                source_path=source_path,
+                consumed_refresh_token=authoritative_refresh,
+            ) from exc
 
 
 _EXPECTED_CLAUDE_REFRESH_UNSET = object()

--- a/agent/credential_persistence.py
+++ b/agent/credential_persistence.py
@@ -130,8 +130,25 @@ def _fingerprint_value(value: Any) -> str | None:
     return f"sha256:{digest[:16]}"
 
 
-def _credential_secret_fingerprint(payload: Mapping[str, Any]) -> str | None:
-    for key in ("agent_key", "access_token", "refresh_token", "api_key", "token", "secret"):
+def _credential_secret_fingerprint(
+    payload: Mapping[str, Any],
+    provider_id: Any = None,
+) -> str | None:
+    if provider_id == "anthropic" and payload.get("source") == "claude_code":
+        # Access tokens can be reissued while the same single-use refresh
+        # token remains the owning lineage. DEAD inheritance clears only when
+        # that refresh lineage changes.
+        keys = ("refresh_token",)
+    else:
+        keys = (
+            "agent_key",
+            "access_token",
+            "refresh_token",
+            "api_key",
+            "token",
+            "secret",
+        )
+    for key in keys:
         fingerprint = _fingerprint_value(payload.get(key))
         if fingerprint:
             return fingerprint
@@ -163,7 +180,7 @@ def sanitize_borrowed_credential_payload(
     if not is_borrowed_credential_source(result.get("source"), provider_id):
         return result
 
-    fingerprint = _credential_secret_fingerprint(result)
+    fingerprint = _credential_secret_fingerprint(result, provider_id)
     sanitized = {
         key: value
         for key, value in result.items()

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -598,10 +598,10 @@ DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL = 1
 
 def _write_through_provider_state_to_global_root(
     provider_id: str, state: Dict[str, Any]
-) -> None:
+) -> bool:
     """Persist a rotated OAuth ``state`` into the global-root auth.json.
 
-    Best-effort write-through for the multi-profile rotation hazard
+    Observable write-through for the multi-profile rotation hazard
     (#48415 / #43589): nous, openai-codex, and xai-oauth rotate the
     refresh_token on refresh, so when a profile pool refresh rotates a grant
     it resolved from the root fallback, the rotated chain must land back in
@@ -619,10 +619,10 @@ def _write_through_provider_state_to_global_root(
     try:
         global_path = auth_mod._global_auth_file_path()
     except Exception:
-        return
+        return False
     if global_path is None:
         # Classic mode (profile == root); the profile save already hit root.
-        return
+        return True
     # Seat belt: under pytest, refuse to write the real user's
     # ~/.hermes/auth.json even when HERMES_HOME points at a profile path
     # (mirrors the read-side guard in _load_global_auth_store). Uses the
@@ -633,9 +633,9 @@ def _write_through_provider_state_to_global_root(
             real_root = Path(real_home_env) / ".hermes" / "auth.json"
             try:
                 if global_path.resolve(strict=False) == real_root.resolve(strict=False):
-                    return
+                    return False
             except Exception:
-                return
+                return False
     try:
         auth_mod._persist_provider_state_to_store(
             provider_id,
@@ -643,12 +643,14 @@ def _write_through_provider_state_to_global_root(
             global_path,
             set_active=False,
         )
-    except Exception as exc:  # pragma: no cover - best effort
+        return True
+    except Exception as exc:  # pragma: no cover - defensive I/O boundary
         logger.debug(
             "%s pool refresh: write-through to global root failed: %s",
             provider_id,
             exc,
         )
+        return False
 
 
 class CredentialPool:
@@ -667,7 +669,7 @@ class CredentialPool:
         # provider/file I/O, and only then take self._lock to validate or commit.
         # The reverse order is forbidden so auth-store/file waits cannot form an
         # ABBA pair with pool persistence.
-        self._external_state_lock = threading.Lock()
+        self._external_state_lock = threading.RLock()
         self._persist_lock = threading.Lock()
         # Persist only entries changed by this pool instance. Borrowed rows are
         # snapshots of another auth store; rewriting every snapshot on an
@@ -2085,7 +2087,7 @@ class CredentialPool:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
 
-    def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> None:
+    def _sync_device_code_entry_to_auth_store(self, entry: PooledCredential) -> bool:
         """Write refreshed pool entry tokens back to auth.json providers.
 
         After a pool-level refresh, the pool entry has fresh tokens but
@@ -2112,7 +2114,7 @@ class CredentialPool:
         # and must not write back to the singleton.  All singleton-seeded
         # device-code sources (nous, openai-codex, xAI) use ``device_code``.
         if entry.source != "device_code":
-            return
+            return True
         try:
             with _auth_store_lock():
                 auth_store = _load_auth_store()
@@ -2144,21 +2146,21 @@ class CredentialPool:
                         auth_store, "nous"
                     )
                     if state is None:
-                        return
+                        return False
                 elif self.provider == "openai-codex":
                     state, source_path = _load_provider_state_with_source(
                         auth_store, "openai-codex"
                     )
                     if not isinstance(state, dict):
-                        return
+                        return False
                 elif self.provider == "xai-oauth":
                     state, source_path = _load_provider_state_with_source(
                         auth_store, "xai-oauth"
                     )
                     if not isinstance(state, dict):
-                        return
+                        return False
                 else:
-                    return
+                    return False
 
                 global_root = auth_mod._global_auth_file_path()
                 is_from_root = bool(
@@ -2189,7 +2191,7 @@ class CredentialPool:
                 elif self.provider == "openai-codex":
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
-                        return
+                        return False
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
@@ -2199,7 +2201,7 @@ class CredentialPool:
                 elif self.provider == "xai-oauth":
                     tokens = state.get("tokens")
                     if not isinstance(tokens, dict):
-                        return
+                        return False
                     tokens["access_token"] = entry.access_token
                     if entry.refresh_token:
                         tokens["refresh_token"] = entry.refresh_token
@@ -2215,7 +2217,7 @@ class CredentialPool:
                     # _load_provider_state has root fallback, so the
                     # profile can always read fresh tokens from root
                     # without needing its own providers block.
-                    _write_through_provider_state_to_global_root(
+                    return _write_through_provider_state_to_global_root(
                         _wt_provider_id, state
                     )
                 else:
@@ -2225,8 +2227,10 @@ class CredentialPool:
                         auth_store, self.provider, state, set_active=False
                     )
                     _save_auth_store(auth_store)
+                    return True
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
+            return False
 
     def _refresh_entry(
         self,
@@ -2236,7 +2240,8 @@ class CredentialPool:
     ) -> Optional[PooledCredential]:
         """Serialize provider refresh and reject superseded token lineages."""
         self._assert_external_state_lock_order()
-        with self._external_state_lock:
+
+        def refresh_current() -> Optional[PooledCredential]:
             with self._lock:
                 current = next(
                     (item for item in self._entries if item.id == entry.id),
@@ -2249,35 +2254,31 @@ class CredentialPool:
                 or not self._entry_tokens_match(current, entry)
             ):
                 return current
-            entry = current
+            return self._refresh_entry_serialized(current, force=force)
 
-            # Claude Code's credentials file is a second source of truth. Read
-            # it after provider serialization and before spending a rotating
-            # refresh token so a login/status update that already won is
-            # adopted without an obsolete POST.
-            if self.provider == "anthropic" and entry.source == "claude_code":
-                synced = self._sync_anthropic_entry_from_credentials_file(
-                    entry,
-                    persist=False,
-                )
-                if not self._entry_tokens_match(synced, entry):
-                    self._persist_pending_changes()
-                    return synced
-                with self._lock:
-                    current = next(
-                        (item for item in self._entries if item.id == entry.id),
-                        None,
-                    )
-                if current is None:
-                    return None
-                if (
-                    current.source != entry.source
-                    or not self._entry_tokens_match(current, entry)
-                ):
-                    return current
-                entry = current
+        source_owned = (
+            self.provider == "anthropic" and entry.source == "claude_code"
+        ) or (
+            self.provider in {"openai-codex", "xai-oauth"}
+        ) or (
+            self.provider == "nous"
+            and entry.source == "device_code"
+        )
+        if source_owned:
+            refreshed = refresh_current()
+        else:
+            with self._external_state_lock:
+                refreshed = refresh_current()
 
-            return self._refresh_entry_serialized(entry, force=force)
+        # Source transactions release their auth/provider locks before pool
+        # persistence.  Normal persistence acquires _persist_lock first and may
+        # then acquire the auth-store lock, so draining here keeps one order.
+        self._persist_pending_changes()
+        if refreshed is None:
+            return None
+        current = self._revalidate_refreshed_entry(refreshed)
+        self._persist_pending_changes()
+        return current
 
     def _refresh_entry_serialized(
         self,
@@ -2289,6 +2290,24 @@ class CredentialPool:
             if force:
                 self._mark_exhausted(entry, None)
             return None
+
+        if self.provider == "anthropic" and entry.source == "claude_code":
+            from agent.anthropic_adapter import _claude_code_credentials_path
+
+            with _auth_store_lock(
+                target_path=_claude_code_credentials_path(),
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ):
+                synced = self._sync_anthropic_entry_from_credentials_file(
+                    entry,
+                    persist=False,
+                )
+                if not self._entry_tokens_match(synced, entry):
+                    return synced
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                return self._refresh_entry_impl(current, force=force)
 
         # Codex and xAI OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
@@ -2418,16 +2437,52 @@ class CredentialPool:
             ):
                 return self._refresh_entry_impl(entry, force=force)
         if self.provider == "xai-oauth":
-            with _auth_store_lock(
-                timeout_seconds=self._single_use_refresh_lock_timeout()
-            ):
-                synced = self._sync_xai_oauth_entry_from_pool_store(entry)
-                if (
-                    synced.access_token != entry.access_token
-                    or synced.refresh_token != entry.refresh_token
+            if entry.source != "device_code":
+                with _auth_store_lock(
+                    timeout_seconds=self._single_use_refresh_lock_timeout()
                 ):
+                    return self._refresh_entry_impl(entry, force=force)
+            auth_store = _load_auth_store()
+            _state, source_path = _load_provider_state_with_source(
+                auth_store,
+                "xai-oauth",
+            )
+            with auth_mod._provider_state_transaction(
+                "xai-oauth",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=source_path,
+            ):
+                synced = self._sync_xai_oauth_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
+                if not self._entry_tokens_match(synced, entry):
                     return synced
-                return self._refresh_entry_impl(synced, force=force)
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                return self._refresh_entry_impl(current, force=force)
+        if self.provider == "nous" and entry.source == "device_code":
+            auth_store = _load_auth_store()
+            _state, source_path = _load_provider_state_with_source(
+                auth_store,
+                "nous",
+            )
+            with auth_mod._provider_state_transaction(
+                "nous",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=source_path,
+            ):
+                synced = self._sync_nous_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
+                if not self._entry_tokens_match(synced, entry):
+                    return synced
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                return self._refresh_entry_impl(current, force=force)
         return self._refresh_entry_impl(entry, force=force)
 
     def _current_refresh_candidate(
@@ -2495,7 +2550,6 @@ class CredentialPool:
                 current.source != expected.source
                 or not self._entry_tokens_match(current, expected)
             ):
-                self._persist_pending_changes()
                 return current
             expected = current
 
@@ -2509,39 +2563,222 @@ class CredentialPool:
         if not self._entry_tokens_match(committed, refreshed):
             return committed
 
-        # Provider/source writes happen only after the current-lineage CAS.
-        # The external-state lock held by _refresh_entry prevents an in-process
-        # status sync from interleaving between this commit and write-through.
         if self.provider == "anthropic" and committed.source == "claude_code":
-            try:
-                from agent.anthropic_adapter import _write_claude_code_credentials
+            from agent.anthropic_adapter import _claude_code_credentials_path
 
-                _write_claude_code_credentials(
-                    committed.access_token or "",
-                    committed.refresh_token or "",
-                    committed.expires_at_ms or 0,
+            with _auth_store_lock(
+                target_path=_claude_code_credentials_path(),
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ):
+                return self._commit_authoritative_source(
+                    expected,
+                    committed,
                 )
-            except Exception as exc:
-                logger.debug(
-                    "Failed to write refreshed token to credentials file: %s",
-                    exc,
+
+        if self.provider in {"nous", "xai-oauth"} and committed.source == "device_code":
+            auth_store = _load_auth_store()
+            _state, source_path = _load_provider_state_with_source(
+                auth_store,
+                self.provider,
+            )
+            with auth_mod._provider_state_transaction(
+                self.provider,
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=source_path,
+            ):
+                return self._commit_authoritative_source(
+                    expected,
+                    committed,
                 )
 
         if self.provider == "openai-codex" and codex_source_path is not None:
-            if codex_singleton_owned:
-                self._persist_codex_device_code_refresh(
-                    committed,
+            with self._external_state_lock:
+                current = self._current_refresh_candidate(committed)
+                if current is None:
+                    return None
+                if codex_singleton_owned:
+                    self._persist_codex_device_code_refresh(
+                        current,
+                        codex_source_path,
+                    )
+                elif not self._persist_codex_exact_alias_refresh(
+                    current,
                     codex_source_path,
+                ):
+                    return None
+                return current
+
+        with self._external_state_lock:
+            return self._current_refresh_candidate(committed)
+
+    def _authoritative_source_entry(
+        self,
+        expected: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Read one source-owned token lineage while its source lock is held."""
+        if self.provider == "anthropic" and expected.source == "claude_code":
+            from agent.anthropic_adapter import read_claude_code_credentials
+
+            credentials = read_claude_code_credentials()
+            if not credentials or not credentials.get("accessToken"):
+                return None
+            return replace(
+                expected,
+                access_token=str(credentials.get("accessToken") or ""),
+                refresh_token=str(credentials.get("refreshToken") or ""),
+                expires_at_ms=credentials.get("expiresAt"),
+            )
+
+        if self.provider not in {"nous", "xai-oauth"} or expected.source != "device_code":
+            return expected
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, self.provider)
+        if not isinstance(state, dict):
+            return None
+        if self.provider == "xai-oauth":
+            tokens = state.get("tokens")
+            if not isinstance(tokens, dict) or not tokens.get("access_token"):
+                return None
+            return replace(
+                expected,
+                access_token=str(tokens.get("access_token") or ""),
+                refresh_token=str(tokens.get("refresh_token") or ""),
+                last_refresh=state.get("last_refresh"),
+            )
+        if not state.get("access_token"):
+            return None
+        return replace(
+            expected,
+            access_token=str(state.get("access_token") or ""),
+            refresh_token=str(state.get("refresh_token") or ""),
+            expires_at=state.get("expires_at"),
+            agent_key=state.get("agent_key"),
+            agent_key_expires_at=state.get("agent_key_expires_at"),
+            inference_base_url=state.get("inference_base_url"),
+        )
+
+    def _commit_authoritative_source(
+        self,
+        expected: PooledCredential,
+        committed: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Validate and write a source lineage under source -> transaction locks."""
+        with self._external_state_lock:
+            current = self._current_refresh_candidate(committed)
+            if current is None:
+                return None
+            authoritative = self._authoritative_source_entry(expected)
+            if authoritative is None:
+                self._replace_entry(current, expected, preserve_routing=True)
+                return None
+            if not self._entry_tokens_match(authoritative, expected):
+                return self._replace_entry(
+                    current,
+                    authoritative,
+                    preserve_routing=True,
                 )
-            else:
-                self._persist_codex_exact_alias_refresh(
-                    committed,
-                    codex_source_path,
+
+            try:
+                if self.provider == "anthropic":
+                    from agent.anthropic_adapter import _write_claude_code_credentials
+
+                    write_result = _write_claude_code_credentials(
+                        current.access_token or "",
+                        current.refresh_token or "",
+                        current.expires_at_ms or 0,
+                    )
+                else:
+                    write_result = self._sync_device_code_entry_to_auth_store(current)
+            except Exception as exc:
+                logger.debug("Failed to persist refreshed source credential: %s", exc)
+                write_result = False
+
+            if not write_result:
+                authoritative = self._authoritative_source_entry(expected) or expected
+                self._replace_entry(
+                    current,
+                    replace(
+                        authoritative,
+                        last_status=STATUS_DEAD,
+                        last_status_at=time.time(),
+                        last_error_reason="source_persistence_failed",
+                        last_error_message="Refreshed credentials were not persisted to their owning source.",
+                    ),
+                    preserve_routing=True,
                 )
-        else:
-            self._persist()
-            self._sync_device_code_entry_to_auth_store(committed)
-        return committed
+                return None
+
+            verified = self._authoritative_source_entry(current)
+            if verified is None:
+                return None
+            if not self._entry_tokens_match(verified, current):
+                return self._replace_entry(
+                    current,
+                    verified,
+                    preserve_routing=True,
+                )
+            return current
+
+    def _revalidate_refreshed_entry(
+        self,
+        refreshed: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Return only a current row that still matches its owning source."""
+
+        def revalidate_source() -> Optional[PooledCredential]:
+            with self._external_state_lock:
+                with self._lock:
+                    current = next(
+                        (item for item in self._entries if item.id == refreshed.id),
+                        None,
+                    )
+                if current is None or current.source != refreshed.source:
+                    return None
+                authoritative = self._authoritative_source_entry(current)
+                if authoritative is None:
+                    return None
+                if not self._entry_tokens_match(authoritative, current):
+                    return self._replace_entry(
+                        current,
+                        authoritative,
+                        preserve_routing=True,
+                    )
+                return current
+
+        if self.provider == "anthropic" and refreshed.source == "claude_code":
+            from agent.anthropic_adapter import _claude_code_credentials_path
+
+            with _auth_store_lock(
+                target_path=_claude_code_credentials_path(),
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ):
+                return revalidate_source()
+
+        if self.provider in {"nous", "xai-oauth"} and refreshed.source == "device_code":
+            auth_store = _load_auth_store()
+            _state, source_path = _load_provider_state_with_source(
+                auth_store,
+                self.provider,
+            )
+            with auth_mod._provider_state_transaction(
+                self.provider,
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=source_path,
+            ):
+                return revalidate_source()
+
+        with self._external_state_lock:
+            with self._lock:
+                return next(
+                    (
+                        item
+                        for item in self._entries
+                        if item.id == refreshed.id
+                        and item.source == refreshed.source
+                        and self._entry_tokens_match(item, refreshed)
+                    ),
+                    None,
+                )
 
     def _refresh_entry_impl(
         self,
@@ -2598,7 +2835,10 @@ class CredentialPool:
                 # process (or another profile sharing the singleton) would
                 # otherwise trigger ``refresh_token_reused`` on the next
                 # POST.  Only meaningful for singleton-seeded entries.
-                synced = self._sync_xai_oauth_entry_from_auth_store(entry)
+                synced = self._sync_xai_oauth_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
                 if synced is not entry:
                     entry = synced
                 current = self._current_refresh_candidate(entry)
@@ -2616,7 +2856,10 @@ class CredentialPool:
                     last_refresh=refreshed.get("last_refresh"),
                 )
             elif self.provider == "nous":
-                synced = self._sync_nous_entry_from_auth_store(entry)
+                synced = self._sync_nous_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
                 if synced is not entry:
                     entry = synced
                 current = self._current_refresh_candidate(entry)
@@ -2626,7 +2869,10 @@ class CredentialPool:
                 auth_mod.resolve_nous_runtime_credentials(
                     force_refresh=force,
                 )
-                updated = self._sync_nous_entry_from_auth_store(entry)
+                updated = self._sync_nous_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
             else:
                 return entry
         except Exception as exc:
@@ -2635,7 +2881,10 @@ class CredentialPool:
             # consumed by another process. Check if ~/.claude/.credentials.json
             # has a newer token pair and retry once.
             if self.provider == "anthropic" and entry.source == "claude_code":
-                synced = self._sync_anthropic_entry_from_credentials_file(entry)
+                synced = self._sync_anthropic_entry_from_credentials_file(
+                    entry,
+                    persist=False,
+                )
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug("Retrying refresh with synced token from credentials file")
                     try:
@@ -2667,7 +2916,10 @@ class CredentialPool:
             # (device_code) entries; manual entries don't share
             # state with the singleton.
             if self.provider == "xai-oauth":
-                synced = self._sync_xai_oauth_entry_from_auth_store(entry)
+                synced = self._sync_xai_oauth_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug(
                         "xAI OAuth refresh failed but auth.json has newer tokens — adopting"
@@ -2690,7 +2942,6 @@ class CredentialPool:
                         return None
                     if not self._entry_tokens_match(committed, updated):
                         return committed
-                    self._persist()
                     return committed
                 # Terminal error: auth.json has no newer tokens — the stored
                 # refresh_token is dead.  Clear it from auth.json so the next
@@ -2733,17 +2984,18 @@ class CredentialPool:
                     # pool lock), so take it here. self._lock is an RLock,
                     # so the still-locked callers re-enter safely.
                     with self._lock:
-                        removed_ids = [
-                            item.id for item in self._entries
+                        removed_entries = [
+                            item for item in self._entries
                             if item.source == "device_code"
                         ]
+                        for removed in removed_entries:
+                            self._queue_removed_entry_unlocked(removed)
                         self._entries = [
                             item for item in self._entries
                             if item.source != "device_code"
                         ]
                         if self._current_id == entry.id:
                             self._current_id = None
-                    self._persist(removed_ids=removed_ids)
                     return None
             # For openai-codex: same race as xAI/nous — another Hermes process
             # may have consumed the refresh token between our proactive sync
@@ -2811,8 +3063,6 @@ class CredentialPool:
                             self._persist_codex_exact_alias_refresh(
                                 committed, codex_source_path
                             )
-                    else:
-                        self._persist()
                     return committed
                 # Terminal error: auth.json has no newer tokens — the stored
                 # refresh_token is dead.  Clear it from auth.json so the next
@@ -2890,24 +3140,25 @@ class CredentialPool:
                     # pool lock), so take it here. self._lock is an RLock,
                     # so the still-locked callers re-enter safely.
                     with self._lock:
+                        removed_entries = [
+                            item for item in self._entries if item.id in removed_ids
+                        ]
+                        for removed in removed_entries:
+                            self._queue_removed_entry_unlocked(removed)
                         self._entries = [
                             item for item in self._entries if item.id not in removed_ids
                         ]
-                        for removed_id in removed_ids:
-                            self._record_entry_mutation_unlocked(
-                                removed_id,
-                                dirty=False,
-                            )
                         if self._current_id in removed_ids:
                             self._current_id = None
-                    if codex_source_path is None:
-                        self._persist(removed_ids=list(removed_ids))
                     return None
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
             # auth.json and adopt the fresh tokens if available.
             if self.provider == "nous":
-                synced = self._sync_nous_entry_from_auth_store(entry)
+                synced = self._sync_nous_entry_from_auth_store(
+                    entry,
+                    persist=False,
+                )
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug("Nous refresh failed but auth.json has newer tokens — adopting")
                     updated = replace(
@@ -2928,8 +3179,6 @@ class CredentialPool:
                         return None
                     if not self._entry_tokens_match(committed, updated):
                         return committed
-                    self._persist()
-                    self._sync_device_code_entry_to_auth_store(committed)
                     return committed
                 if auth_mod._is_terminal_nous_refresh_error(exc):
                     logger.debug("Nous refresh token is terminally invalid; clearing local token state")
@@ -2968,17 +3217,18 @@ class CredentialPool:
                     }
                     # Atomic read-modify-write; see the note above.
                     with self._lock:
-                        removed_ids = [
-                            item.id for item in self._entries
+                        removed_entries = [
+                            item for item in self._entries
                             if item.source in singleton_sources
                         ]
+                        for removed in removed_entries:
+                            self._queue_removed_entry_unlocked(removed)
                         self._entries = [
                             item for item in self._entries
                             if item.source not in singleton_sources
                         ]
                         if self._current_id == entry.id:
                             self._current_id = None
-                    self._persist(removed_ids=removed_ids)
                     return None
             if self.provider == "openai-codex" and codex_source_path is not None:
                 exhausted = self._mark_exhausted(entry, None, persist=False)
@@ -2991,7 +3241,7 @@ class CredentialPool:
                         exhausted, codex_source_path
                     )
             else:
-                self._mark_exhausted(entry, None)
+                self._mark_exhausted(entry, None, persist=False)
             return None
 
         updated = replace(
@@ -3083,8 +3333,7 @@ class CredentialPool:
     def _sync_external_status_entries(self, *, probe_quota: bool = False) -> None:
         """Refresh external status sources without holding the pool lock."""
         self._assert_external_state_lock_order()
-        with self._external_state_lock:
-            self._sync_external_status_entries_locked(probe_quota=probe_quota)
+        self._sync_external_status_entries_locked(probe_quota=probe_quota)
 
     def _sync_external_status_entries_locked(
         self,
@@ -3806,19 +4055,20 @@ class CredentialPool:
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
         self._validate_source_owned_codex_entries()
-        with self._lock:
-            if index < 1 or index > len(self._entries):
-                return None
-            removed = self._entries.pop(index - 1)
-            for new_priority, entry in enumerate(list(self._entries)):
-                if entry.priority != new_priority:
-                    self._replace_entry(
-                        entry,
-                        replace(entry, priority=new_priority),
-                    )
-            self._queue_removed_entry_unlocked(removed)
-            if self._current_id == removed.id:
-                self._current_id = None
+        with self._external_state_lock:
+            with self._lock:
+                if index < 1 or index > len(self._entries):
+                    return None
+                removed = self._entries.pop(index - 1)
+                for new_priority, entry in enumerate(list(self._entries)):
+                    if entry.priority != new_priority:
+                        self._replace_entry(
+                            entry,
+                            replace(entry, priority=new_priority),
+                        )
+                self._queue_removed_entry_unlocked(removed)
+                if self._current_id == removed.id:
+                    self._current_id = None
         self._persist_pending_changes()
         return removed
 
@@ -3850,10 +4100,11 @@ class CredentialPool:
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
         self._validate_source_owned_codex_entries()
-        with self._lock:
-            entry = replace(entry, priority=_next_priority(self._entries))
-            self._entries.append(entry)
-            self._record_entry_mutation_unlocked(entry.id, dirty=True)
+        with self._external_state_lock:
+            with self._lock:
+                entry = replace(entry, priority=_next_priority(self._entries))
+                self._entries.append(entry)
+                self._record_entry_mutation_unlocked(entry.id, dirty=True)
         self._persist_pending_changes()
         return entry
 
@@ -3880,10 +4131,21 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
     field_updates = {}
     extra_updates = {}
     _field_names = {f.name for f in fields(existing)}
+    payload_fingerprint = sanitize_borrowed_credential_payload(
+        {**payload, "source": source},
+        provider,
+    ).get("secret_fingerprint")
+    same_redacted_lineage = bool(
+        provider == "anthropic"
+        and source == "claude_code"
+        and payload_fingerprint
+        and payload_fingerprint == existing.extra.get("secret_fingerprint")
+    )
     token_changed = (
         "access_token" in payload
         and payload["access_token"] is not None
         and payload["access_token"] != existing.access_token
+        and not same_redacted_lineage
     )
     for key, value in payload.items():
         if key in {"id", "priority"} or value is None:
@@ -3897,7 +4159,9 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
             if existing.extra.get(key) != value:
                 extra_updates[key] = value
     # When the credential token itself changes (key rotation), clear any
-    # exhaustion/error state — the old status is stale for the new key.
+    # exhaustion/error state — the old status is stale for the new key. Claude
+    # Code secrets are redacted on disk, so their persisted fingerprint, not the
+    # empty runtime value loaded from that row, determines whether its lineage changed.
     if token_changed and existing.last_status is not None:
         field_updates["last_status"] = None
         field_updates["last_status_at"] = None

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -661,6 +661,13 @@ class CredentialPool:
         # status-sync work performed outside the lock still serializes its
         # in-memory updates. Persistence is always drained after releasing it.
         self._lock = threading.RLock()
+        # External provider state is serialized separately from in-memory pool
+        # mutation. Lock order is always external_state -> pool (brief CAS only):
+        # callers must acquire this lock without holding self._lock, may perform
+        # provider/file I/O, and only then take self._lock to validate or commit.
+        # The reverse order is forbidden so auth-store/file waits cannot form an
+        # ABBA pair with pool persistence.
+        self._external_state_lock = threading.Lock()
         self._persist_lock = threading.Lock()
         # Persist only entries changed by this pool instance. Borrowed rows are
         # snapshots of another auth store; rewriting every snapshot on an
@@ -959,6 +966,7 @@ class CredentialPool:
         new: PooledCredential,
         *,
         mark_dirty: bool = True,
+        preserve_routing: bool = False,
     ) -> Optional[PooledCredential]:
         """Swap an entry only while its id and credential chain still match.
 
@@ -971,23 +979,35 @@ class CredentialPool:
                 if entry.id == old.id:
                     if not self._entry_tokens_match(entry, old):
                         return entry
+                    replacement = (
+                        replace(
+                            new,
+                            priority=entry.priority,
+                            request_count=entry.request_count,
+                        )
+                        if preserve_routing
+                        else new
+                    )
                     owner = self._trusted_codex_source_owner(entry)
-                    self._entries[idx] = new
+                    self._entries[idx] = replacement
                     if owner is not None:
                         self._trusted_codex_source_owners.pop(id(entry), None)
                         if (
-                            new.id == owner.entry_id
-                            and new.source == owner.source
-                            and new.source_store_path is not None
+                            replacement.id == owner.entry_id
+                            and replacement.source == owner.source
+                            and replacement.source_store_path is not None
                             and self._same_store_path(
-                                new.source_store_path,
+                                replacement.source_store_path,
                                 owner.source_path,
                             )
                         ):
-                            self._trusted_codex_source_owners[id(new)] = owner
-                    if mark_dirty and old != new:
-                        self._record_entry_mutation_unlocked(new.id, dirty=True)
-                    return new
+                            self._trusted_codex_source_owners[id(replacement)] = owner
+                    if mark_dirty and entry != replacement:
+                        self._record_entry_mutation_unlocked(
+                            replacement.id,
+                            dirty=True,
+                        )
+                    return replacement
             return None
 
     def _persist(
@@ -1249,10 +1269,14 @@ class CredentialPool:
                     last_error_message=None,
                     last_error_reset_at=None,
                 )
-                self._replace_entry(entry, updated)
+                current = self._replace_entry(
+                    entry,
+                    updated,
+                    preserve_routing=True,
+                )
                 if persist:
                     self._persist_pending_changes()
-                return updated
+                return current or entry
         except Exception as exc:
             logger.debug("Failed to sync from credentials file: %s", exc)
         return entry
@@ -1855,9 +1879,13 @@ class CredentialPool:
                 updated = self._codex_entry_from_provider_state(entry, state)
                 if updated is entry:
                     return entry
-                replaced = self._replace_entry(entry, updated)
+                replaced = self._replace_entry(
+                    entry,
+                    updated,
+                    preserve_routing=True,
+                )
                 if replaced is None or not self._entry_tokens_match(replaced, updated):
-                    return entry
+                    return replaced or entry
                 self._persist_codex_device_code_refresh(replaced, source_path)
                 return replaced
         except Exception as exc:
@@ -1920,10 +1948,14 @@ class CredentialPool:
                 if state.get("last_refresh"):
                     field_updates["last_refresh"] = state["last_refresh"]
                 updated = replace(entry, **field_updates)
-                self._replace_entry(entry, updated)
+                current = self._replace_entry(
+                    entry,
+                    updated,
+                    preserve_routing=True,
+                )
                 if persist:
                     self._persist_pending_changes()
-                return updated
+                return current or entry
         except Exception as exc:
             logger.debug("Failed to sync xAI OAuth entry from auth.json: %s", exc)
         return entry
@@ -1961,8 +1993,12 @@ class CredentialPool:
                     "Pool entry %s: adopting xAI OAuth tokens rotated by another pool instance",
                     entry.id,
                 )
-                self._replace_entry(entry, stored)
-                return stored
+                current = self._replace_entry(
+                    entry,
+                    stored,
+                    preserve_routing=True,
+                )
+                return current or entry
         except Exception as exc:
             logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
@@ -2037,10 +2073,14 @@ class CredentialPool:
                     if val is not None:
                         extra_updates[extra_key] = val
                 updated = replace(entry, extra=extra_updates, **field_updates)
-                self._replace_entry(entry, updated)
+                current = self._replace_entry(
+                    entry,
+                    updated,
+                    preserve_routing=True,
+                )
                 if persist:
                     self._persist_pending_changes()
-                return updated
+                return current or entry
         except Exception as exc:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
         return entry
@@ -2188,7 +2228,63 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
-    def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+    def _refresh_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+    ) -> Optional[PooledCredential]:
+        """Serialize provider refresh and reject superseded token lineages."""
+        self._assert_external_state_lock_order()
+        with self._external_state_lock:
+            with self._lock:
+                current = next(
+                    (item for item in self._entries if item.id == entry.id),
+                    None,
+                )
+            if current is None:
+                return None
+            if (
+                current.source != entry.source
+                or not self._entry_tokens_match(current, entry)
+            ):
+                return current
+            entry = current
+
+            # Claude Code's credentials file is a second source of truth. Read
+            # it after provider serialization and before spending a rotating
+            # refresh token so a login/status update that already won is
+            # adopted without an obsolete POST.
+            if self.provider == "anthropic" and entry.source == "claude_code":
+                synced = self._sync_anthropic_entry_from_credentials_file(
+                    entry,
+                    persist=False,
+                )
+                if not self._entry_tokens_match(synced, entry):
+                    self._persist_pending_changes()
+                    return synced
+                with self._lock:
+                    current = next(
+                        (item for item in self._entries if item.id == entry.id),
+                        None,
+                    )
+                if current is None:
+                    return None
+                if (
+                    current.source != entry.source
+                    or not self._entry_tokens_match(current, entry)
+                ):
+                    return current
+                entry = current
+
+            return self._refresh_entry_serialized(entry, force=force)
+
+    def _refresh_entry_serialized(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+    ) -> Optional[PooledCredential]:
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
@@ -2249,13 +2345,23 @@ class CredentialPool:
                     # A waiter that observed the winner's rotated exact row
                     # adopts it even for force=True; replay would consume a
                     # single-use refresh token twice.
-                    replaced = self._replace_entry(entry, stored, mark_dirty=False)
+                    replaced = self._replace_entry(
+                        entry,
+                        stored,
+                        mark_dirty=False,
+                        preserve_routing=True,
+                    )
                     if replaced is None or not self._entry_tokens_match(replaced, stored):
                         return None
                     if singleton_owned:
                         self._persist_codex_device_code_refresh(replaced, source_path)
                     return replaced
-                replaced = self._replace_entry(entry, stored, mark_dirty=False)
+                replaced = self._replace_entry(
+                    entry,
+                    stored,
+                    mark_dirty=False,
+                    preserve_routing=True,
+                )
                 if replaced is None or not self._entry_tokens_match(replaced, stored):
                     return None
                 return self._refresh_entry_impl(
@@ -2282,9 +2388,21 @@ class CredentialPool:
                     # A waiter that observed the winner's rotated chain adopts
                     # it even when its caller requested force=True. Replaying
                     # the consumed refresh token would invalidate the chain.
-                    self._replace_entry(entry, synced)
-                    self._persist_codex_device_code_refresh(synced, source_path)
-                    return synced
+                    replaced = self._replace_entry(
+                        entry,
+                        synced,
+                        preserve_routing=True,
+                    )
+                    if replaced is None or not self._entry_tokens_match(
+                        replaced,
+                        synced,
+                    ):
+                        return replaced
+                    self._persist_codex_device_code_refresh(
+                        replaced,
+                        source_path,
+                    )
+                    return replaced
                 return self._refresh_entry_impl(
                     entry,
                     force=force,
@@ -2312,6 +2430,25 @@ class CredentialPool:
                 return self._refresh_entry_impl(synced, force=force)
         return self._refresh_entry_impl(entry, force=force)
 
+    def _current_refresh_candidate(
+        self,
+        expected: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Return the current row only when its refresh lineage still matches."""
+        with self._lock:
+            current = next(
+                (item for item in self._entries if item.id == expected.id),
+                None,
+            )
+        if current is None:
+            return None
+        if (
+            current.source != expected.source
+            or not self._entry_tokens_match(current, expected)
+        ):
+            return None
+        return current
+
     def _single_use_refresh_lock_timeout(self) -> float:
         """Lock timeout for single-use-refresh-token providers.
 
@@ -2331,6 +2468,81 @@ class CredentialPool:
             float(refresh_timeout_seconds) + 5.0,
         )
 
+    def _commit_refreshed_entry(
+        self,
+        expected: PooledCredential,
+        refreshed: PooledCredential,
+        *,
+        codex_source_path: Optional[Path] = None,
+        codex_singleton_owned: bool = False,
+    ) -> Optional[PooledCredential]:
+        """Commit refreshed tokens only while their source lineage is current."""
+        if self.provider == "anthropic" and expected.source == "claude_code":
+            # A login may rotate the shared Claude chain while the refresh POST
+            # is in flight. Re-read it before the pool CAS or source-file write.
+            self._sync_anthropic_entry_from_credentials_file(
+                expected,
+                persist=False,
+            )
+            with self._lock:
+                current = next(
+                    (item for item in self._entries if item.id == expected.id),
+                    None,
+                )
+            if current is None:
+                return None
+            if (
+                current.source != expected.source
+                or not self._entry_tokens_match(current, expected)
+            ):
+                self._persist_pending_changes()
+                return current
+            expected = current
+
+        committed = self._replace_entry(
+            expected,
+            refreshed,
+            preserve_routing=True,
+        )
+        if committed is None:
+            return None
+        if not self._entry_tokens_match(committed, refreshed):
+            return committed
+
+        # Provider/source writes happen only after the current-lineage CAS.
+        # The external-state lock held by _refresh_entry prevents an in-process
+        # status sync from interleaving between this commit and write-through.
+        if self.provider == "anthropic" and committed.source == "claude_code":
+            try:
+                from agent.anthropic_adapter import _write_claude_code_credentials
+
+                _write_claude_code_credentials(
+                    committed.access_token or "",
+                    committed.refresh_token or "",
+                    committed.expires_at_ms or 0,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Failed to write refreshed token to credentials file: %s",
+                    exc,
+                )
+
+        if self.provider == "openai-codex" and codex_source_path is not None:
+            if codex_singleton_owned:
+                self._persist_codex_device_code_refresh(
+                    committed,
+                    codex_source_path,
+                )
+            else:
+                self._persist_codex_exact_alias_refresh(
+                    committed,
+                    codex_source_path,
+                )
+        else:
+            self._persist()
+            self._sync_device_code_entry_to_auth_store(committed)
+        return committed
+
     def _refresh_entry_impl(
         self,
         entry: PooledCredential,
@@ -2339,6 +2551,10 @@ class CredentialPool:
         codex_source_path: Optional[Path] = None,
         codex_singleton_owned: bool = False,
     ) -> Optional[PooledCredential]:
+        current = self._current_refresh_candidate(entry)
+        if current is None:
+            return None
+        entry = current
         try:
             if self.provider == "anthropic":
                 from agent.anthropic_adapter import refresh_anthropic_oauth_pure
@@ -2353,19 +2569,6 @@ class CredentialPool:
                     refresh_token=refreshed["refresh_token"],
                     expires_at_ms=refreshed["expires_at_ms"],
                 )
-                # Keep ~/.claude/.credentials.json in sync so that the
-                # fallback path (resolve_anthropic_token) and other profiles
-                # see the latest tokens.
-                if entry.source == "claude_code":
-                    try:
-                        from agent.anthropic_adapter import _write_claude_code_credentials
-                        _write_claude_code_credentials(
-                            refreshed["access_token"],
-                            refreshed["refresh_token"],
-                            refreshed["expires_at_ms"],
-                        )
-                    except Exception as wexc:
-                        logger.debug("Failed to write refreshed token to credentials file: %s", wexc)
             elif self.provider == "openai-codex":
                 # Adopt fresher tokens from auth.json before spending the
                 # refresh_token — single-use tokens consumed by another Hermes
@@ -2375,6 +2578,10 @@ class CredentialPool:
                     synced = self._sync_codex_entry_from_auth_store(entry)
                     if synced is not entry:
                         entry = synced
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                entry = current
                 refreshed = auth_mod.refresh_codex_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,
@@ -2394,6 +2601,10 @@ class CredentialPool:
                 synced = self._sync_xai_oauth_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                entry = current
                 refreshed = auth_mod.refresh_xai_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,
@@ -2408,6 +2619,10 @@ class CredentialPool:
                 synced = self._sync_nous_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                entry = current
                 auth_mod.resolve_nous_runtime_credentials(
                     force_refresh=force,
                 )
@@ -2438,18 +2653,7 @@ class CredentialPool:
                             last_status_at=None,
                             last_error_code=None,
                         )
-                        self._replace_entry(synced, updated)
-                        self._persist()
-                        try:
-                            from agent.anthropic_adapter import _write_claude_code_credentials
-                            _write_claude_code_credentials(
-                                refreshed["access_token"],
-                                refreshed["refresh_token"],
-                                refreshed["expires_at_ms"],
-                            )
-                        except Exception as wexc:
-                            logger.debug("Failed to write refreshed token to credentials file (retry path): %s", wexc)
-                        return updated
+                        return self._commit_refreshed_entry(synced, updated)
                     except Exception as retry_exc:
                         logger.debug("Retry refresh also failed: %s", retry_exc)
                 elif not self._entry_needs_refresh(synced):
@@ -2477,9 +2681,17 @@ class CredentialPool:
                         last_error_message=None,
                         last_error_reset_at=None,
                     )
-                    self._replace_entry(synced, updated)
+                    committed = self._replace_entry(
+                        synced,
+                        updated,
+                        preserve_routing=True,
+                    )
+                    if committed is None:
+                        return None
+                    if not self._entry_tokens_match(committed, updated):
+                        return committed
                     self._persist()
-                    return updated
+                    return committed
                 # Terminal error: auth.json has no newer tokens — the stored
                 # refresh_token is dead.  Clear it from auth.json so the next
                 # session does not re-seed the same revoked credentials, and
@@ -2581,19 +2793,27 @@ class CredentialPool:
                         last_error_message=None,
                         last_error_reset_at=None,
                     )
-                    self._replace_entry(synced, updated)
+                    committed = self._replace_entry(
+                        synced,
+                        updated,
+                        preserve_routing=True,
+                    )
+                    if committed is None:
+                        return None
+                    if not self._entry_tokens_match(committed, updated):
+                        return committed
                     if codex_source_path is not None:
                         if codex_singleton_owned:
                             self._persist_codex_device_code_refresh(
-                                updated, codex_source_path
+                                committed, codex_source_path
                             )
                         else:
                             self._persist_codex_exact_alias_refresh(
-                                updated, codex_source_path
+                                committed, codex_source_path
                             )
                     else:
                         self._persist()
-                    return updated
+                    return committed
                 # Terminal error: auth.json has no newer tokens — the stored
                 # refresh_token is dead.  Clear it from auth.json so the next
                 # session does not re-seed the same revoked credentials, and
@@ -2699,10 +2919,18 @@ class CredentialPool:
                         last_error_message=None,
                         last_error_reset_at=None,
                     )
-                    self._replace_entry(synced, updated)
+                    committed = self._replace_entry(
+                        synced,
+                        updated,
+                        preserve_routing=True,
+                    )
+                    if committed is None:
+                        return None
+                    if not self._entry_tokens_match(committed, updated):
+                        return committed
                     self._persist()
-                    self._sync_device_code_entry_to_auth_store(updated)
-                    return updated
+                    self._sync_device_code_entry_to_auth_store(committed)
+                    return committed
                 if auth_mod._is_terminal_nous_refresh_error(exc):
                     logger.debug("Nous refresh token is terminally invalid; clearing local token state")
                     try:
@@ -2775,19 +3003,12 @@ class CredentialPool:
             last_error_message=None,
             last_error_reset_at=None,
         )
-        self._replace_entry(entry, updated)
-        if self.provider == "openai-codex" and codex_source_path is not None:
-            if codex_singleton_owned:
-                self._persist_codex_device_code_refresh(updated, codex_source_path)
-            else:
-                self._persist_codex_exact_alias_refresh(updated, codex_source_path)
-        else:
-            self._persist()
-            # Sync refreshed tokens back to auth.json providers so that
-            # _seed_from_singletons() on the next load_pool() sees fresh state
-            # instead of re-seeding stale/consumed tokens.
-            self._sync_device_code_entry_to_auth_store(updated)
-        return updated
+        return self._commit_refreshed_entry(
+            entry,
+            updated,
+            codex_source_path=codex_source_path,
+            codex_singleton_owned=codex_singleton_owned,
+        )
 
     def _codex_quota_restored_upstream(self, entry: PooledCredential) -> bool:
         """Live-check whether an exhausted Codex entry's quota reset early.
@@ -2850,8 +3071,26 @@ class CredentialPool:
             return False
         return False
 
+    def _assert_external_state_lock_order(self) -> None:
+        """Reject external synchronization while the pool lock is held."""
+        is_owned = getattr(self._lock, "_is_owned", None)
+        if callable(is_owned) and is_owned():
+            raise RuntimeError(
+                "External credential state cannot be synchronized while the "
+                "credential-pool lock is held"
+            )
+
     def _sync_external_status_entries(self, *, probe_quota: bool = False) -> None:
         """Refresh external status sources without holding the pool lock."""
+        self._assert_external_state_lock_order()
+        with self._external_state_lock:
+            self._sync_external_status_entries_locked(probe_quota=probe_quota)
+
+    def _sync_external_status_entries_locked(
+        self,
+        *,
+        probe_quota: bool = False,
+    ) -> None:
         with self._lock:
             status_entries = [
                 entry
@@ -3071,6 +3310,11 @@ class CredentialPool:
             refresh=refresh,
             excluded_source_ids=excluded_source_ids,
         )
+        if pending_refresh:
+            # Do not select, rotate, or increment counters from a partial view
+            # that excludes refreshable entries. The caller refreshes outside
+            # the lock and performs one selection against the current pool.
+            return None, pending_refresh
         if not available:
             self._current_id = None
             self._log_no_available_entries()
@@ -3376,27 +3620,22 @@ class CredentialPool:
         self._persist_pending_changes()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
-            # Mirror select(): if nothing was leasable but we just refreshed
-            # deferred single-use-token entries, retry now that they are back
-            # in rotation. Without this, a pool whose only entries all needed
-            # a refresh returns None even though the refresh succeeded — the
-            # caller sees "no credentials available" and fails a request that
-            # should have gone through.
-            if chosen_id is None:
-                failed_source_ids = self._validate_source_owned_codex_entries(
-                    entry_ids,
+            # The first pass never leases from a partial view when refreshes
+            # are pending. Re-read and choose once from the current pool.
+            failed_source_ids = self._validate_source_owned_codex_entries(
+                entry_ids,
+            )
+            self._sync_external_status_entries(probe_quota=True)
+            if failed_source_ids:
+                chosen_id, _ = self._acquire_lease_under_lock(
+                    credential_id,
+                    excluded_source_ids=failed_source_ids,
                 )
-                self._sync_external_status_entries(probe_quota=True)
-                if failed_source_ids:
-                    chosen_id, _ = self._acquire_lease_under_lock(
-                        credential_id,
-                        excluded_source_ids=failed_source_ids,
-                    )
-                else:
-                    chosen_id, _ = self._acquire_lease_under_lock(
-                        credential_id,
-                    )
-                self._persist_pending_changes()
+            else:
+                chosen_id, _ = self._acquire_lease_under_lock(
+                    credential_id,
+                )
+            self._persist_pending_changes()
         return chosen_id
 
     def _acquire_lease_under_lock(
@@ -3435,6 +3674,8 @@ class CredentialPool:
                     clear_expired=True,
                     refresh=True,
                 )
+            if pending_refresh:
+                return None, pending_refresh
             if not available:
                 return None, pending_refresh
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1270,6 +1270,10 @@ class CredentialPool:
                     last_error_reason=None,
                     last_error_message=None,
                     last_error_reset_at=None,
+                    extra={
+                        **entry.extra,
+                        "credential_source": creds.get("source"),
+                    },
                 )
                 current = self._replace_entry(
                     entry,
@@ -2437,6 +2441,8 @@ class CredentialPool:
     def _mark_source_persistence_dead(
         self,
         entry: PooledCredential,
+        *,
+        persist: bool = True,
     ) -> None:
         updated = replace(
             entry,
@@ -2451,6 +2457,7 @@ class CredentialPool:
             entry,
             updated,
             preserve_routing=True,
+            mark_dirty=persist,
         )
 
     def _quarantine_terminal_xai_lineage(
@@ -2530,12 +2537,16 @@ class CredentialPool:
             access_token=access_token or entry.access_token,
             refresh_token=refresh_token or entry.refresh_token,
             expires_at_ms=creds.get("expiresAt", 0) or entry.expires_at_ms,
-            last_status=None if changed else entry.last_status,
+            last_status=STATUS_OK if changed else entry.last_status,
             last_status_at=None if changed else entry.last_status_at,
             last_error_code=None if changed else entry.last_error_code,
             last_error_reason=None if changed else entry.last_error_reason,
             last_error_message=None if changed else entry.last_error_message,
             last_error_reset_at=None if changed else entry.last_error_reset_at,
+            extra={
+                **entry.extra,
+                "credential_source": creds.get("source"),
+            },
         )
 
     def _refresh_anthropic_source_entry(
@@ -2545,89 +2556,35 @@ class CredentialPool:
         force: bool,
     ) -> Optional[PooledCredential]:
         from agent.anthropic_adapter import (
-            _read_claude_code_credentials_from_file,
-            _write_claude_code_credentials_locked,
-            claude_code_credentials_transaction,
-            is_claude_code_token_valid,
-            refresh_anthropic_oauth_pure,
+            _refresh_claude_code_source_credentials,
         )
 
-        persistence_failure = False
-        for _attempt in range(3):
-            with claude_code_credentials_transaction(
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-            ) as (_source_path, creds):
-                if not creds:
-                    return None
-                authoritative = self._anthropic_entry_from_locked_credentials(
-                    entry,
-                    creds,
-                )
-                if not self._entry_tokens_match(authoritative, entry):
-                    return self._replace_entry(
-                        entry,
-                        authoritative,
-                        preserve_routing=True,
-                    )
-                current = self._current_refresh_candidate(entry)
-                if current is None:
-                    return None
-                if not force and is_claude_code_token_valid(creds):
-                    return current
-                consumed_refresh_token = str(
-                    creds.get("refreshToken", "") or ""
-                )
-                if not consumed_refresh_token:
-                    return None
-                refreshed = refresh_anthropic_oauth_pure(
-                    consumed_refresh_token,
-                    use_json=False,
-                )
-                try:
-                    _write_claude_code_credentials_locked(
-                        refreshed["access_token"],
-                        refreshed["refresh_token"],
-                        refreshed["expires_at_ms"],
-                        expected_refresh_token=consumed_refresh_token,
-                    )
-                except auth_mod.SourceCredentialLineageChanged:
-                    winner = _read_claude_code_credentials_from_file()
-                    if winner:
-                        authoritative = self._anthropic_entry_from_locked_credentials(
-                            entry,
-                            winner,
-                        )
-                        if is_claude_code_token_valid(winner):
-                            return self._replace_entry(
-                                entry,
-                                authoritative,
-                                preserve_routing=True,
-                            )
-                    continue
-                except auth_mod.SourceCredentialPersistenceError:
-                    persistence_failure = True
-                    break
-                updated = replace(
-                    current,
-                    access_token=refreshed["access_token"],
-                    refresh_token=refreshed["refresh_token"],
-                    expires_at_ms=refreshed["expires_at_ms"],
-                    last_status=STATUS_OK,
-                    last_status_at=None,
-                    last_error_code=None,
-                    last_error_reason=None,
-                    last_error_message=None,
-                    last_error_reset_at=None,
-                )
-                return self._replace_entry(
-                    current,
-                    updated,
-                    preserve_routing=True,
-                )
-        if persistence_failure:
-            self._mark_source_persistence_dead(entry)
+        del force  # A source-owned explicit refresh always reaches this method.
+        observed = {
+            "accessToken": entry.access_token,
+            "refreshToken": entry.refresh_token or "",
+            "expiresAt": entry.expires_at_ms or 0,
+            "source": entry.extra.get("credential_source")
+            or "claude_code_credentials_file",
+        }
+        try:
+            winner = _refresh_claude_code_source_credentials(observed)
+        except auth_mod.SourceCredentialPersistenceError:
+            self._mark_source_persistence_dead(entry, persist=False)
             return None
-        return None
+        if not winner:
+            self._mark_source_persistence_dead(entry, persist=False)
+            return None
+        current = self._current_refresh_candidate(entry) or entry
+        updated = self._anthropic_entry_from_locked_credentials(
+            current,
+            winner,
+        )
+        return self._replace_entry(
+            current,
+            updated,
+            preserve_routing=True,
+        )
 
     def _xai_entry_from_locked_state(
         self,
@@ -2666,41 +2623,72 @@ class CredentialPool:
         *,
         force: bool,
     ) -> Optional[PooledCredential]:
-        expected_source_path = (
-            entry.source_store_path or auth_mod._auth_file_path()
+        observed_source_path, observed_refresh_fingerprint = (
+            auth_mod._observe_provider_refresh_source("xai-oauth")
         )
-        persistence_failure = False
-        terminal_failure: Optional[Exception] = None
-        consumed_refresh_token = ""
-        failed_source_path: Optional[Path] = None
-
+        expected_source_path = observed_source_path
+        winner: Optional[PooledCredential] = None
+        refresh_failed = False
         for _attempt in range(3):
             with auth_mod._provider_state_transaction(
                 "xai-oauth",
                 timeout_seconds=self._single_use_refresh_lock_timeout(),
                 expected_source_path=expected_source_path,
-            ) as (auth_store, state, source_path):
+            ) as (transaction_store, state, source_path):
                 if source_path is None or state is None:
                     expected_source_path = None
                     continue
+                resolved_state, resolved_source_path = (
+                    auth_mod._load_provider_state_with_source(
+                        transaction_store,
+                        "xai-oauth",
+                    )
+                )
+                if (
+                    resolved_state is not None
+                    and resolved_source_path is not None
+                    and not auth_mod._same_path(resolved_source_path, Path(source_path))
+                ):
+                    state = resolved_state
+                    source_path = resolved_source_path
+                if auth_mod._source_state_is_reserved(state):
+                    refresh_failed = True
+                    break
                 authoritative = self._xai_entry_from_locked_state(
                     entry,
                     state,
                     Path(source_path),
                 )
                 if authoritative is None:
-                    return None
-                if not self._entry_tokens_match(authoritative, entry):
-                    return self._replace_entry(
-                        entry,
-                        authoritative,
-                        preserve_routing=True,
+                    refresh_failed = True
+                    break
+                current_refresh_fingerprint = auth_mod._refresh_lineage_fingerprint(
+                    authoritative.refresh_token
+                )
+                owner_changed = bool(
+                    observed_source_path is not None
+                    and not auth_mod._same_path(observed_source_path, Path(source_path))
+                )
+                lineage_changed = bool(
+                    observed_refresh_fingerprint is not None
+                    and current_refresh_fingerprint != observed_refresh_fingerprint
+                )
+                if (
+                    (
+                        owner_changed
+                        or lineage_changed
+                        or not self._entry_tokens_match(authoritative, entry)
                     )
-                current = self._current_refresh_candidate(entry)
-                if current is None:
-                    return None
+                    and not auth_mod._xai_access_token_is_expiring(
+                        authoritative.access_token,
+                        0,
+                    )
+                ):
+                    winner = authoritative
+                    break
                 if not force and not self._entry_needs_refresh(authoritative):
-                    return current
+                    winner = authoritative
+                    break
                 discovery = dict(state.get("discovery") or {})
                 token_endpoint = str(
                     discovery.get("token_endpoint", "") or ""
@@ -2710,6 +2698,12 @@ class CredentialPool:
                         auth_mod.env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
                     )["token_endpoint"]
                 consumed_refresh_token = authoritative.refresh_token or ""
+                reservation = auth_mod._reserve_provider_refresh_source(
+                    "xai-oauth",
+                    state,
+                    source_path,
+                    expected_refresh_token=consumed_refresh_token,
+                )
                 try:
                     refreshed = auth_mod.refresh_xai_oauth_pure(
                         authoritative.access_token,
@@ -2720,35 +2714,26 @@ class CredentialPool:
                             20,
                         ),
                     )
-                except Exception as exc:
-                    if auth_mod._is_terminal_xai_oauth_refresh_error(exc):
-                        terminal_failure = exc
-                        failed_source_path = Path(source_path)
-                        break
-                    raise
+                except Exception:
+                    refresh_failed = True
+                    break
                 updated_state = auth_mod._xai_oauth_state_with_refreshed_tokens(
                     state,
                     refreshed,
                     token_endpoint=token_endpoint,
                 )
                 try:
-                    auth_mod._save_provider_state_to_locked_source(
-                        auth_store,
-                        "xai-oauth",
+                    auth_mod._finalize_provider_refresh_reservation(
+                        reservation,
                         updated_state,
-                        source_path,
-                        expected_refresh_token=consumed_refresh_token,
-                        set_active=False,
                     )
                 except auth_mod.SourceCredentialLineageChanged:
-                    expected_source_path = None
                     continue
-                except (OSError, auth_mod.SourceCredentialPersistenceError):
-                    persistence_failure = True
-                    failed_source_path = Path(source_path)
+                except OSError:
+                    refresh_failed = True
                     break
-                updated = replace(
-                    current,
+                winner = replace(
+                    entry,
                     access_token=refreshed["access_token"],
                     refresh_token=refreshed["refresh_token"],
                     last_refresh=refreshed.get("last_refresh"),
@@ -2760,52 +2745,17 @@ class CredentialPool:
                     last_error_message=None,
                     last_error_reset_at=None,
                 )
-                return self._replace_entry(
-                    current,
-                    updated,
-                    preserve_routing=True,
-                )
-
-        if terminal_failure:
-            with auth_mod._provider_state_transaction(
-                "xai-oauth",
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-            ) as (_auth_store, winner_state, winner_source_path):
-                if winner_state is not None and winner_source_path is not None:
-                    winner = self._xai_entry_from_locked_state(
-                        entry,
-                        winner_state,
-                        Path(winner_source_path),
-                    )
-                    if (
-                        winner is not None
-                        and winner.refresh_token != consumed_refresh_token
-                    ):
-                        return self._replace_entry(
-                            entry,
-                            winner,
-                            preserve_routing=True,
-                        )
-            self._quarantine_terminal_xai_lineage(
-                entry,
-                failed_source_path,
-                terminal_failure,
-            )
+                break
+        if refresh_failed:
+            self._mark_source_persistence_dead(entry, persist=False)
             return None
-
-        if persistence_failure:
-            try:
-                auth_mod._quarantine_xai_consumed_source(
-                    failed_source_path,
-                    consumed_refresh_token,
-                )
-            except Exception:
-                logger.debug(
-                    "Failed to persist xAI source quarantine",
-                    exc_info=True,
-                )
-            self._mark_source_persistence_dead(entry)
-        return None
+        if winner is None:
+            return None
+        return self._replace_entry(
+            entry,
+            winner,
+            preserve_routing=True,
+        )
 
     def _current_refresh_candidate(
         self,
@@ -2854,26 +2804,14 @@ class CredentialPool:
         codex_singleton_owned: bool = False,
     ) -> Optional[PooledCredential]:
         """Commit refreshed tokens only while their source lineage is current."""
-        if self.provider == "anthropic" and expected.source == "claude_code":
-            # A login may rotate the shared Claude chain while the refresh POST
-            # is in flight. Re-read it before the pool CAS or source-file write.
-            self._sync_anthropic_entry_from_credentials_file(
-                expected,
-                persist=False,
-            )
-            with self._lock:
-                current = next(
-                    (item for item in self._entries if item.id == expected.id),
-                    None,
-                )
-            if current is None:
-                return None
-            if (
-                current.source != expected.source
-                or not self._entry_tokens_match(current, expected)
-            ):
-                return current
-            expected = current
+        if (
+            self.provider == "anthropic" and expected.source == "claude_code"
+        ) or (
+            self.provider == "xai-oauth" and expected.source == "device_code"
+        ):
+            # These rotating owners must use their dedicated pre-POST source
+            # transaction. Refuse the legacy post-POST source commit path.
+            return None
 
         committed = self._replace_entry(
             expected,
@@ -2884,34 +2822,6 @@ class CredentialPool:
             return None
         if not self._entry_tokens_match(committed, refreshed):
             return committed
-
-        if self.provider == "anthropic" and committed.source == "claude_code":
-            from agent.anthropic_adapter import _claude_code_credentials_path
-
-            with _auth_store_lock(
-                target_path=_claude_code_credentials_path(),
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-            ):
-                return self._commit_authoritative_source(
-                    expected,
-                    committed,
-                )
-
-        if self.provider in {"nous", "xai-oauth"} and committed.source == "device_code":
-            auth_store = _load_auth_store()
-            _state, source_path = _load_provider_state_with_source(
-                auth_store,
-                self.provider,
-            )
-            with auth_mod._provider_state_transaction(
-                self.provider,
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-                expected_source_path=source_path,
-            ):
-                return self._commit_authoritative_source(
-                    expected,
-                    committed,
-                )
 
         if self.provider == "openai-codex" and codex_source_path is not None:
             with self._external_state_lock:
@@ -2933,114 +2843,6 @@ class CredentialPool:
         with self._external_state_lock:
             return self._current_refresh_candidate(committed)
 
-    def _authoritative_source_entry(
-        self,
-        expected: PooledCredential,
-    ) -> Optional[PooledCredential]:
-        """Read one source-owned token lineage while its source lock is held."""
-        if self.provider == "anthropic" and expected.source == "claude_code":
-            from agent.anthropic_adapter import read_claude_code_credentials
-
-            credentials = read_claude_code_credentials()
-            if not credentials or not credentials.get("accessToken"):
-                return None
-            return replace(
-                expected,
-                access_token=str(credentials.get("accessToken") or ""),
-                refresh_token=str(credentials.get("refreshToken") or ""),
-                expires_at_ms=credentials.get("expiresAt"),
-            )
-
-        if self.provider not in {"nous", "xai-oauth"} or expected.source != "device_code":
-            return expected
-        auth_store = _load_auth_store()
-        state = _load_provider_state(auth_store, self.provider)
-        if not isinstance(state, dict):
-            return None
-        if self.provider == "xai-oauth":
-            tokens = state.get("tokens")
-            if not isinstance(tokens, dict) or not tokens.get("access_token"):
-                return None
-            return replace(
-                expected,
-                access_token=str(tokens.get("access_token") or ""),
-                refresh_token=str(tokens.get("refresh_token") or ""),
-                last_refresh=state.get("last_refresh"),
-            )
-        if not state.get("access_token"):
-            return None
-        return replace(
-            expected,
-            access_token=str(state.get("access_token") or ""),
-            refresh_token=str(state.get("refresh_token") or ""),
-            expires_at=state.get("expires_at"),
-            agent_key=state.get("agent_key"),
-            agent_key_expires_at=state.get("agent_key_expires_at"),
-            inference_base_url=state.get("inference_base_url"),
-        )
-
-    def _commit_authoritative_source(
-        self,
-        expected: PooledCredential,
-        committed: PooledCredential,
-    ) -> Optional[PooledCredential]:
-        """Validate and write a source lineage under source -> transaction locks."""
-        with self._external_state_lock:
-            current = self._current_refresh_candidate(committed)
-            if current is None:
-                return None
-            authoritative = self._authoritative_source_entry(expected)
-            if authoritative is None:
-                self._replace_entry(current, expected, preserve_routing=True)
-                return None
-            if not self._entry_tokens_match(authoritative, expected):
-                return self._replace_entry(
-                    current,
-                    authoritative,
-                    preserve_routing=True,
-                )
-
-            try:
-                if self.provider == "anthropic":
-                    from agent.anthropic_adapter import _write_claude_code_credentials
-
-                    write_result = _write_claude_code_credentials(
-                        current.access_token or "",
-                        current.refresh_token or "",
-                        current.expires_at_ms or 0,
-                    )
-                else:
-                    write_result = self._sync_device_code_entry_to_auth_store(current)
-            except Exception as exc:
-                logger.debug("Failed to persist refreshed source credential: %s", exc)
-                write_result = False
-
-            if not write_result:
-                authoritative = self._authoritative_source_entry(expected) or expected
-                self._replace_entry(
-                    current,
-                    replace(
-                        authoritative,
-                        last_status=STATUS_DEAD,
-                        last_status_at=time.time(),
-                        last_error_reason="source_persistence_failed",
-                        last_error_message="Refreshed credentials were not persisted to their owning source.",
-                    ),
-                    preserve_routing=True,
-                )
-                return None
-
-            verified = self._authoritative_source_entry(current)
-            if verified is None:
-                return None
-            if not self._entry_tokens_match(verified, current):
-                return self._replace_entry(
-                    current,
-                    verified,
-                    preserve_routing=True,
-                )
-            return current
-
     def _revalidate_refreshed_entry(
         self,
         refreshed: PooledCredential,
@@ -3055,29 +2857,30 @@ class CredentialPool:
             ) as (_source_path, creds):
                 if not creds:
                     return None
-                with self._external_state_lock:
-                    with self._lock:
-                        current = next(
-                            (
-                                item
-                                for item in self._entries
-                                if item.id == refreshed.id
-                            ),
-                            None,
-                        )
-                    if current is None or current.source != refreshed.source:
-                        return None
-                    authoritative = self._anthropic_entry_from_locked_credentials(
-                        current,
-                        creds,
+                source_snapshot = dict(creds)
+            with self._external_state_lock:
+                with self._lock:
+                    current = next(
+                        (
+                            item
+                            for item in self._entries
+                            if item.id == refreshed.id
+                        ),
+                        None,
                     )
-                    if not self._entry_tokens_match(authoritative, current):
-                        return self._replace_entry(
-                            current,
-                            authoritative,
-                            preserve_routing=True,
-                        )
-                    return current
+                if current is None or current.source != refreshed.source:
+                    return None
+                authoritative = self._anthropic_entry_from_locked_credentials(
+                    current,
+                    source_snapshot,
+                )
+                if not self._entry_tokens_match(authoritative, current):
+                    return self._replace_entry(
+                        current,
+                        authoritative,
+                        preserve_routing=True,
+                    )
+                return current
 
         if self.provider == "xai-oauth" and refreshed.source == "device_code":
             expected_source_path = (
@@ -3090,43 +2893,25 @@ class CredentialPool:
             ) as (_auth_store, state, source_path):
                 if state is None or source_path is None:
                     return None
-                with self._external_state_lock:
-                    with self._lock:
-                        current = next(
-                            (
-                                item
-                                for item in self._entries
-                                if item.id == refreshed.id
-                            ),
-                            None,
-                        )
-                    if current is None or current.source != refreshed.source:
-                        return None
-                    authoritative = self._xai_entry_from_locked_state(
-                        current,
-                        state,
-                        Path(source_path),
-                    )
-                    if authoritative is None:
-                        return None
-                    if not self._entry_tokens_match(authoritative, current):
-                        return self._replace_entry(
-                            current,
-                            authoritative,
-                            preserve_routing=True,
-                        )
-                    return current
-
-        def revalidate_source() -> Optional[PooledCredential]:
+                source_snapshot = dict(state)
+                snapshot_path = Path(source_path)
             with self._external_state_lock:
                 with self._lock:
                     current = next(
-                        (item for item in self._entries if item.id == refreshed.id),
+                        (
+                            item
+                            for item in self._entries
+                            if item.id == refreshed.id
+                        ),
                         None,
                     )
                 if current is None or current.source != refreshed.source:
                     return None
-                authoritative = self._authoritative_source_entry(current)
+                authoritative = self._xai_entry_from_locked_state(
+                    current,
+                    source_snapshot,
+                    snapshot_path,
+                )
                 if authoritative is None:
                     return None
                 if not self._entry_tokens_match(authoritative, current):
@@ -3147,8 +2932,38 @@ class CredentialPool:
                 self.provider,
                 timeout_seconds=self._single_use_refresh_lock_timeout(),
                 expected_source_path=source_path,
-            ):
-                return revalidate_source()
+            ) as (_auth_store, state, _locked_source_path):
+                if not isinstance(state, dict) or not state.get("access_token"):
+                    return None
+                source_snapshot = dict(state)
+            with self._external_state_lock:
+                with self._lock:
+                    current = next(
+                        (
+                            item
+                            for item in self._entries
+                            if item.id == refreshed.id
+                        ),
+                        None,
+                    )
+                if current is None or current.source != refreshed.source:
+                    return None
+                authoritative = replace(
+                    current,
+                    access_token=str(source_snapshot.get("access_token") or ""),
+                    refresh_token=str(source_snapshot.get("refresh_token") or ""),
+                    expires_at=source_snapshot.get("expires_at"),
+                    agent_key=source_snapshot.get("agent_key"),
+                    agent_key_expires_at=source_snapshot.get("agent_key_expires_at"),
+                    inference_base_url=source_snapshot.get("inference_base_url"),
+                )
+                if not self._entry_tokens_match(authoritative, current):
+                    return self._replace_entry(
+                        current,
+                        authoritative,
+                        preserve_routing=True,
+                    )
+                return current
 
         with self._external_state_lock:
             with self._lock:
@@ -3239,12 +3054,18 @@ class CredentialPool:
                     last_refresh=refreshed.get("last_refresh"),
                 )
             elif self.provider == "nous":
+                observed_refresh_token = entry.refresh_token
                 synced = self._sync_nous_entry_from_auth_store(
                     entry,
                     persist=False,
                 )
                 if synced is not entry:
                     entry = synced
+                if (
+                    entry.refresh_token != observed_refresh_token
+                    and not self._entry_needs_refresh(entry)
+                ):
+                    return entry
                 current = self._current_refresh_candidate(entry)
                 if current is None:
                     return None
@@ -3264,10 +3085,9 @@ class CredentialPool:
                 self.provider == "nous"
                 and isinstance(exc, auth_mod.SourceCredentialPersistenceError)
             ):
-                # The resolver's source transaction is already released here.
-                # Quarantine the exact consumed row and let the caller persist
-                # pool state after all source locks have been dropped.
-                self._mark_source_persistence_dead(entry)
+                # The exact owner is already durably reserved. Keep this pool
+                # instance unavailable without creating a borrower-local copy.
+                self._mark_source_persistence_dead(entry, persist=False)
                 return None
             # For anthropic claude_code entries: the refresh token may have been
             # consumed by another process. Check if ~/.claude/.credentials.json
@@ -3573,7 +3393,8 @@ class CredentialPool:
                         return committed
                     return committed
                 if auth_mod._is_terminal_nous_refresh_error(exc):
-                    logger.debug("Nous refresh token is terminally invalid; clearing local token state")
+                    logger.debug("Nous refresh token is terminally invalid; reconciling source state")
+                    reserved_owner = False
                     try:
                         with _auth_store_lock():
                             auth_store = _load_auth_store()
@@ -3585,9 +3406,13 @@ class CredentialPool:
                                 "scope": entry.scope,
                                 "tls": entry.tls,
                             }
+                            reserved_owner = auth_mod._source_state_is_reserved(state)
                             store_refresh = str(state.get("refresh_token") or "").strip()
                             entry_refresh = str(entry.refresh_token or "").strip()
-                            if not store_refresh or store_refresh == entry_refresh:
+                            if (
+                                not reserved_owner
+                                and (not store_refresh or store_refresh == entry_refresh)
+                            ):
                                 auth_mod._quarantine_nous_oauth_state(
                                     state,
                                     exc,
@@ -3602,6 +3427,10 @@ class CredentialPool:
                                 _save_auth_store(auth_store)
                     except Exception as clear_exc:
                         logger.debug("Failed to clear terminal Nous OAuth state: %s", clear_exc)
+
+                    if reserved_owner:
+                        self._mark_source_persistence_dead(entry, persist=False)
+                        return None
 
                     singleton_sources = {
                         auth_mod.NOUS_DEVICE_CODE_SOURCE,
@@ -4731,9 +4560,17 @@ def _seed_from_singletons(
 
         from agent.anthropic_adapter import read_claude_code_credentials, read_hermes_oauth_credentials
 
+        hermes_creds = read_hermes_oauth_credentials()
+        claude_creds = read_claude_code_credentials()
+        if not claude_creds or not claude_creds.get("accessToken"):
+            retained = [entry for entry in entries if entry.source != "claude_code"]
+            if len(retained) != len(entries):
+                entries[:] = retained
+                changed = True
+
         for source_name, creds in (
-            ("hermes_pkce", read_hermes_oauth_credentials()),
-            ("claude_code", read_claude_code_credentials()),
+            ("hermes_pkce", hermes_creds),
+            ("claude_code", claude_creds),
         ):
             if creds and creds.get("accessToken"):
                 if _is_suppressed(provider, source_name):
@@ -4750,6 +4587,11 @@ def _seed_from_singletons(
                         "refresh_token": creds.get("refreshToken"),
                         "expires_at_ms": creds.get("expiresAt"),
                         "label": label_from_token(creds.get("accessToken", ""), source_name),
+                        **(
+                            {"credential_source": creds.get("source")}
+                            if source_name == "claude_code"
+                            else {}
+                        ),
                     },
                 )
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -653,6 +653,11 @@ class CredentialPool:
         # serializes its pool mutations. In-lock callers re-acquire
         # reentrantly at negligible cost.
         self._lock = threading.RLock()
+        # Persist only entries changed by this pool instance. Borrowed rows are
+        # snapshots of another auth store; rewriting every snapshot on an
+        # unrelated local change can erase a newer owner cooldown/quarantine.
+        self._dirty_entry_ids: Set[str] = set()
+        self._source_status_reset_ids: Set[str] = set()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
         # Monotonic timestamp of the last "no available entries" log, used to
@@ -731,7 +736,14 @@ class CredentialPool:
 
     def current(self) -> Optional[PooledCredential]:
         with self._lock:
-            return self._current_unlocked()
+            current = self._current_unlocked()
+            if (
+                current is not None
+                and self.provider == "openai-codex"
+                and _is_source_owned_elsewhere(current)
+            ):
+                return self._sync_source_owned_codex_entry(current)
+            return current
 
     def entry_id_for_api_key(self, api_key_hint: Any = None) -> Optional[str]:
         """Return the stable id for the runtime credential in use.
@@ -755,7 +767,13 @@ class CredentialPool:
             ]
             return matches[0].id if len(matches) == 1 else None
 
-    def _replace_entry(self, old: PooledCredential, new: PooledCredential) -> None:
+    def _replace_entry(
+        self,
+        old: PooledCredential,
+        new: PooledCredential,
+        *,
+        mark_dirty: bool = True,
+    ) -> None:
         """Swap an entry in-place by id, preserving sort order.
 
         Self-locking (RLock) so the deferred refresh path — which
@@ -766,26 +784,80 @@ class CredentialPool:
             for idx, entry in enumerate(self._entries):
                 if entry.id == old.id:
                     self._entries[idx] = new
+                    if mark_dirty and old != new:
+                        self._dirty_entry_ids.add(new.id)
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        removed_entries: Optional[List[PooledCredential]] = None,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
-            source_owned = [
-                entry for entry in self._entries if _is_source_owned_elsewhere(entry)
+            # Validation is read-only when the owner still exists, but revokes
+            # missing source rows immediately even when this persist was caused
+            # only by a local sibling entry.
+            if self.provider == "openai-codex":
+                for source_entry in list(self._entries):
+                    if (
+                        _is_source_owned_elsewhere(source_entry)
+                        and source_entry.id not in self._dirty_entry_ids
+                    ):
+                        self._sync_source_owned_codex_entry(source_entry)
+
+            entries_by_id = {entry.id: entry for entry in self._entries}
+            dirty_entries = [
+                entries_by_id[entry_id]
+                for entry_id in self._dirty_entry_ids
+                if entry_id in entries_by_id
             ]
-            write_credential_pool(
-                self.provider,
-                [
-                    entry.to_dict()
-                    for entry in self._entries
-                    if not _is_source_owned_elsewhere(entry)
-                ],
-                removed_ids=removed_ids,
+            source_dirty = [
+                entry
+                for entry in dirty_entries
+                if _is_source_owned_elsewhere(entry)
+            ]
+            local_dirty = any(
+                not _is_source_owned_elsewhere(entry) for entry in dirty_entries
             )
-            for entry in source_owned:
-                self._persist_source_owned_alias(entry)
+            local_removed_ids = list(removed_ids or [])
+            source_removed = [
+                entry
+                for entry in (removed_entries or [])
+                if _is_source_owned_elsewhere(entry)
+            ]
+            local_removed_ids.extend(
+                entry.id
+                for entry in (removed_entries or [])
+                if not _is_source_owned_elsewhere(entry)
+            )
+
+            if local_dirty or local_removed_ids:
+                write_credential_pool(
+                    self.provider,
+                    [
+                        entry.to_dict()
+                        for entry in self._entries
+                        if not _is_source_owned_elsewhere(entry)
+                    ],
+                    removed_ids=local_removed_ids,
+                )
+            for entry in source_dirty:
+                self._persist_source_owned_alias(
+                    entry,
+                    allow_status_reset=entry.id in self._source_status_reset_ids,
+                )
+            for entry in source_removed:
+                self._remove_source_owned_alias(entry)
+
+            self._dirty_entry_ids.difference_update(
+                entry.id for entry in dirty_entries
+            )
+            self._source_status_reset_ids.difference_update(
+                entry.id for entry in dirty_entries
+            )
 
     def _is_terminal_auth_failure(
         self,
@@ -977,42 +1049,155 @@ class CredentialPool:
             and str(tokens.get("refresh_token") or "").strip()
         )
 
+    @staticmethod
+    def _codex_exact_pool_alias(
+        source_store: Dict[str, Any],
+        entry: PooledCredential,
+    ) -> Tuple[Optional[List[Any]], Optional[int], Optional[Dict[str, Any]]]:
+        pool = source_store.get("credential_pool")
+        persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
+        if not isinstance(persisted, list):
+            return None, None, None
+        for index, item in enumerate(persisted):
+            if (
+                isinstance(item, dict)
+                and item.get("id") == entry.id
+                and item.get("source") == entry.source
+            ):
+                return persisted, index, item
+        return persisted, None, None
+
+    @staticmethod
+    def _codex_pool_alias_has_complete_credentials(
+        payload: Optional[Dict[str, Any]],
+    ) -> bool:
+        if not isinstance(payload, dict):
+            return False
+        if not str(payload.get("access_token") or "").strip():
+            return False
+        if (
+            payload.get("auth_type") == AUTH_TYPE_OAUTH
+            or payload.get("source") in {"device_code", SOURCE_MANUAL_DEVICE_CODE}
+        ):
+            return bool(str(payload.get("refresh_token") or "").strip())
+        return True
+
+    @staticmethod
+    def _codex_tokens_changed(
+        left: PooledCredential,
+        right: PooledCredential,
+    ) -> bool:
+        return (
+            left.access_token != right.access_token
+            or left.refresh_token != right.refresh_token
+        )
+
+    def _codex_alias_is_singleton(
+        self,
+        entry: PooledCredential,
+        state: Optional[Dict[str, Any]],
+        source_path: Path,
+    ) -> bool:
+        if (
+            entry.source != "device_code"
+            or not self._codex_provider_state_has_refresh_chain(state)
+        ):
+            return False
+        assert isinstance(state, dict)
+        alias = _codex_source_pool_alias(source_path, state)
+        return bool(alias is not None and alias.get("id") == entry.id)
+
+    def _drop_source_owned_entry(self, entry: PooledCredential) -> None:
+        with self._lock:
+            self._entries = [item for item in self._entries if item.id != entry.id]
+            self._dirty_entry_ids.discard(entry.id)
+            self._source_status_reset_ids.discard(entry.id)
+            if self._current_id == entry.id:
+                self._current_id = None
+
+    def _revoke_missing_codex_source(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+        *,
+        source_store: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Drop stale memory and remove an incomplete exact owner alias."""
+        store = source_store if source_store is not None else _load_auth_store(source_path)
+        persisted, index, item = self._codex_exact_pool_alias(store, entry)
+        if (
+            persisted is not None
+            and index is not None
+            and not self._codex_pool_alias_has_complete_credentials(item)
+        ):
+            persisted.pop(index)
+            _save_auth_store(store, target_path=source_path)
+        self._drop_source_owned_entry(entry)
+
     def _revoke_missing_codex_device_code_source(
         self,
         entry: PooledCredential,
         source_path: Path,
     ) -> None:
-        """Drop stale memory and any orphan alias for an absent owner chain."""
-        source_store = _load_auth_store(source_path)
-        pool = source_store.get("credential_pool")
-        persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
-        changed = False
-        if isinstance(pool, dict) and isinstance(persisted, list):
-            retained = [
-                item
-                for item in persisted
-                if not (
-                    isinstance(item, dict)
-                    and item.get("id") == entry.id
-                    and item.get("source") == "device_code"
-                )
-            ]
-            if len(retained) != len(persisted):
-                pool["openai-codex"] = retained
-                changed = True
-        if changed:
-            _save_auth_store(source_store, target_path=source_path)
+        """Compatibility wrapper for the pre-provenance singleton path."""
+        self._revoke_missing_codex_source(entry, source_path)
 
-        with self._lock:
-            self._entries = [item for item in self._entries if item.id != entry.id]
-            if self._current_id == entry.id:
-                self._current_id = None
-
-    def _persist_source_owned_alias(self, entry: PooledCredential) -> None:
-        """Route borrowed Codex alias status to its owner without shadowing."""
+    def _sync_source_owned_codex_entry(
+        self,
+        entry: PooledCredential,
+    ) -> Optional[PooledCredential]:
+        """Re-read one borrowed row by stable id, or revoke it if owner vanished."""
         if (
             self.provider != "openai-codex"
-            or entry.source != "device_code"
+            or entry.source_store_path is None
+        ):
+            return entry
+        try:
+            with auth_mod._provider_state_transaction(
+                "openai-codex",
+                expected_source_path=entry.source_store_path,
+            ) as (_active_store, state, source_path):
+                if source_path is None:
+                    self._drop_source_owned_entry(entry)
+                    return None
+                source_store = _load_auth_store(source_path)
+                _persisted, _index, item = self._codex_exact_pool_alias(
+                    source_store,
+                    entry,
+                )
+                if not self._codex_pool_alias_has_complete_credentials(item):
+                    self._revoke_missing_codex_source(
+                        entry,
+                        source_path,
+                        source_store=source_store,
+                    )
+                    return None
+                assert isinstance(item, dict)
+                stored = replace(
+                    PooledCredential.from_dict("openai-codex", item),
+                    source_store_path=source_path,
+                )
+                if self._codex_alias_is_singleton(stored, state, source_path):
+                    synced = self._codex_entry_from_provider_state(stored, state)
+                    if self._codex_tokens_changed(synced, stored):
+                        self._persist_codex_device_code_refresh(synced, source_path)
+                    stored = synced
+                if stored != entry:
+                    self._replace_entry(entry, stored, mark_dirty=False)
+                return stored
+        except Exception as exc:
+            logger.debug("Failed to validate borrowed Codex entry: %s", exc)
+            return entry
+
+    def _persist_source_owned_alias(
+        self,
+        entry: PooledCredential,
+        *,
+        allow_status_reset: bool = False,
+    ) -> None:
+        """Route one changed borrowed Codex row to its exact owning alias."""
+        if (
+            self.provider != "openai-codex"
             or entry.source_store_path is None
         ):
             return
@@ -1021,33 +1206,104 @@ class CredentialPool:
             "openai-codex",
             expected_source_path=entry.source_store_path,
         ) as (_active_store, state, source_path):
-            if (
-                source_path is None
-                or not self._codex_provider_state_has_refresh_chain(state)
-            ):
+            if source_path is None:
+                self._drop_source_owned_entry(entry)
                 return
-
-            synced = self._codex_entry_from_provider_state(entry, state)
-            if synced is not entry:
-                self._replace_entry(entry, synced)
-                entry = synced
-
             source_store = _load_auth_store(source_path)
-            pool = source_store.get("credential_pool")
-            persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
-            if not isinstance(persisted, list):
+            persisted, index, item = self._codex_exact_pool_alias(source_store, entry)
+            if not self._codex_pool_alias_has_complete_credentials(item):
+                self._revoke_missing_codex_source(
+                    entry,
+                    source_path,
+                    source_store=source_store,
+                )
                 return
-            for index, item in enumerate(persisted):
-                if (
-                    isinstance(item, dict)
-                    and item.get("id") == entry.id
-                    and item.get("source") == "device_code"
-                ):
-                    updated = entry.to_dict()
-                    if updated != item:
-                        persisted[index] = updated
-                        _save_auth_store(source_store, target_path=source_path)
-                    return
+            assert isinstance(item, dict)
+            stored = replace(
+                PooledCredential.from_dict("openai-codex", item),
+                source_store_path=source_path,
+            )
+            if self._codex_alias_is_singleton(stored, state, source_path):
+                synced = self._codex_entry_from_provider_state(stored, state)
+                if self._codex_tokens_changed(synced, stored):
+                    self._persist_codex_device_code_refresh(synced, source_path)
+                stored = synced
+            if self._codex_tokens_changed(stored, entry):
+                self._replace_entry(entry, stored, mark_dirty=False)
+                return
+
+            assert persisted is not None and index is not None and item is not None
+            serialized = entry.to_dict()
+            updated = dict(item)
+            updated.update(serialized)
+            if not allow_status_reset:
+                updated = auth_mod._merge_disk_cooldown_state(
+                    updated,
+                    item,
+                    "openai-codex",
+                )
+            if updated != item:
+                persisted[index] = updated
+                _save_auth_store(source_store, target_path=source_path)
+            final_entry = replace(
+                PooledCredential.from_dict("openai-codex", updated),
+                source_store_path=source_path,
+            )
+            if final_entry != entry:
+                self._replace_entry(entry, final_entry, mark_dirty=False)
+
+    def _remove_source_owned_alias(self, entry: PooledCredential) -> None:
+        if self.provider != "openai-codex" or entry.source_store_path is None:
+            return
+        with auth_mod._provider_state_transaction(
+            "openai-codex",
+            expected_source_path=entry.source_store_path,
+        ) as (_active_store, state, source_path):
+            if source_path is None:
+                return
+            source_store = _load_auth_store(source_path)
+            persisted, index, item = self._codex_exact_pool_alias(source_store, entry)
+            if persisted is None or index is None or not isinstance(item, dict):
+                return
+            stored = replace(
+                PooledCredential.from_dict("openai-codex", item),
+                source_store_path=source_path,
+            )
+            if self._codex_alias_is_singleton(stored, state, source_path):
+                refresh_token = str(item.get("refresh_token") or "").strip()
+                persisted[:] = [
+                    candidate
+                    for candidate in persisted
+                    if not (
+                        isinstance(candidate, dict)
+                        and candidate.get("source") == "device_code"
+                        and (
+                            candidate.get("id") == entry.id
+                            or (
+                                refresh_token
+                                and str(
+                                    candidate.get("refresh_token") or ""
+                                ).strip()
+                                == refresh_token
+                            )
+                        )
+                    )
+                ]
+                providers = source_store.get("providers")
+                persisted_state = (
+                    providers.get("openai-codex")
+                    if isinstance(providers, dict)
+                    else None
+                )
+                if isinstance(persisted_state, dict):
+                    tokens = persisted_state.get("tokens")
+                    if isinstance(tokens, dict):
+                        tokens.pop("access_token", None)
+                        tokens.pop("refresh_token", None)
+                        persisted_state["tokens"] = tokens
+            else:
+                persisted.pop(index)
+            _save_auth_store(source_store, target_path=source_path)
 
     def _persist_codex_device_code_refresh(
         self,
@@ -1101,15 +1357,57 @@ class CredentialPool:
 
         if changed:
             _save_auth_store(auth_store, target_path=source_path)
+        with self._lock:
+            self._dirty_entry_ids.discard(entry.id)
+            self._source_status_reset_ids.discard(entry.id)
+
+    def _persist_codex_exact_alias_refresh(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+    ) -> bool:
+        """Persist a non-singleton Codex refresh to one exact owning row."""
+        auth_store = _load_auth_store(source_path)
+        persisted, index, item = self._codex_exact_pool_alias(auth_store, entry)
+        if not self._codex_pool_alias_has_complete_credentials(item):
+            self._revoke_missing_codex_source(
+                entry,
+                source_path,
+                source_store=auth_store,
+            )
+            return False
+        assert persisted is not None and index is not None and item is not None
+        updated = dict(item)
+        updated.update(entry.to_dict())
+        if updated != item:
+            persisted[index] = updated
+            _save_auth_store(auth_store, target_path=source_path)
+        with self._lock:
+            self._dirty_entry_ids.discard(entry.id)
+            self._source_status_reset_ids.discard(entry.id)
+        return True
+
+    def _quarantine_codex_exact_alias_refresh(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+    ) -> None:
+        """Remove one terminal non-singleton chain without touching singleton."""
+        auth_store = _load_auth_store(source_path)
+        persisted, index, _item = self._codex_exact_pool_alias(auth_store, entry)
+        if persisted is not None and index is not None:
+            persisted.pop(index)
+            _save_auth_store(auth_store, target_path=source_path)
 
     def _quarantine_codex_device_code_refresh(
         self,
         entry: PooledCredential,
         source_path: Path,
         exc: Exception,
-    ) -> None:
-        """Clear one terminal Codex singleton chain in its owning store."""
+    ) -> Set[str]:
+        """Clear every device alias on one terminal singleton chain."""
         auth_store = _load_auth_store(source_path)
+        removed_ids: Set[str] = {entry.id}
         providers = auth_store.get("providers")
         state = providers.get("openai-codex") if isinstance(providers, dict) else None
         if isinstance(state, dict):
@@ -1135,16 +1433,42 @@ class CredentialPool:
             pool.get("openai-codex"), list
         ):
             entries = pool["openai-codex"]
+            entry_refresh = str(entry.refresh_token or "").strip()
+            removed_ids.update(
+                str(persisted.get("id"))
+                for persisted in entries
+                if (
+                    isinstance(persisted, dict)
+                    and persisted.get("source") == "device_code"
+                    and (
+                        persisted.get("id") == entry.id
+                        or (
+                            entry_refresh
+                            and str(persisted.get("refresh_token") or "").strip()
+                            == entry_refresh
+                        )
+                    )
+                    and persisted.get("id")
+                )
+            )
             pool["openai-codex"] = [
                 persisted
                 for persisted in entries
                 if not (
                     isinstance(persisted, dict)
-                    and persisted.get("id") == entry.id
                     and persisted.get("source") == "device_code"
+                    and (
+                        persisted.get("id") == entry.id
+                        or (
+                            entry_refresh
+                            and str(persisted.get("refresh_token") or "").strip()
+                            == entry_refresh
+                        )
+                    )
                 )
             ]
         _save_auth_store(auth_store, target_path=source_path)
+        return removed_ids
 
     def _sync_codex_entry_from_auth_store(
         self, entry: PooledCredential
@@ -1499,6 +1823,53 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
+        if self.provider == "openai-codex" and entry.source_store_path is not None:
+            with auth_mod._provider_state_transaction(
+                "openai-codex",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=entry.source_store_path,
+            ) as (_auth_store, state, source_path):
+                if source_path is None:
+                    self._drop_source_owned_entry(entry)
+                    return None
+                source_store = _load_auth_store(source_path)
+                _persisted, _index, item = self._codex_exact_pool_alias(
+                    source_store,
+                    entry,
+                )
+                if not self._codex_pool_alias_has_complete_credentials(item):
+                    self._revoke_missing_codex_source(
+                        entry,
+                        source_path,
+                        source_store=source_store,
+                    )
+                    return None
+                assert isinstance(item, dict)
+                stored = replace(
+                    PooledCredential.from_dict("openai-codex", item),
+                    source_store_path=source_path,
+                )
+                singleton_owned = self._codex_alias_is_singleton(
+                    stored,
+                    state,
+                    source_path,
+                )
+                if singleton_owned:
+                    stored = self._codex_entry_from_provider_state(stored, state)
+                if self._codex_tokens_changed(stored, entry):
+                    # A waiter that observed the winner's rotated exact row
+                    # adopts it even for force=True; replay would consume a
+                    # single-use refresh token twice.
+                    self._replace_entry(entry, stored, mark_dirty=False)
+                    if singleton_owned:
+                        self._persist_codex_device_code_refresh(stored, source_path)
+                    return stored
+                return self._refresh_entry_impl(
+                    stored,
+                    force=force,
+                    codex_source_path=source_path,
+                    codex_singleton_owned=singleton_owned,
+                )
         if self.provider == "openai-codex" and entry.source == "device_code":
             with auth_mod._provider_state_transaction(
                 "openai-codex",
@@ -1524,6 +1895,7 @@ class CredentialPool:
                     entry,
                     force=force,
                     codex_source_path=source_path,
+                    codex_singleton_owned=True,
                 )
         if self.provider == "openai-codex":
             # Manual Codex accounts are profile-owned and independent of the
@@ -1571,6 +1943,7 @@ class CredentialPool:
         *,
         force: bool,
         codex_source_path: Optional[Path] = None,
+        codex_singleton_owned: bool = False,
     ) -> Optional[PooledCredential]:
         try:
             if self.provider == "anthropic":
@@ -1773,13 +2146,32 @@ class CredentialPool:
             if self.provider == "openai-codex":
                 if codex_source_path is not None:
                     source_store = _load_auth_store(codex_source_path)
-                    providers = source_store.get("providers")
-                    state = (
-                        providers.get("openai-codex")
-                        if isinstance(providers, dict)
-                        else None
-                    )
-                    synced = self._codex_entry_from_provider_state(entry, state)
+                    if codex_singleton_owned:
+                        providers = source_store.get("providers")
+                        state = (
+                            providers.get("openai-codex")
+                            if isinstance(providers, dict)
+                            else None
+                        )
+                        synced = self._codex_entry_from_provider_state(entry, state)
+                    else:
+                        _persisted, _index, item = self._codex_exact_pool_alias(
+                            source_store,
+                            entry,
+                        )
+                        if self._codex_pool_alias_has_complete_credentials(item):
+                            assert isinstance(item, dict)
+                            synced = replace(
+                                PooledCredential.from_dict("openai-codex", item),
+                                source_store_path=codex_source_path,
+                            )
+                        else:
+                            self._revoke_missing_codex_source(
+                                entry,
+                                codex_source_path,
+                                source_store=source_store,
+                            )
+                            return None
                 else:
                     synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced.refresh_token != entry.refresh_token:
@@ -1797,9 +2189,14 @@ class CredentialPool:
                     )
                     self._replace_entry(synced, updated)
                     if codex_source_path is not None:
-                        self._persist_codex_device_code_refresh(
-                            updated, codex_source_path
-                        )
+                        if codex_singleton_owned:
+                            self._persist_codex_device_code_refresh(
+                                updated, codex_source_path
+                            )
+                        else:
+                            self._persist_codex_exact_alias_refresh(
+                                updated, codex_source_path
+                            )
                     else:
                         self._persist()
                     return updated
@@ -1812,12 +2209,22 @@ class CredentialPool:
                     logger.debug(
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"
                     )
+                    removed_ids = {entry.id}
                     try:
                         if codex_source_path is not None:
-                            self._quarantine_codex_device_code_refresh(
-                                entry, codex_source_path, exc
-                            )
+                            if codex_singleton_owned:
+                                removed_ids = (
+                                    self._quarantine_codex_device_code_refresh(
+                                        entry, codex_source_path, exc
+                                    )
+                                )
+                            else:
+                                self._quarantine_codex_exact_alias_refresh(
+                                    entry, codex_source_path
+                                )
+                                removed_ids = {entry.id}
                         else:
+                            removed_ids = {entry.id}
                             with _auth_store_lock():
                                 auth_store = _load_auth_store()
                                 state = (
@@ -1869,14 +2276,15 @@ class CredentialPool:
                     # pool lock), so take it here. self._lock is an RLock,
                     # so the still-locked callers re-enter safely.
                     with self._lock:
-                        removed_ids = [entry.id]
                         self._entries = [
-                            item for item in self._entries if item.id != entry.id
+                            item for item in self._entries if item.id not in removed_ids
                         ]
-                        if self._current_id == entry.id:
+                        self._dirty_entry_ids.difference_update(removed_ids)
+                        self._source_status_reset_ids.difference_update(removed_ids)
+                        if self._current_id in removed_ids:
                             self._current_id = None
                         if codex_source_path is None:
-                            self._persist(removed_ids=removed_ids)
+                            self._persist(removed_ids=list(removed_ids))
                     return None
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
@@ -1949,9 +2357,14 @@ class CredentialPool:
                     return None
             if self.provider == "openai-codex" and codex_source_path is not None:
                 exhausted = self._mark_exhausted(entry, None, persist=False)
-                self._persist_codex_device_code_refresh(
-                    exhausted, codex_source_path
-                )
+                if codex_singleton_owned:
+                    self._persist_codex_device_code_refresh(
+                        exhausted, codex_source_path
+                    )
+                else:
+                    self._persist_codex_exact_alias_refresh(
+                        exhausted, codex_source_path
+                    )
             else:
                 self._mark_exhausted(entry, None)
             return None
@@ -1967,7 +2380,10 @@ class CredentialPool:
         )
         self._replace_entry(entry, updated)
         if self.provider == "openai-codex" and codex_source_path is not None:
-            self._persist_codex_device_code_refresh(updated, codex_source_path)
+            if codex_singleton_owned:
+                self._persist_codex_device_code_refresh(updated, codex_source_path)
+            else:
+                self._persist_codex_exact_alias_refresh(updated, codex_source_path)
         else:
             self._persist()
             # Sync refreshed tokens back to auth.json providers so that
@@ -2102,7 +2518,15 @@ class CredentialPool:
         sole_credential = sum(
             1 for e in self._entries if e.last_status != STATUS_DEAD
         ) <= 1
-        for entry in self._entries:
+        for entry in list(self._entries):
+            if (
+                self.provider == "openai-codex"
+                and _is_source_owned_elsewhere(entry)
+            ):
+                synced_source = self._sync_source_owned_codex_entry(entry)
+                if synced_source is None:
+                    continue
+                entry = synced_source
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
             # can remain unhydrated; never lease or select it as an empty key.
@@ -2135,6 +2559,7 @@ class CredentialPool:
             # future for ChatGPT weekly windows).
             if (self.provider == "openai-codex"
                     and entry.source == "device_code"
+                    and entry.source_store_path is None
                     and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
@@ -2227,9 +2652,14 @@ class CredentialPool:
             available.append(entry)
         if entries_to_prune:
             pruned_ids = set(entries_to_prune)
+            pruned_entries = [
+                entry for entry in self._entries if entry.id in pruned_ids
+            ]
             self._entries = [e for e in self._entries if e.id not in pruned_ids]
+        else:
+            pruned_entries = []
         if cleared_any:
-            self._persist(removed_ids=entries_to_prune)
+            self._persist(removed_entries=pruned_entries)
         return available, pending_refresh
 
     def _log_no_available_entries(self) -> None:
@@ -2278,9 +2708,15 @@ class CredentialPool:
 
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
+            previous_by_id = {candidate.id: candidate for candidate in self._entries}
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
+            self._dirty_entry_ids.update(
+                candidate.id
+                for candidate in self._entries
+                if previous_by_id.get(candidate.id) != candidate
+            )
             self._persist()
             self._current_id = entry.id
             return self._current_unlocked() or entry, pending_refresh
@@ -2293,10 +2729,12 @@ class CredentialPool:
         # Single lock acquisition for the whole read; call the unlocked
         # helpers so we don't re-enter the non-reentrant ``self._lock``.
         with self._lock:
+            available, _pending = self._available_entries()
             current = self._current_unlocked()
             if current is not None:
-                return current
-            available, _pending = self._available_entries()
+                for entry in available:
+                    if entry.id == current.id:
+                        return entry
             return available[0] if available else None
 
     def mark_exhausted_and_rotate(
@@ -2465,6 +2903,22 @@ class CredentialPool:
         """Run lease acquisition under the lock, returning id + pending refreshes."""
         with self._lock:
             if credential_id:
+                candidate = next(
+                    (
+                        entry
+                        for entry in self._entries
+                        if entry.id == credential_id
+                    ),
+                    None,
+                )
+                if candidate is None:
+                    return None, []
+                if (
+                    self.provider == "openai-codex"
+                    and _is_source_owned_elsewhere(candidate)
+                    and self._sync_source_owned_codex_entry(candidate) is None
+                ):
+                    return None, []
                 self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
                 self._current_id = credential_id
                 return credential_id, []
@@ -2555,6 +3009,7 @@ class CredentialPool:
         with self._lock:
             count = 0
             new_entries = []
+            reset_ids: Set[str] = set()
             for entry in self._entries:
                 if entry.last_status or entry.last_status_at or entry.last_error_code:
                     new_entries.append(
@@ -2568,11 +3023,19 @@ class CredentialPool:
                             last_error_reset_at=None,
                         )
                     )
+                    reset_ids.add(entry.id)
                     count += 1
                 else:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
+                self._dirty_entry_ids.update(reset_ids)
+                self._source_status_reset_ids.update(
+                    entry.id
+                    for entry in new_entries
+                    if entry.id in reset_ids
+                    and _is_source_owned_elsewhere(entry)
+                )
                 self._persist()
             return count
 
@@ -2581,15 +3044,17 @@ class CredentialPool:
             if index < 1 or index > len(self._entries):
                 return None
             removed = self._entries.pop(index - 1)
+            previous_by_id = {entry.id: entry for entry in self._entries}
             self._entries = [
                 replace(entry, priority=new_priority)
                 for new_priority, entry in enumerate(self._entries)
             ]
-            self._persist(
-                removed_ids=(
-                    [] if _is_source_owned_elsewhere(removed) else [removed.id]
-                )
+            self._dirty_entry_ids.update(
+                entry.id
+                for entry in self._entries
+                if previous_by_id.get(entry.id) != entry
             )
+            self._persist(removed_entries=[removed])
             if self._current_id == removed.id:
                 self._current_id = None
             return removed
@@ -2624,6 +3089,7 @@ class CredentialPool:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
+            self._dirty_entry_ids.add(entry.id)
             self._persist()
             return entry
 
@@ -3363,6 +3829,12 @@ def _prune_stale_seeded_entries(
         # (e.g. an `hermes auth` command that confirmed the source is gone).
         if entry.source.startswith("env:"):
             return prune_env_sources
+        # Codex may retain independent device-code rows on chains other than
+        # the current singleton. Terminal quarantine removes only aliases that
+        # share the rejected singleton chain; absence of singleton state alone
+        # is not authority to delete the unrelated rows that remain in pool.
+        if entry.provider == "openai-codex" and entry.source == "device_code":
+            return False
         # File-backed singletons (device-code OAuth, claude_code) and Hermes
         # PKCE should disappear from the pool when their backing file is gone.
         return (
@@ -3480,7 +3952,14 @@ def load_pool(provider: str) -> CredentialPool:
         and sanitize_borrowed_credential_payload(payload, provider) != payload
         for payload in raw_entries
     )
-    entries = [PooledCredential.from_dict(provider, payload) for payload in raw_entries]
+    entries = []
+    for payload in raw_entries:
+        entry = PooledCredential.from_dict(provider, payload)
+        if provider == "openai-codex":
+            source_path = auth_mod._credential_pool_row_source_path(payload)
+            if source_path is not None:
+                entry = replace(entry, source_store_path=source_path)
+        entries.append(entry)
     raw_needs_auth_normalization = any(
         isinstance(payload, dict)
         and _normalize_pool_auth_type(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -28,13 +28,11 @@ from hermes_cli.auth import (
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
-    _global_auth_file_path,
     _load_auth_store,
     _load_provider_state,
     _load_provider_state_with_source,
     _resolve_kimi_base_url,
     _resolve_zai_base_url,
-    _same_path,
     _save_auth_store,
     _save_provider_state,
     _store_provider_state,
@@ -207,6 +205,10 @@ class PooledCredential:
     agent_key_expires_at: Optional[str] = None
     request_count: int = 0
     extra: Dict[str, Any] = None  # type: ignore[assignment]
+    # Runtime-only owner for a singleton borrowed from another auth store.
+    # Never hydrate or serialize this path: it is process-local routing state,
+    # not part of the public credential-pool schema.
+    source_store_path: Optional[Path] = None
 
     def __post_init__(self):
         if self.extra is None:
@@ -224,7 +226,11 @@ class PooledCredential:
 
     @classmethod
     def from_dict(cls, provider: str, payload: Dict[str, Any]) -> "PooledCredential":
-        field_names = {f.name for f in fields(cls) if f.name != "provider"}
+        field_names = {
+            f.name
+            for f in fields(cls)
+            if f.name not in {"provider", "source_store_path"}
+        }
         data = {k: payload.get(k) for k in field_names if k in payload}
         # Rehydrated last_status_at may be an ISO string from to_dict() — normalize to float epoch
         if "last_status_at" in data and isinstance(data["last_status_at"], str):
@@ -250,7 +256,7 @@ class PooledCredential:
         }
         result: Dict[str, Any] = {}
         for field_def in fields(self):
-            if field_def.name in {"provider", "extra"}:
+            if field_def.name in {"provider", "extra", "source_store_path"}:
                 continue
             value = getattr(self, field_def.name)
             if value is not None or field_def.name in _ALWAYS_EMIT:
@@ -305,6 +311,11 @@ def _next_priority(entries: List[PooledCredential]) -> int:
 def _is_manual_source(source: str) -> bool:
     normalized = (source or "").strip().lower()
     return normalized == SOURCE_MANUAL or normalized.startswith(f"{SOURCE_MANUAL}:")
+
+
+def _is_source_owned_elsewhere(entry: PooledCredential) -> bool:
+    """Return whether an entry is a read-only alias owned by another store."""
+    return entry.source_store_path is not None
 
 
 def _exhausted_ttl(
@@ -761,11 +772,20 @@ class CredentialPool:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
+            source_owned = [
+                entry for entry in self._entries if _is_source_owned_elsewhere(entry)
+            ]
             write_credential_pool(
                 self.provider,
-                [entry.to_dict() for entry in self._entries],
+                [
+                    entry.to_dict()
+                    for entry in self._entries
+                    if not _is_source_owned_elsewhere(entry)
+                ],
                 removed_ids=removed_ids,
             )
+            for entry in source_owned:
+                self._persist_source_owned_alias(entry)
 
     def _is_terminal_auth_failure(
         self,
@@ -943,6 +963,92 @@ class CredentialPool:
             field_updates["last_refresh"] = state["last_refresh"]
         return replace(entry, **field_updates)
 
+    @staticmethod
+    def _codex_provider_state_has_refresh_chain(
+        state: Optional[Dict[str, Any]],
+    ) -> bool:
+        if not isinstance(state, dict):
+            return False
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return False
+        return bool(
+            str(tokens.get("access_token") or "").strip()
+            and str(tokens.get("refresh_token") or "").strip()
+        )
+
+    def _revoke_missing_codex_device_code_source(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+    ) -> None:
+        """Drop stale memory and any orphan alias for an absent owner chain."""
+        source_store = _load_auth_store(source_path)
+        pool = source_store.get("credential_pool")
+        persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
+        changed = False
+        if isinstance(pool, dict) and isinstance(persisted, list):
+            retained = [
+                item
+                for item in persisted
+                if not (
+                    isinstance(item, dict)
+                    and item.get("id") == entry.id
+                    and item.get("source") == "device_code"
+                )
+            ]
+            if len(retained) != len(persisted):
+                pool["openai-codex"] = retained
+                changed = True
+        if changed:
+            _save_auth_store(source_store, target_path=source_path)
+
+        with self._lock:
+            self._entries = [item for item in self._entries if item.id != entry.id]
+            if self._current_id == entry.id:
+                self._current_id = None
+
+    def _persist_source_owned_alias(self, entry: PooledCredential) -> None:
+        """Route borrowed Codex alias status to its owner without shadowing."""
+        if (
+            self.provider != "openai-codex"
+            or entry.source != "device_code"
+            or entry.source_store_path is None
+        ):
+            return
+
+        with auth_mod._provider_state_transaction(
+            "openai-codex",
+            expected_source_path=entry.source_store_path,
+        ) as (_active_store, state, source_path):
+            if (
+                source_path is None
+                or not self._codex_provider_state_has_refresh_chain(state)
+            ):
+                return
+
+            synced = self._codex_entry_from_provider_state(entry, state)
+            if synced is not entry:
+                self._replace_entry(entry, synced)
+                entry = synced
+
+            source_store = _load_auth_store(source_path)
+            pool = source_store.get("credential_pool")
+            persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
+            if not isinstance(persisted, list):
+                return
+            for index, item in enumerate(persisted):
+                if (
+                    isinstance(item, dict)
+                    and item.get("id") == entry.id
+                    and item.get("source") == "device_code"
+                ):
+                    updated = entry.to_dict()
+                    if updated != item:
+                        persisted[index] = updated
+                        _save_auth_store(source_store, target_path=source_path)
+                    return
+
     def _persist_codex_device_code_refresh(
         self,
         entry: PooledCredential,
@@ -1047,7 +1153,10 @@ class CredentialPool:
         if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
         try:
-            with auth_mod._provider_state_transaction("openai-codex") as (
+            with auth_mod._provider_state_transaction(
+                "openai-codex",
+                expected_source_path=entry.source_store_path,
+            ) as (
                 _auth_store,
                 state,
                 source_path,
@@ -1307,11 +1416,11 @@ class CredentialPool:
                 else:
                     return
 
-                global_root = _global_auth_file_path()
+                global_root = auth_mod._global_auth_file_path()
                 is_from_root = bool(
                     source_path is not None
                     and global_root is not None
-                    and _same_path(source_path, global_root)
+                    and auth_mod._same_path(source_path, global_root)
                 )
 
                 if self.provider == "nous":
@@ -1394,8 +1503,15 @@ class CredentialPool:
             with auth_mod._provider_state_transaction(
                 "openai-codex",
                 timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=entry.source_store_path,
             ) as (_auth_store, state, source_path):
                 source_path = source_path or auth_mod._auth_file_path()
+                if not self._codex_provider_state_has_refresh_chain(state):
+                    self._revoke_missing_codex_device_code_source(
+                        entry,
+                        source_path,
+                    )
+                    return None
                 synced = self._codex_entry_from_provider_state(entry, state)
                 if synced is not entry:
                     # A waiter that observed the winner's rotated chain adopts
@@ -2469,10 +2585,10 @@ class CredentialPool:
                 replace(entry, priority=new_priority)
                 for new_priority, entry in enumerate(self._entries)
             ]
-            write_credential_pool(
-                self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=[removed.id],
+            self._persist(
+                removed_ids=(
+                    [] if _is_source_owned_elsewhere(removed) else [removed.id]
+                )
             )
             if self._current_id == removed.id:
                 self._current_id = None
@@ -2605,10 +2721,54 @@ def _normalize_pool_priorities(provider: str, entries: List[PooledCredential]) -
     return changed
 
 
-def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tuple[bool, Set[str]]:
+def _codex_source_pool_alias(
+    source_path: Path,
+    state: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Return the owning Codex ``device_code`` alias for a singleton state."""
+    source_store = auth_mod._load_auth_store(source_path)
+    pool = source_store.get("credential_pool")
+    persisted = pool.get("openai-codex") if isinstance(pool, dict) else None
+    if not isinstance(persisted, list):
+        return None
+
+    aliases = [
+        item
+        for item in persisted
+        if isinstance(item, dict) and item.get("source") == "device_code"
+    ]
+    if not aliases:
+        return None
+
+    tokens = state.get("tokens")
+    if isinstance(tokens, dict):
+        access_token = str(tokens.get("access_token") or "")
+        refresh_token = str(tokens.get("refresh_token") or "")
+        for alias in aliases:
+            if (
+                str(alias.get("access_token") or "") == access_token
+                and str(alias.get("refresh_token") or "") == refresh_token
+            ):
+                return dict(alias)
+    return dict(aliases[0])
+
+
+def _seed_from_singletons(
+    provider: str,
+    entries: List[PooledCredential],
+) -> Tuple[bool, Set[str]]:
     changed = False
     active_sources: Set[str] = set()
     auth_store = _load_auth_store()
+    active_pool = auth_store.get("credential_pool")
+    local_entries = (
+        active_pool.get(provider) if isinstance(active_pool, dict) else None
+    )
+    local_entry_ids = {
+        str(entry.get("id"))
+        for entry in local_entries or []
+        if isinstance(entry, dict) and entry.get("id")
+    }
 
     # Shared suppression gate — used at every upsert site so
     # `hermes auth remove <provider> <N>` is stable across all source types.
@@ -2914,7 +3074,10 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         if _is_suppressed(provider, "device_code"):
             return changed, active_sources
 
-        state = _load_provider_state(auth_store, "openai-codex")
+        state, source_path = auth_mod._load_provider_state_with_source(
+            auth_store,
+            "openai-codex",
+        )
         tokens = state.get("tokens") if isinstance(state, dict) else None
         # Hermes owns its own Codex auth state — we do NOT auto-import from
         # ~/.codex/auth.json at pool-load time.  OAuth refresh tokens are
@@ -2922,23 +3085,80 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # refresh_token_reused race failures.  Users who want to adopt
         # existing Codex CLI credentials get a one-time, explicit prompt
         # via `hermes auth openai-codex`.
-        if isinstance(tokens, dict) and tokens.get("access_token"):
+        if (
+            isinstance(state, dict)
+            and isinstance(tokens, dict)
+            and tokens.get("access_token")
+        ):
             active_sources.add("device_code")
             custom_label = str(state.get("label") or "").strip()
-            changed |= _upsert_entry(
-                entries,
-                provider,
-                "device_code",
-                {
-                    "source": "device_code",
-                    "auth_type": AUTH_TYPE_OAUTH,
-                    "access_token": tokens.get("access_token", ""),
-                    "refresh_token": tokens.get("refresh_token"),
-                    "base_url": "https://chatgpt.com/backend-api/codex",
-                    "last_refresh": state.get("last_refresh"),
-                    "label": custom_label or label_from_token(tokens.get("access_token", ""), "device_code"),
-                },
+            payload = {
+                "source": "device_code",
+                "auth_type": AUTH_TYPE_OAUTH,
+                "access_token": tokens.get("access_token", ""),
+                "refresh_token": tokens.get("refresh_token"),
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "last_refresh": state.get("last_refresh"),
+                "label": custom_label
+                or label_from_token(tokens.get("access_token", ""), "device_code"),
+            }
+            active_path = auth_mod._auth_file_path()
+            borrowed = bool(
+                source_path is not None
+                and not auth_mod._same_path(source_path, active_path)
             )
+            if borrowed and source_path is not None:
+                alias = _codex_source_pool_alias(source_path, state)
+                if alias is not None:
+                    token_changed = (
+                        alias.get("access_token") != payload["access_token"]
+                        or alias.get("refresh_token") != payload["refresh_token"]
+                    )
+                    alias_payload = dict(alias)
+                    alias_payload.update(
+                        {
+                            key: value
+                            for key, value in payload.items()
+                            if key != "label"
+                        }
+                    )
+                    if not alias_payload.get("label"):
+                        alias_payload["label"] = payload["label"]
+                    if token_changed:
+                        for status_field in (
+                            "last_status",
+                            "last_status_at",
+                            "last_error_code",
+                            "last_error_reason",
+                            "last_error_message",
+                            "last_error_reset_at",
+                        ):
+                            alias_payload[status_field] = None
+                    payload = alias_payload
+
+                local_shadow_present = any(
+                    entry.source == "device_code" and entry.id in local_entry_ids
+                    for entry in entries
+                )
+                entries[:] = [
+                    entry for entry in entries if entry.source != "device_code"
+                ]
+                payload.setdefault("id", uuid.uuid4().hex[:6])
+                payload.setdefault("priority", _next_priority(entries))
+                borrowed_entry = PooledCredential.from_dict(provider, payload)
+                entries.append(
+                    replace(borrowed_entry, source_store_path=source_path)
+                )
+                # Adding a runtime-only borrowed alias is not a profile write.
+                # Only pre-existing copied profile rows require cleanup.
+                changed |= local_shadow_present
+            else:
+                changed |= _upsert_entry(
+                    entries,
+                    provider,
+                    "device_code",
+                    payload,
+                )
 
     elif provider == "xai-oauth":
         # When the user logs in via ``hermes model`` -> xAI Grok OAuth,
@@ -3238,9 +3458,20 @@ def _seed_custom_pool(pool_key: str, entries: List[PooledCredential]) -> Tuple[b
 
 def load_pool(provider: str) -> CredentialPool:
     provider = (provider or "").strip().lower()
+    active_store = _load_auth_store()
+    active_pool = active_store.get("credential_pool")
+    active_entries = (
+        active_pool.get(provider) if isinstance(active_pool, dict) else None
+    )
+    local_raw_entries = list(active_entries) if isinstance(active_entries, list) else []
+    local_entry_ids = {
+        str(entry.get("id"))
+        for entry in local_raw_entries
+        if isinstance(entry, dict) and entry.get("id")
+    }
     raw_entries = read_credential_pool(provider)
     disk_ids = {
-        entry.get("id")
+        str(entry.get("id"))
         for entry in raw_entries
         if isinstance(entry, dict) and entry.get("id")
     }
@@ -3263,8 +3494,6 @@ def load_pool(provider: str) -> CredentialPool:
         # A profile may be reading this provider from the global-root fallback.
         # Keep that fallback read-only: only the store that owns these rows may
         # rewrite them. Loading the default/root profile will heal global rows.
-        active_pool = _load_auth_store().get("credential_pool")
-        active_entries = active_pool.get(provider) if isinstance(active_pool, dict) else None
         raw_needs_auth_normalization = bool(active_entries)
 
     if provider.startswith(CUSTOM_POOL_PREFIX):
@@ -3293,10 +3522,26 @@ def load_pool(provider: str) -> CredentialPool:
         changed |= _normalize_pool_priorities(provider, entries)
 
     if changed:
-        new_ids = {entry.id for entry in entries}
+        persisted_entries = [
+            entry
+            for entry in entries
+            if not _is_source_owned_elsewhere(entry)
+        ]
+        new_ids = {entry.id for entry in persisted_entries}
+        persisted_disk_ids = (
+            local_entry_ids
+            if any(_is_source_owned_elsewhere(entry) for entry in entries)
+            else disk_ids
+        )
         write_credential_pool(
             provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
-            removed_ids=disk_ids - new_ids,
+            [
+                entry.to_dict()
+                for entry in sorted(
+                    persisted_entries,
+                    key=lambda item: item.priority,
+                )
+            ],
+            removed_ids=persisted_disk_ids - new_ids,
         )
     return CredentialPool(provider, entries)

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -657,11 +657,9 @@ class CredentialPool:
         self._entries = sorted(entries, key=lambda entry: entry.priority)
         self._current_id: Optional[str] = None
         self._strategy = get_pool_strategy(provider)
-        # RLock: the mutation primitives below (_replace_entry/_persist)
-        # self-acquire this lock so the DEFERRED single-use-token refresh
-        # path (which runs network I/O outside the lock by design) still
-        # serializes its pool mutations. In-lock callers re-acquire
-        # reentrantly at negligible cost.
+        # RLock: mutation primitives self-acquire this lock so refresh and
+        # status-sync work performed outside the lock still serializes its
+        # in-memory updates. Persistence is always drained after releasing it.
         self._lock = threading.RLock()
         self._persist_lock = threading.Lock()
         # Persist only entries changed by this pool instance. Borrowed rows are
@@ -805,6 +803,7 @@ class CredentialPool:
         # otherwise a status probe here can race a concurrent ``select`` /
         # rotation and tear ``self._entries`` or double-write auth.json.
         failed_source_ids = self._validate_source_owned_codex_entries()
+        self._sync_external_status_entries()
         with self._lock:
             available, _pending = self._available_entries(
                 excluded_source_ids=failed_source_ids,
@@ -829,6 +828,7 @@ class CredentialPool:
         ``_available_entries`` caller (see the comment on ``has_available``).
         """
         failed_source_ids = self._validate_source_owned_codex_entries()
+        self._sync_external_status_entries()
         with self._lock:
             available, _pending = self._available_entries(
                 excluded_source_ids=failed_source_ids,
@@ -996,6 +996,11 @@ class CredentialPool:
         removed_ids: Optional[List[str]] = None,
         removed_entries: Optional[List[PooledCredential]] = None,
     ) -> None:
+        is_owned = getattr(self._lock, "_is_owned", None)
+        if callable(is_owned) and is_owned():
+            raise RuntimeError(
+                "credential pool persistence cannot run while the pool lock is held"
+            )
         # Auth transactions and file writes deliberately happen without the
         # pool lock. Source refresh takes auth locks first and then replaces an
         # in-memory row; holding the pool lock here would invert that order.
@@ -1194,7 +1199,12 @@ class CredentialPool:
             self._persist()
         return replaced
 
-    def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_anthropic_entry_from_credentials_file(
+        self,
+        entry: PooledCredential,
+        *,
+        persist: bool = True,
+    ) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
 
         OAuth refresh tokens are single-use. When something external (e.g.
@@ -1240,7 +1250,8 @@ class CredentialPool:
                     last_error_reset_at=None,
                 )
                 self._replace_entry(entry, updated)
-                self._persist()
+                if persist:
+                    self._persist_pending_changes()
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync from credentials file: %s", exc)
@@ -1853,7 +1864,12 @@ class CredentialPool:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
             return entry
 
-    def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_xai_oauth_entry_from_auth_store(
+        self,
+        entry: PooledCredential,
+        *,
+        persist: bool = True,
+    ) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
 
         xAI OAuth refresh tokens are single-use.  When another Hermes process
@@ -1905,7 +1921,8 @@ class CredentialPool:
                     field_updates["last_refresh"] = state["last_refresh"]
                 updated = replace(entry, **field_updates)
                 self._replace_entry(entry, updated)
-                self._persist()
+                if persist:
+                    self._persist_pending_changes()
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync xAI OAuth entry from auth.json: %s", exc)
@@ -1950,7 +1967,12 @@ class CredentialPool:
             logger.debug("Failed to sync xAI OAuth entry from credential pool: %s", exc)
         return entry
 
-    def _sync_nous_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
+    def _sync_nous_entry_from_auth_store(
+        self,
+        entry: PooledCredential,
+        *,
+        persist: bool = True,
+    ) -> PooledCredential:
         """Sync a Nous pool entry from auth.json if tokens differ.
 
         Nous OAuth refresh tokens are single-use.  When another process
@@ -2016,7 +2038,8 @@ class CredentialPool:
                         extra_updates[extra_key] = val
                 updated = replace(entry, extra=extra_updates, **field_updates)
                 self._replace_entry(entry, updated)
-                self._persist()
+                if persist:
+                    self._persist_pending_changes()
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync Nous entry from auth.json: %s", exc)
@@ -2508,7 +2531,7 @@ class CredentialPool:
                         ]
                         if self._current_id == entry.id:
                             self._current_id = None
-                        self._persist(removed_ids=removed_ids)
+                    self._persist(removed_ids=removed_ids)
                     return None
             # For openai-codex: same race as xAI/nous — another Hermes process
             # may have consumed the refresh token between our proactive sync
@@ -2727,7 +2750,7 @@ class CredentialPool:
                         ]
                         if self._current_id == entry.id:
                             self._current_id = None
-                        self._persist(removed_ids=removed_ids)
+                    self._persist(removed_ids=removed_ids)
                     return None
             if self.provider == "openai-codex" and codex_source_path is not None:
                 exhausted = self._mark_exhausted(entry, None, persist=False)
@@ -2827,8 +2850,57 @@ class CredentialPool:
             return False
         return False
 
+    def _sync_external_status_entries(self, *, probe_quota: bool = False) -> None:
+        """Refresh external status sources without holding the pool lock."""
+        with self._lock:
+            status_entries = [
+                entry
+                for entry in self._entries
+                if entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}
+            ]
+
+        for entry in status_entries:
+            if self.provider == "anthropic" and entry.source == "claude_code":
+                self._sync_anthropic_entry_from_credentials_file(
+                    entry,
+                    persist=False,
+                )
+            elif self.provider == "nous" and entry.source == "device_code":
+                self._sync_nous_entry_from_auth_store(entry, persist=False)
+            elif (
+                self.provider == "openai-codex"
+                and entry.source == "device_code"
+                and entry.source_store_path is None
+            ):
+                self._sync_codex_entry_from_auth_store(entry)
+            elif self.provider == "xai-oauth" and entry.source == "device_code":
+                self._sync_xai_oauth_entry_from_auth_store(entry, persist=False)
+
+        if not probe_quota:
+            return
+        with self._lock:
+            quota_entries = [
+                entry
+                for entry in self._entries
+                if entry.last_status == STATUS_EXHAUSTED
+            ]
+        for entry in quota_entries:
+            if not self._codex_quota_restored_upstream(entry):
+                continue
+            cleared = replace(
+                entry,
+                last_status=STATUS_OK,
+                last_status_at=None,
+                last_error_code=None,
+                last_error_reason=None,
+                last_error_message=None,
+                last_error_reset_at=None,
+            )
+            self._replace_entry(entry, cleared)
+
     def select(self) -> Optional[PooledCredential]:
         failed_source_ids = self._validate_source_owned_codex_entries()
+        self._sync_external_status_entries(probe_quota=True)
         entry, pending_refresh = self._select_under_lock(failed_source_ids)
         self._persist_pending_changes()
         if pending_refresh:
@@ -2840,6 +2912,7 @@ class CredentialPool:
         # now that the refreshed entries are back in the pool.
         if pending_refresh:
             failed_source_ids = self._validate_source_owned_codex_entries()
+            self._sync_external_status_entries(probe_quota=True)
             entry, _ = self._select_under_lock(failed_source_ids)
             self._persist_pending_changes()
             if entry is not None:
@@ -2857,13 +2930,13 @@ class CredentialPool:
             )
 
     def _refresh_pending_entries(self, pending: List[tuple]) -> None:
-        """Refresh deferred single-use-token entries outside the lock.
+        """Refresh deferred OAuth entries outside the lock.
 
         Each entry is refreshed under the cross-process ``_auth_store_lock``
         (which can block for 20+ seconds) and then merged into the pool.
         On failure the entry is silently skipped.
         """
-        for entry, sync_fn in pending:
+        for entry, _sync_fn in pending:
             # _refresh_entry merges the refreshed entry into the pool
             # internally. Its mutation primitives (_replace_entry, _persist)
             # are self-locking, and the quarantine paths inside
@@ -2882,22 +2955,15 @@ class CredentialPool:
         """Return (available, pending_refresh) for entries not in cooldown.
 
         When *clear_expired* is True, entries whose cooldown has elapsed are
-        reset to STATUS_OK and persisted.  When *refresh* is True, entries
-        that need a token refresh are refreshed (skipped on failure).
-
-        Single-use-token refreshes (openai-codex, xai-oauth) are returned as
-        *pending_refresh* tuples so the caller can execute them outside the
-        lock, avoiding stalling all pool consumers during cross-process flock
-        acquisition + OAuth network I/O.
+        reset to STATUS_OK and persisted. When *refresh* is True, entries that
+        need a token refresh are returned to the caller for refresh after the
+        lock is released.
         """
         now = time.time()
-        cleared_any = False
         entries_to_prune: List[str] = []
         available: List[PooledCredential] = []
-        # Entries that need an OAuth refresh via a single-use token provider
-        # (openai-codex, xai-oauth).  These require a cross-process file lock
-        # that can block for 20+ seconds.  We collect them under self._lock
-        # and refresh outside the lock to avoid stalling all pool consumers.
+        # Refresh can perform network and auth-store I/O for every OAuth
+        # provider, so collect candidates here and execute them after unlock.
         pending_refresh: List[tuple] = []  # (entry, sync_entry_fn)
         # DEAD entries never re-enter rotation, so if at most one non-DEAD entry
         # exists there is nothing to rotate to: an exhausted sole credential
@@ -2913,50 +2979,6 @@ class CredentialPool:
             # can remain unhydrated; never lease or select it as an empty key.
             if entry.auth_type == AUTH_TYPE_API_KEY and not entry.runtime_api_key:
                 continue
-            # For anthropic claude_code entries, sync from the credentials file
-            # before any status/refresh checks. This picks up tokens refreshed
-            # by other processes (Claude Code CLI, other Hermes profiles).
-            if (self.provider == "anthropic" and entry.source == "claude_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
-                synced = self._sync_anthropic_entry_from_credentials_file(entry)
-                if synced is not entry:
-                    entry = synced
-                    cleared_any = True
-            # For nous entries, sync from auth.json before status checks.
-            # Another process may have successfully refreshed via
-            # resolve_nous_runtime_credentials(), making this entry's
-            # exhausted status stale.
-            if (self.provider == "nous"
-                    and entry.source == "device_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
-                synced = self._sync_nous_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
-                    cleared_any = True
-            # For openai-codex entries, same pattern: the user may have
-            # re-authed via `hermes model` / `hermes auth` after a 429/401,
-            # leaving fresh tokens on disk while the pool entry is still
-            # frozen behind last_error_reset_at (can be hours in the
-            # future for ChatGPT weekly windows).
-            if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
-                    and entry.source_store_path is None
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
-                synced = self._sync_codex_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
-                    cleared_any = True
-            # For xai-oauth singleton-seeded entries, identical pattern:
-            # an entry frozen as exhausted may simply be holding stale
-            # tokens that another process (or a fresh `hermes model` ->
-            # xAI Grok OAuth login) has since rotated in auth.json.
-            if (self.provider == "xai-oauth"
-                    and entry.source == "device_code"
-                    and entry.last_status in {STATUS_EXHAUSTED, STATUS_DEAD}):
-                synced = self._sync_xai_oauth_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
-                    cleared_any = True
             if entry.last_status == STATUS_DEAD:
                 # Manual DEAD credentials get pruned after a 24h quiet window
                 # so the pool doesn't accumulate dead entries forever.  The
@@ -2980,7 +3002,6 @@ class CredentialPool:
                         # Mark for removal after the loop completes; we can't
                         # mutate self._entries while iterating.
                         entries_to_prune.append(entry.id)
-                        cleared_any = True
                 # Permanently failed credentials never re-enter rotation via
                 # TTL.  They only clear when a write-side re-auth sync rewrites
                 # the tokens (e.g. ``_save_codex_tokens`` after a fresh
@@ -2990,18 +3011,7 @@ class CredentialPool:
             if entry.last_status == STATUS_EXHAUSTED:
                 exhausted_until = _exhausted_until(entry, sole_credential=sole_credential)
                 if exhausted_until is not None and now < exhausted_until:
-                    # Codex quota windows can reopen EARLY: the user redeems a
-                    # banked rate-limit reset (Codex CLI / ChatGPT UI), upgrades
-                    # their plan, or OpenAI resets the window.  The persisted
-                    # ``last_error_reset_at`` can then be days in the future
-                    # while the account is already usable again — a throttled
-                    # live probe of the Codex usage endpoint detects that and
-                    # lifts the stale cooldown (issue #43747).
-                    if not (
-                        clear_expired
-                        and self._codex_quota_restored_upstream(entry)
-                    ):
-                        continue
+                    continue
                 if clear_expired:
                     cleared = replace(
                         entry,
@@ -3014,22 +3024,9 @@ class CredentialPool:
                     )
                     self._replace_entry(entry, cleared)
                     entry = cleared
-                    cleared_any = True
             if refresh and self._entry_needs_refresh(entry):
-                if self.provider in ("openai-codex", "xai-oauth"):
-                    # Defer single-use-token refresh to avoid holding the
-                    # threading lock during cross-process flock + network I/O.
-                    sync_fn = (
-                        self._sync_codex_entry_from_auth_store
-                        if self.provider == "openai-codex"
-                        else self._sync_xai_oauth_entry_from_pool_store
-                    )
-                    pending_refresh.append((entry, sync_fn))
-                    continue
-                refreshed = self._refresh_entry(entry, force=False)
-                if refreshed is None:
-                    continue
-                entry = refreshed
+                pending_refresh.append((entry, None))
+                continue
             available.append(entry)
         if entries_to_prune:
             pruned_ids = set(entries_to_prune)
@@ -3140,6 +3137,7 @@ class CredentialPool:
         # Single lock acquisition for the whole read; call the unlocked
         # helpers so we don't re-enter the non-reentrant ``self._lock``.
         failed_source_ids = self._validate_source_owned_codex_entries()
+        self._sync_external_status_entries()
         with self._lock:
             available, _pending = self._available_entries(
                 excluded_source_ids=failed_source_ids,
@@ -3167,6 +3165,7 @@ class CredentialPool:
         failure_reason: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         failed_source_ids = self._validate_source_owned_codex_entries()
+        self._sync_external_status_entries(probe_quota=True)
         try:
             return self._mark_exhausted_and_rotate_locked(
                 status_code=status_code,
@@ -3364,6 +3363,7 @@ class CredentialPool:
         """
         entry_ids = {credential_id} if credential_id is not None else None
         failed_source_ids = self._validate_source_owned_codex_entries(entry_ids)
+        self._sync_external_status_entries(probe_quota=True)
         if failed_source_ids:
             chosen_id, pending_refresh = self._acquire_lease_under_lock(
                 credential_id,
@@ -3386,6 +3386,7 @@ class CredentialPool:
                 failed_source_ids = self._validate_source_owned_codex_entries(
                     entry_ids,
                 )
+                self._sync_external_status_entries(probe_quota=True)
                 if failed_source_ids:
                     chosen_id, _ = self._acquire_lease_under_lock(
                         credential_id,
@@ -3484,44 +3485,47 @@ class CredentialPool:
         rotating refresh token exactly once.
         """
         failed_source_ids = self._validate_source_owned_codex_entries()
-        with self._lock:
-            if credential_id and credential_id in failed_source_ids:
-                if self._current_id == credential_id:
-                    self._current_id = None
-                return None
-            entry = None
-            if credential_id and credential_id not in failed_source_ids:
-                entry = next(
-                    (
-                        candidate
-                        for candidate in self._entries
-                        if candidate.id == credential_id
-                    ),
-                    None,
-                )
-            if entry is None:
-                if api_key_hint:
+        self._sync_external_status_entries(probe_quota=True)
+        try:
+            with self._lock:
+                if credential_id and credential_id in failed_source_ids:
+                    if self._current_id == credential_id:
+                        self._current_id = None
+                    return None
+                entry = None
+                if credential_id and credential_id not in failed_source_ids:
                     entry = next(
                         (
                             candidate
                             for candidate in self._entries
-                            if candidate.id not in failed_source_ids
-                            and candidate.runtime_api_key == api_key_hint
+                            if candidate.id == credential_id
                         ),
                         None,
                     )
-                else:
-                    current = self._current_unlocked()
-                    if current is not None and current.id in failed_source_ids:
-                        current = None
-                    entry = current or self._select_unlocked(
-                        refresh=False,
-                        excluded_source_ids=failed_source_ids,
-                    )[0]
-            if entry is None:
-                return None
-            self._current_id = entry.id
-        self._persist_pending_changes()
+                if entry is None:
+                    if api_key_hint:
+                        entry = next(
+                            (
+                                candidate
+                                for candidate in self._entries
+                                if candidate.id not in failed_source_ids
+                                and candidate.runtime_api_key == api_key_hint
+                            ),
+                            None,
+                        )
+                    else:
+                        current = self._current_unlocked()
+                        if current is not None and current.id in failed_source_ids:
+                            current = None
+                        entry = current or self._select_unlocked(
+                            refresh=False,
+                            excluded_source_ids=failed_source_ids,
+                        )[0]
+                if entry is None:
+                    return None
+                self._current_id = entry.id
+        finally:
+            self._persist_pending_changes()
         refreshed = self._refresh_entry(entry, force=True)
         if refreshed is not None:
             with self._lock:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -668,7 +668,10 @@ class CredentialPool:
         # snapshots of another auth store; rewriting every snapshot on an
         # unrelated local change can erase a newer owner cooldown/quarantine.
         self._dirty_entry_ids: Set[str] = set()
+        self._dirty_entry_generations: Dict[str, int] = {}
+        self._entry_mutation_generation = 0
         self._pending_removed_entries: List[PooledCredential] = []
+        self._pending_removed_entry_generations: Dict[int, int] = {}
         self._trusted_codex_source_owners: Dict[int, _TrustedCodexSourceOwner] = {}
         self._source_status_reset_ids: Set[str] = set()
         self._active_leases: Dict[str, int] = {}
@@ -900,6 +903,56 @@ class CredentialPool:
             ]
             return matches[0].id if len(matches) == 1 else None
 
+    def _record_entry_mutation_unlocked(
+        self,
+        entry_id: str,
+        *,
+        dirty: bool,
+    ) -> int:
+        """Version one entry mutation while ``self._lock`` is held."""
+        self._entry_mutation_generation += 1
+        generation = self._entry_mutation_generation
+        self._dirty_entry_generations[entry_id] = generation
+        self._source_status_reset_ids.discard(entry_id)
+        if dirty:
+            self._dirty_entry_ids.add(entry_id)
+        else:
+            self._dirty_entry_ids.discard(entry_id)
+        return generation
+
+    def _queue_removed_entry_unlocked(self, entry: PooledCredential) -> None:
+        """Record a versioned removal while ``self._lock`` is held."""
+        generation = self._record_entry_mutation_unlocked(entry.id, dirty=False)
+        self._pending_removed_entries.append(entry)
+        self._pending_removed_entry_generations[id(entry)] = generation
+
+    def _dirty_generation_for_snapshot_unlocked(
+        self,
+        entry: PooledCredential,
+    ) -> Optional[int]:
+        current = next(
+            (candidate for candidate in self._entries if candidate.id == entry.id),
+            None,
+        )
+        if current != entry:
+            return None
+        return self._dirty_entry_generations.get(entry.id)
+
+    def _clear_dirty_generation_unlocked(
+        self,
+        entry_id: str,
+        generation: Optional[int],
+    ) -> bool:
+        if (
+            generation is None
+            or self._dirty_entry_generations.get(entry_id) != generation
+        ):
+            return False
+        self._dirty_entry_ids.discard(entry_id)
+        self._source_status_reset_ids.discard(entry_id)
+        self._dirty_entry_generations.pop(entry_id, None)
+        return True
+
     def _replace_entry(
         self,
         old: PooledCredential,
@@ -933,7 +986,7 @@ class CredentialPool:
                         ):
                             self._trusted_codex_source_owners[id(new)] = owner
                     if mark_dirty and old != new:
-                        self._dirty_entry_ids.add(new.id)
+                        self._record_entry_mutation_unlocked(new.id, dirty=True)
                     return new
             return None
 
@@ -959,22 +1012,34 @@ class CredentialPool:
 
             with self._lock:
                 pending_removed = list(self._pending_removed_entries)
+                pending_removed_generations = {
+                    id(entry): self._pending_removed_entry_generations.get(id(entry))
+                    for entry in pending_removed
+                }
                 all_removed = pending_removed + list(removed_entries or [])
                 entries_snapshot = list(self._entries)
                 entries_by_id = {entry.id: entry for entry in entries_snapshot}
                 dirty_entries = [
-                    entries_by_id[entry_id]
+                    (
+                        entries_by_id[entry_id],
+                        self._dirty_entry_generations.get(entry_id),
+                    )
                     for entry_id in self._dirty_entry_ids
                     if entry_id in entries_by_id
                 ]
+                orphan_dirty_generations = {
+                    entry_id: self._dirty_entry_generations.get(entry_id)
+                    for entry_id in self._dirty_entry_ids
+                    if entry_id not in entries_by_id
+                }
                 source_dirty = [
                     entry
-                    for entry in dirty_entries
+                    for entry, _generation in dirty_entries
                     if self._is_trusted_codex_source_owned(entry)
                 ]
                 local_dirty = any(
                     not self._is_trusted_codex_source_owned(entry)
-                    for entry in dirty_entries
+                    for entry, _generation in dirty_entries
                 )
                 source_removed = [
                     entry
@@ -1009,20 +1074,37 @@ class CredentialPool:
                 self._remove_source_owned_alias(entry)
 
             with self._lock:
-                self._dirty_entry_ids.difference_update(
-                    entry.id for entry in dirty_entries
-                )
-                self._source_status_reset_ids.difference_update(
-                    entry.id for entry in dirty_entries
-                )
-                pending_ids = {id(entry) for entry in pending_removed}
-                self._pending_removed_entries = [
-                    entry
-                    for entry in self._pending_removed_entries
-                    if id(entry) not in pending_ids
-                ]
+                for entry, generation in dirty_entries:
+                    self._clear_dirty_generation_unlocked(entry.id, generation)
+                current_ids = {entry.id for entry in self._entries}
+                for entry_id, generation in orphan_dirty_generations.items():
+                    if entry_id not in current_ids:
+                        self._clear_dirty_generation_unlocked(entry_id, generation)
+                retained_removals: List[PooledCredential] = []
+                for entry in self._pending_removed_entries:
+                    snapshot_generation = pending_removed_generations.get(id(entry))
+                    current_generation = self._pending_removed_entry_generations.get(
+                        id(entry)
+                    )
+                    if (
+                        snapshot_generation is not None
+                        and current_generation == snapshot_generation
+                    ):
+                        self._pending_removed_entry_generations.pop(id(entry), None)
+                    else:
+                        retained_removals.append(entry)
+                self._pending_removed_entries = retained_removals
                 for entry in all_removed:
                     self._forget_trusted_codex_source_owner(entry)
+                pending_entry_ids = {
+                    entry.id for entry in self._pending_removed_entries
+                }
+                for entry_id in list(self._dirty_entry_generations):
+                    if (
+                        entry_id not in self._dirty_entry_ids
+                        and entry_id not in pending_entry_ids
+                    ):
+                        self._dirty_entry_generations.pop(entry_id, None)
 
     def _persist_pending_changes(self) -> None:
         with self._lock:
@@ -1327,8 +1409,7 @@ class CredentialPool:
             if not self._entry_tokens_match(current, entry):
                 return False
             self._entries = [item for item in self._entries if item.id != entry.id]
-            self._dirty_entry_ids.discard(entry.id)
-            self._source_status_reset_ids.discard(entry.id)
+            self._record_entry_mutation_unlocked(entry.id, dirty=False)
             if self._current_id == entry.id:
                 self._current_id = None
             self._forget_trusted_codex_source_owner(current)
@@ -1577,6 +1658,8 @@ class CredentialPool:
             source_path,
         ):
             return
+        with self._lock:
+            dirty_generation = self._dirty_generation_for_snapshot_unlocked(entry)
         auth_store = _load_auth_store(source_path)
         changed = False
 
@@ -1619,8 +1702,7 @@ class CredentialPool:
         if changed:
             _save_auth_store(auth_store, target_path=source_path)
         with self._lock:
-            self._dirty_entry_ids.discard(entry.id)
-            self._source_status_reset_ids.discard(entry.id)
+            self._clear_dirty_generation_unlocked(entry.id, dirty_generation)
 
     def _persist_codex_exact_alias_refresh(
         self,
@@ -1630,6 +1712,8 @@ class CredentialPool:
         """Persist a non-singleton Codex refresh to one exact owning row."""
         if not self._codex_write_path_is_authorized(entry, source_path):
             return False
+        with self._lock:
+            dirty_generation = self._dirty_generation_for_snapshot_unlocked(entry)
         auth_store = _load_auth_store(source_path)
         persisted, index, item = self._codex_exact_pool_alias(auth_store, entry)
         if not self._codex_pool_alias_has_complete_credentials(item):
@@ -1646,8 +1730,7 @@ class CredentialPool:
             persisted[index] = updated
             _save_auth_store(auth_store, target_path=source_path)
         with self._lock:
-            self._dirty_entry_ids.discard(entry.id)
-            self._source_status_reset_ids.discard(entry.id)
+            self._clear_dirty_generation_unlocked(entry.id, dirty_generation)
         return True
 
     def _quarantine_codex_exact_alias_refresh(
@@ -2567,8 +2650,11 @@ class CredentialPool:
                         self._entries = [
                             item for item in self._entries if item.id not in removed_ids
                         ]
-                        self._dirty_entry_ids.difference_update(removed_ids)
-                        self._source_status_reset_ids.difference_update(removed_ids)
+                        for removed_id in removed_ids:
+                            self._record_entry_mutation_unlocked(
+                                removed_id,
+                                dirty=False,
+                            )
                         if self._current_id in removed_ids:
                             self._current_id = None
                     if codex_source_path is None:
@@ -2954,7 +3040,8 @@ class CredentialPool:
         else:
             pruned_entries = []
         if pruned_entries:
-            self._pending_removed_entries.extend(pruned_entries)
+            for pruned_entry in pruned_entries:
+                self._queue_removed_entry_unlocked(pruned_entry)
         return available, pending_refresh
 
     def _log_no_available_entries(self) -> None:
@@ -3036,11 +3123,12 @@ class CredentialPool:
                     )
                 ):
                     self._trusted_codex_source_owners[id(candidate)] = owner
-            self._dirty_entry_ids.update(
-                candidate.id
-                for candidate in self._entries
-                if previous_by_id.get(candidate.id) != candidate
-            )
+            for candidate in self._entries:
+                if previous_by_id.get(candidate.id) != candidate:
+                    self._record_entry_mutation_unlocked(
+                        candidate.id,
+                        dirty=True,
+                    )
             self._current_id = entry.id
             return self._current_unlocked() or entry, pending_refresh
 
@@ -3102,6 +3190,11 @@ class CredentialPool:
         failed_source_ids: Set[str],
     ) -> Optional[PooledCredential]:
         with self._lock:
+            if credential_id and credential_id in failed_source_ids:
+                self._unmatched_rotation_streak = 0
+                if self._current_id == credential_id:
+                    self._current_id = None
+                return None
             entry = None
             identity_supplied = bool(credential_id or api_key_hint)
             if credential_id and credential_id not in failed_source_ids:
@@ -3392,6 +3485,10 @@ class CredentialPool:
         """
         failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
+            if credential_id and credential_id in failed_source_ids:
+                if self._current_id == credential_id:
+                    self._current_id = None
+                return None
             entry = None
             if credential_id and credential_id not in failed_source_ids:
                 entry = next(
@@ -3474,7 +3571,7 @@ class CredentialPool:
                         entry,
                         replace(entry, priority=new_priority),
                     )
-            self._pending_removed_entries.append(removed)
+            self._queue_removed_entry_unlocked(removed)
             if self._current_id == removed.id:
                 self._current_id = None
         self._persist_pending_changes()
@@ -3511,7 +3608,7 @@ class CredentialPool:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
-            self._dirty_entry_ids.add(entry.id)
+            self._record_entry_mutation_unlocked(entry.id, dirty=True)
         self._persist_pending_changes()
         return entry
 
@@ -3642,32 +3739,14 @@ def _codex_source_pool_alias(
 
 
 def _loaded_codex_source_owner_kind(entry: PooledCredential) -> str:
-    """Classify trusted fallback ownership while its source state is readable."""
-    source_path = entry.source_store_path
-    if source_path is None or entry.source != "device_code":
-        return "pool"
-    try:
-        source_store = auth_mod._load_auth_store(source_path)
-        providers = source_store.get("providers")
-        state = providers.get("openai-codex") if isinstance(providers, dict) else None
-        tokens = state.get("tokens") if isinstance(state, dict) else None
-        alias = (
-            _codex_source_pool_alias(source_path, state)
-            if isinstance(state, dict) and isinstance(tokens, dict)
-            else None
-        )
-    except Exception:
-        return "pool"
-    if (
-        alias is not None
-        and str(alias.get("id") or "") == entry.id
-        and str(alias.get("access_token") or "")
-        == str(tokens.get("access_token") or "")
-        and str(alias.get("refresh_token") or "")
-        == str(tokens.get("refresh_token") or "")
-    ):
-        return "singleton"
-    return "pool"
+    """Classify trusted fallback ownership from the hydrated row snapshot.
+
+    Codex singleton aliases use the canonical ``device_code`` source. Explicit
+    independent accounts are written as ``manual:device_code``. Binding owner
+    kind to that trusted row category avoids a later unlocked provider reread;
+    an uncertain canonical row therefore fails closed as singleton-owned.
+    """
+    return "singleton" if entry.source == "device_code" else "pool"
 
 
 def _seed_from_singletons(

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -3607,11 +3607,117 @@ class CredentialPool:
             )
             self._replace_entry(entry, cleared)
 
+    def _converge_empty_xai_source_selection(self) -> bool:
+        """Adopt a durable xAI singleton winner after an in-flight reservation.
+
+        A pool loaded while another process owns the source refresh transaction
+        sees the deliberately secret-free reservation row and therefore has no
+        selectable entry. Wait for that exact source transaction, snapshot its
+        finalized row while still locked, then hydrate this pool only after the
+        source lock is released. A stranded reservation remains fail-closed.
+        """
+        if self.provider != "xai-oauth":
+            return False
+
+        try:
+            with auth_mod._provider_state_transaction(
+                "xai-oauth",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ) as (_auth_store, state, source_path):
+                if (
+                    source_path is None
+                    or not isinstance(state, dict)
+                    or auth_mod._source_state_is_reserved(state)
+                ):
+                    return False
+                tokens = state.get("tokens")
+                if not isinstance(tokens, dict):
+                    return False
+                access_token = str(tokens.get("access_token") or "").strip()
+                if not access_token:
+                    return False
+
+                source_path = Path(source_path)
+                source_store = _load_auth_store(source_path)
+                source_pool = source_store.get("credential_pool")
+                source_rows = (
+                    source_pool.get("xai-oauth")
+                    if isinstance(source_pool, dict)
+                    else None
+                )
+                candidates = [
+                    PooledCredential.from_dict("xai-oauth", row)
+                    for row in source_rows or []
+                    if isinstance(row, dict)
+                ]
+                _upsert_entry(
+                    candidates,
+                    "xai-oauth",
+                    "device_code",
+                    {
+                        "source": "device_code",
+                        "auth_type": AUTH_TYPE_OAUTH,
+                        "access_token": access_token,
+                        "refresh_token": tokens.get("refresh_token"),
+                        "base_url": auth_mod.DEFAULT_XAI_OAUTH_BASE_URL,
+                        "last_refresh": state.get("last_refresh"),
+                        "label": label_from_token(access_token, "device_code"),
+                    },
+                )
+                winner = next(
+                    (
+                        candidate
+                        for candidate in candidates
+                        if candidate.source == "device_code"
+                    ),
+                    None,
+                )
+                if winner is None:
+                    return False
+                winner = replace(winner, source_store_path=source_path)
+        except Exception as exc:
+            logger.debug("Failed to converge empty xAI OAuth pool: %s", exc)
+            return False
+
+        # The source transaction is intentionally over before pool mutation.
+        # Another selector may already have converged this instance; preserve
+        # its complete entry instead of replacing a newer in-memory snapshot.
+        with self._external_state_lock:
+            with self._lock:
+                if any(
+                    entry.source == "device_code" and entry.access_token
+                    for entry in self._entries
+                ):
+                    return True
+                stale_ids = {
+                    entry.id
+                    for entry in self._entries
+                    if entry.source == "device_code"
+                }
+                self._entries = [
+                    entry
+                    for entry in self._entries
+                    if entry.source != "device_code"
+                ]
+                self._entries.append(winner)
+                if self._current_id in stale_ids:
+                    self._current_id = None
+        return True
+
     def select(self) -> Optional[PooledCredential]:
         failed_source_ids = self._validate_source_owned_codex_entries()
         self._sync_external_status_entries(probe_quota=True)
         entry, pending_refresh = self._select_under_lock(failed_source_ids)
         self._persist_pending_changes()
+        if (
+            entry is None
+            and not pending_refresh
+            and self._converge_empty_xai_source_selection()
+        ):
+            failed_source_ids = self._validate_source_owned_codex_entries()
+            self._sync_external_status_entries(probe_quota=True)
+            entry, pending_refresh = self._select_under_lock(failed_source_ids)
+            self._persist_pending_changes()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
         if entry is not None:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -887,93 +887,181 @@ class CredentialPool:
             logger.debug("Failed to sync from credentials file: %s", exc)
         return entry
 
-    def _sync_codex_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
-        """Sync a Codex device_code pool entry from auth.json if tokens differ.
-
-        When a Codex OAuth access token expires (or the ChatGPT account hits
-        its 5h/weekly quota), the pool entry gets marked ``STATUS_EXHAUSTED``
-        with a ``last_error_reset_at`` that can be many hours in the future.
-        Meanwhile the user may run ``hermes model`` / ``hermes auth`` which
-        performs a fresh device-code login and writes new tokens to
-        ``auth.json`` under ``_auth_store_lock``.  Without this sync the pool
-        entry stays frozen until ``last_error_reset_at`` elapses — even
-        though fresh credentials are sitting on disk — and every request
-        fails with "no available entries (all exhausted or empty)".
-
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
-        """
-        if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
+    def _codex_entry_from_provider_state(
+        self,
+        entry: PooledCredential,
+        state: Optional[Dict[str, Any]],
+    ) -> PooledCredential:
+        """Return ``entry`` updated from its singleton state, without I/O."""
+        if (
+            self.provider != "openai-codex"
+            or entry.source != "device_code"
+            or not isinstance(state, dict)
+        ):
             return entry
-        try:
-            with _auth_store_lock():
-                auth_store = _load_auth_store()
-                state = _load_provider_state(auth_store, "openai-codex")
-            if not isinstance(state, dict):
-                return entry
-            tokens = state.get("tokens")
-            if not isinstance(tokens, dict):
-                return entry
-            store_access = tokens.get("access_token", "")
-            store_refresh = tokens.get("refresh_token", "")
-            # Adopt auth.json tokens when either side differs.  Codex refresh
-            # tokens are single-use too, so a fresh refresh_token from
-            # another process means our entry's pair is consumed/stale.
-            #
-            # Also adopt when the store has a refresh_token but no
-            # access_token — another process may have rotated the pair
-            # and the store entry's access_token was already consumed;
-            # the important signal is the refresh_token difference.
-            entry_access = entry.access_token or ""
-            entry_refresh = entry.refresh_token or ""
-            should_adopt = False
-            if store_access and (
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return entry
+        store_access = tokens.get("access_token", "")
+        store_refresh = tokens.get("refresh_token", "")
+        entry_access = entry.access_token or ""
+        entry_refresh = entry.refresh_token or ""
+        should_adopt = bool(
+            store_access
+            and (
                 store_access != entry_access
                 or (store_refresh and store_refresh != entry_refresh)
-            ):
-                should_adopt = True
-            elif (
-                store_refresh
-                and store_refresh != entry_refresh
-                and not store_access
-            ):
-                # Store has only a refresh_token (no access_token) —
-                # another process rotated the pair.  Adopt the
-                # refresh_token so we don't replay the consumed one.
-                logger.info(
-                    "Pool entry %s: auth.json has newer refresh_token "
-                    "but no access_token; adopting refresh_token to "
-                    "avoid replaying consumed token",
-                    entry.id,
-                )
-                should_adopt = True
+            )
+        )
+        if store_refresh and store_refresh != entry_refresh and not store_access:
+            logger.info(
+                "Pool entry %s: auth.json has newer refresh_token but no "
+                "access_token; adopting refresh_token to avoid replaying "
+                "consumed token",
+                entry.id,
+            )
+            should_adopt = True
+        if not should_adopt:
+            return entry
 
-            if should_adopt:
-                logger.debug(
-                    "Pool entry %s: syncing Codex tokens from auth.json "
-                    "(refreshed by another process)",
-                    entry.id,
+        logger.debug(
+            "Pool entry %s: syncing Codex tokens from auth.json "
+            "(refreshed by another process)",
+            entry.id,
+        )
+        field_updates: Dict[str, Any] = {
+            "access_token": store_access or entry.access_token,
+            "refresh_token": store_refresh or entry.refresh_token,
+            "last_status": None,
+            "last_status_at": None,
+            "last_error_code": None,
+            "last_error_reason": None,
+            "last_error_message": None,
+            "last_error_reset_at": None,
+        }
+        if state.get("last_refresh"):
+            field_updates["last_refresh"] = state["last_refresh"]
+        return replace(entry, **field_updates)
+
+    def _persist_codex_device_code_refresh(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+    ) -> None:
+        """Persist one singleton-owned Codex chain to its exact source store.
+
+        The caller holds the active-profile -> source-store transaction. Only
+        the matching ``device_code`` pool alias and singleton are updated;
+        independent manual accounts and unrelated store data remain untouched.
+        """
+        auth_store = _load_auth_store(source_path)
+        changed = False
+
+        providers = auth_store.get("providers")
+        state = providers.get("openai-codex") if isinstance(providers, dict) else None
+        if isinstance(state, dict):
+            tokens = state.get("tokens")
+            if isinstance(tokens, dict):
+                next_tokens = dict(tokens)
+                next_tokens["access_token"] = entry.access_token
+                if entry.refresh_token:
+                    next_tokens["refresh_token"] = entry.refresh_token
+                if next_tokens != tokens:
+                    state["tokens"] = next_tokens
+                    changed = True
+                if entry.last_refresh and state.get("last_refresh") != entry.last_refresh:
+                    state["last_refresh"] = entry.last_refresh
+                    changed = True
+
+        pool = auth_store.get("credential_pool")
+        entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+        if isinstance(entries, list):
+            serialized = entry.to_dict()
+            for persisted in entries:
+                if not isinstance(persisted, dict):
+                    continue
+                if (
+                    persisted.get("id") != entry.id
+                    or persisted.get("source") != "device_code"
+                ):
+                    continue
+                updated_persisted = dict(persisted)
+                updated_persisted.update(serialized)
+                if updated_persisted != persisted:
+                    persisted.clear()
+                    persisted.update(updated_persisted)
+                    changed = True
+                break
+
+        if changed:
+            _save_auth_store(auth_store, target_path=source_path)
+
+    def _quarantine_codex_device_code_refresh(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+        exc: Exception,
+    ) -> None:
+        """Clear one terminal Codex singleton chain in its owning store."""
+        auth_store = _load_auth_store(source_path)
+        providers = auth_store.get("providers")
+        state = providers.get("openai-codex") if isinstance(providers, dict) else None
+        if isinstance(state, dict):
+            tokens = state.get("tokens")
+            if isinstance(tokens, dict):
+                store_refresh = str(tokens.get("refresh_token") or "").strip()
+                entry_refresh = str(entry.refresh_token or "").strip()
+                if not store_refresh or store_refresh == entry_refresh:
+                    tokens.pop("access_token", None)
+                    tokens.pop("refresh_token", None)
+                    state["tokens"] = tokens
+                    state["last_auth_error"] = {
+                        "provider": "openai-codex",
+                        "code": getattr(exc, "code", "unknown"),
+                        "message": str(exc),
+                        "reason": "credential_pool_refresh_failure",
+                        "relogin_required": True,
+                        "at": datetime.now(timezone.utc).isoformat(),
+                    }
+
+        pool = auth_store.get("credential_pool")
+        if isinstance(pool, dict) and isinstance(
+            pool.get("openai-codex"), list
+        ):
+            entries = pool["openai-codex"]
+            pool["openai-codex"] = [
+                persisted
+                for persisted in entries
+                if not (
+                    isinstance(persisted, dict)
+                    and persisted.get("id") == entry.id
+                    and persisted.get("source") == "device_code"
                 )
-                field_updates: Dict[str, Any] = {
-                    "access_token": store_access or entry.access_token,
-                    "refresh_token": store_refresh or entry.refresh_token,
-                    "last_status": None,
-                    "last_status_at": None,
-                    "last_error_code": None,
-                    "last_error_reason": None,
-                    "last_error_message": None,
-                    "last_error_reset_at": None,
-                }
-                if state.get("last_refresh"):
-                    field_updates["last_refresh"] = state["last_refresh"]
-                updated = replace(entry, **field_updates)
+            ]
+        _save_auth_store(auth_store, target_path=source_path)
+
+    def _sync_codex_entry_from_auth_store(
+        self, entry: PooledCredential
+    ) -> PooledCredential:
+        """Sync a singleton-seeded Codex entry from its owning auth store."""
+        if self.provider != "openai-codex" or entry.source != "device_code":
+            return entry
+        try:
+            with auth_mod._provider_state_transaction("openai-codex") as (
+                _auth_store,
+                state,
+                source_path,
+            ):
+                source_path = source_path or auth_mod._auth_file_path()
+                updated = self._codex_entry_from_provider_state(entry, state)
+                if updated is entry:
+                    return entry
                 self._replace_entry(entry, updated)
-                self._persist()
+                self._persist_codex_device_code_refresh(updated, source_path)
                 return updated
         except Exception as exc:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
-        return entry
+            return entry
 
     def _sync_xai_oauth_entry_from_auth_store(self, entry: PooledCredential) -> PooledCredential:
         """Sync an xAI OAuth pool entry from auth.json if tokens differ.
@@ -1302,22 +1390,38 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider in ("openai-codex", "xai-oauth"):
-            sync_entry = (
-                self._sync_codex_entry_from_auth_store
-                if self.provider == "openai-codex"
-                else self._sync_xai_oauth_entry_from_pool_store
-            )
+        if self.provider == "openai-codex" and entry.source == "device_code":
+            with auth_mod._provider_state_transaction(
+                "openai-codex",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ) as (_auth_store, state, source_path):
+                source_path = source_path or auth_mod._auth_file_path()
+                synced = self._codex_entry_from_provider_state(entry, state)
+                if synced is not entry:
+                    # A waiter that observed the winner's rotated chain adopts
+                    # it even when its caller requested force=True. Replaying
+                    # the consumed refresh token would invalidate the chain.
+                    self._replace_entry(entry, synced)
+                    self._persist_codex_device_code_refresh(synced, source_path)
+                    return synced
+                return self._refresh_entry_impl(
+                    entry,
+                    force=force,
+                    codex_source_path=source_path,
+                )
+        if self.provider == "openai-codex":
+            # Manual Codex accounts are profile-owned and independent of the
+            # singleton, but their own single-use refresh still needs the
+            # active profile's pool-store lock.
             with _auth_store_lock(
                 timeout_seconds=self._single_use_refresh_lock_timeout()
             ):
-                synced = sync_entry(entry)
-                if self.provider == "openai-codex":
-                    if synced is not entry:
-                        entry = synced
-                        if not force and not self._entry_needs_refresh(entry):
-                            return entry
-                    return self._refresh_entry_impl(entry, force=force)
+                return self._refresh_entry_impl(entry, force=force)
+        if self.provider == "xai-oauth":
+            with _auth_store_lock(
+                timeout_seconds=self._single_use_refresh_lock_timeout()
+            ):
+                synced = self._sync_xai_oauth_entry_from_pool_store(entry)
                 if (
                     synced.access_token != entry.access_token
                     or synced.refresh_token != entry.refresh_token
@@ -1346,7 +1450,11 @@ class CredentialPool:
         )
 
     def _refresh_entry_impl(
-        self, entry: PooledCredential, *, force: bool
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+        codex_source_path: Optional[Path] = None,
     ) -> Optional[PooledCredential]:
         try:
             if self.provider == "anthropic":
@@ -1380,9 +1488,10 @@ class CredentialPool:
                 # refresh_token — single-use tokens consumed by another Hermes
                 # process sharing the same auth.json singleton would otherwise
                 # trigger ``refresh_token_reused`` on the next POST.
-                synced = self._sync_codex_entry_from_auth_store(entry)
-                if synced is not entry:
-                    entry = synced
+                if codex_source_path is None:
+                    synced = self._sync_codex_entry_from_auth_store(entry)
+                    if synced is not entry:
+                        entry = synced
                 refreshed = auth_mod.refresh_codex_oauth_pure(
                     entry.access_token,
                     entry.refresh_token,
@@ -1546,7 +1655,17 @@ class CredentialPool:
             # and the HTTP call.  Re-check auth.json and adopt the fresh tokens
             # if they have rotated since.
             if self.provider == "openai-codex":
-                synced = self._sync_codex_entry_from_auth_store(entry)
+                if codex_source_path is not None:
+                    source_store = _load_auth_store(codex_source_path)
+                    providers = source_store.get("providers")
+                    state = (
+                        providers.get("openai-codex")
+                        if isinstance(providers, dict)
+                        else None
+                    )
+                    synced = self._codex_entry_from_provider_state(entry, state)
+                else:
+                    synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced.refresh_token != entry.refresh_token:
                     logger.debug(
                         "Codex OAuth refresh failed but auth.json has newer tokens — adopting"
@@ -1561,7 +1680,12 @@ class CredentialPool:
                         last_error_reset_at=None,
                     )
                     self._replace_entry(synced, updated)
-                    self._persist()
+                    if codex_source_path is not None:
+                        self._persist_codex_device_code_refresh(
+                            updated, codex_source_path
+                        )
+                    else:
+                        self._persist()
                     return updated
                 # Terminal error: auth.json has no newer tokens — the stored
                 # refresh_token is dead.  Clear it from auth.json so the next
@@ -1573,28 +1697,53 @@ class CredentialPool:
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"
                     )
                     try:
-                        with _auth_store_lock():
-                            auth_store = _load_auth_store()
-                            state = _load_provider_state(auth_store, "openai-codex") or {}
-                            if isinstance(state, dict):
-                                tokens = state.get("tokens") or {}
-                                if isinstance(tokens, dict):
-                                    store_refresh = str(tokens.get("refresh_token") or "").strip()
-                                    entry_refresh = str(entry.refresh_token or "").strip()
-                                    if not store_refresh or store_refresh == entry_refresh:
-                                        tokens.pop("access_token", None)
-                                        tokens.pop("refresh_token", None)
-                                        state["tokens"] = tokens
-                                        state["last_auth_error"] = {
-                                            "provider": "openai-codex",
-                                            "code": getattr(exc, "code", "unknown"),
-                                            "message": str(exc),
-                                            "reason": "credential_pool_refresh_failure",
-                                            "relogin_required": True,
-                                            "at": datetime.now(timezone.utc).isoformat(),
-                                        }
-                                        _save_provider_state(auth_store, "openai-codex", state)
-                                        _save_auth_store(auth_store)
+                        if codex_source_path is not None:
+                            self._quarantine_codex_device_code_refresh(
+                                entry, codex_source_path, exc
+                            )
+                        else:
+                            with _auth_store_lock():
+                                auth_store = _load_auth_store()
+                                state = (
+                                    _load_provider_state(auth_store, "openai-codex")
+                                    or {}
+                                )
+                                if isinstance(state, dict):
+                                    tokens = state.get("tokens") or {}
+                                    if isinstance(tokens, dict):
+                                        store_refresh = str(
+                                            tokens.get("refresh_token") or ""
+                                        ).strip()
+                                        entry_refresh = str(
+                                            entry.refresh_token or ""
+                                        ).strip()
+                                        if (
+                                            not store_refresh
+                                            or store_refresh == entry_refresh
+                                        ):
+                                            tokens.pop("access_token", None)
+                                            tokens.pop("refresh_token", None)
+                                            state["tokens"] = tokens
+                                            state["last_auth_error"] = {
+                                                "provider": "openai-codex",
+                                                "code": getattr(
+                                                    exc, "code", "unknown"
+                                                ),
+                                                "message": str(exc),
+                                                "reason": (
+                                                    "credential_pool_refresh_failure"
+                                                ),
+                                                "relogin_required": True,
+                                                "at": datetime.now(
+                                                    timezone.utc
+                                                ).isoformat(),
+                                            }
+                                            _save_provider_state(
+                                                auth_store,
+                                                "openai-codex",
+                                                state,
+                                            )
+                                            _save_auth_store(auth_store)
                     except Exception as clear_exc:
                         logger.debug(
                             "Failed to clear terminal Codex OAuth state: %s", clear_exc
@@ -1604,17 +1753,14 @@ class CredentialPool:
                     # pool lock), so take it here. self._lock is an RLock,
                     # so the still-locked callers re-enter safely.
                     with self._lock:
-                        removed_ids = [
-                            item.id for item in self._entries
-                            if item.source == "device_code"
-                        ]
+                        removed_ids = [entry.id]
                         self._entries = [
-                            item for item in self._entries
-                            if item.source != "device_code"
+                            item for item in self._entries if item.id != entry.id
                         ]
                         if self._current_id == entry.id:
                             self._current_id = None
-                        self._persist(removed_ids=removed_ids)
+                        if codex_source_path is None:
+                            self._persist(removed_ids=removed_ids)
                     return None
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
@@ -1685,7 +1831,13 @@ class CredentialPool:
                             self._current_id = None
                         self._persist(removed_ids=removed_ids)
                     return None
-            self._mark_exhausted(entry, None)
+            if self.provider == "openai-codex" and codex_source_path is not None:
+                exhausted = self._mark_exhausted(entry, None, persist=False)
+                self._persist_codex_device_code_refresh(
+                    exhausted, codex_source_path
+                )
+            else:
+                self._mark_exhausted(entry, None)
             return None
 
         updated = replace(
@@ -1698,11 +1850,14 @@ class CredentialPool:
             last_error_reset_at=None,
         )
         self._replace_entry(entry, updated)
-        self._persist()
-        # Sync refreshed tokens back to auth.json providers so that
-        # _seed_from_singletons() on the next load_pool() sees fresh state
-        # instead of re-seeding stale/consumed tokens.
-        self._sync_device_code_entry_to_auth_store(updated)
+        if self.provider == "openai-codex" and codex_source_path is not None:
+            self._persist_codex_device_code_refresh(updated, codex_source_path)
+        else:
+            self._persist()
+            # Sync refreshed tokens back to auth.json providers so that
+            # _seed_from_singletons() on the next load_pool() sees fresh state
+            # instead of re-seeding stale/consumed tokens.
+            self._sync_device_code_entry_to_auth_store(updated)
         return updated
 
     def _codex_quota_restored_upstream(self, entry: PooledCredential) -> bool:

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2292,22 +2292,7 @@ class CredentialPool:
             return None
 
         if self.provider == "anthropic" and entry.source == "claude_code":
-            from agent.anthropic_adapter import _claude_code_credentials_path
-
-            with _auth_store_lock(
-                target_path=_claude_code_credentials_path(),
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-            ):
-                synced = self._sync_anthropic_entry_from_credentials_file(
-                    entry,
-                    persist=False,
-                )
-                if not self._entry_tokens_match(synced, entry):
-                    return synced
-                current = self._current_refresh_candidate(entry)
-                if current is None:
-                    return None
-                return self._refresh_entry_impl(current, force=force)
+            return self._refresh_anthropic_source_entry(entry, force=force)
 
         # Codex and xAI OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
@@ -2442,48 +2427,385 @@ class CredentialPool:
                     timeout_seconds=self._single_use_refresh_lock_timeout()
                 ):
                     return self._refresh_entry_impl(entry, force=force)
-            auth_store = _load_auth_store()
-            _state, source_path = _load_provider_state_with_source(
-                auth_store,
-                "xai-oauth",
-            )
-            with auth_mod._provider_state_transaction(
-                "xai-oauth",
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-                expected_source_path=source_path,
-            ):
-                synced = self._sync_xai_oauth_entry_from_auth_store(
-                    entry,
-                    persist=False,
-                )
-                if not self._entry_tokens_match(synced, entry):
-                    return synced
-                current = self._current_refresh_candidate(entry)
-                if current is None:
-                    return None
-                return self._refresh_entry_impl(current, force=force)
+            return self._refresh_xai_source_entry(entry, force=force)
         if self.provider == "nous" and entry.source == "device_code":
-            auth_store = _load_auth_store()
-            _state, source_path = _load_provider_state_with_source(
-                auth_store,
-                "nous",
-            )
-            with auth_mod._provider_state_transaction(
-                "nous",
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-                expected_source_path=source_path,
-            ):
-                synced = self._sync_nous_entry_from_auth_store(
-                    entry,
-                    persist=False,
+            # The real resolver owns the complete provider-state transaction.
+            # Do not nest a second source lock around its network operation.
+            return self._refresh_entry_impl(entry, force=force)
+        return self._refresh_entry_impl(entry, force=force)
+
+    def _mark_source_persistence_dead(
+        self,
+        entry: PooledCredential,
+    ) -> None:
+        updated = replace(
+            entry,
+            last_status=STATUS_DEAD,
+            last_status_at=time.time(),
+            last_error_reason="source_persistence_failed",
+            last_error_message=(
+                "Refreshed credentials were not persisted to their owning source."
+            ),
+        )
+        self._replace_entry(
+            entry,
+            updated,
+            preserve_routing=True,
+        )
+
+    def _quarantine_terminal_xai_lineage(
+        self,
+        entry: PooledCredential,
+        source_path: Optional[Path],
+        exc: Exception,
+    ) -> None:
+        """Remove one terminal singleton lineage without pool-lock I/O."""
+        if source_path is not None:
+            try:
+                with auth_mod._provider_state_transaction(
+                    "xai-oauth",
+                    timeout_seconds=self._single_use_refresh_lock_timeout(),
+                    expected_source_path=source_path,
+                ) as (_auth_store, state, locked_source_path):
+                    tokens = state.get("tokens") if isinstance(state, dict) else None
+                    if (
+                        locked_source_path is not None
+                        and isinstance(tokens, dict)
+                        and str(tokens.get("refresh_token") or "").strip()
+                        == str(entry.refresh_token or "").strip()
+                    ):
+                        source_store = _load_auth_store(Path(locked_source_path))
+                        providers = source_store.get("providers")
+                        if isinstance(providers, dict):
+                            providers.pop("xai-oauth", None)
+                        pool = source_store.get("credential_pool")
+                        if isinstance(pool, dict) and isinstance(
+                            pool.get("xai-oauth"), list
+                        ):
+                            pool["xai-oauth"] = [
+                                item
+                                for item in pool["xai-oauth"]
+                                if not (
+                                    isinstance(item, dict)
+                                    and item.get("source") == "device_code"
+                                )
+                            ]
+                        _save_auth_store(
+                            source_store,
+                            target_path=Path(locked_source_path),
+                        )
+            except Exception as clear_exc:
+                logger.debug(
+                    "Failed to clear terminal xAI OAuth state after %s: %s",
+                    exc,
+                    clear_exc,
                 )
-                if not self._entry_tokens_match(synced, entry):
-                    return synced
+
+        singleton_sources = {"device_code"}
+        with self._lock:
+            removed_entries = [
+                item for item in self._entries if item.source in singleton_sources
+            ]
+            for removed in removed_entries:
+                self._queue_removed_entry_unlocked(removed)
+            self._entries = [
+                item for item in self._entries if item.source not in singleton_sources
+            ]
+            if self._current_id == entry.id:
+                self._current_id = None
+
+    def _anthropic_entry_from_locked_credentials(
+        self,
+        entry: PooledCredential,
+        creds: Dict[str, Any],
+    ) -> PooledCredential:
+        access_token = str(creds.get("accessToken", "") or "")
+        refresh_token = str(creds.get("refreshToken", "") or "")
+        changed = (
+            access_token != entry.access_token
+            or refresh_token != (entry.refresh_token or "")
+        )
+        return replace(
+            entry,
+            access_token=access_token or entry.access_token,
+            refresh_token=refresh_token or entry.refresh_token,
+            expires_at_ms=creds.get("expiresAt", 0) or entry.expires_at_ms,
+            last_status=None if changed else entry.last_status,
+            last_status_at=None if changed else entry.last_status_at,
+            last_error_code=None if changed else entry.last_error_code,
+            last_error_reason=None if changed else entry.last_error_reason,
+            last_error_message=None if changed else entry.last_error_message,
+            last_error_reset_at=None if changed else entry.last_error_reset_at,
+        )
+
+    def _refresh_anthropic_source_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+    ) -> Optional[PooledCredential]:
+        from agent.anthropic_adapter import (
+            _read_claude_code_credentials_from_file,
+            _write_claude_code_credentials_locked,
+            claude_code_credentials_transaction,
+            is_claude_code_token_valid,
+            refresh_anthropic_oauth_pure,
+        )
+
+        persistence_failure = False
+        for _attempt in range(3):
+            with claude_code_credentials_transaction(
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ) as (_source_path, creds):
+                if not creds:
+                    return None
+                authoritative = self._anthropic_entry_from_locked_credentials(
+                    entry,
+                    creds,
+                )
+                if not self._entry_tokens_match(authoritative, entry):
+                    return self._replace_entry(
+                        entry,
+                        authoritative,
+                        preserve_routing=True,
+                    )
                 current = self._current_refresh_candidate(entry)
                 if current is None:
                     return None
-                return self._refresh_entry_impl(current, force=force)
-        return self._refresh_entry_impl(entry, force=force)
+                if not force and is_claude_code_token_valid(creds):
+                    return current
+                consumed_refresh_token = str(
+                    creds.get("refreshToken", "") or ""
+                )
+                if not consumed_refresh_token:
+                    return None
+                refreshed = refresh_anthropic_oauth_pure(
+                    consumed_refresh_token,
+                    use_json=False,
+                )
+                try:
+                    _write_claude_code_credentials_locked(
+                        refreshed["access_token"],
+                        refreshed["refresh_token"],
+                        refreshed["expires_at_ms"],
+                        expected_refresh_token=consumed_refresh_token,
+                    )
+                except auth_mod.SourceCredentialLineageChanged:
+                    winner = _read_claude_code_credentials_from_file()
+                    if winner:
+                        authoritative = self._anthropic_entry_from_locked_credentials(
+                            entry,
+                            winner,
+                        )
+                        if is_claude_code_token_valid(winner):
+                            return self._replace_entry(
+                                entry,
+                                authoritative,
+                                preserve_routing=True,
+                            )
+                    continue
+                except auth_mod.SourceCredentialPersistenceError:
+                    persistence_failure = True
+                    break
+                updated = replace(
+                    current,
+                    access_token=refreshed["access_token"],
+                    refresh_token=refreshed["refresh_token"],
+                    expires_at_ms=refreshed["expires_at_ms"],
+                    last_status=STATUS_OK,
+                    last_status_at=None,
+                    last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
+                )
+                return self._replace_entry(
+                    current,
+                    updated,
+                    preserve_routing=True,
+                )
+        if persistence_failure:
+            self._mark_source_persistence_dead(entry)
+            return None
+        return None
+
+    def _xai_entry_from_locked_state(
+        self,
+        entry: PooledCredential,
+        state: Dict[str, Any],
+        source_path: Path,
+    ) -> Optional[PooledCredential]:
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return None
+        access_token = str(tokens.get("access_token", "") or "")
+        refresh_token = str(tokens.get("refresh_token", "") or "")
+        if not access_token or not refresh_token:
+            return None
+        changed = (
+            access_token != entry.access_token
+            or refresh_token != (entry.refresh_token or "")
+        )
+        return replace(
+            entry,
+            access_token=access_token,
+            refresh_token=refresh_token,
+            last_refresh=state.get("last_refresh") or entry.last_refresh,
+            source_store_path=source_path,
+            last_status=None if changed else entry.last_status,
+            last_status_at=None if changed else entry.last_status_at,
+            last_error_code=None if changed else entry.last_error_code,
+            last_error_reason=None if changed else entry.last_error_reason,
+            last_error_message=None if changed else entry.last_error_message,
+            last_error_reset_at=None if changed else entry.last_error_reset_at,
+        )
+
+    def _refresh_xai_source_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+    ) -> Optional[PooledCredential]:
+        expected_source_path = (
+            entry.source_store_path or auth_mod._auth_file_path()
+        )
+        persistence_failure = False
+        terminal_failure: Optional[Exception] = None
+        consumed_refresh_token = ""
+        failed_source_path: Optional[Path] = None
+
+        for _attempt in range(3):
+            with auth_mod._provider_state_transaction(
+                "xai-oauth",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=expected_source_path,
+            ) as (auth_store, state, source_path):
+                if source_path is None or state is None:
+                    expected_source_path = None
+                    continue
+                authoritative = self._xai_entry_from_locked_state(
+                    entry,
+                    state,
+                    Path(source_path),
+                )
+                if authoritative is None:
+                    return None
+                if not self._entry_tokens_match(authoritative, entry):
+                    return self._replace_entry(
+                        entry,
+                        authoritative,
+                        preserve_routing=True,
+                    )
+                current = self._current_refresh_candidate(entry)
+                if current is None:
+                    return None
+                if not force and not self._entry_needs_refresh(authoritative):
+                    return current
+                discovery = dict(state.get("discovery") or {})
+                token_endpoint = str(
+                    discovery.get("token_endpoint", "") or ""
+                ).strip()
+                if not token_endpoint:
+                    token_endpoint = auth_mod._xai_oauth_discovery(
+                        auth_mod.env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
+                    )["token_endpoint"]
+                consumed_refresh_token = authoritative.refresh_token or ""
+                try:
+                    refreshed = auth_mod.refresh_xai_oauth_pure(
+                        authoritative.access_token,
+                        consumed_refresh_token,
+                        token_endpoint=token_endpoint,
+                        timeout_seconds=auth_mod.env_float(
+                            "HERMES_XAI_REFRESH_TIMEOUT_SECONDS",
+                            20,
+                        ),
+                    )
+                except Exception as exc:
+                    if auth_mod._is_terminal_xai_oauth_refresh_error(exc):
+                        terminal_failure = exc
+                        failed_source_path = Path(source_path)
+                        break
+                    raise
+                updated_state = auth_mod._xai_oauth_state_with_refreshed_tokens(
+                    state,
+                    refreshed,
+                    token_endpoint=token_endpoint,
+                )
+                try:
+                    auth_mod._save_provider_state_to_locked_source(
+                        auth_store,
+                        "xai-oauth",
+                        updated_state,
+                        source_path,
+                        expected_refresh_token=consumed_refresh_token,
+                        set_active=False,
+                    )
+                except auth_mod.SourceCredentialLineageChanged:
+                    expected_source_path = None
+                    continue
+                except (OSError, auth_mod.SourceCredentialPersistenceError):
+                    persistence_failure = True
+                    failed_source_path = Path(source_path)
+                    break
+                updated = replace(
+                    current,
+                    access_token=refreshed["access_token"],
+                    refresh_token=refreshed["refresh_token"],
+                    last_refresh=refreshed.get("last_refresh"),
+                    source_store_path=Path(source_path),
+                    last_status=STATUS_OK,
+                    last_status_at=None,
+                    last_error_code=None,
+                    last_error_reason=None,
+                    last_error_message=None,
+                    last_error_reset_at=None,
+                )
+                return self._replace_entry(
+                    current,
+                    updated,
+                    preserve_routing=True,
+                )
+
+        if terminal_failure:
+            with auth_mod._provider_state_transaction(
+                "xai-oauth",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ) as (_auth_store, winner_state, winner_source_path):
+                if winner_state is not None and winner_source_path is not None:
+                    winner = self._xai_entry_from_locked_state(
+                        entry,
+                        winner_state,
+                        Path(winner_source_path),
+                    )
+                    if (
+                        winner is not None
+                        and winner.refresh_token != consumed_refresh_token
+                    ):
+                        return self._replace_entry(
+                            entry,
+                            winner,
+                            preserve_routing=True,
+                        )
+            self._quarantine_terminal_xai_lineage(
+                entry,
+                failed_source_path,
+                terminal_failure,
+            )
+            return None
+
+        if persistence_failure:
+            try:
+                auth_mod._quarantine_xai_consumed_source(
+                    failed_source_path,
+                    consumed_refresh_token,
+                )
+            except Exception:
+                logger.debug(
+                    "Failed to persist xAI source quarantine",
+                    exc_info=True,
+                )
+            self._mark_source_persistence_dead(entry)
+        return None
 
     def _current_refresh_candidate(
         self,
@@ -2725,6 +3047,76 @@ class CredentialPool:
     ) -> Optional[PooledCredential]:
         """Return only a current row that still matches its owning source."""
 
+        if self.provider == "anthropic" and refreshed.source == "claude_code":
+            from agent.anthropic_adapter import claude_code_credentials_transaction
+
+            with claude_code_credentials_transaction(
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+            ) as (_source_path, creds):
+                if not creds:
+                    return None
+                with self._external_state_lock:
+                    with self._lock:
+                        current = next(
+                            (
+                                item
+                                for item in self._entries
+                                if item.id == refreshed.id
+                            ),
+                            None,
+                        )
+                    if current is None or current.source != refreshed.source:
+                        return None
+                    authoritative = self._anthropic_entry_from_locked_credentials(
+                        current,
+                        creds,
+                    )
+                    if not self._entry_tokens_match(authoritative, current):
+                        return self._replace_entry(
+                            current,
+                            authoritative,
+                            preserve_routing=True,
+                        )
+                    return current
+
+        if self.provider == "xai-oauth" and refreshed.source == "device_code":
+            expected_source_path = (
+                refreshed.source_store_path or auth_mod._auth_file_path()
+            )
+            with auth_mod._provider_state_transaction(
+                "xai-oauth",
+                timeout_seconds=self._single_use_refresh_lock_timeout(),
+                expected_source_path=expected_source_path,
+            ) as (_auth_store, state, source_path):
+                if state is None or source_path is None:
+                    return None
+                with self._external_state_lock:
+                    with self._lock:
+                        current = next(
+                            (
+                                item
+                                for item in self._entries
+                                if item.id == refreshed.id
+                            ),
+                            None,
+                        )
+                    if current is None or current.source != refreshed.source:
+                        return None
+                    authoritative = self._xai_entry_from_locked_state(
+                        current,
+                        state,
+                        Path(source_path),
+                    )
+                    if authoritative is None:
+                        return None
+                    if not self._entry_tokens_match(authoritative, current):
+                        return self._replace_entry(
+                            current,
+                            authoritative,
+                            preserve_routing=True,
+                        )
+                    return current
+
         def revalidate_source() -> Optional[PooledCredential]:
             with self._external_state_lock:
                 with self._lock:
@@ -2745,16 +3137,7 @@ class CredentialPool:
                     )
                 return current
 
-        if self.provider == "anthropic" and refreshed.source == "claude_code":
-            from agent.anthropic_adapter import _claude_code_credentials_path
-
-            with _auth_store_lock(
-                target_path=_claude_code_credentials_path(),
-                timeout_seconds=self._single_use_refresh_lock_timeout(),
-            ):
-                return revalidate_source()
-
-        if self.provider in {"nous", "xai-oauth"} and refreshed.source == "device_code":
+        if self.provider == "nous" and refreshed.source == "device_code":
             auth_store = _load_auth_store()
             _state, source_path = _load_provider_state_with_source(
                 auth_store,
@@ -2877,6 +3260,15 @@ class CredentialPool:
                 return entry
         except Exception as exc:
             logger.debug("Credential refresh failed for %s/%s: %s", self.provider, entry.id, exc)
+            if (
+                self.provider == "nous"
+                and isinstance(exc, auth_mod.SourceCredentialPersistenceError)
+            ):
+                # The resolver's source transaction is already released here.
+                # Quarantine the exact consumed row and let the caller persist
+                # pool state after all source locks have been dropped.
+                self._mark_source_persistence_dead(entry)
+                return None
             # For anthropic claude_code entries: the refresh token may have been
             # consumed by another process. Check if ~/.claude/.credentials.json
             # has a newer token pair and retry once.

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -295,6 +295,16 @@ class PooledCredential:
         return self.base_url
 
 
+@dataclass(frozen=True)
+class _TrustedCodexSourceOwner:
+    """Pool-private provenance for a root-fallback Codex row."""
+
+    source_path: Path
+    owner_kind: str
+    entry_id: str
+    source: str
+
+
 def label_from_token(token: str, fallback: str) -> str:
     claims = _decode_jwt_claims(token)
     for key in ("email", "preferred_username", "upn"):
@@ -653,10 +663,13 @@ class CredentialPool:
         # serializes its pool mutations. In-lock callers re-acquire
         # reentrantly at negligible cost.
         self._lock = threading.RLock()
+        self._persist_lock = threading.Lock()
         # Persist only entries changed by this pool instance. Borrowed rows are
         # snapshots of another auth store; rewriting every snapshot on an
         # unrelated local change can erase a newer owner cooldown/quarantine.
         self._dirty_entry_ids: Set[str] = set()
+        self._pending_removed_entries: List[PooledCredential] = []
+        self._trusted_codex_source_owners: Dict[int, _TrustedCodexSourceOwner] = {}
         self._source_status_reset_ids: Set[str] = set()
         self._active_leases: Dict[str, int] = {}
         self._max_concurrent = DEFAULT_MAX_CONCURRENT_PER_CREDENTIAL
@@ -675,6 +688,108 @@ class CredentialPool:
         # entry is identified or an escape path returns None.
         self._unmatched_rotation_streak: int = 0
 
+    @staticmethod
+    def _same_store_path(left: Path, right: Path) -> bool:
+        try:
+            return left.expanduser().resolve() == right.expanduser().resolve()
+        except (OSError, RuntimeError):
+            return left.expanduser() == right.expanduser()
+
+    def _trust_codex_source_owner(
+        self,
+        entry: PooledCredential,
+        *,
+        owner_kind: str,
+    ) -> bool:
+        """Register trusted root-fallback provenance issued during loading."""
+        if self.provider != "openai-codex" or owner_kind not in {"singleton", "pool"}:
+            return False
+        source_path = entry.source_store_path
+        if source_path is None:
+            return False
+        try:
+            global_path = auth_mod._global_auth_file_path()
+            active_path = auth_mod._auth_file_path()
+        except Exception:
+            return False
+        if global_path is None:
+            return False
+        if not self._same_store_path(source_path, global_path):
+            return False
+        if self._same_store_path(source_path, active_path):
+            return False
+        self._trusted_codex_source_owners[id(entry)] = _TrustedCodexSourceOwner(
+            source_path=source_path,
+            owner_kind=owner_kind,
+            entry_id=entry.id,
+            source=entry.source,
+        )
+        return True
+
+    def _trusted_codex_source_owner(
+        self, entry: PooledCredential
+    ) -> Optional[_TrustedCodexSourceOwner]:
+        owner = self._trusted_codex_source_owners.get(id(entry))
+        if owner is None:
+            return None
+        source_path = entry.source_store_path
+        if (
+            source_path is None
+            or owner.entry_id != entry.id
+            or owner.source != entry.source
+            or not self._same_store_path(owner.source_path, source_path)
+        ):
+            return None
+        try:
+            global_path = auth_mod._global_auth_file_path()
+            active_path = auth_mod._auth_file_path()
+        except Exception:
+            return None
+        if global_path is None:
+            return None
+        if not self._same_store_path(owner.source_path, global_path):
+            return None
+        if self._same_store_path(owner.source_path, active_path):
+            return None
+        return owner
+
+    def _is_trusted_codex_source_owned(self, entry: PooledCredential) -> bool:
+        return self._trusted_codex_source_owner(entry) is not None
+
+    @staticmethod
+    def _entry_tokens_match(
+        current: PooledCredential, expected: PooledCredential
+    ) -> bool:
+        return (
+            current.id == expected.id
+            and current.source == expected.source
+            and current.access_token == expected.access_token
+            and current.refresh_token == expected.refresh_token
+        )
+
+    def _forget_trusted_codex_source_owner(self, entry: PooledCredential) -> None:
+        self._trusted_codex_source_owners.pop(id(entry), None)
+
+    def _validate_source_owned_codex_entries(
+        self,
+        entry_ids: Optional[Set[str]] = None,
+    ) -> Set[str]:
+        """Validate borrowed snapshots without holding the pool lock."""
+        if self.provider != "openai-codex":
+            return set()
+        with self._lock:
+            snapshots = [
+                entry
+                for entry in self._entries
+                if (entry_ids is None or entry.id in entry_ids)
+                and self._is_trusted_codex_source_owned(entry)
+            ]
+        failed: Set[str] = set()
+        for entry in snapshots:
+            if self._sync_source_owned_codex_entry(entry) is None:
+                failed.add(entry.id)
+        return failed
+
     def has_credentials(self) -> bool:
         with self._lock:
             return bool(self._entries)
@@ -686,9 +801,14 @@ class CredentialPool:
         # run under ``self._lock`` like every other caller (``select`` etc.),
         # otherwise a status probe here can race a concurrent ``select`` /
         # rotation and tear ``self._entries`` or double-write auth.json.
+        failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
-            available, _pending = self._available_entries()
-            return bool(available)
+            available, _pending = self._available_entries(
+                excluded_source_ids=failed_source_ids,
+            )
+            result = bool(available)
+        self._persist_pending_changes()
+        return result
 
     def next_available_at(self) -> Optional[float]:
         """Earliest epoch time (seconds) any entry re-enters rotation.
@@ -705,25 +825,34 @@ class CredentialPool:
         is exactly why this must run under ``self._lock`` like every other
         ``_available_entries`` caller (see the comment on ``has_available``).
         """
+        failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
-            available, _pending = self._available_entries()
+            available, _pending = self._available_entries(
+                excluded_source_ids=failed_source_ids,
+            )
             if available:
-                return None
-            # Mirror _available_entries: if the pool has no other credential
-            # to rotate to, the sole entry's transient throttle cools down in
-            # seconds — next_available_at must report that shorter window too,
-            # or the fallback restore gate waits an hour for a 60s cooldown.
-            sole_credential = sum(
-                1 for e in self._entries if e.last_status != STATUS_DEAD
-            ) <= 1
-            candidates: List[float] = []
-            for entry in self._entries:
-                if entry.last_status != STATUS_EXHAUSTED:
-                    continue
-                until = _exhausted_until(entry, sole_credential=sole_credential)
-                if until is not None:
-                    candidates.append(until)
-            return min(candidates) if candidates else None
+                result = None
+            else:
+                # Mirror _available_entries: if the pool has no other credential
+                # to rotate to, the sole entry's transient throttle cools down in
+                # seconds — next_available_at must report that shorter window too,
+                # or the fallback restore gate waits an hour for a 60s cooldown.
+                sole_credential = sum(
+                    1 for e in self._entries if e.last_status != STATUS_DEAD
+                ) <= 1
+                candidates: List[float] = []
+                for entry in self._entries:
+                    if entry.last_status != STATUS_EXHAUSTED:
+                        continue
+                    until = _exhausted_until(
+                        entry,
+                        sole_credential=sole_credential,
+                    )
+                    if until is not None:
+                        candidates.append(until)
+                result = min(candidates) if candidates else None
+        self._persist_pending_changes()
+        return result
 
     def entries(self) -> List[PooledCredential]:
         with self._lock:
@@ -737,13 +866,17 @@ class CredentialPool:
     def current(self) -> Optional[PooledCredential]:
         with self._lock:
             current = self._current_unlocked()
-            if (
-                current is not None
-                and self.provider == "openai-codex"
-                and _is_source_owned_elsewhere(current)
-            ):
-                return self._sync_source_owned_codex_entry(current)
-            return current
+        if current is not None and self._is_trusted_codex_source_owned(current):
+            synced = self._sync_source_owned_codex_entry(current)
+            if synced is None:
+                return None
+            with self._lock:
+                latest = self._current_unlocked()
+                if latest is None or not self._entry_tokens_match(latest, synced):
+                    return None
+                return latest
+        with self._lock:
+            return self._current_unlocked()
 
     def entry_id_for_api_key(self, api_key_hint: Any = None) -> Optional[str]:
         """Return the stable id for the runtime credential in use.
@@ -773,8 +906,8 @@ class CredentialPool:
         new: PooledCredential,
         *,
         mark_dirty: bool = True,
-    ) -> None:
-        """Swap an entry in-place by id, preserving sort order.
+    ) -> Optional[PooledCredential]:
+        """Swap an entry only while its id and credential chain still match.
 
         Self-locking (RLock) so the deferred refresh path — which
         deliberately runs outside the pool lock — cannot tear
@@ -783,10 +916,26 @@ class CredentialPool:
         with self._lock:
             for idx, entry in enumerate(self._entries):
                 if entry.id == old.id:
+                    if not self._entry_tokens_match(entry, old):
+                        return entry
+                    owner = self._trusted_codex_source_owner(entry)
                     self._entries[idx] = new
+                    if owner is not None:
+                        self._trusted_codex_source_owners.pop(id(entry), None)
+                        if (
+                            new.id == owner.entry_id
+                            and new.source == owner.source
+                            and new.source_store_path is not None
+                            and self._same_store_path(
+                                new.source_store_path,
+                                owner.source_path,
+                            )
+                        ):
+                            self._trusted_codex_source_owners[id(new)] = owner
                     if mark_dirty and old != new:
                         self._dirty_entry_ids.add(new.id)
-                    return
+                    return new
+            return None
 
     def _persist(
         self,
@@ -794,70 +943,95 @@ class CredentialPool:
         removed_ids: Optional[List[str]] = None,
         removed_entries: Optional[List[PooledCredential]] = None,
     ) -> None:
-        # Self-locking (RLock): snapshotting self._entries must not race a
-        # concurrent rotation when called from the deferred refresh path.
-        with self._lock:
-            # Validation is read-only when the owner still exists, but revokes
-            # missing source rows immediately even when this persist was caused
-            # only by a local sibling entry.
-            if self.provider == "openai-codex":
-                for source_entry in list(self._entries):
-                    if (
-                        _is_source_owned_elsewhere(source_entry)
-                        and source_entry.id not in self._dirty_entry_ids
-                    ):
-                        self._sync_source_owned_codex_entry(source_entry)
+        # Auth transactions and file writes deliberately happen without the
+        # pool lock. Source refresh takes auth locks first and then replaces an
+        # in-memory row; holding the pool lock here would invert that order.
+        with self._persist_lock:
+            with self._lock:
+                validate_ids = {
+                    entry.id
+                    for entry in self._entries
+                    if self._is_trusted_codex_source_owned(entry)
+                    and entry.id not in self._dirty_entry_ids
+                }
+            if validate_ids:
+                self._validate_source_owned_codex_entries(validate_ids)
 
-            entries_by_id = {entry.id: entry for entry in self._entries}
-            dirty_entries = [
-                entries_by_id[entry_id]
-                for entry_id in self._dirty_entry_ids
-                if entry_id in entries_by_id
-            ]
-            source_dirty = [
-                entry
-                for entry in dirty_entries
-                if _is_source_owned_elsewhere(entry)
-            ]
-            local_dirty = any(
-                not _is_source_owned_elsewhere(entry) for entry in dirty_entries
-            )
-            local_removed_ids = list(removed_ids or [])
-            source_removed = [
-                entry
-                for entry in (removed_entries or [])
-                if _is_source_owned_elsewhere(entry)
-            ]
-            local_removed_ids.extend(
-                entry.id
-                for entry in (removed_entries or [])
-                if not _is_source_owned_elsewhere(entry)
-            )
+            with self._lock:
+                pending_removed = list(self._pending_removed_entries)
+                all_removed = pending_removed + list(removed_entries or [])
+                entries_snapshot = list(self._entries)
+                entries_by_id = {entry.id: entry for entry in entries_snapshot}
+                dirty_entries = [
+                    entries_by_id[entry_id]
+                    for entry_id in self._dirty_entry_ids
+                    if entry_id in entries_by_id
+                ]
+                source_dirty = [
+                    entry
+                    for entry in dirty_entries
+                    if self._is_trusted_codex_source_owned(entry)
+                ]
+                local_dirty = any(
+                    not self._is_trusted_codex_source_owned(entry)
+                    for entry in dirty_entries
+                )
+                source_removed = [
+                    entry
+                    for entry in all_removed
+                    if self._is_trusted_codex_source_owned(entry)
+                ]
+                local_removed_ids = list(removed_ids or [])
+                local_removed_ids.extend(
+                    entry.id
+                    for entry in all_removed
+                    if not self._is_trusted_codex_source_owned(entry)
+                )
+                local_entries = [
+                    entry
+                    for entry in entries_snapshot
+                    if not self._is_trusted_codex_source_owned(entry)
+                ]
+                status_reset_ids = set(self._source_status_reset_ids)
 
             if local_dirty or local_removed_ids:
                 write_credential_pool(
                     self.provider,
-                    [
-                        entry.to_dict()
-                        for entry in self._entries
-                        if not _is_source_owned_elsewhere(entry)
-                    ],
+                    [entry.to_dict() for entry in local_entries],
                     removed_ids=local_removed_ids,
                 )
             for entry in source_dirty:
                 self._persist_source_owned_alias(
                     entry,
-                    allow_status_reset=entry.id in self._source_status_reset_ids,
+                    allow_status_reset=entry.id in status_reset_ids,
                 )
             for entry in source_removed:
                 self._remove_source_owned_alias(entry)
 
-            self._dirty_entry_ids.difference_update(
-                entry.id for entry in dirty_entries
+            with self._lock:
+                self._dirty_entry_ids.difference_update(
+                    entry.id for entry in dirty_entries
+                )
+                self._source_status_reset_ids.difference_update(
+                    entry.id for entry in dirty_entries
+                )
+                pending_ids = {id(entry) for entry in pending_removed}
+                self._pending_removed_entries = [
+                    entry
+                    for entry in self._pending_removed_entries
+                    if id(entry) not in pending_ids
+                ]
+                for entry in all_removed:
+                    self._forget_trusted_codex_source_owner(entry)
+
+    def _persist_pending_changes(self) -> None:
+        with self._lock:
+            pending = bool(
+                getattr(self, "_dirty_entry_ids", set())
+                or getattr(self, "_pending_removed_entries", [])
             )
-            self._source_status_reset_ids.difference_update(
-                entry.id for entry in dirty_entries
-            )
+        if pending:
+            self._persist()
 
     def _is_terminal_auth_failure(
         self,
@@ -890,7 +1064,16 @@ class CredentialPool:
         *,
         persist: bool = True,
         failure_reason: Optional[str] = None,
+        source_validated: bool = False,
     ) -> PooledCredential:
+        if (
+            not source_validated
+            and self._is_trusted_codex_source_owned(entry)
+        ):
+            synced = self._sync_source_owned_codex_entry(entry)
+            if synced is None:
+                return entry
+            entry = synced
         normalized_error = _normalize_error_context(error_context)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
@@ -922,10 +1105,12 @@ class CredentialPool:
             last_error_reset_at=normalized_error.get("reset_at"),
             extra=updated_extra,
         )
-        self._replace_entry(entry, updated)
+        replaced = self._replace_entry(entry, updated)
+        if replaced is None or replaced != updated:
+            return replaced or entry
         if persist:
             self._persist()
-        return updated
+        return replaced
 
     def _sync_anthropic_entry_from_credentials_file(self, entry: PooledCredential) -> PooledCredential:
         """Sync a claude_code pool entry from ~/.claude/.credentials.json if tokens differ.
@@ -1097,7 +1282,13 @@ class CredentialPool:
         entry: PooledCredential,
         state: Optional[Dict[str, Any]],
         source_path: Path,
+        *,
+        owner_kind: Optional[str] = None,
     ) -> bool:
+        owner = self._trusted_codex_source_owner(entry)
+        trusted_kind = owner.owner_kind if owner is not None else owner_kind
+        if trusted_kind is not None:
+            return trusted_kind == "singleton"
         if (
             entry.source != "device_code"
             or not self._codex_provider_state_has_refresh_chain(state)
@@ -1107,13 +1298,41 @@ class CredentialPool:
         alias = _codex_source_pool_alias(source_path, state)
         return bool(alias is not None and alias.get("id") == entry.id)
 
-    def _drop_source_owned_entry(self, entry: PooledCredential) -> None:
+    def _codex_write_path_is_authorized(
+        self,
+        entry: PooledCredential,
+        source_path: Path,
+    ) -> bool:
+        owner = self._trusted_codex_source_owner(entry)
+        if owner is not None:
+            return self._same_store_path(owner.source_path, source_path)
+        try:
+            active_path = auth_mod._auth_file_path()
+        except Exception:
+            return False
+        return (
+            entry.source_store_path is None
+            and self._same_store_path(active_path, source_path)
+        )
+
+    def _drop_source_owned_entry(self, entry: PooledCredential) -> bool:
         with self._lock:
+            current = next(
+                (item for item in self._entries if item.id == entry.id),
+                None,
+            )
+            if current is None:
+                self._forget_trusted_codex_source_owner(entry)
+                return True
+            if not self._entry_tokens_match(current, entry):
+                return False
             self._entries = [item for item in self._entries if item.id != entry.id]
             self._dirty_entry_ids.discard(entry.id)
             self._source_status_reset_ids.discard(entry.id)
             if self._current_id == entry.id:
                 self._current_id = None
+            self._forget_trusted_codex_source_owner(current)
+            return True
 
     def _revoke_missing_codex_source(
         self,
@@ -1147,15 +1366,13 @@ class CredentialPool:
         entry: PooledCredential,
     ) -> Optional[PooledCredential]:
         """Re-read one borrowed row by stable id, or revoke it if owner vanished."""
-        if (
-            self.provider != "openai-codex"
-            or entry.source_store_path is None
-        ):
+        owner = self._trusted_codex_source_owner(entry)
+        if self.provider != "openai-codex" or owner is None:
             return entry
         try:
             with auth_mod._provider_state_transaction(
                 "openai-codex",
-                expected_source_path=entry.source_store_path,
+                expected_source_path=owner.source_path,
             ) as (_active_store, state, source_path):
                 if source_path is None:
                     self._drop_source_owned_entry(entry)
@@ -1177,17 +1394,34 @@ class CredentialPool:
                     PooledCredential.from_dict("openai-codex", item),
                     source_store_path=source_path,
                 )
-                if self._codex_alias_is_singleton(stored, state, source_path):
+                if self._codex_alias_is_singleton(
+                    stored,
+                    state,
+                    source_path,
+                    owner_kind=owner.owner_kind,
+                ):
+                    if not self._codex_provider_state_has_refresh_chain(state):
+                        self._revoke_missing_codex_source(
+                            entry,
+                            source_path,
+                            source_store=source_store,
+                        )
+                        return None
                     synced = self._codex_entry_from_provider_state(stored, state)
                     if self._codex_tokens_changed(synced, stored):
                         self._persist_codex_device_code_refresh(synced, source_path)
                     stored = synced
                 if stored != entry:
-                    self._replace_entry(entry, stored, mark_dirty=False)
-                return stored
+                    replaced = self._replace_entry(entry, stored, mark_dirty=False)
+                    if replaced is None:
+                        return None
+                    if not self._entry_tokens_match(replaced, stored):
+                        return None
+                    return replaced
+                return entry
         except Exception as exc:
             logger.debug("Failed to validate borrowed Codex entry: %s", exc)
-            return entry
+            return None
 
     def _persist_source_owned_alias(
         self,
@@ -1196,15 +1430,13 @@ class CredentialPool:
         allow_status_reset: bool = False,
     ) -> None:
         """Route one changed borrowed Codex row to its exact owning alias."""
-        if (
-            self.provider != "openai-codex"
-            or entry.source_store_path is None
-        ):
+        owner = self._trusted_codex_source_owner(entry)
+        if self.provider != "openai-codex" or owner is None:
             return
 
         with auth_mod._provider_state_transaction(
             "openai-codex",
-            expected_source_path=entry.source_store_path,
+            expected_source_path=owner.source_path,
         ) as (_active_store, state, source_path):
             if source_path is None:
                 self._drop_source_owned_entry(entry)
@@ -1223,10 +1455,26 @@ class CredentialPool:
                 PooledCredential.from_dict("openai-codex", item),
                 source_store_path=source_path,
             )
-            if self._codex_alias_is_singleton(stored, state, source_path):
+            if self._codex_alias_is_singleton(
+                stored,
+                state,
+                source_path,
+                owner_kind=owner.owner_kind,
+            ):
+                if not self._codex_provider_state_has_refresh_chain(state):
+                    self._revoke_missing_codex_source(
+                        entry,
+                        source_path,
+                        source_store=source_store,
+                    )
+                    return
                 synced = self._codex_entry_from_provider_state(stored, state)
                 if self._codex_tokens_changed(synced, stored):
-                    self._persist_codex_device_code_refresh(synced, source_path)
+                    self._persist_codex_device_code_refresh(
+                        synced,
+                        source_path,
+                        provenance_entry=entry,
+                    )
                 stored = synced
             if self._codex_tokens_changed(stored, entry):
                 self._replace_entry(entry, stored, mark_dirty=False)
@@ -1253,11 +1501,12 @@ class CredentialPool:
                 self._replace_entry(entry, final_entry, mark_dirty=False)
 
     def _remove_source_owned_alias(self, entry: PooledCredential) -> None:
-        if self.provider != "openai-codex" or entry.source_store_path is None:
+        owner = self._trusted_codex_source_owner(entry)
+        if self.provider != "openai-codex" or owner is None:
             return
         with auth_mod._provider_state_transaction(
             "openai-codex",
-            expected_source_path=entry.source_store_path,
+            expected_source_path=owner.source_path,
         ) as (_active_store, state, source_path):
             if source_path is None:
                 return
@@ -1269,7 +1518,12 @@ class CredentialPool:
                 PooledCredential.from_dict("openai-codex", item),
                 source_store_path=source_path,
             )
-            if self._codex_alias_is_singleton(stored, state, source_path):
+            if self._codex_alias_is_singleton(
+                stored,
+                state,
+                source_path,
+                owner_kind=owner.owner_kind,
+            ):
                 refresh_token = str(item.get("refresh_token") or "").strip()
                 persisted[:] = [
                     candidate
@@ -1309,6 +1563,8 @@ class CredentialPool:
         self,
         entry: PooledCredential,
         source_path: Path,
+        *,
+        provenance_entry: Optional[PooledCredential] = None,
     ) -> None:
         """Persist one singleton-owned Codex chain to its exact source store.
 
@@ -1316,6 +1572,11 @@ class CredentialPool:
         the matching ``device_code`` pool alias and singleton are updated;
         independent manual accounts and unrelated store data remain untouched.
         """
+        if not self._codex_write_path_is_authorized(
+            provenance_entry or entry,
+            source_path,
+        ):
+            return
         auth_store = _load_auth_store(source_path)
         changed = False
 
@@ -1367,6 +1628,8 @@ class CredentialPool:
         source_path: Path,
     ) -> bool:
         """Persist a non-singleton Codex refresh to one exact owning row."""
+        if not self._codex_write_path_is_authorized(entry, source_path):
+            return False
         auth_store = _load_auth_store(source_path)
         persisted, index, item = self._codex_exact_pool_alias(auth_store, entry)
         if not self._codex_pool_alias_has_complete_credentials(item):
@@ -1393,6 +1656,8 @@ class CredentialPool:
         source_path: Path,
     ) -> None:
         """Remove one terminal non-singleton chain without touching singleton."""
+        if not self._codex_write_path_is_authorized(entry, source_path):
+            return
         auth_store = _load_auth_store(source_path)
         persisted, index, _item = self._codex_exact_pool_alias(auth_store, entry)
         if persisted is not None and index is not None:
@@ -1406,6 +1671,8 @@ class CredentialPool:
         exc: Exception,
     ) -> Set[str]:
         """Clear every device alias on one terminal singleton chain."""
+        if not self._codex_write_path_is_authorized(entry, source_path):
+            return set()
         auth_store = _load_auth_store(source_path)
         removed_ids: Set[str] = {entry.id}
         providers = auth_store.get("providers")
@@ -1476,10 +1743,15 @@ class CredentialPool:
         """Sync a singleton-seeded Codex entry from its owning auth store."""
         if self.provider != "openai-codex" or entry.source != "device_code":
             return entry
+        owner = self._trusted_codex_source_owner(entry)
         try:
             with auth_mod._provider_state_transaction(
                 "openai-codex",
-                expected_source_path=entry.source_store_path,
+                expected_source_path=(
+                    owner.source_path
+                    if owner is not None
+                    else auth_mod._auth_file_path()
+                ),
             ) as (
                 _auth_store,
                 state,
@@ -1489,9 +1761,11 @@ class CredentialPool:
                 updated = self._codex_entry_from_provider_state(entry, state)
                 if updated is entry:
                     return entry
-                self._replace_entry(entry, updated)
-                self._persist_codex_device_code_refresh(updated, source_path)
-                return updated
+                replaced = self._replace_entry(entry, updated)
+                if replaced is None or not self._entry_tokens_match(replaced, updated):
+                    return entry
+                self._persist_codex_device_code_refresh(replaced, source_path)
+                return replaced
         except Exception as exc:
             logger.debug("Failed to sync Codex entry from auth.json: %s", exc)
             return entry
@@ -1823,11 +2097,12 @@ class CredentialPool:
         # resolve_codex_runtime_credentials()).  When a waiter finally acquires
         # the lock, the in-lock re-sync below picks up the rotated token the
         # winner persisted and skips the POST.
-        if self.provider == "openai-codex" and entry.source_store_path is not None:
+        codex_owner = self._trusted_codex_source_owner(entry)
+        if self.provider == "openai-codex" and codex_owner is not None:
             with auth_mod._provider_state_transaction(
                 "openai-codex",
                 timeout_seconds=self._single_use_refresh_lock_timeout(),
-                expected_source_path=entry.source_store_path,
+                expected_source_path=codex_owner.source_path,
             ) as (_auth_store, state, source_path):
                 if source_path is None:
                     self._drop_source_owned_entry(entry)
@@ -1853,19 +2128,32 @@ class CredentialPool:
                     stored,
                     state,
                     source_path,
+                    owner_kind=codex_owner.owner_kind,
                 )
                 if singleton_owned:
+                    if not self._codex_provider_state_has_refresh_chain(state):
+                        self._revoke_missing_codex_source(
+                            entry,
+                            source_path,
+                            source_store=source_store,
+                        )
+                        return None
                     stored = self._codex_entry_from_provider_state(stored, state)
                 if self._codex_tokens_changed(stored, entry):
                     # A waiter that observed the winner's rotated exact row
                     # adopts it even for force=True; replay would consume a
                     # single-use refresh token twice.
-                    self._replace_entry(entry, stored, mark_dirty=False)
+                    replaced = self._replace_entry(entry, stored, mark_dirty=False)
+                    if replaced is None or not self._entry_tokens_match(replaced, stored):
+                        return None
                     if singleton_owned:
-                        self._persist_codex_device_code_refresh(stored, source_path)
-                    return stored
+                        self._persist_codex_device_code_refresh(replaced, source_path)
+                    return replaced
+                replaced = self._replace_entry(entry, stored, mark_dirty=False)
+                if replaced is None or not self._entry_tokens_match(replaced, stored):
+                    return None
                 return self._refresh_entry_impl(
-                    stored,
+                    replaced,
                     force=force,
                     codex_source_path=source_path,
                     codex_singleton_owned=singleton_owned,
@@ -1874,7 +2162,7 @@ class CredentialPool:
             with auth_mod._provider_state_transaction(
                 "openai-codex",
                 timeout_seconds=self._single_use_refresh_lock_timeout(),
-                expected_source_path=entry.source_store_path,
+                expected_source_path=auth_mod._auth_file_path(),
             ) as (_auth_store, state, source_path):
                 source_path = source_path or auth_mod._auth_file_path()
                 if not self._codex_provider_state_has_refresh_chain(state):
@@ -2283,8 +2571,8 @@ class CredentialPool:
                         self._source_status_reset_ids.difference_update(removed_ids)
                         if self._current_id in removed_ids:
                             self._current_id = None
-                        if codex_source_path is None:
-                            self._persist(removed_ids=list(removed_ids))
+                    if codex_source_path is None:
+                        self._persist(removed_ids=list(removed_ids))
                     return None
             # For nous: another process may have consumed the refresh token
             # between our proactive sync and the HTTP call.  Re-sync from
@@ -2454,7 +2742,9 @@ class CredentialPool:
         return False
 
     def select(self) -> Optional[PooledCredential]:
-        entry, pending_refresh = self._select_under_lock()
+        failed_source_ids = self._validate_source_owned_codex_entries()
+        entry, pending_refresh = self._select_under_lock(failed_source_ids)
+        self._persist_pending_changes()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
         if entry is not None:
@@ -2463,15 +2753,22 @@ class CredentialPool:
         # If no entry was available but we just refreshed some, re-select
         # now that the refreshed entries are back in the pool.
         if pending_refresh:
-            entry, _ = self._select_under_lock()
+            failed_source_ids = self._validate_source_owned_codex_entries()
+            entry, _ = self._select_under_lock(failed_source_ids)
+            self._persist_pending_changes()
             if entry is not None:
                 self._unmatched_rotation_streak = 0
         return entry
 
-    def _select_under_lock(self) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_under_lock(
+        self,
+        excluded_source_ids: Optional[Set[str]] = None,
+    ) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Run selection under the lock, returning entry + pending refreshes."""
         with self._lock:
-            return self._select_unlocked()
+            return self._select_unlocked(
+                excluded_source_ids=excluded_source_ids,
+            )
 
     def _refresh_pending_entries(self, pending: List[tuple]) -> None:
         """Refresh deferred single-use-token entries outside the lock.
@@ -2490,7 +2787,11 @@ class CredentialPool:
             self._refresh_entry(entry, force=False)
 
     def _available_entries(
-        self, *, clear_expired: bool = False, refresh: bool = False,
+        self,
+        *,
+        clear_expired: bool = False,
+        refresh: bool = False,
+        excluded_source_ids: Optional[Set[str]] = None,
     ) -> Tuple[List[PooledCredential], List[tuple]]:
         """Return (available, pending_refresh) for entries not in cooldown.
 
@@ -2519,14 +2820,8 @@ class CredentialPool:
             1 for e in self._entries if e.last_status != STATUS_DEAD
         ) <= 1
         for entry in list(self._entries):
-            if (
-                self.provider == "openai-codex"
-                and _is_source_owned_elsewhere(entry)
-            ):
-                synced_source = self._sync_source_owned_codex_entry(entry)
-                if synced_source is None:
-                    continue
-                entry = synced_source
+            if excluded_source_ids and entry.id in excluded_source_ids:
+                continue
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row
             # can remain unhydrated; never lease or select it as an empty key.
@@ -2658,8 +2953,8 @@ class CredentialPool:
             self._entries = [e for e in self._entries if e.id not in pruned_ids]
         else:
             pruned_entries = []
-        if cleared_any:
-            self._persist(removed_entries=pruned_entries)
+        if pruned_entries:
+            self._pending_removed_entries.extend(pruned_entries)
         return available, pending_refresh
 
     def _log_no_available_entries(self) -> None:
@@ -2676,13 +2971,22 @@ class CredentialPool:
         self._last_no_entries_log_at = now
         logger.info("credential pool: no available entries (all exhausted or empty)")
 
-    def _select_unlocked(self, *, refresh: bool = True) -> Tuple[Optional[PooledCredential], List[tuple]]:
+    def _select_unlocked(
+        self,
+        *,
+        refresh: bool = True,
+        excluded_source_ids: Optional[Set[str]] = None,
+    ) -> Tuple[Optional[PooledCredential], List[tuple]]:
         """Select the best available credential entry.
 
         Returns ``(entry, pending_refresh)`` where *pending_refresh* contains
         single-use-token entries that must be refreshed outside the lock.
         """
-        available, pending_refresh = self._available_entries(clear_expired=True, refresh=refresh)
+        available, pending_refresh = self._available_entries(
+            clear_expired=True,
+            refresh=refresh,
+            excluded_source_ids=excluded_source_ids,
+        )
         if not available:
             self._current_id = None
             self._log_no_available_entries()
@@ -2709,15 +3013,34 @@ class CredentialPool:
         if self._strategy == STRATEGY_ROUND_ROBIN and len(available) > 1:
             entry = available[0]
             previous_by_id = {candidate.id: candidate for candidate in self._entries}
+            previous_owners = {
+                candidate.id: self._trusted_codex_source_owner(candidate)
+                for candidate in self._entries
+            }
             rotated = [candidate for candidate in self._entries if candidate.id != entry.id]
             rotated.append(replace(entry, priority=len(self._entries) - 1))
             self._entries = [replace(candidate, priority=idx) for idx, candidate in enumerate(rotated)]
+            for previous in previous_by_id.values():
+                self._trusted_codex_source_owners.pop(id(previous), None)
+            for candidate in self._entries:
+                owner = previous_owners.get(candidate.id)
+                previous = previous_by_id.get(candidate.id)
+                if (
+                    owner is not None
+                    and previous is not None
+                    and self._entry_tokens_match(candidate, previous)
+                    and candidate.source_store_path is not None
+                    and self._same_store_path(
+                        candidate.source_store_path,
+                        owner.source_path,
+                    )
+                ):
+                    self._trusted_codex_source_owners[id(candidate)] = owner
             self._dirty_entry_ids.update(
                 candidate.id
                 for candidate in self._entries
                 if previous_by_id.get(candidate.id) != candidate
             )
-            self._persist()
             self._current_id = entry.id
             return self._current_unlocked() or entry, pending_refresh
 
@@ -2728,14 +3051,23 @@ class CredentialPool:
     def peek(self) -> Optional[PooledCredential]:
         # Single lock acquisition for the whole read; call the unlocked
         # helpers so we don't re-enter the non-reentrant ``self._lock``.
+        failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
-            available, _pending = self._available_entries()
+            available, _pending = self._available_entries(
+                excluded_source_ids=failed_source_ids,
+            )
             current = self._current_unlocked()
             if current is not None:
                 for entry in available:
                     if entry.id == current.id:
-                        return entry
-            return available[0] if available else None
+                        result = entry
+                        break
+                else:
+                    result = available[0] if available else None
+            else:
+                result = available[0] if available else None
+        self._persist_pending_changes()
+        return result
 
     def mark_exhausted_and_rotate(
         self,
@@ -2746,10 +3078,33 @@ class CredentialPool:
         credential_id: Optional[str] = None,
         failure_reason: Optional[str] = None,
     ) -> Optional[PooledCredential]:
+        failed_source_ids = self._validate_source_owned_codex_entries()
+        try:
+            return self._mark_exhausted_and_rotate_locked(
+                status_code=status_code,
+                error_context=error_context,
+                api_key_hint=api_key_hint,
+                credential_id=credential_id,
+                failure_reason=failure_reason,
+                failed_source_ids=failed_source_ids,
+            )
+        finally:
+            self._persist_pending_changes()
+
+    def _mark_exhausted_and_rotate_locked(
+        self,
+        *,
+        status_code: Optional[int],
+        error_context: Optional[Dict[str, Any]],
+        api_key_hint: Optional[str],
+        credential_id: Optional[str],
+        failure_reason: Optional[str],
+        failed_source_ids: Set[str],
+    ) -> Optional[PooledCredential]:
         with self._lock:
             entry = None
             identity_supplied = bool(credential_id or api_key_hint)
-            if credential_id:
+            if credential_id and credential_id not in failed_source_ids:
                 entry = next(
                     (e for e in self._entries if e.id == credential_id),
                     None,
@@ -2760,7 +3115,12 @@ class CredentialPool:
                 # (another process already rotated), current() is None and
                 # _select_unlocked() would return the NEXT key — the wrong one.
                 entry = next(
-                    (e for e in self._entries if e.runtime_api_key == api_key_hint),
+                    (
+                        e
+                        for e in self._entries
+                        if e.id not in failed_source_ids
+                        and e.runtime_api_key == api_key_hint
+                    ),
                     None,
                 )
             if entry is None and identity_supplied:
@@ -2784,7 +3144,9 @@ class CredentialPool:
                 # guessing and surface the error (no cooldown is written for
                 # anybody — healthy keys stay available for the next turn).
                 self._unmatched_rotation_streak += 1
-                available_count, _ = self._available_entries()
+                available_count, _ = self._available_entries(
+                    excluded_source_ids=failed_source_ids,
+                )
                 available_count = len(available_count)
                 if self._unmatched_rotation_streak > max(available_count, 1):
                     logger.warning(
@@ -2804,9 +3166,21 @@ class CredentialPool:
                     self.provider,
                 )
                 self._current_id = None
-                next_entry, _pending = self._select_unlocked(refresh=False)
-                avail, _ = self._available_entries()
-                if next_entry is not None and len(avail) == 1:
+                next_entry, _pending = self._select_unlocked(
+                    refresh=False,
+                    excluded_source_ids=failed_source_ids,
+                )
+                avail, _ = self._available_entries(
+                    excluded_source_ids=failed_source_ids,
+                )
+                if (
+                    next_entry is not None
+                    and len(avail) == 1
+                    and not (
+                        credential_id in failed_source_ids
+                        and next_entry.id != credential_id
+                    )
+                ):
                     # A single-entry pool cannot rotate. Returning its only
                     # entry reports a successful recovery without changing
                     # the credential, so the caller retries the same 401
@@ -2819,12 +3193,23 @@ class CredentialPool:
             # streak is stale (this mark WILL advance pool state).
             self._unmatched_rotation_streak = 0
             if entry is None:
-                entry = self._current_unlocked() or self._select_unlocked(refresh=False)[0]
+                current = self._current_unlocked()
+                if current is not None and current.id in failed_source_ids:
+                    current = None
+                entry = current or self._select_unlocked(
+                    refresh=False,
+                    excluded_source_ids=failed_source_ids,
+                )[0]
             if entry is None:
                 return None
             _label = entry.label or entry.id[:8]
             self._mark_exhausted(
-                entry, status_code, error_context, failure_reason=failure_reason
+                entry,
+                status_code,
+                error_context,
+                persist=False,
+                failure_reason=failure_reason,
+                source_validated=True,
             )
             # A 402/429/401 is an API-key–level failure: the account is out of
             # balance, rate-limited, or its key is rejected.  The same key can
@@ -2839,7 +3224,6 @@ class CredentialPool:
             # "no available entries" state and let the error propagate.
             failed_runtime_key = getattr(entry, "runtime_api_key", None)
             if identity_supplied and failed_runtime_key:
-                siblings_marked = False
                 for sibling in self._entries:
                     if sibling.id == entry.id:
                         continue
@@ -2850,10 +3234,8 @@ class CredentialPool:
                             error_context,
                             persist=False,
                             failure_reason=failure_reason,
+                            source_validated=True,
                         )
-                        siblings_marked = True
-                if siblings_marked:
-                    self._persist()
             # Re-read the updated entry to log the correct terminal state.
             updated_entry = next(
                 (e for e in self._entries if e.id == entry.id), entry,
@@ -2870,7 +3252,10 @@ class CredentialPool:
                     _label, status_code,
                 )
             self._current_id = None
-            next_entry, _pending = self._select_unlocked(refresh=False)
+            next_entry, _pending = self._select_unlocked(
+                refresh=False,
+                excluded_source_ids=failed_source_ids,
+            )
             if next_entry:
                 _next_label = next_entry.label or next_entry.id[:8]
                 logger.info("credential pool: rotated to %s", _next_label)
@@ -2884,7 +3269,18 @@ class CredentialPool:
         a stable tie-breaker. When every credential is already at the soft cap,
         still return the least-leased one instead of blocking.
         """
-        chosen_id, pending_refresh = self._acquire_lease_under_lock(credential_id)
+        entry_ids = {credential_id} if credential_id is not None else None
+        failed_source_ids = self._validate_source_owned_codex_entries(entry_ids)
+        if failed_source_ids:
+            chosen_id, pending_refresh = self._acquire_lease_under_lock(
+                credential_id,
+                excluded_source_ids=failed_source_ids,
+            )
+        else:
+            chosen_id, pending_refresh = self._acquire_lease_under_lock(
+                credential_id,
+            )
+        self._persist_pending_changes()
         if pending_refresh:
             self._refresh_pending_entries(pending_refresh)
             # Mirror select(): if nothing was leasable but we just refreshed
@@ -2894,15 +3290,32 @@ class CredentialPool:
             # caller sees "no credentials available" and fails a request that
             # should have gone through.
             if chosen_id is None:
-                chosen_id, _ = self._acquire_lease_under_lock(credential_id)
+                failed_source_ids = self._validate_source_owned_codex_entries(
+                    entry_ids,
+                )
+                if failed_source_ids:
+                    chosen_id, _ = self._acquire_lease_under_lock(
+                        credential_id,
+                        excluded_source_ids=failed_source_ids,
+                    )
+                else:
+                    chosen_id, _ = self._acquire_lease_under_lock(
+                        credential_id,
+                    )
+                self._persist_pending_changes()
         return chosen_id
 
     def _acquire_lease_under_lock(
-        self, credential_id: Optional[str],
+        self,
+        credential_id: Optional[str],
+        *,
+        excluded_source_ids: Optional[Set[str]] = None,
     ) -> Tuple[Optional[str], List[tuple]]:
         """Run lease acquisition under the lock, returning id + pending refreshes."""
         with self._lock:
             if credential_id:
+                if excluded_source_ids and credential_id in excluded_source_ids:
+                    return None, []
                 candidate = next(
                     (
                         entry
@@ -2913,17 +3326,21 @@ class CredentialPool:
                 )
                 if candidate is None:
                     return None, []
-                if (
-                    self.provider == "openai-codex"
-                    and _is_source_owned_elsewhere(candidate)
-                    and self._sync_source_owned_codex_entry(candidate) is None
-                ):
-                    return None, []
                 self._active_leases[credential_id] = self._active_leases.get(credential_id, 0) + 1
                 self._current_id = credential_id
                 return credential_id, []
 
-            available, pending_refresh = self._available_entries(clear_expired=True, refresh=True)
+            if excluded_source_ids:
+                available, pending_refresh = self._available_entries(
+                    clear_expired=True,
+                    refresh=True,
+                    excluded_source_ids=excluded_source_ids,
+                )
+            else:
+                available, pending_refresh = self._available_entries(
+                    clear_expired=True,
+                    refresh=True,
+                )
             if not available:
                 return None, pending_refresh
 
@@ -2951,7 +3368,14 @@ class CredentialPool:
 
     def try_refresh_current(self) -> Optional[PooledCredential]:
         with self._lock:
-            return self._try_refresh_current_unlocked()
+            entry = self._current_unlocked()
+        if entry is None:
+            return None
+        refreshed = self._refresh_entry(entry, force=True)
+        if refreshed is not None:
+            with self._lock:
+                self._current_id = refreshed.id
+        return refreshed
 
     def try_refresh_matching(
         self,
@@ -2966,9 +3390,10 @@ class CredentialPool:
         the normal proactive refresh; the forced refresh below must consume a
         rotating refresh token exactly once.
         """
+        failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
             entry = None
-            if credential_id:
+            if credential_id and credential_id not in failed_source_ids:
                 entry = next(
                     (
                         candidate
@@ -2983,81 +3408,77 @@ class CredentialPool:
                         (
                             candidate
                             for candidate in self._entries
-                            if candidate.runtime_api_key == api_key_hint
+                            if candidate.id not in failed_source_ids
+                            and candidate.runtime_api_key == api_key_hint
                         ),
                         None,
                     )
                 else:
-                    entry = self._current_unlocked() or self._select_unlocked(
-                        refresh=False
+                    current = self._current_unlocked()
+                    if current is not None and current.id in failed_source_ids:
+                        current = None
+                    entry = current or self._select_unlocked(
+                        refresh=False,
+                        excluded_source_ids=failed_source_ids,
                     )[0]
             if entry is None:
                 return None
             self._current_id = entry.id
-            return self._try_refresh_current_unlocked()
-
-    def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
-        entry = self._current_unlocked()
-        if entry is None:
-            return None
+        self._persist_pending_changes()
         refreshed = self._refresh_entry(entry, force=True)
         if refreshed is not None:
-            self._current_id = refreshed.id
+            with self._lock:
+                self._current_id = refreshed.id
         return refreshed
 
     def reset_statuses(self) -> int:
+        failed_source_ids = self._validate_source_owned_codex_entries()
         with self._lock:
             count = 0
-            new_entries = []
             reset_ids: Set[str] = set()
-            for entry in self._entries:
+            for entry in list(self._entries):
+                if entry.id in failed_source_ids:
+                    continue
                 if entry.last_status or entry.last_status_at or entry.last_error_code:
-                    new_entries.append(
-                        replace(
-                            entry,
-                            last_status=None,
-                            last_status_at=None,
-                            last_error_code=None,
-                            last_error_reason=None,
-                            last_error_message=None,
-                            last_error_reset_at=None,
-                        )
+                    updated = replace(
+                        entry,
+                        last_status=None,
+                        last_status_at=None,
+                        last_error_code=None,
+                        last_error_reason=None,
+                        last_error_message=None,
+                        last_error_reset_at=None,
                     )
+                    self._replace_entry(entry, updated)
                     reset_ids.add(entry.id)
                     count += 1
-                else:
-                    new_entries.append(entry)
             if count:
-                self._entries = new_entries
-                self._dirty_entry_ids.update(reset_ids)
                 self._source_status_reset_ids.update(
                     entry.id
-                    for entry in new_entries
+                    for entry in self._entries
                     if entry.id in reset_ids
-                    and _is_source_owned_elsewhere(entry)
+                    and self._is_trusted_codex_source_owned(entry)
                 )
-                self._persist()
-            return count
+        self._persist_pending_changes()
+        return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:
+        self._validate_source_owned_codex_entries()
         with self._lock:
             if index < 1 or index > len(self._entries):
                 return None
             removed = self._entries.pop(index - 1)
-            previous_by_id = {entry.id: entry for entry in self._entries}
-            self._entries = [
-                replace(entry, priority=new_priority)
-                for new_priority, entry in enumerate(self._entries)
-            ]
-            self._dirty_entry_ids.update(
-                entry.id
-                for entry in self._entries
-                if previous_by_id.get(entry.id) != entry
-            )
-            self._persist(removed_entries=[removed])
+            for new_priority, entry in enumerate(list(self._entries)):
+                if entry.priority != new_priority:
+                    self._replace_entry(
+                        entry,
+                        replace(entry, priority=new_priority),
+                    )
+            self._pending_removed_entries.append(removed)
             if self._current_id == removed.id:
                 self._current_id = None
-            return removed
+        self._persist_pending_changes()
+        return removed
 
     def resolve_target(self, target: Any) -> Tuple[Optional[int], Optional[PooledCredential], Optional[str]]:
         raw = str(target or "").strip()
@@ -3086,12 +3507,13 @@ class CredentialPool:
             return None, None, f'No credential matching "{raw}".'
 
     def add_entry(self, entry: PooledCredential) -> PooledCredential:
+        self._validate_source_owned_codex_entries()
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
             self._dirty_entry_ids.add(entry.id)
-            self._persist()
-            return entry
+        self._persist_pending_changes()
+        return entry
 
 
 def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, payload: Dict[str, Any]) -> bool:
@@ -3217,6 +3639,35 @@ def _codex_source_pool_alias(
             ):
                 return dict(alias)
     return dict(aliases[0])
+
+
+def _loaded_codex_source_owner_kind(entry: PooledCredential) -> str:
+    """Classify trusted fallback ownership while its source state is readable."""
+    source_path = entry.source_store_path
+    if source_path is None or entry.source != "device_code":
+        return "pool"
+    try:
+        source_store = auth_mod._load_auth_store(source_path)
+        providers = source_store.get("providers")
+        state = providers.get("openai-codex") if isinstance(providers, dict) else None
+        tokens = state.get("tokens") if isinstance(state, dict) else None
+        alias = (
+            _codex_source_pool_alias(source_path, state)
+            if isinstance(state, dict) and isinstance(tokens, dict)
+            else None
+        )
+    except Exception:
+        return "pool"
+    if (
+        alias is not None
+        and str(alias.get("id") or "") == entry.id
+        and str(alias.get("access_token") or "")
+        == str(tokens.get("access_token") or "")
+        and str(alias.get("refresh_token") or "")
+        == str(tokens.get("refresh_token") or "")
+    ):
+        return "singleton"
+    return "pool"
 
 
 def _seed_from_singletons(
@@ -4023,4 +4474,12 @@ def load_pool(provider: str) -> CredentialPool:
             ],
             removed_ids=persisted_disk_ids - new_ids,
         )
-    return CredentialPool(provider, entries)
+    pool = CredentialPool(provider, entries)
+    if provider == "openai-codex":
+        for entry in pool.entries():
+            if entry.source_store_path is not None:
+                pool._trust_codex_source_owner(
+                    entry,
+                    owner_kind=_loaded_codex_source_owner_kind(entry),
+                )
+    return pool

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1366,7 +1366,10 @@ def _load_provider_state_with_source(
 
 
 @contextmanager
-def _provider_state_transaction(provider_id: str):
+def _provider_state_transaction(
+    provider_id: str,
+    timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+):
     """Lock the active auth store and any global fallback source in order.
 
     Profile-backed refresh paths must take the global auth-store lock before
@@ -1374,7 +1377,7 @@ def _provider_state_transaction(provider_id: str):
     target lock is acquired prevents both stale refreshes and whole-file lost
     updates without inverting the documented auth -> shared lock order.
     """
-    with _auth_store_lock():
+    with _auth_store_lock(timeout_seconds=timeout_seconds):
         auth_store = _load_auth_store()
         state, source_path = _load_provider_state_with_source(
             auth_store,
@@ -1385,7 +1388,10 @@ def _provider_state_transaction(provider_id: str):
             yield auth_store, state, source_path
             return
 
-        with _auth_store_lock(target_path=source_path):
+        with _auth_store_lock(
+            timeout_seconds=timeout_seconds,
+            target_path=source_path,
+        ):
             source_store = _load_auth_store(source_path)
             source_providers = source_store.get("providers")
             source_state = None
@@ -3715,12 +3721,18 @@ def _sync_codex_pool_entries(
         entry["last_error_reset_at"] = None
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str = None) -> None:
-    """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
+def _save_codex_tokens(
+    tokens: Dict[str, str],
+    last_refresh: Optional[str] = None,
+    label: Optional[str] = None,
+    *,
+    source_path: Optional[Path] = None,
+) -> None:
+    """Save Codex tokens locally, or back to an explicit credential source."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    with _auth_store_lock():
-        auth_store = _load_auth_store()
+    with _auth_store_lock(target_path=source_path):
+        auth_store = _load_auth_store(source_path)
         state = _load_provider_state(auth_store, "openai-codex") or {}
         # Capture the previous singleton tokens BEFORE overwriting them.  The
         # pool-sync step uses this to distinguish legacy singleton-aliases
@@ -3740,10 +3752,14 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: 
             last_refresh,
             previous_singleton_tokens=previous_singleton_tokens,
         )
-        _save_auth_store(auth_store)
+        _save_auth_store(auth_store, target_path=source_path)
 
 
-def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
+def _recover_codex_tokens_from_cli(
+    reason: str,
+    *,
+    source_path: Optional[Path] = None,
+) -> Optional[Dict[str, str]]:
     """Adopt a valid Codex CLI token pair into Hermes auth, if available."""
     imported = _import_codex_cli_tokens()
     # Require BOTH tokens before adopting: persisting a payload without a
@@ -3755,7 +3771,7 @@ def _recover_codex_tokens_from_cli(reason: str) -> Optional[Dict[str, str]]:
     ):
         return None
     logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
-    _save_codex_tokens(imported)
+    _save_codex_tokens(imported, source_path=source_path)
     return dict(imported)
 
 
@@ -3896,6 +3912,8 @@ def refresh_codex_oauth_pure(
 def _refresh_codex_auth_tokens(
     tokens: Dict[str, str],
     timeout_seconds: float,
+    *,
+    source_path: Optional[Path] = None,
 ) -> Dict[str, str]:
     """Refresh Codex access token using the refresh token.
     
@@ -3923,7 +3941,8 @@ def _refresh_codex_auth_tokens(
         if not getattr(exc, "relogin_required", False):
             raise
         imported = _recover_codex_tokens_from_cli(
-            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}"
+            f"refresh_token rejected: {getattr(exc, 'code', None) or 'auth_error'}",
+            source_path=source_path,
         )
         if not imported:
             raise
@@ -3933,7 +3952,7 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens)
+    _save_codex_tokens(updated_tokens, source_path=source_path)
     return updated_tokens
 
 
@@ -3998,7 +4017,15 @@ def resolve_codex_runtime_credentials(
             "codex_auth_missing_refresh_token",
             "codex_auth_invalid_shape",
         }:
-            imported = _recover_codex_tokens_from_cli(str(getattr(exc, "code", None) or "auth_error"))
+            with _provider_state_transaction("openai-codex") as (
+                _auth_store,
+                _state,
+                state_source_path,
+            ):
+                imported = _recover_codex_tokens_from_cli(
+                    str(getattr(exc, "code", None) or "auth_error"),
+                    source_path=state_source_path,
+                )
             if imported:
                 data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
             else:
@@ -4086,8 +4113,19 @@ def resolve_codex_runtime_credentials(
     if (not should_refresh) and refresh_if_expiring:
         should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
     if should_refresh:
-        # Re-read under lock to avoid racing with other Hermes processes
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
+        # Re-read under the owning store's lock to avoid racing with other
+        # Hermes processes and persist rotating refresh tokens to that source.
+        with _provider_state_transaction(
+            "openai-codex",
+            timeout_seconds=max(
+                float(AUTH_LOCK_TIMEOUT_SECONDS),
+                refresh_timeout_seconds + 5.0,
+            ),
+        ) as (
+            _auth_store,
+            _state,
+            state_source_path,
+        ):
             data = _read_codex_tokens(_lock=False)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
@@ -4097,7 +4135,11 @@ def resolve_codex_runtime_credentials(
                 should_refresh = _codex_access_token_is_expiring(access_token, refresh_skew_seconds)
 
             if should_refresh:
-                tokens = _refresh_codex_auth_tokens(tokens, refresh_timeout_seconds)
+                tokens = _refresh_codex_auth_tokens(
+                    tokens,
+                    refresh_timeout_seconds,
+                    source_path=state_source_path,
+                )
                 access_token = str(tokens.get("access_token", "") or "").strip()
 
     base_url = (

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1369,21 +1369,38 @@ def _load_provider_state_with_source(
 def _provider_state_transaction(
     provider_id: str,
     timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS,
+    *,
+    expected_source_path: Optional[Path] = None,
 ):
     """Lock the active auth store and any global fallback source in order.
 
-    Profile-backed refresh paths must take the global auth-store lock before
-    any provider-specific shared-store lock. Re-reading the source after the
-    target lock is acquired prevents both stale refreshes and whole-file lost
-    updates without inverting the documented auth -> shared lock order.
+    Profile-backed refresh paths must take the active auth-store lock before
+    any fallback source-store lock. Re-reading the source after the target
+    lock is acquired prevents both stale refreshes and whole-file lost updates
+    without inverting the documented active -> source lock order. A caller
+    that already knows an entry's owner may pin ``expected_source_path`` so a
+    removed or newly shadowed singleton cannot silently change ownership.
     """
     with _auth_store_lock(timeout_seconds=timeout_seconds):
         auth_store = _load_auth_store()
-        state, source_path = _load_provider_state_with_source(
-            auth_store,
-            provider_id,
-        )
         active_path = _auth_file_path()
+        if expected_source_path is not None:
+            source_path = Path(expected_source_path)
+            if _same_path(source_path, active_path):
+                providers = auth_store.get("providers")
+                raw_state = (
+                    providers.get(provider_id)
+                    if isinstance(providers, dict)
+                    else None
+                )
+                state = dict(raw_state) if isinstance(raw_state, dict) else None
+            else:
+                state = None
+        else:
+            state, source_path = _load_provider_state_with_source(
+                auth_store,
+                provider_id,
+            )
         if source_path is None or _same_path(source_path, active_path):
             yield auth_store, state, source_path
             return

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1491,6 +1491,302 @@ def _provider_state_from_exact_store(
     return dict(state) if isinstance(state, dict) else None
 
 
+SOURCE_REFRESH_RESERVATION_KEY = "_oauth_refresh_reservation"
+_SOURCE_REFRESH_RESERVATION_VERSION = 1
+_SOURCE_SECRET_FIELDS = frozenset(
+    {
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "agent_key",
+        "api_key",
+        "token",
+    }
+)
+
+
+@dataclass(frozen=True)
+class SourceRefreshReservation:
+    """In-memory handle for one durable source-owned token reservation."""
+
+    provider: str
+    source_path: Path
+    owner_fingerprint: str
+    refresh_fingerprint: str
+    nonce: str
+
+    def metadata(self) -> Dict[str, Any]:
+        return {
+            "version": _SOURCE_REFRESH_RESERVATION_VERSION,
+            "status": "reserved",
+            "provider": self.provider,
+            "owner_fingerprint": self.owner_fingerprint,
+            "refresh_fingerprint": self.refresh_fingerprint,
+            "nonce": self.nonce,
+        }
+
+
+def _refresh_lineage_fingerprint(refresh_token: Any) -> Optional[str]:
+    """Return a full one-way identifier for a rotating refresh lineage."""
+    if not isinstance(refresh_token, str):
+        return None
+    cleaned = refresh_token.strip()
+    if not cleaned:
+        return None
+    return f"sha256:{hashlib.sha256(cleaned.encode('utf-8')).hexdigest()}"
+
+
+def _source_owner_fingerprint(provider_id: str, source_path: Path) -> str:
+    owner = f"{provider_id}\0{source_path.resolve(strict=False)}"
+    return f"sha256:{hashlib.sha256(owner.encode('utf-8')).hexdigest()}"
+
+
+def _source_reservation_metadata(
+    state: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(state, dict):
+        return None
+    metadata = state.get(SOURCE_REFRESH_RESERVATION_KEY)
+    if not isinstance(metadata, dict):
+        return None
+    if metadata.get("status") != "reserved":
+        return None
+    return dict(metadata)
+
+
+def _source_state_is_reserved(state: Optional[Dict[str, Any]]) -> bool:
+    return _source_reservation_metadata(state) is not None
+
+
+def _scrub_source_secret_fields(payload: Dict[str, Any]) -> Dict[str, Any]:
+    scrubbed = dict(payload)
+    for key in _SOURCE_SECRET_FIELDS:
+        scrubbed.pop(key, None)
+    return scrubbed
+
+
+def _reserved_provider_state(
+    provider_id: str,
+    state: Dict[str, Any],
+    metadata: Dict[str, Any],
+) -> Dict[str, Any]:
+    reserved = dict(state)
+    if provider_id == "xai-oauth":
+        tokens = reserved.get("tokens")
+        reserved["tokens"] = (
+            _scrub_source_secret_fields(tokens) if isinstance(tokens, dict) else {}
+        )
+    else:
+        reserved = _scrub_source_secret_fields(reserved)
+    reserved[SOURCE_REFRESH_RESERVATION_KEY] = dict(metadata)
+    return reserved
+
+
+def _reserve_matching_pool_rows(
+    auth_store: Dict[str, Any],
+    provider_id: str,
+    refresh_fingerprint: str,
+    metadata: Dict[str, Any],
+) -> None:
+    credential_pool = auth_store.get("credential_pool")
+    entries = (
+        credential_pool.get(provider_id)
+        if isinstance(credential_pool, dict)
+        else None
+    )
+    if not isinstance(entries, list):
+        return
+    for item in entries:
+        if (
+            not isinstance(item, dict)
+            or _refresh_lineage_fingerprint(item.get("refresh_token"))
+            != refresh_fingerprint
+        ):
+            continue
+        for key in _SOURCE_SECRET_FIELDS:
+            item.pop(key, None)
+        item[SOURCE_REFRESH_RESERVATION_KEY] = dict(metadata)
+        item["last_status"] = "dead"
+        item["last_error_code"] = "refresh_reserved"
+        item["last_error_reason"] = "refresh_reserved"
+        item["last_error_message"] = "Rotating credential refresh is reserved"
+
+
+def _finalize_reserved_pool_rows(
+    auth_store: Dict[str, Any],
+    reservation: SourceRefreshReservation,
+    state: Dict[str, Any],
+) -> None:
+    credential_pool = auth_store.get("credential_pool")
+    entries = (
+        credential_pool.get(reservation.provider)
+        if isinstance(credential_pool, dict)
+        else None
+    )
+    if not isinstance(entries, list):
+        return
+    expected = reservation.metadata()
+    for item in entries:
+        if (
+            not isinstance(item, dict)
+            or item.get(SOURCE_REFRESH_RESERVATION_KEY) != expected
+        ):
+            continue
+        if reservation.provider == "xai-oauth":
+            tokens = state.get("tokens")
+            if isinstance(tokens, dict):
+                item["access_token"] = tokens.get("access_token", "")
+                item["refresh_token"] = tokens.get("refresh_token", "")
+            if state.get("last_refresh") is not None:
+                item["last_refresh"] = state["last_refresh"]
+        else:
+            for key in (
+                "access_token",
+                "refresh_token",
+                "expires_at",
+                "agent_key",
+                "agent_key_expires_at",
+                "inference_base_url",
+            ):
+                if state.get(key) is not None:
+                    item[key] = state[key]
+        item.pop(SOURCE_REFRESH_RESERVATION_KEY, None)
+        for key in (
+            "last_status",
+            "last_status_at",
+            "last_error_code",
+            "last_error_reason",
+            "last_error_message",
+            "last_error_reset_at",
+        ):
+            item.pop(key, None)
+
+
+def _reserve_provider_refresh_source(
+    provider_id: str,
+    state: Dict[str, Any],
+    source_path: Optional[Path],
+    *,
+    expected_refresh_token: Any,
+) -> SourceRefreshReservation:
+    """Durably remove one rotating lineage from its exact auth-store owner.
+
+    The caller must hold the transaction lock yielded for ``source_path``.
+    No network operation may begin until this function returns successfully.
+    """
+    target_path = Path(source_path or _auth_file_path())
+    current_store = _load_auth_store(target_path)
+    current_state = _provider_state_from_exact_store(current_store, provider_id)
+    current_refresh = _provider_refresh_lineage(provider_id, current_state)
+    if current_refresh != expected_refresh_token:
+        raise SourceCredentialLineageChanged(provider_id)
+    refresh_fingerprint = _refresh_lineage_fingerprint(current_refresh)
+    if refresh_fingerprint is None:
+        raise AuthError(
+            f"No usable {provider_id} refresh token is available",
+            provider=provider_id,
+            code="refresh_unavailable",
+            relogin_required=True,
+        )
+    if _source_state_is_reserved(current_state):
+        raise AuthError(
+            f"The {provider_id} refresh credential is already reserved",
+            provider=provider_id,
+            code="refresh_reserved",
+            relogin_required=True,
+        )
+
+    reservation = SourceRefreshReservation(
+        provider=provider_id,
+        source_path=target_path,
+        owner_fingerprint=_source_owner_fingerprint(provider_id, target_path),
+        refresh_fingerprint=refresh_fingerprint,
+        nonce=uuid.uuid4().hex,
+    )
+    metadata = reservation.metadata()
+    providers = current_store.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        raise AuthError(
+            f"The {provider_id} credential owner is malformed",
+            provider=provider_id,
+            code="source_malformed",
+            relogin_required=True,
+        )
+    providers[provider_id] = _reserved_provider_state(
+        provider_id,
+        current_state or state,
+        metadata,
+    )
+    _reserve_matching_pool_rows(
+        current_store,
+        provider_id,
+        refresh_fingerprint,
+        metadata,
+    )
+    _save_auth_store(current_store, target_path=target_path)
+
+    persisted = _provider_state_from_exact_store(
+        _load_auth_store(target_path),
+        provider_id,
+    )
+    if _source_reservation_metadata(persisted) != metadata:
+        raise SourceCredentialLineageChanged(provider_id)
+    if _provider_refresh_lineage(provider_id, persisted) is not None:
+        raise SourceCredentialLineageChanged(provider_id)
+    return reservation
+
+
+def _finalize_provider_refresh_reservation(
+    reservation: SourceRefreshReservation,
+    state: Dict[str, Any],
+) -> None:
+    """Replace an authoritative reservation with its rotated provider state."""
+    target_store = _load_auth_store(reservation.source_path)
+    current_state = _provider_state_from_exact_store(
+        target_store,
+        reservation.provider,
+    )
+    if _source_reservation_metadata(current_state) != reservation.metadata():
+        raise SourceCredentialLineageChanged(reservation.provider)
+
+    finalized = dict(state)
+    finalized.pop(SOURCE_REFRESH_RESERVATION_KEY, None)
+    providers = target_store.setdefault("providers", {})
+    if not isinstance(providers, dict):
+        raise SourceCredentialLineageChanged(reservation.provider)
+    providers[reservation.provider] = finalized
+    _finalize_reserved_pool_rows(target_store, reservation, finalized)
+    _save_auth_store(target_store, target_path=reservation.source_path)
+
+    persisted = _provider_state_from_exact_store(
+        _load_auth_store(reservation.source_path),
+        reservation.provider,
+    )
+    if _provider_oauth_lineage(
+        reservation.provider,
+        persisted,
+    ) != _provider_oauth_lineage(reservation.provider, finalized):
+        raise SourceCredentialLineageChanged(reservation.provider)
+
+
+def _observe_provider_refresh_source(
+    provider_id: str,
+) -> tuple[Optional[Path], Optional[str]]:
+    """Capture the request's source owner and refresh lineage before waiting."""
+    auth_store = _load_auth_store()
+    state, source_path = _load_provider_state_with_source(auth_store, provider_id)
+    refresh_fingerprint = _refresh_lineage_fingerprint(
+        _provider_refresh_lineage(provider_id, state)
+    )
+    if refresh_fingerprint is None and isinstance(state, dict):
+        reservation = state.get(SOURCE_REFRESH_RESERVATION_KEY)
+        if isinstance(reservation, dict):
+            reserved_fingerprint = reservation.get("refresh_fingerprint")
+            if isinstance(reserved_fingerprint, str) and reserved_fingerprint:
+                refresh_fingerprint = reserved_fingerprint
+    return source_path, refresh_fingerprint
+
+
 def _save_provider_state_to_locked_source(
     auth_store: Dict[str, Any],
     provider_id: str,
@@ -5346,75 +5642,6 @@ def _xai_oauth_state_with_refreshed_tokens(
     return updated_state
 
 
-def _mark_xai_pool_lineage_dead(
-    auth_store: Dict[str, Any],
-    consumed_refresh_token: str,
-    *,
-    reason: str = "source_persistence_failed",
-    message: str = "Refreshed credentials were not persisted to their owning source.",
-) -> None:
-    pools = auth_store.get("credential_pool")
-    if not isinstance(pools, dict):
-        return
-    entries = pools.get("xai-oauth")
-    if not isinstance(entries, list):
-        return
-    now = time.time()
-    for raw_entry in entries:
-        if (
-            isinstance(raw_entry, dict)
-            and raw_entry.get("refresh_token") == consumed_refresh_token
-        ):
-            raw_entry["last_status"] = "dead"
-            raw_entry["last_status_at"] = now
-            raw_entry["last_error_reason"] = reason
-            raw_entry["last_error_message"] = message
-
-
-def _quarantine_xai_consumed_source(
-    source_path: Optional[Path],
-    consumed_refresh_token: str,
-) -> None:
-    """Persist fail-closed state for one consumed xAI refresh lineage."""
-    if source_path is None:
-        return
-    with _provider_state_transaction(
-        "xai-oauth",
-        expected_source_path=source_path,
-    ) as (_auth_store, state, locked_source_path):
-        if (
-            locked_source_path is None
-            or not _same_path(Path(locked_source_path), Path(source_path))
-            or _provider_refresh_lineage("xai-oauth", state)
-            != consumed_refresh_token
-        ):
-            return
-        source_store = _load_auth_store(Path(locked_source_path))
-        source_state = _provider_state_from_exact_store(
-            source_store,
-            "xai-oauth",
-        )
-        if source_state is None:
-            return
-        _mark_xai_pool_lineage_dead(source_store, consumed_refresh_token)
-        providers = source_store.get("providers")
-        if isinstance(providers, dict):
-            providers.pop("xai-oauth", None)
-        if source_store.get("active_provider") == "xai-oauth":
-            source_store.pop("active_provider", None)
-        _save_auth_store(
-            source_store,
-            target_path=Path(locked_source_path),
-        )
-        persisted = _load_auth_store(Path(locked_source_path))
-        if _provider_state_from_exact_store(persisted, "xai-oauth") is not None:
-            raise SourceCredentialPersistenceError(
-                "xai-oauth",
-                source_path=Path(locked_source_path),
-                consumed_refresh_token=consumed_refresh_token,
-            )
-
-
 def resolve_xai_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,
@@ -5426,23 +5653,61 @@ def resolve_xai_oauth_runtime_credentials(
         float(AUTH_LOCK_TIMEOUT_SECONDS),
         refresh_timeout_seconds + 5.0,
     )
+    observed_source_path, observed_refresh_fingerprint = (
+        _observe_provider_refresh_source("xai-oauth")
+    )
+    expected_source_path = observed_source_path
     data: Optional[Dict[str, Any]] = None
     access_token = ""
-    persistence_failure: Optional[SourceCredentialPersistenceError] = None
-    consumed_refresh_token = ""
-    source_path: Optional[Path] = None
 
     for _attempt in range(3):
         with _provider_state_transaction(
             "xai-oauth",
             timeout_seconds=lock_timeout,
-        ) as (auth_store, state, state_source_path):
-            source_path = state_source_path
+            expected_source_path=expected_source_path,
+        ) as (transaction_store, state, state_source_path):
             if state is None:
-                break
+                if expected_source_path is None:
+                    break
+                expected_source_path = None
+                continue
+            resolved_state, resolved_source_path = _load_provider_state_with_source(
+                transaction_store,
+                "xai-oauth",
+            )
+            if (
+                resolved_state is not None
+                and resolved_source_path is not None
+                and state_source_path is not None
+                and not _same_path(resolved_source_path, state_source_path)
+            ):
+                state = resolved_state
+                state_source_path = resolved_source_path
+            if _source_state_is_reserved(state):
+                raise AuthError(
+                    "The xAI OAuth refresh credential is reserved and unavailable",
+                    provider="xai-oauth",
+                    code="refresh_reserved",
+                    relogin_required=True,
+                )
             data = _xai_oauth_data_from_provider_state(state)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
+            current_refresh_fingerprint = _refresh_lineage_fingerprint(
+                tokens.get("refresh_token")
+            )
+            owner_changed = bool(
+                observed_source_path is not None
+                and state_source_path is not None
+                and not _same_path(observed_source_path, state_source_path)
+            )
+            lineage_changed = bool(
+                observed_refresh_fingerprint is not None
+                and current_refresh_fingerprint != observed_refresh_fingerprint
+            )
+            competing_winner = bool(
+                access_token and (owner_changed or lineage_changed)
+            )
             discovery = dict(data.get("discovery") or {})
             token_endpoint = str(
                 discovery.get("token_endpoint", "") or ""
@@ -5452,8 +5717,16 @@ def resolve_xai_oauth_runtime_credentials(
                 if refresh_skew_seconds is not None
                 else _xai_proactive_refresh_skew_seconds(access_token)
             )
-            should_refresh = bool(force_refresh)
-            if (not should_refresh) and refresh_if_expiring:
+            competing_winner_valid = bool(
+                competing_winner
+                and not _xai_access_token_is_expiring(access_token, 0)
+            )
+            should_refresh = bool(force_refresh and not competing_winner_valid)
+            if (
+                not competing_winner_valid
+                and not should_refresh
+                and refresh_if_expiring
+            ):
                 should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
             if not should_refresh:
                 break
@@ -5464,6 +5737,12 @@ def resolve_xai_oauth_runtime_credentials(
             consumed_refresh_token = str(
                 tokens.get("refresh_token", "") or ""
             ).strip()
+            reservation = _reserve_provider_refresh_source(
+                "xai-oauth",
+                state,
+                state_source_path,
+                expected_refresh_token=consumed_refresh_token,
+            )
             try:
                 refreshed = refresh_xai_oauth_pure(
                     access_token,
@@ -5471,26 +5750,8 @@ def resolve_xai_oauth_runtime_credentials(
                     token_endpoint=token_endpoint,
                     timeout_seconds=refresh_timeout_seconds,
                 )
-            except AuthError as exc:
-                if _is_terminal_xai_oauth_refresh_error(exc):
-                    source_store = _load_auth_store(
-                        Path(state_source_path or _auth_file_path())
-                    )
-                    _mark_xai_pool_lineage_dead(
-                        source_store,
-                        consumed_refresh_token,
-                        reason="runtime_refresh_failure",
-                        message=str(exc),
-                    )
-                    providers = source_store.get("providers")
-                    if isinstance(providers, dict):
-                        providers.pop("xai-oauth", None)
-                    if source_store.get("active_provider") == "xai-oauth":
-                        source_store.pop("active_provider", None)
-                    _save_auth_store(
-                        source_store,
-                        target_path=Path(state_source_path or _auth_file_path()),
-                    )
+            except AuthError:
+                # The reservation is already the durable fail-closed state.
                 raise
 
             updated_state = _xai_oauth_state_with_refreshed_tokens(
@@ -5499,27 +5760,15 @@ def resolve_xai_oauth_runtime_credentials(
                 token_endpoint=token_endpoint,
             )
             try:
-                _save_provider_state_to_locked_source(
-                    auth_store,
-                    "xai-oauth",
-                    updated_state,
-                    state_source_path,
-                    expected_refresh_token=consumed_refresh_token,
-                    set_active=False,
-                )
+                _finalize_provider_refresh_reservation(reservation, updated_state)
             except SourceCredentialLineageChanged:
                 continue
-            except (OSError, SourceCredentialPersistenceError) as exc:
-                persistence_failure = (
-                    exc
-                    if isinstance(exc, SourceCredentialPersistenceError)
-                    else SourceCredentialPersistenceError(
-                        "xai-oauth",
-                        source_path=state_source_path,
-                        consumed_refresh_token=consumed_refresh_token,
-                    )
-                )
-                break
+            except OSError as exc:
+                raise SourceCredentialPersistenceError(
+                    "xai-oauth",
+                    source_path=reservation.source_path,
+                    consumed_refresh_token=consumed_refresh_token,
+                ) from exc
             data = dict(updated_state)
             access_token = str(
                 updated_state.get("tokens", {}).get("access_token", "") or ""
@@ -5527,19 +5776,6 @@ def resolve_xai_oauth_runtime_credentials(
             break
     else:
         raise SourceCredentialLineageChanged("xai-oauth")
-
-    if persistence_failure is not None:
-        try:
-            _quarantine_xai_consumed_source(
-                source_path,
-                consumed_refresh_token,
-            )
-        except Exception:
-            logger.debug(
-                "xAI OAuth: failed to persist source quarantine",
-                exc_info=True,
-            )
-        raise persistence_failure
 
     if data is None:
         # Pool-only/manual credentials have no providers.xai-oauth singleton.
@@ -5983,6 +6219,40 @@ def _read_shared_nous_state() -> Optional[Dict[str, Any]]:
     if not (isinstance(access_token, str) and access_token.strip()):
         return None
     return payload
+
+
+def _reserve_shared_nous_lineage(refresh_token: str) -> None:
+    """Remove the matching convenience-store lineage before a refresh POST.
+
+    The caller owns ``_nous_shared_store_lock``. Any persistence failure is
+    fatal to the refresh attempt; the per-profile/root source is not reserved
+    until this auxiliary copy has been made unavailable.
+    """
+    path = _nous_shared_store_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise OSError("Shared Nous credential store is malformed")
+    shared_refresh = payload.get("refresh_token")
+    if not isinstance(shared_refresh, str) or not shared_refresh.strip():
+        path.unlink()
+    elif _refresh_lineage_fingerprint(shared_refresh) != _refresh_lineage_fingerprint(
+        refresh_token
+    ):
+        raise SourceCredentialLineageChanged("nous")
+    else:
+        path.unlink()
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    finally:
+        os.close(dir_fd)
 
 
 def _clear_shared_nous_state(reason: str) -> None:
@@ -6740,6 +7010,9 @@ def resolve_nous_runtime_credentials(
     expires_in, source ("invoke_jwt"), and auth_path.
     """
     sequence_id = uuid.uuid4().hex[:12]
+    observed_source_path, observed_refresh_fingerprint = (
+        _observe_provider_refresh_source("nous")
+    )
 
     with _provider_state_transaction("nous") as (
         auth_store,
@@ -6750,10 +7023,32 @@ def resolve_nous_runtime_credentials(
         if not state:
             raise AuthError("Hermes is not logged into Nous Portal.",
                             provider="nous", relogin_required=True)
+        if _source_state_is_reserved(state):
+            raise AuthError(
+                "The Nous refresh credential is reserved and unavailable",
+                provider="nous",
+                code="refresh_reserved",
+                relogin_required=True,
+            )
 
         persisted_state = dict(state)
         state_persisted = False
-        consumed_refresh_token: Any = None
+        effective_force_refresh = bool(force_refresh)
+        current_refresh_fingerprint = _refresh_lineage_fingerprint(
+            state.get("refresh_token")
+        )
+        if (
+            (
+                observed_source_path is not None
+                and state_source_path is not None
+                and not _same_path(observed_source_path, state_source_path)
+            )
+            or (
+                observed_refresh_fingerprint is not None
+                and current_refresh_fingerprint != observed_refresh_fingerprint
+            )
+        ):
+            effective_force_refresh = False
 
         def _resolve_effective_routing_metadata() -> tuple[str, str, str, str]:
             """Resolve every routing value that shared OAuth state can replace."""
@@ -6855,15 +7150,6 @@ def resolve_nous_runtime_credentials(
                     reason=reason,
                     error_type=type(exc).__name__,
                 )
-                if (
-                    reason == "post_refresh_access_token"
-                    and consumed_refresh_token
-                ):
-                    raise SourceCredentialPersistenceError(
-                        "nous",
-                        source_path=state_source_path,
-                        consumed_refresh_token=consumed_refresh_token,
-                    ) from exc
                 raise
             _oauth_trace(
                 "nous_state_persisted",
@@ -6874,11 +7160,6 @@ def resolve_nous_runtime_credentials(
             )
             persisted_state = dict(state)
             state_persisted = True
-            # Mirror post-refresh state to the shared store so sibling
-            # profiles don't hold stale refresh_tokens after rotation.
-            # Best-effort — any failure is logged and swallowed inside
-            # _write_shared_nous_state.
-            _write_shared_nous_state(state)
 
         verify = _resolve_verify(insecure=insecure, ca_bundle=ca_bundle, auth_state=state)
         timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
@@ -6916,11 +7197,17 @@ def resolve_nous_runtime_credentials(
                 scope=state.get("scope"),
                 expires_at=state.get("expires_at"),
             )
-            if force_refresh or invoke_jwt_status is not None:
+            if effective_force_refresh or invoke_jwt_status is not None:
                 with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
                         refresh_token = state.get("refresh_token")
+                        if (
+                            observed_refresh_fingerprint is not None
+                            and _refresh_lineage_fingerprint(refresh_token)
+                            != observed_refresh_fingerprint
+                        ):
+                            effective_force_refresh = False
                         (
                             portal_base_url,
                             stored_inference_base_url,
@@ -6934,7 +7221,7 @@ def resolve_nous_runtime_credentials(
                         )
                         _persist_state("post_shared_merge_access_unusable")
 
-                    if force_refresh or invoke_jwt_status is not None:
+                    if effective_force_refresh or invoke_jwt_status is not None:
                         if not isinstance(refresh_token, str) or not refresh_token:
                             reason = invoke_jwt_status or "force_refresh"
                             raise AuthError(
@@ -6946,36 +7233,35 @@ def resolve_nous_runtime_credentials(
                                 relogin_required=True,
                             )
 
-                        refresh_reason = "force_refresh" if force_refresh else (invoke_jwt_status or "access_unusable")
+                        refresh_reason = (
+                            "force_refresh"
+                            if effective_force_refresh
+                            else (invoke_jwt_status or "access_unusable")
+                        )
                         _oauth_trace(
                             "refresh_start",
                             sequence_id=sequence_id,
                             reason=refresh_reason,
                             refresh_token_fp=_token_fingerprint(refresh_token),
                         )
+                        _reserve_shared_nous_lineage(refresh_token)
+                        reservation = _reserve_provider_refresh_source(
+                            "nous",
+                            state,
+                            state_source_path,
+                            expected_refresh_token=refresh_token,
+                        )
                         try:
                             refreshed = _refresh_access_token(
                                 client=client, portal_base_url=portal_base_url,
                                 client_id=client_id, refresh_token=refresh_token,
                             )
-                        except AuthError as exc:
-                            if _is_terminal_nous_refresh_error(exc):
-                                _quarantine_nous_oauth_state(
-                                    state,
-                                    exc,
-                                    reason="runtime_access_refresh_failure",
-                                )
-                                _quarantine_nous_pool_entries(
-                                    auth_store,
-                                    exc,
-                                    reason="runtime_access_refresh_failure",
-                                )
-                                _persist_state("terminal_runtime_access_refresh_failure")
+                        except AuthError:
+                            # The owner reservation remains the fail-closed state.
                             raise
                         now = datetime.now(timezone.utc)
                         access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
                         previous_refresh_token = refresh_token
-                        consumed_refresh_token = refresh_token
                         state["access_token"] = refreshed["access_token"]
                         state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
                         state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
@@ -7011,8 +7297,42 @@ def resolve_nous_runtime_credentials(
                             previous_refresh_token_fp=_token_fingerprint(previous_refresh_token),
                             new_refresh_token_fp=_token_fingerprint(refresh_token),
                         )
-                        # Persist immediately so validation failures cannot drop rotated refresh tokens.
-                        _persist_state("post_refresh_access_token")
+                        try:
+                            _finalize_provider_refresh_reservation(
+                                reservation,
+                                state,
+                            )
+                        except SourceCredentialLineageChanged:
+                            latest_store = _load_auth_store()
+                            latest_state, latest_source_path = (
+                                _load_provider_state_with_source(latest_store, "nous")
+                            )
+                            if (
+                                not latest_state
+                                or _source_state_is_reserved(latest_state)
+                                or not latest_state.get("access_token")
+                            ):
+                                raise
+                            auth_store = latest_store
+                            state.clear()
+                            state.update(latest_state)
+                            state_source_path = latest_source_path
+                            access_token = state.get("access_token")
+                            refresh_token = state.get("refresh_token")
+                            (
+                                portal_base_url,
+                                stored_inference_base_url,
+                                inference_base_url,
+                                client_id,
+                            ) = _resolve_effective_routing_metadata()
+                        except OSError as exc:
+                            raise SourceCredentialPersistenceError(
+                                "nous",
+                                source_path=reservation.source_path,
+                                consumed_refresh_token=previous_refresh_token,
+                            ) from exc
+                        persisted_state = dict(state)
+                        state_persisted = True
 
             _assert_nous_inference_jwt_usable(
                 state,
@@ -7039,6 +7359,7 @@ def resolve_nous_runtime_credentials(
         _persist_state("resolve_nous_runtime_credentials_final")
 
     if state_persisted:
+        _write_shared_nous_state(state)
         _sync_nous_pool_from_auth_store()
 
     api_key = state.get("agent_key")

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3727,8 +3727,14 @@ def _save_codex_tokens(
     label: Optional[str] = None,
     *,
     source_path: Optional[Path] = None,
+    set_active: bool = True,
 ) -> None:
-    """Save Codex tokens locally, or back to an explicit credential source."""
+    """Save Codex tokens locally, or back to an explicit credential source.
+
+    Interactive login/add callers keep ``set_active=True``. Runtime refresh
+    and recovery callers pass ``False`` because token maintenance is not a
+    provider-selection action.
+    """
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
     with _auth_store_lock(target_path=source_path):
@@ -3745,7 +3751,12 @@ def _save_codex_tokens(
         state["auth_mode"] = "chatgpt"
         if label and str(label).strip():
             state["label"] = str(label).strip()
-        _save_provider_state(auth_store, "openai-codex", state)
+        _store_provider_state(
+            auth_store,
+            "openai-codex",
+            state,
+            set_active=set_active,
+        )
         _sync_codex_pool_entries(
             auth_store,
             tokens,
@@ -3771,7 +3782,7 @@ def _recover_codex_tokens_from_cli(
     ):
         return None
     logger.info("Codex auth recovered from Codex CLI auth.json (%s).", reason)
-    _save_codex_tokens(imported, source_path=source_path)
+    _save_codex_tokens(imported, source_path=source_path, set_active=False)
     return dict(imported)
 
 
@@ -3952,7 +3963,11 @@ def _refresh_codex_auth_tokens(
     updated_tokens["access_token"] = refreshed["access_token"]
     updated_tokens["refresh_token"] = refreshed["refresh_token"]
 
-    _save_codex_tokens(updated_tokens, source_path=source_path)
+    _save_codex_tokens(
+        updated_tokens,
+        source_path=source_path,
+        set_active=False,
+    )
     return updated_tokens
 
 
@@ -4022,14 +4037,40 @@ def resolve_codex_runtime_credentials(
                 _state,
                 state_source_path,
             ):
-                imported = _recover_codex_tokens_from_cli(
-                    str(getattr(exc, "code", None) or "auth_error"),
-                    source_path=state_source_path,
-                )
-            if imported:
-                data = {"tokens": imported, "last_refresh": imported.get("last_refresh")}
-            else:
-                data = None
+                # The pre-lock error is only a hint. Another writer may have
+                # repaired the owning store before this transaction acquired
+                # its source lock, so re-read and revalidate before importing
+                # CLI tokens over the top of that fresh chain.
+                try:
+                    data = _read_codex_tokens(_lock=False)
+                except AuthError as locked_exc:
+                    read_error = locked_exc
+                    if (
+                        getattr(locked_exc, "relogin_required", False)
+                        and getattr(locked_exc, "code", None)
+                        in {
+                            "codex_auth_missing_access_token",
+                            "codex_auth_missing_refresh_token",
+                            "codex_auth_invalid_shape",
+                        }
+                    ):
+                        imported = _recover_codex_tokens_from_cli(
+                            str(
+                                getattr(locked_exc, "code", None)
+                                or "auth_error"
+                            ),
+                            source_path=state_source_path,
+                        )
+                        data = (
+                            {
+                                "tokens": imported,
+                                "last_refresh": imported.get("last_refresh"),
+                            }
+                            if imported
+                            else None
+                        )
+                    else:
+                        data = None
         else:
             data = None
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1556,7 +1556,47 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
-def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
+class _SourceOwnedCredentialPoolRow(dict):
+    """Dictionary payload with trusted, runtime-only owner provenance."""
+
+    _source_store_path: Path
+
+
+def _source_owned_pool_rows(
+    provider_id: str,
+    entries: List[Any],
+    source_path: Optional[Path],
+) -> List[Any]:
+    """Annotate trusted global Codex fallback rows without changing JSON data."""
+    if provider_id != "openai-codex" or source_path is None:
+        return list(entries)
+    annotated: List[Any] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            annotated.append(entry)
+            continue
+        row = _SourceOwnedCredentialPoolRow(entry)
+        row._source_store_path = source_path
+        annotated.append(row)
+    return annotated
+
+
+def _credential_pool_row_source_path(payload: Any) -> Optional[Path]:
+    """Return provenance only for rows created by the trusted fallback reader."""
+    if not isinstance(payload, _SourceOwnedCredentialPoolRow):
+        return None
+    source_path = getattr(payload, "_source_store_path", None)
+    global_path = _global_auth_file_path()
+    if (
+        not isinstance(source_path, Path)
+        or global_path is None
+        or not _same_path(source_path, global_path)
+    ):
+        return None
+    return global_path
+
+
+def read_credential_pool(provider_id: Optional[str] = None) -> Any:
     """Return the persisted credential pool, or one provider slice.
 
     In profile mode, the profile's credential pool is authoritative. If a
@@ -1578,6 +1618,7 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         pool = {}
 
     global_pool: Dict[str, Any] = {}
+    global_path = _global_auth_file_path()
     global_store = _load_global_auth_store()
     maybe_global_pool = global_store.get("credential_pool") if global_store else None
     if isinstance(maybe_global_pool, dict):
@@ -1592,7 +1633,11 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
             existing = merged.get(gp_key)
             if isinstance(existing, list) and existing:
                 continue
-            merged[gp_key] = list(gp_entries)
+            merged[gp_key] = _source_owned_pool_rows(
+                gp_key,
+                gp_entries,
+                global_path,
+            )
         return merged
 
     provider_entries = pool.get(provider_id)
@@ -1600,7 +1645,11 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return list(provider_entries)
     # Profile has no entries for this provider — fall back to global.
     global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    return (
+        _source_owned_pool_rows(provider_id, global_entries, global_path)
+        if isinstance(global_entries, list)
+        else []
+    )
 
 
 _POOL_STATUS_FIELDS = (
@@ -1624,11 +1673,12 @@ def _merge_disk_cooldown_state(
     predate another process marking the same credential exhausted or dead
     (last-writer-wins lost update).  Without this merge, process B's later
     rewrite resurrects a rate-limited key as healthy and both processes
-    resume hammering it.  Adopt the on-disk status fields only when they are
-    strictly more recent (by ``last_status_at``) AND still binding — a DEAD
-    marker, or an EXHAUSTED cooldown that has not yet expired.  Expired
-    cooldowns are not resurrected, so the pool's own expiry-clear (which
-    resets ``last_status_at`` to None) is never overridden.
+    resume hammering it. Adopt on-disk status fields when they are still
+    binding and either newer (by ``last_status_at``) or terminal for the same
+    token chain: a DEAD marker, or an EXHAUSTED cooldown that has not yet
+    expired. Expired cooldowns are not
+    resurrected, so the pool's own expiry-clear (which resets
+    ``last_status_at`` to None) is never overridden.
     """
     if not isinstance(disk_entry, dict):
         return entry
@@ -1652,9 +1702,23 @@ def _merge_disk_cooldown_state(
         disk_access = disk_entry.get("access_token") or ""
         if mem_access and disk_access and mem_access != disk_access:
             return entry
+        mem_refresh = entry.get("refresh_token") or ""
+        disk_refresh = disk_entry.get("refresh_token") or ""
+        if mem_refresh and disk_refresh and mem_refresh != disk_refresh:
+            return entry
         disk_ts = _parse_absolute_timestamp(disk_entry.get("last_status_at")) or 0.0
         mem_ts = _parse_absolute_timestamp(entry.get("last_status_at")) or 0.0
-        if disk_ts <= mem_ts:
+        mem_status = entry.get("last_status")
+        # DEAD is terminal for one token chain. A later non-terminal snapshot
+        # cannot downgrade it; only fresh credentials (handled above) or an
+        # explicit reset path may clear it.
+        if disk_status == STATUS_DEAD and mem_status != STATUS_DEAD:
+            keep_disk = True
+        elif mem_status == STATUS_DEAD and disk_status != STATUS_DEAD:
+            return entry
+        else:
+            keep_disk = disk_ts > mem_ts
+        if not keep_disk:
             return entry
         if disk_status == STATUS_EXHAUSTED:
             until = _exhausted_until(

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -888,6 +888,35 @@ class AuthError(RuntimeError):
         self.relogin_required = relogin_required
 
 
+class SourceCredentialLineageChanged(RuntimeError):
+    """The authoritative rotating credential changed before its write."""
+
+    def __init__(self, provider: str) -> None:
+        super().__init__(f"{provider} credential lineage changed during refresh")
+        self.provider = provider
+
+
+class SourceCredentialPersistenceError(AuthError):
+    """A refresh succeeded upstream but its authoritative write did not."""
+
+    def __init__(
+        self,
+        provider: str,
+        *,
+        source_path: Optional[Path],
+        consumed_refresh_token: Any,
+    ) -> None:
+        super().__init__(
+            f"Failed to persist refreshed {provider} credentials",
+            provider=provider,
+            code="source_persistence_failed",
+            relogin_required=False,
+        )
+        self.provider = provider
+        self.source_path = source_path
+        self.consumed_lineage = _token_fingerprint(consumed_refresh_token)
+
+
 def is_rate_limited_auth_error(error: Exception) -> bool:
     """True when an :class:`AuthError` represents upstream rate-limiting / quota
     exhaustion rather than missing or invalid credentials.
@@ -1417,6 +1446,144 @@ def _provider_state_transaction(
                 if isinstance(raw_state, dict):
                     source_state = dict(raw_state)
             yield auth_store, source_state, source_path
+
+
+_EXPECTED_REFRESH_LINEAGE_UNSET = object()
+
+
+def _provider_refresh_lineage(
+    provider_id: str,
+    state: Optional[Dict[str, Any]],
+) -> Any:
+    """Return the rotating refresh-token lineage for a provider state."""
+    if not isinstance(state, dict):
+        return None
+    if provider_id == "xai-oauth":
+        tokens = state.get("tokens")
+        return tokens.get("refresh_token") if isinstance(tokens, dict) else None
+    return state.get("refresh_token")
+
+
+def _provider_oauth_lineage(
+    provider_id: str,
+    state: Optional[Dict[str, Any]],
+) -> tuple[Any, Any]:
+    """Return the access and refresh lineage used for post-write validation."""
+    if not isinstance(state, dict):
+        return None, None
+    if provider_id == "xai-oauth":
+        tokens = state.get("tokens")
+        if not isinstance(tokens, dict):
+            return None, None
+        return tokens.get("access_token"), tokens.get("refresh_token")
+    return state.get("access_token"), state.get("refresh_token")
+
+
+def _provider_state_from_exact_store(
+    auth_store: Dict[str, Any],
+    provider_id: str,
+) -> Optional[Dict[str, Any]]:
+    """Read a provider block from one store without global fallback."""
+    providers = auth_store.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    state = providers.get(provider_id)
+    return dict(state) if isinstance(state, dict) else None
+
+
+def _save_provider_state_to_locked_source(
+    auth_store: Dict[str, Any],
+    provider_id: str,
+    state: Dict[str, Any],
+    source_path: Optional[Path],
+    *,
+    expected_refresh_token: Any = _EXPECTED_REFRESH_LINEAGE_UNSET,
+    merge_credential_pool: bool = False,
+    set_active: bool = True,
+) -> None:
+    """Conditionally write one provider while its exact source lock is held.
+
+    This helper never acquires a lock. Callers must own the lock for
+    ``source_path`` through :func:`_provider_state_transaction` and must pass
+    the transaction's yielded path and state rather than performing a fallback
+    read of their own.
+    """
+    target_path = Path(source_path or _auth_file_path())
+    target_store = _load_auth_store(target_path)
+    current_state = _provider_state_from_exact_store(target_store, provider_id)
+    if (
+        expected_refresh_token is not _EXPECTED_REFRESH_LINEAGE_UNSET
+        and _provider_refresh_lineage(provider_id, current_state)
+        != expected_refresh_token
+    ):
+        raise SourceCredentialLineageChanged(provider_id)
+
+    if merge_credential_pool:
+        credential_pool = auth_store.get("credential_pool")
+        if isinstance(credential_pool, dict):
+            target_store["credential_pool"] = credential_pool
+
+    if expected_refresh_token is not _EXPECTED_REFRESH_LINEAGE_UNSET:
+        credential_pool = target_store.get("credential_pool")
+        provider_entries = (
+            credential_pool.get(provider_id)
+            if isinstance(credential_pool, dict)
+            else None
+        )
+        if isinstance(provider_entries, list):
+            for item in provider_entries:
+                if (
+                    not isinstance(item, dict)
+                    or item.get("source") != "device_code"
+                    or item.get("refresh_token") != expected_refresh_token
+                ):
+                    continue
+                if provider_id == "xai-oauth":
+                    tokens = state.get("tokens")
+                    if isinstance(tokens, dict):
+                        item["access_token"] = tokens.get("access_token", "")
+                        item["refresh_token"] = tokens.get("refresh_token", "")
+                    if state.get("last_refresh"):
+                        item["last_refresh"] = state["last_refresh"]
+                elif provider_id == "nous":
+                    for key in (
+                        "access_token",
+                        "refresh_token",
+                        "expires_at",
+                        "agent_key",
+                        "agent_key_expires_at",
+                        "inference_base_url",
+                    ):
+                        if state.get(key) is not None:
+                            item[key] = state[key]
+                item.pop("last_status", None)
+                item.pop("last_status_at", None)
+                item.pop("last_error_code", None)
+                item.pop("last_error_reason", None)
+                item.pop("last_error_message", None)
+                item.pop("last_error_reset_at", None)
+    _store_provider_state(
+        target_store,
+        provider_id,
+        dict(state),
+        set_active=set_active,
+    )
+    _save_auth_store(target_store, target_path=target_path)
+
+    persisted_store = _load_auth_store(target_path)
+    persisted_state = _provider_state_from_exact_store(
+        persisted_store,
+        provider_id,
+    )
+    if _provider_oauth_lineage(provider_id, persisted_state) != _provider_oauth_lineage(
+        provider_id,
+        state,
+    ):
+        raise SourceCredentialPersistenceError(
+            provider_id,
+            source_path=target_path,
+            consumed_refresh_token=expected_refresh_token,
+        )
 
 
 def _load_provider_state(auth_store: Dict[str, Any], provider_id: str) -> Optional[Dict[str, Any]]:
@@ -5135,36 +5302,151 @@ def _refresh_xai_oauth_tokens(
     return updated_tokens
 
 
+def _xai_oauth_data_from_provider_state(state: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate one exact xAI provider block without fallback reads."""
+    tokens = state.get("tokens")
+    if not isinstance(tokens, dict):
+        raise AuthError(
+            "xAI OAuth credentials are missing.",
+            provider="xai-oauth",
+            code="xai_auth_missing",
+            relogin_required=True,
+        )
+    access_token = str(tokens.get("access_token", "") or "").strip()
+    if not access_token:
+        raise AuthError(
+            "xAI OAuth access token is missing.",
+            provider="xai-oauth",
+            code="xai_auth_missing",
+            relogin_required=True,
+        )
+    data = dict(state)
+    data["tokens"] = dict(tokens)
+    return data
+
+
+def _xai_oauth_state_with_refreshed_tokens(
+    state: Dict[str, Any],
+    refreshed: Dict[str, Any],
+    *,
+    token_endpoint: str,
+) -> Dict[str, Any]:
+    updated_state = dict(state)
+    updated_tokens = dict(state.get("tokens") or {})
+    updated_tokens["access_token"] = refreshed["access_token"]
+    updated_tokens["refresh_token"] = refreshed["refresh_token"]
+    for key in ("id_token", "expires_in", "token_type"):
+        if refreshed.get(key) is not None:
+            updated_tokens[key] = refreshed[key]
+    updated_state["tokens"] = updated_tokens
+    discovery = dict(updated_state.get("discovery") or {})
+    discovery["token_endpoint"] = token_endpoint
+    updated_state["discovery"] = discovery
+    updated_state["last_refresh"] = refreshed.get("last_refresh")
+    return updated_state
+
+
+def _mark_xai_pool_lineage_dead(
+    auth_store: Dict[str, Any],
+    consumed_refresh_token: str,
+    *,
+    reason: str = "source_persistence_failed",
+    message: str = "Refreshed credentials were not persisted to their owning source.",
+) -> None:
+    pools = auth_store.get("credential_pool")
+    if not isinstance(pools, dict):
+        return
+    entries = pools.get("xai-oauth")
+    if not isinstance(entries, list):
+        return
+    now = time.time()
+    for raw_entry in entries:
+        if (
+            isinstance(raw_entry, dict)
+            and raw_entry.get("refresh_token") == consumed_refresh_token
+        ):
+            raw_entry["last_status"] = "dead"
+            raw_entry["last_status_at"] = now
+            raw_entry["last_error_reason"] = reason
+            raw_entry["last_error_message"] = message
+
+
+def _quarantine_xai_consumed_source(
+    source_path: Optional[Path],
+    consumed_refresh_token: str,
+) -> None:
+    """Persist fail-closed state for one consumed xAI refresh lineage."""
+    if source_path is None:
+        return
+    with _provider_state_transaction(
+        "xai-oauth",
+        expected_source_path=source_path,
+    ) as (_auth_store, state, locked_source_path):
+        if (
+            locked_source_path is None
+            or not _same_path(Path(locked_source_path), Path(source_path))
+            or _provider_refresh_lineage("xai-oauth", state)
+            != consumed_refresh_token
+        ):
+            return
+        source_store = _load_auth_store(Path(locked_source_path))
+        source_state = _provider_state_from_exact_store(
+            source_store,
+            "xai-oauth",
+        )
+        if source_state is None:
+            return
+        _mark_xai_pool_lineage_dead(source_store, consumed_refresh_token)
+        providers = source_store.get("providers")
+        if isinstance(providers, dict):
+            providers.pop("xai-oauth", None)
+        if source_store.get("active_provider") == "xai-oauth":
+            source_store.pop("active_provider", None)
+        _save_auth_store(
+            source_store,
+            target_path=Path(locked_source_path),
+        )
+        persisted = _load_auth_store(Path(locked_source_path))
+        if _provider_state_from_exact_store(persisted, "xai-oauth") is not None:
+            raise SourceCredentialPersistenceError(
+                "xai-oauth",
+                source_path=Path(locked_source_path),
+                consumed_refresh_token=consumed_refresh_token,
+            )
+
+
 def resolve_xai_oauth_runtime_credentials(
     *,
     force_refresh: bool = False,
     refresh_if_expiring: bool = True,
     refresh_skew_seconds: Optional[int] = None,
 ) -> Dict[str, Any]:
-    data = _read_xai_oauth_tokens()
-    tokens = dict(data["tokens"])
-    access_token = str(tokens.get("access_token", "") or "").strip()
     refresh_timeout_seconds = env_float("HERMES_XAI_REFRESH_TIMEOUT_SECONDS", 20)
-    discovery = dict(data.get("discovery") or {})
-    token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
-    redirect_uri = str(data.get("redirect_uri", "") or "").strip()
-
-    effective_skew = (
-        int(refresh_skew_seconds)
-        if refresh_skew_seconds is not None
-        else _xai_proactive_refresh_skew_seconds(access_token)
+    lock_timeout = max(
+        float(AUTH_LOCK_TIMEOUT_SECONDS),
+        refresh_timeout_seconds + 5.0,
     )
-    should_refresh = bool(force_refresh)
-    if (not should_refresh) and refresh_if_expiring:
-        should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
-    if should_refresh:
-        with _auth_store_lock(timeout_seconds=max(float(AUTH_LOCK_TIMEOUT_SECONDS), refresh_timeout_seconds + 5.0)):
-            data = _read_xai_oauth_tokens(_lock=False)
+    data: Optional[Dict[str, Any]] = None
+    access_token = ""
+    persistence_failure: Optional[SourceCredentialPersistenceError] = None
+    consumed_refresh_token = ""
+    source_path: Optional[Path] = None
+
+    for _attempt in range(3):
+        with _provider_state_transaction(
+            "xai-oauth",
+            timeout_seconds=lock_timeout,
+        ) as (auth_store, state, state_source_path):
+            source_path = state_source_path
+            if state is None:
+                break
+            data = _xai_oauth_data_from_provider_state(state)
             tokens = dict(data["tokens"])
             access_token = str(tokens.get("access_token", "") or "").strip()
             discovery = dict(data.get("discovery") or {})
-            token_endpoint = str(discovery.get("token_endpoint", "") or "").strip()
-            redirect_uri = str(data.get("redirect_uri", "") or "").strip()
+            token_endpoint = str(
+                discovery.get("token_endpoint", "") or ""
+            ).strip()
             effective_skew = (
                 int(refresh_skew_seconds)
                 if refresh_skew_seconds is not None
@@ -5173,44 +5455,126 @@ def resolve_xai_oauth_runtime_credentials(
             should_refresh = bool(force_refresh)
             if (not should_refresh) and refresh_if_expiring:
                 should_refresh = _xai_access_token_is_expiring(access_token, effective_skew)
-            if should_refresh:
-                if not token_endpoint:
-                    token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)["token_endpoint"]
-                try:
-                    tokens = _refresh_xai_oauth_tokens(
-                        tokens,
-                        token_endpoint=token_endpoint,
-                        redirect_uri=redirect_uri,
-                        timeout_seconds=refresh_timeout_seconds,
+            if not should_refresh:
+                break
+            if not token_endpoint:
+                token_endpoint = _xai_oauth_discovery(refresh_timeout_seconds)[
+                    "token_endpoint"
+                ]
+            consumed_refresh_token = str(
+                tokens.get("refresh_token", "") or ""
+            ).strip()
+            try:
+                refreshed = refresh_xai_oauth_pure(
+                    access_token,
+                    consumed_refresh_token,
+                    token_endpoint=token_endpoint,
+                    timeout_seconds=refresh_timeout_seconds,
+                )
+            except AuthError as exc:
+                if _is_terminal_xai_oauth_refresh_error(exc):
+                    source_store = _load_auth_store(
+                        Path(state_source_path or _auth_file_path())
                     )
-                    access_token = str(tokens.get("access_token", "") or "").strip()
-                except AuthError as exc:
-                    if _is_terminal_xai_oauth_refresh_error(exc):
-                        # Terminal failure (HTTP 400/401/403 — invalid_grant, token revoked).
-                        # Clear dead tokens from auth.json so subsequent sessions fail fast
-                        # without a network retry. Mirrors credential_pool.py quarantine.
-                        try:
-                            _q_store = _load_auth_store()
-                            _q_state = _load_provider_state(_q_store, "xai-oauth") or {}
-                            _q_tokens = dict(_q_state.get("tokens") or {})
-                            _q_tokens.pop("access_token", None)
-                            _q_tokens.pop("refresh_token", None)
-                            _q_state["tokens"] = _q_tokens
-                            _q_state["last_auth_error"] = {
-                                "provider": "xai-oauth",
-                                "code": exc.code or "xai_refresh_failed",
-                                "message": str(exc),
-                                "reason": "runtime_refresh_failure",
-                                "relogin_required": True,
-                                "at": datetime.now(timezone.utc).isoformat(),
-                            }
-                            _store_provider_state(_q_store, "xai-oauth", _q_state, set_active=False)
-                            _save_auth_store(_q_store)
-                        except Exception as _save_exc:
-                            logger.debug(
-                                "xAI OAuth: failed to persist quarantined state: %s", _save_exc,
-                            )
-                    raise
+                    _mark_xai_pool_lineage_dead(
+                        source_store,
+                        consumed_refresh_token,
+                        reason="runtime_refresh_failure",
+                        message=str(exc),
+                    )
+                    providers = source_store.get("providers")
+                    if isinstance(providers, dict):
+                        providers.pop("xai-oauth", None)
+                    if source_store.get("active_provider") == "xai-oauth":
+                        source_store.pop("active_provider", None)
+                    _save_auth_store(
+                        source_store,
+                        target_path=Path(state_source_path or _auth_file_path()),
+                    )
+                raise
+
+            updated_state = _xai_oauth_state_with_refreshed_tokens(
+                state,
+                refreshed,
+                token_endpoint=token_endpoint,
+            )
+            try:
+                _save_provider_state_to_locked_source(
+                    auth_store,
+                    "xai-oauth",
+                    updated_state,
+                    state_source_path,
+                    expected_refresh_token=consumed_refresh_token,
+                    set_active=False,
+                )
+            except SourceCredentialLineageChanged:
+                continue
+            except (OSError, SourceCredentialPersistenceError) as exc:
+                persistence_failure = (
+                    exc
+                    if isinstance(exc, SourceCredentialPersistenceError)
+                    else SourceCredentialPersistenceError(
+                        "xai-oauth",
+                        source_path=state_source_path,
+                        consumed_refresh_token=consumed_refresh_token,
+                    )
+                )
+                break
+            data = dict(updated_state)
+            access_token = str(
+                updated_state.get("tokens", {}).get("access_token", "") or ""
+            ).strip()
+            break
+    else:
+        raise SourceCredentialLineageChanged("xai-oauth")
+
+    if persistence_failure is not None:
+        try:
+            _quarantine_xai_consumed_source(
+                source_path,
+                consumed_refresh_token,
+            )
+        except Exception:
+            logger.debug(
+                "xAI OAuth: failed to persist source quarantine",
+                exc_info=True,
+            )
+        raise persistence_failure
+
+    if data is None:
+        # Pool-only/manual credentials have no providers.xai-oauth singleton.
+        # Delegate their refresh to CredentialPool so the pool row remains the
+        # authoritative transaction owner.
+        from agent.credential_pool import load_pool
+
+        pool = load_pool("xai-oauth")
+        selected = pool.peek()
+        if selected is not None:
+            selected_access_token = str(selected.access_token or "").strip()
+            effective_skew = (
+                int(refresh_skew_seconds)
+                if refresh_skew_seconds is not None
+                else _xai_proactive_refresh_skew_seconds(selected_access_token)
+            )
+            should_refresh = bool(force_refresh)
+            if (not should_refresh) and refresh_if_expiring:
+                should_refresh = _xai_access_token_is_expiring(
+                    selected_access_token,
+                    effective_skew,
+                )
+            if should_refresh:
+                selected = pool.try_refresh_matching(credential_id=selected.id)
+        if selected is None or not selected.access_token:
+            raise AuthError(
+                "xAI OAuth credentials are missing.",
+                provider="xai-oauth",
+                code="xai_auth_missing",
+                relogin_required=True,
+            )
+        access_token = selected.access_token
+        data = {
+            "last_refresh": selected.last_refresh,
+        }
 
     base_url = _xai_validate_inference_base_url(
         os.getenv("HERMES_XAI_BASE_URL", "").strip().rstrip("/")
@@ -6389,6 +6753,7 @@ def resolve_nous_runtime_credentials(
 
         persisted_state = dict(state)
         state_persisted = False
+        consumed_refresh_token: Any = None
 
         def _resolve_effective_routing_metadata() -> tuple[str, str, str, str]:
             """Resolve every routing value that shared OAuth state can replace."""
@@ -6472,7 +6837,17 @@ def resolve_nous_runtime_credentials(
                 )
                 return
             try:
-                _save_provider_state_to_source(auth_store, "nous", state, state_source_path)
+                _save_provider_state_to_locked_source(
+                    auth_store,
+                    "nous",
+                    state,
+                    state_source_path,
+                    expected_refresh_token=_provider_refresh_lineage(
+                        "nous",
+                        persisted_state,
+                    ),
+                    merge_credential_pool=reason.startswith("terminal_"),
+                )
             except Exception as exc:
                 _oauth_trace(
                     "nous_state_persist_failed",
@@ -6480,6 +6855,15 @@ def resolve_nous_runtime_credentials(
                     reason=reason,
                     error_type=type(exc).__name__,
                 )
+                if (
+                    reason == "post_refresh_access_token"
+                    and consumed_refresh_token
+                ):
+                    raise SourceCredentialPersistenceError(
+                        "nous",
+                        source_path=state_source_path,
+                        consumed_refresh_token=consumed_refresh_token,
+                    ) from exc
                 raise
             _oauth_trace(
                 "nous_state_persisted",
@@ -6591,6 +6975,7 @@ def resolve_nous_runtime_credentials(
                         now = datetime.now(timezone.utc)
                         access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
                         previous_refresh_token = refresh_token
+                        consumed_refresh_token = refresh_token
                         state["access_token"] = refreshed["access_token"]
                         state["refresh_token"] = refreshed.get("refresh_token") or refresh_token
                         state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -388,15 +388,17 @@ class TestRefreshOauthToken:
 
     def test_successful_refresh(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
-        )
 
         creds = {
             "accessToken": "old-token",
             "refreshToken": "refresh-123",
             "expiresAt": int(time.time() * 1000) - 3600_000,
         }
+        _write_claude_code_credentials(
+            creds["accessToken"],
+            creds["refreshToken"],
+            creds["expiresAt"],
+        )
 
         mock_response = json.dumps({
             "access_token": "new-token-abc",
@@ -424,14 +426,16 @@ class TestRefreshOauthToken:
 
     def test_failed_refresh_returns_none(self, tmp_path, monkeypatch):
         monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
-        monkeypatch.setattr(
-            "agent.anthropic_adapter.read_claude_code_credentials", lambda: None
-        )
         creds = {
             "accessToken": "old",
             "refreshToken": "refresh-123",
             "expiresAt": 0,
         }
+        _write_claude_code_credentials(
+            creds["accessToken"],
+            creds["refreshToken"],
+            creds["expiresAt"],
+        )
 
         with patch("urllib.request.urlopen", side_effect=Exception("network error")):
             assert _refresh_oauth_token(creds) is None

--- a/tests/agent/test_anthropic_keychain.py
+++ b/tests/agent/test_anthropic_keychain.py
@@ -9,6 +9,7 @@ from agent.anthropic_adapter import (
     _read_claude_code_credentials_from_keychain,
     read_claude_code_credentials,
     _refresh_oauth_token,
+    _write_claude_code_credentials,
 )
 
 
@@ -227,15 +228,16 @@ class TestRefreshOAuthTokenAdoptsFreshCredential:
         result = _refresh_oauth_token({"refreshToken": "stale", "expiresAt": 1})
         assert result == "already-refreshed-token"
 
-    def test_falls_back_to_network_refresh_when_no_fresh_credential(self, monkeypatch):
+    def test_falls_back_to_network_refresh_when_no_fresh_credential(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
         """When no live source has a valid token, fall back to refreshing
         ourselves using the freshest available refresh token.
         """
-        # Live read returns an expired credential carrying a refresh token.
-        monkeypatch.setattr(
-            "agent.anthropic_adapter.read_claude_code_credentials",
-            lambda: {"accessToken": "expired", "refreshToken": "live-refresh", "expiresAt": 1},
-        )
+        monkeypatch.setattr("agent.anthropic_adapter.Path.home", lambda: tmp_path)
+        _write_claude_code_credentials("expired", "live-refresh", 1)
         captured = {}
 
         def _fake_refresh(refresh_token, **kwargs):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2541,19 +2541,30 @@ class TestAuxiliaryAuthRefreshRetry:
                 "refreshToken": "refresh-token",
                 "expiresAt": 0,
             }),
+            patch("agent.anthropic_adapter._read_claude_code_credentials_from_file", return_value={
+                "accessToken": "expired-token",
+                "refreshToken": "refresh-token",
+                "expiresAt": 0,
+            }),
             patch("agent.anthropic_adapter.refresh_anthropic_oauth_pure", return_value={
                 "access_token": "fresh-token",
                 "refresh_token": "refresh-token-2",
                 "expires_at_ms": 9999999999999,
             }) as mock_refresh_oauth,
-            patch("agent.anthropic_adapter._write_claude_code_credentials") as mock_write,
+            patch("agent.anthropic_adapter._write_claude_code_credentials_locked") as mock_write,
         ):
             from agent.auxiliary_client import _refresh_provider_credentials
 
             assert _refresh_provider_credentials("anthropic") is True
 
         mock_refresh_oauth.assert_called_once_with("refresh-token", use_json=False)
-        mock_write.assert_called_once_with("fresh-token", "refresh-token-2", 9999999999999)
+        mock_write.assert_called_once_with(
+            "fresh-token",
+            "refresh-token-2",
+            9999999999999,
+            expected_refresh_token="refresh-token",
+            allow_missing=False,
+        )
         stale_client.close.assert_called_once()
 
     def test_refresh_provider_credentials_remints_vertex_token_and_evicts_cache(self):

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2540,31 +2540,23 @@ class TestAuxiliaryAuthRefreshRetry:
                 "accessToken": "expired-token",
                 "refreshToken": "refresh-token",
                 "expiresAt": 0,
+                "source": "claude_code_credentials_file",
             }),
-            patch("agent.anthropic_adapter._read_claude_code_credentials_from_file", return_value={
-                "accessToken": "expired-token",
-                "refreshToken": "refresh-token",
-                "expiresAt": 0,
-            }),
-            patch("agent.anthropic_adapter.refresh_anthropic_oauth_pure", return_value={
-                "access_token": "fresh-token",
-                "refresh_token": "refresh-token-2",
-                "expires_at_ms": 9999999999999,
-            }) as mock_refresh_oauth,
-            patch("agent.anthropic_adapter._write_claude_code_credentials_locked") as mock_write,
+            patch(
+                "agent.anthropic_adapter._refresh_claude_code_source_credentials",
+                return_value={
+                    "accessToken": "fresh-token",
+                    "refreshToken": "refresh-token-2",
+                    "expiresAt": 9999999999999,
+                    "source": "claude_code_credentials_file",
+                },
+            ) as mock_refresh_source,
         ):
             from agent.auxiliary_client import _refresh_provider_credentials
 
             assert _refresh_provider_credentials("anthropic") is True
 
-        mock_refresh_oauth.assert_called_once_with("refresh-token", use_json=False)
-        mock_write.assert_called_once_with(
-            "fresh-token",
-            "refresh-token-2",
-            9999999999999,
-            expected_refresh_token="refresh-token",
-            allow_missing=False,
-        )
+        mock_refresh_source.assert_called_once()
         stale_client.close.assert_called_once()
 
     def test_refresh_provider_credentials_remints_vertex_token_and_evicts_cache(self):

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -738,6 +738,34 @@ def test_pooled_credential_to_dict_strips_borrowed_secret_fields():
 
 
 
+@pytest.mark.parametrize("source", ["device_code", "manual:device_code"])
+def test_codex_source_store_provenance_is_runtime_only(source, tmp_path):
+    from agent.credential_pool import PooledCredential
+
+    trusted_source = tmp_path / "trusted-root" / "auth.json"
+    credential = PooledCredential(
+        provider="openai-codex",
+        id=f"runtime-{source}",
+        label="runtime provenance",
+        auth_type="oauth",
+        priority=0,
+        source=source,
+        access_token="fake-access",
+        refresh_token="fake-refresh",
+        source_store_path=trusted_source,
+    )
+
+    payload = credential.to_dict()
+    assert "source_store_path" not in payload
+    assert str(trusted_source) not in json.dumps(payload)
+
+    untrusted = dict(payload)
+    untrusted["source_store_path"] = str(tmp_path / "untrusted" / "auth.json")
+    restored = PooledCredential.from_dict("openai-codex", untrusted)
+    assert restored.source_store_path is None
+
+
+
 @pytest.mark.parametrize("source", [
     "age://openrouter/api-key",
     "systemd",

--- a/tests/agent/test_credential_pool_deferred_refresh.py
+++ b/tests/agent/test_credential_pool_deferred_refresh.py
@@ -196,6 +196,7 @@ def _install_claude_source(monkeypatch, initial):
             "refreshToken": refresh_token,
             "expiresAt": expires_at_ms,
         }
+        return True
 
     monkeypatch.setattr(
         anthropic_adapter,
@@ -514,6 +515,167 @@ def test_concurrent_selectors_refresh_rotating_chain_once(tmp_path, monkeypatch)
         "rotated-access",
         "rotated-refresh",
     )
+
+
+@pytest.mark.parametrize("mutation", ["remove", "replace"])
+def test_post_cas_lineage_mutation_cannot_write_or_return_stale_refresh(
+    tmp_path,
+    monkeypatch,
+    mutation,
+):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+    )
+    _auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "obsolete-access",
+            "refresh_token": "obsolete-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+
+    cas_complete = threading.Event()
+    allow_write_boundary = threading.Event()
+    real_replace = pool._replace_entry
+
+    def pause_after_refresh_cas(previous, updated, **kwargs):
+        result = real_replace(previous, updated, **kwargs)
+        if (
+            threading.current_thread().name == "refresh-selector"
+            and result is not None
+            and updated.access_token == "obsolete-access"
+        ):
+            cas_complete.set()
+            assert allow_write_boundary.wait(timeout=5)
+        return result
+
+    pool._replace_entry = pause_after_refresh_cas
+    results = []
+    errors = []
+
+    def select_worker():
+        try:
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+
+    selector = threading.Thread(target=select_worker, name="refresh-selector")
+    selector.start()
+    assert cas_complete.wait(timeout=5)
+
+    if mutation == "remove":
+        assert pool.remove_index(1) is not None
+        expected = None
+    else:
+        current = pool.entries()[0]
+        winner = replace(
+            current,
+            access_token="winner-access",
+            refresh_token="winner-refresh",
+            expires_at_ms=9_999_999_999_999,
+        )
+        source["credentials"] = {
+            "accessToken": "winner-access",
+            "refreshToken": "winner-refresh",
+            "expiresAt": 9_999_999_999_999,
+        }
+        assert real_replace(current, winner) == winner
+        expected = winner
+
+    allow_write_boundary.set()
+    selector.join(timeout=5)
+
+    assert not selector.is_alive()
+    assert errors == []
+    assert source["writes"] == []
+    if expected is None:
+        assert results == [None]
+        assert pool.entries() == []
+        assert source["credentials"]["refreshToken"] == "old-refresh"
+    else:
+        assert len(results) == 1 and results[0] is not None
+        assert _tokens(results[0]) == _tokens(expected)
+        assert _tokens(pool.entries()[0]) == _tokens(expected)
+        assert source["credentials"]["refreshToken"] == "winner-refresh"
+
+
+def test_source_lineage_change_after_commit_read_wins_before_write(
+    tmp_path,
+    monkeypatch,
+):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+    )
+    _auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "obsolete-access",
+            "refresh_token": "obsolete-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+
+    commit_read = threading.Event()
+    allow_commit = threading.Event()
+    reads = 0
+    real_sync = pool._sync_anthropic_entry_from_credentials_file
+
+    def pause_after_commit_read(entry, *, persist=True):
+        nonlocal reads
+        result = real_sync(entry, persist=persist)
+        reads += 1
+        if reads == 2:
+            commit_read.set()
+            assert allow_commit.wait(timeout=5)
+        return result
+
+    pool._sync_anthropic_entry_from_credentials_file = pause_after_commit_read
+    results = []
+    selector = threading.Thread(target=lambda: results.append(pool.select()))
+    selector.start()
+    assert commit_read.wait(timeout=5)
+
+    source["credentials"] = {
+        "accessToken": "winner-access",
+        "refreshToken": "winner-refresh",
+        "expiresAt": 9_999_999_999_999,
+    }
+    allow_commit.set()
+    selector.join(timeout=5)
+
+    assert not selector.is_alive()
+    assert source["writes"] == []
+    assert source["credentials"]["refreshToken"] == "winner-refresh"
+    assert len(results) == 1 and results[0] is not None
+    assert _tokens(results[0]) == ("winner-access", "winner-refresh")
+    assert _tokens(pool.entries()[0]) == ("winner-access", "winner-refresh")
 
 
 @pytest.mark.parametrize(

--- a/tests/agent/test_credential_pool_deferred_refresh.py
+++ b/tests/agent/test_credential_pool_deferred_refresh.py
@@ -11,14 +11,25 @@ lock. These tests pin the two invariants that make that safe:
    auth.json.
 """
 
+import json
 import threading
+import time
 from dataclasses import replace
 
+import pytest
+
+from agent import anthropic_adapter
+from agent import credential_pool as CP
 from agent.credential_pool import (
     AUTH_TYPE_OAUTH,
     CredentialPool,
     PooledCredential,
+    STATUS_EXHAUSTED,
+    STRATEGY_FILL_FIRST,
+    STRATEGY_LEAST_USED,
+    STRATEGY_ROUND_ROBIN,
 )
+from hermes_cli import auth as auth_mod
 
 
 def _codex_entry(entry_id: str = "codex-1") -> PooledCredential:
@@ -91,3 +102,593 @@ def test_deferred_mutations_serialize_against_concurrent_rotation(monkeypatch):
     t.join(timeout=5)
     assert mutated.is_set()
     assert pool._entries[0].access_token == "at-fresh"
+
+
+def test_external_state_lock_is_never_acquired_under_pool_lock():
+    pool = CredentialPool("anthropic", [_anthropic_entry("entry")])
+
+    with pool._lock:
+        with pytest.raises(RuntimeError, match="pool lock is held"):
+            pool._sync_external_status_entries()
+        with pytest.raises(RuntimeError, match="pool lock is held"):
+            pool._refresh_entry(pool._entries[0], force=False)
+
+
+def _anthropic_entry(
+    entry_id: str,
+    *,
+    priority: int = 0,
+    access_token: str | None = None,
+    refresh_token: str | None = None,
+    expires_at_ms: int = 1,
+    request_count: int = 0,
+    source: str = "manual:oauth",
+    last_status: str | None = None,
+    last_status_at: float | None = None,
+) -> PooledCredential:
+    return PooledCredential(
+        provider="anthropic",
+        id=entry_id,
+        label=entry_id,
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=priority,
+        source=source,
+        access_token=access_token or f"{entry_id}-access",
+        refresh_token=refresh_token or f"{entry_id}-refresh",
+        expires_at_ms=expires_at_ms,
+        request_count=request_count,
+        last_status=last_status,
+        last_status_at=last_status_at,
+        last_error_code=429 if last_status == STATUS_EXHAUSTED else None,
+    )
+
+
+def _pool_with_store(tmp_path, monkeypatch, entries, *, strategy=STRATEGY_FILL_FIRST):
+    auth_path = tmp_path / "auth.json"
+    monkeypatch.setattr(auth_mod, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(auth_mod, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(
+        auth_mod,
+        "is_provider_explicitly_configured",
+        lambda _provider: True,
+    )
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    auth_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "credential_pool": {
+                    "anthropic": [entry.to_dict() for entry in entries],
+                },
+            }
+        )
+    )
+    pool = CredentialPool("anthropic", entries)
+    pool._strategy = strategy
+    return auth_path, pool
+
+
+def _disk_entries(auth_path):
+    payloads = json.loads(auth_path.read_text())["credential_pool"]["anthropic"]
+    return [PooledCredential.from_dict("anthropic", payload) for payload in payloads]
+
+
+def _reloaded_claude_entry():
+    return next(
+        entry
+        for entry in CP.load_pool("anthropic").entries()
+        if entry.source == "claude_code"
+    )
+
+
+def _install_claude_source(monkeypatch, initial):
+    state = {"credentials": dict(initial), "writes": []}
+
+    def read_credentials():
+        return dict(state["credentials"])
+
+    def write_credentials(access_token, refresh_token, expires_at_ms):
+        write = (access_token, refresh_token, expires_at_ms)
+        state["writes"].append(write)
+        state["credentials"] = {
+            "accessToken": access_token,
+            "refreshToken": refresh_token,
+            "expiresAt": expires_at_ms,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_claude_code_credentials",
+        read_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_write_claude_code_credentials",
+        write_credentials,
+    )
+    return state
+
+
+def _tokens(entry):
+    return entry.access_token, entry.refresh_token
+
+
+def test_public_status_sync_wins_before_deferred_refresh_starts(tmp_path, monkeypatch):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+        last_status=STATUS_EXHAUSTED,
+        last_status_at=0.0,
+    )
+    auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    posts = []
+
+    def refresh_credentials(refresh_token, *, use_json):
+        posts.append((refresh_token, use_json))
+        return {
+            "access_token": "old-rotated-access",
+            "refresh_token": "old-rotated-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    candidate_captured = threading.Event()
+    allow_refresh = threading.Event()
+    real_refresh = pool._refresh_entry
+
+    def paused_refresh(entry, *, force):
+        candidate_captured.set()
+        assert allow_refresh.wait(timeout=5)
+        return real_refresh(entry, force=force)
+
+    monkeypatch.setattr(pool, "_refresh_entry", paused_refresh)
+    results = []
+    errors = []
+
+    def select_worker():
+        try:
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+
+    selector = threading.Thread(target=select_worker)
+    selector.start()
+    assert candidate_captured.wait(timeout=5)
+
+    current = pool.entries()[0]
+    pool._replace_entry(
+        current,
+        replace(
+            current,
+            last_status=STATUS_EXHAUSTED,
+            last_status_at=time.time(),
+            last_error_code=429,
+        ),
+        mark_dirty=False,
+    )
+    source["credentials"] = {
+        "accessToken": "concurrent-new-access",
+        "refreshToken": "concurrent-new-refresh",
+        "expiresAt": 9_999_999_999_999,
+    }
+    assert pool.has_available() is True
+    allow_refresh.set()
+    selector.join(timeout=5)
+
+    assert not selector.is_alive()
+    assert errors == []
+    assert posts == []
+    assert source["writes"] == []
+    assert source["credentials"] == {
+        "accessToken": "concurrent-new-access",
+        "refreshToken": "concurrent-new-refresh",
+        "expiresAt": 9_999_999_999_999,
+    }
+    assert len(results) == 1 and results[0] is not None
+    assert _tokens(results[0]) == (
+        "concurrent-new-access",
+        "concurrent-new-refresh",
+    )
+    assert _tokens(pool.entries()[0]) == _tokens(results[0])
+    assert _disk_entries(auth_path)[0].source == "claude_code"
+    assert _tokens(_reloaded_claude_entry()) == _tokens(results[0])
+
+
+def test_inflight_refresh_cannot_commit_over_newer_chain(tmp_path, monkeypatch):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+    )
+    auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    post_entered = threading.Event()
+    release_post = threading.Event()
+    posts = []
+
+    def refresh_credentials(refresh_token, *, use_json):
+        posts.append((refresh_token, use_json))
+        post_entered.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "old-rotated-access",
+            "refresh_token": "old-rotated-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    results = []
+    errors = []
+
+    def select_worker():
+        try:
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+
+    selector = threading.Thread(target=select_worker)
+    selector.start()
+    assert post_entered.wait(timeout=5)
+
+    current = pool.entries()[0]
+    newer = replace(
+        current,
+        access_token="concurrent-new-access",
+        refresh_token="concurrent-new-refresh",
+        expires_at_ms=9_999_999_999_999,
+    )
+    assert pool._replace_entry(current, newer) == newer
+    pool._persist_pending_changes()
+    source["credentials"] = {
+        "accessToken": "concurrent-new-access",
+        "refreshToken": "concurrent-new-refresh",
+        "expiresAt": 9_999_999_999_999,
+    }
+    release_post.set()
+    selector.join(timeout=5)
+
+    assert not selector.is_alive()
+    assert errors == []
+    assert posts == [("old-refresh", False)]
+    assert source["writes"] == []
+    assert len(results) == 1 and results[0] is not None
+    assert _tokens(results[0]) == _tokens(newer)
+    assert _tokens(pool.entries()[0]) == _tokens(newer)
+    assert _disk_entries(auth_path)[0].source == "claude_code"
+    assert _tokens(_reloaded_claude_entry()) == _tokens(newer)
+    assert source["credentials"]["refreshToken"] == "concurrent-new-refresh"
+
+
+def test_removed_inflight_candidate_is_not_written_or_resurrected(tmp_path, monkeypatch):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+    )
+    auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    post_entered = threading.Event()
+    release_post = threading.Event()
+
+    def refresh_credentials(_refresh_token, *, use_json):
+        assert use_json is False
+        post_entered.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "removed-rotated-access",
+            "refresh_token": "removed-rotated-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    results = []
+    selector = threading.Thread(target=lambda: results.append(pool.select()))
+    selector.start()
+    assert post_entered.wait(timeout=5)
+    assert pool.remove_index(1) is not None
+    release_post.set()
+    selector.join(timeout=5)
+
+    assert not selector.is_alive()
+    assert results == [None]
+    assert source["writes"] == []
+    assert source["credentials"]["refreshToken"] == "old-refresh"
+    assert pool.entries() == []
+    assert _disk_entries(auth_path) == []
+
+
+def test_concurrent_selectors_refresh_rotating_chain_once(tmp_path, monkeypatch):
+    old = _anthropic_entry(
+        "claude-entry",
+        source="claude_code",
+        access_token="old-access",
+        refresh_token="old-refresh",
+    )
+    auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [old])
+    source = _install_claude_source(
+        monkeypatch,
+        {
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        },
+    )
+    first_post_entered = threading.Event()
+    second_post_entered = threading.Event()
+    release_post = threading.Event()
+    calls = []
+    calls_lock = threading.Lock()
+
+    def refresh_credentials(refresh_token, *, use_json):
+        with calls_lock:
+            calls.append((refresh_token, use_json))
+            if len(calls) == 1:
+                first_post_entered.set()
+            else:
+                second_post_entered.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    start = threading.Barrier(3)
+    results = []
+    errors = []
+
+    def select_worker():
+        try:
+            start.wait(timeout=5)
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+
+    selectors = [threading.Thread(target=select_worker) for _ in range(2)]
+    for selector in selectors:
+        selector.start()
+    start.wait(timeout=5)
+    assert first_post_entered.wait(timeout=5)
+    second_post_entered.wait(timeout=0.3)
+    release_post.set()
+    for selector in selectors:
+        selector.join(timeout=5)
+
+    assert all(not selector.is_alive() for selector in selectors)
+    assert errors == []
+    assert calls == [("old-refresh", False)]
+    assert source["writes"] == [
+        ("rotated-access", "rotated-refresh", 9_999_999_999_999)
+    ]
+    assert len(results) == 2 and all(result is not None for result in results)
+    assert {_tokens(result) for result in results} == {
+        ("rotated-access", "rotated-refresh")
+    }
+    assert _tokens(pool.entries()[0]) == ("rotated-access", "rotated-refresh")
+    assert _disk_entries(auth_path)[0].source == "claude_code"
+    assert _tokens(_reloaded_claude_entry()) == (
+        "rotated-access",
+        "rotated-refresh",
+    )
+
+
+@pytest.mark.parametrize(
+    ("refresh_succeeds", "expected_id"),
+    [(True, "preferred-expiring"), (False, "healthy-fallback")],
+)
+def test_fill_first_waits_for_pending_refresh(
+    tmp_path,
+    monkeypatch,
+    refresh_succeeds,
+    expected_id,
+):
+    preferred = _anthropic_entry("preferred-expiring", priority=0)
+    healthy = _anthropic_entry(
+        "healthy-fallback",
+        priority=1,
+        expires_at_ms=9_999_999_999_999,
+    )
+    auth_path, pool = _pool_with_store(
+        tmp_path,
+        monkeypatch,
+        [preferred, healthy],
+        strategy=STRATEGY_FILL_FIRST,
+    )
+
+    def refresh_credentials(_refresh_token, *, use_json):
+        assert use_json is False
+        if not refresh_succeeds:
+            raise RuntimeError("refresh failed")
+        return {
+            "access_token": "preferred-refreshed-access",
+            "refresh_token": "preferred-refreshed-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    selected = pool.select()
+
+    assert selected is not None and selected.id == expected_id
+    memory = pool.entries()
+    disk = _disk_entries(auth_path)
+    assert [(entry.id, entry.priority) for entry in disk] == [
+        (entry.id, entry.priority) for entry in memory
+    ]
+
+
+def test_round_robin_refreshes_before_one_rotation(tmp_path, monkeypatch):
+    entries = [
+        _anthropic_entry(
+            "healthy-0",
+            priority=0,
+            expires_at_ms=9_999_999_999_999,
+        ),
+        _anthropic_entry("expiring-1", priority=1),
+        _anthropic_entry(
+            "healthy-2",
+            priority=2,
+            expires_at_ms=9_999_999_999_999,
+        ),
+    ]
+    auth_path, pool = _pool_with_store(
+        tmp_path,
+        monkeypatch,
+        entries,
+        strategy=STRATEGY_ROUND_ROBIN,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "expiring-refreshed-access",
+            "refresh_token": "expiring-refreshed-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+
+    selected = pool.select()
+
+    assert selected is not None and selected.id == "healthy-0"
+    memory = pool.entries()
+    assert [(entry.id, entry.priority) for entry in memory] == [
+        ("expiring-1", 0),
+        ("healthy-2", 1),
+        ("healthy-0", 2),
+    ]
+    assert [(entry.id, entry.priority) for entry in _disk_entries(auth_path)] == [
+        (entry.id, entry.priority) for entry in memory
+    ]
+
+
+def test_least_used_refreshes_before_incrementing_final_selection(tmp_path, monkeypatch):
+    entries = [
+        _anthropic_entry("expiring", priority=0, request_count=0),
+        _anthropic_entry(
+            "healthy-low",
+            priority=1,
+            request_count=3,
+            expires_at_ms=9_999_999_999_999,
+        ),
+        _anthropic_entry(
+            "healthy-high",
+            priority=2,
+            request_count=7,
+            expires_at_ms=9_999_999_999_999,
+        ),
+    ]
+    auth_path, pool = _pool_with_store(
+        tmp_path,
+        monkeypatch,
+        entries,
+        strategy=STRATEGY_LEAST_USED,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "expiring-refreshed-access",
+            "refresh_token": "expiring-refreshed-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+
+    selected = pool.select()
+
+    assert selected is not None and selected.id == "expiring"
+    counts = {entry.id: entry.request_count for entry in pool.entries()}
+    assert counts == {"expiring": 1, "healthy-low": 3, "healthy-high": 7}
+    assert {
+        entry.id: entry.request_count for entry in _disk_entries(auth_path)
+    } == counts
+
+
+def test_refresh_commit_preserves_concurrent_routing_fields(tmp_path, monkeypatch):
+    entry = _anthropic_entry("expiring", priority=0, request_count=2)
+    auth_path, pool = _pool_with_store(tmp_path, monkeypatch, [entry])
+    post_entered = threading.Event()
+    release_post = threading.Event()
+
+    def refresh_credentials(_refresh_token, *, use_json):
+        assert use_json is False
+        post_entered.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "refreshed-access",
+            "refresh_token": "refreshed-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    results = []
+    refresher = threading.Thread(
+        target=lambda: results.append(pool._refresh_entry(entry, force=False))
+    )
+    refresher.start()
+    assert post_entered.wait(timeout=5)
+    current = pool.entries()[0]
+    routed = replace(current, priority=4, request_count=9)
+    assert pool._replace_entry(current, routed) == routed
+    pool._persist_pending_changes()
+    release_post.set()
+    refresher.join(timeout=5)
+
+    assert not refresher.is_alive()
+    assert len(results) == 1 and results[0] is not None
+    assert _tokens(results[0]) == ("refreshed-access", "refreshed-refresh")
+    assert (results[0].priority, results[0].request_count) == (4, 9)
+    memory = pool.entries()[0]
+    disk = _disk_entries(auth_path)[0]
+    assert (memory.priority, memory.request_count) == (4, 9)
+    assert (disk.priority, disk.request_count) == (4, 9)

--- a/tests/agent/test_credential_pool_deferred_refresh.py
+++ b/tests/agent/test_credential_pool_deferred_refresh.py
@@ -184,9 +184,13 @@ def _reloaded_claude_entry():
 
 def _install_claude_source(monkeypatch, initial):
     state = {"credentials": dict(initial), "writes": []}
+    source_lock = threading.RLock()
 
     def read_credentials():
-        return dict(state["credentials"])
+        return {
+            **state["credentials"],
+            "source": "claude_code_credentials_file",
+        }
 
     def write_credentials(access_token, refresh_token, expires_at_ms):
         write = (access_token, refresh_token, expires_at_ms)
@@ -212,6 +216,27 @@ def _install_claude_source(monkeypatch, initial):
             raise auth_mod.SourceCredentialLineageChanged("anthropic")
         return write_credentials(access_token, refresh_token, expires_at_ms)
 
+    def refresh_source(observed):
+        with source_lock:
+            current = read_credentials()
+            if current.get("refreshToken") != observed.get("refreshToken"):
+                return current
+            refreshed = anthropic_adapter.refresh_anthropic_oauth_pure(
+                observed["refreshToken"],
+                use_json=False,
+            )
+            try:
+                anthropic_adapter._write_claude_code_credentials_locked(
+                    refreshed["access_token"],
+                    refreshed["refresh_token"],
+                    refreshed["expires_at_ms"],
+                    expected_refresh_token=observed["refreshToken"],
+                    allow_missing=False,
+                )
+            except auth_mod.SourceCredentialLineageChanged:
+                return read_credentials()
+            return read_credentials()
+
     monkeypatch.setattr(
         anthropic_adapter,
         "read_claude_code_credentials",
@@ -231,6 +256,11 @@ def _install_claude_source(monkeypatch, initial):
         anthropic_adapter,
         "_write_claude_code_credentials_locked",
         write_locked,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_refresh_claude_code_source_credentials",
+        refresh_source,
     )
     return state
 

--- a/tests/agent/test_credential_pool_deferred_refresh.py
+++ b/tests/agent/test_credential_pool_deferred_refresh.py
@@ -198,6 +198,20 @@ def _install_claude_source(monkeypatch, initial):
         }
         return True
 
+    def write_locked(
+        access_token,
+        refresh_token,
+        expires_at_ms,
+        *,
+        expected_refresh_token,
+        allow_missing=False,
+    ):
+        del allow_missing
+        current = state["credentials"]
+        if current.get("refreshToken") != expected_refresh_token:
+            raise auth_mod.SourceCredentialLineageChanged("anthropic")
+        return write_credentials(access_token, refresh_token, expires_at_ms)
+
     monkeypatch.setattr(
         anthropic_adapter,
         "read_claude_code_credentials",
@@ -205,8 +219,18 @@ def _install_claude_source(monkeypatch, initial):
     )
     monkeypatch.setattr(
         anthropic_adapter,
+        "_read_claude_code_credentials_from_file",
+        read_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
         "_write_claude_code_credentials",
         write_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_write_claude_code_credentials_locked",
+        write_locked,
     )
     return state
 
@@ -431,8 +455,14 @@ def test_removed_inflight_candidate_is_not_written_or_resurrected(tmp_path, monk
 
     assert not selector.is_alive()
     assert results == [None]
-    assert source["writes"] == []
-    assert source["credentials"]["refreshToken"] == "old-refresh"
+    assert source["writes"] == [
+        (
+            "removed-rotated-access",
+            "removed-rotated-refresh",
+            9_999_999_999_999,
+        )
+    ]
+    assert source["credentials"]["refreshToken"] == "removed-rotated-refresh"
     assert pool.entries() == []
     assert _disk_entries(auth_path) == []
 
@@ -601,11 +631,13 @@ def test_post_cas_lineage_mutation_cannot_write_or_return_stale_refresh(
 
     assert not selector.is_alive()
     assert errors == []
-    assert source["writes"] == []
+    assert source["writes"] == [
+        ("obsolete-access", "obsolete-refresh", 9_999_999_999_999)
+    ]
     if expected is None:
         assert results == [None]
         assert pool.entries() == []
-        assert source["credentials"]["refreshToken"] == "old-refresh"
+        assert source["credentials"]["refreshToken"] == "obsolete-refresh"
     else:
         assert len(results) == 1 and results[0] is not None
         assert _tokens(results[0]) == _tokens(expected)
@@ -644,19 +676,18 @@ def test_source_lineage_change_after_commit_read_wins_before_write(
 
     commit_read = threading.Event()
     allow_commit = threading.Event()
-    reads = 0
-    real_sync = pool._sync_anthropic_entry_from_credentials_file
+    real_write_locked = anthropic_adapter._write_claude_code_credentials_locked
 
-    def pause_after_commit_read(entry, *, persist=True):
-        nonlocal reads
-        result = real_sync(entry, persist=persist)
-        reads += 1
-        if reads == 2:
-            commit_read.set()
-            assert allow_commit.wait(timeout=5)
-        return result
+    def pause_at_commit_boundary(*args, **kwargs):
+        commit_read.set()
+        assert allow_commit.wait(timeout=5)
+        return real_write_locked(*args, **kwargs)
 
-    pool._sync_anthropic_entry_from_credentials_file = pause_after_commit_read
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_write_claude_code_credentials_locked",
+        pause_at_commit_boundary,
+    )
     results = []
     selector = threading.Thread(target=lambda: results.append(pool.select()))
     selector.start()

--- a/tests/agent/test_credential_pool_lease_refresh_reselect.py
+++ b/tests/agent/test_credential_pool_lease_refresh_reselect.py
@@ -35,6 +35,7 @@ def _bare_pool(entries):
     """Minimal pool shell — avoids disk/keyring I/O in __init__."""
     pool = CredentialPool.__new__(CredentialPool)
     pool._lock = threading.RLock()
+    pool._external_state_lock = threading.Lock()
     pool._entries = list(entries)
     pool._active_leases = {}
     pool._current_id = None

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -18,6 +18,7 @@ mocking the save boundary, so they exercise the actual atomic write path.
 
 import json
 import threading
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,7 @@ from agent.credential_pool import (
     CredentialPool,
     PooledCredential,
 )
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 from hermes_cli import auth as A
 
 
@@ -232,6 +234,242 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     assert refreshed.refresh_token == "rotated-refresh"
     # The invariant: the single-use token POST ran inside the auth-store lock.
     assert lock_held["during_post"] is True
+
+
+def test_codex_pool_refresh_serializes_borrowed_root_chain_across_profiles(
+    monkeypatch, tmp_path
+):
+    """Profiles borrowing one root grant must serialize on the root store."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_paths = [
+        root_home / "profiles" / "alpha" / "auth.json",
+        root_home / "profiles" / "beta" / "auth.json",
+    ]
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "active_provider": "openrouter",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "root-old-access",
+                        "refresh_token": "root-old-refresh",
+                    },
+                    "last_refresh": "2026-08-01T00:00:00Z",
+                    "auth_mode": "chatgpt",
+                },
+                "anthropic": {"api_key": "root-unrelated-provider"},
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "root-codex",
+                        "label": "root singleton",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "root-old-access",
+                        "refresh_token": "root-old-refresh",
+                    },
+                    {
+                        "id": "independent-codex",
+                        "label": "independent account",
+                        "source": "manual:device_code",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "access_token": "independent-access",
+                        "refresh_token": "independent-refresh",
+                        "last_status": "exhausted",
+                        "last_error_code": 429,
+                    },
+                ],
+                "openrouter": [{"id": "root-unrelated-pool"}],
+            },
+            "root_marker": {"preserve": True},
+        },
+    )
+    for index, profile_path in enumerate(profile_paths):
+        _write_store(
+            profile_path,
+            {
+                "version": 1,
+                "active_provider": "anthropic",
+                "providers": {
+                    "anthropic": {"api_key": f"profile-{index}-provider"}
+                },
+                "credential_pool": {
+                    "anthropic": [{"id": f"profile-{index}-pool"}]
+                },
+                "profile_marker": index,
+            },
+        )
+    profile_before = {path: path.read_bytes() for path in profile_paths}
+
+    calls = []
+    calls_lock = threading.Lock()
+    second_post_entered = threading.Event()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        with calls_lock:
+            calls.append((access_token, refresh_token))
+            call_number = len(calls)
+        if call_number == 1:
+            # On the broken code the other profile owns a different lock and
+            # enters the second POST immediately. On fixed code it waits on
+            # the root lock, then adopts this rotated pair without POSTing.
+            second_post_entered.wait(timeout=1)
+        else:
+            second_post_entered.set()
+        return {
+            "access_token": "root-new-access",
+            "refresh_token": "root-new-refresh",
+            "last_refresh": "2026-08-06T00:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+
+    start = threading.Barrier(3)
+    results = []
+    errors = []
+
+    def refresh_from_profile(profile_path):
+        token = set_hermes_home_override(profile_path.parent)
+        try:
+            payload = A.read_credential_pool("openai-codex")[0]
+            entry = PooledCredential.from_dict("openai-codex", payload)
+            pool = CredentialPool("openai-codex", [entry])
+            start.wait(timeout=5)
+            results.append(pool._refresh_entry(entry, force=True))
+        except BaseException as exc:  # surfaced in the main test thread below
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    threads = [
+        threading.Thread(target=refresh_from_profile, args=(path,))
+        for path in profile_paths
+    ]
+    for thread in threads:
+        thread.start()
+    start.wait(timeout=5)
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+    assert calls == [("root-old-access", "root-old-refresh")]
+    assert len(results) == 2
+    assert {result.access_token for result in results if result is not None} == {
+        "root-new-access"
+    }
+    assert {result.refresh_token for result in results if result is not None} == {
+        "root-new-refresh"
+    }
+
+    root = _read_store(root_path)
+    assert root["active_provider"] == "openrouter"
+    assert root["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "root-new-access",
+        "refresh_token": "root-new-refresh",
+    }
+    root_pool = {
+        entry["id"]: entry for entry in root["credential_pool"]["openai-codex"]
+    }
+    assert root_pool["root-codex"]["access_token"] == "root-new-access"
+    assert root_pool["root-codex"]["refresh_token"] == "root-new-refresh"
+    assert root_pool["independent-codex"]["access_token"] == "independent-access"
+    assert root_pool["independent-codex"]["refresh_token"] == "independent-refresh"
+    assert root_pool["independent-codex"]["last_status"] == "exhausted"
+    assert root_pool["independent-codex"]["last_error_code"] == 429
+    assert root["providers"]["anthropic"] == {
+        "api_key": "root-unrelated-provider"
+    }
+    assert root["credential_pool"]["openrouter"] == [
+        {"id": "root-unrelated-pool"}
+    ]
+    assert root["root_marker"] == {"preserve": True}
+    for path in profile_paths:
+        assert path.read_bytes() == profile_before[path]
+
+
+def test_codex_pool_refresh_keeps_profile_owned_chain_local(monkeypatch, tmp_path):
+    profile_home = tmp_path / "profile"
+    profile_path = profile_home / "auth.json"
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "active_provider": "openrouter",
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": "profile-old-access",
+                        "refresh_token": "profile-old-refresh",
+                    }
+                },
+                "anthropic": {"api_key": "profile-unrelated"},
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "profile-codex",
+                        "source": "device_code",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "access_token": "profile-old-access",
+                        "refresh_token": "profile-old-refresh",
+                    }
+                ],
+                "openrouter": [{"id": "profile-unrelated-pool"}],
+            },
+            "profile_marker": {"preserve": True},
+        },
+    )
+
+    monkeypatch.setattr(
+        A,
+        "refresh_codex_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "profile-new-access",
+            "refresh_token": "profile-new-refresh",
+            "last_refresh": "2026-08-06T00:00:00Z",
+        },
+    )
+    payload = A.read_credential_pool("openai-codex")[0]
+    entry = PooledCredential.from_dict("openai-codex", payload)
+    refreshed = CredentialPool("openai-codex", [entry])._refresh_entry(
+        entry, force=True
+    )
+
+    assert refreshed is not None
+    assert refreshed.access_token == "profile-new-access"
+    stored = _read_store(profile_path)
+    assert stored["active_provider"] == "openrouter"
+    assert stored["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "profile-new-access",
+        "refresh_token": "profile-new-refresh",
+    }
+    assert stored["credential_pool"]["openai-codex"][0][
+        "access_token"
+    ] == "profile-new-access"
+    assert stored["credential_pool"]["openai-codex"][0][
+        "refresh_token"
+    ] == "profile-new-refresh"
+    assert stored["providers"]["anthropic"] == {
+        "api_key": "profile-unrelated"
+    }
+    assert stored["credential_pool"]["openrouter"] == [
+        {"id": "profile-unrelated-pool"}
+    ]
+    assert stored["profile_marker"] == {"preserve": True}
 
 
 def test_write_through_fires_on_every_refresh_not_just_first(

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -2026,6 +2026,23 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
         assert credentials["refreshToken"] == expected_refresh_token
         return write_credentials(access_token, refresh_token, expires_at_ms)
 
+    def refresh_source(observed):
+        refreshed = anthropic_adapter.refresh_anthropic_oauth_pure(
+            observed["refreshToken"],
+            use_json=False,
+        )
+        anthropic_adapter._write_claude_code_credentials_locked(
+            refreshed["access_token"],
+            refreshed["refresh_token"],
+            refreshed["expires_at_ms"],
+            expected_refresh_token=observed["refreshToken"],
+            allow_missing=False,
+        )
+        return {
+            **credentials,
+            "source": "claude_code_credentials_file",
+        }
+
     monkeypatch.setattr(
         anthropic_adapter,
         "read_claude_code_credentials",
@@ -2050,6 +2067,11 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
         anthropic_adapter,
         "_write_claude_code_credentials_locked",
         write_credentials_locked,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_refresh_claude_code_source_credentials",
+        refresh_source,
     )
     monkeypatch.setattr(CP, "write_credential_pool", recording_write)
 
@@ -2166,7 +2188,7 @@ def test_terminal_provider_cleanup_persists_removed_ids_outside_pool_lock(
     if provider == "xai-oauth":
         monkeypatch.setattr(A, "refresh_xai_oauth_pure", reject_refresh)
         monkeypatch.setattr(A, "_is_terminal_xai_oauth_refresh_error", lambda _exc: True)
-        expected_ids = {extra_removed.id, survivor.id}
+        expected_ids = {device.id, extra_removed.id, survivor.id}
     else:
         monkeypatch.setattr(A, "resolve_nous_runtime_credentials", reject_refresh)
         monkeypatch.setattr(A, "_is_terminal_nous_refresh_error", lambda _exc: True)
@@ -2186,8 +2208,11 @@ def test_terminal_provider_cleanup_persists_removed_ids_outside_pool_lock(
 
     assert not worker.is_alive()
     assert errors == []
-    assert write_lock_states
-    assert not any(write_lock_states)
+    if provider == "xai-oauth":
+        assert write_lock_states == []
+    else:
+        assert write_lock_states
+        assert not any(write_lock_states)
     assert {entry.id for entry in pool.entries()} == expected_ids
     persisted = _read_store(auth_path)["credential_pool"][provider]
     assert {entry["id"] for entry in persisted} == expected_ids
@@ -2937,7 +2962,8 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
             },
         )
 
-        def reject_claude_source_write(*_args, **_kwargs):
+        def reject_claude_source_write(_observed):
+            claude_credentials.clear()
             raise A.SourceCredentialPersistenceError(
                 "anthropic",
                 source_path=None,
@@ -2946,7 +2972,7 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
 
         monkeypatch.setattr(
             anthropic_adapter,
-            "_write_claude_code_credentials_locked",
+            "_refresh_claude_code_source_credentials",
             reject_claude_source_write,
         )
     elif provider == "xai-oauth":
@@ -2960,66 +2986,62 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
                 "last_refresh": "2026-08-06T05:00:00Z",
             },
         )
-        real_locked_save = A._save_provider_state_to_locked_source
+        real_save = A._save_auth_store
+        xai_saves = 0
 
-        def reject_xai_source_write(auth_store, provider_id, state, source_path, **kwargs):
-            if provider_id == "xai-oauth":
-                raise OSError("simulated source persistence failure")
-            return real_locked_save(
-                auth_store,
-                provider_id,
-                state,
-                source_path,
-                **kwargs,
-            )
+        def reject_xai_source_write(store, target_path=None):
+            nonlocal xai_saves
+            if target_path is not None and A._same_path(Path(target_path), auth_path):
+                xai_saves += 1
+                if xai_saves > 1:
+                    raise OSError("simulated source persistence failure")
+            return real_save(store, target_path)
 
         monkeypatch.setattr(
             A,
-            "_save_provider_state_to_locked_source",
+            "_save_auth_store",
             reject_xai_source_write,
         )
     else:
         pool = CredentialPool(provider, [old])
-        nous_refreshed = False
-
-        def fake_nous_sync(entry, *, persist=True):
-            if not nous_refreshed:
-                return entry
-            return replace(
-                entry,
-                access_token="orphan-access",
-                refresh_token="orphan-refresh",
-                expires_at_ms=9_999_999_999_999,
-            )
 
         def fake_nous_refresh(**_kwargs):
-            nonlocal nous_refreshed
-            nous_refreshed = True
-            return {"api_key": "orphan-access"}
+            reserved = _read_store(auth_path)
+            reserved["providers"]["nous"] = {
+                A.SOURCE_REFRESH_RESERVATION_KEY: {"status": "reserved"},
+            }
+            for item in reserved["credential_pool"]["nous"]:
+                item.pop("access_token", None)
+                item.pop("refresh_token", None)
+                item["last_status"] = CP.STATUS_DEAD
+            _write_store(auth_path, reserved)
+            raise A.SourceCredentialPersistenceError(
+                "nous",
+                source_path=auth_path,
+                consumed_refresh_token="old-refresh",
+            )
 
         monkeypatch.setattr(
             A,
             "resolve_nous_runtime_credentials",
             fake_nous_refresh,
         )
-        pool._sync_nous_entry_from_auth_store = fake_nous_sync
-        pool._sync_device_code_entry_to_auth_store = lambda entry: False
 
     refreshed = pool._refresh_entry(old, force=True)
     reloaded = CP.load_pool(provider)
     source = "claude_code" if provider == "anthropic" else "device_code"
-    authoritative = next(
-        entry
-        for entry in reloaded.entries()
-        if entry.source == source
-    )
 
     assert refreshed is None
-    assert authoritative.access_token == "old-access"
-    assert authoritative.refresh_token == "old-refresh"
-    assert authoritative.last_status == CP.STATUS_DEAD
     assert reloaded.has_available() is False
     assert all(entry.access_token != "orphan-access" for entry in reloaded.entries())
+    if provider in {"anthropic", "nous"}:
+        assert all(entry.source != source for entry in reloaded.entries())
+    else:
+        source_entries = [
+            entry for entry in reloaded.entries() if entry.source == source
+        ]
+        assert all(entry.refresh_token != "old-refresh" for entry in source_entries)
+        assert all(entry.last_status == CP.STATUS_DEAD for entry in source_entries)
 
     if provider == "anthropic":
         claude_credentials.update(

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -17,7 +17,9 @@ mocking the save boundary, so they exercise the actual atomic write path.
 """
 
 import json
+import multiprocessing
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -54,6 +56,79 @@ def _entry(provider: str, *, id: str, access_token: str, refresh_token: str):
     )
 
 
+def _root_codex_store(*, access_token="root-old-access", refresh_token="root-old-refresh"):
+    return {
+        "version": 1,
+        "active_provider": "openrouter",
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "last_refresh": "2026-08-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+            "anthropic": {"api_key": "root-unrelated-provider"},
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": "root-device",
+                    "label": "root singleton",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                {
+                    "id": "root-independent",
+                    "label": "root independent",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "priority": 1,
+                    "access_token": "root-independent-access",
+                    "refresh_token": "root-independent-refresh",
+                    "last_status": "exhausted",
+                    "last_error_code": 429,
+                },
+            ],
+            "openrouter": [{"id": "root-unrelated-pool"}],
+        },
+        "root_marker": {"preserve": True},
+    }
+
+
+def _profile_codex_store(marker: str):
+    return {
+        "version": 1,
+        "active_provider": "anthropic",
+        "providers": {
+            "anthropic": {"api_key": f"profile-{marker}-provider"},
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": f"profile-{marker}-manual",
+                    "label": f"profile {marker} manual",
+                    "source": "manual:device_code",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "access_token": f"profile-{marker}-access",
+                    "refresh_token": f"profile-{marker}-refresh",
+                    "last_status": "exhausted",
+                    "last_status_at": "2026-08-01T00:00:00+00:00",
+                    "last_error_code": 429,
+                    "last_error_reason": "usage_limit",
+                }
+            ],
+            "anthropic": [{"id": f"profile-{marker}-unrelated"}],
+        },
+        "profile_marker": marker,
+    }
+
+
 @pytest.fixture
 def profile_and_root(tmp_path, monkeypatch):
     """Wire a profile auth store + a distinct global-root auth store on disk.
@@ -70,6 +145,340 @@ def profile_and_root(tmp_path, monkeypatch):
     monkeypatch.setattr(A, "_global_auth_file_path", lambda: root_path)
     monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
     return profile_path, root_path
+
+
+def test_load_pool_borrows_root_alias_without_persisting_profile_shadow(
+    profile_and_root,
+):
+    """A non-empty manual profile pool must not fork the root singleton."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _root_codex_store())
+    _write_store(profile_path, _profile_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+
+    pool = CP.load_pool("openai-codex")
+
+    entries = pool.entries()
+    borrowed = [entry for entry in entries if entry.source == "device_code"]
+    manual = [entry for entry in entries if entry.source == "manual:device_code"]
+    assert [entry.id for entry in borrowed] == ["root-device"]
+    assert [entry.id for entry in manual] == ["profile-work-manual"]
+    assert manual[0].last_status == "exhausted"
+    assert manual[0].last_error_code == 429
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_borrowed_root_alias_status_routes_to_owner_without_profile_shadow(
+    profile_and_root,
+):
+    """Borrowed status persists at the root while the profile keeps only manual rows."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _root_codex_store())
+    _write_store(profile_path, _profile_codex_store("work"))
+    pool = CP.load_pool("openai-codex")
+    borrowed = next(item for item in pool.entries() if item.id == "root-device")
+    assert borrowed.source_store_path == root_path
+
+    pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id="root-device",
+        failure_reason="rate_limit",
+    )
+
+    root = _read_store(root_path)
+    root_alias = next(
+        item
+        for item in root["credential_pool"]["openai-codex"]
+        if item.get("id") == "root-device"
+    )
+    assert root_alias["last_status"] == "exhausted"
+    assert root_alias["last_error_code"] == 429
+    profile = _read_store(profile_path)
+    assert [
+        item["id"] for item in profile["credential_pool"]["openai-codex"]
+    ] == ["profile-work-manual"]
+
+
+def test_load_pool_refresh_serializes_root_source_across_processes(
+    monkeypatch, tmp_path
+):
+    """Two real profile pools share one root lock, chain, and alias identity."""
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires fork so patched fake refresh stays network-free")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_paths = [
+        root_home / "profiles" / "alpha" / "auth.json",
+        root_home / "profiles" / "beta" / "auth.json",
+    ]
+    _write_store(root_path, _root_codex_store())
+    for marker, profile_path in zip(("alpha", "beta"), profile_paths):
+        _write_store(profile_path, _profile_codex_store(marker))
+    profile_before = {path: path.read_bytes() for path in profile_paths}
+
+    ctx = multiprocessing.get_context("fork")
+    start = ctx.Event()
+    post_entered = ctx.Event()
+    allow_post_return = ctx.Event()
+    post_count = ctx.Value("i", 0)
+    reports = ctx.Queue()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        assert access_token == "root-old-access"
+        assert refresh_token == "root-old-refresh"
+        with post_count.get_lock():
+            post_count.value += 1
+        post_entered.set()
+        assert allow_post_return.wait(timeout=5)
+        return {
+            "access_token": "root-new-access",
+            "refresh_token": "root-new-refresh",
+            "last_refresh": "2026-08-06T00:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+
+    def refresh_from_profile(profile_path):
+        token = set_hermes_home_override(profile_path.parent)
+        try:
+            pool = CP.load_pool("openai-codex")
+            entry = next(item for item in pool.entries() if item.source == "device_code")
+            reports.put(("loaded", profile_path.name, entry.id))
+            assert start.wait(timeout=5)
+            refreshed = pool._refresh_entry(entry, force=True)
+            reports.put(
+                (
+                    "result",
+                    profile_path.name,
+                    refreshed.id if refreshed else None,
+                    refreshed.access_token if refreshed else None,
+                    refreshed.refresh_token if refreshed else None,
+                )
+            )
+        except BaseException as exc:
+            reports.put(("error", profile_path.name, repr(exc)))
+        finally:
+            reset_hermes_home_override(token)
+
+    processes = [
+        ctx.Process(
+            target=refresh_from_profile,
+            args=(profile_path,),
+            name=f"codex-profile-{index}",
+        )
+        for index, profile_path in enumerate(profile_paths)
+    ]
+    for process in processes:
+        process.start()
+
+    loaded = [reports.get(timeout=5), reports.get(timeout=5)]
+    assert all(report[0] == "loaded" for report in loaded), loaded
+    start.set()
+    assert post_entered.wait(timeout=5)
+    allow_post_return.set()
+    results = [reports.get(timeout=5), reports.get(timeout=5)]
+    for process in processes:
+        process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in processes)
+    assert all(report[0] == "result" for report in results), results
+    assert {report[2] for report in loaded} == {"root-device"}
+    assert post_count.value == 1
+    assert {report[2] for report in results} == {"root-device"}
+    assert {report[3] for report in results} == {"root-new-access"}
+    assert {report[4] for report in results} == {"root-new-refresh"}
+
+    root = _read_store(root_path)
+    assert root["active_provider"] == "openrouter"
+    assert root["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "root-new-access",
+        "refresh_token": "root-new-refresh",
+    }
+    root_entries = {
+        entry["id"]: entry for entry in root["credential_pool"]["openai-codex"]
+    }
+    assert root_entries["root-device"]["access_token"] == "root-new-access"
+    assert root_entries["root-device"]["refresh_token"] == "root-new-refresh"
+    assert root_entries["root-independent"]["access_token"] == (
+        "root-independent-access"
+    )
+    assert root_entries["root-independent"]["last_status"] == "exhausted"
+    assert root_entries["root-independent"]["last_error_code"] == 429
+    for path in profile_paths:
+        assert path.read_bytes() == profile_before[path]
+
+
+def test_load_pool_terminal_refresh_quarantines_only_root_source(
+    profile_and_root, monkeypatch
+):
+    """Terminal refresh failure clears the root chain without a profile alias."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _root_codex_store())
+    _write_store(profile_path, _profile_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+    post_count = 0
+
+    def reject_refresh(*_args, **_kwargs):
+        nonlocal post_count
+        post_count += 1
+        raise A.AuthError(
+            "fake invalid grant",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", reject_refresh)
+    pool = CP.load_pool("openai-codex")
+    entry = next(item for item in pool.entries() if item.source == "device_code")
+
+    assert pool._refresh_entry(entry, force=True) is None
+    assert post_count == 1
+    assert all(item.source != "device_code" for item in pool.entries())
+
+    root = _read_store(root_path)
+    root_tokens = root["providers"]["openai-codex"]["tokens"]
+    assert "access_token" not in root_tokens
+    assert "refresh_token" not in root_tokens
+    assert all(
+        item.get("source") != "device_code"
+        for item in root["credential_pool"]["openai-codex"]
+    )
+    assert any(
+        item.get("id") == "root-independent"
+        for item in root["credential_pool"]["openai-codex"]
+    )
+    assert profile_path.read_bytes() == profile_before
+
+    monkeypatch.setattr(A, "_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    root_pool = CP.load_pool("openai-codex")
+    assert all(item.source != "device_code" for item in root_pool.entries())
+    assert post_count == 1
+
+
+def test_load_pool_waiter_treats_removed_root_source_as_revoked(
+    monkeypatch, tmp_path
+):
+    """A waiter must not refresh stale memory after its owning chain is removed."""
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires fork so patched fake refresh stays network-free")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_path = root_home / "profiles" / "waiter" / "auth.json"
+    _write_store(root_path, _root_codex_store())
+    _write_store(profile_path, _profile_codex_store("waiter"))
+    profile_before = profile_path.read_bytes()
+
+    ctx = multiprocessing.get_context("fork")
+    refresh_start = ctx.Event()
+    source_lock_held = ctx.Event()
+    waiter_attempting_source_lock = ctx.Event()
+    post_count = ctx.Value("i", 0)
+    reports = ctx.Queue()
+    real_auth_lock = A._auth_store_lock
+
+    @contextmanager
+    def tracking_auth_lock(*args, **kwargs):
+        target_path = kwargs.get("target_path")
+        if (
+            multiprocessing.current_process().name == "codex-revocation-waiter"
+            and target_path is not None
+            and A._same_path(target_path, root_path)
+        ):
+            waiter_attempting_source_lock.set()
+        with real_auth_lock(*args, **kwargs):
+            yield
+
+    monkeypatch.setattr(A, "_auth_store_lock", tracking_auth_lock)
+
+    def fake_refresh(*_args, **_kwargs):
+        with post_count.get_lock():
+            post_count.value += 1
+        return {
+            "access_token": "must-not-be-used-access",
+            "refresh_token": "must-not-be-used-refresh",
+            "last_refresh": "2026-08-06T00:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+
+    def wait_then_refresh():
+        token = set_hermes_home_override(profile_path.parent)
+        try:
+            pool = CP.load_pool("openai-codex")
+            entry = next(item for item in pool.entries() if item.source == "device_code")
+            reports.put(("loaded", entry.id))
+            assert refresh_start.wait(timeout=5)
+            refreshed = pool._refresh_entry(entry, force=True)
+            usable_device_entries = [
+                item.id
+                for item in pool.entries()
+                if item.source == "device_code" and item.access_token
+            ]
+            reports.put(
+                (
+                    "result",
+                    refreshed.id if refreshed else None,
+                    usable_device_entries,
+                )
+            )
+        except BaseException as exc:
+            reports.put(("error", repr(exc)))
+        finally:
+            reset_hermes_home_override(token)
+
+    def remove_source_while_holding_lock():
+        with A._auth_store_lock(target_path=root_path):
+            source_lock_held.set()
+            assert waiter_attempting_source_lock.wait(timeout=5)
+            store = A._load_auth_store(root_path)
+            store["providers"].pop("openai-codex", None)
+            entries = store["credential_pool"]["openai-codex"]
+            store["credential_pool"]["openai-codex"] = [
+                item for item in entries if item.get("source") != "device_code"
+            ]
+            A._save_auth_store(store, target_path=root_path)
+
+    waiter = ctx.Process(
+        target=wait_then_refresh,
+        name="codex-revocation-waiter",
+    )
+    owner = ctx.Process(
+        target=remove_source_while_holding_lock,
+        name="codex-revocation-owner",
+    )
+    waiter.start()
+    loaded = reports.get(timeout=5)
+    assert loaded[0] == "loaded", loaded
+    owner.start()
+    assert source_lock_held.wait(timeout=5)
+    refresh_start.set()
+
+    result = reports.get(timeout=5)
+    waiter.join(timeout=5)
+    owner.join(timeout=5)
+
+    assert waiter.exitcode == 0
+    assert owner.exitcode == 0
+    assert result == ("result", None, [])
+    assert post_count.value == 0
+    assert loaded == ("loaded", "root-device")
+    root = _read_store(root_path)
+    assert "openai-codex" not in root["providers"]
+    assert all(
+        item.get("source") != "device_code"
+        for item in root["credential_pool"]["openai-codex"]
+    )
+    assert profile_path.read_bytes() == profile_before
 
 
 
@@ -187,6 +596,30 @@ def test_codex_pool_refresh_holds_auth_store_lock_across_post(monkeypatch, tmp_p
     monkeypatch.setattr(A, "_auth_file_path", lambda: profile_path)
     monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
     monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    _write_store(
+        profile_path,
+        {
+            "version": 1,
+            "providers": {
+                provider: {
+                    "tokens": {
+                        "access_token": "stale-access",
+                        "refresh_token": "stale-refresh",
+                    }
+                }
+            },
+            "credential_pool": {
+                provider: [
+                    {
+                        "id": "codex-1",
+                        "source": "device_code",
+                        "access_token": "stale-access",
+                        "refresh_token": "stale-refresh",
+                    }
+                ]
+            },
+        },
+    )
 
     lock_held: dict = {"during_post": None}
     real_lock = A._auth_store_lock
@@ -341,9 +774,10 @@ def test_codex_pool_refresh_serializes_borrowed_root_chain_across_profiles(
     def refresh_from_profile(profile_path):
         token = set_hermes_home_override(profile_path.parent)
         try:
-            payload = A.read_credential_pool("openai-codex")[0]
-            entry = PooledCredential.from_dict("openai-codex", payload)
-            pool = CredentialPool("openai-codex", [entry])
+            pool = CP.load_pool("openai-codex")
+            entry = next(
+                item for item in pool.entries() if item.source == "device_code"
+            )
             start.wait(timeout=5)
             results.append(pool._refresh_entry(entry, force=True))
         except BaseException as exc:  # surfaced in the main test thread below
@@ -502,14 +936,8 @@ def test_write_through_fires_on_every_refresh_not_just_first(
     )
 
     provider = "openai-codex"
-    # After patching A's module-level attributes, the bare-name imports in
-    # credential_pool.py still hold references to the original functions
-    # (``from X import Y`` creates a local binding that does not update when
-    # ``X.Y`` is reassigned).  Patch CP's bindings separately so the
-    # ``_sync_device_code_entry_to_auth_store`` method — whose __globals__
-    # are ``agent.credential_pool.__dict__`` — sees the mocked paths.
-    monkeypatch.setattr(CP, "_global_auth_file_path", lambda: root_path)
-    monkeypatch.setattr(CP, "_same_path", lambda a, b: a == b)
+    # Patch only the runtime auth-module bindings. credential_pool must resolve
+    # source paths through that binding instead of a stale direct import.
     # Let _write_through_provider_state_to_global_root run for real so it
     # persists the rotated token pair to the root auth.json — the test
     # asserts the on-disk values after each refresh.

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -849,8 +849,12 @@ def test_terminal_singleton_quarantine_removes_only_matching_device_aliases(
     "operation",
     ["status", "reset", "rotation", "selection", "persistence"],
 )
+@pytest.mark.parametrize(
+    "source_removal",
+    ["alias_only", "provider_and_alias"],
+)
 def test_removed_source_revokes_cached_borrower_on_every_pool_path(
-    profile_and_root, operation
+    profile_and_root, operation, source_removal
 ):
     """A cached root row cannot survive once its exact owning source is gone."""
     profile_path, root_path = profile_and_root
@@ -877,7 +881,8 @@ def test_removed_source_revokes_cached_borrower_on_every_pool_path(
     assert cached.source_store_path == root_path
 
     removed = _read_store(root_path)
-    removed["providers"].pop("openai-codex")
+    if source_removal == "provider_and_alias":
+        removed["providers"].pop("openai-codex")
     removed["credential_pool"]["openai-codex"] = [
         item
         for item in removed["credential_pool"]["openai-codex"]
@@ -1036,9 +1041,9 @@ def test_provider_only_removal_revokes_cached_singleton_but_keeps_root_manual(
 
     assert post_count == 0
     assert "root-device" not in {item.id for item in pool.entries()}
-    if operation in {"current", "lease", "refresh"}:
+    if operation in {"current", "lease", "refresh", "rotation"}:
         assert result is None
-    elif operation in {"rotation", "select", "peek"}:
+    elif operation in {"select", "peek"}:
         assert result is not None
         assert result.id == "root-independent"
 
@@ -1325,6 +1330,506 @@ def test_source_validation_failure_fails_borrowed_selection_closed(
     assert result is None
     assert root_path.read_bytes() == root_before
     assert profile_path.read_bytes() == profile_before
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "status",
+        "reset",
+        "rotation",
+        "select",
+        "current",
+        "peek",
+        "lease",
+        "refresh",
+        "persistence",
+    ],
+)
+def test_load_time_provider_removal_never_reclassifies_singleton_as_pool_owned(
+    profile_and_root, monkeypatch, operation
+):
+    """Owner kind comes from the hydrated row, not a later unlocked reread."""
+    profile_path, root_path = profile_and_root
+    root_store = _root_codex_store()
+    root_store["credential_pool"]["openai-codex"] = [
+        root_store["credential_pool"]["openai-codex"][0]
+    ]
+    if operation == "reset":
+        root_store["credential_pool"]["openai-codex"][0].update(
+            {
+                "last_status": "exhausted",
+                "last_status_at": 1.0,
+                "last_error_code": 429,
+            }
+        )
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("load-race"))
+    profile_before = profile_path.read_bytes()
+
+    real_init = CredentialPool.__init__
+    provider_removed = threading.Event()
+
+    def init_then_remove_provider(self, provider, entries):
+        real_init(self, provider, entries)
+        if provider != "openai-codex":
+            return
+        source = _read_store(root_path)
+        source["providers"].pop("openai-codex")
+        _write_store(root_path, source)
+        provider_removed.set()
+
+    monkeypatch.setattr(CredentialPool, "__init__", init_then_remove_provider)
+    post_calls = []
+
+    def unexpected_post(access_token, refresh_token, **_kwargs):
+        post_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "must-not-be-used-access",
+            "refresh_token": "must-not-be-used-refresh",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", unexpected_post)
+    pool = CP.load_pool("openai-codex")
+    assert provider_removed.is_set()
+    cached = next(item for item in pool.entries() if item.id == "root-device")
+    if operation == "current":
+        pool._current_id = cached.id
+    root_after_removal = root_path.read_bytes()
+
+    result = None
+    if operation == "status":
+        pool._mark_exhausted(cached, 429)
+    elif operation == "reset":
+        pool.reset_statuses()
+    elif operation == "rotation":
+        result = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="root-device",
+        )
+    elif operation == "select":
+        result = pool.select()
+    elif operation == "current":
+        result = pool.current()
+    elif operation == "peek":
+        result = pool.peek()
+    elif operation == "lease":
+        result = pool.acquire_lease("root-device")
+    elif operation == "refresh":
+        result = pool._refresh_entry(cached, force=True)
+    else:
+        pool.add_entry(
+            PooledCredential(
+                provider="openai-codex",
+                id="profile-load-race-added",
+                label="profile load race added",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=99,
+                source="manual:device_code",
+                access_token="profile-load-race-access",
+                refresh_token="profile-load-race-refresh",
+            )
+        )
+
+    assert result is None
+    assert post_calls == []
+    assert "root-device" not in {item.id for item in pool.entries()}
+    current = pool.current()
+    assert current is None or current.id != "root-device"
+    peeked = pool.peek()
+    assert peeked is None or peeked.id != "root-device"
+    assert pool.acquire_lease("root-device") is None
+    assert root_path.read_bytes() == root_after_removal
+    if operation == "persistence":
+        profile_ids = {
+            item["id"]
+            for item in _read_store(profile_path)["credential_pool"]["openai-codex"]
+        }
+        assert profile_ids == {"profile-load-race-added"}
+    else:
+        assert profile_path.read_bytes() == profile_before
+
+
+def test_unreadable_load_time_owner_classification_fails_singleton_closed(
+    profile_and_root, monkeypatch
+):
+    profile_path, root_path = profile_and_root
+    root_store = _root_codex_store()
+    root_store["credential_pool"]["openai-codex"] = [
+        root_store["credential_pool"]["openai-codex"][0]
+    ]
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("unreadable-kind"))
+    root_before = root_path.read_bytes()
+    profile_before = profile_path.read_bytes()
+
+    real_init = CredentialPool.__init__
+    fail_next_root_read = threading.Event()
+
+    def init_then_arm_unreadable_source(self, provider, entries):
+        real_init(self, provider, entries)
+        if provider == "openai-codex":
+            fail_next_root_read.set()
+
+    real_load = A._load_auth_store
+
+    def fail_one_root_read(path=None):
+        if (
+            fail_next_root_read.is_set()
+            and path is not None
+            and A._same_path(path, root_path)
+        ):
+            fail_next_root_read.clear()
+            raise RuntimeError("fake unreadable owner classification")
+        return real_load(path)
+
+    monkeypatch.setattr(CredentialPool, "__init__", init_then_arm_unreadable_source)
+    monkeypatch.setattr(A, "_load_auth_store", fail_one_root_read)
+
+    pool = CP.load_pool("openai-codex")
+    assert pool.select() is None
+    assert not fail_next_root_read.is_set()
+    assert root_path.read_bytes() == root_before
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_root_manual_row_remains_independently_pool_owned_without_singleton(
+    profile_and_root,
+):
+    profile_path, root_path = profile_and_root
+    root_store = _healthy_root_manual_store()
+    root_store["providers"].pop("openai-codex")
+    root_store["credential_pool"]["openai-codex"] = [
+        item
+        for item in root_store["credential_pool"]["openai-codex"]
+        if item["id"] == "root-independent"
+    ]
+    root_store["credential_pool"]["openai-codex"][0]["priority"] = 0
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("manual-control"))
+
+    pool = CP.load_pool("openai-codex")
+    manual = next(item for item in pool.entries() if item.id == "root-independent")
+    owner = pool._trusted_codex_source_owner(manual)
+    assert owner is not None
+    assert owner.owner_kind == "pool"
+    assert pool.select() == manual
+
+
+@pytest.mark.parametrize("operation", ["rotation", "refresh", "lease"])
+def test_exact_failed_source_id_never_falls_back_to_unrelated_survivors(
+    profile_and_root, monkeypatch, operation
+):
+    profile_path, root_path = profile_and_root
+    root_store = _root_codex_store()
+    root_store["credential_pool"]["openai-codex"] = [
+        root_store["credential_pool"]["openai-codex"][0]
+    ]
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("exact-failed"))
+    pool = CP.load_pool("openai-codex")
+    for suffix in ("a", "b"):
+        pool.add_entry(
+            PooledCredential(
+                provider="openai-codex",
+                id=f"local-{suffix}",
+                label=f"local {suffix}",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=99,
+                source="manual:device_code",
+                access_token=f"local-{suffix}-access",
+                refresh_token=f"local-{suffix}-refresh",
+            )
+        )
+    survivor_before = {
+        item.id: item
+        for item in pool.entries()
+        if item.id in {"local-a", "local-b"}
+    }
+
+    @contextmanager
+    def fail_validation(*_args, **_kwargs):
+        raise TimeoutError("fake source validation timeout")
+        yield
+
+    post_calls = []
+
+    def unexpected_post(access_token, refresh_token, **_kwargs):
+        post_calls.append((access_token, refresh_token))
+        return {
+            "access_token": "must-not-be-used-access",
+            "refresh_token": "must-not-be-used-refresh",
+        }
+
+    monkeypatch.setattr(A, "_provider_state_transaction", fail_validation)
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", unexpected_post)
+
+    if operation == "rotation":
+        result = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="root-device",
+        )
+    elif operation == "refresh":
+        result = pool.try_refresh_matching(credential_id="root-device")
+    else:
+        result = pool.acquire_lease("root-device")
+
+    assert result is None
+    assert post_calls == []
+    assert pool.current() is None
+    assert {
+        item.id: item
+        for item in pool.entries()
+        if item.id in {"local-a", "local-b"}
+    } == survivor_before
+
+
+def _local_pool_for_persistence_race(
+    tmp_path,
+    monkeypatch,
+    *,
+    initial_status=None,
+):
+    auth_path = tmp_path / "profile" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    entry = PooledCredential(
+        provider="openrouter",
+        id="local-entry",
+        label="local entry",
+        auth_type="api_key",
+        priority=0,
+        source="manual:api_key",
+        access_token="local-access",
+        last_status=initial_status,
+        last_status_at=1.0 if initial_status else None,
+        last_error_code=429 if initial_status else None,
+        last_error_reason="old_rate_limit" if initial_status else None,
+    )
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "credential_pool": {"openrouter": [entry.to_dict()]},
+        },
+    )
+    return auth_path, CredentialPool("openrouter", [entry])
+
+
+def _run_two_generation_persistence_race(
+    tmp_path,
+    monkeypatch,
+    *,
+    first_mutation,
+    initial_status=None,
+):
+    auth_path, pool = _local_pool_for_persistence_race(
+        tmp_path,
+        monkeypatch,
+        initial_status=initial_status,
+    )
+    first_write_entered = threading.Event()
+    allow_first_write = threading.Event()
+    newer_mutation_done = threading.Event()
+    writes = []
+    errors = []
+    real_write = CP.write_credential_pool
+
+    def paused_write(provider, entries, *, removed_ids=None):
+        writes.append(
+            {
+                "statuses": [entry.get("last_status") for entry in entries],
+                "reasons": [entry.get("last_error_reason") for entry in entries],
+                "removed_ids": list(removed_ids or []),
+            }
+        )
+        if len(writes) == 1:
+            first_write_entered.set()
+            assert allow_first_write.wait(timeout=5)
+        return real_write(provider, entries, removed_ids=removed_ids)
+
+    real_replace = pool._replace_entry
+
+    def tracked_replace(old, new, **kwargs):
+        result = real_replace(old, new, **kwargs)
+        if threading.current_thread().name == "newer-terminal-mutation":
+            newer_mutation_done.set()
+        return result
+
+    monkeypatch.setattr(CP, "write_credential_pool", paused_write)
+    pool._replace_entry = tracked_replace
+
+    def first_worker():
+        try:
+            if first_mutation == "reset":
+                assert pool.reset_statuses() == 1
+            else:
+                current = pool.entries()[0]
+                pool._mark_exhausted(
+                    current,
+                    429,
+                    {"reason": "rate_limit"},
+                )
+        except BaseException as exc:
+            errors.append(("first", exc))
+
+    def newer_worker():
+        try:
+            current = pool.entries()[0]
+            pool._mark_exhausted(
+                current,
+                401,
+                {"reason": "invalid_grant"},
+            )
+        except BaseException as exc:
+            errors.append(("newer", exc))
+
+    first = threading.Thread(target=first_worker, name="older-persistence")
+    newer = threading.Thread(target=newer_worker, name="newer-terminal-mutation")
+    first.start()
+    assert first_write_entered.wait(timeout=5)
+    assert pool._lock.acquire(timeout=1)
+    pool._lock.release()
+    newer.start()
+    assert newer_mutation_done.wait(timeout=5)
+    allow_first_write.set()
+    first.join(timeout=5)
+    newer.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not newer.is_alive()
+    assert errors == []
+    memory_entry = pool.entries()[0]
+    disk_entry = _read_store(auth_path)["credential_pool"]["openrouter"][0]
+    assert memory_entry.last_status == "dead"
+    assert memory_entry.last_error_reason == "invalid_grant"
+    assert disk_entry["last_status"] == "dead"
+    assert disk_entry["last_error_reason"] == "invalid_grant"
+    expected_first_status = None if first_mutation == "reset" else "exhausted"
+    expected_first_reason = None if first_mutation == "reset" else "rate_limit"
+    assert [write["statuses"] for write in writes] == [
+        [expected_first_status],
+        ["dead"],
+    ]
+    assert [write["reasons"] for write in writes] == [
+        [expected_first_reason],
+        ["invalid_grant"],
+    ]
+    pool._persist_pending_changes()
+    assert len(writes) == 2
+
+
+def test_reset_snapshot_cannot_clear_newer_terminal_dirty_generation(
+    tmp_path, monkeypatch
+):
+    _run_two_generation_persistence_race(
+        tmp_path,
+        monkeypatch,
+        first_mutation="reset",
+        initial_status="exhausted",
+    )
+
+
+def test_cooldown_snapshot_cannot_clear_newer_terminal_dirty_generation(
+    tmp_path, monkeypatch
+):
+    _run_two_generation_persistence_race(
+        tmp_path,
+        monkeypatch,
+        first_mutation="cooldown",
+    )
+
+
+def test_removal_persistence_converges_after_same_id_readd(
+    tmp_path, monkeypatch
+):
+    auth_path, pool = _local_pool_for_persistence_race(tmp_path, monkeypatch)
+    first_write_entered = threading.Event()
+    allow_first_write = threading.Event()
+    readd_mutated = threading.Event()
+    writes = []
+    errors = []
+    real_write = CP.write_credential_pool
+    real_pending = pool._persist_pending_changes
+
+    def paused_write(provider, entries, *, removed_ids=None):
+        writes.append(
+            {
+                "ids": [entry.get("id") for entry in entries],
+                "tokens": [entry.get("access_token") for entry in entries],
+                "removed_ids": list(removed_ids or []),
+            }
+        )
+        if len(writes) == 1:
+            first_write_entered.set()
+            assert allow_first_write.wait(timeout=5)
+        return real_write(provider, entries, removed_ids=removed_ids)
+
+    def tracked_pending():
+        if threading.current_thread().name == "same-id-readd":
+            readd_mutated.set()
+        return real_pending()
+
+    monkeypatch.setattr(CP, "write_credential_pool", paused_write)
+    pool._persist_pending_changes = tracked_pending
+
+    def remove_worker():
+        try:
+            removed = pool.remove_index(1)
+            assert removed is not None
+            assert removed.id == "local-entry"
+        except BaseException as exc:
+            errors.append(("remove", exc))
+
+    def readd_worker():
+        try:
+            pool.add_entry(
+                PooledCredential(
+                    provider="openrouter",
+                    id="local-entry",
+                    label="replacement entry",
+                    auth_type="api_key",
+                    priority=0,
+                    source="manual:api_key",
+                    access_token="replacement-access",
+                )
+            )
+        except BaseException as exc:
+            errors.append(("readd", exc))
+
+    remover = threading.Thread(target=remove_worker, name="remove-entry")
+    readd = threading.Thread(target=readd_worker, name="same-id-readd")
+    remover.start()
+    assert first_write_entered.wait(timeout=5)
+    assert pool._lock.acquire(timeout=1)
+    pool._lock.release()
+    readd.start()
+    assert readd_mutated.wait(timeout=5)
+    allow_first_write.set()
+    remover.join(timeout=5)
+    readd.join(timeout=5)
+
+    assert not remover.is_alive()
+    assert not readd.is_alive()
+    assert errors == []
+    memory_entries = pool.entries()
+    assert [(entry.id, entry.access_token) for entry in memory_entries] == [
+        ("local-entry", "replacement-access")
+    ]
+    disk_entries = _read_store(auth_path)["credential_pool"]["openrouter"]
+    assert [(entry["id"], entry["access_token"]) for entry in disk_entries] == [
+        ("local-entry", "replacement-access")
+    ]
+    assert writes == [
+        {"ids": [], "tokens": [], "removed_ids": ["local-entry"]},
+        {
+            "ids": ["local-entry"],
+            "tokens": ["replacement-access"],
+            "removed_ids": [],
+        },
+    ]
+    pool._persist_pending_changes()
+    assert len(writes) == 2
 
 
 @pytest.mark.parametrize("construction", ["direct", "replace_then_add"])

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 import pytest
 
+from agent import anthropic_adapter
 from agent import credential_pool as CP
 from agent.credential_pool import (
     AUTH_TYPE_OAUTH,
@@ -1973,14 +1974,15 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
     auth_path, pool = _anthropic_pool_for_lock_order_test(tmp_path, monkeypatch)
     io_lock_states = []
     real_write = CP.write_credential_pool
+    credentials = {
+        "accessToken": "fresh-access",
+        "refreshToken": "fresh-refresh",
+        "expiresAt": 9_999_999_999_999,
+    }
 
     def fresh_credentials():
         io_lock_states.append(("credentials_read", _pool_lock_owned_by_current_thread(pool)))
-        return {
-            "accessToken": "fresh-access",
-            "refreshToken": "fresh-refresh",
-            "expiresAt": 9_999_999_999_999,
-        }
+        return dict(credentials)
 
     def recording_write(provider, entries, *, removed_ids=None):
         io_lock_states.append(("pool_write", _pool_lock_owned_by_current_thread(pool)))
@@ -2005,6 +2007,12 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
             "rotated-refresh",
             9_999_999_999_999,
         )
+        credentials.update(
+            accessToken=access_token,
+            refreshToken=refresh_token,
+            expiresAt=expires_at_ms,
+        )
+        return True
 
     monkeypatch.setattr(
         anthropic_adapter,
@@ -2055,6 +2063,20 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
     assert disk == memory
     assert pool._dirty_entry_ids == set()
     assert pool._pending_removed_entries == []
+    if operation == "refresh":
+        monkeypatch.setattr(
+            A,
+            "is_provider_explicitly_configured",
+            lambda provider: provider == "anthropic",
+        )
+        reloaded = next(
+            entry
+            for entry in CP.load_pool("anthropic").entries()
+            if entry.source == "claude_code"
+        )
+        assert reloaded.access_token == "rotated-access"
+        assert reloaded.refresh_token == "rotated-refresh"
+        assert reloaded.last_status == CP.STATUS_OK
 
 
 @pytest.mark.parametrize("provider", ["xai-oauth", "nous"])
@@ -2819,4 +2841,361 @@ def test_write_through_fires_on_every_refresh_not_just_first(
         "The old code self-disabled write-through here (#74339)"
     )
     assert root_tokens["refresh_token"] == "rf2"
+
+
+@pytest.mark.parametrize("provider", ["anthropic", "xai-oauth", "nous"])
+def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
+    tmp_path,
+    monkeypatch,
+    provider,
+):
+    auth_path = tmp_path / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+
+    old = replace(
+        _entry(
+            provider,
+            id=f"{provider}-source",
+            access_token="old-access",
+            refresh_token="old-refresh",
+        ),
+        expires_at_ms=1,
+        source="claude_code" if provider == "anthropic" else "device_code",
+    )
+    store = {
+        "version": 1,
+        "credential_pool": {provider: [old.to_dict()]},
+        "providers": {},
+    }
+    if provider == "xai-oauth":
+        store["providers"][provider] = {
+            "tokens": {
+                "access_token": "old-access",
+                "refresh_token": "old-refresh",
+            },
+            "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+        }
+    elif provider == "nous":
+        store["providers"][provider] = {
+            "access_token": "old-access",
+            "refresh_token": "old-refresh",
+            "expires_at": "2000-01-01T00:00:00+00:00",
+        }
+    _write_store(auth_path, store)
+
+    claude_credentials = {}
+    if provider == "anthropic":
+        claude_credentials.update({
+            "accessToken": "old-access",
+            "refreshToken": "old-refresh",
+            "expiresAt": 1,
+        })
+        monkeypatch.setattr(
+            anthropic_adapter,
+            "read_claude_code_credentials",
+            lambda: dict(claude_credentials),
+        )
+        pool = CredentialPool(provider, [old])
+        monkeypatch.setattr(
+            anthropic_adapter,
+            "refresh_anthropic_oauth_pure",
+            lambda *_args, **_kwargs: {
+                "access_token": "orphan-access",
+                "refresh_token": "orphan-refresh",
+                "expires_at_ms": 9_999_999_999_999,
+            },
+        )
+        monkeypatch.setattr(
+            anthropic_adapter,
+            "_write_claude_code_credentials",
+            lambda *_args, **_kwargs: False,
+        )
+    elif provider == "xai-oauth":
+        pool = CredentialPool(provider, [old])
+        monkeypatch.setattr(
+            A,
+            "refresh_xai_oauth_pure",
+            lambda *_args, **_kwargs: {
+                "access_token": "orphan-access",
+                "refresh_token": "orphan-refresh",
+                "last_refresh": "2026-08-06T05:00:00Z",
+            },
+        )
+        pool._sync_device_code_entry_to_auth_store = lambda entry: False
+    else:
+        pool = CredentialPool(provider, [old])
+        nous_refreshed = False
+
+        def fake_nous_sync(entry, *, persist=True):
+            if not nous_refreshed:
+                return entry
+            return replace(
+                entry,
+                access_token="orphan-access",
+                refresh_token="orphan-refresh",
+                expires_at_ms=9_999_999_999_999,
+            )
+
+        def fake_nous_refresh(**_kwargs):
+            nonlocal nous_refreshed
+            nous_refreshed = True
+            return {"api_key": "orphan-access"}
+
+        monkeypatch.setattr(
+            A,
+            "resolve_nous_runtime_credentials",
+            fake_nous_refresh,
+        )
+        pool._sync_nous_entry_from_auth_store = fake_nous_sync
+        pool._sync_device_code_entry_to_auth_store = lambda entry: False
+
+    refreshed = pool._refresh_entry(old, force=True)
+    reloaded = CP.load_pool(provider)
+    source = "claude_code" if provider == "anthropic" else "device_code"
+    authoritative = next(
+        entry
+        for entry in reloaded.entries()
+        if entry.source == source
+    )
+
+    assert refreshed is None
+    assert authoritative.access_token == "old-access"
+    assert authoritative.refresh_token == "old-refresh"
+    assert authoritative.last_status == CP.STATUS_DEAD
+    assert reloaded.has_available() is False
+    assert all(entry.access_token != "orphan-access" for entry in reloaded.entries())
+
+    if provider == "anthropic":
+        claude_credentials.update(
+            accessToken="owner-access",
+            refreshToken="owner-refresh",
+            expiresAt=9_999_999_999_999,
+        )
+        adopted = next(
+            entry
+            for entry in CP.load_pool(provider).entries()
+            if entry.source == "claude_code"
+        )
+        assert adopted.access_token == "owner-access"
+        assert adopted.refresh_token == "owner-refresh"
+        assert adopted.last_status is None
+
+
+def test_two_profile_xai_refreshes_lock_the_shared_global_source(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_paths = [
+        root_home / "profiles" / "alpha" / "auth.json",
+        root_home / "profiles" / "beta" / "auth.json",
+    ]
+    root_entry = replace(
+        _entry(
+            "xai-oauth",
+            id="root-xai",
+            access_token="root-old-access",
+            refresh_token="root-old-refresh",
+        ),
+        expires_at_ms=1,
+    )
+    _write_store(
+        root_path,
+        {
+            "version": 1,
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "root-old-access",
+                        "refresh_token": "root-old-refresh",
+                    },
+                    "discovery": {
+                        "token_endpoint": "https://auth.x.ai/oauth/token"
+                    },
+                }
+            },
+            "credential_pool": {"xai-oauth": [root_entry.to_dict()]},
+        },
+    )
+    for marker, profile_path in zip(("alpha", "beta"), profile_paths):
+        _write_store(
+            profile_path,
+            {
+                "version": 1,
+                "providers": {"anthropic": {"api_key": f"{marker}-key"}},
+                "credential_pool": {},
+            },
+        )
+
+    calls = []
+    calls_lock = threading.Lock()
+    second_post_entered = threading.Event()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        with calls_lock:
+            calls.append((access_token, refresh_token))
+            call_number = len(calls)
+        if call_number == 1:
+            second_post_entered.wait(timeout=1)
+        else:
+            second_post_entered.set()
+        return {
+            "access_token": "root-new-access",
+            "refresh_token": "root-new-refresh",
+            "last_refresh": "2026-08-06T06:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_refresh)
+    monkeypatch.setattr(
+        CredentialPool,
+        "_entry_needs_refresh",
+        lambda self, entry: (
+            self.provider == "xai-oauth"
+            and entry.access_token == "root-old-access"
+        ),
+    )
+    start = threading.Barrier(3)
+    results = []
+    errors = []
+
+    def select_from_profile(profile_path):
+        token = set_hermes_home_override(profile_path.parent)
+        try:
+            pool = CP.load_pool("xai-oauth")
+            start.wait(timeout=5)
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    selectors = [
+        threading.Thread(target=select_from_profile, args=(path,))
+        for path in profile_paths
+    ]
+    for selector in selectors:
+        selector.start()
+    start.wait(timeout=5)
+    for selector in selectors:
+        selector.join(timeout=5)
+
+    assert all(not selector.is_alive() for selector in selectors)
+    assert errors == []
+    assert calls == [("root-old-access", "root-old-refresh")]
+    assert len(results) == 2 and all(result is not None for result in results)
+    assert {result.access_token for result in results} == {"root-new-access"}
+    assert {result.refresh_token for result in results} == {"root-new-refresh"}
+    root = _read_store(root_path)
+    assert root["providers"]["xai-oauth"]["tokens"] == {
+        "access_token": "root-new-access",
+        "refresh_token": "root-new-refresh",
+    }
+
+
+def test_refresh_persistence_does_not_invert_auth_store_lock(
+    monkeypatch,
+    tmp_path,
+):
+    auth_path = tmp_path / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    entry = replace(
+        _entry(
+            "xai-oauth",
+            id="xai-source",
+            access_token="old-access",
+            refresh_token="old-refresh",
+        ),
+        expires_at_ms=1,
+    )
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "providers": {
+                "xai-oauth": {
+                    "tokens": {
+                        "access_token": "old-access",
+                        "refresh_token": "old-refresh",
+                    },
+                    "discovery": {
+                        "token_endpoint": "https://auth.x.ai/oauth/token"
+                    },
+                }
+            },
+            "credential_pool": {"xai-oauth": [entry.to_dict()]},
+        },
+    )
+    pool = CredentialPool("xai-oauth", [entry])
+    with pool._lock:
+        pool._record_entry_mutation_unlocked(entry.id, dirty=True)
+
+    post_entered = threading.Event()
+    persistence_has_lock = threading.Event()
+    allow_auth_attempt = threading.Event()
+    errors = []
+    results = []
+    real_write = CP.write_credential_pool
+
+    def fake_refresh(*_args, **_kwargs):
+        post_entered.set()
+        assert persistence_has_lock.wait(timeout=5)
+        allow_auth_attempt.set()
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "last_refresh": "2026-08-06T07:00:00Z",
+        }
+
+    def barrier_write(provider, entries, *, removed_ids=None):
+        if threading.current_thread().name == "persistence-owner":
+            persistence_has_lock.set()
+            assert allow_auth_attempt.wait(timeout=5)
+            with A._auth_store_lock(target_path=auth_path, timeout_seconds=1):
+                return real_write(provider, entries, removed_ids=removed_ids)
+        return real_write(provider, entries, removed_ids=removed_ids)
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_refresh)
+    monkeypatch.setattr(CP, "write_credential_pool", barrier_write)
+
+    def refresh_worker():
+        try:
+            results.append(pool._refresh_entry(entry, force=True))
+        except BaseException as exc:
+            errors.append(("refresh", exc))
+
+    def persistence_worker():
+        try:
+            pool._persist_pending_changes()
+        except BaseException as exc:
+            errors.append(("persistence", exc))
+
+    refresher = threading.Thread(target=refresh_worker, name="refresh-owner")
+    persister = threading.Thread(target=persistence_worker, name="persistence-owner")
+    refresher.start()
+    assert post_entered.wait(timeout=5)
+    persister.start()
+    refresher.join(timeout=5)
+    persister.join(timeout=5)
+
+    assert not refresher.is_alive()
+    assert not persister.is_alive()
+    assert errors == []
+    assert len(results) == 1 and results[0] is not None
+    assert results[0].access_token == "new-access"
+    stored = _read_store(auth_path)
+    assert stored["providers"]["xai-oauth"]["tokens"]["refresh_token"] == (
+        "new-refresh"
+    )
+    assert stored["credential_pool"]["xai-oauth"][0]["refresh_token"] == (
+        "new-refresh"
+    )
 

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -2014,9 +2014,26 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
         )
         return True
 
+    def write_credentials_locked(
+        access_token,
+        refresh_token,
+        expires_at_ms,
+        *,
+        expected_refresh_token,
+        allow_missing=False,
+    ):
+        del allow_missing
+        assert credentials["refreshToken"] == expected_refresh_token
+        return write_credentials(access_token, refresh_token, expires_at_ms)
+
     monkeypatch.setattr(
         anthropic_adapter,
         "read_claude_code_credentials",
+        fresh_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_read_claude_code_credentials_from_file",
         fresh_credentials,
     )
     monkeypatch.setattr(
@@ -2028,6 +2045,11 @@ def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
         anthropic_adapter,
         "_write_claude_code_credentials",
         write_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_write_claude_code_credentials_locked",
+        write_credentials_locked,
     )
     monkeypatch.setattr(CP, "write_credential_pool", recording_write)
 
@@ -2899,6 +2921,11 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
             "read_claude_code_credentials",
             lambda: dict(claude_credentials),
         )
+        monkeypatch.setattr(
+            anthropic_adapter,
+            "_read_claude_code_credentials_from_file",
+            lambda: dict(claude_credentials),
+        )
         pool = CredentialPool(provider, [old])
         monkeypatch.setattr(
             anthropic_adapter,
@@ -2909,10 +2936,18 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
                 "expires_at_ms": 9_999_999_999_999,
             },
         )
+
+        def reject_claude_source_write(*_args, **_kwargs):
+            raise A.SourceCredentialPersistenceError(
+                "anthropic",
+                source_path=None,
+                consumed_refresh_token="old-refresh",
+            )
+
         monkeypatch.setattr(
             anthropic_adapter,
-            "_write_claude_code_credentials",
-            lambda *_args, **_kwargs: False,
+            "_write_claude_code_credentials_locked",
+            reject_claude_source_write,
         )
     elif provider == "xai-oauth":
         pool = CredentialPool(provider, [old])
@@ -2925,7 +2960,24 @@ def test_source_write_failure_fails_refresh_closed_and_fresh_load_uses_source(
                 "last_refresh": "2026-08-06T05:00:00Z",
             },
         )
-        pool._sync_device_code_entry_to_auth_store = lambda entry: False
+        real_locked_save = A._save_provider_state_to_locked_source
+
+        def reject_xai_source_write(auth_store, provider_id, state, source_path, **kwargs):
+            if provider_id == "xai-oauth":
+                raise OSError("simulated source persistence failure")
+            return real_locked_save(
+                auth_store,
+                provider_id,
+                state,
+                source_path,
+                **kwargs,
+            )
+
+        monkeypatch.setattr(
+            A,
+            "_save_provider_state_to_locked_source",
+            reject_xai_source_write,
+        )
     else:
         pool = CredentialPool(provider, [old])
         nous_refreshed = False

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -20,6 +20,7 @@ import json
 import multiprocessing
 import threading
 from contextlib import contextmanager
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -938,6 +939,441 @@ def test_removed_source_revokes_cached_borrower_on_every_pool_path(
         for item in _read_store(root_path)["credential_pool"]["openai-codex"]
     }
     assert remaining_root_ids == {"root-independent"}
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "status",
+        "reset",
+        "rotation",
+        "select",
+        "current",
+        "peek",
+        "lease",
+        "refresh",
+        "persistence",
+    ],
+)
+def test_provider_only_removal_revokes_cached_singleton_but_keeps_root_manual(
+    profile_and_root, monkeypatch, operation
+):
+    """A borrowed singleton never downgrades to an independent root row."""
+    profile_path, root_path = profile_and_root
+    root_store = _healthy_root_manual_store()
+    if operation == "reset":
+        singleton = next(
+            item
+            for item in root_store["credential_pool"]["openai-codex"]
+            if item["id"] == "root-device"
+        )
+        singleton.update(
+            {
+                "last_status": "exhausted",
+                "last_status_at": "2026-08-06T03:00:00+00:00",
+                "last_error_code": 429,
+            }
+        )
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+
+    pool = CP.load_pool("openai-codex")
+    cached = next(item for item in pool.entries() if item.id == "root-device")
+    assert cached.source_store_path == root_path
+    if operation == "current":
+        pool._current_id = cached.id
+
+    removed = _read_store(root_path)
+    removed["providers"].pop("openai-codex")
+    _write_store(root_path, removed)
+    root_after_removal = root_path.read_bytes()
+    post_count = 0
+
+    def fake_refresh(*_args, **_kwargs):
+        nonlocal post_count
+        post_count += 1
+        return {
+            "access_token": "must-not-be-used-access",
+            "refresh_token": "must-not-be-used-refresh",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+
+    result = None
+    if operation == "status":
+        pool._mark_exhausted(cached, 429)
+    elif operation == "reset":
+        pool.reset_statuses()
+    elif operation == "rotation":
+        result = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="root-device",
+        )
+    elif operation == "select":
+        result = pool.select()
+    elif operation == "current":
+        result = pool.current()
+    elif operation == "peek":
+        result = pool.peek()
+    elif operation == "lease":
+        result = pool.acquire_lease("root-device")
+    elif operation == "refresh":
+        result = pool._refresh_entry(cached, force=True)
+    else:
+        pool.add_entry(
+            PooledCredential(
+                provider="openai-codex",
+                id="profile-work-added",
+                label="profile work added",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=99,
+                source="manual:device_code",
+                access_token="profile-work-added-access",
+                refresh_token="profile-work-added-refresh",
+            )
+        )
+
+    assert post_count == 0
+    assert "root-device" not in {item.id for item in pool.entries()}
+    if operation in {"current", "lease", "refresh"}:
+        assert result is None
+    elif operation in {"rotation", "select", "peek"}:
+        assert result is not None
+        assert result.id == "root-independent"
+
+    survivor = pool.select()
+    assert survivor is not None
+    assert survivor.id == "root-independent"
+    assert survivor.access_token == "root-independent-access"
+    assert root_path.read_bytes() == root_after_removal
+
+    if operation == "persistence":
+        profile_ids = {
+            item["id"]
+            for item in _read_store(profile_path)["credential_pool"]["openai-codex"]
+        }
+        assert profile_ids == {"profile-work-added"}
+    else:
+        assert profile_path.read_bytes() == profile_before
+
+
+def _run_refresh_overlap(
+    *,
+    profile_path,
+    root_path,
+    monkeypatch,
+    operation,
+    manual_only=False,
+):
+    root_store = _healthy_root_manual_store()
+    credential_id = "root-independent" if manual_only else "root-device"
+    old_access = (
+        "root-independent-access" if manual_only else "root-old-access"
+    )
+    old_refresh = (
+        "root-independent-refresh" if manual_only else "root-old-refresh"
+    )
+    if manual_only:
+        root_store["providers"].pop("openai-codex")
+        root_store["credential_pool"]["openai-codex"] = [
+            item
+            for item in root_store["credential_pool"]["openai-codex"]
+            if item["id"] == credential_id
+        ]
+        root_store["credential_pool"]["openai-codex"][0]["priority"] = 0
+    elif operation == "reset":
+        singleton = next(
+            item
+            for item in root_store["credential_pool"]["openai-codex"]
+            if item["id"] == credential_id
+        )
+        singleton.update(
+            {
+                "last_status": "exhausted",
+                "last_status_at": "2026-08-06T03:00:00+00:00",
+                "last_error_code": 429,
+            }
+        )
+
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("overlap"))
+    profile_before = profile_path.read_bytes()
+    pool = CP.load_pool("openai-codex")
+    cached = next(item for item in pool.entries() if item.id == credential_id)
+    if operation == "current":
+        pool._current_id = credential_id
+
+    post_entered = threading.Event()
+    allow_post_return = threading.Event()
+    operation_transaction_entered = threading.Event()
+    validation_timed_out = threading.Event()
+    refresh_done = threading.Event()
+    operation_done = threading.Event()
+    post_count = 0
+    results = {}
+    errors = []
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        nonlocal post_count
+        assert access_token == old_access
+        assert refresh_token == old_refresh
+        post_count += 1
+        post_entered.set()
+        assert allow_post_return.wait(timeout=3)
+        return {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "last_refresh": "2026-08-06T04:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+    real_transaction = A._provider_state_transaction
+    real_auth_lock = A._auth_store_lock
+
+    @contextmanager
+    def bounded_auth_lock(*args, **kwargs):
+        is_operation = threading.current_thread().name == "pool-operation"
+        if is_operation:
+            kwargs["timeout_seconds"] = 1.0
+        try:
+            with real_auth_lock(*args, **kwargs):
+                yield
+        except TimeoutError:
+            if is_operation:
+                validation_timed_out.set()
+            raise
+
+    monkeypatch.setattr(A, "_auth_store_lock", bounded_auth_lock)
+
+    @contextmanager
+    def tracked_transaction(*args, **kwargs):
+        is_operation = threading.current_thread().name == "pool-operation"
+        if is_operation:
+            operation_transaction_entered.set()
+            kwargs["timeout_seconds"] = 1.0
+        try:
+            with real_transaction(*args, **kwargs) as transaction:
+                yield transaction
+        except TimeoutError:
+            if is_operation:
+                validation_timed_out.set()
+            raise
+
+    monkeypatch.setattr(A, "_provider_state_transaction", tracked_transaction)
+
+    def refresh_worker():
+        try:
+            results["refresh"] = pool._refresh_entry(cached, force=True)
+        except BaseException as exc:
+            errors.append(("refresh", exc))
+        finally:
+            refresh_done.set()
+
+    def operation_worker():
+        try:
+            if operation == "select":
+                results["operation"] = pool.select()
+            elif operation == "peek":
+                results["operation"] = pool.peek()
+            elif operation == "current":
+                results["operation"] = pool.current()
+            elif operation == "lease":
+                results["lease_id"] = pool.acquire_lease(credential_id)
+                results["operation"] = pool.current()
+            elif operation == "rotation":
+                results["operation"] = pool.mark_exhausted_and_rotate(
+                    status_code=429,
+                    credential_id=credential_id,
+                )
+            elif operation == "status":
+                results["operation"] = pool._mark_exhausted(cached, 429)
+            elif operation == "reset":
+                results["operation"] = pool.reset_statuses()
+            else:
+                results["operation"] = pool.add_entry(
+                    PooledCredential(
+                        provider="openai-codex",
+                        id="profile-overlap-added",
+                        label="profile overlap added",
+                        auth_type=AUTH_TYPE_OAUTH,
+                        priority=99,
+                        source="manual:device_code",
+                        access_token="profile-overlap-access",
+                        refresh_token="profile-overlap-refresh",
+                    )
+                )
+        except BaseException as exc:
+            errors.append(("operation", exc))
+        finally:
+            operation_done.set()
+
+    refresher = threading.Thread(target=refresh_worker, name="pool-refresh")
+    operator = threading.Thread(target=operation_worker, name="pool-operation")
+    refresher.start()
+    assert post_entered.wait(timeout=3)
+    operator.start()
+    assert operation_transaction_entered.wait(timeout=3)
+    allow_post_return.set()
+    refresher.join(timeout=3)
+    operator.join(timeout=3)
+
+    assert refresh_done.is_set()
+    assert operation_done.is_set()
+    assert not refresher.is_alive()
+    assert not operator.is_alive()
+    assert not errors
+    assert not validation_timed_out.is_set()
+    assert post_count == 1
+    assert results["refresh"] is not None
+    assert results["refresh"].access_token == "rotated-access"
+
+    root_after = _read_store(root_path)
+    root_entry = next(
+        item
+        for item in root_after["credential_pool"]["openai-codex"]
+        if item["id"] == credential_id
+    )
+    assert root_entry["access_token"] == "rotated-access"
+    assert root_entry["refresh_token"] == "rotated-refresh"
+    in_memory = next(item for item in pool.entries() if item.id == credential_id)
+    assert in_memory.access_token == "rotated-access"
+    assert in_memory.refresh_token == "rotated-refresh"
+
+    if operation in {"select", "peek", "current", "lease"}:
+        assert results["operation"] is not None
+        assert results["operation"].id == credential_id
+        assert results["operation"].access_token == "rotated-access"
+    elif operation == "rotation":
+        assert results["operation"] is not None
+        assert results["operation"].id == "root-independent"
+
+    if operation == "persistence":
+        profile_ids = {
+            item["id"]
+            for item in _read_store(profile_path)["credential_pool"]["openai-codex"]
+        }
+        assert profile_ids == {"profile-overlap-added"}
+    else:
+        assert profile_path.read_bytes() == profile_before
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["select", "peek", "current", "lease", "rotation", "status", "reset", "persistence"],
+)
+def test_singleton_refresh_overlap_never_inverts_pool_and_auth_locks(
+    profile_and_root, monkeypatch, operation
+):
+    profile_path, root_path = profile_and_root
+    _run_refresh_overlap(
+        profile_path=profile_path,
+        root_path=root_path,
+        monkeypatch=monkeypatch,
+        operation=operation,
+    )
+
+
+def test_source_owned_manual_refresh_overlap_never_inverts_selection_lock(
+    profile_and_root, monkeypatch
+):
+    profile_path, root_path = profile_and_root
+    _run_refresh_overlap(
+        profile_path=profile_path,
+        root_path=root_path,
+        monkeypatch=monkeypatch,
+        operation="select",
+        manual_only=True,
+    )
+
+
+@pytest.mark.parametrize("failure", [TimeoutError, RuntimeError])
+@pytest.mark.parametrize("operation", ["select", "peek", "current", "lease", "rotation"])
+def test_source_validation_failure_fails_borrowed_selection_closed(
+    profile_and_root, monkeypatch, operation, failure
+):
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _healthy_root_manual_store())
+    _write_store(profile_path, _profile_without_codex_store("validation"))
+    profile_before = profile_path.read_bytes()
+    root_before = root_path.read_bytes()
+    pool = CP.load_pool("openai-codex")
+    if operation == "current":
+        pool._current_id = "root-device"
+
+    @contextmanager
+    def fail_validation(*_args, **_kwargs):
+        raise failure("fake source validation failure")
+        yield
+
+    monkeypatch.setattr(A, "_provider_state_transaction", fail_validation)
+
+    if operation == "select":
+        result = pool.select()
+    elif operation == "peek":
+        result = pool.peek()
+    elif operation == "current":
+        result = pool.current()
+    elif operation == "lease":
+        result = pool.acquire_lease("root-device")
+    else:
+        result = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="root-device",
+        )
+
+    assert result is None
+    assert root_path.read_bytes() == root_before
+    assert profile_path.read_bytes() == profile_before
+
+
+@pytest.mark.parametrize("construction", ["direct", "replace_then_add"])
+@pytest.mark.parametrize("target_kind", ["arbitrary", "known_global"])
+def test_untrusted_runtime_source_path_never_gains_owner_write_authority(
+    profile_and_root, construction, target_kind
+):
+    profile_path, root_path = profile_and_root
+    if target_kind == "arbitrary":
+        source_path = profile_path.parent / "arbitrary-owner" / "auth.json"
+        source_store = _healthy_root_manual_store()
+        source_store["credential_pool"]["openai-codex"] = [
+            item
+            for item in source_store["credential_pool"]["openai-codex"]
+            if item["id"] == "root-independent"
+        ]
+        _write_store(source_path, source_store)
+    else:
+        source_path = root_path
+        _write_store(source_path, _healthy_root_manual_store())
+    source_before = source_path.read_bytes()
+    _write_store(profile_path, _profile_without_codex_store("untrusted"))
+
+    untrusted = PooledCredential(
+        provider="openai-codex",
+        id="root-independent",
+        label="untrusted runtime path",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="manual:device_code",
+        access_token="root-independent-access",
+        refresh_token="root-independent-refresh",
+        source_store_path=source_path,
+    )
+    if construction == "direct":
+        pool = CredentialPool("openai-codex", [untrusted])
+        entry = untrusted
+    else:
+        pool = CredentialPool("openai-codex", [])
+        entry = pool.add_entry(replace(untrusted))
+
+    pool._mark_exhausted(entry, 429)
+
+    assert source_path.read_bytes() == source_before
+    persisted = _read_store(profile_path)["credential_pool"]["openai-codex"]
+    assert [item["id"] for item in persisted] == ["root-independent"]
+    assert persisted[0]["last_status"] == "exhausted"
+    assert persisted[0]["last_error_code"] == 429
+    assert "source_store_path" not in persisted[0]
 
 
 def test_load_pool_waiter_treats_removed_root_source_as_revoked(

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -1832,6 +1832,323 @@ def test_removal_persistence_converges_after_same_id_readd(
     assert len(writes) == 2
 
 
+def _pool_lock_owned_by_current_thread(pool):
+    is_owned = getattr(pool._lock, "_is_owned", None)
+    return bool(is_owned and is_owned())
+
+
+def _anthropic_pool_for_lock_order_test(tmp_path, monkeypatch):
+    auth_path = tmp_path / "profile" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    entry = PooledCredential(
+        provider="anthropic",
+        id="claude-entry",
+        label="Claude entry",
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source="claude_code",
+        access_token="stale-access",
+        refresh_token="stale-refresh",
+        expires_at_ms=9_999_999_999_999,
+        last_status="exhausted",
+        last_status_at=1.0,
+        last_error_code=429,
+        last_error_reason="rate_limit",
+    )
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "credential_pool": {"anthropic": [entry.to_dict()]},
+        },
+    )
+    return auth_path, CredentialPool("anthropic", [entry])
+
+
+def test_anthropic_status_sync_cannot_deadlock_with_concurrent_persistence(
+    tmp_path, monkeypatch
+):
+    """A real provider status sync must not oppose the persistence lock."""
+    from agent import anthropic_adapter
+
+    auth_path, pool = _anthropic_pool_for_lock_order_test(tmp_path, monkeypatch)
+    original = pool.entries()[0]
+    pool._replace_entry(original, replace(original, request_count=1))
+
+    status_sync_entered = threading.Event()
+    persist_lock_acquired = threading.Event()
+    raw_persist_lock = threading.Lock()
+    errors = []
+
+    class SignalingPersistLock:
+        def __enter__(self):
+            raw_persist_lock.acquire()
+            persist_lock_acquired.set()
+            return self
+
+        def __exit__(self, *_exc_info):
+            raw_persist_lock.release()
+
+    pool.__dict__["_persist_lock"] = SignalingPersistLock()
+
+    def controlled_credentials_read():
+        status_sync_entered.set()
+        assert persist_lock_acquired.wait(timeout=5)
+        return {
+            "accessToken": "fresh-access",
+            "refreshToken": "fresh-refresh",
+            "expiresAt": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_claude_code_credentials",
+        controlled_credentials_read,
+    )
+
+    def status_worker():
+        try:
+            assert pool.has_available() is True
+        except BaseException as exc:
+            errors.append(("status", exc))
+
+    def persistence_worker():
+        try:
+            assert status_sync_entered.wait(timeout=5)
+            pool._persist()
+        except BaseException as exc:
+            errors.append(("persistence", exc))
+
+    status_thread = threading.Thread(target=status_worker, daemon=True)
+    persistence_thread = threading.Thread(target=persistence_worker, daemon=True)
+    status_thread.start()
+    persistence_thread.start()
+    assert status_sync_entered.wait(timeout=5)
+    assert persist_lock_acquired.wait(timeout=5)
+    status_thread.join(timeout=0.5)
+    persistence_thread.join(timeout=0.5)
+
+    deadlock_reproduced = status_thread.is_alive() and persistence_thread.is_alive()
+    if status_thread.is_alive() or persistence_thread.is_alive():
+        if raw_persist_lock.locked():
+            raw_persist_lock.release()
+        status_thread.join(timeout=5)
+        persistence_thread.join(timeout=5)
+
+    assert not deadlock_reproduced, (
+        f"status_thread_alive={status_thread.is_alive()} "
+        f"persistence_thread_alive={persistence_thread.is_alive()}"
+    )
+    assert not status_thread.is_alive()
+    assert not persistence_thread.is_alive()
+    assert errors == []
+    memory = pool.entries()[0]
+    disk = _read_store(auth_path)["credential_pool"]["anthropic"][0]
+    assert memory.access_token == "fresh-access"
+    assert memory.refresh_token == "fresh-refresh"
+    assert memory.last_status is None
+    assert disk["last_status"] is None
+    assert disk["request_count"] == 1
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "has_available",
+        "next_available_at",
+        "peek",
+        "select",
+        "lease",
+        "rotation",
+        "refresh",
+        "status",
+    ],
+)
+def test_public_pool_mutations_drain_persistence_after_releasing_pool_lock(
+    tmp_path, monkeypatch, operation
+):
+    from agent import anthropic_adapter
+
+    auth_path, pool = _anthropic_pool_for_lock_order_test(tmp_path, monkeypatch)
+    io_lock_states = []
+    real_write = CP.write_credential_pool
+
+    def fresh_credentials():
+        io_lock_states.append(("credentials_read", _pool_lock_owned_by_current_thread(pool)))
+        return {
+            "accessToken": "fresh-access",
+            "refreshToken": "fresh-refresh",
+            "expiresAt": 9_999_999_999_999,
+        }
+
+    def recording_write(provider, entries, *, removed_ids=None):
+        io_lock_states.append(("pool_write", _pool_lock_owned_by_current_thread(pool)))
+        return real_write(provider, entries, removed_ids=removed_ids)
+
+    def refresh_credentials(refresh_token, *, use_json):
+        io_lock_states.append(("refresh", _pool_lock_owned_by_current_thread(pool)))
+        assert refresh_token == "fresh-refresh"
+        assert use_json is False
+        return {
+            "access_token": "rotated-access",
+            "refresh_token": "rotated-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    def write_credentials(access_token, refresh_token, expires_at_ms):
+        io_lock_states.append(
+            ("credentials_write", _pool_lock_owned_by_current_thread(pool))
+        )
+        assert (access_token, refresh_token, expires_at_ms) == (
+            "rotated-access",
+            "rotated-refresh",
+            9_999_999_999_999,
+        )
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "read_claude_code_credentials",
+        fresh_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        refresh_credentials,
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_write_claude_code_credentials",
+        write_credentials,
+    )
+    monkeypatch.setattr(CP, "write_credential_pool", recording_write)
+
+    if operation == "has_available":
+        assert pool.has_available() is True
+    elif operation == "next_available_at":
+        assert pool.next_available_at() is None
+    elif operation == "peek":
+        assert pool.peek() is not None
+    elif operation == "select":
+        assert pool.select() is not None
+    elif operation == "lease":
+        assert pool.acquire_lease() == "claude-entry"
+    elif operation == "rotation":
+        assert (
+            pool.mark_exhausted_and_rotate(
+                status_code=429,
+                credential_id="claude-entry",
+            )
+            is None
+        )
+    elif operation == "refresh":
+        refreshed = pool.try_refresh_matching(credential_id="claude-entry")
+        assert refreshed is not None
+        assert refreshed.access_token == "rotated-access"
+    else:
+        assert pool.reset_statuses() == 1
+
+    assert io_lock_states
+    assert [kind for kind, owned in io_lock_states if owned] == []
+    memory = [entry.to_dict() for entry in pool.entries()]
+    disk = _read_store(auth_path)["credential_pool"]["anthropic"]
+    assert disk == memory
+    assert pool._dirty_entry_ids == set()
+    assert pool._pending_removed_entries == []
+
+
+@pytest.mark.parametrize("provider", ["xai-oauth", "nous"])
+def test_terminal_provider_cleanup_persists_removed_ids_outside_pool_lock(
+    tmp_path, monkeypatch, provider
+):
+    auth_path = tmp_path / provider / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    device = _entry(
+        provider,
+        id=f"{provider}-device",
+        access_token="device-access",
+        refresh_token="device-refresh",
+    )
+    extra_removed = replace(
+        device,
+        id=f"{provider}-manual-device",
+        source="manual:device_code",
+        priority=1,
+        access_token="manual-device-access",
+        refresh_token="manual-device-refresh",
+    )
+    survivor = replace(
+        device,
+        id=f"{provider}-survivor",
+        source="manual:oauth",
+        priority=2,
+        access_token="survivor-access",
+        refresh_token="survivor-refresh",
+    )
+    entries = [device, extra_removed, survivor]
+    if provider == "xai-oauth":
+        provider_state = {
+            "tokens": {
+                "access_token": device.access_token,
+                "refresh_token": device.refresh_token,
+            }
+        }
+    else:
+        provider_state = {
+            "access_token": device.access_token,
+            "refresh_token": device.refresh_token,
+        }
+    _write_store(
+        auth_path,
+        {
+            "version": 1,
+            "providers": {provider: provider_state},
+            "credential_pool": {provider: [entry.to_dict() for entry in entries]},
+        },
+    )
+    pool = CredentialPool(provider, entries)
+    write_lock_states = []
+    real_write = CP.write_credential_pool
+
+    def recording_write(provider_name, persisted, *, removed_ids=None):
+        write_lock_states.append(_pool_lock_owned_by_current_thread(pool))
+        return real_write(provider_name, persisted, removed_ids=removed_ids)
+
+    def reject_refresh(*_args, **_kwargs):
+        raise RuntimeError("terminal refresh failure")
+
+    monkeypatch.setattr(CP, "write_credential_pool", recording_write)
+    if provider == "xai-oauth":
+        monkeypatch.setattr(A, "refresh_xai_oauth_pure", reject_refresh)
+        monkeypatch.setattr(A, "_is_terminal_xai_oauth_refresh_error", lambda _exc: True)
+        expected_ids = {extra_removed.id, survivor.id}
+    else:
+        monkeypatch.setattr(A, "resolve_nous_runtime_credentials", reject_refresh)
+        monkeypatch.setattr(A, "_is_terminal_nous_refresh_error", lambda _exc: True)
+        expected_ids = {survivor.id}
+
+    errors = []
+
+    def cleanup_worker():
+        try:
+            assert pool._refresh_entry(device, force=True) is None
+        except BaseException as exc:
+            errors.append(exc)
+
+    worker = threading.Thread(target=cleanup_worker, daemon=True)
+    worker.start()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert errors == []
+    assert write_lock_states
+    assert not any(write_lock_states)
+    assert {entry.id for entry in pool.entries()} == expected_ids
+    persisted = _read_store(auth_path)["credential_pool"][provider]
+    assert {entry["id"] for entry in persisted} == expected_ids
+
+
 @pytest.mark.parametrize("construction", ["direct", "replace_then_add"])
 @pytest.mark.parametrize("target_kind", ["arbitrary", "known_global"])
 def test_untrusted_runtime_source_path_never_gains_owner_write_authority(

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -129,6 +129,39 @@ def _profile_codex_store(marker: str):
     }
 
 
+def _profile_without_codex_store(marker: str):
+    return {
+        "version": 1,
+        "active_provider": "anthropic",
+        "providers": {
+            "anthropic": {"api_key": f"profile-{marker}-provider"},
+        },
+        "credential_pool": {
+            "anthropic": [{"id": f"profile-{marker}-unrelated"}],
+        },
+        "profile_marker": marker,
+    }
+
+
+def _healthy_root_manual_store():
+    store = _root_codex_store()
+    manual = next(
+        item
+        for item in store["credential_pool"]["openai-codex"]
+        if item["id"] == "root-independent"
+    )
+    for field in (
+        "last_status",
+        "last_status_at",
+        "last_error_code",
+        "last_error_reason",
+        "last_error_message",
+        "last_error_reset_at",
+    ):
+        manual.pop(field, None)
+    return store
+
+
 @pytest.fixture
 def profile_and_root(tmp_path, monkeypatch):
     """Wire a profile auth store + a distinct global-root auth store on disk.
@@ -176,12 +209,13 @@ def test_borrowed_root_alias_status_routes_to_owner_without_profile_shadow(
     _write_store(root_path, _root_codex_store())
     _write_store(profile_path, _profile_codex_store("work"))
     pool = CP.load_pool("openai-codex")
+    profile_before = profile_path.read_bytes()
     borrowed = next(item for item in pool.entries() if item.id == "root-device")
     assert borrowed.source_store_path == root_path
 
-    pool.mark_exhausted_and_rotate(
-        status_code=429,
-        credential_id="root-device",
+    pool._mark_exhausted(
+        borrowed,
+        429,
         failure_reason="rate_limit",
     )
 
@@ -197,6 +231,7 @@ def test_borrowed_root_alias_status_routes_to_owner_without_profile_shadow(
     assert [
         item["id"] for item in profile["credential_pool"]["openai-codex"]
     ] == ["profile-work-manual"]
+    assert profile_path.read_bytes() == profile_before
 
 
 def test_load_pool_refresh_serializes_root_source_across_processes(
@@ -312,6 +347,372 @@ def test_load_pool_refresh_serializes_root_source_across_processes(
         assert path.read_bytes() == profile_before[path]
 
 
+def test_root_manual_refresh_serializes_across_profile_processes(
+    monkeypatch, tmp_path
+):
+    """Every root-fallback Codex row keeps root ownership, not just singleton."""
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires fork so patched fake refresh stays network-free")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_paths = [
+        root_home / "profiles" / "alpha" / "auth.json",
+        root_home / "profiles" / "beta" / "auth.json",
+    ]
+    _write_store(root_path, _healthy_root_manual_store())
+    for marker, profile_path in zip(("alpha", "beta"), profile_paths):
+        _write_store(profile_path, _profile_without_codex_store(marker))
+    profile_before = {path: path.read_bytes() for path in profile_paths}
+
+    ctx = multiprocessing.get_context("fork")
+    start = ctx.Event()
+    second_post_entered = ctx.Event()
+    post_count = ctx.Value("i", 0)
+    reports = ctx.Queue()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        assert access_token == "root-independent-access"
+        assert refresh_token == "root-independent-refresh"
+        with post_count.get_lock():
+            post_count.value += 1
+            call_number = post_count.value
+        if call_number == 1:
+            second_post_entered.wait(timeout=1)
+        else:
+            second_post_entered.set()
+        return {
+            "access_token": "root-manual-new-access",
+            "refresh_token": "root-manual-new-refresh",
+            "last_refresh": "2026-08-06T01:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", fake_refresh)
+
+    def refresh_from_profile(profile_path):
+        token = set_hermes_home_override(profile_path.parent)
+        try:
+            pool = CP.load_pool("openai-codex")
+            entry = next(item for item in pool.entries() if item.id == "root-independent")
+            reports.put(
+                (
+                    "loaded",
+                    entry.id,
+                    str(entry.source_store_path) if entry.source_store_path else None,
+                )
+            )
+            assert start.wait(timeout=5)
+            refreshed = pool._refresh_entry(entry, force=True)
+            reports.put(
+                (
+                    "result",
+                    refreshed.id if refreshed else None,
+                    refreshed.access_token if refreshed else None,
+                    refreshed.refresh_token if refreshed else None,
+                )
+            )
+        except BaseException as exc:
+            reports.put(("error", repr(exc)))
+        finally:
+            reset_hermes_home_override(token)
+
+    processes = [
+        ctx.Process(target=refresh_from_profile, args=(path,))
+        for path in profile_paths
+    ]
+    for process in processes:
+        process.start()
+    loaded = [reports.get(timeout=5), reports.get(timeout=5)]
+    assert all(report[0] == "loaded" for report in loaded), loaded
+    start.set()
+    results = [reports.get(timeout=5), reports.get(timeout=5)]
+    for process in processes:
+        process.join(timeout=5)
+
+    assert all(process.exitcode == 0 for process in processes)
+    assert all(report[0] == "result" for report in results), results
+    assert {report[1] for report in loaded} == {"root-independent"}
+    assert {report[2] for report in loaded} == {str(root_path)}
+    assert post_count.value == 1
+    assert {report[1] for report in results} == {"root-independent"}
+    assert {report[2] for report in results} == {"root-manual-new-access"}
+    assert {report[3] for report in results} == {"root-manual-new-refresh"}
+
+    root = _read_store(root_path)
+    assert root["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "root-old-access",
+        "refresh_token": "root-old-refresh",
+    }
+    root_entries = {
+        item["id"]: item for item in root["credential_pool"]["openai-codex"]
+    }
+    assert root_entries["root-device"]["access_token"] == "root-old-access"
+    assert root_entries["root-device"]["refresh_token"] == "root-old-refresh"
+    assert root_entries["root-independent"]["access_token"] == (
+        "root-manual-new-access"
+    )
+    assert root_entries["root-independent"]["refresh_token"] == (
+        "root-manual-new-refresh"
+    )
+    for path in profile_paths:
+        assert path.read_bytes() == profile_before[path]
+
+
+def test_root_manual_waiter_adopts_rotated_exact_alias_without_post(
+    profile_and_root, monkeypatch
+):
+    """A stale borrower adopts the exact manual alias and leaves singleton alone."""
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _healthy_root_manual_store())
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+
+    pool = CP.load_pool("openai-codex")
+    stale = next(item for item in pool.entries() if item.id == "root-independent")
+    assert stale.source_store_path == root_path
+
+    root = _read_store(root_path)
+    exact = next(
+        item
+        for item in root["credential_pool"]["openai-codex"]
+        if item["id"] == "root-independent"
+    )
+    exact["access_token"] = "winner-access"
+    exact["refresh_token"] = "winner-refresh"
+    exact["last_refresh"] = "2026-08-06T02:00:00Z"
+    _write_store(root_path, root)
+
+    post_count = 0
+
+    def unexpected_post(*_args, **_kwargs):
+        nonlocal post_count
+        post_count += 1
+        raise AssertionError("waiter replayed the already-rotated refresh token")
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", unexpected_post)
+    refreshed = pool._refresh_entry(stale, force=True)
+
+    assert refreshed is not None
+    assert refreshed.id == "root-independent"
+    assert refreshed.access_token == "winner-access"
+    assert refreshed.refresh_token == "winner-refresh"
+    assert post_count == 0
+    root_after = _read_store(root_path)
+    assert root_after["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "root-old-access",
+        "refresh_token": "root-old-refresh",
+    }
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_root_manual_status_persists_exact_alias_without_profile_churn(
+    profile_and_root,
+):
+    profile_path, root_path = profile_and_root
+    _write_store(root_path, _healthy_root_manual_store())
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+    singleton_before = _read_store(root_path)["providers"]["openai-codex"]
+
+    pool = CP.load_pool("openai-codex")
+    rotated = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        error_context={"reason": "rate_limit", "message": "fake root manual limit"},
+        credential_id="root-independent",
+    )
+
+    assert rotated is not None
+    assert rotated.id == "root-device"
+    root_after = _read_store(root_path)
+    manual = next(
+        item
+        for item in root_after["credential_pool"]["openai-codex"]
+        if item["id"] == "root-independent"
+    )
+    assert manual["last_status"] == "exhausted"
+    assert manual["last_error_code"] == 429
+    assert manual["last_error_reason"] == "rate_limit"
+    assert root_after["providers"]["openai-codex"] == singleton_before
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_root_manual_terminal_refresh_removes_only_exact_alias(
+    profile_and_root, monkeypatch
+):
+    profile_path, root_path = profile_and_root
+    root_store = _healthy_root_manual_store()
+    root_store["credential_pool"]["openai-codex"].append(
+        {
+            "id": "root-manual-survivor",
+            "label": "independent manual survivor",
+            "source": "manual:device_code",
+            "auth_type": "oauth",
+            "priority": 2,
+            "access_token": "manual-survivor-access",
+            "refresh_token": "manual-survivor-refresh",
+        }
+    )
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+    singleton_before = _read_store(root_path)["providers"]["openai-codex"]
+
+    def reject_refresh(*_args, **_kwargs):
+        raise A.AuthError(
+            "fake invalid grant",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", reject_refresh)
+    pool = CP.load_pool("openai-codex")
+    target = next(item for item in pool.entries() if item.id == "root-independent")
+    assert pool._refresh_entry(target, force=True) is None
+
+    root_after = _read_store(root_path)
+    root_ids = {
+        item["id"]
+        for item in root_after["credential_pool"]["openai-codex"]
+    }
+    assert "root-independent" not in root_ids
+    assert {"root-device", "root-manual-survivor"} <= root_ids
+    assert root_after["providers"]["openai-codex"] == singleton_before
+    assert profile_path.read_bytes() == profile_before
+
+    reloaded = CP.load_pool("openai-codex")
+    reloaded_ids = {item.id for item in reloaded.entries()}
+    assert "root-independent" not in reloaded_ids
+    assert {"root-device", "root-manual-survivor"} <= reloaded_ids
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_context", "expected_status"),
+    [
+        (429, {"reason": "rate_limit"}, "exhausted"),
+        (401, {"reason": "invalid_grant"}, "dead"),
+    ],
+)
+def test_stale_profile_local_write_preserves_newer_root_status(
+    monkeypatch,
+    tmp_path,
+    status_code,
+    error_context,
+    expected_status,
+):
+    """A stale borrower changing only local rows cannot rewrite root metadata."""
+    if "fork" not in multiprocessing.get_all_start_methods():
+        pytest.skip("requires fork for deterministic stale-process coverage")
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "not-the-root"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_a = root_home / "profiles" / "alpha" / "auth.json"
+    profile_b = root_home / "profiles" / "beta" / "auth.json"
+    _write_store(root_path, _healthy_root_manual_store())
+    _write_store(profile_a, _profile_without_codex_store("alpha"))
+    _write_store(profile_b, _profile_without_codex_store("beta"))
+    profile_a_before = profile_a.read_bytes()
+
+    ctx = multiprocessing.get_context("fork")
+    loaded = ctx.Event()
+    allow_local_write = ctx.Event()
+    reports = ctx.Queue()
+
+    def stale_profile_writer():
+        token = set_hermes_home_override(profile_b.parent)
+        try:
+            pool = CP.load_pool("openai-codex")
+            root_entry = next(item for item in pool.entries() if item.id == "root-device")
+            reports.put(
+                (
+                    "loaded",
+                    root_entry.last_status,
+                    str(root_entry.source_store_path)
+                    if root_entry.source_store_path
+                    else None,
+                )
+            )
+            loaded.set()
+            assert allow_local_write.wait(timeout=5)
+            pool.add_entry(
+                PooledCredential(
+                    provider="openai-codex",
+                    id="profile-beta-added",
+                    label="profile beta added",
+                    auth_type=AUTH_TYPE_OAUTH,
+                    priority=99,
+                    source="manual:device_code",
+                    access_token="profile-beta-access",
+                    refresh_token="profile-beta-refresh",
+                )
+            )
+            reports.put(("written", [item.id for item in pool.entries()]))
+        except BaseException as exc:
+            reports.put(("error", repr(exc)))
+        finally:
+            reset_hermes_home_override(token)
+
+    writer = ctx.Process(target=stale_profile_writer)
+    writer.start()
+    assert loaded.wait(timeout=5)
+    loaded_report = reports.get(timeout=5)
+    assert loaded_report == ("loaded", None, str(root_path))
+
+    token = set_hermes_home_override(profile_a.parent)
+    try:
+        owner_pool = CP.load_pool("openai-codex")
+        owner_pool.mark_exhausted_and_rotate(
+            status_code=status_code,
+            error_context=error_context,
+            credential_id="root-device",
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    marked_root = _read_store(root_path)
+    marked_alias = next(
+        item
+        for item in marked_root["credential_pool"]["openai-codex"]
+        if item["id"] == "root-device"
+    )
+    assert marked_alias["last_status"] == expected_status
+    marked_at = marked_alias["last_status_at"]
+
+    allow_local_write.set()
+    written_report = reports.get(timeout=5)
+    writer.join(timeout=5)
+    assert writer.exitcode == 0
+    assert written_report[0] == "written", written_report
+
+    root_after = _read_store(root_path)
+    root_alias = next(
+        item
+        for item in root_after["credential_pool"]["openai-codex"]
+        if item["id"] == "root-device"
+    )
+    assert root_alias["last_status"] == expected_status
+    assert root_alias["last_status_at"] == marked_at
+    root_manual = next(
+        item
+        for item in root_after["credential_pool"]["openai-codex"]
+        if item["id"] == "root-independent"
+    )
+    assert root_manual["access_token"] == "root-independent-access"
+    assert root_manual["refresh_token"] == "root-independent-refresh"
+    profile_b_ids = {
+        item["id"]
+        for item in _read_store(profile_b)["credential_pool"]["openai-codex"]
+    }
+    assert profile_b_ids == {"profile-beta-added"}
+    assert profile_a.read_bytes() == profile_a_before
+
+
 def test_load_pool_terminal_refresh_quarantines_only_root_source(
     profile_and_root, monkeypatch
 ):
@@ -359,6 +760,184 @@ def test_load_pool_terminal_refresh_quarantines_only_root_source(
     root_pool = CP.load_pool("openai-codex")
     assert all(item.source != "device_code" for item in root_pool.entries())
     assert post_count == 1
+
+
+def test_terminal_singleton_quarantine_removes_only_matching_device_aliases(
+    profile_and_root, monkeypatch
+):
+    """Duplicate aliases on one dead chain disappear; independent rows survive."""
+    profile_path, root_path = profile_and_root
+    root_store = _healthy_root_manual_store()
+    root_store["credential_pool"]["openai-codex"].extend(
+        [
+            {
+                "id": "root-device-duplicate",
+                "label": "duplicate singleton alias",
+                "source": "device_code",
+                "auth_type": "oauth",
+                "priority": 2,
+                "access_token": "root-old-access",
+                "refresh_token": "root-old-refresh",
+            },
+            {
+                "id": "root-device-unrelated",
+                "label": "different device chain",
+                "source": "device_code",
+                "auth_type": "oauth",
+                "priority": 3,
+                "access_token": "different-access",
+                "refresh_token": "different-refresh",
+            },
+            {
+                "id": "root-manual-same-chain",
+                "label": "manual row sharing token literals",
+                "source": "manual:device_code",
+                "auth_type": "oauth",
+                "priority": 4,
+                "access_token": "root-old-access",
+                "refresh_token": "root-old-refresh",
+            },
+        ]
+    )
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+
+    def reject_refresh(*_args, **_kwargs):
+        raise A.AuthError(
+            "fake invalid grant",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(A, "refresh_codex_oauth_pure", reject_refresh)
+    pool = CP.load_pool("openai-codex")
+    selected = next(item for item in pool.entries() if item.id == "root-device")
+
+    assert pool._refresh_entry(selected, force=True) is None
+
+    root_after = _read_store(root_path)
+    remaining_ids = {
+        item["id"]
+        for item in root_after["credential_pool"]["openai-codex"]
+    }
+    assert "root-device" not in remaining_ids
+    assert "root-device-duplicate" not in remaining_ids
+    assert {
+        "root-device-unrelated",
+        "root-independent",
+        "root-manual-same-chain",
+    } <= remaining_ids
+    assert profile_path.read_bytes() == profile_before
+
+    monkeypatch.setattr(A, "_auth_file_path", lambda: root_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    root_pool = CP.load_pool("openai-codex")
+    reloaded_ids = {item.id for item in root_pool.entries()}
+    assert "root-device" not in reloaded_ids
+    assert "root-device-duplicate" not in reloaded_ids
+    assert {
+        "root-device-unrelated",
+        "root-independent",
+        "root-manual-same-chain",
+    } <= reloaded_ids
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ["status", "reset", "rotation", "selection", "persistence"],
+)
+def test_removed_source_revokes_cached_borrower_on_every_pool_path(
+    profile_and_root, operation
+):
+    """A cached root row cannot survive once its exact owning source is gone."""
+    profile_path, root_path = profile_and_root
+    root_store = _healthy_root_manual_store()
+    if operation == "reset":
+        root_device = next(
+            item
+            for item in root_store["credential_pool"]["openai-codex"]
+            if item["id"] == "root-device"
+        )
+        root_device.update(
+            {
+                "last_status": "exhausted",
+                "last_status_at": "2026-08-06T03:00:00+00:00",
+                "last_error_code": 429,
+            }
+        )
+    _write_store(root_path, root_store)
+    _write_store(profile_path, _profile_without_codex_store("work"))
+    profile_before = profile_path.read_bytes()
+
+    pool = CP.load_pool("openai-codex")
+    cached = next(item for item in pool.entries() if item.id == "root-device")
+    assert cached.source_store_path == root_path
+
+    removed = _read_store(root_path)
+    removed["providers"].pop("openai-codex")
+    removed["credential_pool"]["openai-codex"] = [
+        item
+        for item in removed["credential_pool"]["openai-codex"]
+        if item["id"] != "root-device"
+    ]
+    _write_store(root_path, removed)
+    root_after_removal = root_path.read_bytes()
+
+    selected = None
+    if operation == "status":
+        pool._mark_exhausted(cached, 429)
+    elif operation == "reset":
+        pool.reset_statuses()
+    elif operation == "rotation":
+        selected = pool.mark_exhausted_and_rotate(
+            status_code=429,
+            credential_id="root-device",
+        )
+    elif operation == "selection":
+        selected = pool.select()
+    else:
+        pool.add_entry(
+            PooledCredential(
+                provider="openai-codex",
+                id="profile-work-added",
+                label="profile work added",
+                auth_type=AUTH_TYPE_OAUTH,
+                priority=99,
+                source="manual:device_code",
+                access_token="profile-work-added-access",
+                refresh_token="profile-work-added-refresh",
+            )
+        )
+
+    assert "root-device" not in {item.id for item in pool.entries()}
+    current = pool.current()
+    assert current is None or current.id != "root-device"
+    peeked = pool.peek()
+    assert peeked is None or peeked.id != "root-device"
+    assert pool.acquire_lease("root-device") is None
+    if selected is not None:
+        assert selected.id == "root-independent"
+    assert root_path.read_bytes() == root_after_removal
+
+    profile_after = _read_store(profile_path)
+    profile_ids = {
+        item["id"]
+        for item in profile_after.get("credential_pool", {}).get(
+            "openai-codex", []
+        )
+    }
+    if operation == "persistence":
+        assert profile_ids == {"profile-work-added"}
+    else:
+        assert profile_path.read_bytes() == profile_before
+
+    remaining_root_ids = {
+        item["id"]
+        for item in _read_store(root_path)["credential_pool"]["openai-codex"]
+    }
+    assert remaining_root_ids == {"root-independent"}
 
 
 def test_load_pool_waiter_treats_removed_root_source_as_revoked(

--- a/tests/agent/test_refresh_source_reservations.py
+++ b/tests/agent/test_refresh_source_reservations.py
@@ -1,0 +1,1262 @@
+"""Schedules for durable reservation of rotating source credentials."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import threading
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+from agent import anthropic_adapter
+from agent import credential_pool as CP
+from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+from hermes_cli import auth as A
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+_RESERVATION_KEY = "_oauth_refresh_reservation"
+
+
+def _assert_non_secret_reservation(
+    metadata: dict[str, Any],
+    *secrets: str,
+) -> None:
+    encoded = json.dumps(metadata, sort_keys=True)
+    assert metadata["status"] == "reserved"
+    assert metadata["nonce"]
+    assert metadata["owner_fingerprint"].startswith("sha256:")
+    assert metadata["refresh_fingerprint"].startswith("sha256:")
+    assert all(secret not in encoded for secret in secrets)
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jwt(*, seconds: int, scope: str | None = None) -> str:
+    claims: dict[str, Any] = {"sub": "test-user", "exp": int(time.time() + seconds)}
+    if scope is not None:
+        claims["scope"] = scope
+
+    def encode(value: dict[str, Any]) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(claims)}.signature"
+
+
+def _pool_entry(
+    provider: str,
+    *,
+    entry_id: str,
+    access_token: str,
+    refresh_token: str,
+    source: str = "device_code",
+    expires_at_ms: int | None = 1,
+) -> PooledCredential:
+    return PooledCredential(
+        provider=provider,
+        id=entry_id,
+        label=entry_id,
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at_ms=expires_at_ms,
+    )
+
+
+def _xai_store(
+    access_token: str,
+    refresh_token: str,
+    *,
+    entry_id: str = "xai-source",
+) -> dict[str, Any]:
+    entry = _pool_entry(
+        "xai-oauth",
+        entry_id=entry_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+    return {
+        "version": 1,
+        "providers": {
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+                "auth_mode": "oauth_device_code",
+            }
+        },
+        "credential_pool": {"xai-oauth": [entry.to_dict()]},
+    }
+
+
+def _nous_entry(access_token: str, refresh_token: str) -> PooledCredential:
+    expires_at = datetime.fromtimestamp(
+        time.time() + 3600,
+        tz=timezone.utc,
+    ).isoformat()
+    return replace(
+        _pool_entry(
+            "nous",
+            entry_id="nous-source",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            expires_at_ms=None,
+        ),
+        expires_at=expires_at,
+        agent_key=access_token,
+        agent_key_expires_at=expires_at,
+        inference_base_url=A.DEFAULT_NOUS_INFERENCE_URL,
+        extra={
+            "scope": A.DEFAULT_NOUS_SCOPE,
+            "client_id": A.DEFAULT_NOUS_CLIENT_ID,
+            "portal_base_url": A.DEFAULT_NOUS_PORTAL_URL,
+        },
+    )
+
+
+def _nous_store(access_token: str, refresh_token: str) -> dict[str, Any]:
+    entry = _nous_entry(access_token, refresh_token)
+    return {
+        "version": 1,
+        "providers": {
+            "nous": {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "expires_at": entry.expires_at,
+                "scope": A.DEFAULT_NOUS_SCOPE,
+                "portal_base_url": A.DEFAULT_NOUS_PORTAL_URL,
+                "inference_base_url": A.DEFAULT_NOUS_INFERENCE_URL,
+                "client_id": A.DEFAULT_NOUS_CLIENT_ID,
+                "agent_key": access_token,
+                "agent_key_expires_at": entry.agent_key_expires_at,
+            }
+        },
+        "credential_pool": {"nous": [entry.to_dict()]},
+    }
+
+
+def _write_claude_credentials(
+    path: Path,
+    *,
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+) -> None:
+    _write_json(
+        path,
+        {
+            "claudeAiOauth": {
+                "accessToken": access_token,
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at_ms,
+                "scopes": ["user:inference"],
+            },
+            "unrelated": {"preserved": True},
+        },
+    )
+
+
+def _configure_profiles(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path]:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+    shared = tmp_path / "shared"
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared))
+    return tmp_path / ".hermes", shared
+
+
+def _configure_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+
+
+def _install_xai_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    same_access: bool = False,
+) -> tuple[list[tuple[str, str]], threading.Event, threading.Event, threading.Event]:
+    calls: list[tuple[str, str]] = []
+    calls_lock = threading.Lock()
+    first_post = threading.Event()
+    second_post = threading.Event()
+    release_post = threading.Event()
+
+    def fake_refresh(access_token: str, refresh_token: str, **_kwargs: Any) -> dict[str, Any]:
+        with calls_lock:
+            calls.append((access_token, refresh_token))
+            call_number = len(calls)
+        (first_post if call_number == 1 else second_post).set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": access_token if same_access else _jwt(seconds=86_400),
+            "refresh_token": f"winner-refresh-{call_number}",
+            "last_refresh": "2026-08-06T12:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_refresh)
+    return calls, first_post, second_post, release_post
+
+
+def _join_threads(workers: list[threading.Thread]) -> None:
+    for worker in workers:
+        worker.join(timeout=5)
+    assert all(not worker.is_alive() for worker in workers)
+
+
+def _install_nous_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    new_access: str,
+    new_refresh: str,
+    entered: threading.Event | None = None,
+    release: threading.Event | None = None,
+    fail_after_enter: bool = False,
+) -> list[str]:
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.headers["x-nous-refresh-token"])
+        if entered is not None:
+            entered.set()
+        if release is not None:
+            assert release.wait(timeout=5)
+        if fail_after_enter:
+            raise httpx.ConnectError("simulated interrupted exchange", request=request)
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "access_token": new_access,
+                "refresh_token": new_refresh,
+                "expires_in": 7200,
+                "token_type": "Bearer",
+                "scope": A.DEFAULT_NOUS_SCOPE,
+                "inference_base_url": A.DEFAULT_NOUS_INFERENCE_URL,
+            },
+        )
+
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        return real_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(A.httpx, "Client", client_factory)
+    monkeypatch.setattr(A, "_read_shared_nous_state", lambda: None)
+    monkeypatch.setattr(A, "_write_shared_nous_state", lambda _state: None)
+    return requests
+
+
+def test_forced_xai_runtime_waiter_adopts_rotated_root_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    root_path = root_home / "auth.json"
+    homes = [root_home / "profiles" / name for name in ("one", "two")]
+    old_access = _jwt(seconds=3600)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    for home in homes:
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+
+    calls, first_post, second_post, release_post = _install_xai_refresh(monkeypatch)
+    start = threading.Barrier(3)
+    results: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+
+    def worker(home: Path) -> None:
+        token = set_hermes_home_override(home)
+        try:
+            start.wait(timeout=5)
+            results.append(A.resolve_xai_oauth_runtime_credentials(force_refresh=True))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    workers = [threading.Thread(target=worker, args=(home,)) for home in homes]
+    for item in workers:
+        item.start()
+    start.wait(timeout=5)
+    assert first_post.wait(timeout=5)
+    assert not second_post.wait(timeout=0.5)
+    release_post.set()
+    _join_threads(workers)
+
+    assert errors == []
+    assert len(calls) == 1
+    assert len(results) == 2
+    winner_access = _read_json(root_path)["providers"]["xai-oauth"]["tokens"]["access_token"]
+    assert {result["api_key"] for result in results} == {winner_access}
+
+
+def test_forced_xai_pool_and_runtime_waiters_share_root_reservation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    pool_home = root_home / "profiles" / "pool"
+    runtime_home = root_home / "profiles" / "runtime"
+    old_access = _jwt(seconds=3600)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    for home in (pool_home, runtime_home):
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+
+    pool_token = set_hermes_home_override(pool_home)
+    try:
+        pool = CP.load_pool("xai-oauth")
+        entry = next(item for item in pool.entries() if item.source == "device_code")
+    finally:
+        reset_hermes_home_override(pool_token)
+
+    calls, first_post, second_post, release_post = _install_xai_refresh(monkeypatch)
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    def pool_worker() -> None:
+        token = set_hermes_home_override(pool_home)
+        try:
+            results.append(pool._refresh_entry(entry, force=True))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    def runtime_worker() -> None:
+        token = set_hermes_home_override(runtime_home)
+        try:
+            results.append(A.resolve_xai_oauth_runtime_credentials(force_refresh=True))
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    workers = [threading.Thread(target=pool_worker), threading.Thread(target=runtime_worker)]
+    workers[0].start()
+    assert first_post.wait(timeout=5)
+    workers[1].start()
+    assert not second_post.wait(timeout=0.5)
+    release_post.set()
+    _join_threads(workers)
+
+    assert errors == []
+    assert len(calls) == 1
+    assert len(results) == 2
+    winner_access = _read_json(root_path)["providers"]["xai-oauth"]["tokens"]["access_token"]
+    assert all(
+        result is not None
+        and (
+            result.get("api_key") == winner_access
+            if isinstance(result, dict)
+            else result.access_token == winner_access
+        )
+        for result in results
+    )
+
+
+def test_forced_nous_pool_adopts_changed_root_lineage_without_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    profile_home = root_home / "profiles" / "worker"
+    old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+    winner_access = _jwt(seconds=86_400, scope=A.DEFAULT_NOUS_SCOPE)
+    _write_json(root_path, _nous_store(old_access, "nous-refresh-old"))
+    _write_json(profile_home / "auth.json", {"version": 1, "providers": {}})
+    stale = _pool_entry(
+        "nous",
+        entry_id="nous-source",
+        access_token=old_access,
+        refresh_token="nous-refresh-old",
+        source="device_code",
+    )
+    pool = CredentialPool("nous", [stale])
+    _write_json(root_path, _nous_store(winner_access, "nous-refresh-winner"))
+    requests = _install_nous_transport(
+        monkeypatch,
+        new_access=_jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE),
+        new_refresh="nous-refresh-obsolete",
+    )
+
+    token = set_hermes_home_override(profile_home)
+    try:
+        adopted = pool._refresh_entry(stale, force=True)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert adopted is not None
+    assert adopted.access_token == winner_access
+    assert adopted.refresh_token == "nous-refresh-winner"
+    assert requests == []
+
+
+def test_xai_persistent_finalization_failure_leaves_root_reserved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    profile_home = root_home / "profiles" / "runtime"
+    reload_home = root_home / "profiles" / "reload"
+    old_access = _jwt(seconds=3600)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    for home in (profile_home, reload_home):
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+
+    post_calls = 0
+
+    def fake_refresh(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal post_calls
+        post_calls += 1
+        return {
+            "access_token": _jwt(seconds=86_400),
+            "refresh_token": "root-refresh-new",
+            "last_refresh": "2026-08-06T12:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_refresh)
+    real_save = A._save_auth_store
+    root_save_count = 0
+
+    def fail_after_reservation(store: dict[str, Any], target_path: Path | None = None, **kwargs: Any):
+        nonlocal root_save_count
+        if target_path is not None and A._same_path(Path(target_path), root_path):
+            root_save_count += 1
+            if root_save_count > 1:
+                raise OSError("persistent owner finalization failure")
+        return real_save(store, target_path, **kwargs)
+
+    monkeypatch.setattr(A, "_save_auth_store", fail_after_reservation)
+    token = set_hermes_home_override(profile_home)
+    try:
+        with pytest.raises(A.SourceCredentialPersistenceError) as raised:
+            A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert raised.value.source_path is not None
+    assert A._same_path(Path(raised.value.source_path), root_path)
+    assert post_calls == 1
+    root_text = root_path.read_text(encoding="utf-8")
+    assert "root-refresh-old" not in root_text
+    assert _RESERVATION_KEY in root_text
+
+    token = set_hermes_home_override(reload_home)
+    try:
+        fresh = CP.load_pool("xai-oauth")
+        with pytest.raises(A.AuthError):
+            A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    finally:
+        reset_hermes_home_override(token)
+    assert fresh.has_available() is False
+    assert post_calls == 1
+    assert root_save_count >= 2
+
+
+def test_nous_root_finalization_failure_is_not_redirected_to_borrower(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    borrower_home = root_home / "profiles" / "borrower"
+    reload_home = root_home / "profiles" / "reload"
+    borrower_path = borrower_home / "auth.json"
+    old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+    new_access = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
+    _write_json(root_path, _nous_store(old_access, "nous-refresh-old"))
+    for home in (borrower_home, reload_home):
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+
+    requests = _install_nous_transport(
+        monkeypatch,
+        new_access=new_access,
+        new_refresh="nous-refresh-new",
+    )
+    token = set_hermes_home_override(borrower_home)
+    try:
+        pool = CP.load_pool("nous")
+        entry = next(item for item in pool.entries() if item.source == "device_code")
+    finally:
+        reset_hermes_home_override(token)
+
+    real_save = A._save_auth_store
+    root_save_count = 0
+
+    def fail_after_reservation(store: dict[str, Any], target_path: Path | None = None, **kwargs: Any):
+        nonlocal root_save_count
+        if target_path is not None and A._same_path(Path(target_path), root_path):
+            root_save_count += 1
+            if root_save_count > 1:
+                raise OSError("persistent root finalization failure")
+        return real_save(store, target_path, **kwargs)
+
+    monkeypatch.setattr(A, "_save_auth_store", fail_after_reservation)
+    token = set_hermes_home_override(borrower_home)
+    try:
+        assert pool._refresh_entry(entry, force=True) is None
+    finally:
+        reset_hermes_home_override(token)
+
+    assert requests == ["nous-refresh-old"]
+    assert "nous-refresh-old" not in root_path.read_text(encoding="utf-8")
+    assert _RESERVATION_KEY in root_path.read_text(encoding="utf-8")
+    borrower = _read_json(borrower_path)
+    assert "nous-refresh-old" not in json.dumps(borrower)
+
+    token = set_hermes_home_override(reload_home)
+    try:
+        fresh = CP.load_pool("nous")
+        assert fresh.has_available() is False
+        with pytest.raises(A.AuthError):
+            A.resolve_nous_runtime_credentials(force_refresh=True)
+    finally:
+        reset_hermes_home_override(token)
+    assert requests == ["nous-refresh-old"]
+    assert root_save_count >= 2
+
+
+def test_anthropic_persistent_finalization_failure_cannot_be_replayed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    old = {
+        "accessToken": "claude-access-old",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+        "source": "claude_code_credentials_file",
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    calls: list[str] = []
+
+    def fake_refresh(refresh_token: str, *, use_json: bool) -> dict[str, Any]:
+        calls.append(refresh_token)
+        return {
+            "access_token": "claude-access-new",
+            "refresh_token": "claude-refresh-new",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
+    real_replace = os.replace
+    credential_replaces = 0
+
+    def fail_after_reservation(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+        nonlocal credential_replaces
+        if Path(src) == credentials_path or Path(dst) == credentials_path:
+            credential_replaces += 1
+            if credential_replaces > 1:
+                raise OSError("persistent Claude finalization failure")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(anthropic_adapter.os, "replace", fail_after_reservation)
+
+    assert anthropic_adapter._refresh_oauth_token(dict(old)) is None
+    for _ in range(2):
+        assert anthropic_adapter._resolve_claude_code_token_from_credentials() is None
+    assert calls == ["claude-refresh-old"]
+    payload = _read_json(credentials_path)
+    assert payload["unrelated"] == {"preserved": True}
+    serialized = json.dumps(payload)
+    assert "claude-refresh-old" not in serialized
+    assert _RESERVATION_KEY in serialized
+    assert credential_replaces >= 2
+
+
+def test_newer_keychain_owner_never_falls_back_to_stale_file_refresh(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    _write_claude_credentials(
+        credentials_path,
+        access_token="stale-file-access",
+        refresh_token="stale-file-refresh",
+        expires_at_ms=1,
+    )
+    keychain = {
+        "accessToken": "newer-keychain-access",
+        "refreshToken": "newer-keychain-refresh",
+        "expiresAt": 2,
+        "source": "macos_keychain",
+    }
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_read_claude_code_credentials_from_keychain",
+        lambda: dict(keychain),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda refresh_token, **_kwargs: calls.append(refresh_token),
+    )
+
+    selected = anthropic_adapter.read_claude_code_credentials()
+    assert selected is not None and selected["source"] == "macos_keychain"
+    assert anthropic_adapter._refresh_oauth_token(selected) is None
+    assert calls == []
+    assert _read_json(credentials_path)["claudeAiOauth"]["refreshToken"] == "stale-file-refresh"
+
+
+def _run_anthropic_waiter_schedule(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    peer: str,
+) -> tuple[list[str], list[Any], list[BaseException], Path]:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    auth_path = tmp_path / "hermes" / "auth.json"
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    _configure_pool(monkeypatch)
+    old = {
+        "accessToken": "same-claude-access",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+        "source": "claude_code_credentials_file",
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    pool_entry = _pool_entry(
+        "anthropic",
+        entry_id="claude-source",
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        source="claude_code",
+    )
+    _write_json(
+        auth_path,
+        {"version": 1, "credential_pool": {"anthropic": [pool_entry.to_dict()]}},
+    )
+    pool = CredentialPool("anthropic", [pool_entry])
+    calls: list[str] = []
+    calls_lock = threading.Lock()
+    first_post = threading.Event()
+    second_post = threading.Event()
+    release_post = threading.Event()
+
+    def fake_refresh(refresh_token: str, *, use_json: bool) -> dict[str, Any]:
+        assert use_json is False
+        with calls_lock:
+            calls.append(refresh_token)
+            call_number = len(calls)
+        (first_post if call_number == 1 else second_post).set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "same-claude-access",
+            "refresh_token": f"claude-refresh-new-{call_number}",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    def direct_worker() -> None:
+        try:
+            results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def peer_worker() -> None:
+        try:
+            if peer == "direct":
+                results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+            else:
+                results.append(pool._refresh_entry(pool_entry, force=True))
+        except BaseException as exc:
+            errors.append(exc)
+
+    workers = (
+        [threading.Thread(target=peer_worker), threading.Thread(target=direct_worker)]
+        if peer == "pool"
+        else [threading.Thread(target=direct_worker), threading.Thread(target=peer_worker)]
+    )
+    workers[0].start()
+    assert first_post.wait(timeout=5)
+    workers[1].start()
+    assert not second_post.wait(timeout=0.5)
+    release_post.set()
+    _join_threads(workers)
+    return calls, results, errors, credentials_path
+
+
+def test_anthropic_same_access_new_refresh_direct_waiter_coalesces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls, results, errors, credentials_path = _run_anthropic_waiter_schedule(
+        tmp_path,
+        monkeypatch,
+        peer="direct",
+    )
+    assert errors == []
+    assert calls == ["claude-refresh-old"]
+    assert results == ["same-claude-access", "same-claude-access"]
+    assert _read_json(credentials_path)["claudeAiOauth"]["refreshToken"] == "claude-refresh-new-1"
+
+
+def test_anthropic_same_access_new_refresh_direct_pool_waiter_coalesces(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls, results, errors, credentials_path = _run_anthropic_waiter_schedule(
+        tmp_path,
+        monkeypatch,
+        peer="pool",
+    )
+    assert errors == []
+    assert calls == ["claude-refresh-old"]
+    assert len(results) == 2
+    assert all(
+        result == "same-claude-access"
+        or (
+            isinstance(result, PooledCredential)
+            and result.access_token == "same-claude-access"
+            and result.refresh_token == "claude-refresh-new-1"
+        )
+        for result in results
+    )
+    assert _read_json(credentials_path)["claudeAiOauth"]["refreshToken"] == "claude-refresh-new-1"
+
+
+def test_claude_external_replacement_after_final_reservation_check_survives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    old = {
+        "accessToken": "claude-access-old",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+        "source": "claude_code_credentials_file",
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "refresh_anthropic_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": "obsolete-access",
+            "refresh_token": "obsolete-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        },
+    )
+    final_check = threading.Event()
+    release_commit = threading.Event()
+
+    def commit_hook() -> None:
+        final_check.set()
+        assert release_commit.wait(timeout=5)
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        "_claude_reservation_commit_hook",
+        commit_hook,
+        raising=False,
+    )
+    results: list[str | None] = []
+    worker = threading.Thread(
+        target=lambda: results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+    )
+    worker.start()
+    reached = final_check.wait(timeout=2)
+    if reached:
+        winner_path = credentials_path.with_suffix(".external-winner")
+        _write_claude_credentials(
+            winner_path,
+            access_token="winner-access",
+            refresh_token="winner-refresh",
+            expires_at_ms=9_999_999_999_999,
+        )
+        os.replace(winner_path, credentials_path)
+    release_commit.set()
+    worker.join(timeout=5)
+
+    assert reached is True
+    assert not worker.is_alive()
+    oauth = _read_json(credentials_path)["claudeAiOauth"]
+    assert (oauth["accessToken"], oauth["refreshToken"]) == (
+        "winner-access",
+        "winner-refresh",
+    )
+    assert results == ["winner-access"]
+
+
+@pytest.mark.parametrize("provider", ["xai-oauth", "nous"])
+def test_external_newer_auth_owner_state_wins_over_stale_finalizer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    root_path = root_home / "auth.json"
+    profile_home = root_home / "profiles" / "worker"
+    _write_json(profile_home / "auth.json", {"version": 1, "providers": {}})
+    entered = threading.Event()
+    release = threading.Event()
+    results: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+
+    if provider == "xai-oauth":
+        old_access = _jwt(seconds=3600)
+        winner_access = _jwt(seconds=86_400)
+        obsolete_access = _jwt(seconds=7200)
+        _write_json(root_path, _xai_store(old_access, "xai-refresh-old"))
+
+        def blocked_refresh(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            entered.set()
+            assert release.wait(timeout=5)
+            return {
+                "access_token": obsolete_access,
+                "refresh_token": "xai-refresh-obsolete",
+                "last_refresh": "2026-08-06T12:00:00Z",
+            }
+
+        monkeypatch.setattr(A, "refresh_xai_oauth_pure", blocked_refresh)
+
+        def invoke() -> dict[str, Any]:
+            return A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+
+        winner_store = _xai_store(winner_access, "xai-refresh-winner")
+        expected_key = winner_access
+    else:
+        old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+        winner_access = _jwt(seconds=86_400, scope=A.DEFAULT_NOUS_SCOPE)
+        obsolete_access = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
+        _write_json(root_path, _nous_store(old_access, "nous-refresh-old"))
+        _install_nous_transport(
+            monkeypatch,
+            new_access=obsolete_access,
+            new_refresh="nous-refresh-obsolete",
+            entered=entered,
+            release=release,
+        )
+
+        def invoke() -> dict[str, Any]:
+            return A.resolve_nous_runtime_credentials(force_refresh=True)
+
+        winner_store = _nous_store(winner_access, "nous-refresh-winner")
+        expected_key = winner_access
+
+    def worker() -> None:
+        token = set_hermes_home_override(profile_home)
+        try:
+            results.append(invoke())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    assert entered.wait(timeout=5)
+    external_path = root_path.with_suffix(".external-winner")
+    _write_json(external_path, winner_store)
+    os.replace(external_path, root_path)
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors == []
+    assert len(results) == 1
+    assert results[0]["api_key"] == expected_key
+    persisted = _read_json(root_path)["providers"][provider]
+    persisted_refresh = (
+        persisted["tokens"]["refresh_token"]
+        if provider == "xai-oauth"
+        else persisted["refresh_token"]
+    )
+    assert persisted_refresh == f"{provider.removesuffix('-oauth')}-refresh-winner"
+
+
+@pytest.mark.parametrize("provider", ["xai-oauth", "nous", "anthropic"])
+def test_reservation_persistence_failure_prevents_post(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    provider: str,
+) -> None:
+    post_calls = 0
+    requests: list[str] = []
+
+    if provider == "anthropic":
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        path = tmp_path / ".claude" / ".credentials.json"
+        creds = {
+            "accessToken": "claude-access-old",
+            "refreshToken": "claude-refresh-old",
+            "expiresAt": 1,
+            "source": "claude_code_credentials_file",
+        }
+        _write_claude_credentials(
+            path,
+            access_token=creds["accessToken"],
+            refresh_token=creds["refreshToken"],
+            expires_at_ms=creds["expiresAt"],
+        )
+
+        def fake_refresh(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            nonlocal post_calls
+            post_calls += 1
+            return {}
+
+        monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
+        monkeypatch.setattr(
+            anthropic_adapter.os,
+            "replace",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("reservation failed")),
+        )
+        assert anthropic_adapter._refresh_oauth_token(creds) is None
+    else:
+        root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+        profile_home = root_home / "profiles" / "worker"
+        root_path = root_home / "auth.json"
+        _write_json(profile_home / "auth.json", {"version": 1, "providers": {}})
+        if provider == "xai-oauth":
+            _write_json(root_path, _xai_store(_jwt(seconds=3600), "xai-refresh-old"))
+
+            def fake_xai(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+                nonlocal post_calls
+                post_calls += 1
+                return {}
+
+            monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_xai)
+        else:
+            old = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+            new = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
+            _write_json(root_path, _nous_store(old, "nous-refresh-old"))
+            requests = _install_nous_transport(
+                monkeypatch,
+                new_access=new,
+                new_refresh="nous-refresh-new",
+            )
+
+        real_save = A._save_auth_store
+
+        def fail_root_save(store: dict[str, Any], target_path: Path | None = None, **kwargs: Any):
+            if target_path is not None and A._same_path(Path(target_path), root_path):
+                raise OSError("reservation failed")
+            return real_save(store, target_path, **kwargs)
+
+        monkeypatch.setattr(A, "_save_auth_store", fail_root_save)
+        token = set_hermes_home_override(profile_home)
+        try:
+            with pytest.raises(Exception):
+                if provider == "xai-oauth":
+                    A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+                else:
+                    A.resolve_nous_runtime_credentials(force_refresh=True)
+        finally:
+            reset_hermes_home_override(token)
+        if provider == "nous":
+            post_calls = len(requests)
+
+    assert post_calls == 0
+
+
+def test_xai_reserved_crash_state_reloads_fail_closed_and_new_lineage_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    worker_home = root_home / "profiles" / "worker"
+    fresh_home = root_home / "profiles" / "fresh"
+    old_access = _jwt(seconds=3600)
+    _write_json(root_path, _xai_store(old_access, "xai-refresh-old"))
+    for home in (worker_home, fresh_home):
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+    entered = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def interrupted_post(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=5)
+        raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", interrupted_post)
+    real_save = A._save_auth_store
+    root_saves = 0
+
+    def reject_cleanup_writes(
+        store: dict[str, Any],
+        target_path: Path | None = None,
+        **kwargs: Any,
+    ):
+        nonlocal root_saves
+        if target_path is not None and A._same_path(Path(target_path), root_path):
+            root_saves += 1
+            if root_saves > 1:
+                raise OSError("persistent cleanup failure")
+        return real_save(store, target_path, **kwargs)
+
+    monkeypatch.setattr(A, "_save_auth_store", reject_cleanup_writes)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        token = set_hermes_home_override(worker_home)
+        try:
+            A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    assert entered.wait(timeout=5)
+    during = root_path.read_text(encoding="utf-8")
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors
+    assert root_saves == 1
+    assert _RESERVATION_KEY in during
+    assert "xai-refresh-old" not in during
+    assert old_access not in during
+    xai_reservation = json.loads(during)["providers"]["xai-oauth"][
+        _RESERVATION_KEY
+    ]
+    _assert_non_secret_reservation(
+        xai_reservation,
+        old_access,
+        "xai-refresh-old",
+    )
+    token = set_hermes_home_override(fresh_home)
+    try:
+        assert CP.load_pool("xai-oauth").has_available() is False
+    finally:
+        reset_hermes_home_override(token)
+    assert calls == 1
+
+    newer_access = _jwt(seconds=86_400)
+    _write_json(root_path, _xai_store(newer_access, "xai-refresh-newer"))
+    token = set_hermes_home_override(fresh_home)
+    try:
+        recovered = CP.load_pool("xai-oauth")
+    finally:
+        reset_hermes_home_override(token)
+    assert recovered.has_available() is True
+    assert any(item.refresh_token == "xai-refresh-newer" for item in recovered.entries())
+
+
+def test_nous_reserved_crash_state_reloads_fail_closed_and_new_lineage_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root_home, _shared = _configure_profiles(tmp_path, monkeypatch)
+    _configure_pool(monkeypatch)
+    root_path = root_home / "auth.json"
+    worker_home = root_home / "profiles" / "worker"
+    fresh_home = root_home / "profiles" / "fresh"
+    old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+    new_access = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
+    _write_json(root_path, _nous_store(old_access, "nous-refresh-old"))
+    for home in (worker_home, fresh_home):
+        _write_json(home / "auth.json", {"version": 1, "providers": {}})
+    entered = threading.Event()
+    release = threading.Event()
+    requests = _install_nous_transport(
+        monkeypatch,
+        new_access=new_access,
+        new_refresh="nous-refresh-new",
+        entered=entered,
+        release=release,
+        fail_after_enter=True,
+    )
+    real_save = A._save_auth_store
+    root_saves = 0
+
+    def reject_cleanup_writes(
+        store: dict[str, Any],
+        target_path: Path | None = None,
+        **kwargs: Any,
+    ):
+        nonlocal root_saves
+        if target_path is not None and A._same_path(Path(target_path), root_path):
+            root_saves += 1
+            if root_saves > 1:
+                raise OSError("persistent cleanup failure")
+        return real_save(store, target_path, **kwargs)
+
+    monkeypatch.setattr(A, "_save_auth_store", reject_cleanup_writes)
+    errors: list[BaseException] = []
+
+    def worker() -> None:
+        token = set_hermes_home_override(worker_home)
+        try:
+            A.resolve_nous_runtime_credentials(force_refresh=True)
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    assert entered.wait(timeout=5)
+    during = root_path.read_text(encoding="utf-8")
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert errors
+    assert root_saves == 1
+    assert _RESERVATION_KEY in during
+    assert "nous-refresh-old" not in during
+    assert old_access not in during
+    nous_reservation = json.loads(during)["providers"]["nous"][_RESERVATION_KEY]
+    _assert_non_secret_reservation(
+        nous_reservation,
+        old_access,
+        "nous-refresh-old",
+    )
+    token = set_hermes_home_override(fresh_home)
+    try:
+        assert CP.load_pool("nous").has_available() is False
+    finally:
+        reset_hermes_home_override(token)
+    assert requests == ["nous-refresh-old"]
+
+    _write_json(root_path, _nous_store(new_access, "nous-refresh-newer"))
+    token = set_hermes_home_override(fresh_home)
+    try:
+        recovered = CP.load_pool("nous")
+    finally:
+        reset_hermes_home_override(token)
+    assert recovered.has_available() is True
+    assert any(item.refresh_token == "nous-refresh-newer" for item in recovered.entries())
+
+
+def test_claude_reserved_crash_state_reloads_fail_closed_and_new_lineage_recovers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    old = {
+        "accessToken": "claude-access-old",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+        "source": "claude_code_credentials_file",
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def interrupted_post(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        assert release.wait(timeout=5)
+        raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", interrupted_post)
+    real_replace = anthropic_adapter.os.replace
+    source_commits = 0
+
+    def reject_cleanup_writes(
+        src: str | os.PathLike[str],
+        dst: str | os.PathLike[str],
+    ) -> None:
+        nonlocal source_commits
+        if Path(src) == credentials_path or Path(dst) == credentials_path:
+            source_commits += 1
+            if source_commits > 1:
+                raise OSError("persistent cleanup failure")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(anthropic_adapter.os, "replace", reject_cleanup_writes)
+    results: list[str | None] = []
+    thread = threading.Thread(
+        target=lambda: results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+    )
+    thread.start()
+    assert entered.wait(timeout=5)
+    during = credentials_path.read_text(encoding="utf-8")
+    release.set()
+    thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert results == [None]
+    assert source_commits == 1
+    assert _RESERVATION_KEY in during
+    assert "claude-refresh-old" not in during
+    assert "claude-access-old" not in during
+    claude_reservation = json.loads(during)["claudeAiOauth"][_RESERVATION_KEY]
+    _assert_non_secret_reservation(
+        claude_reservation,
+        "claude-access-old",
+        "claude-refresh-old",
+    )
+    assert anthropic_adapter.read_claude_code_credentials() is None
+    assert calls == 1
+
+    _write_claude_credentials(
+        credentials_path,
+        access_token="claude-access-newer",
+        refresh_token="claude-refresh-newer",
+        expires_at_ms=9_999_999_999_999,
+    )
+    recovered = anthropic_adapter.read_claude_code_credentials()
+    assert recovered is not None
+    assert recovered["refreshToken"] == "claude-refresh-newer"

--- a/tests/agent/test_source_owned_refresh_transactions.py
+++ b/tests/agent/test_source_owned_refresh_transactions.py
@@ -323,19 +323,43 @@ def test_xai_pool_restarts_when_local_owner_disappears_before_lock(
             yield transaction
 
     monkeypatch.setattr(A, "_provider_state_transaction", scheduled_transaction)
-    calls, first_post, second_post, release_post = _install_xai_refresh(
+    calls, first_post, _second_post, release_post = _install_xai_refresh(
         monkeypatch,
         new_access=new_access,
         new_refresh="shared-refresh-new",
     )
     results: list[PooledCredential | None] = []
     errors: list[BaseException] = []
+    root_empty_selection = threading.Event()
+    release_empty_selection = threading.Event()
+    real_select_under_lock = CP.CredentialPool._select_under_lock
+
+    def scheduled_select_under_lock(
+        pool: CP.CredentialPool,
+        excluded_source_ids: set[str] | None = None,
+    ) -> tuple[PooledCredential | None, list[tuple[Any, Any]]]:
+        selected = real_select_under_lock(pool, excluded_source_ids)
+        if (
+            threading.current_thread().name == "root-selector"
+            and selected == (None, [])
+            and not root_empty_selection.is_set()
+        ):
+            root_empty_selection.set()
+            assert release_empty_selection.wait(timeout=5)
+        return selected
+
+    monkeypatch.setattr(
+        CP.CredentialPool,
+        "_select_under_lock",
+        scheduled_select_under_lock,
+    )
 
     def select(profile: Path, *, wait_for_removal: bool) -> None:
         token = set_hermes_home_override(profile)
         try:
             if wait_for_removal:
                 assert removed.wait(timeout=5)
+                assert first_post.wait(timeout=5)
             pool = CP.load_pool("xai-oauth")
             results.append(pool.select())
         except BaseException as exc:
@@ -359,10 +383,12 @@ def test_xai_pool_restarts_when_local_owner_disappears_before_lock(
         worker.start()
     assert removed.wait(timeout=5)
     assert first_post.wait(timeout=5)
-    second_post.wait(timeout=1)
+    assert root_empty_selection.wait(timeout=5)
     release_post.set()
-    for worker in workers:
-        worker.join(timeout=5)
+    workers[0].join(timeout=5)
+    assert not workers[0].is_alive()
+    release_empty_selection.set()
+    workers[1].join(timeout=5)
 
     assert all(not worker.is_alive() for worker in workers)
     assert errors == []

--- a/tests/agent/test_source_owned_refresh_transactions.py
+++ b/tests/agent/test_source_owned_refresh_transactions.py
@@ -1,0 +1,861 @@
+"""Production-path regressions for source-owned rotating OAuth credentials."""
+
+from __future__ import annotations
+
+import base64
+import json
+import threading
+import time
+from contextlib import contextmanager
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from agent import anthropic_adapter
+from agent import credential_pool as CP
+from agent.credential_persistence import sanitize_borrowed_credential_payload
+from agent.credential_pool import AUTH_TYPE_OAUTH, CredentialPool, PooledCredential
+from hermes_cli import auth as A
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _jwt(*, seconds: int, scope: str | None = None) -> str:
+    claims: dict[str, Any] = {"sub": "test-user", "exp": int(time.time() + seconds)}
+    if scope is not None:
+        claims["scope"] = scope
+
+    def encode(value: dict[str, Any]) -> str:
+        raw = json.dumps(value, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{encode({'alg': 'none', 'typ': 'JWT'})}.{encode(claims)}.signature"
+
+
+def _pool_entry(
+    provider: str,
+    *,
+    entry_id: str,
+    access_token: str,
+    refresh_token: str,
+    source: str = "device_code",
+    expires_at_ms: int | None = 1,
+    last_status: str | None = None,
+) -> PooledCredential:
+    return PooledCredential(
+        provider=provider,
+        id=entry_id,
+        label=entry_id,
+        auth_type=AUTH_TYPE_OAUTH,
+        priority=0,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at_ms=expires_at_ms,
+        last_status=last_status,
+        last_status_at=time.time() if last_status else None,
+    )
+
+
+def _xai_store(
+    access_token: str,
+    refresh_token: str,
+    *,
+    entry_id: str = "xai-source",
+) -> dict[str, Any]:
+    entry = _pool_entry(
+        "xai-oauth",
+        entry_id=entry_id,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+    return {
+        "version": 1,
+        "providers": {
+            "xai-oauth": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "discovery": {"token_endpoint": "https://auth.x.ai/oauth/token"},
+                "auth_mode": "oauth_device_code",
+            }
+        },
+        "credential_pool": {"xai-oauth": [entry.to_dict()]},
+    }
+
+
+def _install_xai_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    new_access: str,
+    new_refresh: str,
+) -> tuple[
+    list[tuple[str, str]],
+    threading.Event,
+    threading.Event,
+    threading.Event,
+]:
+    calls: list[tuple[str, str]] = []
+    calls_lock = threading.Lock()
+    first_post = threading.Event()
+    second_post = threading.Event()
+    release_post = threading.Event()
+
+    def fake_refresh(access_token: str, refresh_token: str, **_kwargs: Any) -> dict[str, Any]:
+        with calls_lock:
+            calls.append((access_token, refresh_token))
+            call_number = len(calls)
+        if call_number == 1:
+            first_post.set()
+        else:
+            second_post.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": new_access,
+            "refresh_token": new_refresh,
+            "last_refresh": "2026-08-06T12:00:00Z",
+        }
+
+    monkeypatch.setattr(A, "refresh_xai_oauth_pure", fake_refresh)
+    return calls, first_post, second_post, release_post
+
+
+def _run_threads(workers: list[threading.Thread]) -> None:
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+    assert all(not worker.is_alive() for worker in workers)
+
+
+def test_two_profile_xai_runtime_resolvers_share_the_root_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_homes = [
+        root_home / "profiles" / "one",
+        root_home / "profiles" / "two",
+    ]
+    old_access = _jwt(seconds=-60)
+    new_access = _jwt(seconds=86_400)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    for profile_home in profile_homes:
+        _write_json(profile_home / "auth.json", {"version": 1, "providers": {}})
+
+    calls, first_post, second_post, release_post = _install_xai_refresh(
+        monkeypatch,
+        new_access=new_access,
+        new_refresh="root-refresh-new",
+    )
+    start = threading.Barrier(3)
+    results: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+
+    def resolve(profile_home: Path) -> None:
+        token = set_hermes_home_override(profile_home)
+        try:
+            start.wait(timeout=5)
+            results.append(
+                A.resolve_xai_oauth_runtime_credentials(refresh_skew_seconds=0)
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    workers = [threading.Thread(target=resolve, args=(home,)) for home in profile_homes]
+    for worker in workers:
+        worker.start()
+    start.wait(timeout=5)
+    assert first_post.wait(timeout=5)
+    second_post.wait(timeout=1)
+    release_post.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    assert calls == [(old_access, "root-refresh-old")]
+    assert len(results) == 2
+    assert {result["api_key"] for result in results} == {new_access}
+    root_tokens = _read_json(root_path)["providers"]["xai-oauth"]["tokens"]
+    assert root_tokens["access_token"] == new_access
+    assert root_tokens["refresh_token"] == "root-refresh-new"
+
+
+def test_xai_pool_and_runtime_resolver_share_the_root_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    pool_home = root_home / "profiles" / "pool"
+    runtime_home = root_home / "profiles" / "runtime"
+    old_access = _jwt(seconds=-60)
+    new_access = _jwt(seconds=86_400)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    for profile_home in (pool_home, runtime_home):
+        _write_json(profile_home / "auth.json", {"version": 1, "providers": {}})
+
+    calls, first_post, second_post, release_post = _install_xai_refresh(
+        monkeypatch,
+        new_access=new_access,
+        new_refresh="root-refresh-new",
+    )
+    start = threading.Barrier(3)
+    pool_results: list[PooledCredential | None] = []
+    runtime_results: list[dict[str, Any]] = []
+    errors: list[BaseException] = []
+
+    def select_pool() -> None:
+        token = set_hermes_home_override(pool_home)
+        try:
+            pool = CP.load_pool("xai-oauth")
+            start.wait(timeout=5)
+            pool_results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    def resolve_runtime() -> None:
+        token = set_hermes_home_override(runtime_home)
+        try:
+            start.wait(timeout=5)
+            runtime_results.append(
+                A.resolve_xai_oauth_runtime_credentials(refresh_skew_seconds=0)
+            )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    workers = [threading.Thread(target=select_pool), threading.Thread(target=resolve_runtime)]
+    for worker in workers:
+        worker.start()
+    start.wait(timeout=5)
+    assert first_post.wait(timeout=5)
+    second_post.wait(timeout=1)
+    release_post.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    assert calls == [(old_access, "root-refresh-old")]
+    assert len(pool_results) == 1 and pool_results[0] is not None
+    assert pool_results[0].access_token == new_access
+    assert len(runtime_results) == 1 and runtime_results[0]["api_key"] == new_access
+    root = _read_json(root_path)
+    assert root["providers"]["xai-oauth"]["tokens"]["refresh_token"] == "root-refresh-new"
+    persisted = root["credential_pool"]["xai-oauth"][0]
+    assert persisted["access_token"] == new_access
+    assert persisted["refresh_token"] == "root-refresh-new"
+
+
+def test_xai_pool_restarts_when_local_owner_disappears_before_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_home = root_home / "profiles" / "local"
+    root_peer_home = root_home / "profiles" / "root-peer"
+    profile_path = profile_home / "auth.json"
+    old_access = _jwt(seconds=-60)
+    new_access = _jwt(seconds=86_400)
+    _write_json(root_path, _xai_store(old_access, "shared-refresh-old", entry_id="root-xai"))
+    _write_json(profile_path, _xai_store(old_access, "shared-refresh-old", entry_id="local-xai"))
+    _write_json(root_peer_home / "auth.json", {"version": 1, "providers": {}})
+
+    removed = threading.Event()
+    transaction_paths: list[tuple[str, Path | None]] = []
+    real_transaction = A._provider_state_transaction
+
+    @contextmanager
+    def scheduled_transaction(provider_id: str, *args: Any, **kwargs: Any):
+        expected = kwargs.get("expected_source_path")
+        if (
+            provider_id == "xai-oauth"
+            and threading.current_thread().name == "local-selector"
+            and expected is not None
+            and A._same_path(Path(expected), profile_path)
+            and not removed.is_set()
+        ):
+            local = _read_json(profile_path)
+            local.get("providers", {}).pop("xai-oauth", None)
+            _write_json(profile_path, local)
+            removed.set()
+        with real_transaction(provider_id, *args, **kwargs) as transaction:
+            transaction_paths.append(
+                (threading.current_thread().name, transaction[2])
+            )
+            yield transaction
+
+    monkeypatch.setattr(A, "_provider_state_transaction", scheduled_transaction)
+    calls, first_post, second_post, release_post = _install_xai_refresh(
+        monkeypatch,
+        new_access=new_access,
+        new_refresh="shared-refresh-new",
+    )
+    results: list[PooledCredential | None] = []
+    errors: list[BaseException] = []
+
+    def select(profile: Path, *, wait_for_removal: bool) -> None:
+        token = set_hermes_home_override(profile)
+        try:
+            if wait_for_removal:
+                assert removed.wait(timeout=5)
+            pool = CP.load_pool("xai-oauth")
+            results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            reset_hermes_home_override(token)
+
+    workers = [
+        threading.Thread(
+            target=select,
+            kwargs={"profile": profile_home, "wait_for_removal": False},
+            name="local-selector",
+        ),
+        threading.Thread(
+            target=select,
+            kwargs={"profile": root_peer_home, "wait_for_removal": True},
+            name="root-selector",
+        ),
+    ]
+    for worker in workers:
+        worker.start()
+    assert removed.wait(timeout=5)
+    assert first_post.wait(timeout=5)
+    second_post.wait(timeout=1)
+    release_post.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    assert calls == [(old_access, "shared-refresh-old")]
+    local_paths = [path for name, path in transaction_paths if name == "local-selector"]
+    assert any(path is not None and A._same_path(Path(path), profile_path) for path in local_paths)
+    assert any(path is not None and A._same_path(Path(path), root_path) for path in local_paths)
+    assert len(results) == 2 and all(result is not None for result in results)
+    assert {result.access_token for result in results if result is not None} == {new_access}
+
+
+def test_xai_root_write_failure_never_returns_or_reloads_consumed_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    root_home = tmp_path / ".hermes"
+    root_path = root_home / "auth.json"
+    profile_home = root_home / "profiles" / "runtime"
+    profile_path = profile_home / "auth.json"
+    old_access = _jwt(seconds=-60)
+    orphan_access = _jwt(seconds=3600)
+    _write_json(root_path, _xai_store(old_access, "root-refresh-old"))
+    _write_json(profile_path, {"version": 1, "providers": {}})
+    monkeypatch.setattr(
+        A,
+        "refresh_xai_oauth_pure",
+        lambda *_args, **_kwargs: {
+            "access_token": orphan_access,
+            "refresh_token": "orphan-refresh",
+            "last_refresh": "2026-08-06T12:00:00Z",
+        },
+    )
+    real_save = A._save_auth_store
+    failed = False
+
+    def fail_rotated_root_write(store: dict[str, Any], target_path: Path | None = None):
+        nonlocal failed
+        if target_path is not None and A._same_path(Path(target_path), root_path) and not failed:
+            failed = True
+            raise OSError("simulated source persistence failure")
+        return real_save(store, target_path)
+
+    monkeypatch.setattr(A, "_save_auth_store", fail_rotated_root_write)
+    token = set_hermes_home_override(profile_home)
+    try:
+        with pytest.raises(Exception):
+            A.resolve_xai_oauth_runtime_credentials(force_refresh=True)
+    finally:
+        reset_hermes_home_override(token)
+
+    assert failed is True
+    reload_home = root_home / "profiles" / "reload"
+    _write_json(reload_home / "auth.json", {"version": 1, "providers": {}})
+    token = set_hermes_home_override(reload_home)
+    try:
+        reloaded = CP.load_pool("xai-oauth")
+    finally:
+        reset_hermes_home_override(token)
+    assert reloaded.has_available() is False
+    assert all(entry.access_token != orphan_access for entry in reloaded.entries())
+
+
+def _write_claude_credentials(
+    path: Path,
+    *,
+    access_token: str,
+    refresh_token: str,
+    expires_at_ms: int,
+) -> None:
+    _write_json(
+        path,
+        {
+            "claudeAiOauth": {
+                "accessToken": access_token,
+                "refreshToken": refresh_token,
+                "expiresAt": expires_at_ms,
+            }
+        },
+    )
+
+
+def _claude_tokens(path: Path) -> tuple[str, str]:
+    oauth = _read_json(path)["claudeAiOauth"]
+    return oauth["accessToken"], oauth["refreshToken"]
+
+
+@pytest.mark.parametrize("peer", ["direct", "pool"])
+def test_anthropic_direct_refresh_shares_credentials_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    peer: str,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    auth_path = tmp_path / "hermes" / "auth.json"
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    old = {
+        "accessToken": "claude-access-old",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    pool_entry = _pool_entry(
+        "anthropic",
+        entry_id="claude-source",
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        source="claude_code",
+    )
+    _write_json(
+        auth_path,
+        {
+            "version": 1,
+            "credential_pool": {"anthropic": [pool_entry.to_dict()]},
+        },
+    )
+    pool = CredentialPool("anthropic", [pool_entry])
+    calls: list[str] = []
+    calls_lock = threading.Lock()
+    first_post = threading.Event()
+    second_post = threading.Event()
+    release_post = threading.Event()
+
+    def fake_refresh(refresh_token: str, *, use_json: bool) -> dict[str, Any]:
+        assert use_json is False
+        with calls_lock:
+            calls.append(refresh_token)
+            call_number = len(calls)
+        if call_number == 1:
+            first_post.set()
+        else:
+            second_post.set()
+        assert release_post.wait(timeout=5)
+        return {
+            "access_token": "claude-access-new",
+            "refresh_token": "claude-refresh-new",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
+    start = threading.Barrier(3)
+    results: list[Any] = []
+    errors: list[BaseException] = []
+
+    def direct_worker() -> None:
+        try:
+            start.wait(timeout=5)
+            results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+        except BaseException as exc:
+            errors.append(exc)
+
+    def peer_worker() -> None:
+        try:
+            start.wait(timeout=5)
+            if peer == "direct":
+                results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+            else:
+                results.append(pool.select())
+        except BaseException as exc:
+            errors.append(exc)
+
+    workers = [threading.Thread(target=direct_worker), threading.Thread(target=peer_worker)]
+    for worker in workers:
+        worker.start()
+    start.wait(timeout=5)
+    assert first_post.wait(timeout=5)
+    second_post.wait(timeout=1)
+    release_post.set()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert all(not worker.is_alive() for worker in workers)
+    assert errors == []
+    assert calls == ["claude-refresh-old"]
+    assert _claude_tokens(credentials_path) == (
+        "claude-access-new",
+        "claude-refresh-new",
+    )
+    assert len(results) == 2
+    assert all(
+        result == "claude-access-new"
+        or (
+            isinstance(result, PooledCredential)
+            and result.access_token == "claude-access-new"
+            and result.refresh_token == "claude-refresh-new"
+        )
+        for result in results
+    )
+
+
+def test_anthropic_replacement_after_post_survives_conditional_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    old = {
+        "accessToken": "claude-access-old",
+        "refreshToken": "claude-refresh-old",
+        "expiresAt": 1,
+    }
+    _write_claude_credentials(
+        credentials_path,
+        access_token=old["accessToken"],
+        refresh_token=old["refreshToken"],
+        expires_at_ms=old["expiresAt"],
+    )
+    write_boundary = threading.Event()
+    release_write = threading.Event()
+
+    def fake_refresh(_refresh_token: str, *, use_json: bool) -> dict[str, Any]:
+        assert use_json is False
+        return {
+            "access_token": "obsolete-access",
+            "refresh_token": "obsolete-refresh",
+            "expires_at_ms": 9_999_999_999_999,
+        }
+
+    monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
+    write_name = (
+        "_write_claude_code_credentials_file"
+        if hasattr(anthropic_adapter, "_write_claude_code_credentials_file")
+        else "_write_claude_code_credentials"
+    )
+    real_write = getattr(anthropic_adapter, write_name)
+
+    def pause_at_write_boundary(*args: Any, **kwargs: Any) -> None:
+        write_boundary.set()
+        assert release_write.wait(timeout=5)
+        real_write(*args, **kwargs)
+
+    monkeypatch.setattr(
+        anthropic_adapter,
+        write_name,
+        pause_at_write_boundary,
+    )
+    results: list[str | None] = []
+    worker = threading.Thread(
+        target=lambda: results.append(anthropic_adapter._refresh_oauth_token(dict(old)))
+    )
+    worker.start()
+    assert write_boundary.wait(timeout=5)
+    _write_claude_credentials(
+        credentials_path,
+        access_token="winner-access",
+        refresh_token="winner-refresh",
+        expires_at_ms=9_999_999_999_999,
+    )
+    release_write.set()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert _claude_tokens(credentials_path) == ("winner-access", "winner-refresh")
+    assert results[0] != "obsolete-access"
+
+
+def _nous_entry(
+    *,
+    access_token: str,
+    refresh_token: str,
+    status: str | None = None,
+) -> PooledCredential:
+    expires_at = datetime.fromtimestamp(time.time() + 3600, tz=timezone.utc).isoformat()
+    return replace(
+        _pool_entry(
+            "nous",
+            entry_id="nous-source",
+            access_token=access_token,
+            refresh_token=refresh_token,
+            source="device_code",
+            expires_at_ms=None,
+            last_status=status,
+        ),
+        expires_at=expires_at,
+        agent_key=access_token,
+        agent_key_expires_at=expires_at,
+        inference_base_url=A.DEFAULT_NOUS_INFERENCE_URL,
+        extra={
+            "scope": A.DEFAULT_NOUS_SCOPE,
+            "client_id": A.DEFAULT_NOUS_CLIENT_ID,
+            "portal_base_url": A.DEFAULT_NOUS_PORTAL_URL,
+        },
+    )
+
+
+def test_nous_resolver_persistence_failure_quarantines_consumed_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    auth_path = tmp_path / "hermes" / "auth.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    monkeypatch.setattr(A, "_write_shared_nous_state", lambda _state: None)
+    old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
+    new_access = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
+    old = _nous_entry(access_token=old_access, refresh_token="nous-refresh-old")
+    _write_json(
+        auth_path,
+        {
+            "version": 1,
+            "providers": {
+                "nous": {
+                    "access_token": old_access,
+                    "refresh_token": "nous-refresh-old",
+                    "expires_at": old.expires_at,
+                    "scope": A.DEFAULT_NOUS_SCOPE,
+                    "portal_base_url": A.DEFAULT_NOUS_PORTAL_URL,
+                    "inference_base_url": A.DEFAULT_NOUS_INFERENCE_URL,
+                    "client_id": A.DEFAULT_NOUS_CLIENT_ID,
+                    "agent_key": old_access,
+                    "agent_key_expires_at": old.agent_key_expires_at,
+                }
+            },
+            "credential_pool": {"nous": [old.to_dict()]},
+        },
+    )
+    requests: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request.headers["x-nous-refresh-token"])
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "access_token": new_access,
+                "refresh_token": "nous-refresh-new",
+                "expires_in": 7200,
+                "token_type": "Bearer",
+                "scope": A.DEFAULT_NOUS_SCOPE,
+                "inference_base_url": A.DEFAULT_NOUS_INFERENCE_URL,
+            },
+        )
+
+    real_client = httpx.Client
+    transport = httpx.MockTransport(handler)
+
+    def client_factory(*args: Any, **kwargs: Any) -> httpx.Client:
+        return real_client(*args, transport=transport, **kwargs)
+
+    monkeypatch.setattr(A.httpx, "Client", client_factory)
+    save_name = (
+        "_save_provider_state_to_locked_source"
+        if hasattr(A, "_save_provider_state_to_locked_source")
+        else "_save_provider_state_to_source"
+    )
+    real_save = getattr(A, save_name)
+    failed = False
+
+    def fail_post_refresh_save(*args: Any, **kwargs: Any) -> None:
+        nonlocal failed
+        if not failed:
+            failed = True
+            raise OSError("simulated provider-state save failure")
+        real_save(*args, **kwargs)
+
+    monkeypatch.setattr(A, save_name, fail_post_refresh_save)
+    pool = CredentialPool("nous", [old])
+    refreshed = pool._refresh_entry(old, force=True)
+
+    assert failed is True
+    assert requests == ["nous-refresh-old"]
+    assert refreshed is None
+    fresh = CP.load_pool("nous")
+    authoritative = next(entry for entry in fresh.entries() if entry.source == "device_code")
+    assert authoritative.access_token == old_access
+    assert authoritative.refresh_token == "nous-refresh-old"
+    assert authoritative.last_status == CP.STATUS_DEAD
+    assert fresh.has_available() is False
+
+    newer = _read_json(auth_path)
+    newer_state = newer["providers"]["nous"]
+    newer_state["access_token"] = new_access
+    newer_state["refresh_token"] = "nous-refresh-newer"
+    newer_state["agent_key"] = new_access
+    newer_state["agent_key_expires_at"] = datetime.fromtimestamp(
+        time.time() + 7200,
+        tz=timezone.utc,
+    ).isoformat()
+    _write_json(auth_path, newer)
+    recovered = CP.load_pool("nous")
+    recovered_entry = next(
+        entry for entry in recovered.entries() if entry.source == "device_code"
+    )
+    assert recovered_entry.refresh_token == "nous-refresh-newer"
+    assert recovered_entry.last_status is None
+    assert recovered.has_available() is True
+
+
+@pytest.mark.parametrize(
+    ("source_access", "source_refresh", "expected_status"),
+    [
+        ("claude-access-old", "claude-refresh-new", None),
+        ("claude-access-new", "claude-refresh-old", CP.STATUS_DEAD),
+    ],
+)
+def test_claude_dead_state_tracks_refresh_lineage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    source_access: str,
+    source_refresh: str,
+    expected_status: str | None,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    auth_path = tmp_path / "hermes" / "auth.json"
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    consumed = _pool_entry(
+        "anthropic",
+        entry_id="claude-source",
+        access_token="claude-access-old",
+        refresh_token="claude-refresh-old",
+        source="claude_code",
+        last_status=CP.STATUS_DEAD,
+    )
+    persisted = sanitize_borrowed_credential_payload(consumed.to_dict(), "anthropic")
+    _write_json(
+        auth_path,
+        {"version": 1, "credential_pool": {"anthropic": [persisted]}},
+    )
+    _write_claude_credentials(
+        credentials_path,
+        access_token=source_access,
+        refresh_token=source_refresh,
+        expires_at_ms=9_999_999_999_999,
+    )
+
+    loaded = CP.load_pool("anthropic")
+    claude = next(entry for entry in loaded.entries() if entry.source == "claude_code")
+
+    assert claude.access_token == source_access
+    assert claude.refresh_token == source_refresh
+    assert claude.last_status == expected_status
+    assert loaded.has_available() is (expected_status is None)
+
+
+def test_claude_normal_rotation_reloads_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    auth_path = tmp_path / "hermes" / "auth.json"
+    credentials_path = tmp_path / ".claude" / ".credentials.json"
+    monkeypatch.setattr(A, "_auth_file_path", lambda: auth_path)
+    monkeypatch.setattr(A, "_global_auth_file_path", lambda: None)
+    monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
+    monkeypatch.setattr(CP, "load_env", lambda: {})
+    monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    previous = _pool_entry(
+        "anthropic",
+        entry_id="claude-source",
+        access_token="claude-access-old",
+        refresh_token="claude-refresh-old",
+        source="claude_code",
+    )
+    persisted = sanitize_borrowed_credential_payload(previous.to_dict(), "anthropic")
+    _write_json(
+        auth_path,
+        {"version": 1, "credential_pool": {"anthropic": [persisted]}},
+    )
+    _write_claude_credentials(
+        credentials_path,
+        access_token="claude-access-new",
+        refresh_token="claude-refresh-new",
+        expires_at_ms=9_999_999_999_999,
+    )
+
+    loaded = CP.load_pool("anthropic")
+    claude = next(entry for entry in loaded.entries() if entry.source == "claude_code")
+
+    assert claude.access_token == "claude-access-new"
+    assert claude.refresh_token == "claude-refresh-new"
+    assert claude.last_status is None
+    assert loaded.has_available() is True

--- a/tests/agent/test_source_owned_refresh_transactions.py
+++ b/tests/agent/test_source_owned_refresh_transactions.py
@@ -403,12 +403,15 @@ def test_xai_root_write_failure_never_returns_or_reloads_consumed_lineage(
     )
     real_save = A._save_auth_store
     failed = False
+    root_saves = 0
 
     def fail_rotated_root_write(store: dict[str, Any], target_path: Path | None = None):
-        nonlocal failed
-        if target_path is not None and A._same_path(Path(target_path), root_path) and not failed:
-            failed = True
-            raise OSError("simulated source persistence failure")
+        nonlocal failed, root_saves
+        if target_path is not None and A._same_path(Path(target_path), root_path):
+            root_saves += 1
+            if root_saves > 1:
+                failed = True
+                raise OSError("simulated source persistence failure")
         return real_save(store, target_path)
 
     monkeypatch.setattr(A, "_save_auth_store", fail_rotated_root_write)
@@ -597,21 +600,13 @@ def test_anthropic_replacement_after_post_survives_conditional_write(
         }
 
     monkeypatch.setattr(anthropic_adapter, "refresh_anthropic_oauth_pure", fake_refresh)
-    write_name = (
-        "_write_claude_code_credentials_file"
-        if hasattr(anthropic_adapter, "_write_claude_code_credentials_file")
-        else "_write_claude_code_credentials"
-    )
-    real_write = getattr(anthropic_adapter, write_name)
-
-    def pause_at_write_boundary(*args: Any, **kwargs: Any) -> None:
+    def pause_at_write_boundary() -> None:
         write_boundary.set()
         assert release_write.wait(timeout=5)
-        real_write(*args, **kwargs)
 
     monkeypatch.setattr(
         anthropic_adapter,
-        write_name,
+        "_claude_reservation_commit_hook",
         pause_at_write_boundary,
     )
     results: list[str | None] = []
@@ -663,7 +658,7 @@ def _nous_entry(
     )
 
 
-def test_nous_resolver_persistence_failure_quarantines_consumed_lineage(
+def test_nous_resolver_persistence_failure_reserves_consumed_lineage(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -674,6 +669,8 @@ def test_nous_resolver_persistence_failure_quarantines_consumed_lineage(
     monkeypatch.setattr(A, "is_provider_explicitly_configured", lambda _provider: True)
     monkeypatch.setattr(CP, "load_env", lambda: {})
     monkeypatch.setattr(CP, "_get_secret", lambda *_args: "")
+    monkeypatch.setattr(A, "_read_shared_nous_state", lambda: None)
+    monkeypatch.setattr(A, "_reserve_shared_nous_lineage", lambda _token: None)
     monkeypatch.setattr(A, "_write_shared_nous_state", lambda _state: None)
     old_access = _jwt(seconds=3600, scope=A.DEFAULT_NOUS_SCOPE)
     new_access = _jwt(seconds=7200, scope=A.DEFAULT_NOUS_SCOPE)
@@ -722,22 +719,23 @@ def test_nous_resolver_persistence_failure_quarantines_consumed_lineage(
         return real_client(*args, transport=transport, **kwargs)
 
     monkeypatch.setattr(A.httpx, "Client", client_factory)
-    save_name = (
-        "_save_provider_state_to_locked_source"
-        if hasattr(A, "_save_provider_state_to_locked_source")
-        else "_save_provider_state_to_source"
-    )
-    real_save = getattr(A, save_name)
+    real_save = A._save_auth_store
     failed = False
+    auth_saves = 0
 
-    def fail_post_refresh_save(*args: Any, **kwargs: Any) -> None:
-        nonlocal failed
-        if not failed:
-            failed = True
-            raise OSError("simulated provider-state save failure")
-        real_save(*args, **kwargs)
+    def fail_post_refresh_save(
+        store: dict[str, Any],
+        target_path: Path | None = None,
+    ) -> None:
+        nonlocal failed, auth_saves
+        if target_path is not None and A._same_path(Path(target_path), auth_path):
+            auth_saves += 1
+            if auth_saves > 1:
+                failed = True
+                raise OSError("simulated provider-state save failure")
+        real_save(store, target_path)
 
-    monkeypatch.setattr(A, save_name, fail_post_refresh_save)
+    monkeypatch.setattr(A, "_save_auth_store", fail_post_refresh_save)
     pool = CredentialPool("nous", [old])
     refreshed = pool._refresh_entry(old, force=True)
 
@@ -745,14 +743,15 @@ def test_nous_resolver_persistence_failure_quarantines_consumed_lineage(
     assert requests == ["nous-refresh-old"]
     assert refreshed is None
     fresh = CP.load_pool("nous")
-    authoritative = next(entry for entry in fresh.entries() if entry.source == "device_code")
-    assert authoritative.access_token == old_access
-    assert authoritative.refresh_token == "nous-refresh-old"
-    assert authoritative.last_status == CP.STATUS_DEAD
     assert fresh.has_available() is False
+    assert all(
+        entry.refresh_token != "nous-refresh-old"
+        for entry in fresh.entries()
+    )
 
     newer = _read_json(auth_path)
     newer_state = newer["providers"]["nous"]
+    newer_state.pop(A.SOURCE_REFRESH_RESERVATION_KEY, None)
     newer_state["access_token"] = new_access
     newer_state["refresh_token"] = "nous-refresh-newer"
     newer_state["agent_key"] = new_access

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -118,6 +118,7 @@ def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):
     hermes_home.mkdir(parents=True, exist_ok=True)
     (hermes_home / "auth.json").write_text(json.dumps({
         "version": 1,
+        "active_provider": "openrouter",
         "providers": {
             "openai-codex": {
                 "tokens": {"access_token": "old-at", "refresh_token": "old-rt"},
@@ -171,6 +172,9 @@ def test_save_codex_tokens_syncs_credential_pool(tmp_path, monkeypatch):
 
     # Provider singleton is updated too.
     assert auth["providers"]["openai-codex"]["tokens"]["access_token"] == "new-at"
+    # This direct save is the explicit login/add boundary, so it still selects
+    # Codex. Automatic refresh/recovery callers opt out separately.
+    assert auth["active_provider"] == "openai-codex"
 
 
 def test_save_codex_tokens_syncs_manual_device_code_entries(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_auth_codex_self_heal.py
+++ b/tests/hermes_cli/test_auth_codex_self_heal.py
@@ -65,6 +65,7 @@ def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monk
     codex_home.mkdir()
     (hermes_home / "auth.json").write_text(json.dumps({
         "version": 1,
+        "active_provider": "openrouter",
         "providers": {
             "openai-codex": {
                 "tokens": {"refresh_token": "stale-refresh"},
@@ -90,5 +91,6 @@ def test_self_heals_missing_singleton_access_token_from_codex_cli(tmp_path, monk
     tokens = stored["providers"]["openai-codex"]["tokens"]
     assert tokens["access_token"] == "fresh-access"
     assert tokens["refresh_token"] == "fresh-refresh"
+    assert stored["active_provider"] == "openrouter"
 
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -361,6 +361,7 @@ def test_nous_inference_auth_logs_do_not_include_secret_values(
         expires_in=3600,
     )
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
 
     def _fake_refresh_access_token(*, client, portal_base_url, client_id, refresh_token):
         del client, portal_base_url, client_id, refresh_token
@@ -1030,6 +1031,7 @@ class TestStalePortalBaseUrlMigration:
 
         hermes_home = tmp_path / "hermes"
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(tmp_path / "shared"))
         _setup_nous_auth(
             hermes_home,
             access_token=_invoke_jwt(seconds=-60),

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -53,10 +53,16 @@ def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 
-def _codex_auth_store(access_token: str, refresh_token: str, *, marker: str) -> dict:
+def _codex_auth_store(
+    access_token: str,
+    refresh_token: str,
+    *,
+    marker: str,
+    active_provider: str = "openai-codex",
+) -> dict:
     return {
         "version": 1,
-        "active_provider": "openai-codex",
+        "active_provider": active_provider,
         "providers": {
             "openai-codex": {
                 "tokens": {
@@ -173,13 +179,24 @@ def test_codex_refresh_persists_to_root_fallback_without_profile_shadow(
 
     root_path = profile_env["global"] / "auth.json"
     profile_path = profile_env["profile"] / "auth.json"
-    _write(root_path, _codex_auth_store("root-old-at", "root-old-rt", marker="root"))
+    _write(
+        root_path,
+        _codex_auth_store(
+            "root-old-at",
+            "root-old-rt",
+            marker="root",
+            active_provider="openrouter",
+        ),
+    )
     _write(
         profile_path,
-        _make_auth_store(
-            pool={"anthropic": [{"id": "profile-unrelated"}]},
-            providers={"anthropic": {"api_key": "profile-unrelated"}},
-        ),
+        {
+            **_make_auth_store(
+                pool={"anthropic": [{"id": "profile-unrelated"}]},
+                providers={"anthropic": {"api_key": "profile-unrelated"}},
+            ),
+            "active_provider": "anthropic",
+        },
     )
     profile_before = profile_path.read_bytes()
 
@@ -203,6 +220,7 @@ def test_codex_refresh_persists_to_root_fallback_without_profile_shadow(
     }
     assert root["credential_pool"]["openai-codex"][0]["access_token"] == "root-new-at"
     assert root["credential_pool"]["openai-codex"][0]["refresh_token"] == "root-new-rt"
+    assert root["active_provider"] == "openrouter"
     assert root["marker"] == "root"
     assert profile_path.read_bytes() == profile_before
 
@@ -213,7 +231,15 @@ def test_codex_refresh_keeps_profile_owned_auth_local(profile_env, monkeypatch):
     root_path = profile_env["global"] / "auth.json"
     profile_path = profile_env["profile"] / "auth.json"
     _write(root_path, _codex_auth_store("root-at", "root-rt", marker="root"))
-    _write(profile_path, _codex_auth_store("profile-old-at", "profile-old-rt", marker="profile"))
+    _write(
+        profile_path,
+        _codex_auth_store(
+            "profile-old-at",
+            "profile-old-rt",
+            marker="profile",
+            active_provider="openrouter",
+        ),
+    )
     root_before = root_path.read_bytes()
 
     def fake_refresh(access_token, refresh_token, **_kwargs):
@@ -236,6 +262,7 @@ def test_codex_refresh_keeps_profile_owned_auth_local(profile_env, monkeypatch):
     }
     assert profile["credential_pool"]["openai-codex"][0]["access_token"] == "profile-new-at"
     assert profile["credential_pool"]["openai-codex"][0]["refresh_token"] == "profile-new-rt"
+    assert profile["active_provider"] == "openrouter"
     assert profile["marker"] == "profile"
     assert root_path.read_bytes() == root_before
 
@@ -247,8 +274,23 @@ def test_codex_cli_recovery_persists_to_root_fallback_without_profile_shadow(
 
     root_path = profile_env["global"] / "auth.json"
     profile_path = profile_env["profile"] / "auth.json"
-    _write(root_path, _codex_auth_store("root-old-at", "root-rejected-rt", marker="root"))
-    _write(profile_path, _make_auth_store(pool={}, providers={}))
+    _write(
+        root_path,
+        _codex_auth_store(
+            "root-old-at",
+            "root-rejected-rt",
+            marker="root",
+            active_provider="openrouter",
+        ),
+    )
+    _write(
+        profile_path,
+        {
+            **_make_auth_store(pool={}, providers={}),
+            "active_provider": "anthropic",
+            "profile_marker": "preserve",
+        },
+    )
     profile_before = profile_path.read_bytes()
 
     def reject_refresh(*_args, **_kwargs):
@@ -279,7 +321,76 @@ def test_codex_cli_recovery_persists_to_root_fallback_without_profile_shadow(
     }
     assert root["credential_pool"]["openai-codex"][0]["access_token"] == "recovered-at"
     assert root["credential_pool"]["openai-codex"][0]["refresh_token"] == "recovered-rt"
+    assert root["active_provider"] == "openrouter"
     assert root["marker"] == "root"
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_codex_malformed_root_recovery_rechecks_concurrent_in_lock_repair(
+    profile_env, monkeypatch
+):
+    """A fresh root repair must win over a stale pre-transaction read error."""
+    import hermes_cli.auth as auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    malformed = _codex_auth_store(
+        "root-malformed-access",
+        "root-malformed-refresh",
+        marker="root",
+        active_provider="openrouter",
+    )
+    malformed["providers"]["openai-codex"]["tokens"].pop("access_token")
+    _write(root_path, malformed)
+    _write(
+        profile_path,
+        {
+            **_make_auth_store(
+                pool={"anthropic": [{"id": "profile-unrelated"}]},
+                providers={"anthropic": {"api_key": "profile-unrelated"}},
+            ),
+            "active_provider": "anthropic",
+            "profile_marker": "preserve",
+        },
+    )
+    profile_before = profile_path.read_bytes()
+
+    repaired = _codex_auth_store(
+        "root-repaired-access",
+        "root-repaired-refresh",
+        marker="root",
+        active_provider="openrouter",
+    )
+    repaired["providers"]["anthropic"] = {
+        "api_key": "root-unrelated-provider"
+    }
+    repaired["root_marker"] = {"preserve": True}
+    real_transaction = auth._provider_state_transaction
+    repair_bytes = []
+
+    @contextmanager
+    def repair_before_source_transaction(*args, **kwargs):
+        # This wrapper is reached only after the first malformed read raised.
+        # Install the competing writer's valid chain before this reader gets
+        # the real active-profile -> source-store transaction.
+        _write(root_path, repaired)
+        repair_bytes.append(root_path.read_bytes())
+        with real_transaction(*args, **kwargs) as transaction:
+            yield transaction
+
+    def fail_if_cli_imported():
+        pytest.fail("CLI import must not overwrite a valid concurrent root repair")
+
+    monkeypatch.setattr(
+        auth, "_provider_state_transaction", repair_before_source_transaction
+    )
+    monkeypatch.setattr(auth, "_import_codex_cli_tokens", fail_if_cli_imported)
+
+    resolved = auth.resolve_codex_runtime_credentials()
+
+    assert resolved["api_key"] == "root-repaired-access"
+    assert repair_bytes
+    assert root_path.read_bytes() == repair_bytes[-1]
     assert profile_path.read_bytes() == profile_before
 
 

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -3,7 +3,8 @@
 When ``HERMES_HOME`` points to a named profile, ``read_credential_pool()``
 and ``get_provider_auth_state()`` fall back to the global-root
 ``auth.json`` per-provider when the profile has no entries for that
-provider.  Writes still target the profile only.
+provider. Ordinary writes still target the profile; refreshes persist rotating
+credentials back to the store that supplied them.
 
 See the #18594 follow-up report: profile workers couldn't see providers
 authenticated only at the global root.

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -52,6 +52,35 @@ def _write(path: Path, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2))
 
 
+def _codex_auth_store(access_token: str, refresh_token: str, *, marker: str) -> dict:
+    return {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+                "last_refresh": "2026-08-01T00:00:00Z",
+                "auth_mode": "chatgpt",
+            },
+        },
+        "credential_pool": {
+            "openai-codex": [
+                {
+                    "id": f"{marker}-codex",
+                    "source": "device_code",
+                    "auth_type": "oauth",
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                },
+            ],
+        },
+        "marker": marker,
+    }
+
+
 # ---------------------------------------------------------------------------
 # read_credential_pool — provider-slice reads
 # ---------------------------------------------------------------------------
@@ -134,6 +163,123 @@ def test_provider_auth_state_returns_none_when_neither_has_it(profile_env):
     _write(profile_env["profile"] / "auth.json", _make_auth_store(providers={}))
 
     assert get_provider_auth_state("nous") is None
+
+
+def test_codex_refresh_persists_to_root_fallback_without_profile_shadow(
+    profile_env, monkeypatch
+):
+    import hermes_cli.auth as auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(root_path, _codex_auth_store("root-old-at", "root-old-rt", marker="root"))
+    _write(
+        profile_path,
+        _make_auth_store(
+            pool={"anthropic": [{"id": "profile-unrelated"}]},
+            providers={"anthropic": {"api_key": "profile-unrelated"}},
+        ),
+    )
+    profile_before = profile_path.read_bytes()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        assert access_token == "root-old-at"
+        assert refresh_token == "root-old-rt"
+        return {
+            "access_token": "root-new-at",
+            "refresh_token": "root-new-rt",
+        }
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", fake_refresh)
+
+    resolved = auth.resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "root-new-at"
+    root = json.loads(root_path.read_text())
+    assert root["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "root-new-at",
+        "refresh_token": "root-new-rt",
+    }
+    assert root["credential_pool"]["openai-codex"][0]["access_token"] == "root-new-at"
+    assert root["credential_pool"]["openai-codex"][0]["refresh_token"] == "root-new-rt"
+    assert root["marker"] == "root"
+    assert profile_path.read_bytes() == profile_before
+
+
+def test_codex_refresh_keeps_profile_owned_auth_local(profile_env, monkeypatch):
+    import hermes_cli.auth as auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(root_path, _codex_auth_store("root-at", "root-rt", marker="root"))
+    _write(profile_path, _codex_auth_store("profile-old-at", "profile-old-rt", marker="profile"))
+    root_before = root_path.read_bytes()
+
+    def fake_refresh(access_token, refresh_token, **_kwargs):
+        assert access_token == "profile-old-at"
+        assert refresh_token == "profile-old-rt"
+        return {
+            "access_token": "profile-new-at",
+            "refresh_token": "profile-new-rt",
+        }
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", fake_refresh)
+
+    resolved = auth.resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "profile-new-at"
+    profile = json.loads(profile_path.read_text())
+    assert profile["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "profile-new-at",
+        "refresh_token": "profile-new-rt",
+    }
+    assert profile["credential_pool"]["openai-codex"][0]["access_token"] == "profile-new-at"
+    assert profile["credential_pool"]["openai-codex"][0]["refresh_token"] == "profile-new-rt"
+    assert profile["marker"] == "profile"
+    assert root_path.read_bytes() == root_before
+
+
+def test_codex_cli_recovery_persists_to_root_fallback_without_profile_shadow(
+    profile_env, monkeypatch
+):
+    import hermes_cli.auth as auth
+
+    root_path = profile_env["global"] / "auth.json"
+    profile_path = profile_env["profile"] / "auth.json"
+    _write(root_path, _codex_auth_store("root-old-at", "root-rejected-rt", marker="root"))
+    _write(profile_path, _make_auth_store(pool={}, providers={}))
+    profile_before = profile_path.read_bytes()
+
+    def reject_refresh(*_args, **_kwargs):
+        raise auth.AuthError(
+            "refresh token rejected",
+            provider="openai-codex",
+            code="invalid_grant",
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr(auth, "refresh_codex_oauth_pure", reject_refresh)
+    monkeypatch.setattr(
+        auth,
+        "_import_codex_cli_tokens",
+        lambda: {
+            "access_token": "recovered-at",
+            "refresh_token": "recovered-rt",
+        },
+    )
+
+    resolved = auth.resolve_codex_runtime_credentials(force_refresh=True)
+
+    assert resolved["api_key"] == "recovered-at"
+    root = json.loads(root_path.read_text())
+    assert root["providers"]["openai-codex"]["tokens"] == {
+        "access_token": "recovered-at",
+        "refresh_token": "recovered-rt",
+    }
+    assert root["credential_pool"]["openai-codex"][0]["access_token"] == "recovered-at"
+    assert root["credential_pool"]["openai-codex"][0]["refresh_token"] == "recovered-rt"
+    assert root["marker"] == "root"
+    assert profile_path.read_bytes() == profile_before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -11,6 +11,7 @@ from hermes_cli.auth import (
     AuthError,
     DEFAULT_XAI_OAUTH_BASE_URL,
     PROVIDER_REGISTRY,
+    SOURCE_REFRESH_RESERVATION_KEY,
     XAI_OAUTH_CLIENT_ID,
     XAI_OAUTH_SCOPE,
     _read_xai_oauth_tokens,
@@ -307,14 +308,11 @@ def _seed_xai_oauth_state(
     (hermes_home / "auth.json").write_text(json.dumps(auth_store, indent=2))
 
 
-def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure(
+def test_resolve_credentials_reserves_tokens_before_terminal_refresh_failure(
     tmp_path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Terminal refresh failure (relogin_required=True, code=xai_refresh_failed)
-    must remove the consumed singleton so reload cannot seed an empty or stale
-    credential. Mirrors the pool quarantine for the direct resolve path.
-    """
+    """A terminal refresh failure leaves the pre-POST reservation authoritative."""
     hermes_home = tmp_path / "hermes"
     _seed_xai_oauth_state(hermes_home, dict(_STALE_XAI_OAUTH_STATE), active_provider="nous")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -336,7 +334,10 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
     assert exc_info.value.relogin_required is True
 
     raw = json.loads((hermes_home / "auth.json").read_text())
-    assert "xai-oauth" not in raw["providers"]
+    reserved = raw["providers"]["xai-oauth"]
+    assert reserved[SOURCE_REFRESH_RESERVATION_KEY]["status"] == "reserved"
+    assert "access_token" not in reserved["tokens"]
+    assert "refresh_token" not in reserved["tokens"]
 
     # Active provider must be unchanged.
     assert raw["active_provider"] == "nous"

--- a/tests/hermes_cli/test_auth_xai_oauth_provider.py
+++ b/tests/hermes_cli/test_auth_xai_oauth_provider.py
@@ -245,14 +245,17 @@ def test_resolve_xai_runtime_credentials_refreshes_expiring_token(tmp_path, monk
     new_access = _jwt_with_exp(int(time.time()) + 2 * 60 * 60)
     called = {"count": 0}
 
-    def _fake_refresh(tokens, **kwargs):
+    def _fake_refresh(access_token, refresh_token, **kwargs):
+        assert access_token == expiring
+        assert refresh_token == "rt-old"
         called["count"] += 1
-        updated = dict(tokens)
-        updated["access_token"] = new_access
-        updated["refresh_token"] = "rt-new"
-        return updated
+        return {
+            "access_token": new_access,
+            "refresh_token": "rt-new",
+            "last_refresh": "2026-08-06T12:00:00Z",
+        }
 
-    monkeypatch.setattr("hermes_cli.auth._refresh_xai_oauth_tokens", _fake_refresh)
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _fake_refresh)
 
     creds = resolve_xai_oauth_runtime_credentials()
     assert called["count"] == 1
@@ -309,15 +312,14 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Terminal refresh failure (relogin_required=True, code=xai_refresh_failed)
-    must clear access_token/refresh_token from auth.json and write a
-    last_auth_error marker so subsequent calls fail fast without a network retry.
-    Mirrors the credential_pool.py quarantine for the singleton/direct resolve path.
+    must remove the consumed singleton so reload cannot seed an empty or stale
+    credential. Mirrors the pool quarantine for the direct resolve path.
     """
     hermes_home = tmp_path / "hermes"
     _seed_xai_oauth_state(hermes_home, dict(_STALE_XAI_OAUTH_STATE), active_provider="nous")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
-    def _terminal_refresh(tokens, **kwargs):
+    def _terminal_refresh(*_args, **_kwargs):
         raise AuthError(
             "xAI token refresh failed. Response: invalid_grant",
             provider="xai-oauth",
@@ -325,7 +327,7 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
             relogin_required=True,
         )
 
-    monkeypatch.setattr("hermes_cli.auth._refresh_xai_oauth_tokens", _terminal_refresh)
+    monkeypatch.setattr("hermes_cli.auth.refresh_xai_oauth_pure", _terminal_refresh)
 
     with pytest.raises(AuthError) as exc_info:
         resolve_xai_oauth_runtime_credentials(force_refresh=True)
@@ -334,23 +336,7 @@ def test_resolve_credentials_quarantines_dead_tokens_on_terminal_refresh_failure
     assert exc_info.value.relogin_required is True
 
     raw = json.loads((hermes_home / "auth.json").read_text())
-    tokens = raw["providers"]["xai-oauth"]["tokens"]
-
-    # Dead OAuth fields must be cleared.
-    assert "access_token" not in tokens
-    assert "refresh_token" not in tokens
-
-    # Non-credential metadata must be preserved.
-    assert tokens.get("token_type") == "Bearer"
-
-    # Structured diagnostic blob must be written.
-    err = raw["providers"]["xai-oauth"].get("last_auth_error")
-    assert isinstance(err, dict)
-    assert err["provider"] == "xai-oauth"
-    assert err["code"] == "xai_refresh_failed"
-    assert err["reason"] == "runtime_refresh_failure"
-    assert err["relogin_required"] is True
-    assert "at" in err
+    assert "xai-oauth" not in raw["providers"]
 
     # Active provider must be unchanged.
     assert raw["active_provider"] == "nous"


### PR DESCRIPTION
## Summary

Codex OAuth credentials can be inherited from the root auth store by named profiles. Refresh and pool maintenance must write back to that owning store instead of creating profile-local copies.

This change keeps root-owned Codex credentials attached to their source through refresh, status updates, quarantine, and recovery.

## Problem

- Runtime refresh locked and persisted the active profile even when the credential came from the root auth store.
- Pool loading could assign a new identity to a borrowed singleton alias and save it into the profile.
- Root fallback rows outside the singleton alias lost their owner, allowing two profiles to refresh the same rotating token independently.
- A stale process could overwrite a newer cooldown or reuse a credential after its owning source had been removed.
- Terminal refresh failure could leave duplicate aliases for the rejected token chain available for reuse.
- Automatic recovery selected `openai-codex` as `active_provider`, even though maintenance writes should not change provider selection.

## Fix

- Track source-store ownership as runtime-only metadata that is neither accepted from nor written to `auth.json`.
- Retain whether a borrowed row originally represented the singleton owner, so partial source removal cannot downgrade it to an independent credential.
- Bind singleton ownership to the row's trusted fallback category instead of a later store reread, closing removal races during pool loading.
- Keep borrowed ownership authority in pool-issued provenance and reject arbitrary caller-supplied source paths.
- Route refreshes, status updates, and removals to the exact owning store and pool row.
- Serialize rotating-token refreshes on the source-store lock. Waiting processes re-read and adopt the updated chain instead of issuing a second refresh request.
- Validate borrowed credentials outside the pool lock, then apply an identity-checked replacement. Validation errors fail that credential closed instead of returning stale cached tokens.
- Run provider status synchronization, OAuth refresh, and persistence outside the pool lock, with an explicit guard against reversed lock acquisition.
- Stop exact-ID rotation and refresh when that source credential fails validation; do not consume an unrelated credential's refresh chain.
- Keep profile-owned manual credentials local while preserving root ownership for every row read through root fallback.
- Merge status changes against current on-disk state so stale processes cannot clear newer cooldown or terminal state.
- Version dirty pool mutations so an older write cannot clear a newer terminal state while persistence is in progress.
- Treat a missing owning source as revocation across refresh, selection, lease, reset, and rotation paths.
- Remove every duplicate singleton alias on a terminally rejected token chain while preserving independent manual credentials and unrelated chains.
- Revalidate malformed state after acquiring the source transaction before attempting CLI recovery.
- Preserve `active_provider` during automatic refresh and recovery. Explicit login and add flows still select the provider.

## Scope

Production:

- `hermes_cli/auth.py`
- `agent/credential_pool.py`

Regression coverage:

- `tests/hermes_cli/test_auth_profile_fallback.py`
- `tests/hermes_cli/test_auth_codex_provider.py`
- `tests/hermes_cli/test_auth_codex_self_heal.py`
- `tests/agent/test_credential_pool_oauth_writethrough.py`
- `tests/agent/test_credential_pool.py`

No configuration, service, model, documentation, or deployment behavior changes.

## Verification

Exact head: `eda275e80a5e65f05b873dacd3dda729f9fc29de`

```text
Focused auth, Codex, and credential-pool tests: 171 passed
Lock-order and persistence regression tests: 11 passed
Broader auth and credential suite: 585 passed, 1 skipped, 1 deselected
Focused xAI and Nous regression tests: 61 passed
Focused Anthropic and custom-provider regression tests: 387 passed
Credential-pool routing with the known base failure excluded: 16 passed
Ruff on changed Python files: passed
Production py_compile: passed
git diff --check origin/main...HEAD: passed
```

The deselected routing test fails with the same assertion on the exact base commit and does not exercise the changed ownership or refresh paths.

GitHub Actions run `31073686584` is awaiting maintainer approval for an external-contributor workflow. No check contexts have run yet.