### PR TITLE
fix(async-delegation): bound the replay window for undelivered completions

### DIFF
--- a/tests/tools/test_async_delegation_orphan_expiry.py
+++ b/tests/tools/test_async_delegation_orphan_expiry.py
@@ -1,0 +1,145 @@
+"""Durable pending completions must not replay forever.
+
+`restore_undelivered_completions()` re-enqueues every row still marked
+`delivery_state='pending'` on process start. Delivery is deliberately
+fail-closed — a restored event is never adopted by an unrelated session — so a
+completion whose owning session never comes back stays `pending` and is
+re-enqueued on *every* start, forever, and `_prune_durable_records()` never
+removes it because it only deletes `delivered` rows.
+
+`expire_stale_pending_completions()` bounds that replay window by moving aged
+rows to the terminal `orphaned` state: unlike `delivered` it does not claim the
+user saw the result, and unlike `pending` it is not replayed again.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+import tools.async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def _clean_table():
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("DELETE FROM async_delegations")
+    yield
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute("DELETE FROM async_delegations")
+
+
+def _insert(
+    delegation_id: str,
+    *,
+    state: str,
+    delivery_state: str,
+    completed_at: float | None,
+    updated_at: float,
+) -> None:
+    event = json.dumps({"delegation_id": delegation_id, "summary": "done"})
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+                   (delegation_id, origin_session, state, delivery_state,
+                    event_json, completed_at, updated_at, dispatched_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                delegation_id,
+                "session-A",
+                state,
+                delivery_state,
+                event,
+                completed_at,
+                updated_at,
+                updated_at,
+            ),
+        )
+
+
+def _row(delegation_id: str) -> tuple[str, str] | None:
+    with ad._DB_LOCK, ad._transaction() as conn:
+        cur = conn.execute(
+            "SELECT state, delivery_state FROM async_delegations WHERE delegation_id=?",
+            (delegation_id,),
+        )
+        row = cur.fetchone()
+    return (row[0], row[1]) if row else None
+
+
+def test_aged_pending_completion_becomes_orphaned():
+    old = time.time() - 10 * 24 * 60 * 60
+    _insert("aged", state="completed", delivery_state="pending",
+            completed_at=old, updated_at=old)
+
+    assert ad.expire_stale_pending_completions() == 1
+    assert _row("aged") == ("completed", "orphaned")
+
+
+def test_recent_pending_completion_is_left_alone():
+    recent = time.time() - 60
+    _insert("recent", state="completed", delivery_state="pending",
+            completed_at=recent, updated_at=recent)
+
+    assert ad.expire_stale_pending_completions() == 0
+    assert _row("recent") == ("completed", "pending")
+
+
+@pytest.mark.parametrize("live_state", ["running", "finalizing"])
+def test_live_work_is_never_expired(live_state):
+    """Age alone must not orphan work that has not finished yet."""
+    old = time.time() - 10 * 24 * 60 * 60
+    _insert(live_state, state=live_state, delivery_state="pending",
+            completed_at=None, updated_at=old)
+
+    assert ad.expire_stale_pending_completions() == 0
+    assert _row(live_state) == (live_state, "pending")
+
+
+def test_legacy_row_without_completed_at_uses_updated_at():
+    old = time.time() - 10 * 24 * 60 * 60
+    _insert("legacy", state="completed", delivery_state="pending",
+            completed_at=None, updated_at=old)
+
+    assert ad.expire_stale_pending_completions() == 1
+    assert _row("legacy") == ("completed", "orphaned")
+
+
+def test_orphaned_rows_are_not_replayed():
+    """The whole point: an orphaned row must not be re-enqueued on start."""
+    old = time.time() - 10 * 24 * 60 * 60
+    _insert("aged", state="completed", delivery_state="pending",
+            completed_at=old, updated_at=old)
+    _insert("fresh", state="completed", delivery_state="pending",
+            completed_at=time.time(), updated_at=time.time())
+
+    enqueued: list[object] = []
+
+    class _Queue:
+        def put(self, item):
+            enqueued.append(item)
+
+        def put_nowait(self, item):
+            enqueued.append(item)
+
+    restored = ad.restore_undelivered_completions(_Queue())
+
+    assert restored == 1, "only the fresh completion should be replayed"
+    assert _row("aged")[1] == "orphaned"
+    assert _row("fresh")[1] == "pending"
+
+
+def test_orphaned_rows_age_out_of_retention():
+    """`orphaned` must share the retention window with `delivered`.
+
+    Otherwise expiry just swaps an infinite replay for an infinite row.
+    """
+    ancient = time.time() - 2 * ad._DURABLE_RETENTION_SECONDS
+    _insert("ancient", state="completed", delivery_state="orphaned",
+            completed_at=ancient, updated_at=ancient)
+
+    ad._prune_durable_records()
+
+    assert _row("ancient") is None

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -236,8 +236,13 @@ def _prune_durable_records() -> None:
     now = time.time()
     cutoff = now - _DURABLE_RETENTION_SECONDS
     with _DB_LOCK, _transaction() as conn:
+        # 'orphaned' is a terminal non-delivery state (see
+        # expire_stale_pending_completions) and must age out on the same
+        # retention window as 'delivered' — otherwise expired rows accumulate
+        # forever and only the audit-preserving extra window was intended.
         conn.execute(
-            "DELETE FROM async_delegations WHERE delivery_state='delivered' AND updated_at < ?",
+            """DELETE FROM async_delegations
+               WHERE delivery_state IN ('delivered','orphaned') AND updated_at < ?""",
             (cutoff,),
         )
         terminal_count = conn.execute(
@@ -341,6 +346,38 @@ def recover_abandoned_delegations() -> int:
     return recovered
 
 
+def expire_stale_pending_completions(
+    max_age_seconds: float = _DURABLE_RETENTION_SECONDS,
+) -> int:
+    """Mark terminal completions that outlived their owner as ``orphaned``.
+
+    Durable pending delivery is intentionally fail-closed: a
+    restored event is never adopted by an unrelated session. Without an expiry
+    boundary that also means an owner that never returns is re-enqueued on every
+    process start forever. ``orphaned`` is an explicit non-delivery terminal
+    state — unlike ``delivered`` it does not claim the user saw the result, and
+    unlike ``pending`` it is not replayed again.
+
+    The completion timestamp (falling back to ``updated_at`` for legacy rows)
+    is used for age. Running/finalizing work is never touched. ``updated_at``
+    is reset when orphaned so ordinary retention cleanup preserves the audit
+    row for one additional retention window.
+    """
+    now = time.time()
+    cutoff = now - max(0.0, float(max_age_seconds))
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegations
+               SET delivery_state='orphaned', updated_at=?,
+                   delivery_claim=NULL, delivery_claimed_at=NULL
+               WHERE state NOT IN ('running','finalizing')
+                 AND delivery_state='pending'
+                 AND COALESCE(completed_at, updated_at) < ?""",
+            (now, cutoff),
+        )
+        return cur.rowcount
+
+
 def restore_undelivered_completions(target_queue) -> int:
     """Enqueue durable pending completions as fresh turns after process start.
 
@@ -354,6 +391,10 @@ def restore_undelivered_completions(target_queue) -> int:
     results seconds after boot (#64484).
     """
     recover_abandoned_delegations()
+    # Bound the replay window before re-enqueueing, so a completion
+    # whose owner never came back becomes 'orphaned' instead of replaying on
+    # every Desktop start forever.
+    expire_stale_pending_completions()
     with _DB_LOCK, _transaction() as conn:
         rows = conn.execute(
             """SELECT delegation_id, event_json FROM async_delegations


### PR DESCRIPTION
## What does this PR do?

A delegation result can reappear after **every** restart and never go away.

`restore_undelivered_completions()` re-enqueues every row still marked
`delivery_state='pending'` at process start. Delivery is deliberately
fail-closed — a restored event is never adopted by an unrelated session — so a
completion whose owning session never comes back stays `pending` forever and is
replayed on every start. `_prune_durable_records()` cannot clear it either,
because it only deletes `delivered` rows.

So the row has no exit: not deliverable, not replay-exhausted, not collectable.

- Add `expire_stale_pending_completions()`. Terminal completions older than the
  durable retention window move to an explicit `orphaned` state. Unlike
  `delivered` it does not claim the user saw the result; unlike `pending` it is
  not replayed again. Running/finalizing work is never touched, and
  `COALESCE(completed_at, updated_at)` keeps pre-existing rows working.
- Call it from `restore_undelivered_completions()` before the replay query.
- Let retention delete `orphaned` alongside `delivered` — otherwise expiry just
  swaps an infinite replay for an infinite row. `updated_at` is reset on
  transition, so the audit row survives one further retention window.

## How was it tested?

New: `tests/tools/test_async_delegation_orphan_expiry.py` — **7 passing**.

Coverage: aged rows expire; recent rows do not; `running` and `finalizing` are
immune regardless of age; legacy rows without `completed_at` fall back to
`updated_at`; orphaned rows are excluded from replay; orphaned rows are
eventually collected by retention.

```
=== Summary: 1 files, 7 tests passed, 0 failed (100% complete) in 1.6s ===
```

Existing suites unaffected — **31 passing**:

```
=== Summary: 4 files, 31 tests passed, 0 failed (100% complete) in 15.4s ===
```
(`tests/tools/test_async_delegation.py`,
`tests/tools/test_async_delegation_fd_leak.py`,
`tests/cli/test_cli_async_delegation_delivery.py`,
`tests/gateway/test_async_delegation_session_binding.py`)

**Fault injection**, both halves of the fix broken independently:

```
OK   expiry not called on restore:      1 files, 6 tests passed, 1 failed
OK   orphaned excluded from retention:  1 files, 6 tests passed, 1 failed
restored ->                             1 files, 7 tests passed, 0 failed
```

Each half turns a *different* assertion red, so neither is covered only by the
other.

## Notes

`orphaned` is introduced as a value in the existing `delivery_state` column; no
schema migration is required, and rows written by older versions keep working
through the `COALESCE` fallback.

The retention change is the part worth reviewing closely: expiry alone would
stop the replay but leave the row in place forever, which trades one leak for
another.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal change

## Checklist

- [x] I have searched existing issues and PRs to avoid duplicates
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed

## Platform

- [x] Windows
- [ ] macOS
- [ ] Linux

Verified on Windows 10. The change is platform-neutral — plain SQLite state
transitions with no filesystem or process-model dependency.
