### PR TITLE
fix(memory): make Hindsight prefetch wait configurable

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -721,6 +721,7 @@ class HindsightMemoryProvider(MemoryProvider):
         self._prefetch_result = ""
         self._prefetch_lock = threading.Lock()
         self._prefetch_thread = None
+        self._prefetch_join_timeout = 3.0
         # Single-writer model for retain. sync_turn() enqueues; the writer
         # thread drains sequentially. Avoids spawning ad-hoc threads that
         # can race the interpreter shutdown and emit "cannot schedule new
@@ -1075,6 +1076,7 @@ class HindsightMemoryProvider(MemoryProvider):
             {"key": "recall_budget", "description": "Recall thoroughness", "default": "mid", "choices": ["low", "mid", "high"]},
             {"key": "memory_mode", "description": "Memory integration mode", "default": "hybrid", "choices": ["hybrid", "context", "tools"]},
             {"key": "recall_prefetch_method", "description": "Auto-recall method", "default": "recall", "choices": ["recall", "reflect"]},
+            {"key": "prefetch_join_timeout", "description": "Maximum seconds the reply path waits for a background prefetch to finish before continuing without injected recall context", "default": 3.0},
             {"key": "retain_tags", "description": "Default tags applied to retained memories (comma-separated)", "default": ""},
             {"key": "observation_scopes", "description": "How observations are scoped during consolidation: 'combined' (default — one pass over all tags), 'per_tag' (one isolated observation per tag), 'all_combinations' (every tag subset — expensive), or a JSON list of tag-lists for explicit custom scopes. Empty uses Hindsight's 'combined' default.", "default": ""},
             {"key": "retain_source", "description": "Metadata source value attached to retained memories", "default": ""},
@@ -1549,6 +1551,9 @@ class HindsightMemoryProvider(MemoryProvider):
 
         prefetch_method = self._config.get("recall_prefetch_method") or self._config.get("prefetch_method", "recall")
         self._prefetch_method = prefetch_method if prefetch_method in {"recall", "reflect"} else "recall"
+        self._prefetch_join_timeout = max(
+            0.0, float(self._config.get("prefetch_join_timeout", 3.0))
+        )
 
         # Bank options
         self._bank_mission = self._config.get("bank_mission", "")
@@ -1716,7 +1721,7 @@ class HindsightMemoryProvider(MemoryProvider):
     def prefetch(self, query: str, *, session_id: str = "") -> str:
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             logger.debug("Prefetch: waiting for background thread to complete")
-            self._prefetch_thread.join(timeout=3.0)
+            self._prefetch_thread.join(timeout=self._prefetch_join_timeout)
         with self._prefetch_lock:
             result = self._prefetch_result
             self._prefetch_result = ""

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -495,6 +495,27 @@ class TestPrefetch:
     def test_prefetch_returns_empty_when_no_result(self, provider):
         assert provider.prefetch("test") == ""
 
+    def test_prefetch_join_timeout_is_configurable(self, provider_with_config):
+        import threading
+
+        p = provider_with_config(prefetch_join_timeout=0.05)
+
+        def _slow_prefetch():
+            time.sleep(0.2)
+            with p._prefetch_lock:
+                p._prefetch_result = "late result"
+
+        p._prefetch_thread = threading.Thread(target=_slow_prefetch, daemon=True)
+        p._prefetch_thread.start()
+
+        started = time.monotonic()
+        assert p.prefetch("test") == ""
+        elapsed = time.monotonic() - started
+
+        assert p._prefetch_join_timeout == 0.05
+        assert elapsed < 0.15
+        p._prefetch_thread.join(timeout=1.0)
+
 
     def test_queue_prefetch_skipped_in_tools_mode(self, provider_with_config):
         p = provider_with_config(memory_mode="tools")


### PR DESCRIPTION
## Summary
- replace the fixed 3-second Hindsight prefetch join with a configurable setting
- preserve the current 3-second default for backward compatibility
- add regression coverage for the configurable timeout

## Validation
- python -m py_compile plugins/memory/hindsight/__init__.py
- pytest -q tests/plugins/memory/test_hindsight_provider.py (58 passed)