### PR TITLE
fix(desktop): keep new sessions in front of the terminal

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.test.tsx
@@ -2,9 +2,16 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { hiddenPaneProps, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { $paneStates } from '@/store/panes'
 
+import { $terminalTakeover } from '../store'
+
 import { PersistentTerminal, TerminalSlot } from './persistent'
+
+vi.mock('../store', async () => ({
+  $terminalTakeover: (await import('nanostores')).atom(false)
+}))
 
 vi.mock('./terminals', () => ({
   ensureTerminal: vi.fn()
@@ -125,6 +132,17 @@ function Harness() {
   )
 }
 
+function HiddenPaneHarness({ hidden }: { hidden: boolean }) {
+  return (
+    <>
+      <div {...hiddenPaneProps(hidden)}>
+        <TerminalSlot className="slot" />
+      </div>
+      <PersistentTerminal onAddSelectionToChat={() => undefined} />
+    </>
+  )
+}
+
 describe('PersistentTerminal rect tracking', () => {
   beforeEach(() => {
     ;(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -164,6 +182,7 @@ describe('PersistentTerminal rect tracking', () => {
 
   afterEach(() => {
     cleanup()
+    $terminalTakeover.set(false)
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
     setVisibility(false)
@@ -332,5 +351,63 @@ describe('PersistentTerminal rect tracking', () => {
     act(() => window.dispatchEvent(new Event('focus')))
 
     expect(raf.pending()).toBe(1)
+  })
+
+  it('hides the overlay but keeps its workspace mounted when the terminal tab becomes inactive', () => {
+    const raf = installRaf()
+    vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue(rect(10, 20, 200, 100))
+    $terminalTakeover.set(true)
+
+    render(<HiddenPaneHarness hidden={false} />)
+
+    const overlay = container!.lastElementChild as HTMLElement
+    const workspace = container!.querySelector('[data-testid="terminal-workspace"]')
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(workspace).not.toBeNull()
+    expect(mutationObserveCalls.some(call => call.options?.attributeFilter?.includes(PANE_HIDDEN_ATTR))).toBe(true)
+
+    // Let the initial changed-rect follow-up settle. The hidden-pane transition
+    // must wake the observer from an otherwise idle state.
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+    expect(raf.pending()).toBe(1)
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('hidden')
+    expect(overlay.style.opacity).toBe('0')
+    expect(overlay.style.pointerEvents).toBe('none')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
+
+    act(() => {
+      raf.runNext()
+    })
+    expect(raf.pending()).toBe(0)
+
+    act(() => {
+      root!.render(<HiddenPaneHarness hidden={false} />)
+      mutationObserverCallback?.([], {} as MutationObserver)
+    })
+
+    act(() => {
+      raf.runNext()
+    })
+
+    expect(overlay.style.visibility).toBe('visible')
+    expect(overlay.style.opacity).toBe('1')
+    expect(overlay.style.pointerEvents).toBe('auto')
+    expect(container!.querySelector('[data-testid="terminal-workspace"]')).toBe(workspace)
   })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
+++ b/apps/desktop/src/app/right-sidebar/terminal/persistent.tsx
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { atom } from 'nanostores'
 import { type CSSProperties, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { isElementInHiddenPane, PANE_HIDDEN_ATTR } from '@/components/pane-shell/pane-visibility'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { createRendererLoopPauseController } from '@/lib/renderer-loop-pause'
@@ -50,6 +51,7 @@ interface PersistentTerminalProps {
 }
 
 interface Rect {
+  hidden: boolean
   top: number
   left: number
   width: number
@@ -57,7 +59,7 @@ interface Rect {
 }
 
 const sameRect = (a: Rect | null, b: Rect) =>
-  !!a && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
+  !!a && a.hidden === b.hidden && a.top === b.top && a.left === b.left && a.width === b.width && a.height === b.height
 
 export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalProps) {
   const slot = useStore($slot)
@@ -112,7 +114,16 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
       // full pixel footprint, so half-pixel rects can't leak page bg through.
       const top = Math.floor(r.top)
       const left = Math.floor(r.left)
-      const next: Rect = { top, left, width: Math.ceil(r.right) - left, height: Math.ceil(r.bottom) - top }
+
+      // Inactive keep-alive panes deliberately retain the same rect as the
+      // foreground pane, so visibility must be sampled independently.
+      const next: Rect = {
+        hidden: isElementInHiddenPane(slot),
+        top,
+        left,
+        width: Math.ceil(r.right) - left,
+        height: Math.ceil(r.bottom) - top
+      }
 
       if (!sameRect(prev, next)) {
         prev = next
@@ -182,7 +193,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
 
     for (let node: HTMLElement | null = slot; node; node = node.parentElement) {
       positionObserver?.observe(node, {
-        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state'],
+        attributeFilter: ['class', 'style', 'hidden', 'aria-hidden', 'data-state', PANE_HIDDEN_ATTR],
         attributes: true,
         childList: true,
         subtree: false
@@ -218,7 +229,7 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     }
   }, [slot])
 
-  const visible = Boolean(rect && rect.width > 0 && rect.height > 0)
+  const visible = Boolean(rect && !rect.hidden && rect.width > 0 && rect.height > 0)
 
   const style: CSSProperties = {
     position: 'fixed',
@@ -229,6 +240,10 @@ export function PersistentTerminal({ onAddSelectionToChat }: PersistentTerminalP
     display: 'flex',
     flexDirection: 'column',
     visibility: visible ? 'visible' : 'hidden',
+    // Electron may keep xterm's WebGL canvas visually composited after an
+    // ancestor becomes visibility:hidden. Opacity clears that compositor layer
+    // while preserving the mounted DOM, terminal dimensions, and live PTY.
+    opacity: visible ? 1 : 0,
     pointerEvents: visible ? 'auto' : 'none',
     zIndex: 4,
     // Match the live skin surface so the header strip (transparent) and body

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -3,6 +3,7 @@ import type { MutableRefObject } from 'react'
 import { useEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { noteActiveTreeGroup, revealTreePane } from '@/components/pane-shell/tree/store'
 import { getSession, getSessionMessages, type SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
@@ -431,6 +432,26 @@ describe('startFreshSessionDraft', () => {
     expect(navigate).not.toHaveBeenCalled()
     expect($currentCwd.get()).toBe('')
     expect($newChatWorkspaceTarget.get()).toBeNull()
+  })
+
+  it('clears the terminal takeover so the fresh chat takes the screen', async () => {
+    // Regression: a persisted terminal takeover (⌃` / statusbar toggle) kept
+    // the terminal pane fronted after New Session / ⌘N, bouncing the user
+    // straight back to the terminal. A fresh chat must collapse the pane to
+    // its rail (PTYs stay alive) and surface the new session.
+    const navigate = vi.fn()
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    setTerminalTakeover(true)
+    expect($terminalTakeover.get()).toBe(true)
+
+    render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    act(() => handle!.startFreshSessionDraft({ preserveRoute: true, workspaceTarget: null }))
+
+    expect($terminalTakeover.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2,6 +2,7 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 import type { NavigateFunction } from 'react-router'
 
+import { setTerminalTakeover } from '@/app/right-sidebar/store'
 import { revealTreePane } from '@/components/pane-shell/tree/store'
 import { deleteSession, getSessionMessages, setSessionArchived } from '@/hermes'
 import { useI18n } from '@/i18n'
@@ -297,6 +298,13 @@ export function useSessionActions({
       setAwaitingResponse(false)
       clearNotifications()
       setIntroSeed(seed => seed + 1)
+      // A fresh chat takes the screen: the terminal's persisted takeover flag
+      // (⌃` / the statusbar toggle) must not keep the pane fronted over the
+      // new session — otherwise New Session / ⌘N bounces straight back to the
+      // terminal. The terminal itself stays alive (tool panels collapse to a
+      // rail, PTYs are never torn down); only the fronting flag is cleared.
+      setTerminalTakeover(false)
+      revealTreePane('workspace')
       // Clear the durable route intent synchronously, before React Router
       // publishes /new. Submit uses that intent to heal an existing-session
       // rebind race, so leaving the old id here could revive it on a very fast

--- a/apps/desktop/src/components/pane-shell/pane-visibility.ts
+++ b/apps/desktop/src/components/pane-shell/pane-visibility.ts
@@ -42,9 +42,12 @@ export const PaneGroupContext = createContext(NO_PANE_GROUP)
 
 export const usePaneGroup = (): string => useContext(PaneGroupContext)
 
+/** Whether an element belongs to an inactive keep-alive pane. */
+export const isElementInHiddenPane = (element: Element): boolean => Boolean(element.closest(HIDDEN_PANE))
+
 /** `querySelectorAll` minus anything inside an inactive tab. */
 export const queryAllVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): T[] =>
-  [...root.querySelectorAll<T>(selector)].filter(el => !el.closest(HIDDEN_PANE))
+  [...root.querySelectorAll<T>(selector)].filter(el => !isElementInHiddenPane(el))
 
 /** `querySelector` minus anything inside an inactive tab. */
 export const queryVisible = <T extends HTMLElement>(selector: string, root: ParentNode = document): null | T =>

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -1380,11 +1380,22 @@ export function setPaneCollapsed(paneId: string, collapsed: boolean) {
   if (group.panes.length > 1) {
     if (collapsed && group.active === paneId) {
       if (group.panes.some(isUncloseablePane)) {
-        // Workspace can't minimize (strands the app) → tab-switch to a sibling
-        // (guaranteed to exist by length > 1).
+        // Workspace can't minimize (strands the app) → hand the active slot to
+        // the uncloseable (workspace) pane rather than an arbitrary adjacent
+        // sibling. [workspace, files, review, terminal] with the terminal
+        // active must land on workspace (New Session semantics), not on review
+        // via `panes[at - 1]` — which left the user stranded on a tool pane
+        // and (before the overlay fix) the terminal visually foreground.
+        const anchor = group.panes.find(isUncloseablePane)
         const at = group.panes.indexOf(paneId)
 
-        activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
+        if (anchor && anchor !== paneId) {
+          activateTreePane(group.id, anchor)
+        } else {
+          // Defensive: collapsing the uncloseable pane itself (never bound to
+          // a tool toggle store) — fall back to the sibling.
+          activateTreePane(group.id, group.panes[at - 1] ?? group.panes[at + 1])
+        }
       } else {
         setTreeGroupMinimized(group.id, true) // pure tool zone folds as a unit
       }

--- a/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/tool-pane-toggle.test.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
+import { $terminalTakeover, setTerminalTakeover } from '@/app/right-sidebar/store'
 import { registry } from '@/contrib/registry'
 
 import { allPaneIds, group, split } from './model'
@@ -11,6 +12,7 @@ import {
   bindToolPaneCollapse,
   closeToolPane,
   isPaneVisible,
+  revealTreePane,
   setTreeGroupHeaderHidden,
   togglePaneVisible
 } from './store'
@@ -44,6 +46,8 @@ beforeEach(() => {
 
   for (const [id, data] of [
     ['workspace', { placement: 'main', uncloseable: true }],
+    ['files', { placement: 'right' }],
+    ['review', { placement: 'right' }],
     ['terminal', { placement: 'bottom' }],
     ['logs', { placement: 'bottom' }]
   ] as const) {
@@ -167,6 +171,97 @@ describe('toggling the terminal while it is stacked with logs', () => {
 
     expect(allPaneIds($layoutTree.get()!)).toContain('terminal')
     expect(isPaneVisible('terminal')).toBe(true)
+  })
+})
+
+describe('collapsing the active terminal in a shared group with the workspace', () => {
+  // Ground truth for PR #79864's second act: New Session from a Focus-layout
+  // group [workspace, files, review, terminal] with the terminal active used to
+  // land on 'review' (`panes[at - 1]`) — an arbitrary adjacent sibling — so
+  // after the takeover atom cleared, the wrong pane held the slot: blank pane
+  // with the terminal overlay hidden. Collapsing an active tool pane must hand
+  // the slot to the uncloseable workspace pane, not a strip neighbour.
+
+  function focusGroup() {
+    $layoutTree.set(
+      group(['workspace', 'files', 'review', 'terminal'], { active: 'terminal', id: 'g-focus' })
+    )
+  }
+
+  const focusActive = () => {
+    const tree = $layoutTree.get()
+
+    return tree?.type === 'group' ? tree.active : undefined
+  }
+
+  it('startFreshSessionDraft: clearing takeover lands on workspace, not review', () => {
+    focusGroup()
+
+    // Production wiring (controller.tsx): the takeover atom IS the terminal's
+    // toggle store; the closer/opener write it back.
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    // User had the terminal open and active.
+    setTerminalTakeover(true)
+    expect($terminalTakeover.get()).toBe(true)
+    expect(focusActive()).toBe('terminal')
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    // Exactly what startFreshSessionDraft does on ⌘N / the sidebar button.
+    setTerminalTakeover(false)
+
+    expect($terminalTakeover.get()).toBe(false)
+    expect(isPaneVisible('terminal')).toBe(false)
+    // THE regression: used to be 'review' (group.panes[at - 1]).
+    expect(focusActive()).toBe('workspace')
+    expect(isPaneVisible('workspace')).toBe(true)
+  })
+
+  it('openNewSessionTile (+ / ⌘T): the new session tab fronts and the terminal tab goes hidden', () => {
+    const stored = 'stored-1'
+    const tilePaneId = `session-tile:${stored}`
+    const dispose = registry.register({
+      area: 'panes',
+      data: { placement: 'main' },
+      id: tilePaneId,
+      render: () => null,
+      title: 'new session'
+    })
+    disposers.push(dispose)
+
+    // The tile lands in the same shared zone as the workspace + terminal
+    // (Focus preset: docked 'center' into the focused chat zone).
+    $layoutTree.set(
+      group(['workspace', 'files', 'review', 'terminal', tilePaneId], { active: 'terminal', id: 'g-focus' })
+    )
+
+    bindToolPaneCollapse(
+      'terminal',
+      $terminalTakeover,
+      () => setTerminalTakeover(false),
+      () => setTerminalTakeover(true)
+    )
+
+    setTerminalTakeover(true)
+    expect(focusActive()).toBe('terminal')
+    expect(isPaneVisible('terminal')).toBe(true)
+
+    // Exactly what openNewSessionTile does after openSessionTile + patch:
+    // `revealTreePane(`session-tile:${stored}`)` (use-session-actions:521).
+    revealTreePane(tilePaneId)
+
+    expect(focusActive()).toBe(tilePaneId)
+    expect(isPaneVisible('terminal')).toBe(false)
+    // The terminal layer gets data-pane-hidden (tree-group spreads
+    // hiddenPaneProps(!isActive)), which the PersistentTerminal overlay now
+    // measures — so the terminal surface stops covering the new session tab.
+    expect(isPaneVisible(tilePaneId)).toBe(true)
+    expect($terminalTakeover.get()).toBe(true) // toggle store stays truthful
   })
 })
 


### PR DESCRIPTION
## What does this PR do?

Fixes the Desktop Focus-layout failure where creating or switching to a fresh chat can leave the terminal visually/structurally in front of the chat, or land the shared zone on the wrong tool tab.

The failure has three cooperating layers:

1. **Fresh-session foreground intent** — `startFreshSessionDraft` must clear the persisted terminal takeover state and explicitly front the workspace pane.
2. **Shared-zone collapse target** — when an active tool pane is collapsed inside a group that also contains the uncloseable workspace pane, the tree must activate the workspace rather than an arbitrary adjacent tab such as `review`.
3. **Persistent terminal overlay visibility** — inactive keep-alive panes retain geometry by design, so `PersistentTerminal` cannot decide visibility from `getBoundingClientRect()` alone. It must also honor the pane-shell hidden marker so the fixed xterm overlay stops painting/intercepting input while the terminal DOM/PTY stays mounted.

This explains both observed symptoms:

- before takeover clearing, a fresh chat could appear to bounce back to terminal;
- after takeover clearing, the same shared-group state could expose a blank/wrong pane;
- tab-strip `+` / ⌘T can reproduce the overlay layer independently of the ⌘N path because it creates a session tile rather than calling `startFreshSessionDraft`.

## Relationship to #71457 / #71407

The persistent-terminal portion is the same bug family already tracked by **#71407** and implemented in open **#71457**. This PR carries a current-main adaptation of that established hidden-pane approach because the new-session regression exercises the same overlay path. It is not intended as a competing overlay design. If #71457 lands first, these overlay hunks should be reconciled/dropped in favor of the landed implementation.

The overlay behavior used here matches #71457's fix set:

- export/use `isElementInHiddenPane` from the pane visibility policy;
- sample hidden state alongside terminal slot geometry;
- observe `PANE_HIDDEN_ATTR` so tab visibility transitions trigger remeasurement;
- gate the fixed overlay on `!rect.hidden`;
- use `visibility: hidden`, `opacity: 0`, and `pointer-events: none` while hidden;
- keep `TerminalWorkspace` mounted so PTYs survive tab switches.

## Changes Made

### Fresh session foreground

`apps/desktop/src/app/session/hooks/use-session-actions/index.ts`

- clear `$terminalTakeover` in `startFreshSessionDraft`;
- explicitly reveal the `workspace` pane so New Session / ⌘N lands on chat even when terminal takeover state and tree activity have drifted apart.

### Shared-zone collapse semantics

`apps/desktop/src/components/pane-shell/tree/store.ts`

When collapsing the **active** tool pane in a group that contains an uncloseable pane, prefer that uncloseable workspace pane instead of `group.panes[at - 1]`.

For the Focus group:

```text
[workspace, files, review, terminal]
```

collapsing `terminal` now activates `workspace`, not `review`.

**Behavioral scope:** this is intentionally broader than New Session. The same rule applies whenever an active tool pane is collapsed in a shared group, including rail / keyboard terminal toggles. Pure tool-only zones still minimize as a unit, and the defensive sibling fallback remains for the uncloseable-pane-itself case.

### Persistent terminal overlay

`apps/desktop/src/app/right-sidebar/terminal/persistent.tsx`
`apps/desktop/src/components/pane-shell/pane-visibility.ts`

Inactive kept-alive panes deliberately keep their layout box, so the terminal slot can still report a non-zero rect while its pane is inactive. PersistentTerminal now tracks that hidden-pane state separately and suppresses the fixed overlay without unmounting xterm or killing its PTY.

## Regression coverage

Coverage includes:

- `startFreshSessionDraft` clears terminal takeover;
- Focus group `[workspace, files, review, terminal]` with terminal active collapses to `workspace`, not `review`;
- `PersistentTerminal` transitions visible → hidden → visible while retaining the same mounted `TerminalWorkspace` and observing `PANE_HIDDEN_ATTR`.

The intended invariant after sidebar New Session / ⌘N is:

```text
terminalTakeover === false
isPaneVisible('terminal') === false
group.active === 'workspace'
isPaneVisible('workspace') === true
```

For tab-strip `+` / ⌘T, no takeover clear is required: the tree reveals the new session tile and the hidden-pane-aware terminal overlay must stop painting over it.

## How to Test

### Sidebar New Session / ⌘N

1. Use the Focus layout.
2. Open Terminal.
3. Click sidebar **New Session** or press ⌘N.
4. Fresh chat should be visible immediately; terminal should no longer cover or intercept it.
5. Re-open Terminal and confirm the existing shell is still alive.

### Tab-strip `+` / ⌘T

1. Use the Focus layout and open Terminal.
2. Click the chat-strip `+` or press ⌘T.
3. The new session tab should become active and its composer should be usable.
4. Terminal pixels/controls must not remain composited over the new tab.
5. Return to Terminal and confirm the same terminal workspace/PTY is still alive.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

- [x] Changes are limited to the Desktop pane/session regression.
- [x] Regression coverage added for takeover, tree collapse target, and hidden terminal overlay.
- [x] Cross-platform renderer behavior considered; opacity guard preserves the Electron/Wayland compositor fix from #71457.
- [x] No user data, session storage, or migration behavior is changed by this PR.
