### PR TITLE
fix(email): split long cron output instead of truncating at 4,000 chars

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -467,6 +467,8 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    splits_long_messages = True  # send() chunks via truncate_message(MAX_MESSAGE_LENGTH)
+
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.EMAIL)
 
@@ -942,12 +944,23 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        Long content is split into multiple emails at ``MAX_MESSAGE_LENGTH``
+        (Gmail-safe body size) rather than being cut off.  This is what
+        ``splits_long_messages = True`` promises the delivery router: cron
+        output above the router's non-chunking cap reaches the mailbox whole
+        instead of truncated at 4,000 chars (a Telegram-era limit that email
+        never shared).
+        """
         try:
             loop = asyncio.get_running_loop()
-            message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
-            )
+            chunks = self.truncate_message(content, MAX_MESSAGE_LENGTH) or [content]
+            message_id = None
+            for chunk in chunks:
+                message_id = await loop.run_in_executor(
+                    None, self._send_email, chat_id, chunk, reply_to
+                )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
             logger.error("[Email] Send failed to %s: %s", chat_id, e)

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -398,6 +398,76 @@ class TestSendMethods(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_declares_native_chunking(self):
+        """Email must advertise chunking so the delivery router skips its
+        non-chunking truncation cap (a Telegram-era 4,000-char limit that
+        silently severed a 5,199-char cron memo)."""
+        from plugins.platforms.email.adapter import EmailAdapter
+        self.assertTrue(EmailAdapter.splits_long_messages)
+
+    def test_send_delivers_long_content_whole(self):
+        """Content above the router's 4,000-char cap must arrive intact."""
+        import asyncio
+        adapter = self._make_adapter()
+        sent = []
+        adapter._send_email = lambda to, body, reply=None: (
+            sent.append(body), "<id@test>")[1]
+
+        long_content = "line\n" * 1200  # 6,000 chars — over the old cap
+        result = asyncio.run(adapter.send("user@test.com", long_content))
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(sent), 1)  # under MAX_MESSAGE_LENGTH: one email
+        self.assertEqual(sent[0], long_content)
+        self.assertNotIn("truncated", sent[0].lower())
+
+    def test_send_splits_above_body_limit(self):
+        """Beyond the Gmail-safe body size, send() splits across emails
+        instead of dropping the overflow."""
+        import asyncio
+        from plugins.platforms.email.adapter import MAX_MESSAGE_LENGTH
+        adapter = self._make_adapter()
+        sent = []
+        adapter._send_email = lambda to, body, reply=None: (
+            sent.append(body), "<id@test>")[1]
+
+        huge = "z" * (MAX_MESSAGE_LENGTH * 2 + 100)
+        result = asyncio.run(adapter.send("user@test.com", huge))
+
+        self.assertTrue(result.success)
+        self.assertGreater(len(sent), 1)
+        # Every original character survives across the chunks.
+        self.assertEqual(sum(c.count("z") for c in sent), huge.count("z"))
+
+    def test_router_does_not_truncate_email_delivery(self):
+        """End-to-end through the real DeliveryRouter: an oversized cron
+        payload reaches the email adapter whole, with the audit copy still
+        written to disk."""
+        import asyncio, tempfile, pathlib
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        from gateway.config import GatewayConfig, Platform
+
+        adapter = self._make_adapter()
+        sent = []
+        adapter._send_email = lambda to, body, reply=None: (
+            sent.append(body), "<id@test>")[1]
+
+        payload = "memo body\n" * 600  # 6,000 chars
+        tmp = pathlib.Path(tempfile.mkdtemp())
+        with patch("gateway.delivery.get_hermes_home", lambda: tmp):
+            router = DeliveryRouter(
+                GatewayConfig(), adapters={Platform.EMAIL: adapter})
+            asyncio.run(router._deliver_to_platform(
+                DeliveryTarget.parse("email:user@test.com"),
+                payload,
+                metadata={"job_id": "shift1"},
+            ))
+
+        self.assertEqual("".join(sent), payload)
+        self.assertNotIn("truncated", "".join(sent).lower())
+        saved = list(tmp.glob("cron/output/shift1_*.txt"))
+        self.assertEqual(len(saved), 1)
+        self.assertEqual(saved[0].read_text(), payload)
 
     def test_send_document_with_attachment(self):
         """send_document should send email with file attachment."""


### PR DESCRIPTION
## What & why

`EmailAdapter` never declares `splits_long_messages`, so `gateway/delivery.py` treats email as a non-chunking platform and applies `MAX_PLATFORM_OUTPUT = 4000` (delivery.py:29, 488, 503). That cap is sized for Telegram's 4096-char API limit. Email has no such constraint — the adapter already defines `MAX_MESSAGE_LENGTH = 50_000` (Gmail-safe body size, adapter.py:110) but **never uses it**.

Result: any scheduled-job output over 4,000 chars is silently cut before it reaches the mailbox, with no way to opt out (#61990).

**Observed data loss.** A 5,199-char cron memo was truncated to the 4,000-char envelope, severing an escalation bullet, a deadline statement, and a whole closing section. Nothing in the delivered mail indicated content was missing.

## Why this isn't a duplicate of #62000 / #68900

Those PRs set `splits_long_messages = True` and stop there. That flag is a *promise to the router that the adapter chunks* — but upstream `send()` does no chunking at all:

```python
async def send(self, chat_id, content, reply_to=None, metadata=None):
    """Send an email reply to the given address."""
    message_id = await loop.run_in_executor(None, self._send_email, chat_id, content, reply_to)
```

Setting the flag alone converts a 4,000-char truncation into an *unbounded* body handed to SMTP, past the 50,000-char limit the adapter itself declares. This PR implements the chunking the flag advertises — which is precisely why `MAX_MESSAGE_LENGTH` stops being dead code.

## How it works

`send()` splits at `MAX_MESSAGE_LENGTH` via the shared `truncate_message()` helper — the same pattern every peer adapter uses (Slack, Discord, Telegram, Mattermost, Matrix, Teams, Feishu) — and the class declares `splits_long_messages = True` so the router hands over the full payload.

No shared code changed. The router's cap stays correct for platforms that genuinely have one; behavior for every other adapter is untouched.

## How to test

```bash
pytest tests/gateway/test_email.py tests/gateway/test_delivery.py -v
```

4 new regression cases in `tests/gateway/test_email.py`:

| Test | Asserts |
|---|---|
| `test_declares_native_chunking` | the flag is set, so the router skips its cap |
| `test_send_delivers_long_content_whole` | 6,000 chars arrives as one intact email |
| `test_send_splits_above_body_limit` | beyond 50,000 chars, splits across emails; every character survives |
| `test_router_does_not_truncate_email_delivery` | end-to-end through the real `DeliveryRouter`: oversized payload arrives byte-identical, audit copy still written |

Manual reproduction: configure an email platform, schedule a cron job whose output exceeds 4,000 chars, compare the delivered body against `~/.hermes/cron/output/<job_id>_*.txt` (the audit copy is written whole — it is the delivered mail that loses the tail).

## Platforms tested

Linux (Ubuntu 24.04, Python 3.11.15). No OS-specific code paths touched — the change is adapter-level string handling plus one class attribute.

Fixes #61990
