### PR TITLE
fix(tools): scope Docker reuse to immutable config

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from io import StringIO
 import subprocess
 
@@ -594,6 +595,37 @@ def test_label_sanitizer_rejects_invalid_characters():
     assert len(docker_env._sanitize_label_value(long_value)) == 63
 
 
+def test_reuse_environment_fingerprint_tracks_immutable_configuration():
+    """Containers with different images, mounts, or Hermes homes must not
+    share the label used for cross-process reuse."""
+    base = docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+
+    assert base == docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.12",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-b:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/beta",
+    )
+
+
 def test_run_command_sanitizes_unsafe_task_id(monkeypatch):
     """A task_id containing characters Docker rejects in label values must be
     sanitized before reaching ``docker run --label``; otherwise the daemon
@@ -728,28 +760,80 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
+    labels = dict(env._labels)
+    environment_label = labels.pop("hermes-environment")
+    assert labels == {
         "hermes-agent": "1",
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
     }
+    assert re.fullmatch(r"[0-9a-f]{24}", environment_label)
 
 
-def test_shared_container_key_replaces_profile_identity(monkeypatch):
+@pytest.mark.parametrize("changed_setting", ["image", "volumes", "hermes_home"])
+def test_reuse_probe_filters_on_environment_fingerprint(monkeypatch, tmp_path, changed_setting):
+    """Reuse and recovery must select the requested configuration, not stale mounts."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "alpha"))
+    # Keep the auto-mounted skills directory present from the first startup.
+    for name in ("alpha", "beta"):
+        (tmp_path / name / "skills").mkdir(parents=True)
+    calls = _mock_subprocess_run(monkeypatch)
+
+    def reuse_filters():
+        return tuple(
+            arg for cmd, _ in calls if isinstance(cmd, list) and cmd[1] == "ps"
+            for arg in cmd if arg.startswith("label=")
+        )
+
+    config = {"image": "python:3.11", "volumes": ["volume-a:/workspace"]}
+    _make_dummy_env(**config)
+    original_filters = reuse_filters()
+    assert original_filters
+    calls.clear()
+    _make_dummy_env(**config)
+    assert reuse_filters() == original_filters
+
+    if changed_setting == "hermes_home":
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "beta"))
+    else:
+        config[changed_setting] = {"image": "python:3.12", "volumes": ["volume-b:/workspace"]}[changed_setting]
+    calls.clear()
+    env = _make_dummy_env(**config)
+    changed_filters = reuse_filters()
+    assert changed_filters != original_filters
+    assert f"label=hermes-environment={env._labels['hermes-environment']}" in changed_filters
+    assert set(f.removeprefix("label=") for f in changed_filters) <= _labels_in_run_args(_run_args_from_calls(calls))
+
+    calls.clear()
+    assert env._recreate_container()
+    assert reuse_filters() == changed_filters
+
+
+def test_shared_container_key_replaces_profile_identity(monkeypatch, tmp_path):
     """Trusted profiles using the same explicit key share the reuse label."""
     monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
     monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "research")
     _mock_subprocess_run(monkeypatch)
 
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "research"))
     a = _make_dummy_env(task_id="abc", shared_container_key="team/workspace")
-    b = _make_dummy_env(task_id="abc", shared_container_key="team/workspace")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "coding")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "coding"))
+    b = _make_dummy_env(
+        task_id="abc", shared_container_key="team/workspace",
+        image="python:3.12", volumes=["team-volume:/workspace"],
+    )
 
     # Deterministic across processes/profiles, not the profile label, and
     # digest-suffixed (label sanitization alone is lossy).
     assert a._labels["hermes-profile"] == b._labels["hermes-profile"]
     assert a._labels["hermes-profile"] != "research"
     assert a._labels["hermes-profile"].startswith("team_workspace-")
+    # Explicit sharing retains the first creator's immutable settings.
+    assert a._labels == b._labels
 
 
 def test_distinct_shared_keys_never_collide(monkeypatch):

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from io import StringIO
 import subprocess
 
@@ -573,6 +574,37 @@ def test_label_sanitizer_rejects_invalid_characters():
     assert len(docker_env._sanitize_label_value(long_value)) == 63
 
 
+def test_reuse_environment_fingerprint_tracks_immutable_configuration():
+    """Containers with different images, mounts, or Hermes homes must not
+    share the label used for cross-process reuse."""
+    base = docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+
+    assert base == docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.12",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-b:/workspace"],
+        hermes_home="/profiles/alpha",
+    )
+    assert base != docker_env._reuse_environment_fingerprint(
+        image="python:3.11",
+        mount_args=["-v", "volume-a:/workspace"],
+        hermes_home="/profiles/beta",
+    )
+
+
 def test_run_command_sanitizes_unsafe_task_id(monkeypatch):
     """A task_id containing characters Docker rejects in label values must be
     sanitized before reaching ``docker run --label``; otherwise the daemon
@@ -600,12 +632,36 @@ def test_labels_attribute_populated_after_init(monkeypatch):
 
     env = _make_dummy_env(task_id="abc")
 
-    assert env._labels == {
+    labels = dict(env._labels)
+    environment_label = labels.pop("hermes-environment")
+    assert labels == {
         "hermes-agent": "1",
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
     }
+    assert re.fullmatch(r"[0-9a-f]{24}", environment_label)
+
+
+def test_reuse_probe_filters_on_environment_fingerprint(monkeypatch):
+    """The fingerprint on a new container must also constrain later reuse
+    probes, otherwise the label would not prevent cross-profile collisions."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(task_id="fingerprinted-reuse")
+    fingerprint = env._labels["hermes-environment"]
+
+    ps_calls = [
+        c[0] for c in calls
+        if isinstance(c[0], list) and len(c[0]) >= 2 and c[0][1] == "ps"
+    ]
+    assert ps_calls
+    assert any(
+        f"label=hermes-environment={fingerprint}" in call
+        for call in ps_calls
+    )
 
 
 # ── Cross-process container reuse (issue #20561) ──────────────────

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -20,6 +20,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import get_hermes_home
 from tools.environments.base import BaseEnvironment, EnvironmentConnectionError, _SHELL_ENV_NAME_RE
 from tools.environments.base_output import _popen_bash
 from tools.environments.docker_egress import (
@@ -41,6 +42,7 @@ _DOCKER_SEARCH_PATHS = [
 
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = _SHELL_ENV_NAME_RE
+_ENVIRONMENT_LABEL_KEY = "hermes-environment"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -119,6 +121,19 @@ def _container_identity(shared_key: str = "") -> str:
         return _sanitize_label_value(_get_active_profile_name())
     digest = hashlib.sha256(shared_key.encode("utf-8")).hexdigest()[:12]
     return f"{_sanitize_label_value(shared_key)[:50]}-{digest}"
+
+
+def _reuse_environment_fingerprint(*, image: str, mount_args: list[str], hermes_home: str) -> str:
+    """Hash immutable configuration so reuse cannot silently attach to stale mounts.
+
+    Hash requested values rather than exposing profile paths and volume sources in labels.
+    Keep mount order: later arguments can override earlier mount destinations.
+    """
+    normalized_home = os.path.normcase(os.path.abspath(os.path.expanduser(hermes_home)))
+    payload = json.dumps(
+        {"image": image, "mount_args": mount_args, "hermes_home": normalized_home},
+        sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
 
 
 def reap_orphan_containers(
@@ -550,6 +565,12 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label}
+        # Explicit sharing opts into the first creator's settings. Otherwise,
+        # changed image/mount/home configuration must start a fresh container.
+        if not shared_container_key:
+            self._labels[_ENVIRONMENT_LABEL_KEY] = _reuse_environment_fingerprint(
+                image=image, mount_args=[*writable_args, *volume_args],
+                hermes_home=str(get_hermes_home()))
         # Saved for container recreation on "No such container" recovery.
         self._image = image
         self._image_uses_s6_init = image_uses_s6_init
@@ -919,7 +940,8 @@ class DockerEnvironment(BaseEnvironment):
     def _find_reusable_container(
         self, task_label: str, profile_label: str, egress_label: str) -> Optional[tuple[str, str]]:
         """``(container_id, state)`` of an existing container labeled for this task/profile/
-        egress posture, or ``None`` on miss or any failure. The egress posture is a label
+        egress posture and immutable environment, or ``None`` on miss or any failure.
+        Explicit shared keys opt out of the environment filter. The egress posture is a label
         FILTER for every posture, "off" included: a container built with egress on must not be
         reused after ``hermes egress disable`` (baked-in proxy env and CA mounts), and every
         container this class creates carries the label. The ``{{.Label "key"}}`` template
@@ -929,6 +951,8 @@ class DockerEnvironment(BaseEnvironment):
             "--filter", f"label=hermes-task-id={task_label}",
             "--filter", f"label=hermes-profile={profile_label}",
             "--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"]
+        if environment_label := self._labels.get(_ENVIRONMENT_LABEL_KEY):
+            filters.extend(["--filter", f"label={_ENVIRONMENT_LABEL_KEY}={environment_label}"])
         result = _docker_query(
             [self._docker_exe, "ps", "-a", *filters, "--format", "{{.ID}}\t{{.State}}"], timeout=10,
             fail="docker ps probe failed: %s — will start a fresh container",

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -18,6 +18,7 @@ import uuid
 from pathlib import Path
 from typing import Optional
 
+from hermes_constants import get_hermes_home
 from tools.environments.base import (
     BaseEnvironment,
     EnvironmentConnectionError,
@@ -43,6 +44,7 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_ENVIRONMENT_LABEL_KEY = "hermes-environment"
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -568,6 +570,35 @@ def _egress_reuse_fingerprint(
             "volume_args": volume_args,
             "env_overrides": env_overrides,
             "host_args": host_args,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:24]
+
+
+def _reuse_environment_fingerprint(
+    *,
+    image: str,
+    mount_args: list[str],
+    hermes_home: str,
+) -> str:
+    """Stable Docker-label value for immutable container configuration.
+
+    Cross-process reuse cannot safely attach to a container created with a
+    different image, mount layout, or Hermes home. Hash the requested values
+    so profile paths and volume sources are not exposed in Docker labels.
+    Preserve mount-argument order because Docker can treat later duplicate
+    destinations as overrides.
+    """
+    normalized_home = os.path.normcase(
+        os.path.abspath(os.path.expanduser(hermes_home))
+    )
+    payload = json.dumps(
+        {
+            "image": image,
+            "mount_args": mount_args,
+            "hermes_home": normalized_home,
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -1359,18 +1390,24 @@ class DockerEnvironment(BaseEnvironment):
         container_name = f"hermes-{uuid.uuid4().hex[:8]}"
         # Labels make hermes-created containers identifiable to:
         #   * the orphan reaper (`hermes-agent=1` for the global sweep filter)
-        #   * future cross-process reuse (`hermes-task-id`, `hermes-profile`)
+        #   * cross-process reuse (task, profile, egress, and environment)
         #   * operators running `docker ps --filter label=hermes-agent=1`
         # Values are limited to the safe character set defined by
         # _sanitize_label_value(); the active Hermes profile is captured at
         # container-start time and never changes for the container's lifetime.
         profile_name = _sanitize_label_value(_get_active_profile_name())
         task_label = _sanitize_label_value(task_id)
+        environment_label = _reuse_environment_fingerprint(
+            image=image,
+            mount_args=[*writable_args, *volume_args],
+            hermes_home=str(get_hermes_home()),
+        )
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"{_ENVIRONMENT_LABEL_KEY}={environment_label}",
         ]
         # Save args for container recreation on "No such container" recovery.
         self._image = image
@@ -1383,6 +1420,7 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            _ENVIRONMENT_LABEL_KEY: environment_label,
         }
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
@@ -1392,14 +1430,15 @@ class DockerEnvironment(BaseEnvironment):
         # restores the documented contract; opt out via
         # ``terminal.docker_persist_across_processes: false``.
         #
-        # Reuse matches on labels only.  The egress posture gets its own label
-        # because env vars, CA mounts, and host mappings are immutable after
-        # container creation — reusing a pre-egress or pre-rotation container
-        # would silently bypass the credential firewall.
+        # Reuse matches on labels only. Immutable egress configuration and the
+        # requested image/mount/home configuration get separate fingerprints;
+        # a changed value starts a fresh container instead of silently reusing
+        # stale settings. Containers created before either label existed do not
+        # match, causing a one-time fresh container after upgrade.
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
-                task_label, profile_name, egress_label,
+                task_label, profile_name, egress_label, environment_label,
             )
             if existing is not None:
                 container_id, state = existing
@@ -1659,7 +1698,10 @@ class DockerEnvironment(BaseEnvironment):
         task_label = self._labels.get("hermes-task-id", "")
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
-            task_label, profile_label, self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            task_label,
+            profile_label,
+            self._labels.get(_EGRESS_LABEL_KEY, "off"),
+            self._labels.get(_ENVIRONMENT_LABEL_KEY, ""),
         )
         if existing is not None:
             cid, state = existing
@@ -1824,8 +1866,9 @@ class DockerEnvironment(BaseEnvironment):
         task_label: str,
         profile_label: str,
         egress_label: str,
+        environment_label: str,
     ) -> Optional[tuple[str, str]]:
-        """Look for an existing container labeled for this (task, profile).
+        """Look for an existing container with the same immutable environment.
 
         Returns ``(container_id, state)`` on hit, ``None`` on miss / on any
         failure (including ``docker ps`` itself failing). State is one of the
@@ -1842,6 +1885,7 @@ class DockerEnvironment(BaseEnvironment):
                 "--filter", "label=hermes-agent=1",
                 "--filter", f"label=hermes-task-id={task_label}",
                 "--filter", f"label=hermes-profile={profile_label}",
+                "--filter", f"label={_ENVIRONMENT_LABEL_KEY}={environment_label}",
             ]
             if egress_label != "off":
                 filters.extend(["--filter", f"label={_EGRESS_LABEL_KEY}={egress_label}"])

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -329,13 +329,16 @@ terminal:
 
 #### Container lifecycle
 
-Every Hermes-managed container is tagged with three labels so subsequent processes (and the orphan reaper) can identify it:
+Hermes-managed containers carry labels so subsequent processes (and the orphan reaper) can identify them:
 
 - `hermes-agent=1` — marks it as Hermes-managed
 - `hermes-task-id=<sanitized task_id>` — keys the per-task reuse probe
 - `hermes-profile=<sanitized profile name>` — scopes reuse and reaping to the active Hermes profile by default; when `docker_shared_container_key` is set, its sanitized value is used instead
+- `hermes-environment=<digest>` — for containers without an explicit shared key, scopes reuse to the requested image, mount arguments, and active `HERMES_HOME`; host paths and volume sources are hashed rather than exposed in this label
 
 On startup, Hermes runs `docker ps --filter label=hermes-task-id=<id> --filter label=hermes-profile=<identity>` and **attaches to the existing container** when it finds one. The identity is the active profile unless `docker_shared_container_key` explicitly opts trusted profiles into a common value. If the container is `exited` (e.g. after a Docker daemon restart), it's `docker start`'d and reused — filesystem state and any installed packages survive, but in-container background processes do not.
+
+Without an explicit shared key, the reuse probe also requires a matching `hermes-environment` label. Changing the image, mount arguments, or `HERMES_HOME` starts a fresh container instead of silently using another configuration. Containers created before this label was introduced do not match, so the first session after upgrading starts a fresh container; existing running containers are not removed.
 
 When a Hermes process exits — `/quit`, closing a TUI session, gateway shutdown, even SIGKILL — the cleanup path is a **no-op for the container in default mode**. The container keeps running. The next Hermes process attaches to it in milliseconds via the label probe. This is the behavior the "one long-lived container shared across sessions" contract requires: it's the only way background processes (npm watchers, dev servers, long-running pytest) survive across sessions.
 


### PR DESCRIPTION
## What does this PR do?

Cross-process Docker reuse currently matches containers by task, profile, and egress labels. Profiles selected through different `HERMES_HOME` values can both appear as `default`, so a process may silently attach to a container created with a different image or mount layout.

This adds a `hermes-environment` reuse fingerprint derived from the requested image, Hermes-managed/user volume arguments, and the normalized active Hermes home. For normal isolated reuse, the fingerprint is stored on new containers and included in both startup and recovery probes, so incompatible configurations start a fresh container instead of sharing stale mounts.

The approach follows the existing `hermes-egress` fingerprint pattern and hashes host paths/volume sources rather than exposing them in labels. Containers created before this label existed intentionally do not match, resulting in a one-time fresh container after upgrade while preserving the existing rule that Hermes does not remove a running persisted container.

Explicit `docker_shared_container_key` sharing keeps its documented first-creator-wins behavior: the environment fingerprint is omitted for that opt-in mode. Existing task, egress, and network checks are preserved.

I used AI to help with this fix and its regression tests.

## Related Issue

Fixes #79816

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a stable 24-character fingerprint for Docker image, mount arguments, and active `HERMES_HOME`.
- Label newly created, non-shared containers with the fingerprint and require the same label during normal reuse and missing-container recovery.
- Preserve explicit cross-profile sharing and document the isolated-reuse behavior.
- Add regression coverage for image, volume, and Hermes-home isolation plus create/probe label consistency.

## How to Test

1. Run the Docker-focused suite:
   `scripts/run_tests.sh tests/tools/test_docker_orphan_reaper_integration.py tests/tools/test_docker_network_config.py tests/tools/test_dockerfile_node_modules_perms.py tests/tools/test_docker_environment.py tests/tools/test_docker_cgroup_limits.py tests/tools/test_dockerfile_immutable_install.py tests/tools/test_docker_rebootstrap_nous_session.py tests/tools/test_docker_daemon_redirect.py tests/tools/test_dockerfile_pid1_reaping.py tests/tools/test_container_cwd_sanitize.py tests/tools/test_docker_config_migrate.py tests/tools/test_docker_find.py tests/tools/test_docker_session_isolation.py tests/tools/test_terminal_scope_multiplex.py -q -j 2`
2. On the rebased snapshot, all 160 tests pass across these 14 files.
3. With `docker_shared_container_key` unset, configure the same task/profile under two different `HERMES_HOME` values or change `docker_image`/`docker_volumes`; verify the later process creates a differently labeled container instead of reusing the first one.

Additional checks:

- `ruff check tools/environments/docker.py tests/tools/test_docker_environment.py`
- `python scripts/check-windows-footguns.py tools/environments/docker.py tests/tools/test_docker_environment.py`

The parameterized regression test reproduces unchanged reuse filters on upstream for changed images, volumes, and Hermes homes. It also fails in all three cases when the new filter is removed, and passes with it restored. Coverage includes stable filters for unchanged configuration, create/probe label consistency, and missing-container recovery.

Validation used real Python imports and temporary Hermes homes with a mocked Docker CLI on macOS; no live-daemon integration or full-repository test run was performed for this update.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (mocked Docker CLI; no live-daemon integration)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — container lifecycle documentation and inline behavior
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```text
=== Summary: 14 files, 160 tests passed, 0 failed (100% complete)
All checks passed!  # Ruff
✓ No Windows footguns found (2 file(s) scanned).
```
