### PR TITLE
fix: prevent lifecycle guard crashes on NUL paths

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -273,7 +273,10 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
         # chunk tells us if this is a binary (NUL bytes) that should be
         # skipped as "nothing to scan" rather than failing closed (#76762).
         data = os.read(descriptor, _MAX_REFERENCED_SCRIPT_BYTES + 1)
-    except OSError:
+    except (OSError, ValueError):
+        # OSError: unreadable/long paths. ValueError: embedded NUL byte from
+        # a binary's decoded contents tokenized as a path — a guarded path
+        # must never crash the guard (#76762).
         return None, False
     finally:
         os.close(descriptor)


### PR DESCRIPTION
## Summary

Prevents the terminal lifecycle guard from crashing when recursive referenced-script inspection reaches a path token containing an embedded NUL byte.

The observed trigger was a command that invoked a native binary by full path. Its decoded binary contents produced NUL-bearing tokens; os.open() raises ValueError for those tokens, while this recovery path previously caught only OSError.

## Change

- Catch ValueError alongside OSError in _read_referenced_script().
- Preserve the existing safe fallback: unreadable or invalid candidate paths are not treated as scripts to scan.

## Validation

- Reproduced the failure with the local Matter Mach-O executable, then verified the guard returns normally after the change.
- Ran python -m py_compile cron/lifecycle_guard.py.
- Ran git diff --check.
- Confirmed the existing regression test for an absolute-path native executable covers the no-crash behavior.

No configuration or public API changes.