### PR TITLE
fix: heredoc body false-positives the gateway-lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -112,9 +112,54 @@ _CONTROL_CHARS = frozenset(";&|()")
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
+# A heredoc redirect (`<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`) introduces a
+# literal data block terminated by a line containing only the delimiter.
+# shlex has no concept of this: it tokenizes the heredoc body as if it were
+# additional shell commands, and any bare-looking token in that body (e.g. a
+# file path embedded in Python/JS source passed via heredoc) gets treated as
+# a "referenced script" by `_iter_referenced_shell_scripts` below — which
+# then reads that unrelated file from disk and recursively scans its
+# contents for lifecycle patterns. On a large third-party payload (e.g. a
+# downloaded HTML page) that is a false-positive generator: the regex
+# branches use unbounded `[^\n]*`, so incidental substrings in a big
+# minified blob can coincidentally satisfy a match. The heredoc body is
+# data, not shell commands, so segment-tokenization must skip it entirely.
+# `contains_gateway_lifecycle_command`'s direct substring scan still covers
+# the full raw text (heredoc body included), so a real lifecycle command
+# written inside a heredoc payload is still caught by that separate check.
+_HEREDOC_START = re.compile(r"<<-?\s*(['\"]?)(\w+)\1")
+
+
+def _strip_heredoc_bodies(command: str) -> str:
+    """Remove heredoc payload lines so they aren't tokenized as commands."""
+    lines = command.splitlines()
+    out: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = _HEREDOC_START.search(line)
+        if match is None:
+            out.append(line)
+            i += 1
+            continue
+        out.append(line)
+        delimiter = match.group(2)
+        i += 1
+        # Skip body lines until an exact delimiter line (heredoc terminator
+        # lines allow leading tabs only with the `<<-` form; a plain
+        # stripped-equality check covers both forms safely).
+        while i < len(lines) and lines[i].strip() != delimiter:
+            i += 1
+        if i < len(lines):
+            out.append(lines[i])  # keep the terminator line itself
+            i += 1
+    return "\n".join(out)
+
+
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
     """Yield shell-tokenized command segments, honoring quotes and comments."""
     normalized = command.replace("\\\n", "")
+    normalized = _strip_heredoc_bodies(normalized)
     for line in normalized.splitlines() or [normalized]:
         try:
             lexer = shlex.shlex(

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -762,6 +762,157 @@ class TestLifecycleGuardModule:
             check_gateway_lifecycle("daily ops", str(script))
 
 
+class TestHeredocFalsePositive:
+    """A real production false positive: a terminal command piping a heredoc
+    payload to `python3 -` got blocked as a gateway-lifecycle command.
+
+    shlex has no concept of heredoc syntax (`<<'EOF' ... EOF`): it tokenized
+    the heredoc BODY (arbitrary Python/shell source) as if it were additional
+    shell commands. A bare-looking token inside that body — e.g. a file path
+    literal from `open('/tmp/vids.html')` embedded in the Python source — was
+    then picked up by `_iter_referenced_shell_scripts` as "a script being
+    executed", read from disk, and recursively scanned. When the referenced
+    file was large third-party content (a downloaded HTML page, in the field
+    report), the regex branches' unbounded `[^\\n]*` spans meant an incidental
+    substring inside that big blob could coincidentally satisfy a match —
+    blocking a completely unrelated, benign command.
+
+    The fix strips heredoc body lines before tokenizing (they are literal
+    stdin data, never additional shell commands to parse), while leaving
+    `contains_gateway_lifecycle_command`'s direct full-text substring scan
+    untouched — that scan still covers heredoc bodies, so a genuine lifecycle
+    command written *inside* a heredoc payload is still caught (see
+    `test_lifecycle_command_inside_heredoc_still_blocked` below).
+    """
+
+    def test_field_report_command_not_blocked(self, tmp_path):
+        """The exact command shape that triggered the false positive: a
+        `grep | head` pipeline followed by `python3 - <<'EOF' ... EOF`,
+        where the heredoc body references a file by *absolute path* via
+        `open(...)` (the referenced-script walk only treats a bare token as
+        a script reference when it contains a `/` or a `.sh`/`.bash`/`.zsh`
+        suffix — a relative filename would never trigger the walk at all,
+        so the repro must use an absolute path to match the field report)."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        html_path = tmp_path / "vids.html"
+        # Simulates the real downloaded-page payload: large unrelated content
+        # that incidentally contains a lifecycle-shaped substring somewhere
+        # inside it (e.g. a quoted doc snippet on the page) — exactly what
+        # made the unbounded regex spans a false-positive generator once the
+        # heredoc body caused this file to be read and scanned as "a script".
+        noise = "x" * 5000
+        html_path.write_text(
+            noise + " unrelated page text mentions hermes   gateway   restart "
+            "in passing " + noise,
+            encoding="utf-8",
+        )
+        command = (
+            f"grep -oP 'ytInitialData = .{{0,50}}' {html_path} | head -1; "
+            "python3 - <<'EOF'\n"
+            "import re, json\n"
+            f"html = open('{html_path}').read()\n"
+            "m = re.search(r'var ytInitialData = (\\{.*?\\});</script>', html)\n"
+            "print(m)\n"
+            "EOF"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        )
+        assert result is False, (
+            "Heredoc body referencing a file by absolute path must not be "
+            "tokenized as a referenced script and scanned"
+        )
+
+    @pytest.mark.parametrize("quote_style", ["'EOF'", '"EOF"', "EOF", "-EOF"])
+    def test_heredoc_variants_not_blocked(self, quote_style, tmp_path):
+        """All heredoc introducer forms (`<<EOF`, `<<'EOF'`, `<<"EOF"`,
+        `<<-EOF`) must have their body skipped during tokenization. The
+        referenced file must exist on disk with real lifecycle-shaped noise
+        content, otherwise `_read_referenced_script` short-circuits on a
+        missing path and the test proves nothing about the actual fix."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        target = tmp_path / "file.txt"
+        noise = "x" * 5000
+        target.write_text(
+            noise + " hermes   gateway   restart " + noise, encoding="utf-8"
+        )
+        delimiter = quote_style.lstrip("-").strip("'\"")
+        redirect = f"<<{quote_style}"
+        command = (
+            f"python3 - {redirect}\n"
+            f"path = open('{target}').read()\n"
+            f"{delimiter}"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        )
+        assert result is False, f"heredoc form {quote_style!r} should not trip the guard"
+
+    def test_lifecycle_command_inside_heredoc_still_blocked(self):
+        """The fix must not weaken the guard: a real lifecycle command
+        written as data inside a heredoc payload is still caught by the
+        separate direct full-text substring scan."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = (
+            "python3 - <<'EOF'\n"
+            "import os\n"
+            "os.system('systemctl restart hermes-gateway')\n"
+            "EOF"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(command)
+        assert result is True, (
+            "A lifecycle command embedded inside heredoc data must still "
+            "be blocked by the direct substring scan"
+        )
+
+    def test_command_after_heredoc_still_scanned(self):
+        """Content after a heredoc's closing delimiter is a real shell
+        command again and must still be tokenized/scanned normally."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        command = (
+            "cat <<'EOF'\n"
+            "just some data\n"
+            "EOF\n"
+            "hermes gateway restart"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(command)
+        assert result is True, (
+            "A real command following a heredoc block must still be scanned"
+        )
+
+    def test_multiple_heredocs_in_one_command(self, tmp_path):
+        """Two separate heredoc blocks in one command line must both have
+        their bodies skipped, without bleeding into each other."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        noise = "x" * 5000
+        one = tmp_path / "one.txt"
+        two = tmp_path / "two.txt"
+        one.write_text(noise + " hermes   gateway   restart " + noise, encoding="utf-8")
+        two.write_text(noise + " hermes   gateway   stop " + noise, encoding="utf-8")
+        command = (
+            "cat <<'A'\n"
+            f"open('{one}')\n"
+            "A\n"
+            "cat <<'B'\n"
+            f"open('{two}')\n"
+            "B"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            command, cwd=str(tmp_path)
+        )
+        assert result is False
+
+
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_iter_command_segments()` shell-tokenizes every terminal command via `shlex` to detect referenced scripts for the gateway-lifecycle guard (`contains_gateway_lifecycle_command_or_referenced_script`, #30719). `shlex` has no concept of heredoc syntax (`<<EOF ... EOF`): it tokenized the heredoc **body** as if it were additional shell commands.

A bare-looking token inside that body — e.g. a file path literal from `open('/tmp/vids.html')` embedded in Python/shell source passed via heredoc — was then picked up by `_iter_referenced_shell_scripts` as "a script being executed", read from disk, and recursively scanned by the guard. When the referenced file was large third-party content (a downloaded HTML page, in the field report that surfaced this), the guard's regex branches use unbounded `[^\n]*` spans, so an incidental lifecycle-shaped substring anywhere in that blob could coincidentally satisfy a match — blocking a completely unrelated, benign command with a "cannot restart or stop the gateway" error.

### Real-world repro

An agent ran (paraphrased):
```bash
grep -oP 'ytInitialData = .{0,50}' /tmp/vids.html | head -1; python3 - <<'EOF'
import re, json
html = open('/tmp/vids.html').read()
...
EOF
```
This is a benign command scraping a downloaded YouTube page for video metadata. It was blocked because `/tmp/vids.html` (the downloaded page, containing arbitrary third-party text) got tokenized out of the heredoc body and re-scanned as if it were a referenced shell script.

## Fix

Strip heredoc body lines before tokenizing in `_iter_command_segments()`, since heredoc bodies are literal stdin data, never additional shell commands to parse. The heredoc's own terminator line is preserved so subsequent real commands on the same line are still tokenized normally.

`contains_gateway_lifecycle_command()`'s direct full-text substring scan is untouched — it still covers heredoc bodies, so a genuine lifecycle command written *inside* a heredoc payload is still blocked (covered by a new test).

## Test plan

Adds `TestHeredocFalsePositive` (8 cases) to `tests/hermes_cli/test_gateway_restart_loop.py`:
- the field-report repro itself (absolute-path file reference + incidental lifecycle-shaped noise content) — verified red-then-green against the pre-fix code, not just written to pass
- all four heredoc introducer forms: `<<EOF`, `<<'EOF'`, `<<"EOF"`, `<<-EOF`
- a lifecycle command embedded *inside* heredoc data — must still block (guard not weakened)
- a real command following a heredoc block — must still be scanned
- multiple heredocs in one command line

Ran the full canonical suite via `scripts/run_tests.sh tests/hermes_cli/test_gateway_restart_loop.py`: **93/93 passing** (85 pre-existing + 8 new), zero regressions. Also manually reverted the fix and re-ran the new tests to confirm 6 of the 8 fail against the pre-fix code (the other 2 are defensive tests that were never broken — they assert real lifecycle commands are still caught).

## Scope

Pure addition — no existing lines removed, no behavior changed outside the heredoc-body-skipping path. Does not touch the #77703/#76762 NUL-byte/binary-handling fixes already on `main`.