### PR TITLE
fix(fallback): benched credentials must not disqualify a chain entry

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1723,10 +1723,125 @@ def _fallback_chain_exhausted(agent, reason: "FailoverReason | None") -> bool:
     return False
 
 
+# How long a fallback entry stays suppressed after resolving to no client.
+# The memo exists so an unconfigured provider is not re-probed on every
+# activation, but it used to be cleared only by a ``fallback_providers`` content
+# edit. Credentials normally arrive via ``hermes auth`` (auth.json) or a new env
+# var — neither touches config.yaml — so a provider configured mid-uptime stayed
+# suppressed for the entire life of a cached agent. A TTL keeps the
+# rate-limiting benefit while guaranteeing the memo cannot outlive the condition
+# that created it.
+UNAVAILABLE_FALLBACK_RETRY_SECONDS = 10 * 60
+
+# Stamp tables for memo sets that reject attributes (a plain ``set``), keyed by
+# id(). Bounded by the number of live agents; entries are dropped on expiry.
+_FALLBACK_STAMP_TABLE: dict = {}
+
+
+def _unavailable_stamps(memo):
+    """Side table of ``fb_key -> marked_at`` for a memo container.
+
+    Kept beside the set rather than inside it so the container type (and every
+    ``key in unavailable`` check in callers and tests) stays unchanged.
+    """
+    stamps = getattr(memo, "_hermes_marked_at", None)
+    if stamps is None:
+        stamps = _FALLBACK_STAMP_TABLE.setdefault(id(memo), {})
+        try:
+            memo._hermes_marked_at = stamps
+        except AttributeError:
+            pass  # plain set: the id()-keyed table is the only home
+    return stamps
+
+
+def _memo_mark_unavailable(memo, fb_key) -> None:
+    """Record ``fb_key`` as unavailable, stamped so the TTL can expire it."""
+    memo.add(fb_key)
+    _unavailable_stamps(memo)[fb_key] = time.time()
+
+
+def _memo_is_suppressed(memo, fb_key) -> bool:
+    """True when ``fb_key`` is memoized AND still inside its retry window.
+
+    Expired entries are dropped, so the next activation re-probes the provider.
+    """
+    if fb_key not in memo:
+        return False
+    stamps = _unavailable_stamps(memo)
+    marked_at = stamps.get(fb_key)
+    if marked_at is None:
+        # Marked before this stamping existed (or by a caller that added
+        # directly): adopt it now rather than suppressing forever.
+        stamps[fb_key] = time.time()
+        return True
+    if time.time() - marked_at < UNAVAILABLE_FALLBACK_RETRY_SECONDS:
+        return True
+    memo.discard(fb_key)
+    stamps.pop(fb_key, None)
+    return False
+
+
+def _expire_unavailable_entry_for_test(memo, fb_key) -> None:
+    """Age a memo entry past its retry window (test helper)."""
+    _unavailable_stamps(memo)[fb_key] = (
+        time.time() - UNAVAILABLE_FALLBACK_RETRY_SECONDS - 1
+    )
+    _memo_is_suppressed(memo, fb_key)
+
+
+def _fallback_provider_benched_until(provider):
+    """Distinguish "no credentials" from "credentials all cooling down".
+
+    Returns ``None`` when the provider has no credential material at all (or the
+    pool cannot be read — treated as unconfigured, matching the previous
+    behavior). When credentials exist but none are currently selectable, returns
+    the epoch time the next one re-enters rotation, or ``0.0`` when the pool
+    gives no recovery hint. ``0.0`` is deliberately falsy-but-not-None: callers
+    must test ``is None``.
+    """
+    try:
+        from agent.credential_pool import load_pool
+
+        pool = load_pool(provider)
+    except Exception as exc:
+        logger.debug(
+            "Fallback bench check: could not load pool for %s: %s", provider, exc
+        )
+        return None
+    if pool is None or not pool.has_credentials():
+        return None
+    try:
+        if pool.has_available():
+            # Credentials exist and one is usable, so the None client came from
+            # something else (missing aux model, unknown provider id, ...).
+            # Treat as unconfigured so the existing suppression still applies.
+            return None
+        return pool.next_available_at() or 0.0
+    except Exception as exc:
+        logger.debug(
+            "Fallback bench check: could not read availability for %s: %s",
+            provider,
+            exc,
+        )
+        return None
+
+
+def _format_benched_suffix(benched_until) -> str:
+    """Render " (retry in Nm)" when a recovery time is known, else ""."""
+    if not benched_until:
+        return ""
+    remaining = benched_until - time.time()
+    if remaining <= 0:
+        return ""
+    if remaining < 90:
+        return f" (retry in {int(remaining)}s)"
+    return f" (retry in {int(remaining // 60)}m)"
+
+
 def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider: str, fb_model: str, unavailable: set) -> bool:
     """True when the entry is already unavailable, malformed, locally unusable, or resolves
     to the backend that just failed (falling back to it would loop the failure)."""
-    if fb_key in unavailable:
+    if _memo_is_suppressed(unavailable, fb_key):
         logger.debug("Fallback skip: %s previously marked unavailable", fb_key)
         return True
     if not fb_provider or not fb_model:
@@ -1737,7 +1852,7 @@ def _should_skip_fallback_candidate(agent, fb: dict, fb_key: tuple, fb_provider:
         return True
     local_skip_reason = _fallback_entry_unavailable_without_network(agent, fb)
     if local_skip_reason:
-        unavailable.add(fb_key)
+        _memo_mark_unavailable(unavailable, fb_key)
         logger.warning("Fallback skip: %s/%s is not locally usable (%s); suppressing for this session", fb_provider, fb_model, local_skip_reason)
         return True
     # Identity semantics (axes, shim aliases, credential surfaces, multi-endpoint pools)
@@ -1862,8 +1977,23 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_client, _resolved_fb_model = resolve_provider_client(
                 fb_provider, model=fb_model, raw_codex=True, explicit_base_url=fb_base_url_hint, explicit_api_key=fb_api_key_hint, api_mode=fb_api_mode)
             if fb_client is None:
-                logger.warning("Fallback to %s failed: provider not configured", fb_provider)
-                unavailable.add(fb_key)
+                # A None client has two very different causes that look identical here: the
+                # provider was never configured, or it IS configured but every credential is in
+                # exhaustion cooldown right now (a DeepSeek 402 benches the key for an hour).
+                # Only the first deserves the memo: a benched credential recovers on its own,
+                # and memoizing it drops a healthy provider from the chain for the whole life of
+                # a cached agent, which is how the last resort ends up being a free model.
+                benched_until = _fallback_provider_benched_until(fb_provider)
+                if benched_until is None:
+                    logger.warning("Fallback to %s failed: provider not configured", fb_provider)
+                    _memo_mark_unavailable(unavailable, fb_key)
+                else:
+                    logger.warning(
+                        "Fallback to %s skipped: configured, but all credentials are "
+                        "in cooldown%s. Staying retryable for later turns.",
+                        fb_provider,
+                        _format_benched_suffix(benched_until),
+                    )
                 continue
             try:
                 from hermes_cli.model_normalize import normalize_model_for_provider
@@ -1925,7 +2055,7 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             return True
         except Exception as e:
             if fb_provider == "nous":
-                unavailable.add(fb_key)
+                _memo_mark_unavailable(unavailable, fb_key)
             logger.error("Failed to activate fallback %s: %s", fb_model, e)
             continue  # try next in chain
 

--- a/hermes_cli/kanban_db_graph.py
+++ b/hermes_cli/kanban_db_graph.py
@@ -174,11 +174,14 @@ def _insert_decomposed_child(
     the dispatcher only ever sees a coherent graph); returns its id.
 
     Workspace: per-child override wins, else inherit the root's kind. Path
-    inherits only when kinds match (a 'dir' child must not point at the
-    root's worktree) and NEVER for worktrees — siblings dispatch concurrently
-    and one shared checkout would put them all on the first sibling's branch
-    with no lock; leaving it unset makes dispatch materialize a fresh
-    ``<repo>/.worktrees/<child-id>`` per child from the board anchor.
+    NEVER inherits for scratch or worktree children — both are per-task
+    transient kinds, siblings dispatch concurrently, and one shared
+    checkout/dir would silently cross-contaminate sibling work (scratch
+    inherits the root's already-claimed path verbatim when kinds match, since
+    a claimed root has a persisted workspace_path). Leaving it unset makes
+    dispatch materialize a fresh ``<workspaces_root>/<child-id>`` or
+    ``<repo>/.worktrees/<child-id>`` per child. Only 'dir' — an explicitly
+    shared persistent checkout — inherits the root's path when kinds match.
     """
     from hermes_cli.kanban_db import (
         _new_task_id, _canonical_assignee, _append_event,
@@ -188,9 +191,11 @@ def _insert_decomposed_child(
     child_ws_kind = child.get("workspace_kind") or root_ws_kind
     if child.get("workspace_path"):
         child_ws_path = child.get("workspace_path")
-    elif child_ws_kind == "worktree":
+    elif child_ws_kind in ("worktree", "scratch"):
         child_ws_path = None
     elif child_ws_kind == root_ws_kind:
+        # Only persistent kinds (dir) reach this branch: the shared checkout
+        # is the point of 'dir'.
         child_ws_path = root_row["workspace_path"]
     else:
         child_ws_path = None

--- a/tests/hermes_cli/test_kanban_decompose_db.py
+++ b/tests/hermes_cli/test_kanban_decompose_db.py
@@ -11,6 +11,7 @@ import pytest
 from hermes_cli import kanban_db as kb
 from hermes_cli.kanban_db_graph import decompose_triage_task
 from hermes_cli import kanban_db_connect as kbc
+from hermes_cli import kanban_db_workspace as kbw
 
 
 @pytest.fixture
@@ -90,5 +91,58 @@ def test_decompose_records_audit_comment_and_event(kanban_home):
     assert any(ev.kind == "decomposed" for ev in events)
 
 
+def test_decompose_scratch_children_do_not_inherit_claimed_root_path(kanban_home):
+    """Regression: a claimed scratch root has a persisted workspace_path
+    (dispatch persists the resolved dir on claim). A fan-out must NOT copy
+    that literal path onto scratch children — siblings would all run inside
+    the parent's directory. Children stay unset so dispatch materializes a
+    fresh ``<workspaces_root>/<child-id>`` per child. See #103303."""
+    with kbc.connect() as conn:
+        tid = _create_triage(conn, title="fan out research")
+        # Simulate a root that has already been claimed by the dispatcher.
+        kbw.set_workspace_path(conn, tid, str(kanban_home / "kanban" / "workspaces" / tid))
+        child_ids = decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[
+                {"title": "task A", "assignee": "researcher"},
+                {"title": "task B", "assignee": "researcher"},
+            ],
+            author="decomposer",
+        )
+    assert child_ids is not None
+    assert len(child_ids) == 2
+    with kbc.connect() as conn:
+        paths = [
+            conn.execute("SELECT workspace_path FROM tasks WHERE id = ?", (cid,)).fetchone()[0]
+            for cid in child_ids
+        ]
+    # Each child is unset -> dispatch derives workspaces/<child-id> per child.
+    assert paths == [None, None]
+
+
+def test_decompose_dir_children_keep_inheriting_shared_root_path(kanban_home):
+    """'dir' is an explicitly shared persistent checkout: children of a dir
+    root inherit its path when kinds match. Guards against over-fixing the
+    scratch isolation above (shared checkout is the point of 'dir')."""
+    shared = str(kanban_home / "boards" / "default" / "shared-proj")
+    with kbc.connect() as conn:
+        tid = _create_triage(conn, title="dir fan out")
+        conn.execute("UPDATE tasks SET workspace_kind='dir' WHERE id = ?", (tid,))
+        kbw.set_workspace_path(conn, tid, shared)
+        child_ids = decompose_triage_task(
+            conn,
+            tid,
+            root_assignee="orchestrator",
+            children=[{"title": "task A", "assignee": "researcher"}],
+            author="decomposer",
+        )
+    assert child_ids is not None
+    with kbc.connect() as conn:
+        path = conn.execute(
+            "SELECT workspace_path FROM tasks WHERE id = ?", (child_ids[0],)
+        ).fetchone()[0]
+    assert path == shared
 
 

--- a/tests/run_agent/test_fallback_benched_credential.py
+++ b/tests/run_agent/test_fallback_benched_credential.py
@@ -1,0 +1,178 @@
+"""A temporarily-benched credential must not permanently disqualify a fallback.
+
+When a provider's only credential is cooling down (e.g. DeepSeek 402 Insufficient
+Balance, benched for an hour), ``resolve_provider_client`` returns ``None``. At the
+call site that is indistinguishable from a provider the user never set up, so the
+chain both logged it as "provider not configured" and added the entry to the
+session-scoped ``_unavailable_fallback_keys`` memo — which is only cleared by a
+config edit. A one-hour billing bench therefore removed the entry for the whole
+lifetime of the cached agent.
+
+``credential_pool`` already separates the two cases: ``has_credentials()`` means
+the user configured something, ``has_available()`` means one is usable right now.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from run_agent import AIAgent
+
+
+def _make_agent(fallback_model=None):
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            provider="zai",
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = None
+        return agent
+
+
+def _mock_client(base_url="https://api.deepseek.com/v1", api_key="fb-key"):
+    mock = type("Client", (), {})()
+    mock.base_url = base_url
+    mock.api_key = api_key
+    mock.chat = type("Chat", (), {})()
+    mock.chat.completions = type("Completions", (), {})()
+    mock.chat.completions.create = lambda *args, **kwargs: None
+    return mock
+
+
+class _Pool:
+    """Stand-in for credential_pool.CredentialPool."""
+
+    def __init__(self, *, configured: bool, available: bool):
+        self._configured = configured
+        self._available = available
+
+    def has_credentials(self) -> bool:
+        return self._configured
+
+    def has_available(self) -> bool:
+        return self._available
+
+    def next_available_at(self):
+        return None
+
+
+CHAIN = [
+    {"provider": "deepseek", "model": "deepseek-v4-pro"},
+    {"provider": "openai-codex", "model": "gpt-5.5"},
+]
+KEY = ("deepseek", "deepseek-v4-pro", "")
+
+
+def _activate(agent, *, configured: bool, available: bool):
+    def resolve(provider, **kwargs):
+        if provider == "deepseek":
+            return (None, None)  # benched or unconfigured — both look like this
+        return (_mock_client(), "gpt-5.5")
+
+    with (
+        patch("agent.auxiliary_client.resolve_provider_client", side_effect=resolve),
+        patch(
+            "agent.credential_pool.load_pool",
+            return_value=_Pool(configured=configured, available=available),
+        ),
+    ):
+        return agent._try_activate_fallback(None)
+
+
+class TestBenchedCredentialIsNotPermanentlyUnavailable:
+    def test_benched_provider_is_not_memoized_as_unavailable(self):
+        """Configured but cooling down: skip this turn, stay retryable later."""
+        agent = _make_agent(fallback_model=list(CHAIN))
+
+        assert _activate(agent, configured=True, available=False) is True
+        assert agent.model == "gpt-5.5"
+        assert KEY not in getattr(agent, "_unavailable_fallback_keys", set()), (
+            "a temporarily-benched credential must stay retryable for later turns"
+        )
+
+    def test_genuinely_unconfigured_provider_is_still_memoized(self):
+        """No credentials at all: keep the existing per-session suppression."""
+        agent = _make_agent(fallback_model=list(CHAIN))
+
+        assert _activate(agent, configured=False, available=False) is True
+        assert KEY in getattr(agent, "_unavailable_fallback_keys", set()), (
+            "an unconfigured provider should not be retried every turn"
+        )
+
+
+class TestUnavailableMemoExpires:
+    """The memo must not outlive the condition that created it.
+
+    Suppressing an unconfigured provider avoids retrying it every turn, but the
+    memo was only cleared by a ``fallback_providers`` content edit. Credentials
+    are commonly added via ``hermes auth`` (which writes auth.json, not
+    config.yaml), so a provider configured mid-uptime stayed suppressed for the
+    whole life of the cached agent.
+    """
+
+    def test_memo_entry_expires_so_newly_configured_provider_is_retried(self):
+        agent = _make_agent(fallback_model=list(CHAIN))
+
+        # First pass: genuinely unconfigured, so it gets memoized.
+        assert _activate(agent, configured=False, available=False) is True
+        memo = getattr(agent, "_unavailable_fallback_keys")
+        assert KEY in memo
+
+        # Simulate the memo aging past its retry window.
+        import agent.chat_completion_helpers as ch
+
+        ch._expire_unavailable_entry_for_test(memo, KEY)
+        assert KEY not in memo, "an aged-out memo entry must not keep suppressing"
+
+        # Credentials have since been added; the entry is reconsidered.
+        agent2 = _make_agent(fallback_model=list(CHAIN))
+        agent2._unavailable_fallback_keys = memo
+
+        def resolve(provider, **kwargs):
+            return (_mock_client(), "deepseek-v4-pro")
+
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", side_effect=resolve),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=_Pool(configured=True, available=True),
+            ),
+        ):
+            assert agent2._try_activate_fallback(None) is True
+        assert agent2.model == "deepseek-v4-pro", (
+            "a provider configured after being memoized must become usable again"
+        )
+
+    def test_memo_still_suppresses_within_the_retry_window(self):
+        """Back-to-back activations must not re-probe an unconfigured provider."""
+        agent = _make_agent(fallback_model=list(CHAIN))
+        assert _activate(agent, configured=False, available=False) is True
+
+        calls = []
+
+        def resolve(provider, **kwargs):
+            calls.append(provider)
+            return (_mock_client(), "gpt-5.5")
+
+        agent._fallback_index = 0
+        agent._fallback_activated = False
+        with (
+            patch("agent.auxiliary_client.resolve_provider_client", side_effect=resolve),
+            patch(
+                "agent.credential_pool.load_pool",
+                return_value=_Pool(configured=False, available=False),
+            ),
+        ):
+            agent._try_activate_fallback(None)
+        assert "deepseek" not in calls, (
+            "within the retry window the memo should short-circuit before resolving"
+        )


### PR DESCRIPTION
## Problem

A healthy provider silently vanished from the fallback chain, leaving a free-tier model as the last resort for 47 minutes.

When DeepSeek returned `402 Insufficient Balance`, `credential_pool` benched the key for an hour (`EXHAUSTED_TTL_DEFAULT_SECONDS`; 402 is billing by definition, so it correctly keeps the full bench). `resolve_provider_client` then returned `None` — which at the call site in `try_activate_fallback` is **indistinguishable** from a provider the user never configured. Two things followed:

**1. A false log message.** The chain logged:

```
Fallback to deepseek failed: provider not configured
```

DeepSeek was the *primary* provider in `config.yaml` and had served 195 calls earlier the same day. The message sent diagnosis toward config and credentials when the real cause was a billing bench with a known expiry.

**2. Permanent suppression from a temporary condition.** The entry was added to `_unavailable_fallback_keys`, a memo cleared only when `fallback_providers` content changes (`gateway/run.py:_apply_fallback_chain_to_agent`). Credentials normally arrive via `hermes auth` (writes `auth.json`) or a new env var — neither touches `config.yaml` — so a **one-hour** bench removed the entry for the **entire life of the cached agent**.

Reproduced deterministically by setting the pool entry to `last_status=exhausted, last_error_code=402, last_status_at=now-7s`:

```
pool.has_credentials=True  pool.has_available=False
_select_pool_entry -> (True, None)      # pool present, nothing selectable
resolve_provider_client -> None         # logged as "provider not configured"
```

## Fix

`credential_pool` already separates the two cases — `has_credentials()` means the user configured something, `has_available()` means one is usable right now. Use it:

- `_fallback_provider_benched_until()` returns `None` for genuinely unconfigured (memoize, as before), or the epoch time the next credential re-enters rotation for a benched one (skip this turn, stay retryable). An unreadable pool is treated as unconfigured, preserving previous behavior.
- Benched entries log honestly and surface the wait: `Fallback to deepseek skipped: configured, but all credentials are in cooldown (retry in 59m). Staying retryable for later turns.`
- `_unavailable_fallback_keys` gains a 10-minute TTL (`UNAVAILABLE_FALLBACK_RETRY_SECONDS`). An unconfigured provider still is not re-probed on every activation, but the memo can no longer outlive the condition that created it. The container stays a `set` so every existing `key in unavailable` check — including `tests/run_agent/test_nous_fallback_unavailable.py` — is unaffected; stamps live in a side table.

## Impact

The affected chain had 6 entries but only **3 distinct credentials** (zai ×2 sharing `GLM_API_KEY`, openai-codex ×2 sharing one `device_code`, nous). With deepseek wrongly dropped, the only pool not already exhausted was the free tier, which then ran 467 API calls and produced a 517-iteration tool loop (separate fix in #79839).

Redundancy that collapses under pressure into "the worst model is the only survivor" is worth guarding: this fix keeps a temporarily-benched good provider in the running instead of retiring it.

## Verification

- Reproduction above now classifies as `BENCHED (retryable) (retry in 59m)` and is not memoized.
- New `tests/run_agent/test_fallback_benched_credential.py`: benched entry stays retryable; unconfigured entry still memoized; memo expires so a provider configured mid-uptime is reconsidered; memo still short-circuits within its window.
- `pytest -k "fallback or failover or credential_pool or guardrail or chat_completion"` → 960 passed, 4 skipped. `ruff` clean.

(One unrelated pre-existing failure in `tests/tools/test_web_tools_config.py::TestParallelClientConfig` reproduces on a clean checkout — order-dependent state leakage, untouched here.)
