### PR TITLE
fix(gateway): suppress internal errors on customer-facing channels

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -581,6 +581,10 @@ class PlatformConfig:
     # noise; keep True for back-channels where the operator wants them.
     gateway_restart_notification: bool = True
 
+    # Suppress Hermes/provider diagnostics on customer-facing channels. Errors
+    # remain in gateway logs and processing hooks still receive FAILURE.
+    suppress_system_errors: bool = False
+
     # Whether the gateway shows a "typing…" / "is thinking…" status indicator
     # while the agent processes a message on this platform. Default True
     # preserves prior behavior. Set False on platforms where the indicator is
@@ -611,6 +615,7 @@ class PlatformConfig:
             "extra": self.extra,
             "reply_to_mode": self.reply_to_mode,
             "gateway_restart_notification": self.gateway_restart_notification,
+            "suppress_system_errors": self.suppress_system_errors,
             "typing_indicator": self.typing_indicator,
         }
         if self.typing_status_text is not None:
@@ -643,6 +648,10 @@ class PlatformConfig:
         if _grn is None:
             _grn = extra.get("gateway_restart_notification")
 
+        _sse = data.get("suppress_system_errors")
+        if _sse is None:
+            _sse = extra.get("suppress_system_errors")
+
         # typing_indicator mirrors gateway_restart_notification: it may arrive
         # top-level or bridged into extra by the shared-key loop in
         # load_gateway_config(), so check both.
@@ -670,6 +679,7 @@ class PlatformConfig:
             home_channel=home_channel,
             reply_to_mode=data.get("reply_to_mode", "first"),
             gateway_restart_notification=_coerce_bool(_grn, True),
+            suppress_system_errors=_coerce_bool(_sse, False),
             typing_indicator=_coerce_bool(_typing, True),
             typing_status_text=_typing_text,
             channel_overrides=channel_overrides,
@@ -1493,6 +1503,8 @@ def load_gateway_config() -> GatewayConfig:
                         bridged["channel_prompts"] = channel_prompts
                 if "gateway_restart_notification" in platform_cfg:
                     bridged["gateway_restart_notification"] = platform_cfg["gateway_restart_notification"]
+                if "suppress_system_errors" in platform_cfg:
+                    bridged["suppress_system_errors"] = platform_cfg["suppress_system_errors"]
                 if "typing_indicator" in platform_cfg:
                     bridged["typing_indicator"] = platform_cfg["typing_indicator"]
                 if "typing_status_text" in platform_cfg:
@@ -1988,13 +2000,23 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # SMS (Twilio)
     twilio_sid = getenv("TWILIO_ACCOUNT_SID")
-    if twilio_sid:
+    sms_config = config.platforms.get(Platform.SMS)
+    sms_explicitly_disabled = bool(
+        sms_config is not None
+        and not sms_config.enabled
+        and sms_config.extra.get("_enabled_explicit", False)
+    )
+    if twilio_sid and not sms_explicitly_disabled:
         if Platform.SMS not in config.platforms:
             config.platforms[Platform.SMS] = PlatformConfig()
         config.platforms[Platform.SMS].enabled = True
         config.platforms[Platform.SMS].api_key = getenv("TWILIO_AUTH_TOKEN", "")
     sms_home = getenv("SMS_HOME_CHANNEL")
-    if sms_home and Platform.SMS in config.platforms:
+    if (
+        sms_home
+        and Platform.SMS in config.platforms
+        and config.platforms[Platform.SMS].enabled
+    ):
         config.platforms[Platform.SMS].home_channel = HomeChannel(
             platform=Platform.SMS,
             chat_id=sms_home,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5039,6 +5039,7 @@ class BasePlatformAdapter(ABC):
         # Track delivery outcomes for the processing-complete hook
         delivery_attempted = False
         delivery_succeeded = False
+        suppressed_system_error = False
 
         def _record_delivery(result):
             nonlocal delivery_attempted, delivery_succeeded
@@ -5097,6 +5098,18 @@ class BasePlatformAdapter(ABC):
             # string, and remember the TTL + platform capability so the
             # post-send block can schedule the deletion.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
+
+            if self.config.suppress_system_errors:
+                from gateway.response_filters import is_internal_gateway_error_response
+
+                if is_internal_gateway_error_response(response):
+                    logger.error(
+                        "[%s] Suppressed internal gateway error on customer-safe channel %s",
+                        self.name,
+                        event.source.chat_id,
+                    )
+                    response = None
+                    suppressed_system_error = True
 
             # Send response if any.  A None/empty response is normal when
             # streaming already delivered the text (already_sent=True) or
@@ -5446,7 +5459,11 @@ class BasePlatformAdapter(ABC):
                     )
 
             # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            processing_ok = (
+                False
+                if suppressed_system_error
+                else delivery_succeeded if delivery_attempted else not bool(response)
+            )
             await self._run_processing_hook(
                 "on_processing_complete",
                 event,
@@ -5508,24 +5525,25 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook("on_processing_complete", event, ProcessingOutcome.FAILURE)
             logger.error("[%s] Error handling message: %s", self.name, e, exc_info=True)
             # Send the error to the user so they aren't left with radio silence
-            try:
-                error_type = type(e).__name__
-                error_detail = str(e)[:300] if str(e) else "no details available"
-                _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
-                await self.send(
-                    chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
-                    metadata=_thread_metadata,
-                )
-            except Exception as notify_err:
-                logger.error(
-                    "[%s] Failed to send error notification to user: %s",
-                    self.name, notify_err, exc_info=True,
-                )  # Last resort — don't let error reporting crash the handler
+            if not self.config.suppress_system_errors:
+                try:
+                    error_type = type(e).__name__
+                    error_detail = str(e)[:300] if str(e) else "no details available"
+                    _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                    await self.send(
+                        chat_id=event.source.chat_id,
+                        content=(
+                            f"Sorry, I encountered an error ({error_type}).\n"
+                            f"{error_detail}\n"
+                            "Try again or use /reset to start a fresh session."
+                        ),
+                        metadata=_thread_metadata,
+                    )
+                except Exception as notify_err:
+                    logger.error(
+                        "[%s] Failed to send error notification to user: %s",
+                        self.name, notify_err, exc_info=True,
+                    )  # Last resort — don't let error reporting crash the handler
         finally:
             # Stop typing before any deferred callback work.  Post-delivery
             # callbacks may perform platform I/O; a stuck callback must not

--- a/gateway/response_filters.py
+++ b/gateway/response_filters.py
@@ -23,6 +23,17 @@ LIVE_GATEWAY_SILENT_MARKERS = frozenset({
     "NO REPLY",
 })
 
+_INTERNAL_GATEWAY_ERROR_PREFIXES = (
+    "Provider authentication failed",
+    "The model provider failed",
+    "The model provider rejected",
+    "The model provider is rate-limiting",
+    "The model returned no response",
+    "Session too large for the model's context window",
+    "Sorry, I encountered an unexpected error",
+    "Codex gpt-5.",
+)
+
 
 def _canonical_silence_candidate(text: str) -> str:
     return " ".join(text.strip().upper().split())
@@ -77,6 +88,18 @@ def is_intentional_silence_agent_result(agent_result: dict | None, response: Any
     if agent_result.get("failed"):
         return False
     return is_intentional_silence_response(response)
+
+
+def is_internal_gateway_error_response(response: Any) -> bool:
+    """Return True for Hermes infrastructure notices that customers must not see.
+
+    Prefix matching is intentionally narrow. Business-facing warnings remain
+    deliverable even when a platform enables customer-safe error suppression.
+    """
+    if not isinstance(response, str):
+        return False
+    text = response.strip().lstrip("⚠️ℹ ")
+    return text.startswith(_INTERNAL_GATEWAY_ERROR_PREFIXES)
 
 
 def is_partial_silence_marker(text: Any) -> bool:

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -205,6 +205,52 @@ class TestBasePlatformTopicSessions:
         ]
 
     @pytest.mark.asyncio
+    async def test_customer_safe_adapter_suppresses_internal_gateway_error_response(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.suppress_system_errors = True
+
+        async def handler(_event):
+            return "⚠️ The model provider failed after retries. Check gateway logs."
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == []
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_customer_safe_adapter_suppresses_uncaught_exception_notice(self):
+        adapter = DummyTelegramAdapter()
+        adapter.config.suppress_system_errors = True
+
+        async def handler(_event):
+            raise RuntimeError("private provider failure")
+
+        async def hold_typing(_chat_id, interval=2.0, metadata=None):
+            await asyncio.Event().wait()
+
+        adapter.set_message_handler(handler)
+        adapter._keep_typing = hold_typing
+
+        event = _make_event("-1001", "17585")
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+        assert adapter.sent == []
+        assert adapter.processing_hooks == [
+            ("start", "1"),
+            ("complete", "1", ProcessingOutcome.FAILURE),
+        ]
+
+    @pytest.mark.asyncio
     async def test_process_message_background_marks_cancellation_unsuccessful(self):
         adapter = DummyTelegramAdapter()
         release = asyncio.Event()

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -77,6 +77,11 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_suppress_system_errors_roundtrip_true(self):
+        pc = PlatformConfig(enabled=True, suppress_system_errors=True)
+        restored = PlatformConfig.from_dict(pc.to_dict())
+        assert restored.suppress_system_errors is True
+
     def test_typing_indicator_defaults_true(self):
         assert PlatformConfig().typing_indicator is True
         assert PlatformConfig.from_dict({}).typing_indicator is True
@@ -1923,6 +1928,30 @@ class TestHomeChannelEnvOverrides:
             home = config.platforms[platform].home_channel
             assert home is not None, f"{platform.value}: home_channel should not be None"
             assert (home.chat_id, home.name) == expected, platform.value
+
+
+def test_explicit_sms_disable_is_not_overridden_by_twilio_environment():
+    config = GatewayConfig(
+        platforms={
+            Platform.SMS: PlatformConfig(
+                enabled=False,
+                extra={"_enabled_explicit": True},
+            )
+        }
+    )
+
+    with patch.dict(
+        os.environ,
+        {
+            "TWILIO_ACCOUNT_SID": "AC_test",
+            "TWILIO_AUTH_TOKEN": "secret",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+        },
+        clear=True,
+    ):
+        _apply_env_overrides(config)
+
+    assert config.platforms[Platform.SMS].enabled is False
 
 
 class TestMultiplexProfilesEnvOverride:

--- a/tests/gateway/test_response_filters.py
+++ b/tests/gateway/test_response_filters.py
@@ -1,4 +1,5 @@
 from gateway.response_filters import (
+    is_internal_gateway_error_response,
     is_intentional_silence_agent_result,
     is_intentional_silence_response,
 )
@@ -25,3 +26,18 @@ def test_blank_and_prose_mentions_are_not_silence():
 def test_failed_agent_result_never_counts_as_intentional_silence():
     assert is_intentional_silence_agent_result({"failed": False}, "NO_REPLY")
     assert not is_intentional_silence_agent_result({"failed": True}, "NO_REPLY")
+
+
+def test_internal_gateway_errors_are_detected_without_suppressing_business_warnings():
+    assert is_internal_gateway_error_response(
+        "⚠️ The model provider failed after retries. Check gateway logs."
+    )
+    assert is_internal_gateway_error_response(
+        "Sorry, I encountered an unexpected error. Try again."
+    )
+    assert is_internal_gateway_error_response(
+        "ℹ Codex gpt-5.6-luna caps context at 272K, so auto-compaction was raised."
+    )
+    assert not is_internal_gateway_error_response(
+        "⚠️ Heavy rain is forecast. We can reschedule your pest treatment."
+    )


### PR DESCRIPTION
## Summary
- Add `PlatformConfig.suppress_system_errors` so customer-facing channels (e.g. SMS) can drop provider/auth diagnostics and uncaught exception detail messages.
- Failures still go to gateway logs and processing hooks still receive `FAILURE`.
- Honor explicit SMS disable when Twilio env vars are present (env override must not re-enable a deliberately disabled SMS platform).

## Why
Hermes currently always tries to notify the end-user chat on provider/auth failures. That is correct for operator back-channels (Telegram), but leaks infrastructure text to customers on SMS. SOUL/prompts cannot stop this path because it runs in the gateway after/without a model turn.

## Test plan
- [x] `python -m pytest tests/gateway/test_response_filters.py tests/gateway/test_base_topic_sessions.py tests/gateway/test_config.py -q` (154 passed)
- [ ] Confirm business-facing warnings still deliver when suppression is on
- [ ] Confirm Telegram (default `suppress_system_errors: false`) still shows error notices to operators