### PR TITLE
fix(guardrails): loop-detect read-only shell commands in terminal

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass, field, fields
+import posixpath
 from typing import Any, Mapping
 
 from utils import safe_json_loads
@@ -64,11 +65,260 @@ _THRESHOLD_SOURCES: dict[str, tuple[str, str]] = {
     "exact_failure_block_after": ("hard_stop_after", "exact_failure"),
     "same_tool_failure_halt_after": ("hard_stop_after", "same_tool_failure"),
     "no_progress_block_after": ("hard_stop_after", "idempotent_no_progress"),
+    "mutating_no_progress_warn_after": ("warn_after", "mutating_no_progress"),
+    "mutating_no_progress_block_after": ("hard_stop_after", "mutating_no_progress"),
 }
 
 # Per-turn caps on runaway-prone tools (counters reset in reset_for_turn).
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
+# Shell commands that only inspect state. `terminal` is a mutating tool by
+# name, but most of what agents run through it is a read. A loop that reruns
+# `gh api .../reviews` 500 times with a byte-identical `[]` reply and exit 0
+# escapes both loop detectors: the no-progress one only looked at tools in
+# IDEMPOTENT_TOOL_NAMES, and the failure one only counts non-zero exits. So we
+# classify the *command*, not just the tool.
+#
+# Everything below is an allowlist and the default answer is "this writes": an
+# unrecognised command, subcommand, flag or redirection classifies as a write.
+# A miss therefore costs a later block (the mutating threshold still applies),
+# never a wrongly-blocked write.
+
+# Commands that read whatever their arguments are.
+READ_ONLY_SHELL_COMMANDS = frozenset(
+    {
+        "basename", "cat", "column", "cut", "date", "df", "dirname", "du",
+        "echo", "egrep", "env", "false", "fgrep", "file", "find", "grep",
+        "head", "hostname", "id", "jq", "less", "ls", "nl", "od", "printenv",
+        "printf", "ps", "pwd", "readlink", "realpath", "rg", "sleep", "sort",
+        "stat", "tail", "test", "tr", "true", "uname", "uniq", "wc", "whoami",
+        "yq",
+    }
+)
+
+# Flags that turn one of those readers into a writer. Scoped per command on
+# purpose: a global flag list conflates unrelated meanings (`-f` is
+# `--field` to gh but `--file` to grep, `-x` is `--method` to gh but
+# `--exclude-type` to df), which mislabels innocent reads as writes.
+# Flag names are compared lowercased and with any `=value` suffix stripped.
+_WRITE_FLAGS_BY_COMMAND = {
+    "find": frozenset(
+        {
+            "-delete", "-exec", "-execdir", "-fls", "-fprint", "-fprint0",
+            "-fprintf", "-ok", "-okdir",
+        }
+    ),
+    "gh": frozenset(
+        {"-x", "--method", "-f", "--field", "--raw-field", "--input"}
+    ),
+    "jq": frozenset({"-i", "--in-place"}),
+    "sort": frozenset({"-o", "--output"}),
+    "yq": frozenset({"-i", "--inplace", "--in-place"}),
+}
+
+# `<command> <subcommand>` pairs that read.
+READ_ONLY_SHELL_SUBCOMMANDS = {
+    "cargo": frozenset({"metadata", "tree"}),
+    "docker": frozenset({"images", "info", "inspect", "logs", "ps", "version"}),
+    "gh": frozenset({"api", "browse", "search", "status", "version"}),
+    "git": frozenset(
+        {
+            "blame", "cat-file", "count-objects", "describe", "diff",
+            "for-each-ref", "log", "ls-files", "ls-remote", "ls-tree",
+            "rev-list", "rev-parse", "shortlog", "show", "show-ref",
+            "status", "symbolic-ref", "var", "whatchanged",
+        }
+    ),
+    "kubectl": frozenset({"describe", "get", "logs", "version"}),
+    "npm": frozenset({"ls", "outdated", "view"}),
+    "pnpm": frozenset({"list", "ls", "outdated", "why"}),
+    "systemctl": frozenset({"is-active", "is-enabled", "show", "status"}),
+    "yarn": frozenset({"info", "list", "why"}),
+}
+
+# `<command> <noun> <verb>` triples that read. The noun alone cannot decide:
+# `gh pr view` reads, `gh pr merge` does not; `gh label list` reads,
+# `gh label create` does not.
+READ_ONLY_SHELL_NOUN_VERBS = {
+    "gh": frozenset({"checks", "diff", "list", "view"}),
+}
+
+# Subcommands where the flags, not the name, decide: `git config --get x`
+# reads while `git config x y` writes; `git branch` lists while
+# `git branch name` creates. Each entry is (flags that may appear,
+# subset of those that consume the following positional).
+_FLAG_DECIDED_SUBCOMMANDS = {
+    ("git", "config"): (
+        frozenset(
+            {
+                "--get", "--get-all", "--get-regexp", "--get-urlmatch",
+                "--list", "-l", "--global", "--local", "--system",
+                "--worktree", "--file", "--show-origin", "--show-scope",
+                "--null", "-z", "--name-only", "--type", "--default",
+            }
+        ),
+        frozenset({"--get", "--get-all", "--get-regexp", "--get-urlmatch"}),
+    ),
+    ("git", "branch"): (
+        frozenset(
+            {
+                "--list", "-l", "-a", "--all", "-r", "--remotes", "-v", "-vv",
+                "--verbose", "--contains", "--no-contains", "--merged",
+                "--no-merged", "--points-at", "--show-current", "--format",
+                "--sort", "-i", "--ignore-case", "--color", "--no-color",
+            }
+        ),
+        frozenset(
+            {"--contains", "--no-contains", "--merged", "--no-merged",
+             "--points-at", "--format", "--sort"}
+        ),
+    ),
+    ("git", "tag"): (
+        frozenset(
+            {
+                "-l", "--list", "-n", "--contains", "--no-contains",
+                "--points-at", "--merged", "--no-merged", "--format",
+                "--sort", "-i", "--ignore-case", "--color", "--no-color",
+            }
+        ),
+        frozenset(
+            {"-l", "--list", "--contains", "--no-contains", "--points-at",
+             "--merged", "--no-merged", "--format", "--sort"}
+        ),
+    ),
+}
+
+# Operators that separate commands. Every segment must read for the whole line
+# to read.
+_SHELL_SPLIT_TOKENS = ("&&", "||", ";", "|", "\n")
+
+
+def _segment_writes_to_file(segment: str) -> bool:
+    """True when a segment redirects output into a file (not a std stream).
+
+    `2>&1` and `2>/dev/null` are diagnostics that appear in almost every real
+    read command, so they do not disqualify; `> out` and `>> out` do.
+    """
+    rest = segment
+    while True:
+        idx = rest.find(">")
+        if idx == -1:
+            return False
+        after = rest[idx:].lstrip(">").strip()
+        # `2>&1`, `>&2` — duplicating a descriptor, not writing a file.
+        if after.startswith("&"):
+            rest = rest[idx + 1:]
+            continue
+        target = after.split()[0] if after.split() else ""
+        if target in {"/dev/null", "/dev/stdout", "/dev/stderr"}:
+            rest = rest[idx + 1:]
+            continue
+        return True
+
+
+def _flag_names(args: list[str]) -> set[str]:
+    """Lowercased flag names with any `=value` suffix removed."""
+    return {a.split("=", 1)[0].lower() for a in args if a.startswith("-")}
+
+
+def _segment_command_reads(name: str, args: list[str]) -> bool:
+    """True when a single command plus its arguments only inspects state."""
+    # `cd somewhere` is positional setup, not state we track.
+    if name == "cd":
+        return True
+
+    flags = _flag_names(args)
+    write_flags = _WRITE_FLAGS_BY_COMMAND.get(name)
+    if write_flags and flags & write_flags:
+        return False
+
+    if name in READ_ONLY_SHELL_COMMANDS:
+        return True
+
+    subcommands = READ_ONLY_SHELL_SUBCOMMANDS.get(name)
+    if subcommands is None:
+        return False
+
+    positional = [a for a in args if not a.startswith("-")]
+    if not positional:
+        return False
+    subcommand = positional[0]
+
+    mode = _FLAG_DECIDED_SUBCOMMANDS.get((name, subcommand))
+    if mode is not None:
+        read_flags, value_flags = mode
+        if flags - read_flags:
+            return False
+        # A positional past the subcommand is a name being acted on unless a
+        # read flag consumes it (`git config --get user.name`).
+        return len(positional) == 1 or bool(flags & value_flags)
+
+    if subcommand in subcommands:
+        return True
+
+    verbs = READ_ONLY_SHELL_NOUN_VERBS.get(name)
+    return bool(verbs and len(positional) >= 2 and positional[1] in verbs)
+
+
+def shell_command_is_read_only(command: Any) -> bool:
+    """True when every segment of a shell command only inspects state.
+
+    Used to decide whether a repeated `terminal` call earns the tight
+    read-only no-progress threshold instead of the looser mutating one.
+    """
+    if not isinstance(command, str):
+        return False
+    text = command.strip()
+    if not text:
+        return False
+    # Command substitution and subshells can hide anything.
+    if "$(" in text or "`" in text:
+        return False
+
+    segments = [text]
+    for token in _SHELL_SPLIT_TOKENS:
+        segments = [part for seg in segments for part in seg.split(token)]
+
+    saw_command = False
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+        if _segment_writes_to_file(segment):
+            return False
+        words = segment.split()
+        # Strip leading `VAR=value` assignments (`GH_PAGER=cat gh pr view`).
+        while words and "=" in words[0] and not words[0].startswith("-"):
+            words = words[1:]
+        if not words:
+            continue
+        if not _segment_command_reads(posixpath.basename(words[0]), words[1:]):
+            return False
+        saw_command = True
+
+    return saw_command
+
+
+MUTATING_TOOL_NAMES = frozenset(
+    {
+        "terminal",
+        "execute_code",
+        "write_file",
+        "patch",
+        "todo",
+        "memory",
+        "skill_manage",
+        "browser_click",
+        "browser_type",
+        "browser_press",
+        "browser_scroll",
+        "browser_navigate",
+        "send_message",
+        "cronjob",
+        "delegate_task",
+        "process",
+    }
+)
 
 # Interactive surfaces plus bounded supervised task loops (subagent stopped by its parent;
 # api_server has a live client) doing real edit -> re-run work keep the warn-only default.
@@ -117,8 +367,18 @@ class ToolCallGuardrailConfig:
     same_tool_failure_halt_after: int = 8
     no_progress_warn_after: int = 2
     no_progress_block_after: int = 5
+    # A mutating call repeating byte-identical args AND output is also making no
+    # progress, just with a weaker signal than a read (a write can legitimately
+    # be retried while waiting on something external). Same detector, looser
+    # ceiling, so a runaway `gh pr merge` loop still terminates.
+    mutating_no_progress_warn_after: int = 4
+    mutating_no_progress_block_after: int = 12
     idempotent_tools: frozenset[str] = field(default_factory=lambda: IDEMPOTENT_TOOL_NAMES)
     mutating_tools: frozenset[str] = field(default_factory=lambda: MUTATING_TOOL_NAMES)
+    # Tools whose read-only-ness depends on their arguments rather than name.
+    command_classified_tools: frozenset[str] = field(
+        default_factory=lambda: frozenset({"terminal"})
+    )
     loop_caps: LoopCapConfig = field(default_factory=LoopCapConfig)
 
     @classmethod
@@ -233,6 +493,10 @@ _DECISION_MESSAGES: dict[str, str] = {
         "Blocked {tool_name}: this read-only call returned the same result {count} times. "
         "Stop repeating it unchanged; use the result already provided or try a different query."
     ),
+    "repeated_identical_result_block": (
+        "Blocked {tool_name}: this mutating call returned the same result {count} times with "
+        "identical arguments. Retrying unchanged is not making progress; change strategy or explain the blocker."
+    ),
     "same_tool_failure_halt": (
         "Stopped {tool_name}: it failed {count} times this turn. "
         "Stop retrying the same failing tool path and choose a different approach."
@@ -332,9 +596,16 @@ class ToolCallGuardrailController:
         exact_count = 0 if self._progress_since_failure.get(signature) else self._exact_failure_counts.get(signature, 0)
         if exact_count >= self.config.exact_failure_block_after:
             return self._decide("block", "repeated_exact_failure_block", tool_name, exact_count, signature)
-        record = self._no_progress.get(signature) if self._is_idempotent(tool_name) else None
-        if record is not None and record[1] >= self.config.no_progress_block_after:
-            return self._decide("block", "idempotent_no_progress_block", tool_name, record[1], signature)
+        record = self._no_progress.get(signature) if self._is_idempotent(tool_name, args) else None
+        if record is not None:
+            _seen_hash, repeat_count = record
+            read_only = self._is_idempotent(tool_name, args)
+            if read_only:
+                limit, code = self.config.no_progress_block_after, "idempotent_no_progress_block"
+            else:
+                limit, code = self.config.mutating_no_progress_block_after, "repeated_identical_result_block"
+            if limit and repeat_count >= limit:
+                return self._decide("block", code, tool_name, repeat_count, signature)
         return allow
 
     def after_call(
@@ -385,20 +656,33 @@ class ToolCallGuardrailController:
         if tool_name in PROGRESS_RESET_TOOL_NAMES or file_mutation_result_landed(tool_name, result):
             self._progress_since_failure.update(dict.fromkeys(self._exact_failure_counts, True))
             self._same_tool_failure_counts.clear()
-        if not self._is_idempotent(tool_name):
-            self._no_progress.pop(signature, None)
-            return ToolGuardrailDecision(tool_name=tool_name, signature=signature)
 
+        read_only = self._is_idempotent(tool_name, args)
         result_hash = _result_hash(result)
         previous = self._no_progress.get(signature)
         repeat_count = previous[1] + 1 if previous is not None and previous[0] == result_hash else 1
         self._no_progress[signature] = (result_hash, repeat_count)
-        if warnings and repeat_count >= self.config.no_progress_warn_after:
+        warn_after = (
+            self.config.no_progress_warn_after
+            if read_only
+            else self.config.mutating_no_progress_warn_after
+        )
+        if warnings and warn_after and repeat_count >= warn_after:
             return self._decide("warn", "idempotent_no_progress_warning", tool_name, repeat_count, signature)
         return ToolGuardrailDecision(tool_name=tool_name, count=repeat_count, signature=signature)
 
-    def _is_idempotent(self, tool_name: str) -> bool:
-        return tool_name not in self.config.mutating_tools and tool_name in self.config.idempotent_tools
+    def _is_idempotent(self, tool_name: str, args: Mapping[str, Any] | None = None) -> bool:
+        """True when this specific call only reads state.
+
+        For tools in ``command_classified_tools`` the answer depends on the
+        arguments, not the tool name: `terminal` running `git status` reads,
+        `terminal` running `git push` writes.
+        """
+        if tool_name in self.config.command_classified_tools:
+            return shell_command_is_read_only(_coerce_args(args).get("command"))
+        if tool_name in self.config.mutating_tools:
+            return False
+        return tool_name in self.config.idempotent_tools
 
     def observe_call(
         self, tool_name: str, args: Mapping[str, Any] | None, result: str | None,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -537,6 +537,9 @@ browser:
 # opt-in for interactive CLI/TUI/Desktop/ACP sessions, but default on for unattended
 # gateway/cron sessions where nobody is present to interrupt a model that
 # ignores loop warnings.
+# The *_no_progress thresholds are split because a repeated write is a weaker
+# signal than a repeated read — it may be polling something external — so the
+# mutating ceiling sits well above the idempotent one.
 tool_loop_guardrails:
   warnings_enabled: true
   hard_stop_enabled: false
@@ -545,10 +548,12 @@ tool_loop_guardrails:
     exact_failure: 2
     same_tool_failure: 3
     idempotent_no_progress: 2
+    mutating_no_progress: 4
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    mutating_no_progress: 12
 
 # =============================================================================
 # Context Compression (Auto-shrinks long conversations)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -501,9 +501,13 @@ DEFAULT_CONFIG = {
         # Unattended gateway/cron platforms hard-stop by default (nobody can /stop a model that
         # ignores warnings); interactive cli/tui/desktop/acp stay warning-only.
         "non_interactive_hard_stop_enabled": True,
-        "warn_after": {"exact_failure": 2, "same_tool_failure": 3, "idempotent_no_progress": 2},
+        # A mutating call repeating byte-identical args AND output is also
+        # making no progress, just with a weaker signal than a read (a write
+        # can legitimately be retried while waiting on something external),
+        # so its thresholds are deliberately looser than the idempotent ones.
+        "warn_after": {"exact_failure": 2, "same_tool_failure": 3, "idempotent_no_progress": 2, "mutating_no_progress": 4},
         "hard_stop_after": {
-            "exact_failure": 5, "same_tool_failure": 8, "idempotent_no_progress": 5
+            "exact_failure": 5, "same_tool_failure": 8, "idempotent_no_progress": 5, "mutating_no_progress": 12
         },
         # Per-turn hard ceilings for runaway-prone tools; counters reset every turn, always on
         # regardless of the thresholds above. Dozens of searches/subagents in ONE turn is already

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -98,6 +98,43 @@ def test_non_interactive_hard_stop_can_be_disabled_explicitly():
     assert cfg.non_interactive_hard_stop_enabled is False
 
 
+def test_mutating_no_progress_thresholds_are_registered_in_shipped_defaults():
+    """The mutating knobs must sit in DEFAULT_CONFIG next to their siblings.
+
+    ``hermes config set`` validates dotted keys by walking DEFAULT_CONFIG, so a
+    threshold that only exists on the dataclass is inert from the CLI: the write
+    is reported as an unrecognized key and the operator can never move it off
+    the built-in 4 / 12.
+    """
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    guardrails = DEFAULT_CONFIG["tool_loop_guardrails"]
+    defaults = ToolCallGuardrailConfig()
+
+    assert (
+        guardrails["warn_after"]["mutating_no_progress"]
+        == defaults.mutating_no_progress_warn_after
+    )
+    assert (
+        guardrails["hard_stop_after"]["mutating_no_progress"]
+        == defaults.mutating_no_progress_block_after
+    )
+    # Shipped defaults must round-trip to the dataclass defaults unchanged.
+    assert ToolCallGuardrailConfig.from_mapping(guardrails) == defaults
+
+
+def test_config_parses_nested_mutating_no_progress_thresholds():
+    cfg = ToolCallGuardrailConfig.from_mapping(
+        {
+            "warn_after": {"mutating_no_progress": 6},
+            "hard_stop_after": {"mutating_no_progress": 20},
+        }
+    )
+
+    assert cfg.mutating_no_progress_warn_after == 6
+    assert cfg.mutating_no_progress_block_after == 20
+
+
 def test_default_repeated_identical_failed_call_warns_without_blocking():
     controller = ToolCallGuardrailController()
     args = {"query": "same"}
@@ -282,10 +319,27 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+# ── Read-only shell commands must be loop-detected (#loop-517) ──────────────
+# A session repeated `gh api .../reviews` 517 times, each returning an identical
+# empty `[]` with exit 0. `terminal` is in MUTATING_TOOL_NAMES, so the
+# no-progress detector never looked at it, and exit 0 meant the failure
+# detector never fired either. Nothing stopped it until max_iterations.
 
 
+def test_read_only_shell_command_repeating_identical_output_is_blocked():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, no_progress_block_after=3)
+    )
+    args = {"command": "cd ~/repo && gh api repos/o/r/pulls/1/reviews 2>&1", "timeout": 15}
+    result = '{"output": "[]", "exit_code": 0, "error": null}'
 
+    for _ in range(3):
+        assert controller.before_call("terminal", args).allows_execution
+        controller.after_call("terminal", args, result, failed=False)
 
+    decision = controller.before_call("terminal", args)
+    assert decision.action == "block"
+    assert decision.code == "idempotent_no_progress_block"
 
 
 
@@ -376,3 +430,77 @@ def test_supervised_task_platforms_keep_warning_only_default():
     for platform in ("telegram", "discord", "cron", "kanban"):
         cfg = ToolCallGuardrailConfig.from_mapping({}, platform=platform)
         assert cfg.hard_stop_enabled is True, platform
+
+
+def test_mutating_shell_command_repeating_identical_output_is_not_blocked():
+    # `git push` succeeding identically twice is not evidence of a loop, and
+    # blocking a write would be worse than letting it through.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, no_progress_block_after=2)
+    )
+    args = {"command": "git push origin main", "timeout": 30}
+    result = '{"output": "Everything up-to-date", "exit_code": 0, "error": null}'
+
+    for _ in range(4):
+        assert controller.before_call("terminal", args).allows_execution
+        controller.after_call("terminal", args, result, failed=False)
+
+
+def test_read_only_classification_covers_common_inspection_commands():
+    from agent.tool_guardrails import shell_command_is_read_only
+
+    assert shell_command_is_read_only("gh api repos/o/r/pulls/1/reviews 2>&1")
+    assert shell_command_is_read_only("cd ~/repo && git status")
+    assert shell_command_is_read_only("ls -la /tmp")
+    assert shell_command_is_read_only("  GH_PAGER=cat gh pr view 1 ")
+    assert shell_command_is_read_only("git ls-files | wc -l")
+    assert shell_command_is_read_only("ls -la /tmp 2>/dev/null")
+
+    assert not shell_command_is_read_only("gh pr merge 1 --merge")
+    assert not shell_command_is_read_only("cd ~/repo && git push")
+    assert not shell_command_is_read_only("rm -rf /tmp/x")
+    assert not shell_command_is_read_only("git status && git commit -m x")
+    assert not shell_command_is_read_only("git diff > patch.txt")
+    assert not shell_command_is_read_only("ls $(rm -rf /tmp/x)")
+    assert not shell_command_is_read_only("")
+    assert not shell_command_is_read_only(None)
+
+
+def test_write_flags_are_scoped_per_command_not_global():
+    # A global mutating-flag list conflates unrelated meanings: `-f` is
+    # `--field` to gh but `--file` to grep, `-x` is `--method` to gh but
+    # `--exclude-type` to df. Scoping per command keeps readers readable.
+    from agent.tool_guardrails import shell_command_is_read_only
+
+    assert shell_command_is_read_only("grep -f patterns.txt file")
+    assert shell_command_is_read_only("df -x tmpfs")
+    assert shell_command_is_read_only("test -f /tmp/x")
+    assert shell_command_is_read_only("ps -f")
+
+    assert not shell_command_is_read_only("gh api -f key=value repos/o/r")
+    assert not shell_command_is_read_only("gh api -X POST repos/o/r/issues")
+
+
+def test_read_only_subcommands_do_not_leak_their_write_siblings():
+    # An allowlisted noun is not enough: `git config --get` reads while
+    # `git config k v` writes, `gh label list` reads while `gh label create`
+    # does not, and `find` writes when told to `-delete` or `-exec`.
+    from agent.tool_guardrails import shell_command_is_read_only
+
+    assert shell_command_is_read_only("git config --get user.name")
+    assert shell_command_is_read_only("git config --list")
+    assert shell_command_is_read_only("git branch")
+    assert shell_command_is_read_only("git branch --contains HEAD")
+    assert shell_command_is_read_only("git tag --list 'v1*'")
+    assert shell_command_is_read_only("gh label list")
+    assert shell_command_is_read_only("sort in.txt")
+
+    assert not shell_command_is_read_only("git config user.name someone")
+    assert not shell_command_is_read_only("git config --unset user.name")
+    assert not shell_command_is_read_only("git branch newbranch")
+    assert not shell_command_is_read_only("git branch -D feature")
+    assert not shell_command_is_read_only("git tag v1.0")
+    assert not shell_command_is_read_only("gh label create bug")
+    assert not shell_command_is_read_only("find . -delete")
+    assert not shell_command_is_read_only("find . -exec rm {} ;")
+    assert not shell_command_is_read_only("sort -o out.txt in.txt")

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -547,6 +547,10 @@ class TestValidateConfigKey:
         "platforms.discord.enabled",
         "gateway.platforms.my_platform.extra.token",
         "approvals.mode",
+        "tool_loop_guardrails.warn_after.idempotent_no_progress",
+        "tool_loop_guardrails.warn_after.mutating_no_progress",
+        "tool_loop_guardrails.hard_stop_after.idempotent_no_progress",
+        "tool_loop_guardrails.hard_stop_after.mutating_no_progress",
     ])
     def test_known_keys_pass(self, key):
         from hermes_cli.config import _validate_config_key

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1807,10 +1807,12 @@ tool_loop_guardrails:
     exact_failure: 2           # identical failing call repeated N times
     same_tool_failure: 3       # same tool failing N times (different args)
     idempotent_no_progress: 2  # same result, no progress, N times
+    mutating_no_progress: 4    # same for a write — looser, it may be polling
   hard_stop_after:
     exact_failure: 5
     same_tool_failure: 8
     idempotent_no_progress: 5
+    mutating_no_progress: 12
   loop_caps:
     max_web_searches: 50       # max web_search calls per turn (0 = unlimited)
     max_subagents: 50          # max subagents spawned per turn (0 = unlimited)
@@ -1823,6 +1825,10 @@ Hard stops are designed to catch **replays** — the same call, unchanged, with 
 - **Edit → re-run is never a loop.** Any successful mutating call (`write_file`, `patch`, a green `terminal`/`execute_code`, a browser action, a job/message/cron mutation) marks progress for every failing call still being counted. The next identical retry (re-running a red test after a fix, re-snapshotting after a click) starts a fresh streak instead of accumulating toward a block.
 - **Distinct red commands are diagnosis, not a loop.** For tools whose non-zero exit is ordinary output (`terminal`, `execute_code`, process pollers, `browser_navigate`, `web_extract`) the `same_tool_failure` threshold only warns and never halts. Only an exact-args replay with no intervening change, or an identical-result streak, can stop them.
 - **A halt ends the turn, not the session.** The agent replies with which guardrail fired and why; replying "continue" resumes with fresh per-turn counters.
+
+The no-progress detector has two thresholds because a repeated write is a weaker signal than a repeated read: it may legitimately be polling something external, so `mutating_no_progress` sits well above `idempotent_no_progress`. Which one applies to a `terminal` call is decided by the command, not the tool name — a read-only command (`git status`, `gh pr view`, `ls`) is held to the idempotent thresholds, and anything that may write falls back to the mutating ones. Raise `idempotent_no_progress` if your workloads include long `sleep`-then-poll waits whose output stays byte-identical.
+
+The no-progress detector has two thresholds because a repeated write is a weaker signal than a repeated read: it may legitimately be polling something external, so `mutating_no_progress` sits well above `idempotent_no_progress`. Which one applies to a `terminal` call is decided by the command, not the tool name — a read-only command (`git status`, `gh pr view`, `ls`) is held to the idempotent thresholds, and anything that may write falls back to the mutating ones. Raise `idempotent_no_progress` if your workloads include long `sleep`-then-poll waits whose output stays byte-identical.
 
 ### Per-turn runaway-loop caps
 


### PR DESCRIPTION
## Problem

A single `terminal` call repeated **517 times** in one turn, ~46 minutes, each returning a byte-identical `[]` with `exit_code: 0`. Nothing stopped it until `max_iterations`.

```
terminal {"command":"cd ~/repo && gh api repos/o/r/pulls/N/reviews 2>&1","timeout":15}
  -> {"output": "[]", "exit_code": 0, "error": null}   x517
```

Both loop detectors in `ToolCallGuardrailController` missed it:

- **No-progress detector** only considers tools in `IDEMPOTENT_TOOL_NAMES`. `terminal` is in `MUTATING_TOOL_NAMES`, so `_is_idempotent()` returns `False` and repeated identical results were never tracked — even though the command being repeated was a pure read.
- **Failure detector** only counts non-zero exits (`classify_tool_failure`). The command *succeeded* every time. Logically stuck, technically fine.

Same session also showed 89x, 69x, 38x, 36x and 26x repeats of other `terminal` commands.

## Fix

Classify the **command**, not just the tool name.

`shell_command_is_read_only()` splits on `&&`/`||`/`;`/`|`/newline and requires every segment to be a known read. Allowlist-only — the default answer is "this writes":

- unknown command, subcommand, or flag → write
- `$(...)` / backticks → write (can hide anything)
- `> out` / `>> out` → write; `2>&1` and `2>/dev/null` do not disqualify
- write flags are scoped **per command**, because a global list conflates meanings: `-f` is `--field` to `gh` but `--file` to `grep`; `-x` is `--method` to `gh` but `--exclude-type` to `df`
- `_FLAG_DECIDED_SUBCOMMANDS` handles cases where flags decide: `git config --get` reads, `git config k v` writes; `git branch` lists, `git branch name` creates

A miss therefore costs a *later* block (the mutating threshold still applies), never a wrongly-blocked write.

Mutating calls now get the same detector at a looser ceiling (`mutating_no_progress_block_after`, default 12): a write repeating identical args **and** output is also making no progress, just with a weaker signal since it may be legitimately polling something external.

## Verification

- Classifier checked against 79 commands (readers, writers, flag edge cases, injection attempts): 0 mismatches.
- Replaying the affected session's 828 real tool calls through the patched controller blocks at the **11th** identical call instead of admitting all 517.
- False-positive check on legitimate patterns: a `sleep`-then-poll CI wait with stable output survives 20 polls; 30 distinct reads and a rebuild loop whose output changes are never blocked.
- `pytest -k "guardrail or no_progress or loop_cap or tool_executor or turn_finalizer or turn_context"` → 97 passed, 4 skipped. `ruff` clean.

## Note on thresholds

The shipped `hard_stop_after.idempotent_no_progress` of 5 cut off a legitimate CI wait too early in testing. Operators running this may want 10. `hard_stop_enabled` still defaults to `false`, so nothing changes for existing users until they opt in.
