### PR TITLE
refactor(main): extract node runtime leaf into node_runtime (main.py god-file slice R4)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7258,6 +7258,15 @@ from hermes_cli.dashboard_procs import (  # noqa: F401
     _scan_dashboard_processes,
 )
 
+# Node-runtime resolution helpers extracted to hermes_cli/node_runtime.py
+# (main.py decomposition, mechanical move). Re-exported so callers and test
+# monkeypatches on hermes_cli.main.<name> keep resolving unchanged.
+from hermes_cli.node_runtime import (  # noqa: F401
+    _is_termux_env,
+    _is_windows_npm_path,
+    _resolve_node_runtime_npm,
+)
+
 def _find_stale_dashboard_pids(
     *,
     exclude_pids: set[int] | None = None,
@@ -8829,67 +8838,6 @@ def _resolve_install_target_python(
         if first.exists() and "uv" not in first.name.lower():
             return first
 
-    return None
-
-
-def _is_termux_env(env: dict[str, str] | None = None) -> bool:
-    return _is_termux_startup_environment(env)
-
-
-def _is_windows_npm_path(npm_path: str) -> bool:
-    """Return True if ``npm_path`` points at a Windows npm shim.
-
-    On WSL the Windows install dir is exposed through the ``/mnt/c`` drive
-    mount and PATH interop, so ``shutil.which("npm")`` can hand back
-    ``/mnt/c/Program Files/nodejs/npm`` (or the ``npm.cmd`` / ``npm.exe``
-    shim). Those are detected here by their ``.exe``/``.cmd``/``.bat``
-    suffix, a ``/mnt/`` drive-mount prefix, or an embedded backslash (a UNC
-    path). Callers use this only on a POSIX host — on native Windows an
-    ``npm.cmd`` shim is the correct executable.
-    """
-    low = npm_path.lower()
-    return (
-        low.endswith((".exe", ".cmd", ".bat"))
-        or low.startswith("/mnt/")
-        or "\\" in npm_path
-    )
-
-
-def _resolve_node_runtime_npm() -> str | None:
-    """Resolve an npm executable that belongs to the host's Node runtime.
-
-    On WSL/Linux ``shutil.which("npm")`` may resolve a Windows npm exposed
-    through PATH interop. Running that Windows npm against the Linux checkout
-    operates over ``\\wsl.localhost\\...`` UNC paths and fails with EISDIR /
-    symlink errors in symlink-heavy trees like ``ui-tui`` (#30271). Refuse a
-    Windows npm on a POSIX host and re-scan PATH (skipping ``/mnt/*`` interop
-    entries) for a Linux-native npm. Returns the npm path, or ``None`` when
-    no suitable npm is reachable.
-    """
-    from hermes_constants import find_node_executable
-
-    npm = find_node_executable("npm")
-
-    # On native Windows the platform npm (``npm.cmd``) is exactly what we
-    # want — only reject Windows shims when we're a POSIX/WSL process.
-    if _is_windows():
-        return npm
-
-    if not npm:
-        return None
-
-    if not _is_windows_npm_path(npm):
-        return npm
-
-    # The first resolution was a Windows npm. Re-scan PATH skipping the
-    # ``/mnt/*`` Windows drive mounts WSL injects, so a Linux-native npm that
-    # came later on PATH is still found.
-    for directory in os.environ.get("PATH", "").split(os.pathsep):
-        if not directory or directory.lower().startswith("/mnt/"):
-            continue
-        candidate = shutil.which("npm", path=directory)
-        if candidate and not _is_windows_npm_path(candidate):
-            return candidate
     return None
 
 

--- a/hermes_cli/node_runtime.py
+++ b/hermes_cli/node_runtime.py
@@ -1,0 +1,83 @@
+"""Node-runtime resolution helpers — extracted from ``hermes_cli/main.py``.
+
+Mechanical move (main.py decomposition): the three node-runtime leaf helpers
+(``_is_termux_env``, ``_is_windows_npm_path``, ``_resolve_node_runtime_npm``)
+are lifted verbatim. References to helpers that STAY in ``hermes_cli.main``
+(``_is_termux_startup_environment``, ``_is_windows``) are routed through a
+lazy ``_m()`` main reference so existing test monkeypatches on
+``hermes_cli.main.<name>`` keep reaching this code path, and imports stay
+one-way at import time (main.py imports this module, never the reverse).
+``main.py`` re-exports all three names (``# noqa: F401``) so callers and test
+patches on ``hermes_cli.main`` resolve unchanged.
+"""
+
+import os
+import shutil
+
+
+def _m():
+    """Lazy ``hermes_cli.main`` reference (call-time; keeps patches working)."""
+    from hermes_cli import main
+
+    return main
+
+
+def _is_termux_env(env: dict[str, str] | None = None) -> bool:
+    return _m()._is_termux_startup_environment(env)
+
+
+def _is_windows_npm_path(npm_path: str) -> bool:
+    """Return True if ``npm_path`` points at a Windows npm shim.
+
+    On WSL the Windows install dir is exposed through the ``/mnt/c`` drive
+    mount and PATH interop, so ``shutil.which("npm")`` can hand back
+    ``/mnt/c/Program Files/nodejs/npm`` (or the ``npm.cmd`` / ``npm.exe``
+    shim). Those are detected here by their ``.exe``/``.cmd``/``.bat``
+    suffix, a ``/mnt/`` drive-mount prefix, or an embedded backslash (a UNC
+    path). Callers use this only on a POSIX host — on native Windows an
+    ``npm.cmd`` shim is the correct executable.
+    """
+    low = npm_path.lower()
+    return (
+        low.endswith((".exe", ".cmd", ".bat"))
+        or low.startswith("/mnt/")
+        or "\\" in npm_path
+    )
+
+
+def _resolve_node_runtime_npm() -> str | None:
+    """Resolve an npm executable that belongs to the host's Node runtime.
+
+    On WSL/Linux ``shutil.which("npm")`` may resolve a Windows npm exposed
+    through PATH interop. Running that Windows npm against the Linux checkout
+    operates over ``\\wsl.localhost\\...`` UNC paths and fails with EISDIR /
+    symlink errors in symlink-heavy trees like ``ui-tui`` (#30271). Refuse a
+    Windows npm on a POSIX host and re-scan PATH (skipping ``/mnt/*`` interop
+    entries) for a Linux-native npm. Returns the npm path, or ``None`` when
+    no suitable npm is reachable.
+    """
+    from hermes_constants import find_node_executable
+
+    npm = find_node_executable("npm")
+
+    # On native Windows the platform npm (``npm.cmd``) is exactly what we
+    # want — only reject Windows shims when we're a POSIX/WSL process.
+    if _m()._is_windows():
+        return npm
+
+    if not npm:
+        return None
+
+    if not _is_windows_npm_path(npm):
+        return npm
+
+    # The first resolution was a Windows npm. Re-scan PATH skipping the
+    # ``/mnt/*`` Windows drive mounts WSL injects, so a Linux-native npm that
+    # came later on PATH is still found.
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        if not directory or directory.lower().startswith("/mnt/"):
+            continue
+        candidate = shutil.which("npm", path=directory)
+        if candidate and not _is_windows_npm_path(candidate):
+            return candidate
+    return None

--- a/tests/cli/test_node_runtime_seam.py
+++ b/tests/cli/test_node_runtime_seam.py
@@ -1,0 +1,124 @@
+"""Seam tests for the node_runtime extraction (main.py god-file slice R4-S1).
+
+The three node-runtime leaf helpers (``_is_termux_env``,
+``_is_windows_npm_path``, ``_resolve_node_runtime_npm``) moved verbatim from
+``hermes_cli/main.py`` into ``hermes_cli/node_runtime.py``; main.py re-exports
+them (``# noqa: F401``) so callers and test monkeypatches on
+``hermes_cli.main.<name>`` keep resolving unchanged. These tests pin the
+seam: object identity through the re-export, patch reachability through
+``hermes_cli.main``, the two sanctioned ``_m()`` delegations, and the WSL
+npm-rejection re-scan loop (#30271).
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import main as hm
+from hermes_cli import node_runtime
+
+
+# --- identity: re-export must not shadow the moved objects -------------------
+
+def test_reexport_object_identity_termux_env():
+    assert hm._is_termux_env is node_runtime._is_termux_env
+
+
+def test_reexport_object_identity_windows_npm_path():
+    assert hm._is_windows_npm_path is node_runtime._is_windows_npm_path
+
+
+def test_reexport_object_identity_resolve_node_runtime_npm():
+    assert hm._resolve_node_runtime_npm is node_runtime._resolve_node_runtime_npm
+
+
+# --- patch reachability through hermes_cli.main (existing patch sites) -------
+
+def test_patch_main_name_reaches_in_main_caller(monkeypatch):
+    """Monkeypatching ``hermes_cli.main._is_termux_env`` must be observed by
+    in-main callers that resolve the name at call time (mirror of
+    test_cmd_update.py:165 style) — the re-export keeps the name live in
+    main's namespace for `_default_venv_install_target` (stays in main.py)."""
+    from hermes_cli import main as hm
+
+    calls = []
+
+    def fake_termux(env=None):
+        calls.append(env)
+        return True
+
+    monkeypatch.setattr(hm, "_is_termux_env", fake_termux)
+    monkeypatch.setattr(
+        "hermes_cli.managed_uv.ensure_uv", lambda: "/data/data/com.termux/files/usr/bin/uv"
+    )
+
+    install_prefix, env = hm._default_venv_install_target()
+
+    assert install_prefix == ["/data/data/com.termux/files/usr/bin/uv", "pip"]
+    assert calls, "in-main caller must reach the patched _is_termux_env"
+    assert env is not None
+    # termux branch popped PYTHONPATH/PYTHONHOME — proves the patch was honored.
+    assert "PYTHONPATH" not in env
+    assert "PYTHONHOME" not in env
+
+
+# --- sanctioned _m() delegations (helpers stay in main.py) -------------------
+
+def test_is_termux_env_delegates_to_main_helper(monkeypatch):
+    """_is_termux_env body routes through ``_m()._is_termux_startup_environment``
+    (helper stays in main.py at R3)."""
+    monkeypatch.setattr(hm, "_is_termux_startup_environment", lambda env: True)
+    assert node_runtime._is_termux_env({"PREFIX": "/data/data/com.termux/files/usr"}) is True
+
+
+def test_resolve_node_runtime_npm_delegates_windows_check(monkeypatch):
+    """The ``_is_windows()`` gate inside _resolve_node_runtime_npm routes
+    through ``_m()`` (stays in main.py; post-#79661 resolves via win_quarantine
+    re-export). Native Windows must short-circuit to the platform npm."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: True)
+    with patch("hermes_constants.find_node_executable", return_value="C:\\nodejs\\npm.cmd") as find:
+        assert node_runtime._resolve_node_runtime_npm() == "C:\\nodejs\\npm.cmd"
+        find.assert_called_once_with("npm")
+
+
+# --- aggressive: node resolution + version/WSL matrix ------------------------
+
+def test_is_windows_npm_path_matrix():
+    assert node_runtime._is_windows_npm_path("/mnt/c/Program Files/nodejs/npm") is True
+    assert node_runtime._is_windows_npm_path("/usr/bin/npm") is False
+    assert node_runtime._is_windows_npm_path("C:\\nodejs\\npm.cmd") is True
+
+
+def test_resolve_node_runtime_npm_linux_native_passthrough(monkeypatch):
+    """POSIX host, Linux-native npm on PATH → returned as-is."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: False)
+    with patch("hermes_constants.find_node_executable", return_value="/usr/bin/npm"):
+        assert node_runtime._resolve_node_runtime_npm() == "/usr/bin/npm"
+
+
+def test_resolve_node_runtime_npm_no_npm_returns_none(monkeypatch):
+    monkeypatch.setattr(hm, "_is_windows", lambda: False)
+    with patch("hermes_constants.find_node_executable", return_value=None):
+        assert node_runtime._resolve_node_runtime_npm() is None
+
+
+def test_resolve_node_runtime_npm_wsl_rejects_windows_shim(monkeypatch):
+    """#30271 regression: POSIX host whose PATH resolves a Windows npm first
+    (via WSL interop) must re-scan and return a Linux-native npm."""
+    monkeypatch.setattr(hm, "_is_windows", lambda: False)
+    with patch("hermes_constants.find_node_executable", return_value="/mnt/c/Program Files/nodejs/npm"):
+        # find_node_executable already refused; the re-scan loop owns the path.
+        with patch("hermes_cli.node_runtime.shutil.which") as which:
+            def fake_which(cmd, path=None):
+                assert cmd == "npm"
+                if path and path.endswith("/usr/bin"):
+                    return "/usr/bin/npm"
+                return None
+
+            which.side_effect = fake_which
+            monkeypatch.setenv(
+                "PATH",
+                os.pathsep.join(["/mnt/c/Program Files/nodejs", "/usr/bin", "/bin"]),
+            )
+            assert node_runtime._resolve_node_runtime_npm() == "/usr/bin/npm"

--- a/tests/test_managed_runtime_resolution.py
+++ b/tests/test_managed_runtime_resolution.py
@@ -89,6 +89,13 @@ _ALLOWED: dict[tuple[str, str], str] = {
         "agent-browser runs via `npx`, resolved against the extended browser "
         "PATH that _merge_browser_path() already seeds with the managed dirs."
     ),
+    ("hermes_cli/node_runtime.py", "npm"): (
+        "WSL fallback in _resolve_node_runtime_npm(): after "
+        "find_node_executable('npm') returns a Windows shim on a POSIX host, "
+        "deliberately re-scans PATH (skipping /mnt/* interop entries) for a "
+        "Linux-native npm — same reviewed class as the update_cmd.py npm "
+        "WSL diagnostic."
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

hermes_cli/main.py god-file slice **R4**: extract the node-runtime leaf from `hermes_cli/main.py` into `hermes_cli/node_runtime.py`. Part of the repo-wide large-file decomposition (tracker #78647).

## What changed and why

- Node-runtime leaf (window 8835–8893, 59 lines — `_is_termux_env`, `_is_windows_npm_path`, `_resolve_node_runtime_npm`) moved byte-verbatim into `node_runtime.py` (golden blob verified at both pin and HEAD)
- **3-name re-export shim** at main.py:7258 (dashboard_procs precedent) + the 2 sanctioned `_m()` edits
- **Zero collision with #79661** (which owns update_recovery + win_quarantine — verified diff-touch only main.py shim + new module)
- **Double-blind**: 2 analysts → consensus (R4-CONSENSUS.md — node_runtime won over the #79661-colliding update_install) → implementer → 2 blind re-reviewers + final verification

## Testing

- **10 passed** seam tests (identity, patch-reachability, `_m()` delegation, WSL npm-rejection matrix)
- Import smoke OK · git diff --check clean · LF-only · DCO signed

## Coordination / interlock

- **Epic:** Part of #78647 · **Target:** Part of #78631
- **#79661** (recovery/quarantine): disjoint windows verified — its title says "kanban shard s4" but the diff is main.py update_recovery/win_quarantine; credit-correction noted in R4-CONSENSUS
- **Sibling PRs:** the 4 other main.py wave-1 slices — disjoint windows
- **Dedup:** no existing PR extracts the node-runtime leaf

Part of #78647
Part of #78631
