### PR TITLE
fix(tools): decode JSON-wrapped tool output before persisting

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -196,12 +196,15 @@ class TestMaybePersistToolResult:
         assert len(result) < len(content)
         env.execute.assert_called_once()
 
-    def test_persists_full_content_as_is(self):
-        """Content is persisted verbatim — no JSON extraction."""
+    def test_persists_json_output_field_decoded(self):
+        """Regression (#79818): a JSON-wrapped tool result must be persisted
+        as the DECODED text (real newlines), not as a single JSON-escaped
+        line -- otherwise read_file offset/limit cannot paginate by line."""
         import json
         env = MagicMock()
         env.execute.return_value = {"output": "", "returncode": 0}
-        raw = "line1\nline2\n" * 5_000
+        lines = [f"line{i}" for i in range(5_000)]
+        raw = "\n".join(lines)
         content = json.dumps({"output": raw, "exit_code": 0, "error": None})
         result = maybe_persist_tool_result(
             content=content,
@@ -211,8 +214,47 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         assert PERSISTED_OUTPUT_TAG in result
+        written = env.execute.call_args[1]["stdin_data"]
+        # The persisted file carries the decoded text with real newlines,
+        # so it is multi-line and line-paginable by read_file offset/limit.
+        assert written == raw
+        assert "\n" in written
+        assert written.count("\n") == len(lines) - 1
+        # The raw JSON blob must NOT be written verbatim.
+        assert written != content
+
+    def test_persists_json_content_field_decoded(self):
+        """Regression (#79818): a `content` string field is decoded too."""
+        import json
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        raw = "alpha\nbeta\n" * 5_000
+        content = json.dumps({"content": raw, "status": "ok"})
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_content",
+            env=env,
+            threshold=30_000,
+        )
+        assert env.execute.call_args[1]["stdin_data"] == raw
+
+    def test_persists_non_json_content_verbatim(self):
+        """Regression (#79818): non-JSON content keeps the existing verbatim
+        behavior -- plain text is written exactly as-is."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "line1\nline2\n" * 5_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_plain",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
         # Content is delivered through stdin (no longer embedded in the
-        # command string — see test_large_content_via_stdin for why).
+        # command string -- see test_large_content_via_stdin for why).
         assert env.execute.call_args[1]["stdin_data"] == content
 
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -23,6 +23,7 @@ Defense against context-window overflow operates at three levels:
 """
 
 import hashlib
+import json
 import logging
 import os
 import re
@@ -77,6 +78,31 @@ def _safe_result_filename(tool_use_id: str) -> str:
         safe_stem = f"{safe_stem}_{digest}"
 
     return f"{safe_stem}.txt"
+
+
+def _decode_json_wrapped_text(content: str) -> str:
+    """Return the decoded text when content is a JSON blob carrying a string
+    ``output`` or ``content`` field; otherwise return content unchanged.
+
+    Some tools (e.g. terminal) return their result serialized as JSON, e.g.
+    ``{"output": "line1\\nline2", "exit_code": 0}``. Persisting that blob
+    verbatim writes every newline as the two characters ``\\n``, producing a
+    single physical line -- which read_file's line-based offset/limit cannot
+    paginate. Extracting the text field keeps persisted files line-oriented
+    so offset/limit work as documented (#79818).
+    """
+    if not content.lstrip().startswith("{"):
+        return content
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        return content
+    if isinstance(parsed, dict):
+        for key in ("output", "content"):
+            value = parsed.get(key)
+            if isinstance(value, str):
+                return value
+    return content
 
 
 def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) -> tuple[str, bool]:
@@ -176,11 +202,17 @@ def maybe_persist_tool_result(
 
     storage_dir = _resolve_storage_dir(env)
     remote_path = f"{storage_dir}/{_safe_result_filename(tool_use_id)}"
-    preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    # If the raw result is a JSON blob wrapping a string field (e.g. the
+    # terminal tool's {"output": ..., "exit_code": ...}), persist the DECODED
+    # text so the file keeps real newlines and read_file offset/limit can
+    # paginate by line. Persisting the escaped blob produces a single physical
+    # line that line-based pagination cannot slice (#79818).
+    persist_content = _decode_json_wrapped_text(content)
+    preview, has_more = generate_preview(persist_content, max_chars=config.preview_size)
 
     if env is not None:
         try:
-            if _write_to_sandbox(content, remote_path, env):
+            if _write_to_sandbox(persist_content, remote_path, env):
                 logger.info(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,


### PR DESCRIPTION
## Summary
Persisted tool output was written as a single escaped JSON line. For the `terminal` tool, `function_result` is a JSON string (`{"output": "...", "exit_code": 0}`), so every newline in the captured output was escaped — producing a file with one physical line. The `read_file` `offset`/`limit` instructions (which page per line) became useless, and per-line truncation silently capped what the model received.

## Root Cause
`maybe_persist_tool_result` in `tools/tool_result_storage.py` wrote the content verbatim. JSON-wrapped results kept escaped `\n` sequences, so the persisted file had 1 line regardless of output size.

## Change
- New `_decode_json_wrapped_text(content)` helper: if content parses as a JSON object with a string `output` or `content` field, returns the decoded text (real newlines); otherwise returns content intact. Fast-path `lstrip().startswith("{")` avoids parsing non-JSON.
- `maybe_persist_tool_result` now persists the decoded text (sandbox write and the generated preview both use it, keeping preview consistent with the file). No caller changes needed — signature/contract preserved.

## Verification
- `tests/tools/test_tool_result_storage.py`: **28 passed** (existing + new coverage: JSON with output → multi-line file with real newlines; non-JSON → unchanged behavior).

Closes #79818