### PR TITLE
fix(api_server): recovery net must never recover the advertised virtual alias

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2790,7 +2790,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if not model:
             _recovered = (self._last_resolved_model.get(_resolved_key)
                           or self._last_resolved_model.get("*"))
-            if _recovered:
+            if _recovered and _recovered != self._model_name:
                 logger.warning(
                     "Empty model resolved for session=%s — recovering "
                     "last-known-good model %s (config read likely returned "
@@ -2799,9 +2799,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 model = _recovered
         elif model:
-            if _resolved_key:
-                self._last_resolved_model[_resolved_key] = model
-            self._last_resolved_model["*"] = model
+            if model != self._model_name:
+                if _resolved_key:
+                    self._last_resolved_model[_resolved_key] = model
+                self._last_resolved_model["*"] = model
 
         user_config = _load_gateway_config()
         enabled_toolsets = sorted(_get_platform_tools(user_config, "api_server"))

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2860,3 +2860,97 @@ class TestCreateAgentModelRecovery:
         adapter._create_agent(session_id="another-session", gateway_session_key="stable-chan-1")
         assert captured[1]["model"] == "minimax/minimax-m3"
 
+    # ── Recovery-net alias guards (PR for #79101) ──────────────────────
+
+    def test_create_agent_does_not_cache_virtual_alias(self, monkeypatch):
+        """Write-side guard: the advertised virtual model (``hermes-agent``)
+        must never enter ``_last_resolved_model``, even when a prior turn
+        (or the session-row bug) dispatched it."""
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        _patch_create_agent_runtime(monkeypatch, {}, FakeAgent)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        virtual = adapter._model_name
+        # Make _resolve_gateway_model return the virtual alias — the
+        # condition the session-row bug can produce after a prior turn.
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model", lambda: virtual,
+        )
+
+        adapter._create_agent(session_id="s1", gateway_session_key="ch")
+        assert captured[0]["model"] == virtual
+        # Cache must reject the alias.
+        assert adapter._last_resolved_model.get("ch") != virtual
+        assert adapter._last_resolved_model.get("*") != virtual
+
+    def test_create_agent_rejects_virtual_alias_from_cache(self, monkeypatch):
+        """Read-side gate: an empty-model dispatch with the alias in
+        ``_last_resolved_model`` must NOT recover it — the recovery net
+        must never serve the advertised virtual model."""
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        _patch_create_agent_runtime(monkeypatch, {}, FakeAgent)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # Seed the cache with the alias (simulate a prior poisoned turn).
+        adapter._last_resolved_model["ch"] = adapter._model_name
+        adapter._last_resolved_model["*"] = adapter._model_name
+
+        # Trigger an empty resolution.
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": None, "base_url": None, "api_mode": None},
+        )
+        adapter._create_agent(session_id="s1", gateway_session_key="ch")
+
+        # The alias must not be dispatched.
+        assert captured[0]["model"] != adapter._model_name
+
+    def test_create_agent_recovery_still_works_for_legitimate_model(
+        self, monkeypatch,
+    ):
+        """Non-regression: a real dispatched model still enters the cache
+        and recovers on a subsequent empty-resolution turn — the alias
+        guard must not break legitimate recovery."""
+        captured = []
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.append(dict(kwargs))
+
+        _patch_create_agent_runtime(monkeypatch, {}, FakeAgent)
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # Turn 1: legitimate model — must enter the cache.
+        monkeypatch.setattr(
+            "gateway.run._resolve_gateway_model",
+            lambda: "anthropic/claude-opus-4.6",
+        )
+        adapter._create_agent(session_id="s1", gateway_session_key="ch")
+        assert captured[0]["model"] == "anthropic/claude-opus-4.6"
+        assert adapter._last_resolved_model["ch"] == "anthropic/claude-opus-4.6"
+
+        # Turn 2: empty resolution — must recover the legitimate model.
+        monkeypatch.setattr("gateway.run._resolve_gateway_model", lambda: "")
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {"provider": None, "base_url": None, "api_mode": None},
+        )
+        adapter._create_agent(session_id="s2", gateway_session_key="ch")
+        assert captured[1]["model"] == "anthropic/claude-opus-4.6"


### PR DESCRIPTION
**Fixes:** #79101 (class bug — the #35314 recovery net can serve the virtual model alias)
**Complements:** #72739, #79102 (session-row symptom fixes)
**Evidence:** [Comment on #79101](https://github.com/NousResearch/hermes-agent/issues/79101) — reproduction transcript and root-cause bisect from the canary investigation

## Mechanism

The empty-dispatch recovery path, added by `7dd00bb47` (#35314), caches the last successfully resolved model string in `APIServerAdapter._last_resolved_model` (per-session and process-global fallback). When a subsequent turn resolves an empty model — a transient config-cache miss, or the session-row alias bug tracked by #72739/#79102 — the recovery net does:

```python
_recovered = (self._last_resolved_model.get(key) or self._last_resolved_model.get("*"))
if _recovered:
    model = _recovered   # <-- any string, including the alias
```

Nothing prevents the advertised virtual model name (`"hermes-agent"` by default, via `_model_name`) from entering this cache (e.g., any turn that dispatched the alias through the session-row bug, or a misconfigured provider that normalizes an empty model to the alias), or from being recovered back out of it. When served as a dispatch model, the alias produces `provider=custom base_url=<default> model=hermes-agent` → HTTP 404, with the wrong base URL.

This is not the same bug as the session-row alias (#72739/#79102) — it's an independent channel: the recovery net itself is the persistent poison vector, and the alias survives across turns and sessions through it even after the session-row write is fixed.

## Fix

Two minimal guards in `_create_agent` (`gateway/platforms/api_server.py`):

1. **Read-side** (line ~2793): the recovery lookup rejects a cached value equal to the advertised virtual model — it cannot be a dispatched model, so it is never legitimate recovery material.
2. **Write-side** (line ~2801): the cache-write path refuses to store a model string equal to the advertised virtual model — so a turn that dispatched the alias (for any reason) cannot poison the next turn.

The combination means the alias survives at most one turn (if it reaches dispatch at all) and cannot propagate across turns through the recovery cache.

## Tests

Three new tests in `TestCreateAgentModelRecovery` (`tests/gateway/test_api_server.py`):

- **Write-side:** alias dispatched → agent created with it, but cache rejects it (`test_create_agent_does_not_cache_virtual_alias`).
- **Read-side:** poisoned cache (alias pre-seeded) → empty dispatch → alias NOT recovered (`test_create_agent_rejects_virtual_alias_from_cache`).
- **Non-regression:** legitimate model still enters cache and recovers on a subsequent empty-resolution turn (`test_create_agent_recovery_still_works_for_legitimate_model`).

All five tests in the class pass (2 existing + 3 new). RED→GREEN: before the fix, the two new write-side and read-side tests fail with the alias dispatched; after the fix, they pass while legitimate recovery still works.
