### PR TITLE
fix(lifecycle-guard): return a verdict when the home directory is unresolvable

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -171,9 +171,24 @@ def contains_launchctl_submit_command(command: str) -> bool:
 
 
 def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+    try:
+        path = Path(candidate).expanduser()
+    except RuntimeError:
+        # expanduser() raises RuntimeError (not OSError) when the home directory
+        # cannot be determined — e.g. a process started with `env -i`, a service
+        # account, or a stripped container environment. This guard runs on every
+        # terminal command, so letting that propagate turns an unresolvable `~`
+        # into a hard failure for commands that have nothing to do with gateway
+        # lifecycle. Fall back to the literal path: an unexpanded `~/x.sh` simply
+        # will not be readable, which the caller already handles.
+        path = Path(candidate)
     if not path.is_absolute():
-        path = Path(cwd or Path.cwd()) / path
+        try:
+            base = Path(cwd) if cwd else Path.cwd()
+        except OSError:
+            # A deleted or inaccessible cwd must not break the scan either.
+            return path
+        path = base / path
     return path
 
 

--- a/tests/cron/test_lifecycle_guard_unresolvable_home.py
+++ b/tests/cron/test_lifecycle_guard_unresolvable_home.py
@@ -1,0 +1,121 @@
+"""The lifecycle guard must return a verdict, not raise, when `~` cannot expand.
+
+`_resolve_terminal_script_path()` called `Path(candidate).expanduser()`, which
+raises `RuntimeError` — not `OSError` — when the home directory cannot be
+determined. The guard runs on *every* terminal command, so a command mentioning
+a `~/`-relative script in an environment without HOME/USERPROFILE aborted the
+whole tool call instead of producing a scan verdict.
+
+Environments that hit this: processes started with `env -i`, service accounts,
+stripped containers, and CI runners.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from cron.lifecycle_guard import (
+    contains_gateway_lifecycle_command_or_referenced_script,
+)
+
+HOME_VARS = ("HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH")
+
+
+@pytest.fixture
+def no_home(monkeypatch):
+    """Remove every variable Path.expanduser() consults."""
+    for var in HOME_VARS:
+        monkeypatch.delenv(var, raising=False)
+    # Guard the premise: if expanduser still resolves, the test proves nothing.
+    with pytest.raises(RuntimeError):
+        Path("~/anything").expanduser()
+    yield
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "bash ~/script.sh",
+        "sh ~/nested/run.sh",
+        "bash ~/a.sh && echo done",
+    ],
+)
+def test_tilde_script_does_not_raise_without_home(no_home, command, tmp_path):
+    """A `~`-relative script reference must not abort the guard."""
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        command, cwd=str(tmp_path)
+    )
+    assert verdict is False
+
+
+def test_unrelated_command_unaffected_without_home(no_home, tmp_path):
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "echo hello", cwd=str(tmp_path)
+    )
+    assert verdict is False
+
+
+def test_dangerous_command_still_detected_without_home(no_home, tmp_path):
+    """Degrading on `~` must not weaken detection of the real thing."""
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "hermes gateway restart", cwd=str(tmp_path)
+    )
+    assert verdict is True
+
+
+def test_referenced_script_still_scanned_without_home(tmp_path, monkeypatch):
+    """With HOME absent, a *relative* script must still be read and scanned.
+
+    Confirms the fallback only affects `~` expansion — the rest of the
+    resolution path keeps working, so the guard does not silently stop
+    inspecting script bodies.
+    """
+    for var in HOME_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+    script = tmp_path / "danger.sh"
+    script.write_text("hermes gateway restart\n", encoding="utf-8")
+
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "bash danger.sh", cwd=str(tmp_path)
+    )
+    assert verdict is True
+
+
+def test_home_present_behaviour_unchanged(tmp_path, monkeypatch):
+    """Baseline: with HOME set, a tilde path resolves and yields a verdict."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "bash ~/missing.sh", cwd=str(tmp_path)
+    )
+    assert verdict is False
+
+
+def test_tilde_script_body_scanned_when_home_present(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    script = tmp_path / "boom.sh"
+    script.write_text("hermes gateway stop\n", encoding="utf-8")
+
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "bash ~/boom.sh", cwd=str(tmp_path)
+    )
+    assert verdict is True
+
+
+def test_missing_cwd_does_not_raise(no_home, tmp_path):
+    """A deleted cwd must not turn into an exception either."""
+    gone = tmp_path / "gone"
+    gone.mkdir()
+    os.rmdir(gone)
+
+    verdict = contains_gateway_lifecycle_command_or_referenced_script(
+        "bash ~/x.sh", cwd=str(gone)
+    )
+    assert verdict is False


### PR DESCRIPTION
## What does this PR do?

The lifecycle guard **raises instead of returning a verdict** when `~` cannot be
expanded, which aborts the whole terminal tool call:

```
RuntimeError: Could not determine home directory.
  File "cron/lifecycle_guard.py", line 174, in _resolve_terminal_script_path
    path = Path(candidate).expanduser()
```

`Path.expanduser()` raises `RuntimeError`, not `OSError`, so the surrounding
`except OSError` handlers do not catch it. Because this guard runs on *every*
terminal command, the result is not "command blocked" and not "command failed" —
it is the guard itself crashing for a command that has nothing to do with
gateway lifecycle.

Encountered in real use while running an unrelated `git add` + `python`
pipeline.

## Reproduction

With `HOME` / `USERPROFILE` / `HOMEDRIVE` / `HOMEPATH` unset:

```
'echo hello'         -> verdict=False
'bash ~/script.sh'   -> RAISED RuntimeError: Could not determine home directory.
'sh ~/nested/run.sh' -> RAISED RuntimeError: Could not determine home directory.
'bash ./local.sh'    -> verdict=False
```

Two conditions must coincide:

1. the command references a `~/`-relative script, and
2. the environment lacks the home variables.

Commands without `~` never reach `expanduser()` and are unaffected.

Environments that land in this state: processes started with `env -i`, service
accounts, stripped containers, and CI runners. This repo's own
`scripts/run_tests.sh` has needed fixes for the same class of problem, since
`env -i` drops `USERPROFILE` on Windows.

## The fix

- Catch `RuntimeError` around `expanduser()` and fall back to the literal path.
  An unexpanded `~/x.sh` simply will not be readable, and the caller already
  handles unreadable scripts.
- Also guard `Path.cwd()`, so a deleted or inaccessible working directory cannot
  break the scan either.

Detection strength is unchanged. With `HOME` absent, a gateway lifecycle command
is still caught, and a *relative* script's body is still read and scanned — the
degradation is confined to `~` expansion.

## How was it tested?

New: `tests/cron/test_lifecycle_guard_unresolvable_home.py` — **9 passing**.

The no-HOME fixture asserts that `Path('~').expanduser()` really does raise
before running the case, so the tests cannot silently pass on a platform where
it resolves.

Cases: three `~`-script shapes return a verdict instead of raising; unrelated
commands unaffected; a dangerous command is still detected; a relative script
body is still scanned; baseline behaviour with `HOME` present is unchanged
(including scanning a tilde script's body); a deleted cwd does not raise.

```
9 passed, 1 warning in 0.77s
```

**Fault injection.** Restoring the bare `expanduser()` call turns 4 assertions
red; the fix returns 9/9:

```
--- with the fix
    9 passed, 1 warning in 0.77s
--- fault injection: revert to bare expanduser()
    FAILED test_tilde_script_does_not_raise_without_home[bash ~/a.sh && echo done]
    FAILED test_missing_cwd_does_not_raise
    4 failed, 5 passed, 1 warning in 0.67s
```

## Relationship to existing PRs (not a duplicate)

Two open PRs touch the same class of defect. Both were checked against the
current `main`:

- **#56517** — *fix(cron): catch RuntimeError from Path.expanduser() in
  lifecycle guard.* Same file, **different function and different call path**:
  it guards `_read_script_for_scanning` / `_resolve_script_path`, reached when a
  *cron job's* `script` field is scanned. On current `main` those symbols no
  longer exist under those names, so that patch does not cover the terminal
  path. This PR guards `_resolve_terminal_script_path`, reached for every
  *terminal command* that references a script.
- **#41881** — *sweep remaining bare expanduser() to safe_expanduser().* Its 39
  changed files **do not include** `cron/lifecycle_guard.py`, so the sweep leaves
  this call site untouched.

If `safe_expanduser()` from #41870/#41881 lands first, this change should be
rewritten to call it instead of the local `try/except` — the fallback semantics
are identical, and I am happy to rebase onto that helper. The test file stays
valid either way, since it asserts observable behaviour (returns a verdict,
detection unchanged) rather than the mechanism.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / internal change

## Checklist

- [x] I have searched existing issues and PRs to avoid duplicates (see
      "Relationship to existing PRs" above — #56517 and #41881 both checked)
- [x] My code follows the project's style guidelines
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally
- [x] I have updated documentation as needed

## Platform

- [x] Windows
- [ ] macOS
- [ ] Linux

Reproduced and verified on Windows 10, but the defect is not
Windows-specific: `Path.expanduser()` raises the same `RuntimeError` on POSIX
when `HOME` is unset and the uid has no passwd entry. On Windows the trigger is
simply easier to hit, because both `USERPROFILE` and the
`HOMEDRIVE`+`HOMEPATH` pair must be present.
