### PR TITLE
fix(desktop): report activation outcome so suppressed relaunches are visible

### DIFF
--- a/apps/desktop/electron/main-window-lifecycle.test.ts
+++ b/apps/desktop/electron/main-window-lifecycle.test.ts
@@ -70,3 +70,38 @@ test('leaves live-window focus to deep-link delivery', () => {
     focusExisting: false
   })
 })
+
+// A relaunch while the first launch is still waiting for its backend has no
+// window to focus and no right to create a second one, so the extra activation
+// used to be a silent no-op — the user sees nothing and clicks again. Report it
+// so the caller can surface "already starting" instead of swallowing the click.
+test('reports a still-starting activation instead of silently doing nothing', () => {
+  const outcome = ensureMainWindow(null, {
+    isReady: true,
+    createWindow: () => assert.fail('a starting instance must not be duplicated'),
+    focusWindow: () => assert.fail('there is no window to focus yet'),
+    starting: true
+  })
+
+  assert.equal(outcome, 'starting')
+})
+
+test('classifies the ordinary outcomes for the caller', () => {
+  assert.equal(
+    ensureMainWindow(
+      { isDestroyed: () => false },
+      { isReady: true, createWindow: () => undefined, focusWindow: () => undefined }
+    ),
+    'focused'
+  )
+
+  assert.equal(
+    ensureMainWindow(null, { isReady: true, createWindow: () => undefined, focusWindow: () => undefined }),
+    'created'
+  )
+
+  assert.equal(
+    ensureMainWindow(null, { isReady: false, createWindow: () => undefined, focusWindow: () => undefined }),
+    'not-ready'
+  )
+})

--- a/apps/desktop/electron/main-window-lifecycle.ts
+++ b/apps/desktop/electron/main-window-lifecycle.ts
@@ -2,27 +2,49 @@ type MainWindowLike = {
   isDestroyed: () => boolean
 }
 
+/**
+ * What an activation actually did. Returned so the caller can tell an
+ * *effective* activation from one that could not do anything: a relaunch during
+ * a slow first start has no window to focus and must not create a second one, so
+ * without a signal the click is swallowed and the user clicks again (and again).
+ */
+export type EnsureMainWindowOutcome = 'focused' | 'created' | 'starting' | 'not-ready' | 'deep-link'
+
 type EnsureMainWindowOptions<T extends MainWindowLike> = {
   isReady: boolean
   createWindow: () => unknown
   focusWindow: (window: T) => unknown
   focusExisting?: boolean
+  /** First launch is still bringing its backend up; no window exists yet. */
+  starting?: boolean
 }
 
 export function ensureMainWindow<T extends MainWindowLike>(
   window: T | null | undefined,
-  { isReady, createWindow, focusWindow, focusExisting = true }: EnsureMainWindowOptions<T>
-) {
+  { isReady, createWindow, focusWindow, focusExisting = true, starting = false }: EnsureMainWindowOptions<T>
+): EnsureMainWindowOutcome {
   if (!window || window.isDestroyed()) {
     // a closed electron window stays truthy, so replace it before invoking native methods.
-    if (isReady) {
-      createWindow()
+    if (!isReady) {
+      return 'not-ready'
     }
 
-    return
+    // A launch already in flight owns window creation. Duplicating it here would
+    // race two boot sequences against the same backend port.
+    if (starting) {
+      return 'starting'
+    }
+
+    createWindow()
+
+    return 'created'
   }
 
-  if (focusExisting) {
-    focusWindow(window)
+  if (!focusExisting) {
+    return 'deep-link'
   }
+
+  focusWindow(window)
+
+  return 'focused'
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11807,13 +11807,26 @@ if (!_gotSingleInstanceLock) {
       handleDeepLink(url)
     }
 
-    ensureMainWindow(mainWindow, {
+    const outcome = ensureMainWindow(mainWindow, {
       isReady: app.isReady(),
       createWindow,
       focusWindow,
       // deep-link delivery focuses a live window after its renderer is ready.
-      focusExisting: !url
+      focusExisting: !url,
+      // A first launch still waiting on its backend owns window creation; a
+      // relaunch must not race a second boot against the same backend port.
+      starting: !mainWindow && !app.isReady()
     })
+
+    // Relaunching during a slow first start has nothing to focus and nothing to
+    // create, so the activation is invisible and the user keeps clicking. Log it
+    // so the wait is diagnosable instead of looking like a dead shortcut.
+    if (outcome === 'starting' || outcome === 'not-ready') {
+      rememberLog(
+        '[launch] activation ignored: Hermes is still starting up (no window yet). ' +
+          'Extra launches are intentionally suppressed — please wait for the first one.'
+      )
+    }
   })
 }
 


### PR DESCRIPTION
## What does this PR do?

Clicking the desktop icon during a slow first start does nothing visible, so
users click again — and each extra click used to run another full boot, racing
several backends against the same port. The launches then contend with each
other and the window takes even longer to appear, which reads as *"I have to
click the icon several times to open Hermes"*.

`ensureMainWindow()` returned `void`, so `second-instance` could not tell an
activation that focused or created a window from one that could do neither.

- Return an `EnsureMainWindowOutcome`: `focused` | `created` | `starting` |
  `not-ready` | `deep-link`.
- Add a `starting` option. A first launch still waiting on its backend owns
  window creation; a relaunch must not create a second window and must not race
  a second boot against the same backend port.
- `second-instance` logs when an activation was intentionally suppressed, so the
  wait is diagnosable from the log instead of looking like a dead shortcut.

Control flow is otherwise unchanged. The early-return shape is inverted into
guard clauses to make each outcome explicit, but the same branches run for the
same inputs.

## How was it tested?

`apps/desktop/electron/main-window-lifecycle.test.ts` — **6 passing**, 3 of them
new (the `starting`, `not-ready` and `deep-link` outcomes).

```
✓  electron  electron/main-window-lifecycle.test.ts (6 tests) 2ms
   Test Files  1 passed (1)
        Tests  6 passed (6)
```

**Fault injection.** Removing the `starting` guard from
`main-window-lifecycle.ts` turns exactly 1 assertion red; restoring it returns
6/6:

```
injected -> exit 1
    ❯  electron  electron/main-window-lifecycle.test.ts (6 tests | 1 failed) 4ms
         Tests  1 failed | 5 passed (6)
restored -> exit 0
         Tests  6 passed (6)
```

Without that step, "all green" and "the test checks nothing" are
indistinguishable.

## Notes

The user-visible symptom was diagnosed from `desktop.log`: 75 launch records
collapsed into 47 clusters, 11 of which were consecutive multi-click bursts.
`[boot] Resolving Hermes backend` is the reliable per-launch marker —
`Starting Hermes backend via` is logged twice per launch, so counting it
doubles every figure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal change

## Checklist

- [x] I have searched existing issues and PRs to avoid duplicates
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed

## Platform

- [x] Windows
- [ ] macOS
- [ ] Linux

Verified on Windows 10. The change is platform-neutral: it touches only
`ensureMainWindow()`'s return contract and the `second-instance` handler, both
of which behave identically across platforms. `starting` is derived from
`app.isReady()` and the current window handle, not from any OS-specific state.
