### PR TITLE
fix(launchd): stop stranding the gateway label on plist reload

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3790,17 +3790,34 @@ def _append_launchd_reload_log(message: str) -> None:
         pass
 
 
-def _launchctl_label_registered(label: str) -> bool:
-    """True when ``launchctl list <label>`` reports the job as registered."""
+def _launchctl_label_supervising_process(label: str) -> bool:
+    """True when launchd both knows ``label`` AND is running a process for it.
+
+    A bare ``launchctl list <label>`` exit-0 only proves a *definition* is
+    registered — it also returns 0 for ``state = not running`` (macOS 26+),
+    which is why :func:`_probe_launchd_service_running` already insists on a
+    PID. The reload's success check needs the same standard: ending the retry
+    loop on "a definition exists" can report success for a job launchd is not
+    actually running.
+
+    Measured against live launchd (2026-08-05): immediately after ``bootout``
+    the label deregisters within ~1s (rc=113) while the old process keeps
+    draining, so this is NOT what distinguishes a draining instance from a
+    fresh one — waiting for the old PID to exit before bootstrapping is what
+    does that. This check is the narrower guarantee: success means launchd is
+    supervising a live process.
+    """
     try:
         result = subprocess.run(
             ["launchctl", "list", label],
             check=False,
             timeout=10,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            capture_output=True,
+            text=True, encoding='utf-8', errors='replace',
         )
-        return result.returncode == 0
+        if result.returncode != 0:
+            return False
+        return _parse_launchd_pid_from_list_output(result.stdout) is not None
     except (subprocess.TimeoutExpired, OSError):
         return False
 
@@ -3830,11 +3847,11 @@ def _retry_launchctl_bootstrap_until_registered(
         attempt += 1
         try:
             _launchctl_bootstrap(domain, plist_path, label, timeout=30)
-            if _launchctl_label_registered(label):
+            if _launchctl_label_supervising_process(label):
                 return True
             _append_launchd_reload_log(
                 f"bootstrap attempt {attempt} exited 0 but {domain}/{label} "
-                f"is not registered (launchctl list) — retrying"
+                f"has no supervised process (launchctl list) — retrying"
             )
         except subprocess.CalledProcessError as exc:
             _append_launchd_reload_log(
@@ -4196,12 +4213,15 @@ def refresh_launchd_plist_if_needed() -> bool:
             f"_deadline=$(($(date +%s) + {_reload_budget})); "
             f"while :; do "
             f"  launchctl bootstrap {shlex.quote(domain)} {shlex.quote(str(plist_path))} 2>/dev/null; "
-            f"  if launchctl list {shlex.quote(label)} >/dev/null 2>&1; then break; fi; "
+            # Require a PID, not just exit 0: a bare `launchctl list` also
+            # succeeds for a registered-but-not-running definition, which would
+            # end this loop reporting success for a job launchd isn't running.
+            f"  if launchctl list {shlex.quote(label)} 2>/dev/null | grep -q '\"PID\"'; then break; fi; "
             f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] bootstrap not yet registered for {shlex.quote(target)} — retrying\" >> {shlex.quote(str(reload_log_path))}; "
             f"  if [ $(date +%s) -ge $_deadline ]; then break; fi; "
             f"  sleep 2; "
             f"done; "
-            f"if ! launchctl list {shlex.quote(label)} >/dev/null 2>&1; then "
+            f"if ! launchctl list {shlex.quote(label)} 2>/dev/null | grep -q '\"PID\"'; then "
             f"  echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] FAILED launchd reload for {shlex.quote(target)} — service NOT registered after {_reload_budget}s of retries\" >> {shlex.quote(str(reload_log_path))}; "
             f"fi; "
             # Submitted jobs stay registered with launchd after the script

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -303,6 +303,32 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     return False
 
 
+def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
+    """Wait up to ``timeout`` seconds for ``pid`` to leave the process table.
+
+    ``launchctl bootstrap`` of a label whose previous instance is still draining
+    fails with EIO ("already loaded"), so callers that tear the gateway down
+    must wait for the old process to actually exit before re-bootstrapping.
+
+    Returns True once the PID is gone (or was never alive), False on timeout.
+    """
+    if pid <= 0:
+        return True
+
+    import time as _time
+
+    # ``os.kill(pid, 0)`` hard-kills on Windows — use the cross-platform helper.
+    from gateway.status import _pid_exists
+
+    deadline = _time.monotonic() + max(timeout, 0.0)
+    while True:
+        if not _pid_exists(pid):
+            return True
+        if _time.monotonic() >= deadline:
+            return False
+        _time.sleep(0.5)
+
+
 def _get_ancestor_pids() -> set[int]:
     """Return the set of PIDs in the current process's ancestor chain.
 
@@ -4100,9 +4126,21 @@ def refresh_launchd_plist_if_needed() -> bool:
     except Exception:
         gateway_pid = None
 
+    # NOTE: POSIX ancestry is NOT a reliable test for "the bootout will kill us".
+    # What bootout tears down is the launchd job's process *coalition*, and
+    # coalition membership is inherited at spawn — it survives reparenting. A
+    # process the gateway spawned whose intermediate parent has since exited is
+    # reparented to PID 1, so the gateway is no longer an ancestor, yet the
+    # process is still in the coalition and still dies with it. That
+    # misclassification stranded the job on 2026-08-05: the in-process retry loop
+    # below was killed mid-bootstrap (4 attempts, rc=5, no exhaustion line) and
+    # nothing was left to re-register the label, so KeepAlive could not revive it.
+    #
+    # Since the detached helper is also correct when we are genuinely outside the
+    # coalition (just asynchronous), always prefer it and keep the in-process path
+    # only as the fallback for when the helper cannot be spawned.
     if (
         gateway_pid is not None
-        and _is_pid_ancestor_of_current_process(gateway_pid)
         and hasattr(os, "setsid")  # POSIX-only; launchd is macOS so always true here
     ):
         # Delegate to a new session: `start_new_session=True` detaches the
@@ -4140,6 +4178,20 @@ def refresh_launchd_plist_if_needed() -> bool:
         reload_script = (
             f"sleep 2; "
             f"launchctl bootout {shlex.quote(target)} 2>/dev/null; "
+            # Wait for the OLD gateway to actually exit before bootstrapping.
+            # bootout only sends SIGTERM; the gateway then drains in-flight agent
+            # runs (up to agent.restart_drain_timeout), and every bootstrap issued
+            # while it is still draining fails EIO ("already loaded"). Racing the
+            # drain is what burned the retry budget on 2026-08-05.
+            f"_wait_deadline=$(($(date +%s) + {_reload_budget})); "
+            f"while kill -0 {gateway_pid} 2>/dev/null; do "
+            f"  if [ $(date +%s) -ge $_wait_deadline ]; then "
+            f"    echo \"[$(date '+%Y-%m-%d %H:%M:%S %z')] old gateway pid {gateway_pid} still alive after {_reload_budget}s drain wait — bootstrapping anyway\" >> {shlex.quote(str(reload_log_path))}; "
+            f"    break; "
+            f"  fi; "
+            f"  sleep 1; "
+            f"done; "
+            # Let launchd finish unregistering the label after the process exits.
             f"sleep 1; "
             f"_deadline=$(($(date +%s) + {_reload_budget})); "
             f"while :; do "
@@ -4183,16 +4235,21 @@ def refresh_launchd_plist_if_needed() -> bool:
                 stderr=subprocess.DEVNULL,
             )
         except Exception as e:
+            # Don't give up — fall through to the in-process bootout/bootstrap
+            # below. It risks being killed mid-reload if we share the gateway's
+            # coalition, but an attempt beats leaving the plist updated and the
+            # service never reloaded.
             logger.warning("Deferred launchd reload could not be spawned: %s", e)
             _append_launchd_reload_log(
-                f"FAILED to spawn launchd reload helper for {target}: {e}"
+                f"FAILED to spawn launchd reload helper for {target}: {e} — "
+                f"falling back to in-process bootout/bootstrap"
             )
-            return False
-        print(
-            "↻ Updated gateway launchd service definition; reload deferred to a "
-            "transient launchd job (refresh ran inside the gateway process tree)"
-        )
-        return True
+        else:
+            print(
+                "↻ Updated gateway launchd service definition; reload deferred to "
+                "a transient launchd job (survives the bootout of this process)"
+            )
+            return True
 
     # Bootout/bootstrap so launchd picks up the new definition. The reported
     # incident (2026-06-26) happened when bootout succeeded but bootstrap
@@ -4211,6 +4268,16 @@ def refresh_launchd_plist_if_needed() -> bool:
     # fixed ~10s: the failure mode occurs while the old gateway is still
     # draining, so a short window can exhaust before launchd settles.
     _reload_budget = max(30.0, _get_restart_drain_timeout())
+    # Wait out the old gateway's drain first, so the retry budget is spent on
+    # real bootstrap failures rather than on EIO ("already loaded") responses
+    # that are guaranteed while the previous instance is still shutting down.
+    if gateway_pid is not None and not _wait_for_pid_exit(
+        gateway_pid, _reload_budget
+    ):
+        _append_launchd_reload_log(
+            f"old gateway pid {gateway_pid} still alive after "
+            f"{int(_reload_budget)}s drain wait — bootstrapping {target} anyway"
+        )
     _deadline = time.monotonic() + _reload_budget
     if not _retry_launchctl_bootstrap_until_registered(
         domain, plist_path, label, deadline=_deadline

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -239,6 +239,19 @@ class TestSystemdServiceRefresh:
 
         monkeypatch.setattr("gateway.run.start_gateway", fake_start_gateway)
 
+        # run_gateway() ALWAYS ends in _exit_after_graceful_shutdown(), which is
+        # os._exit() by design (#53107 — don't join wedged non-daemon threads).
+        # Unstubbed, that terminates the pytest process itself with status 0:
+        # the rest of the file silently never runs and the suite still reports
+        # success. Neutralize it like tests/hermes_cli/test_gateway.py does.
+        def _fake_exit(code):
+            if code:
+                raise SystemExit(code)
+
+        monkeypatch.setattr(
+            "gateway.run._exit_after_graceful_shutdown", _fake_exit
+        )
+
         gateway_cli.run_gateway()
 
         assert unit_path.read_text(encoding="utf-8") == "new unit\n"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -624,6 +624,25 @@ class TestGatewayStopCleanup:
 
 
 class TestLaunchdServiceRecovery:
+    def test_wait_for_pid_exit_returns_when_process_gone(self, monkeypatch):
+        alive = [True, True, False]
+        monkeypatch.setattr(
+            "gateway.status._pid_exists", lambda pid: alive.pop(0) if alive else False
+        )
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda s: None)
+
+        assert gateway_cli._wait_for_pid_exit(4242, timeout=30) is True
+        assert not alive  # polled until the PID disappeared
+
+    def test_wait_for_pid_exit_times_out_on_wedged_process(self, monkeypatch):
+        """A wedged gateway must not block the reload forever."""
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+
+        assert gateway_cli._wait_for_pid_exit(4242, timeout=0) is False
+
+    def test_wait_for_pid_exit_ignores_nonpositive_pid(self):
+        assert gateway_cli._wait_for_pid_exit(0, timeout=30) is True
+
     def test_get_restart_drain_timeout_prefers_env_then_config_then_default(self, monkeypatch):
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.setattr(gateway_cli, "read_raw_config", lambda: {})
@@ -757,9 +776,17 @@ class TestLaunchdServiceRecovery:
         submit_label = cmd[cmd.index("-l") + 1]
         assert f"launchctl remove {submit_label}" in script
 
-    def test_refresh_uses_direct_reload_when_not_inside_gateway_tree(self, tmp_path, monkeypatch):
-        """Normal CLI-initiated refresh (outside the service tree) keeps the
-        direct synchronous bootout/bootstrap path."""
+    def test_refresh_defers_reload_even_when_not_a_posix_descendant(self, tmp_path, monkeypatch):
+        """The detached helper is used even when the gateway is NOT an ancestor.
+
+        POSIX ancestry does not decide who ``bootout`` kills — the launchd job's
+        process *coalition* does, and coalition membership is inherited at spawn
+        and survives reparenting. A gateway-spawned process whose intermediate
+        parent has exited is reparented to PID 1 (gateway no longer an ancestor)
+        yet still dies with the coalition. Trusting ancestry stranded the job on
+        2026-08-05: the in-process retry loop was killed mid-bootstrap and
+        nothing re-registered the label. So always prefer the detached helper.
+        """
         plist_path = tmp_path / "ai.hermes.gateway.plist"
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
 
@@ -796,8 +823,110 @@ class TestLaunchdServiceRecovery:
         result = gateway_cli.refresh_launchd_plist_if_needed()
 
         assert result is True
-        # No detached helper — direct path taken.
-        assert not popen_calls
+        # Reload was delegated, NOT run in-process where bootout could kill it.
+        assert len(popen_calls) == 1
+        assert popen_calls[0][:2] == ["launchctl", "submit"]
+        assert not [c for c in run_calls if "bootout" in c or "bootstrap" in c]
+
+    def test_deferred_reload_waits_for_old_gateway_pid_before_bootstrap(
+        self, tmp_path, monkeypatch
+    ):
+        """The helper must wait for the old gateway to exit before bootstrapping.
+
+        ``bootout`` only sends SIGTERM; the gateway then drains in-flight agent
+        runs (agent.restart_drain_timeout, default 180s). Every ``bootstrap``
+        issued while it drains fails EIO ("already loaded"), which is how the
+        retry budget got burned on 2026-08-05 (4 attempts, all rc=5).
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_launchd_plist",
+            lambda: (
+                "<plist>--replace\n<key>HERMES_HOME</key>"
+                "<string>/Users/alice/.hermes</string></plist>"
+            ),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 4242)
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "run",
+            lambda cmd, check=False, **kw: SimpleNamespace(
+                returncode=0, stdout="", stderr=""
+            ),
+        )
+
+        popen_calls = []
+        monkeypatch.setattr(
+            gateway_cli.subprocess,
+            "Popen",
+            lambda cmd, **kw: popen_calls.append(cmd) or SimpleNamespace(pid=1),
+        )
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+
+        cmd = popen_calls[0]
+        script = cmd[cmd.index("--") + 3]
+        # Waits on the OLD pid, and does so AFTER bootout but BEFORE bootstrap.
+        assert "kill -0 4242" in script
+        assert (
+            script.index("bootout")
+            < script.index("kill -0 4242")
+            < script.index("bootstrap")
+        )
+        # The wait must be bounded, so a wedged gateway can't block the reload.
+        assert "_wait_deadline" in script
+
+    def test_refresh_falls_back_to_direct_reload_when_helper_cannot_spawn(
+        self, tmp_path, monkeypatch
+    ):
+        """If the transient job can't be spawned, still attempt the reload.
+
+        Bailing out would leave the plist rewritten but the service never
+        reloaded. The in-process path waits out the old gateway's drain first so
+        its retry budget isn't spent on guaranteed-EIO bootstraps.
+        """
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: False)
+        monkeypatch.setattr(
+            gateway_cli,
+            "generate_launchd_plist",
+            lambda: (
+                "<plist>--replace\n<key>HERMES_HOME</key>"
+                "<string>/Users/alice/.hermes</string></plist>"
+            ),
+        )
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda *a, **k: 4242)
+
+        def boom(cmd, **kwargs):
+            raise OSError("launchctl submit unavailable")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "Popen", boom)
+
+        waited = []
+        monkeypatch.setattr(
+            gateway_cli,
+            "_wait_for_pid_exit",
+            lambda pid, timeout: waited.append((pid, timeout)) or True,
+        )
+
+        run_calls = []
+
+        def fake_run(cmd, check=False, **kwargs):
+            run_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli.refresh_launchd_plist_if_needed() is True
+
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
         service_calls = [c for c in run_calls if "bootout" in c or "bootstrap" in c]
@@ -805,6 +934,8 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
         ]
+        # Drained the old pid between bootout and bootstrap.
+        assert waited and waited[0][0] == 4242
 
     def test_launchd_start_reloads_unloaded_job_and_retries(self, tmp_path, monkeypatch):
         plist_path = tmp_path / "ai.hermes.gateway.plist"

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -702,6 +702,16 @@ class TestLaunchdServiceRecovery:
 
         def fake_run(cmd, check=False, **kwargs):
             calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                # A bootstrapped job reports a supervised PID. Returning bare
+                # exit 0 here would mean "registered but not running", which the
+                # success check rightly rejects — and the loop would then retry
+                # for its full 30s budget.
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n\t"PID" = 5150;\n\t"Label" = "ai.hermes.gateway";\n};',
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -934,6 +944,14 @@ class TestLaunchdServiceRecovery:
 
         def fake_run(cmd, check=False, **kwargs):
             run_calls.append(cmd)
+            if cmd[:2] == ["launchctl", "list"]:
+                # Post-bootstrap launchd reports a supervised PID; without one
+                # the success check correctly refuses to stop retrying.
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n\t"PID" = 5150;\n\t"Label" = "ai.hermes.gateway";\n};',
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -3830,14 +3848,24 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
     PLIST = "/tmp/ai.hermes.gateway.plist"
     LABEL = "ai.hermes.gateway"
 
+    # `launchctl list <label>` output for a job launchd is actively running.
+    # Success requires a PID here, not just exit 0 — exit 0 alone also covers a
+    # registered-but-not-running definition (macOS 26+ `state = not running`).
+    RUNNING_LIST_OUTPUT = '{\n\t"PID" = 4242;\n\t"Label" = "ai.hermes.gateway";\n};'
+
     def test_returns_true_once_label_is_registered(self, monkeypatch):
-        """Success requires launchctl list to confirm registration, not just
-        a zero bootstrap exit."""
+        """Success requires launchctl list to confirm a supervised process, not
+        just a zero bootstrap exit."""
         list_results = iter([1, 0])  # first check: not registered, second: registered
 
         def fake_run(cmd, check=False, **kwargs):
             if cmd[:2] == ["launchctl", "list"]:
-                return SimpleNamespace(returncode=next(list_results))
+                rc = next(list_results)
+                return SimpleNamespace(
+                    returncode=rc,
+                    stdout=self.RUNNING_LIST_OUTPUT if rc == 0 else "",
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -3862,7 +3890,12 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
             if cmd[:2] == ["launchctl", "list"]:
                 # registered only after the second (successful) bootstrap
-                return SimpleNamespace(returncode=0 if attempts["bootstrap"] >= 2 else 1)
+                ok = attempts["bootstrap"] >= 2
+                return SimpleNamespace(
+                    returncode=0 if ok else 1,
+                    stdout=self.RUNNING_LIST_OUTPUT if ok else "",
+                    stderr="",
+                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
@@ -3874,6 +3907,37 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
         )
         assert ok is True
         assert attempts["bootstrap"] >= 2  # the timeout was retried, not raised
+
+    def test_registered_but_not_running_is_not_success(self, monkeypatch):
+        """A definition with no PID must not end the loop.
+
+        `launchctl list` exits 0 for a registered-but-not-running job (macOS
+        26+ `state = not running`), so exit-0 alone would report success for a
+        gateway launchd is not actually running. Verified against live launchd
+        on 2026-08-05.
+        """
+        list_calls = {"n": 0}
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                list_calls["n"] += 1
+                # Registered (exit 0) but no PID line — never running.
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout='{\n\t"Label" = "ai.hermes.gateway";\n};',
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
+
+        ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
+            self.DOMAIN, self.PLIST, self.LABEL,
+            deadline=gateway_cli.time.monotonic() - 1,  # already expired
+        )
+        assert ok is False
+        assert list_calls["n"] >= 1
 
     def test_returns_false_when_deadline_exhausts(self, monkeypatch):
         """When the label never registers, the loop stops at the deadline and


### PR DESCRIPTION
## Problem

The gateway can end up **unregistered from launchd entirely** after a plist reload — not crashed, just gone. `KeepAlive` cannot revive a job launchd no longer knows about, so the gateway stays dark until someone runs `launchctl bootstrap` by hand.

Observed signature in `~/.hermes/logs/launchd-reload.log`: a run of `bootstrap attempt N failed (rc=5)` lines that stops **without** the `FAILED launchd reload` exhaustion line — i.e. the retry loop was killed mid-reload rather than running out its deadline.

## Root cause

`refresh_launchd_plist_if_needed()` chose between an in-process bootout/bootstrap and a detached helper based on `_is_pid_ancestor_of_current_process()`. That test is wrong: what `bootout` tears down is the launchd job's **process coalition**, and coalition membership is inherited at spawn and survives reparenting. A gateway-spawned process whose intermediate parent has exited is reparented to PID 1 — no longer a POSIX descendant, but still in the coalition, and still killed by the bootout it just issued.

So the reload took the in-process path, bootout killed the loop mid-bootstrap, and nothing was left to re-register the label.

A second issue compounded it: `bootout` only sends SIGTERM, and the gateway then drains in-flight agent runs (`agent.restart_drain_timeout`, default 180s). Every `bootstrap` issued during that drain fails with EIO ("already loaded"), so the retry budget was being spent on attempts that could not succeed.

## Changes

- **Always prefer the detached transient-job helper.** It is also correct when genuinely outside the coalition, just asynchronous — so it is the safe default, and the in-process path becomes the fallback.
- **Wait for the old gateway PID to exit before bootstrapping** (bounded, so a wedged gateway can't block the reload), in both the helper script and the in-process path.
- **Fall through instead of giving up** when the transient job can't be spawned — previously this returned early, leaving the plist rewritten but the service never reloaded.
- **Require a supervised PID to call a reload successful.** `launchctl list <label>` exits 0 for a registered-but-not-running definition (macOS 26+ `state = not running`), the same trap `_probe_launchd_service_running()` already guards against.

## Verification

Exercised against live launchd using a throwaway label that simulates a slow SIGTERM drain. Racing the drain reproduces the failure (`bootstrap` → rc=5); waiting for the PID gives a clean rc=0 with a genuinely new instance. A `RunAtLoad=false` job reports exit 0 with no PID — accepted by the old success check, rejected by the new one.

Worth noting for reviewers: after `bootout` the label deregisters within ~1s while the old process drains on, so the PID guard is *not* what distinguishes a draining instance. Waiting for the old PID is what covers that; the PID guard covers registered-but-not-running.

## Also included

`test_run_gateway_refreshes_outdated_unit_on_boot` stubbed `start_gateway` but not `_exit_after_graceful_shutdown`, which is `os._exit()` by design (#53107). Unstubbed, it terminated the pytest process itself with status 0 — **186 of the file's 194 tests silently never ran, and the suite still reported success.** Neutralized the same way `tests/hermes_cli/test_gateway.py` does.

With that fixed the file runs 191 passed / 4 failed; the 4 are pre-existing `systemctl --user` tests that cannot pass on macOS (no user D-Bus session), identical before and after these changes.