### PR TITLE
fix: redirect stdin to DEVNULL in non-verbose cua-driver installer (#79684)

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1549,6 +1549,7 @@ def _run_cua_driver_installer(
         else:
             proc = subprocess.Popen(
                 install_cmd, shell=use_shell, env=installer_env,
+                stdin=subprocess.DEVNULL,
                 stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                 text=True, encoding="utf-8", errors="replace",
                 creationflags=_post_setup_no_window_flags(),


### PR DESCRIPTION
## Summary

When `hermes update` runs the cua-driver installer non-interactively (verbose=False), stdout is captured via `subprocess.PIPE` but stdin is inherited from the parent process. The upstream `install.ps1` prompts `[Y/n]` when it detects a stale cua-driver daemon, but the prompt goes to captured stdout (invisible to the user) while stdin blocks waiting for input — causing an 11-minute hang until the 660s watchdog timeout.

## Root Cause

In `hermes_cli/tools_config.py:_run_cua_driver_installer()`, the non-verbose `subprocess.Popen` call (line 1550) captures stdout but does not redirect stdin. When the upstream installer's stale-daemon detection fires, it calls `Read-Host` (or equivalent) which:
1. Writes the prompt to stdout (captured/invisible)
2. Blocks on stdin (inherited from parent, still connected)
3. The user never sees the prompt and cannot respond
4. Hermes waits 660s then times out

## Fix

Add `stdin=subprocess.DEVNULL` to the non-verbose Popen call. The installer reads EOF immediately, exits quickly with a non-zero code, and the existing handler surfaces the manual re-run hint.

This is a 1-line change.

## Testing

- Verified the patch applies cleanly on current upstream/main
- The verbose path (interactive `computer-use install`) is unchanged — stdin remains inherited for that code path

Fixes #79684