### PR TITLE
fix(email): use BODY.PEEK[] for IMAP fetch and add send-only mode

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -208,11 +208,18 @@ def check_email_requirements() -> bool:
 
     Treats blank/whitespace-only values as missing so an abandoned setup that
     left empty ``EMAIL_*`` keys in ``.env`` does not enable the platform (#40715).
+
+    In send-only mode (EMAIL_RECEIVE=false) the IMAP host is not required —
+    the platform then works purely as an SMTP sender.
     """
     addr = _get_secret("EMAIL_ADDRESS", "").strip()
     pwd = _get_secret("EMAIL_PASSWORD", "").strip()
     imap = _get_secret("EMAIL_IMAP_HOST", "").strip()
     smtp = _get_secret("EMAIL_SMTP_HOST", "").strip()
+    receive_env = _get_secret("EMAIL_RECEIVE", "").strip().lower()
+    receive_disabled = bool(receive_env) and receive_env in {"0", "false", "no", "off"}
+    if receive_disabled:
+        return all([addr, pwd, smtp])
     return all([addr, pwd, imap, smtp])
 
 
@@ -487,6 +494,17 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_port = _esecret_int("EMAIL_SMTP_PORT", 587)
         self._poll_interval = _esecret_int("EMAIL_POLL_INTERVAL", 15)
 
+        # Send-only mode: when EMAIL_RECEIVE=false the adapter skips IMAP
+        # entirely (no connection test, no polling) and is used purely as an
+        # SMTP sender. Configurable via env or platforms.email.receive in
+        # config.yaml. Enabled by default (backwards compatible) — an unset
+        # variable must NOT flip the adapter into send-only mode.
+        if "receive" in extra:
+            self._receive_enabled = bool(extra["receive"])
+        else:
+            receive_env = _get_secret("EMAIL_RECEIVE", "").strip().lower()
+            self._receive_enabled = True if not receive_env else receive_env in {"1", "true", "yes", "on"}
+
         # Skip attachments — configured via config.yaml:
         #   platforms:
         #     email:
@@ -594,7 +612,11 @@ class EmailAdapter(BasePlatformAdapter):
             return _connect(ipv4_only=True)
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to the IMAP server and start polling for new messages."""
+        """Connect to the IMAP server and start polling for new messages.
+
+        In send-only mode (EMAIL_RECEIVE=false) the IMAP connection test and
+        the polling loop are skipped entirely — only SMTP is validated.
+        """
         # Validate up front so a missing host surfaces as an actionable config
         # error instead of IMAP4_SSL("") raising the cryptic
         # ``[Errno 8] nodename nor servname provided, or not known``.
@@ -603,11 +625,12 @@ class EmailAdapter(BasePlatformAdapter):
             for name, value in (
                 ("EMAIL_ADDRESS", self._address),
                 ("EMAIL_PASSWORD", self._password),
-                ("EMAIL_IMAP_HOST", self._imap_host),
                 ("EMAIL_SMTP_HOST", self._smtp_host),
             )
             if not value
         ]
+        if self._receive_enabled and not self._imap_host:
+            missing.append("EMAIL_IMAP_HOST")
         if missing:
             message = (
                 "Not configured — missing "
@@ -625,24 +648,27 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
-        try:
-            # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-            imap.login(self._address, self._password)
-            _send_imap_id(imap)
-            # Mark all existing messages as seen so we only process new ones
-            imap.select("INBOX")
-            status, data = imap.uid("search", None, "ALL")
-            if status == "OK" and data and data[0]:
-                for uid in data[0].split():
-                    self._seen_uids.add(uid)
-            # Keep only the most recent UIDs to prevent unbounded growth
-            self._trim_seen_uids()
-            imap.logout()
-            logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
-        except Exception as e:
-            logger.error("[Email] IMAP connection failed: %s", e)
-            return False
+        if self._receive_enabled:
+            try:
+                # Test IMAP connection
+                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+                imap.login(self._address, self._password)
+                _send_imap_id(imap)
+                # Mark all existing messages as seen so we only process new ones
+                imap.select("INBOX")
+                status, data = imap.uid("search", None, "ALL")
+                if status == "OK" and data and data[0]:
+                    for uid in data[0].split():
+                        self._seen_uids.add(uid)
+                # Keep only the most recent UIDs to prevent unbounded growth
+                self._trim_seen_uids()
+                imap.logout()
+                logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+            except Exception as e:
+                logger.error("[Email] IMAP connection failed: %s", e)
+                return False
+        else:
+            logger.info("[Email] Send-only mode (EMAIL_RECEIVE=false) — IMAP skipped, SMTP only.")
 
         try:
             # Test SMTP connection
@@ -657,8 +683,9 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         self._running = True
-        self._poll_task = asyncio.create_task(self._poll_loop())
-        print(f"[Email] Connected as {self._address}")
+        if self._receive_enabled:
+            self._poll_task = asyncio.create_task(self._poll_loop())
+        print(f"[Email] Connected as {self._address}" + ("" if self._receive_enabled else " (send-only, IMAP polling off)"))
         return True
 
     async def disconnect(self) -> None:
@@ -714,7 +741,7 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -56,6 +56,32 @@ class TestCheckRequirements(unittest.TestCase):
         from plugins.platforms.email.adapter import check_email_requirements
         self.assertTrue(check_email_requirements())
 
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "a@b.com",
+        "EMAIL_PASSWORD": "pw",
+        "EMAIL_IMAP_HOST": "imap.b.com",
+        "EMAIL_SMTP_HOST": "smtp.b.com",
+        "EMAIL_RECEIVE": "false",
+    }, clear=False)
+    def test_requirements_send_only_ignores_missing_imap(self):
+        """Send-only mode (EMAIL_RECEIVE=false) must not require an IMAP host —
+        the platform is then a pure SMTP sender."""
+        from plugins.platforms.email.adapter import check_email_requirements
+        with patch.dict(os.environ, {"EMAIL_IMAP_HOST": ""}, clear=False):
+            self.assertTrue(check_email_requirements())
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "",
+        "EMAIL_PASSWORD": "",
+        "EMAIL_IMAP_HOST": "",
+        "EMAIL_SMTP_HOST": "",
+        "EMAIL_RECEIVE": "false",
+    }, clear=False)
+    def test_requirements_send_only_still_needs_smtp_creds(self):
+        """Send-only mode still requires address/password/SMTP host."""
+        from plugins.platforms.email.adapter import check_email_requirements
+        self.assertFalse(check_email_requirements())
+
 
 class TestHelperFunctions(unittest.TestCase):
     """Test email parsing helper functions."""
@@ -486,6 +512,37 @@ class TestConnectDisconnect(unittest.TestCase):
             if adapter._poll_task:
                 adapter._poll_task.cancel()
 
+    def test_connect_send_only_skips_imap(self):
+        """EMAIL_RECEIVE=false: connect() must skip IMAP entirely (no
+        connection test, no polling loop) and only validate SMTP."""
+        import asyncio
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_RECEIVE": "false",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        with patch("imaplib.IMAP4_SSL") as mock_imap, \
+             patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            result = asyncio.run(adapter.connect())
+
+            self.assertTrue(result)
+            # IMAP must never be touched in send-only mode
+            mock_imap.assert_not_called()
+            # No polling loop may start
+            self.assertIsNone(adapter._poll_task)
+            # SMTP still validated
+            mock_smtp.assert_called()
+            adapter._running = False
+
 
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
@@ -530,6 +587,42 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
         self.assertIn(b"3", adapter._seen_uids)
+
+    def test_fetch_uses_body_peek_not_rfc822(self):
+        """IMAP fetch must use BODY.PEEK[] so Gmail does not auto-mark
+        messages as seen (RFC822 is treated by Gmail as a body read)."""
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+
+        # Assert the fetch command explicitly uses BODY.PEEK[] — the
+        # regression this guards against is (RFC822), which Gmail's IMAP
+        # server treats as a body read and marks the message as seen.
+        fetch_calls = [
+            args for args in mock_imap.uid.call_args_list
+            if args[0] and args[0][0] == "fetch"
+        ]
+        self.assertTrue(fetch_calls, "expected at least one uid fetch call")
+        fetch_args = fetch_calls[0][0]
+        self.assertEqual(fetch_args[2], "(BODY.PEEK[])")
+        self.assertNotIn("RFC822", fetch_args[2])
 
 
 class TestPollLoop(unittest.TestCase):


### PR DESCRIPTION
## Problem

Two issues in the email gateway adapter (`plugins/platforms/email/adapter.py`):

### 1. Gmail auto-marks polled messages as read
The adapter fetches new messages with `imap.uid("fetch", uid, "(RFC822)")`. Although RFC 3501 defines `RFC822` as an obsolete synonym for `BODY.PEEK[]`, **Gmail's IMAP implementation treats an RFC822 fetch as a body read and silently sets the `\Seen` flag**. Every message the gateway polls gets auto-marked as read in Gmail — an inbox with ~30k messages ended up with only a handful still unread within weeks of enabling the email gateway.

`BODY.PEEK[]` is the standard, server-agnostic way to read a message body without mutating its seen state.

### 2. No way to run the adapter send-only
The email platform always connects to IMAP and starts a polling loop. Operators who only want outbound email delivery (cron notifications, `hermes send`) have no way to stop the gateway from reading their inbox.

## Changes

1. **`plugins/platforms/email/adapter.py`**
   - Fetch with `(BODY.PEEK[])` instead of `(RFC822)`.
   - New `EMAIL_RECEIVE=false` env var (or `platforms.email.receive: false` in config.yaml): skips the IMAP connection test and polling loop entirely, keeps SMTP sending. Default remains receive-enabled; an unset variable never flips behavior (backwards compatible).

2. **`tests/gateway/test_email.py`**
   - `test_fetch_uses_body_peek_not_rfc822` — guards the fetch command against regressing to RFC822.
   - `test_connect_send_only_skips_imap` — EMAIL_RECEIVE=false skips IMAP and starts no poll loop.
   - `test_requirements_send_only_*` — check_email_requirements accepts a missing IMAP host in send-only mode, still requires SMTP creds.

## Testing

```
env -u EMAIL_RECEIVE venv/bin/python -m pytest tests/gateway/test_email.py
36 passed
```

Note: the test env must be free of a leaked `EMAIL_RECEIVE` value (the adapter now honors it); the project's `scripts/run_tests.sh` already runs with a hermetic env.