### PR TITLE
fix(memory): pgvector dims check and password handling in mem0 plugin

### DIFF
--- a/plugins/memory/mem0/_backend.py
+++ b/plugins/memory/mem0/_backend.py
@@ -180,6 +180,14 @@ class OSSBackend(Mem0Backend):
         vector_store = dict(oss_config["vector_store"])
         vs_config = dict(vector_store.get("config", {}))
 
+        if "password" not in vs_config:
+            # Legacy wizard versions stored the PG password in mem0.json; new
+            # setups keep it in .env only. Prefer the config value (backward
+            # compat), fall back to the env secret.
+            env_password = os.environ.get("MEM0_PGVECTOR_PASSWORD", "")
+            if env_password:
+                vs_config["password"] = env_password
+
         if "path" in vs_config:
             vs_config["path"] = os.path.expanduser(vs_config["path"])
 
@@ -258,7 +266,8 @@ class OSSBackend(Mem0Backend):
                             (collection_name,),
                         )
                         row = cur.fetchone()
-                        if row and row[0] > 0 and row[0] != expected_dims:
+                        # atttypmod encodes dims + VARHDRSZ (4-byte header); compare dims, not raw typmod.
+                        if row and row[0] > 0 and row[0] - 4 != expected_dims:
                             cur.execute(pgsql.SQL("DROP TABLE IF EXISTS {}").format(
                                 pgsql.Identifier(collection_name)
                             ))

--- a/plugins/memory/mem0/_setup.py
+++ b/plugins/memory/mem0/_setup.py
@@ -131,6 +131,7 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
     Returns (oss_config, env_writes) where oss_config goes into mem0.json
     and env_writes maps env var names to secret values for .env.
     """
+    env_writes: dict[str, str] = {}
     llm_id = flags.get("oss_llm", "openai")
     llm_def = LLM_PROVIDERS[llm_id]
     llm_model = flags.get("oss_llm_model") or llm_def["default_model"]
@@ -167,7 +168,9 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
         if flags.get("oss_vector_user"):
             vector_config["user"] = flags["oss_vector_user"]
         if flags.get("oss_vector_password"):
-            vector_config["password"] = flags["oss_vector_password"]
+            # Secrets belong in .env, never in mem0.json (which is merged into
+            # config wholesale and written without restrictive permissions).
+            env_writes["MEM0_PGVECTOR_PASSWORD"] = flags["oss_vector_password"]
         if flags.get("oss_vector_dbname"):
             vector_config["dbname"] = flags["oss_vector_dbname"]
 
@@ -177,7 +180,6 @@ def build_oss_config(flags: dict[str, str]) -> tuple[dict, dict[str, str]]:
         "vector_store": {"provider": vector_id, "config": vector_config},
     }
 
-    env_writes: dict[str, str] = {}
     if llm_def.get("needs_key") and flags.get("oss_llm_key"):
         env_writes[llm_def["env_var"]] = flags["oss_llm_key"]
     if embedder_def.get("needs_key") and flags.get("oss_embedder_key"):
@@ -228,7 +230,8 @@ def _save_mem0_json(hermes_home: str, data: dict) -> None:
         except Exception:
             pass
     existing.update(data)
-    config_path.write_text(json.dumps(existing, indent=2) + "\n", encoding="utf-8")
+    from utils import atomic_json_write
+    atomic_json_write(config_path, existing, mode=0o600)
 
 
 def _setup_platform(hermes_home: str, config: dict, flags: dict[str, str]) -> None:
@@ -825,7 +828,8 @@ def _setup_oss_interactive(hermes_home: str, config: dict) -> None:
             flags["oss_vector_password"] = pgvector_config["password"]
         flags["oss_vector_dbname"] = pgvector_config["dbname"]
 
-    oss_config, _ = build_oss_config(flags)
+    oss_config, built_env_writes = build_oss_config(flags)
+    env_writes.update(built_env_writes)
 
     if env_writes:
         _write_env(Path(hermes_home) / ".env", env_writes)

--- a/tests/plugins/memory/test_mem0_backend.py
+++ b/tests/plugins/memory/test_mem0_backend.py
@@ -153,6 +153,61 @@ class TestOSSBackend:
         assert raw == before
 
 
+    def test_oss_pgvector_password_reads_from_env_when_absent(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        # Unknown embedder model -> dims unknown -> dims-migration check skipped
+        # (avoids a real psycopg2 connection attempt in the test).
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "custom-unknown-model"}},
+            "vector_store": {"provider": "pgvector", "config": {"host": "localhost"}},
+        }
+        monkeypatch.setenv("MEM0_PGVECTOR_PASSWORD", "s3cret")
+
+        OSSBackend(raw)
+
+        assert captured["vector_store"]["config"]["password"] == "s3cret"
+
+    def test_oss_pgvector_password_keeps_mem0_json_value(self, monkeypatch):
+        import sys
+        import types
+
+        captured = {}
+
+        class Memory:
+            @staticmethod
+            def from_config(config):
+                captured.update(config)
+                return FakeOSSMemory()
+
+        stub_mem0 = types.ModuleType("mem0")
+        stub_mem0.Memory = Memory  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "mem0", stub_mem0)
+        raw = {
+            "llm": {"provider": "openai", "config": {"model": "gpt-5-mini"}},
+            "embedder": {"provider": "openai", "config": {"model": "custom-unknown-model"}},
+            "vector_store": {"provider": "pgvector", "config": {"host": "localhost", "password": "legacy"}},
+        }
+
+        OSSBackend(raw)
+
+        # Backward compat: a password already in mem0.json (written by older
+        # wizard versions) still wins over the env var.
+        assert captured["vector_store"]["config"]["password"] == "legacy"
+
 httpx = pytest.importorskip("httpx")
 
 
@@ -213,3 +268,120 @@ class TestSelfHostedBackend:
         s = _StubServer()
         with pytest.raises(httpx.HTTPStatusError):
             _backend(s).delete("missing")  # 404 -> raise_for_status; 'not found' won't trip breaker
+
+def _make_pg_stub(row, monkeypatch):
+    """Stub psycopg2 (incl. its ``sql`` submodule) whose cursor returns ``row``."""
+    import sys
+    import types
+
+    class _Sql:
+        @staticmethod
+        def SQL(s):
+            return s
+
+        @staticmethod
+        def Identifier(s):
+            return s
+
+    class _Cursor:
+        def __init__(self):
+            self.statements = []
+
+        def execute(self, sql, params=None):
+            self.statements.append(str(sql))
+
+        def fetchone(self):
+            return row
+
+        def close(self):
+            pass
+
+    class _Conn:
+        def __init__(self):
+            self.autocommit = False
+            self._c = _Cursor()
+
+        def cursor(self):
+            return self._c
+
+        def close(self):
+            pass
+
+    class _Module:
+        sql = _Sql
+
+        def __init__(self):
+            self._conn = _Conn()
+
+        def connect(self, **kwargs):
+            return self._conn
+
+    mod = _Module()
+    monkeypatch.setitem(sys.modules, "psycopg2", mod)
+    return mod
+
+
+class TestRecreateCollectionDims:
+    """Regression: pgvector ``atttypmod`` stores dims + 4 (VARHDRSZ header),
+    so a same-dims collection must NOT be dropped on every startup."""
+
+    def _call_pgvector(self, row, monkeypatch):
+        mod = _make_pg_stub(row, monkeypatch)
+        OSSBackend._recreate_collection_if_dims_changed(
+            "pgvector",
+            {"collection_name": "mem0", "host": "localhost", "port": 5432},
+            1536,
+        )
+        return mod._conn._c.statements
+
+    def test_pgvector_unchanged_dims_does_not_drop_table(self, monkeypatch):
+        # atttypmod for vector(1536) is 1540, not 1536.
+        stmts = self._call_pgvector((1536 + 4,), monkeypatch)
+        assert not any("DROP TABLE" in s for s in stmts)
+
+    def test_pgvector_changed_dims_drops_table(self, monkeypatch):
+        # Collection was built for 768-dims embeddings; drop is the intended
+        # migration so the new dims can be recreated cleanly.
+        stmts = self._call_pgvector((768 + 4,), monkeypatch)
+        assert any("DROP TABLE" in s for s in stmts)
+
+    def test_pgvector_missing_column_does_not_drop(self, monkeypatch):
+        stmts = self._call_pgvector(None, monkeypatch)
+        assert not any("DROP TABLE" in s for s in stmts)
+
+    def test_qdrant_unchanged_dims_does_not_delete_collection(self, monkeypatch):
+        import sys
+        import types
+        from types import SimpleNamespace
+
+        calls = []
+
+        class _FakeQdrant:
+            def __init__(self, **kwargs):
+                pass
+
+            def collection_exists(self, name):
+                return True
+
+            def get_collection(self, name):
+                return SimpleNamespace(
+                    config=SimpleNamespace(
+                        params=SimpleNamespace(vectors=SimpleNamespace(size=1536))
+                    )
+                )
+
+            def delete_collection(self, name):
+                calls.append(name)
+
+            def close(self):
+                pass
+
+        mod = types.ModuleType("qdrant_client")
+        mod.QdrantClient = _FakeQdrant
+        monkeypatch.setitem(sys.modules, "qdrant_client", mod)
+
+        OSSBackend._recreate_collection_if_dims_changed(
+            "qdrant", {"collection_name": "mem0", "path": "~/.hermes/mem0_qdrant"}, 1536
+        )
+        assert calls == []
+

--- a/tests/plugins/memory/test_mem0_setup.py
+++ b/tests/plugins/memory/test_mem0_setup.py
@@ -124,6 +124,20 @@ class TestBuildOSSConfig:
         assert oss["vector_store"]["config"]["path"] == "/data/qdrant"
 
 
+    def test_pgvector_password_goes_to_env_not_mem0_json(self):
+        flags = parse_flags([
+            "--mode", "oss", "--oss-llm-key", "sk-oai",
+            "--oss-vector", "pgvector",
+            "--oss-vector-user", "pg",
+            "--oss-vector-password", "s3cret",
+            "--oss-vector-dbname", "memdb",
+        ])
+        oss, env_writes = build_oss_config(flags)
+        # Secrets belong in .env, never in mem0.json (which is merged into
+        # config wholesale and written without restrictive permissions).
+        assert "password" not in oss["vector_store"]["config"]
+        assert env_writes["MEM0_PGVECTOR_PASSWORD"] == "s3cret"
+
 class TestWriteEnv:
 
     def test_write_new_vars(self, tmp_path):
@@ -231,3 +245,27 @@ class TestConnectivityChecks:
         assert ok is True
 
 
+
+
+class TestSaveMem0Json:
+    def test_uses_atomic_write_with_0600(self, tmp_path, monkeypatch):
+        import json as _json
+        import utils
+        from plugins.memory.mem0._setup import _save_mem0_json
+
+        calls = []
+        real = utils.atomic_json_write
+
+        def spy(path, data, mode=None):
+            calls.append((str(path), dict(data), mode))
+            return real(path, data, mode=mode)
+
+        monkeypatch.setattr(utils, "atomic_json_write", spy)
+
+        _save_mem0_json(str(tmp_path), {"mode": "oss", "oss": {"a": 1}})
+        _save_mem0_json(str(tmp_path), {"user_id": "u"})
+
+        assert calls[-1][2] == 0o600
+        data = _json.loads((tmp_path / "mem0.json").read_text(encoding="utf-8"))
+        assert data["mode"] == "oss"
+        assert data["user_id"] == "u"


### PR DESCRIPTION
## Summary

Two fixes for the mem0 memory plugin's OSS/pgvector paths:

1. **Stop dropping the pgvector memory table when embedding dims are unchanged** (`_backend.py`)

   `atttypmod` stores `dims + 4` (it includes the 4-byte VARHDRSZ header), so comparing the raw value against `expected_dims` was always unequal whenever the embedder model was in `KNOWN_DIMS`. The plugin therefore executed `DROP TABLE` on every startup, wiping memories repeatedly in pgvector mode. The check now compares `atttypmod - 4`.

2. **Keep the pgvector password out of `mem0.json`** (`_setup.py`, `_backend.py`)

   The OSS setup wizard wrote the PostgreSQL password into `mem0.json`, which is merged wholesale into the provider config and written without restrictive permissions. The password now goes to `.env` as `MEM0_PGVECTOR_PASSWORD`; `OSSBackend` falls back to the env secret at runtime and keeps backward compatibility for passwords already present in `mem0.json`. `mem0.json` is also written atomically with `0600` permissions (same helper the provider config uses).

## Tests

Added regression tests covering:
- pgvector dims migration: unchanged dims must not drop the table; changed dims must; missing column must not
- qdrant dims migration (no deletion on unchanged dims)
- password routing: flag path writes to env only; runtime env fallback; legacy `mem0.json` value wins when present
- atomic write with `0600` for `mem0.json`

Local run: `pytest tests/plugins/memory/test_mem0_backend.py tests/plugins/memory/test_mem0_providers.py tests/plugins/memory/test_mem0_setup.py tests/plugins/memory/test_mem0_v3.py` - 65 passed.