### PR TITLE
fix(vision): per-model image input for kimi-coding (kimi-k3 is multimodal)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -938,20 +938,12 @@ def _resolve_provider_vision_default(provider: str) -> Optional[str]:
     except Exception:
         return None
 
-# Providers whose endpoint does not accept image input, even though the
-# provider's broader ecosystem has vision models available elsewhere.  When
-# `auxiliary.vision.provider: auto` sees one of these as the main provider,
-# it must skip straight to the aggregator chain instead of returning a client
-# that will 404 on every vision request.
-#
-# kimi-coding / kimi-coding-cn: the Kimi Coding Plan routes through
-# api.kimi.com/coding (Anthropic Messages wire) which Kimi's own docs
-# describe as having no image_in capability. Vision lives on the separate
-# Kimi Platform (api.moonshot.ai, OpenAI-wire, pay-as-you-go).  See #17076.
-_PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
-    "kimi-coding",
-    "kimi-coding-cn",
-})
+# NOTE: kimi-coding was previously listed here as vision-incapable (#17076,
+# era of the text-only kimi-code model).  The Kimi Coding endpoint
+# (api.kimi.com/coding, Anthropic Messages wire) accepts image input for
+# kimi-k3 — verified against the live endpoint 2026-08-05 — so capability is
+# now decided per-model by _main_model_supports_vision (models.dev via
+# PROVIDER_TO_MODELS_DEV) instead of a blanket provider skip.
 
 # OpenRouter app attribution headers (base — always sent).
 # `X-Title` is the canonical attribution header OpenRouter's dashboard
@@ -6931,8 +6923,8 @@ def resolve_vision_provider_client(
         main_model = str(runtime.get("model") or _read_main_model())
         if main_provider.strip().lower() == "moa":
             # MoA virtual provider: main_model is a preset NAME, and every
-            # capability probe below (_PROVIDERS_WITHOUT_VISION,
-            # _main_model_supports_vision, _resolve_provider_vision_default)
+            # capability probe below (_main_model_supports_vision,
+            # _resolve_provider_vision_default)
             # would run against a provider/model pair that doesn't exist on
             # any wire. Unwrap to the preset's aggregator slot first so the
             # checks and the eventual client target the real acting model.
@@ -6972,19 +6964,6 @@ def resolve_vision_provider_client(
                         main_provider, default_model or resolved_model or main_model,
                     )
                     return _finalize(main_provider, sync_client, default_model)
-            elif main_provider in _PROVIDERS_WITHOUT_VISION:
-                # Kimi Coding Plan's /coding endpoint (Anthropic Messages wire)
-                # does not accept image input — Kimi's own docs say "Current
-                # model does not support image input, switch to a model with
-                # image_in capability" and vision lives on the separate Kimi
-                # Platform (api.moonshot.ai). Skip the main provider and fall
-                # through to the aggregator chain instead of returning a
-                # client that will 404 on every vision request (#17076).
-                logger.debug(
-                    "Vision auto-detect: skipping main provider %s (no "
-                    "vision support) — falling through to aggregator chain",
-                    main_provider,
-                )
             elif not _main_model_supports_vision(main_provider, vision_model):
                 # The main model is known to be text-only (e.g. DeepSeek V4,
                 # gpt-oss-120b without vision). Building a client and sending
@@ -6992,8 +6971,7 @@ def resolve_vision_provider_client(
                 # ``unknown variant `image_url`, expected `text``` (#31179).
                 # Fall through to the aggregator chain instead.
                 #
-                # Only log the provider name (not the model) — mirrors the
-                # sibling _PROVIDERS_WITHOUT_VISION branch above, and avoids
+                # Only log the provider name (not the model) — avoids
                 # CodeQL py/clear-text-logging-sensitive-data heuristic false
                 # positives on multi-value interpolations.
                 logger.debug(

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -506,20 +506,14 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     if not isinstance(models, dict):
         return None
 
-    # Exact match
-    entry = models.get(model)
+    # Shared matcher: exact, case-insensitive, and kimi- prefix-strip
+    # (models.dev kimi-for-coding catalog uses bare slugs like ``k3`` while
+    # the Kimi Coding API is configured with ``kimi-k3``).
+    entry = _find_model_entry(models, model)
     if entry:
         ctx = _extract_context(entry)
         if ctx:
             return ctx
-
-    # Case-insensitive match
-    model_lower = model.lower()
-    for mid, mdata in models.items():
-        if mid.lower() == model_lower:
-            ctx = _extract_context(mdata)
-            if ctx:
-                return ctx
 
     # Suffix-aware fallback: some providers (e.g. ollama-cloud) store
     # model IDs with :cloud / -cloud suffixes in models.dev while the
@@ -528,6 +522,7 @@ def lookup_models_dev_context(provider: str, model: str) -> Optional[int]:
     # reporting 32768 — tripping the 64k minimum-context guard.
     # The suffix-stripping in fetch_ollama_cloud_models() handles the
     # model-picker UX; this handles the context-length lookup path.
+    model_lower = model.lower()
     for suffix in (":cloud", "-cloud"):
         suffixed_key = model + suffix
         entry = models.get(suffixed_key)
@@ -601,7 +596,15 @@ def _get_provider_models(provider: str) -> Optional[Dict[str, Any]]:
 
 
 def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, Any]]:
-    """Find a model entry by exact match, then case-insensitive fallback."""
+    """Find a model entry by exact match, then case-insensitive fallback.
+
+    Prefix-aware fallback: the models.dev ``kimi-for-coding`` catalog keys its
+    models with bare slugs (``k3``, ``k3-256k``) while the Kimi Coding API is
+    configured with ``kimi-``-prefixed slugs (``kimi-k3``).  Without the strip,
+    every ``kimi-*`` lookup misses the catalog and the caller falls back to
+    "capability unknown" — which for image routing means a multimodal model
+    like kimi-k3 is treated as text-only.
+    """
     # Exact match
     entry = models.get(model)
     if isinstance(entry, dict):
@@ -612,6 +615,17 @@ def _find_model_entry(models: Dict[str, Any], model: str) -> Optional[Dict[str, 
     for mid, mdata in models.items():
         if mid.lower() == model_lower and isinstance(mdata, dict):
             return mdata
+
+    # kimi- prefix strip (exact + case-insensitive)
+    if model_lower.startswith("kimi-") and len(model_lower) > len("kimi-"):
+        stripped = model[len("kimi-"):]
+        entry = models.get(stripped)
+        if isinstance(entry, dict):
+            return entry
+        stripped_lower = stripped.lower()
+        for mid, mdata in models.items():
+            if mid.lower() == stripped_lower and isinstance(mdata, dict):
+                return mdata
 
     return None
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3067,15 +3067,56 @@ class TestCodexAdapterGithubResponsesMessageIdDrop:
         assert message_item["id"] == "msg_short_but_connection_scoped"
 
 
-class TestVisionAutoSkipsKimiCoding:
-    """_resolve_auto vision branch skips providers that have no vision on
-    their main endpoint (e.g. Kimi Coding Plan /coding) and falls through
-    to the aggregator chain instead of handing back a client that will 404
-    on every request (#17076).
+class TestVisionAutoKimiCoding:
+    """Per-model vision decision for kimi-coding (the #17076 skip was written
+    in the kimi-code era, when the /coding endpoint rejected images).
+
+    kimi-k3 accepts image input on the Kimi Coding endpoint (verified live
+    against api.kimi.com/coding 2026-08-05), so vision auto-detect must decide
+    per-model via _main_model_supports_vision: vision-capable kimi models use
+    the main provider; text-only models still fall through to the aggregator
+    chain.
     """
 
-    def test_kimi_coding_skipped_falls_through_to_openrouter(self, monkeypatch):
-        """kimi-coding as main + vision auto → OpenRouter (not kimi)."""
+    def test_kimi_k3_uses_main_provider_not_aggregator(self, monkeypatch):
+        """kimi-coding + vision-capable kimi-k3 → main provider, no skip."""
+        fake_kimi_client = MagicMock(name="kimi_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "kimi-coding",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "kimi-k3",
+        )
+        # Per-model capability lookup reports kimi-k3 as vision-capable.
+        monkeypatch.setattr(
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: True,
+        )
+
+        def fake_rpc(provider, model=None, **kwargs):
+            if provider == "kimi-coding":
+                return fake_kimi_client, model
+            raise AssertionError(
+                f"aggregator path should not be reached for {provider!r} "
+                "when the main model is vision-capable kimi-k3"
+            )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", fake_rpc,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            MagicMock(side_effect=AssertionError(
+                "strict vision backend must not be consulted before the "
+                "main-provider capability check")),
+        )
+
+        provider, client, model = resolve_vision_provider_client()
+        assert provider == "kimi-coding"
+        assert client is fake_kimi_client
+
+    def test_text_only_kimi_model_still_falls_through(self, monkeypatch):
+        """kimi-coding + text-only model → aggregator chain (guard intact)."""
         fake_or_client = MagicMock(name="openrouter_client")
 
         monkeypatch.setattr(
@@ -3084,14 +3125,16 @@ class TestVisionAutoSkipsKimiCoding:
         monkeypatch.setattr(
             "agent.auxiliary_client._read_main_model", lambda: "kimi-code",
         )
-        # Guard: if the skip doesn't fire, _resolve_strict_vision_backend
-        # and resolve_provider_client both would try kimi-coding — detect
-        # either via the main-provider call and fail loud.
-        rpc_mock = MagicMock(side_effect=AssertionError(
-            "resolve_provider_client should NOT be called for kimi-coding "
-            "on the vision auto path"))
+        # Per-model capability lookup reports the model as text-only.
         monkeypatch.setattr(
-            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+            "agent.auxiliary_client._main_model_supports_vision",
+            lambda provider, model: False,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client",
+            MagicMock(side_effect=AssertionError(
+                "resolve_provider_client should NOT be called for a "
+                "text-only kimi model on the vision auto path")),
         )
 
         def fake_strict(provider, model=None):
@@ -3100,8 +3143,7 @@ class TestVisionAutoSkipsKimiCoding:
             if provider == "nous":
                 return None, None
             raise AssertionError(
-                f"strict vision backend should not be called for {provider!r} "
-                "when main provider is kimi-coding"
+                f"strict vision backend should not be called for {provider!r}"
             )
         monkeypatch.setattr(
             "agent.auxiliary_client._resolve_strict_vision_backend",
@@ -3115,13 +3157,18 @@ class TestVisionAutoSkipsKimiCoding:
 
 
 
-    def test_skip_set_covers_exactly_known_entries(self):
-        """Guard against accidental widening of the skip list."""
-        from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
-        assert _PROVIDERS_WITHOUT_VISION == frozenset({
-            "kimi-coding",
-            "kimi-coding-cn",
-        })
+    def test_kimi_coding_not_provider_blocklisted(self):
+        """kimi-coding vision is decided per-model, not by provider skip.
+
+        Regression cover for the stale #17076-era blanket skip: the Kimi
+        Coding endpoint accepts image input for kimi-k3 (verified live
+        2026-08-05), so no provider-level vision blocklist may exist.
+        """
+        import agent.auxiliary_client as ac
+
+        skip = getattr(ac, "_PROVIDERS_WITHOUT_VISION", frozenset())
+        assert "kimi-coding" not in skip
+        assert "kimi-coding-cn" not in skip
 
 
 class TestCodexAuxiliaryAdapterTimeout:

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -506,3 +506,56 @@ class TestCustomProviderVisionAlias:
             ]
         }
         assert _supports_vision_override(cfg, "custom:my-vllm", "other") is None
+
+
+# ─── kimi-coding native vision routing ───────────────────────────────────────
+
+_KIMI_REGISTRY = {
+    "kimi-for-coding": {
+        "id": "kimi-for-coding",
+        "models": {
+            "k3": {
+                "id": "k3",
+                "limit": {"context": 1048576, "output": 8192},
+                "modalities": {"input": ["text", "image", "video"]},
+            },
+        },
+    },
+}
+
+
+class TestKimiCodingVisionRouting:
+    """kimi-k3 is multimodal on the Kimi Coding endpoint (verified live
+    2026-08-05); auto mode must attach images natively once the models.dev
+    slug match (bare ``k3`` vs configured ``kimi-k3``) resolves."""
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_kimi_k3_routes_native(self, mock_fetch):
+        mock_fetch.return_value = _KIMI_REGISTRY
+        assert (
+            decide_image_input_mode(
+                "kimi-coding", "kimi-k3", None, requested_provider="kimi-coding"
+            )
+            == "native"
+        )
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_lookup_supports_vision_prefixed_slug(self, mock_fetch):
+        mock_fetch.return_value = _KIMI_REGISTRY
+        assert (
+            _lookup_supports_vision(
+                "kimi-coding", "kimi-k3", None, requested_provider="kimi-coding"
+            )
+            is True
+        )
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_unknown_kimi_model_stays_text(self, mock_fetch):
+        mock_fetch.return_value = _KIMI_REGISTRY
+        assert (
+            decide_image_input_mode(
+                "kimi-coding", "kimi-k2", None, requested_provider="kimi-coding"
+            )
+            == "text"
+        )
+

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -390,3 +390,69 @@ class TestGetModelCapabilities:
         assert caps is not None
         assert caps.supports_vision is False
 
+
+KIMI_REGISTRY = {
+    "kimi-for-coding": {
+        "id": "kimi-for-coding",
+        "name": "Kimi for Coding",
+        "models": {
+            "k3": {
+                "id": "k3",
+                "limit": {"context": 1048576, "output": 8192},
+                "modalities": {"input": ["text", "image", "video"]},
+                "tool_call": True,
+                "reasoning": True,
+            },
+            "k3-256k": {
+                "id": "k3-256k",
+                "limit": {"context": 262144, "output": 8192},
+                "modalities": {"input": ["text", "image"]},
+                "tool_call": True,
+                "reasoning": True,
+            },
+        },
+    },
+}
+
+
+class TestKimiPrefixMatching:
+    """models.dev keys kimi-for-coding models with bare slugs (``k3``) while
+    the Kimi Coding API is configured with ``kimi-``-prefixed slugs
+    (``kimi-k3``).  Without the prefix strip, multimodal kimi-k3 resolves as
+    "capability unknown" and image routing treats it as text-only."""
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_capabilities_prefixed_slug(self, mock_fetch):
+        mock_fetch.return_value = KIMI_REGISTRY
+        caps = get_model_capabilities("kimi-coding", "kimi-k3")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.context_window == 1048576
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_capabilities_case_insensitive_prefixed(self, mock_fetch):
+        mock_fetch.return_value = KIMI_REGISTRY
+        caps = get_model_capabilities("kimi-coding", "Kimi-K3-256K")
+        assert caps is not None
+        assert caps.supports_vision is True
+        assert caps.context_window == 262144
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_context_lookup_prefixed_slug(self, mock_fetch):
+        mock_fetch.return_value = KIMI_REGISTRY
+        assert lookup_models_dev_context("kimi-coding", "kimi-k3") == 1048576
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_unknown_kimi_model_still_none(self, mock_fetch):
+        mock_fetch.return_value = KIMI_REGISTRY
+        assert get_model_capabilities("kimi-coding", "kimi-k2") is None
+        assert lookup_models_dev_context("kimi-coding", "kimi-k2") is None
+
+    def test_find_model_entry_strips_only_kimi_prefix(self):
+        from agent.models_dev import _find_model_entry
+
+        models = KIMI_REGISTRY["kimi-for-coding"]["models"]
+        assert _find_model_entry(models, "kimi-k3") is models["k3"]
+        # Other prefixes must NOT be stripped — no false matches.
+        assert _find_model_entry(models, "gpt-k3") is None
+


### PR DESCRIPTION
## Summary

kimi-k3 is multimodal on the Kimi Coding endpoint, but Hermes treats every kimi-coding model as text-only. Two sibling defects share one root cause:

1. **Blanket provider skip (#17076-era).** `_PROVIDERS_WITHOUT_VISION` skips `kimi-coding` / `kimi-coding-cn` in vision auto-detect because the `/coding` endpoint rejected images for the text-only `kimi-code` model back in April. kimi-k3 accepts image (and video) input on `api.kimi.com/coding`, so the skip now breaks vision for every kimi-k3 user.
2. **models.dev slug mismatch.** The `kimi-for-coding` catalog on models.dev keys its models with bare slugs (`k3`, `k3-256k`) while the Kimi Coding API is configured with `kimi-`-prefixed slugs (`kimi-k3`). Exact/case-insensitive matching missed the catalog, so capability *and* context-length lookups resolved as "unknown" — and image routing defaulted to text mode.

## Evidence (live, 2026-08-05)

- `POST https://api.kimi.com/coding/v1/messages` with `model: kimi-k3` and a base64 PNG content block → **HTTP 200**, correct image description ("The image appears to be a solid red square").
- Kimi's own model card for K3 now advertises `Multimodal: Image, video input`.
- models.dev `kimi-for-coding` catalog lists `k3` with `modalities.input = ["text", "image", "video"]` and `k3-256k` with `["text", "image"]` — the data was already correct; the lookup just never matched it.
- Before the patch: `_lookup_supports_vision("kimi-coding", "kimi-k3", cfg)` → `None`, `decide_image_input_mode(...)` → `"text"`. After: `True` / `"native"`, and `lookup_models_dev_context("kimi-coding", "kimi-k3")` → `1048576` (previously missed as well).

## Fix

- `agent/models_dev.py` — `_find_model_entry` gains a `kimi-` prefix-strip fallback (exact + case-insensitive), documented and scoped to the `kimi-` prefix so no other model can false-match. `lookup_models_dev_context` now shares the same matcher (previously it had its own exact/CI-only matching — same bug class, sibling call path).
- `agent/auxiliary_client.py` — `_PROVIDERS_WITHOUT_VISION` (kimi-only entries) removed. The per-model `_main_model_supports_vision` guard that immediately followed the skip branch now decides kimi like every other provider: vision-capable models use the main provider, known text-only models still fall through to the aggregator chain, unknown models keep the historical attempt-and-fail-soft behavior (no worse than today, where all kimi users get text mode regardless).

## Tests

- `test_models_dev.py`: new `TestKimiPrefixMatching` — capabilities + context for prefixed slugs, case-insensitivity, unknown kimi model stays `None`, non-kimi prefixes are not stripped.
- `test_image_routing.py`: new `TestKimiCodingVisionRouting` — `kimi-coding`/`kimi-k3` routes `native`, unknown kimi model stays `text`.
- `test_auxiliary_client.py`: `TestVisionAutoSkipsKimiCoding` (asserted the old blanket skip) replaced with `TestVisionAutoKimiCoding` — vision-capable kimi-k3 uses the main provider (aggregator never consulted), text-only kimi model still falls through to OpenRouter. The old `test_skip_set_covers_exactly_known_entries` change-detector was replaced with a behavioral assertion.
- `pytest tests/agent/test_models_dev.py tests/agent/test_image_routing.py tests/tui_gateway/test_image_routing_stale_model.py` → 66 passed. `test_auxiliary_client.py` → 166 passed, 4 failed — all 4 fail identically on clean `main` (`TestKimiTemperatureOmitted`, `TestAuxiliaryTaskExtraBody`, `TestAuxiliaryProviderProfileReasoning`, `TestAsynchronousFallbackCachePlans`); pre-existing, unrelated.

Refs #17076 (the original report — correct fix at the time; the endpoint has since gained image input).
