### PR TITLE
fix(weixin): surface iLink business errors on media sends

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -402,6 +402,25 @@ async def _api_post(
     return await asyncio.wait_for(_do(), timeout=timeout_ms / 1000)
 
 
+def _raise_if_ilink_error(resp: Dict[str, Any], endpoint: str) -> None:
+    """Raise when an iLink API response carries a business-level error.
+
+    ``_api_post`` only checks the HTTP status; iLink reports failures in the
+    response body (``ret`` / ``errcode``). Callers that must not silently drop
+    a message (media/file sends) should call this right after ``_api_post`` so
+    a rejected message surfaces as an exception instead of a fake success.
+    """
+    if not isinstance(resp, dict):
+        return
+    ret = resp.get("ret")
+    errcode = resp.get("errcode")
+    if (ret is not None and ret != 0) or (errcode is not None and errcode != 0):
+        errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
+        raise RuntimeError(
+            f"iLink {endpoint} error: ret={ret} errcode={errcode} errmsg={errmsg}"
+        )
+
+
 async def _api_get(
     session: "aiohttp.ClientSession",
     *,
@@ -2190,7 +2209,7 @@ class WeixinAdapter(BasePlatformAdapter):
         last_message_id = None
         if caption:
             last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
-            await _send_message(
+            caption_resp = await _send_message(
                 self._send_session,
                 base_url=self._base_url,
                 token=self._token,
@@ -2199,9 +2218,10 @@ class WeixinAdapter(BasePlatformAdapter):
                 context_token=context_token,
                 client_id=last_message_id,
             )
+            _raise_if_ilink_error(caption_resp, EP_SEND_MESSAGE)
 
         last_message_id = f"hermes-weixin-{uuid.uuid4().hex}"
-        await _api_post(
+        send_resp = await _api_post(
             self._send_session,
             base_url=self._base_url,
             endpoint=EP_SEND_MESSAGE,
@@ -2219,6 +2239,7 @@ class WeixinAdapter(BasePlatformAdapter):
             token=self._token,
             timeout_ms=API_TIMEOUT_MS,
         )
+        _raise_if_ilink_error(send_resp, EP_SEND_MESSAGE)
         return last_message_id
 
     def _outbound_media_builder(self, path: str, force_file_attachment: bool = False):

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -338,6 +338,51 @@ class TestWeixinOutboundMedia:
         assert media["encrypt_query_param"] == "enc-param"
         assert media["aes_key"] == expected_aes_key
 
+    def test_send_file_raises_on_ilink_business_error(self, tmp_path):
+        """A rate-limited file message must surface as an error instead of a
+        silent drop. _api_post only checks the HTTP status, so iLink's
+        ret/errcode used to be swallowed and the send looked successful while
+        the receiver never got the file."""
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        adapter = _make_adapter()
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._cdn_base_url = "https://cdn.example.com/c2c"
+        adapter._token_store.get = lambda account_id, chat_id: None
+
+        with patch("gateway.platforms.weixin._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"})), \
+             patch("gateway.platforms.weixin._upload_ciphertext", new=AsyncMock(return_value="enc-param")), \
+             patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock, return_value={"ret": -2, "errcode": -2, "errmsg": "rate limited"}), \
+             patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"), \
+             patch("gateway.platforms.weixin.secrets.token_bytes", return_value=bytes(range(16))):
+            with pytest.raises(RuntimeError, match="ret=-2"):
+                asyncio.run(adapter._send_file("wxid_test123", str(image_path), ""))
+
+    def test_send_file_raises_on_caption_business_error(self, tmp_path):
+        """The caption text send follows the same iLink error contract and
+        must not be silently dropped either."""
+        image_path = tmp_path / "demo.png"
+        image_path.write_bytes(b"fake-png-bytes")
+
+        adapter = _make_adapter()
+        adapter._send_session = object()
+        adapter._token = "test-token"
+        adapter._base_url = "https://weixin.example.com"
+        adapter._cdn_base_url = "https://cdn.example.com/c2c"
+        adapter._token_store.get = lambda account_id, chat_id: None
+
+        with patch("gateway.platforms.weixin._get_upload_url", new=AsyncMock(return_value={"upload_full_url": "https://upload.example.com/media"})), \
+             patch("gateway.platforms.weixin._upload_ciphertext", new=AsyncMock(return_value="enc-param")), \
+             patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock, return_value={"ret": -2, "errcode": -2, "errmsg": "rate limited"}), \
+             patch("gateway.platforms.weixin._api_post", new_callable=AsyncMock, return_value={"ret": 0}), \
+             patch("gateway.platforms.weixin.secrets.token_hex", return_value="filekey-123"), \
+             patch("gateway.platforms.weixin.secrets.token_bytes", return_value=bytes(range(16))):
+            with pytest.raises(RuntimeError, match="ret=-2"):
+                asyncio.run(adapter._send_file("wxid_test123", str(image_path), "caption text"))
+
 
 class TestWeixinRemoteMediaSafety:
     def test_download_remote_media_blocks_unsafe_urls(self):


### PR DESCRIPTION
## Problem

When the Weixin adapter sends a media/file message (image, video, document, voice), a rate-limited send is silently swallowed.

`_api_post` only checks the HTTP status of the iLink response. iLink reports failures in the response body via `ret` / `errcode`. So when iLink returns `ret=-2` (rate limited) on the sendmessage call inside `_send_file`, the code treats it as success, returns `success=True`, and the receiver simply never gets the file — while the logs claim the message was delivered.

I hit this for real: a scheduled job produced a daily report `.txt`, the text arrived, the attachment silently vanished. The scheduler logged "delivered via live adapter" with zero errors.

## Fix

Add `_raise_if_ilink_error()` and call it after both sendmessage calls in `_send_file` (the caption text and the media item). A non-zero `ret` / `errcode` now raises, so `send_document` reports failure and the caller can retry instead of pretending the send went through.

I deliberately did **not** add the check to `_api_post` itself:
- `_get_updates` (long-poll) and `_send_typing` must stay tolerant of non-zero rets.
- `_send_text_chunk_locked` already inspects `ret` and handles rate-limit backoff plus the session-expired retry-without-token path — raising inside `_api_post` would short-circuit that logic.

## Tests

Two new tests in `tests/gateway/test_weixin.py`:
- media sendmessage returning `ret=-2` → `_send_file` raises
- caption sendmessage returning `ret=-2` → `_send_file` raises

Full weixin test file: 32 passed.
