### PR TITLE
fix(guard): bound lifecycle-guard shlex scan against binary/oversized input

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -106,14 +106,30 @@ _MAX_REFERENCED_SCRIPT_BYTES = 1024 * 1024
 _MAX_REFERENCED_SCRIPT_DEPTH = 8
 _CONTROL_CHARS = frozenset(";&|()")
 
-
+# Bounded scan budget for the shlex tokenizer. shlex reads one char at a time
+# in pure Python and its cost is superlinear on pathological input (a single
+# multi-megabyte token makes the string append quadratic — a 2MB scan took ~70s
+# in the field). The referenced-script reader caps files at
+# _MAX_REFERENCED_SCRIPT_BYTES; applying the same budget to every tokenization
+# keeps a decoded binary or an oversized command line from wedging the gateway
+# inside shlex for minutes-to-hours.
+_MAX_SCAN_CHARS = _MAX_REFERENCED_SCRIPT_BYTES  # 1 MiB
+_MAX_SCAN_TOKENS = 50_000
 
 
 _ReadRemoteScriptFn = Callable[[str], Optional[str]]
 
 
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
-    """Yield shell-tokenized command segments, honoring quotes and comments."""
+    """Yield shell-tokenized command segments, honoring quotes and comments.
+
+    Inputs larger than ``_MAX_SCAN_CHARS``, or yielding more than
+    ``_MAX_SCAN_TOKENS`` tokens, are treated as un-scanable and skipped —
+    tokenizing unbounded text is pathologically slow and buys nothing for
+    lifecycle detection.
+    """
+    if not command or len(command) > _MAX_SCAN_CHARS:
+        return
     normalized = command.replace("\\\n", "")
     for line in normalized.splitlines() or [normalized]:
         try:
@@ -124,7 +140,11 @@ def _iter_command_segments(command: str) -> Iterator[list[str]]:
             )
             lexer.whitespace_split = True
             lexer.commenters = "#"
-            tokens = list(lexer)
+            tokens: list[str] = []
+            for token in lexer:
+                tokens.append(token)
+                if len(tokens) >= _MAX_SCAN_TOKENS:
+                    raise ValueError("command scan token budget exceeded")
         except ValueError:
             continue
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -560,6 +560,38 @@ class TestTerminalToolGatewayLifecycleGuard:
         assert result["exit_code"] == 0
         assert calls == ["systemctl status nginx"]
 
+    def test_oversized_local_binary_not_slurped_via_cat_fallback(
+        self, monkeypatch, tmp_path
+    ):
+        """A large binary executable referenced by absolute path (e.g. `kimi`)
+        must NOT be `cat`-ed whole into the lifecycle guard — the decoded
+        machine code would be tokenized for tens of minutes, wedging the
+        gateway and stalling the session."""
+        import tools.terminal_tool as tt
+
+        blob = tmp_path / "big.bin"
+        blob.write_bytes(b"\x00ELF" * 300 * 1024)  # ~1.2MB binary with NUL bytes
+
+        calls = []
+
+        class _FakeEnv:
+            env = {}
+            def execute(self, command, **kwargs):
+                calls.append(command)
+                return {"output": "", "returncode": 0}
+
+        self._patch_env(monkeypatch, _FakeEnv(), inside_gateway=True)
+        monkeypatch.setattr(
+            tt, "_check_all_guards", lambda cmd, env, **kwargs: {"approved": True}
+        )
+
+        command = f"{blob} --version"
+        result = json.loads(tt.terminal_tool(command=command))
+
+        assert result["exit_code"] == 0
+        # The ONLY execute call is the real command — never a `cat <binary>`.
+        assert calls == [command]
+
 
 # ---------------------------------------------------------------------------
 # cron.lifecycle_guard module — the shared checker create_job/CLI/terminal use
@@ -913,3 +945,63 @@ class TestCronCreateLifecycleBlockExtra:
         assert rc == 1
         out = capsys.readouterr().out
         assert "Blocked" in out
+
+
+# ---------------------------------------------------------------------------
+# Regression: the lifecycle guard must never wedge the gateway in shlex on
+# pathological input (binary / oversized "script" content). Real incident: a
+# terminal_tool command referencing `/data/homes/star/.kimi-code/bin/kimi` (a
+# 166MB ELF) by absolute path — the guard's referenced-script reader fell back
+# to `env.execute("cat <path>")`, dumped the whole binary back as decoded text,
+# and the shlex tokenizer chewed on it for tens of minutes (superlinear cost),
+# stalling the session and tripping the stall watchdog.
+# ---------------------------------------------------------------------------
+
+class TestLifecycleGuardScanBounds:
+    """The shlex-based scan is bounded: oversized or token-flood inputs are
+    skipped instead of tokenized for minutes."""
+
+    def test_iter_command_segments_skips_oversized_input(self):
+        from cron.lifecycle_guard import _iter_command_segments
+        oversized = "x " * 700_000  # 1.4MB single line
+        assert list(_iter_command_segments(oversized)) == []
+
+    def test_iter_command_segments_bounds_token_flood(self):
+        from cron.lifecycle_guard import _iter_command_segments
+        flood = "a " * 60_000  # 120KB but >50K tokens
+        assert list(_iter_command_segments(flood)) == []
+
+    def test_iter_command_segments_still_tokenizes_normal_commands(self):
+        from cron.lifecycle_guard import _iter_command_segments
+        segments = list(_iter_command_segments("echo hi && cat /tmp/x.sh"))
+        assert ["echo", "hi"] in segments
+        assert ["cat", "/tmp/x.sh"] in segments
+
+    def test_guard_returns_without_wedging_on_oversized_binary_script_text(self):
+        import signal
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        # 3.4MB of NUL-separated symbol-table junk: one huge single line with
+        # no shlex punctuation — exactly the shape that makes the tokenizer
+        # superlinear. The scan must be skipped, not chew CPU for minutes.
+        blob = "ZSTD_symbol_name\x00" * 200_000
+
+        class _Alarm(Exception):
+            pass
+
+        def _alarm_handler(signum, frame):
+            raise _Alarm()
+
+        old_handler = signal.signal(signal.SIGALRM, _alarm_handler)
+        signal.alarm(5)
+        try:
+            result = contains_gateway_lifecycle_command_or_referenced_script(
+                "/some/abs/path",
+                cwd="/tmp",
+                read_remote_script=lambda path: blob,
+            )
+            assert result is False
+        finally:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, old_handler)

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2503,6 +2503,7 @@ def terminal_tool(
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from cron.lifecycle_guard import (
+                _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
             )
@@ -2542,18 +2543,31 @@ def terminal_tool(
                         local_path = Path(guard_cwd) / local_path
                     if local_path.is_file():
                         metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
+                        if (
+                            stat.S_ISREG(metadata.st_mode)
+                            and metadata.st_size <= _MAX_REFERENCED_SCRIPT_BYTES
+                        ):
                             data = local_path.read_bytes()
-                            if len(data) <= 1024 * 1024:
+                            if len(data) <= _MAX_REFERENCED_SCRIPT_BYTES:
                                 if b"\x00" in data:
-                                    # Binary (ELF/Mach-O/PE), not a shell script:
-                                    # feeding its decoded bytes back into the guard
-                                    # tokenizes machine code into bogus NUL-bearing
-                                    # paths and crashes the scanner (#77703). Mirror
-                                    # lifecycle_guard._read_referenced_script and
-                                    # treat it as nothing to scan.
+                                    # NUL bytes -> a binary (ELF/Mach-O/PE), not a
+                                    # shell script. Feeding its decoded bytes back
+                                    # into the guard tokenizes machine code into
+                                    # bogus NUL-bearing paths and crashes the
+                                    # scanner (#77703); it is also pathologically
+                                    # slow. Mirror lifecycle_guard.
+                                    # _read_referenced_script and treat it as
+                                    # nothing to scan.
                                     return None
                                 return data.decode("utf-8", errors="replace")
+                        else:
+                            # A local regular file that is oversized (or not
+                            # regular) must not be slurped via `cat`: a large
+                            # executable referenced by absolute path (e.g.
+                            # `kimi`, `node`) would otherwise be dumped whole
+                            # into the guard's tokenizer and wedge the gateway
+                            # for tens of minutes or longer.
+                            return None
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
@@ -2561,9 +2575,10 @@ def terminal_tool(
                     result = env.execute(f"cat {shlex.quote(script_path)}")
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")
-                        if output and "\x00" in output:
-                            # Binary content from a remote `cat`: skip for the
-                            # same reason as the local branch above (#77703).
+                        # Same guards as the local read: a remote binary or an
+                        # oversized file is not a scanable shell script
+                        # (NUL-skip mirrors #77703).
+                        if "\x00" in output or len(output) > _MAX_REFERENCED_SCRIPT_BYTES:
                             return None
                         return output
                 except Exception:


### PR DESCRIPTION
## What

The gateway-lifecycle guard in `terminal_tool` treats every absolute-path executable referenced by a command as a potential shell script and scans it. When the agent runs a large binary by absolute path (e.g. `/data/homes/star/.kimi-code/bin/kimi`, a 166MB ELF), the referenced-script reader's `env.execute("cat <path>")` fallback dumps the whole binary back as decoded text, and the guard tokenizes it with `shlex` — whose cost is superlinear on such input. In the field a 2MB scan took ~70s; the 166MB binary kept the gateway's tool thread at 100% CPU for 30+ minutes. The session looked stalled (`last_activity=executing tool: terminal`), the 300s stall watchdog fired, and the 1800s idle timeout eventually killed the turn. The same session/pattern hit twice on consecutive days.

## Root cause chain

1. `terminal_tool` (running inside the gateway) executes a command referencing `/path/to/kimi` (absolute path).
2. `cron/lifecycle_guard._iter_referenced_shell_scripts` treats any executable token containing `/` as a referenced shell script.
3. `_read_referenced_script` correctly skips the 166MB ELF (NUL bytes), but `terminal_tool`'s `_read_script_in_env` fallback then runs `env.execute("cat <path>")`, pulling the entire binary back as decoded text (`utf-8, errors="replace"`).
4. The guard recurses into that text; `contains_launchctl_submit_command` → `_iter_command_segments` → `shlex.shlex(punctuation_chars=";&|()", whitespace_split=True)` chews on it with superlinear cost (char-by-char pure-Python tokenizer; a single multi-MB token makes the string append quadratic).
5. The tool call never returns → session activity pinned at "executing tool: terminal" → stall watchdog fires and the 1800s idle timeout kills the turn.

## Fix (two layers)

- `tools/terminal_tool.py` `_read_script_in_env`: skip NUL-byte (binary) and oversized files on both the local read and the remote `cat` fallback, mirroring `_read_referenced_script`'s guards. A large executable referenced by absolute path is no longer slurped into the tokenizer.
- `cron/lifecycle_guard.py` `_iter_command_segments`: bound every tokenization to 1MiB of input / 50k tokens, so pathological text can never wedge the gateway in shlex for minutes no matter how it reaches the guard.

## Repro

- `shlex.shlex(binary_text, posix=True, punctuation_chars=";&|()"); lexer.whitespace_split = True` on 2MB of decoded ELF content: ~71s; on the full 166MB binary: hours.
- py-spy stack of the wedged thread: `read_token (shlex.py) ← _iter_command_segments (cron/lifecycle_guard.py:127) ← contains_launchctl_submit_command ← _contains_unsafe_gateway_action ← terminal_tool`.

## Tests

5 new regression tests in `tests/hermes_cli/test_gateway_restart_loop.py`:
- oversized input skipped by `_iter_command_segments`
- token-flood input bounded
- normal commands still tokenize (no over-blocking)
- end-to-end guard on a multi-MB NUL-separated blob (alarm-bounded: returns instead of wedging)
- `terminal_tool` never runs `cat` on an oversized local binary

Verified: `pytest tests/hermes_cli/test_gateway_restart_loop.py` → 87 passed; `pytest tests/tools -k "terminal or guard or lifecycle"` → 512 passed, 4 skipped; `ruff check` clean on the changed files.
