### PR TITLE
fix(agent): fire plugin hooks for auxiliary LLM calls

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3053,6 +3053,198 @@ def _relay_auxiliary_metadata(
     }
 
 
+# ── Plugin hooks for auxiliary calls (#79733) ───────────────────────────────
+# Every auxiliary LLM call funnels through the ``_relay_*`` helpers below,
+# which now fire the same pre_api_request / post_api_request plugin hooks the
+# main loop fires per API call (agent/conversation_loop.py). Before this,
+# hook-based observability plugins (Langfuse, NeMo Relay, cost guards) were
+# structurally blind to approval / title_generation / compression / vision /
+# web_extract / session_search calls. The auxiliary task name is surfaced as
+# both ``task`` and ``task_id`` (plus ``auxiliary=True``) so plugins can tell
+# auxiliary calls apart from main-turn calls. Everything here is fail-open:
+# a raising hook or a missing plugin never breaks the auxiliary call.
+
+def _aux_hook_usage_summary(response: Any, *, provider: str | None = None) -> dict:
+    """Best-effort canonical usage summary for the post_api_request hook payload.
+
+    Mirrors the usage normalisation in ``agent.aux_accounting.record_aux_usage``
+    (``usage_pricing.normalize_usage``) so hook consumers see the same token
+    buckets the storage layer records.
+    """
+    try:
+        raw_usage = getattr(response, "usage", None)
+        if raw_usage is None:
+            return {}
+        from agent.usage_pricing import normalize_usage
+
+        usage = normalize_usage(raw_usage, provider=provider)
+        summary = {
+            "input_tokens": usage.input_tokens,
+            "output_tokens": usage.output_tokens,
+        }
+        if usage.cache_read_tokens:
+            summary["cache_read_tokens"] = usage.cache_read_tokens
+        if usage.cache_write_tokens:
+            summary["cache_write_tokens"] = usage.cache_write_tokens
+        if usage.reasoning_tokens:
+            summary["reasoning_tokens"] = usage.reasoning_tokens
+        return summary
+    except Exception:
+        return {}
+
+
+def _aux_hook_finish_reason(response: Any) -> str:
+    """Best-effort finish_reason for the post_api_request hook payload."""
+    try:
+        choices = getattr(response, "choices", None)
+        if choices:
+            return str(getattr(choices[0], "finish_reason", "") or "")
+    except Exception:
+        pass
+    return ""
+
+
+def _aux_api_hook_identity(
+    *,
+    metadata: dict[str, Any],
+    client: Any,
+    model_name: str,
+    provider_name: str,
+    api_mode: str | None,
+) -> Dict[str, Any]:
+    """Shared hook identity kwargs for one auxiliary provider attempt."""
+    task = str(metadata.get("auxiliary_task") or "")
+    return {
+        "task_id": task,
+        "task": task,
+        "auxiliary": True,
+        "turn_id": "",
+        "api_request_id": str(metadata.get("api_request_id") or ""),
+        "api_call_count": int(metadata.get("retry_count") or 0) + 1,
+        "session_id": "",
+        "platform": "",
+        "model": model_name,
+        "provider": provider_name,
+        "base_url": str(getattr(client, "base_url", "") or ""),
+        "api_mode": str(api_mode or ""),
+    }
+
+
+def _aux_fire_api_hook(
+    hook_name: str,
+    identity: Dict[str, Any],
+    *,
+    started_at: float,
+    ended_at: Optional[float] = None,
+    response: Any = None,
+    error: Optional[BaseException] = None,
+    request_messages: Any = None,
+    streaming: bool = False,
+) -> None:
+    """Fire one pre_api_request / post_api_request hook for an auxiliary call.
+
+    Gated on ``has_hook`` and fail-open, matching the main loop's per-API-call
+    hook pattern (agent/conversation_loop.py).
+    """
+    try:
+        from hermes_cli.lifecycle import has_hook as _has_hook, invoke_hook as _invoke_hook
+
+        if not _has_hook(hook_name):
+            return
+        payload = dict(identity)
+        payload.update(started_at=started_at, streaming=streaming)
+        if hook_name == "pre_api_request":
+            payload["request_messages"] = (
+                list(request_messages) if isinstance(request_messages, list) else []
+            )
+        else:
+            ended_at = ended_at or time.time()
+            payload.update(ended_at=ended_at, api_duration=max(0.0, ended_at - started_at))
+            if error is not None:
+                payload.update(error=error, error_type=type(error).__name__)
+            else:
+                payload["response"] = response
+                payload["usage"] = _aux_hook_usage_summary(
+                    response, provider=identity.get("provider") or ""
+                )
+                payload["finish_reason"] = _aux_hook_finish_reason(response)
+        _invoke_hook(hook_name, **payload)
+    except Exception:
+        pass
+
+
+def _aux_invoke_with_hooks(
+    call_fn: Callable[[], Any],
+    *,
+    client: Any,
+    kwargs: dict[str, Any],
+    provider_name: str,
+    model_name: str,
+    api_mode: str | None,
+    metadata: dict[str, Any],
+    streaming: bool = False,
+) -> Any:
+    """Run one synchronous auxiliary provider call wrapped in API hooks."""
+    identity = _aux_api_hook_identity(
+        metadata=metadata, client=client, model_name=model_name,
+        provider_name=provider_name, api_mode=api_mode,
+    )
+    started_at = time.time()
+    _aux_fire_api_hook(
+        "pre_api_request", identity, started_at=started_at,
+        request_messages=kwargs.get("messages"), streaming=streaming,
+    )
+    try:
+        result = call_fn()
+    except Exception as exc:
+        _aux_fire_api_hook(
+            "post_api_request", identity, started_at=started_at,
+            ended_at=time.time(), error=exc, streaming=streaming,
+        )
+        raise
+    _aux_fire_api_hook(
+        "post_api_request", identity, started_at=started_at,
+        ended_at=time.time(), response=result, streaming=streaming,
+    )
+    return result
+
+
+async def _aux_invoke_with_hooks_async(
+    call_fn: Callable[[], Any],
+    *,
+    client: Any,
+    kwargs: dict[str, Any],
+    provider_name: str,
+    model_name: str,
+    api_mode: str | None,
+    metadata: dict[str, Any],
+    streaming: bool = False,
+) -> Any:
+    """Run one asynchronous auxiliary provider call wrapped in API hooks."""
+    identity = _aux_api_hook_identity(
+        metadata=metadata, client=client, model_name=model_name,
+        provider_name=provider_name, api_mode=api_mode,
+    )
+    started_at = time.time()
+    _aux_fire_api_hook(
+        "pre_api_request", identity, started_at=started_at,
+        request_messages=kwargs.get("messages"), streaming=streaming,
+    )
+    try:
+        result = await call_fn()
+    except Exception as exc:
+        _aux_fire_api_hook(
+            "post_api_request", identity, started_at=started_at,
+            ended_at=time.time(), error=exc, streaming=streaming,
+        )
+        raise
+    _aux_fire_api_hook(
+        "post_api_request", identity, started_at=started_at,
+        ended_at=time.time(), response=result, streaming=streaming,
+    )
+    return result
+
+
 def _relay_sync_completion(
     client: Any,
     kwargs: dict[str, Any],
@@ -3069,15 +3261,27 @@ def _relay_sync_completion(
     if route is None:
         return _run_protected_sync_provider_call(callback, kwargs)
     provider_name, fallback_model, metadata = route
-    from agent import relay_llm
 
-    return relay_llm.execute_current(
-        kwargs,
-        lambda request: _run_protected_sync_provider_call(callback, request),
-        name=provider_name,
+    def _call() -> Any:
+        from agent import relay_llm
+
+        return relay_llm.execute_current(
+            kwargs,
+            lambda request: _run_protected_sync_provider_call(callback, request),
+            name=provider_name,
+            model_name=str(kwargs.get("model") or fallback_model),
+            metadata=metadata,
+            defer_logical_completion=True,
+        )
+
+    return _aux_invoke_with_hooks(
+        _call,
+        client=client,
+        kwargs=kwargs,
+        provider_name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
+        api_mode=api_mode,
         metadata=metadata,
-        defer_logical_completion=True,
     )
 
 
@@ -3094,15 +3298,27 @@ async def _relay_async_completion(
     if route is None:
         return await callback(kwargs)
     provider_name, fallback_model, metadata = route
-    from agent import relay_llm
 
-    return await relay_llm.execute_current_async(
-        kwargs,
-        callback,
-        name=provider_name,
+    async def _call() -> Any:
+        from agent import relay_llm
+
+        return await relay_llm.execute_current_async(
+            kwargs,
+            callback,
+            name=provider_name,
+            model_name=str(kwargs.get("model") or fallback_model),
+            metadata=metadata,
+            defer_logical_completion=True,
+        )
+
+    return await _aux_invoke_with_hooks_async(
+        _call,
+        client=client,
+        kwargs=kwargs,
+        provider_name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
+        api_mode=api_mode,
         metadata=metadata,
-        defer_logical_completion=True,
     )
 
 
@@ -3117,16 +3333,29 @@ def _relay_sync_stream(
     if route is None:
         return client.chat.completions.create(**kwargs)
     provider_name, fallback_model, metadata = route
-    from agent import relay_llm
 
-    return relay_llm.stream_current(
-        kwargs,
-        lambda request: client.chat.completions.create(**request),
-        name=provider_name,
+    def _call() -> Any:
+        from agent import relay_llm
+
+        return relay_llm.stream_current(
+            kwargs,
+            lambda request: client.chat.completions.create(**request),
+            name=provider_name,
+            model_name=str(kwargs.get("model") or fallback_model),
+            finalizer=dict,
+            metadata=metadata,
+            completed_response_predicate=lambda value: hasattr(value, "choices"),
+        )
+
+    return _aux_invoke_with_hooks(
+        _call,
+        client=client,
+        kwargs=kwargs,
+        provider_name=provider_name,
         model_name=str(kwargs.get("model") or fallback_model),
-        finalizer=dict,
+        api_mode=api_mode,
         metadata=metadata,
-        completed_response_predicate=lambda value: hasattr(value, "choices"),
+        streaming=True,
     )
 _RUNTIME_MAIN_COMPAT_SNAPSHOT: Tuple[Any, ...] = ("", "", "", "", "", "")
 _RUNTIME_MAIN_COMPAT_LOCK = threading.Lock()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4546,3 +4546,219 @@ class TestFastModelTier:
             _FAST_MODEL_TASKS
         )
         assert not overlap
+
+
+# ── Plugin hooks for auxiliary calls (#79733) ──────────────────────────────
+
+
+class TestAuxiliaryCallPluginHooks:
+    """auxiliary_client.call_llm() fires pre/post_api_request plugin hooks.
+
+    Every auxiliary task (approval, title_generation, compression, vision,
+    web_extract, session_search, ...) funnels through call_llm()'s relay
+    boundary. Before #79733 those calls never fired any plugin hook, so
+    hook-based observability plugins (Langfuse, NeMo Relay, cost guards) were
+    structurally blind to them. These tests pin the hook contract: the
+    auxiliary task name is surfaced as both ``task`` and ``task_id`` (plus
+    ``auxiliary=True``), pre/post share one api_request_id, and errors are
+    reported on post_api_request.
+    """
+
+    def _make_response(self):
+        """A chat-completions-shaped response carrying full usage details."""
+        return SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(content="ok"),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(
+                prompt_tokens=10,
+                completion_tokens=5,
+                prompt_tokens_details=SimpleNamespace(
+                    cached_tokens=2, cache_write_tokens=3,
+                ),
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=1),
+            ),
+            model="mock-model",
+        )
+
+    def _patch_call_llm(self, monkeypatch, client):
+        """Patch the resolution/validation chain so call_llm uses ``client``."""
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *a, **k: ("openrouter", "mock-model", None, None, None),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *a, **k: (client, "mock-model"),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._validate_llm_response",
+            lambda resp, _task, **_kw: resp,
+        )
+        return client
+
+    def _capture_hooks(self, monkeypatch):
+        """Route lifecycle hooks into a captured list; has_hook → True."""
+        hook_calls = []
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        return hook_calls
+
+    def test_call_llm_fires_hooks_on_success(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        response = self._make_response()
+        client.chat.completions.create.return_value = response
+        self._patch_call_llm(monkeypatch, client)
+        hook_calls = self._capture_hooks(monkeypatch)
+
+        result = call_llm(task="title_generation", messages=messages)
+
+        assert result is response
+        names = [name for name, _ in hook_calls]
+        assert names == ["pre_api_request", "post_api_request"]
+
+        pre = hook_calls[0][1]
+        assert pre["task"] == "title_generation"
+        assert pre["task_id"] == "title_generation"
+        assert pre["auxiliary"] is True
+        assert pre["api_call_count"] == 1
+        assert pre["api_request_id"].startswith("aux-")
+        assert pre["request_messages"] == messages
+        assert pre["model"] == "mock-model"
+        assert pre["provider"] == "openrouter"
+        assert pre["base_url"] == "https://openrouter.ai/api/v1"
+        assert pre["streaming"] is False
+        assert pre["started_at"] > 0
+
+        post = hook_calls[1][1]
+        assert post["api_request_id"] == pre["api_request_id"]
+        assert post["response"] is response
+        assert post["finish_reason"] == "stop"
+        assert post["api_duration"] >= 0
+        assert post["usage"] == {
+            "input_tokens": 5,
+            "output_tokens": 5,
+            "cache_read_tokens": 2,
+            "cache_write_tokens": 3,
+            "reasoning_tokens": 1,
+        }
+        # Same task scoping on the completion side.
+        assert post["task"] == "title_generation"
+        assert post["auxiliary"] is True
+
+    def test_call_llm_fires_post_hook_with_error(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        boom = RuntimeError("boom")
+        client.chat.completions.create.side_effect = boom
+        self._patch_call_llm(monkeypatch, client)
+        hook_calls = self._capture_hooks(monkeypatch)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            call_llm(task="session_search", messages=messages)
+
+        names = [name for name, _ in hook_calls]
+        assert names == ["pre_api_request", "post_api_request"]
+        pre = hook_calls[0][1]
+        post = hook_calls[1][1]
+        assert post["api_request_id"] == pre["api_request_id"]
+        assert post["error"] is boom
+        assert post["error_type"] == "RuntimeError"
+        assert post["task"] == "session_search"
+        assert post["api_duration"] >= 0
+
+    def test_async_call_llm_fires_hooks_on_success(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        response = self._make_response()
+        client.chat.completions.create = AsyncMock(return_value=response)
+        self._patch_call_llm(monkeypatch, client)
+        hook_calls = self._capture_hooks(monkeypatch)
+
+        async def _run():
+            return await async_call_llm(task="web_extract", messages=messages)
+
+        import asyncio
+
+        result = asyncio.run(_run())
+
+        assert result is response
+        names = [name for name, _ in hook_calls]
+        assert names == ["pre_api_request", "post_api_request"]
+        pre = hook_calls[0][1]
+        post = hook_calls[1][1]
+        assert pre["task"] == "web_extract"
+        assert pre["request_messages"] == messages
+        assert post["api_request_id"] == pre["api_request_id"]
+        assert post["response"] is response
+
+    def test_streaming_call_fires_hooks_with_streaming_flag(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        stream = iter([SimpleNamespace(choices=[])])
+        client.chat.completions.create.return_value = stream
+        self._patch_call_llm(monkeypatch, client)
+        hook_calls = self._capture_hooks(monkeypatch)
+
+        result = call_llm(
+            task="moa_aggregator",
+            provider="openrouter",
+            model="mock-model",
+            messages=messages,
+            stream=True,
+        )
+
+        assert result is stream
+        names = [name for name, _ in hook_calls]
+        assert names == ["pre_api_request", "post_api_request"]
+        assert hook_calls[0][1]["streaming"] is True
+        assert hook_calls[1][1]["streaming"] is True
+        assert hook_calls[1][1]["api_request_id"] == hook_calls[0][1]["api_request_id"]
+        assert hook_calls[1][1]["task"] == "moa_aggregator"
+
+    def test_no_hook_registered_skips_invoke(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        response = self._make_response()
+        client.chat.completions.create.return_value = response
+        self._patch_call_llm(monkeypatch, client)
+
+        invoked = []
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda *a, **k: invoked.append((a, k)),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: False)
+
+        result = call_llm(task="title_generation", messages=messages)
+
+        assert result is response
+        assert invoked == []
+
+    def test_raising_hook_does_not_break_aux_call(self, monkeypatch):
+        messages = [{"role": "user", "content": "hello"}]
+        client = MagicMock()
+        client.base_url = "https://openrouter.ai/api/v1"
+        response = self._make_response()
+        client.chat.completions.create.return_value = response
+        self._patch_call_llm(monkeypatch, client)
+
+        def _boom(*a, **k):
+            raise RuntimeError("hook failed")
+
+        monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", _boom)
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+
+        result = call_llm(task="compression", messages=messages)
+
+        assert result is response


### PR DESCRIPTION
## Summary
`agent/auxiliary_client.py` — the shared router every auxiliary task (approval, title_generation, compression, vision, web_extract, session_search, moa) funnels through via its `call_llm()` entry point — never invoked `invoke_hook(...)` for any lifecycle event. Every hook-based plugin (Langfuse, NeMo Relay, any observability/cost-guard) was structurally blind to auxiliary-task calls.

## Root Cause
`call_llm()` has dozens of `return`/fallback paths, and none fired the hook bus. The main loop (`conversation_loop.py`) fires `pre_api_request`/`post_api_request` per API call; the auxiliary router skipped that entirely.

## Change
Hooks are now fired at the Relay boundary (`_relay_sync_completion`, `_relay_async_completion`, `_relay_sync_stream`) — the single junction covering **all** auxiliary-task paths including fallbacks/retries (each physical attempt gets a pre/post pair):
- `_aux_hook_usage_summary` — normalizes `usage` via `usage_pricing.normalize_usage` (same buckets as storage: input/output/cache_read/cache_write/reasoning)
- `_aux_hook_finish_reason` — best-effort `finish_reason` extraction
- Pre/post `invoke_hook` calls follow the main-loop pattern (`has_hook` gate + fail-open), passing `request_messages`, `api_request_id`, `task_id`, `usage`, `finish_reason`.

Distinct from #78953 (storage-layer bad data): this restores visibility at the plugin-hook layer, so observability plugins can see auxiliary calls regardless of token accounting.

## Verification
- `tests/agent/test_auxiliary_client.py`: **177 passed** (existing + new: hook fired on successful auxiliary call and on error).

Closes #79733