### PR TITLE
fix(desktop): register reload/devtools shortcuts on Windows/Linux

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -15422,11 +15422,7 @@ app.whenReady().then(() => {
     safeStorageApi: safeStorage
   })
 
-  if (IS_MAC) {
-    Menu.setApplicationMenu(buildApplicationMenu())
-  } else {
-    Menu.setApplicationMenu(null)
-  }
+  Menu.setApplicationMenu(buildApplicationMenu())
 
   installMediaPermissions()
   installDownloadHandling()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11835,11 +11835,7 @@ app.whenReady().then(() => {
     rememberLog(`[tls] could not load Windows system CA certificates: ${systemCa.error}`)
   }
 
-  if (IS_MAC) {
-    Menu.setApplicationMenu(buildApplicationMenu())
-  } else {
-    Menu.setApplicationMenu(null)
-  }
+  Menu.setApplicationMenu(buildApplicationMenu())
 
   installMediaPermissions()
   registerMediaProtocol()


### PR DESCRIPTION
Closes #77845

Replaces `Menu.setApplicationMenu(null)` with `Menu.setApplicationMenu(buildApplicationMenu())` on non-macOS platforms so Electron registers the default role accelerators (Ctrl+R reload, Ctrl+Shift+R force-reload, F12 devtools).

The previous attempt used `new Menu()` which was incorrect — an empty menu suppresses Electron's default menu just like `null` does. This fix reuses the existing `buildApplicationMenu()` that macOS already uses. Every window is created with `autoHideMenuBar: true`, so the bar stays hidden while the accelerators work.