### PR TITLE
fix: preserve UTF-8 text at sample boundaries

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -242,7 +242,11 @@ def file_ops(mock_env):
     return ShellFileOperations(mock_env)
 
 
-def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMock:
+def make_real_subprocess_env(
+    cwd: str,
+    include_stderr: bool = False,
+    decode_errors: str = "strict",
+) -> MagicMock:
     """Mock env whose execute() runs the command in a real subprocess.
 
     For tests that need the generated shell scripts to actually run
@@ -255,16 +259,29 @@ def make_real_subprocess_env(cwd: str, include_stderr: bool = False) -> MagicMoc
     env.cwd = cwd
 
     def execute(command, **kwargs):
-        completed = subprocess.run(
-            command,
-            shell=True,
-            text=True,
-            capture_output=True,
-            input=kwargs.get("stdin_data"),
-        )
-        output = completed.stdout
-        if include_stderr:
-            output += completed.stderr
+        stdin_data = kwargs.get("stdin_data")
+        if decode_errors == "strict":
+            completed = subprocess.run(
+                command,
+                shell=True,
+                text=True,
+                capture_output=True,
+                input=stdin_data,
+            )
+            output = completed.stdout
+            if include_stderr:
+                output += completed.stderr
+        else:
+            completed = subprocess.run(
+                command,
+                shell=True,
+                text=False,
+                capture_output=True,
+                input=stdin_data.encode("utf-8") if stdin_data is not None else None,
+            )
+            output = completed.stdout.decode("utf-8", errors=decode_errors)
+            if include_stderr:
+                output += completed.stderr.decode("utf-8", errors=decode_errors)
         return {
             "output": output,
             "returncode": completed.returncode,
@@ -318,9 +335,14 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
-        assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
+        assert commands[1] == (
+            "if command -v base64 >/dev/null 2>&1; then "
+            "head -c 1004 < '/c/Users/alice/notes.txt' 2>/dev/null "
+            "| base64 | tr -d '\\n'; else exit 127; fi"
+        )
+        assert commands[2] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert commands[3] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
+        assert commands[4] == "wc -l < '/c/Users/alice/notes.txt'"
 
     def test_is_likely_binary_by_extension(self, file_ops):
         assert file_ops._is_likely_binary("photo.png") is True
@@ -673,3 +695,44 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+
+class TestReadFileUtf8SampleBoundary:
+    def test_read_file_allows_utf8_codepoint_crossing_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), decode_errors="replace")
+        )
+        path = tmp_path / "boundary.txt"
+        path.write_text(("a" * 999) + "€\nsecond\n", encoding="utf-8")
+
+        result = ops.read_file(str(path))
+
+        assert result.error is None
+        assert result.is_binary is False
+        assert "€" in result.content
+
+    def test_read_file_raw_allows_utf8_codepoint_crossing_sample_boundary(self, tmp_path):
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), decode_errors="replace")
+        )
+        path = tmp_path / "boundary.txt"
+        expected = ("a" * 999) + "€\nsecond\n"
+        path.write_text(expected, encoding="utf-8")
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.error is None
+        assert result.is_binary is False
+        assert result.content == expected
+
+    def test_incomplete_lead_byte_before_boundary_is_still_binary(self, tmp_path):
+        ops = ShellFileOperations(
+            make_real_subprocess_env(str(tmp_path), decode_errors="replace")
+        )
+        path = tmp_path / "invalid.txt"
+        path.write_bytes((b"a" * 999) + b"\xc3\n")
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True
+        assert result.error is not None

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -25,6 +25,7 @@ Usage:
     result = file_ops.search("TODO", path=".", file_glob="*.py")
 """
 
+import base64
 import os
 import re
 import difflib
@@ -127,6 +128,8 @@ def _normalize_line_endings(text: str, target: str) -> str:
 # write when the original file had one — exactly mirroring the line-ending
 # preservation above (detect on disk, preserve across the edit).
 _UTF8_BOM = "\ufeff"
+_BINARY_SAMPLE_BYTES = 1000
+_UTF8_LOOKAHEAD_BYTES = 4
 
 
 def _strip_bom(text: str) -> tuple[str, bool]:
@@ -881,8 +884,49 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
+
+    def _read_binary_sample(self, path: str) -> Optional[bytes]:
+        """Read raw sample bytes through an ASCII-safe terminal transport."""
+        sample_size = _BINARY_SAMPLE_BYTES + _UTF8_LOOKAHEAD_BYTES
+        result = self._exec(
+            "if command -v base64 >/dev/null 2>&1; then "
+            f"head -c {sample_size} < {self._escape_shell_arg(path)} 2>/dev/null "
+            "| base64 | tr -d '\\n'; else exit 127; fi"
+        )
+        if result.exit_code != 0:
+            return None
+        encoded = _strip_terminal_fence_leaks(result.stdout).strip()
+        if not encoded:
+            return None
+        try:
+            return base64.b64decode(encoded, validate=True)
+        except (ValueError, TypeError):
+            return None
+
+    def _decode_binary_sample(
+        self, sample: bytes, *, boundary_may_continue: bool
+    ) -> Optional[str]:
+        """Decode UTF-8, tolerating only a cut beyond the inspected bytes."""
+        try:
+            return sample.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            if (
+                boundary_may_continue
+                and exc.start >= _BINARY_SAMPLE_BYTES
+                and exc.reason == "unexpected end of data"
+                and exc.end == len(sample)
+            ):
+                return sample[:exc.start].decode("utf-8")
+            return None
     
-    def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
+    def _is_likely_binary(
+        self,
+        path: str,
+        content_sample: Optional[str] = None,
+        *,
+        sample_bytes: Optional[bytes] = None,
+        boundary_may_continue: bool = False,
+    ) -> bool:
         """
         Check if a file is likely binary.
         
@@ -891,6 +935,13 @@ class ShellFileOperations(FileOperations):
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
             return True
+
+        if sample_bytes is not None:
+            content_sample = self._decode_binary_sample(
+                sample_bytes, boundary_may_continue=boundary_may_continue
+            )
+            if content_sample is None:
+                return True
         
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
@@ -903,11 +954,11 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            if sample_bytes is None and "\ufffd" in content_sample[:_BINARY_SAMPLE_BYTES]:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in content_sample[:_BINARY_SAMPLE_BYTES]
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(content_sample), _BINARY_SAMPLE_BYTES) > 0.30
         
         return False
     
@@ -1188,12 +1239,22 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        
-        if self._is_likely_binary(path, sample_output):
+        # Read a sample to check for binary content. Base64 preserves raw bytes
+        # across terminal backends that otherwise decode stdout lossily.
+        sample_bytes = self._read_binary_sample(path)
+        if sample_bytes is None:
+            sample_cmd = f"head -c {_BINARY_SAMPLE_BYTES} {self._escape_shell_arg(path)} 2>/dev/null"
+            sample_result = self._exec(sample_cmd)
+            sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+            is_binary = self._is_likely_binary(path, sample_output)
+        else:
+            is_binary = self._is_likely_binary(
+                path,
+                sample_bytes=sample_bytes,
+                boundary_may_continue=file_size > len(sample_bytes),
+            )
+
+        if is_binary:
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
@@ -1307,9 +1368,20 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        sample_bytes = self._read_binary_sample(path)
+        if sample_bytes is None:
+            sample_result = self._exec(
+                f"head -c {_BINARY_SAMPLE_BYTES} {self._escape_shell_arg(path)} 2>/dev/null"
+            )
+            sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+            is_binary = self._is_likely_binary(path, sample_output)
+        else:
+            is_binary = self._is_likely_binary(
+                path,
+                sample_bytes=sample_bytes,
+                boundary_may_continue=file_size > len(sample_bytes),
+            )
+        if is_binary:
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
## Summary

- read binary-detection samples through an ASCII-safe base64 transport
- inspect four bytes beyond the 1,000-byte classification boundary so valid UTF-8 code points split at the boundary remain text
- retain invalid UTF-8 and binary rejection, plus the existing direct-sample fallback when base64 is unavailable
- apply the raw-byte classification path consistently to `read_file` and `read_file_raw`

## Root cause

The terminal backend decodes subprocess output with replacement semantics. When `head -c 1000` ended inside a multibyte UTF-8 code point, the orphaned lead byte became `U+FFFD`; `_is_likely_binary` then rejected an otherwise valid UTF-8 Markdown file as binary.

## Verification

- `170 passed` across:
  - `tests/tools/test_file_operations.py`
  - `tests/tools/test_file_operations_edge_cases.py`
  - `tests/tools/test_file_ops_cwd_tracking.py`
  - `tests/tools/test_file_read_guards.py`
  - `tests/tools/test_file_tools.py`
  - `tests/tools/test_file_tools_cwd_resolution.py`
  - `tests/tools/test_file_tools_tilde_profile.py`
- independent exact-diff review: APPROVE
- existing terminal-fence fixtures remain byte-identical to `main`
