### PR TITLE
fix(gateway): drop stale waiters after /stop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18936,37 +18936,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # to prevent. Released in _handle_message's finally via
         # _release_turn_lease — granted per (routing key, run generation) so a
         # stale unwind can't release a newer turn's lease.
-        _lease_registry = getattr(self, "_turn_leases", None)
-        if _lease_registry is not None:
-            try:
-                _lease_token = await _lease_registry.acquire(
-                    session_entry.session_id,
-                    owner_key=_quick_key,
-                    generation=run_generation,
-                    timeout=_float_env(
-                        "HERMES_TURN_LEASE_TIMEOUT", DEFAULT_LEASE_WAIT
-                    ),
-                )
-            except TurnLeaseTimeoutError:
-                # The broad session-context cleanup finally starts later in this
-                # method. Restore the tokens here before propagating the rejection
-                # to outer dispatch, or this early exit leaks task-local identity.
-                self._clear_session_env(_session_env_tokens)
-                raise
-            if _lease_token is not None:
-                _lease_state = self._session_state(_quick_key).turn
-                _lease_state.lease_token = _lease_token
-                _lease_state.lease_generation = run_generation
-        # /stop and /new invalidate the generation before releasing the active
-        # slot. A turn that was waiting on the old holder can wake afterward;
-        # drop it before transcript load or compression, while keeping the
-        # acquired token registered for the dispatch finally to release.
-        if not self._is_session_run_current(_quick_key, run_generation):
+        try:
+            _lease_is_current = await self._acquire_turn_lease_for_run(
+                _quick_key,
+                session_entry.session_id,
+                run_generation,
+                timeout=_float_env(
+                    "HERMES_TURN_LEASE_TIMEOUT", DEFAULT_LEASE_WAIT
+                ),
+            )
+        except TurnLeaseTimeoutError:
+            # The broad session-context cleanup finally starts later in this
+            # method. Restore the tokens here before propagating the rejection
+            # to outer dispatch, or this early exit leaks task-local identity.
+            self._clear_session_env(_session_env_tokens)
+            raise
+        # /stop and /new invalidate both the routing-key generation and the
+        # resolved-session lease epoch before releasing the active slot. A turn
+        # waiting under an alias key can wake afterward; drop it before history.
+        if not _lease_is_current:
             # /stop and /new invalidate the generation before releasing the
             # active slot. A turn already waiting on the old holder can wake
             # afterward; stop it before transcript load or compression. Mark
-            # this event so the outer finally preserves any newer owner.
+            # this event so the outer finally preserves any newer owner. This
+            # early return also precedes the broad session-context cleanup.
             setattr(event, "_stale_turn_before_history", True)
+            self._clear_session_env(_session_env_tokens)
             return {"final_response": "", "api_calls": 0, "interrupted": True}
 
         # A turn only becomes durable recovery work after it owns (or has
@@ -26178,6 +26173,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         token is registered first so the dispatch finally releases it normally.
         """
         registry = getattr(self, "_turn_leases", None)
+        token = None
         if registry is not None:
             token = await registry.acquire(
                 session_id,
@@ -26190,15 +26186,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 turn.lease_token = token
                 turn.lease_generation = run_generation
 
-        if not self._is_session_run_current(session_key, run_generation):
+        token_is_current = True
+        if registry is not None and token is not None:
+            token_is_current = registry.is_current(token)
+        if (
+            not token_is_current
+            or not self._is_session_run_current(session_key, run_generation)
+        ):
             logger.info(
                 "Dropping stale turn before transcript load for %s — "
-                "generation %s is no longer current",
+                "generation %s or resolved-session epoch is no longer current",
                 session_key or "?",
                 run_generation,
             )
             return False
         return True
+
+    def _invalidate_turn_lease_waiters(
+        self, session_key: str = "", session_id: str = ""
+    ) -> bool:
+        """Invalidate pre-existing waiters in one resolved-session lease domain."""
+        registry = getattr(self, "_turn_leases", None)
+        if registry is None:
+            return False
+        if not session_id and session_key:
+            state = self._peek_session_state(session_key)
+            token = state.turn.lease_token if state is not None else None
+            session_id = str(getattr(token, "session_id", "") or "")
+        if not session_id:
+            return False
+        return registry.invalidate(session_id)
 
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:
         """Release the turn lease acquired by (``session_key``, ``run_generation``).
@@ -26419,6 +26436,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not session_key:
             return
         _iac_state = self._peek_session_state(session_key)
+        # Invalidate the resolved-session lease domain before releasing the
+        # holder. This rejects alias-key waiters that have independent routing-
+        # key generations but target the same durable transcript.
+        self._invalidate_turn_lease_waiters(session_key=session_key)
         running_agent = _iac_state.turn.agent if _iac_state else None
         _process_task_id = ""
         _process_baseline = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17818,7 +17818,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
             # inside _run_agent returns False, and the old sentinel-only check here
             # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            # A turn rejected as stale before transcript load is different: a
+            # newer generation may already own this routing-key slot, so its
+            # unwind must use the generation guard and preserve that successor.
+            if getattr(event, "_stale_turn_before_history", False):
+                self._release_running_agent_state(
+                    _quick_key,
+                    run_generation=_run_generation,
+                )
+            else:
+                self._release_running_agent_state(_quick_key)
             # Turn lease (#64934): release THIS turn's lease token — keyed by
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
@@ -18948,6 +18957,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _lease_state = self._session_state(_quick_key).turn
                 _lease_state.lease_token = _lease_token
                 _lease_state.lease_generation = run_generation
+        # /stop and /new invalidate the generation before releasing the active
+        # slot. A turn that was waiting on the old holder can wake afterward;
+        # drop it before transcript load or compression, while keeping the
+        # acquired token registered for the dispatch finally to release.
+        if not self._is_session_run_current(_quick_key, run_generation):
+            # /stop and /new invalidate the generation before releasing the
+            # active slot. A turn already waiting on the old holder can wake
+            # afterward; stop it before transcript load or compression. Mark
+            # this event so the outer finally preserves any newer owner.
+            setattr(event, "_stale_turn_before_history", True)
+            return {"final_response": "", "api_calls": 0, "interrupted": True}
 
         # A turn only becomes durable recovery work after it owns (or has
         # explicitly degraded past) the per-session lease.  Marking before the
@@ -26140,6 +26160,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # between lifecycle transitions.  Preserves gateway_state (see
         # _persist_active_agents).
         self._persist_active_agents()
+        return True
+
+    async def _acquire_turn_lease_for_run(
+        self,
+        session_key: str,
+        session_id: str,
+        run_generation: int,
+        *,
+        timeout: float,
+    ) -> bool:
+        """Acquire the resolved-session lease and reject stale waiters.
+
+        A waiter may claim its routing-key slot before /stop invalidates the
+        generation, then resume only after the interrupted turn releases the
+        lease. Re-checking after the await closes that stale-waiter race. The
+        token is registered first so the dispatch finally releases it normally.
+        """
+        registry = getattr(self, "_turn_leases", None)
+        if registry is not None:
+            token = await registry.acquire(
+                session_id,
+                owner_key=session_key,
+                generation=run_generation,
+                timeout=timeout,
+            )
+            if token is not None:
+                turn = self._session_state(session_key).turn
+                turn.lease_token = token
+                turn.lease_generation = run_generation
+
+        if not self._is_session_run_current(session_key, run_generation):
+            logger.info(
+                "Dropping stale turn before transcript load for %s — "
+                "generation %s is no longer current",
+                session_key or "?",
+                run_generation,
+            )
+            return False
         return True
 
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15666,14 +15666,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # and interrupt alike.
             self._restore_moa_one_shot(event, _quick_key)
             self._restore_pending_one_turn_model_override(_quick_key)
-            # Unconditional release covers every exit path. _release_running_agent_state
-            # is idempotent (pop-on-absent is harmless) and, called without a
-            # run_generation guard, always clears the slot regardless of which
-            # generation it holds. This evicts the zombie left when session_reset
-            # bumps the generation (N -> N+1) mid-flight: gen-N's guarded release
-            # inside _run_agent returns False, and the old sentinel-only check here
-            # missed the leftover real agent — locking the session out forever (#28686).
-            self._release_running_agent_state(_quick_key)
+            # Normal exits clear unconditionally to evict zombies left by a mid-run
+            # reset (#28686). A turn rejected as stale before transcript load is
+            # different: a newer generation may already own this routing-key slot,
+            # so the stale unwind must use the generation guard and preserve it.
+            if getattr(event, "_stale_turn_before_history", False):
+                self._release_running_agent_state(
+                    _quick_key,
+                    run_generation=_run_generation,
+                )
+            else:
+                self._release_running_agent_state(_quick_key)
             # Turn lease (#64934): release THIS turn's lease token — keyed by
             # (routing key, run generation) so this unwind can only ever free
             # the lease its own turn acquired, never a newer turn's.
@@ -16516,18 +16519,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # _handle_message's finally via _release_turn_lease — granted per
         # (routing key, run generation) so a stale unwind can't release a
         # newer turn's lease.
-        _lease_registry = getattr(self, "_turn_leases", None)
-        if _lease_registry is not None:
-            _lease_token = await _lease_registry.acquire(
-                session_entry.session_id,
-                owner_key=_quick_key,
-                generation=run_generation,
-                timeout=_float_env("HERMES_AGENT_TIMEOUT", 1800),
-            )
-            if _lease_token is not None:
-                _lease_state = self._session_state(_quick_key).turn
-                _lease_state.lease_token = _lease_token
-                _lease_state.lease_generation = run_generation
+        if not await self._acquire_turn_lease_for_run(
+            _quick_key,
+            session_entry.session_id,
+            run_generation,
+            timeout=_float_env("HERMES_AGENT_TIMEOUT", 1800),
+        ):
+            # /stop and /new invalidate the generation before releasing the
+            # active slot. A turn already waiting on the old holder can wake
+            # afterward; stop it before transcript load or compression. Mark
+            # this event so the outer finally preserves any newer owner.
+            setattr(event, "_stale_turn_before_history", True)
+            return {"final_response": "", "api_calls": 0, "interrupted": True}
 
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)
@@ -22694,6 +22697,44 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # between lifecycle transitions.  Preserves gateway_state (see
         # _persist_active_agents).
         self._persist_active_agents()
+        return True
+
+    async def _acquire_turn_lease_for_run(
+        self,
+        session_key: str,
+        session_id: str,
+        run_generation: int,
+        *,
+        timeout: float,
+    ) -> bool:
+        """Acquire the resolved-session lease and reject stale waiters.
+
+        A waiter may claim its routing-key slot before /stop invalidates the
+        generation, then resume only after the interrupted turn releases the
+        lease. Re-checking after the await closes that stale-waiter race. The
+        token is registered first so the dispatch finally releases it normally.
+        """
+        registry = getattr(self, "_turn_leases", None)
+        if registry is not None:
+            token = await registry.acquire(
+                session_id,
+                owner_key=session_key,
+                generation=run_generation,
+                timeout=timeout,
+            )
+            if token is not None:
+                turn = self._session_state(session_key).turn
+                turn.lease_token = token
+                turn.lease_generation = run_generation
+
+        if not self._is_session_run_current(session_key, run_generation):
+            logger.info(
+                "Dropping stale turn before transcript load for %s — "
+                "generation %s is no longer current",
+                session_key or "?",
+                run_generation,
+            )
+            return False
         return True
 
     def _release_turn_lease(self, session_key: str, run_generation: int) -> bool:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -145,8 +145,15 @@ class GatewaySlashCommandsMixin:
         """Handle /new or /reset command."""
         source = event.source
         
-        # Get existing session key
+        # Get existing session key and invalidate the resolved-session lease
+        # domain before releasing the holder. This catches blocked alias-key
+        # waiters whose routing-key generation is independent.
         session_key = self._session_key_for_source(source)
+        old_entry = self.session_store._entries.get(session_key)
+        self._invalidate_turn_lease_waiters(
+            session_key=session_key,
+            session_id=str(getattr(old_entry, "session_id", "") or ""),
+        )
         self._invalidate_session_run_generation(session_key, reason="session_reset")
         # Evict the running-agent slot now that the generation is bumped. The
         # in-flight run's own guarded release (run_generation=old) will return
@@ -154,10 +161,6 @@ class GatewaySlashCommandsMixin:
         # from becoming a zombie that silently drops all later messages (#28686).
         # Idempotent, so the run's finally calling it again is harmless.
         self._release_running_agent_state(session_key)
-
-        # Snapshot the old entry so on_session_finalize can report the
-        # expiring session id before reset_session() rotates it.
-        old_entry = self.session_store._entries.get(session_key)
 
         # Close tool resources on the old agent (terminal sandboxes, browser
         # daemons, background processes) before evicting from cache.

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -102,23 +102,26 @@ class TurnLeaseToken:
     release idempotent.
     """
 
-    __slots__ = ("session_id", "owner_key", "generation", "released")
+    __slots__ = ("session_id", "owner_key", "generation", "epoch", "released")
 
     def __init__(
         self,
         session_id: str,
         owner_key: str,
         generation: int,
+        epoch: int,
     ) -> None:
         self.session_id = session_id
         self.owner_key = owner_key
         self.generation = generation
+        self.epoch = epoch
         self.released = False
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return (
             f"TurnLeaseToken(session_id={self.session_id!r}, "
             f"owner_key={self.owner_key!r}, generation={self.generation}, "
+            f"epoch={self.epoch}, "
             f"released={self.released})"
         )
 
@@ -130,6 +133,7 @@ class _SessionLease:
         "acquired_at",
         "last_used",
         "pending_acquires",
+        "epoch",
     )
 
     def __init__(self) -> None:
@@ -138,6 +142,7 @@ class _SessionLease:
         self.acquired_at = 0.0
         self.last_used = time.time()
         self.pending_acquires = 0
+        self.epoch = 0
 
     @property
     def idle(self) -> bool:
@@ -206,8 +211,12 @@ class SessionTurnLeaseRegistry:
         if not session_id:
             return None
         wait = float(timeout) if timeout and timeout > 0 else DEFAULT_LEASE_WAIT
-        token = TurnLeaseToken(session_id, owner_key, int(generation))
         lease = self._get_or_create(session_id)
+        # Snapshot before waiting: /stop or /new can invalidate the resolved
+        # session while this acquire is blocked behind an alias-key holder.
+        token = TurnLeaseToken(
+            session_id, owner_key, int(generation), epoch=lease.epoch
+        )
 
         if lease.lock.locked():
             holder = lease.holder
@@ -262,6 +271,22 @@ class SessionTurnLeaseRegistry:
         lease.acquired_at = time.time()
         lease.last_used = lease.acquired_at
         return token
+
+    def invalidate(self, session_id: str) -> bool:
+        """Invalidate acquires already waiting in this resolved-session domain."""
+        lease = self._leases.get(session_id)
+        if lease is None:
+            return False
+        lease.epoch += 1
+        lease.last_used = time.time()
+        return True
+
+    def is_current(self, token: Optional[TurnLeaseToken]) -> bool:
+        """Return whether ``token`` survived resolved-session invalidation."""
+        if token is None or token.released:
+            return False
+        lease = self._leases.get(token.session_id)
+        return lease is not None and token.epoch == lease.epoch
 
     def rebind(self, token: Optional[TurnLeaseToken], new_session_id: str) -> bool:
         """Alias a HELD lease onto ``new_session_id`` after mid-turn rotation.

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -103,6 +103,30 @@ async def test_sentinel_placed_before_agent_setup():
     )
 
 
+@pytest.mark.asyncio
+async def test_stale_pre_history_unwind_preserves_newer_generation_state():
+    """A waiter invalidated behind the turn lease must not clear its successor."""
+    runner = _make_runner()
+    event = _make_event()
+    session_key = build_session_key(event.source)
+    newer_agent = MagicMock()
+
+    async def stale_inner(self_inner, ev, src, qk, generation):
+        self_inner._invalidate_session_run_generation(qk, reason="test-stop")
+        state = self_inner._session_state(qk)
+        state.turn.agent = newer_agent
+        state.turn.started_ts = 123.0
+        setattr(ev, "_stale_turn_before_history", True)
+        return {"final_response": "", "api_calls": 0, "interrupted": True}
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", stale_inner):
+        result = await runner._handle_message(event)
+
+    assert result == {"final_response": "", "api_calls": 0, "interrupted": True}
+    assert runner._running_agents.get(session_key) is newer_agent
+    assert runner._running_agents_ts.get(session_key) == 123.0
+
+
 # ------------------------------------------------------------------
 # Test 2: Sentinel is cleaned up after _handle_message_with_agent
 # ------------------------------------------------------------------

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -514,3 +514,113 @@ def test_runner_drops_waiter_invalidated_while_acquiring_turn_lease():
         assert runner._release_turn_lease(key, 1) is True
 
     _run(scenario())
+
+
+def test_runner_drops_alias_waiter_when_holder_session_is_invalidated():
+    """Stopping one routing key invalidates a blocked alias on the same session."""
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        runner._sessions = {}
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        session_id = "sess-alias-stop-race"
+        runner._session_state("key-b").persistent.run_generation = 1
+
+        holder = await runner._turn_leases.acquire(
+            session_id, owner_key="key-a", generation=1, timeout=5
+        )
+        runner._session_state("key-a").turn.lease_token = holder
+        runner._session_state("key-a").turn.lease_generation = 1
+        waiter = asyncio.create_task(
+            runner._acquire_turn_lease_for_run("key-b", session_id, 1, timeout=5)
+        )
+        await asyncio.sleep(0.02)
+        assert not waiter.done()
+
+        assert runner._invalidate_turn_lease_waiters(session_key="key-a") is True
+        assert runner._turn_leases.release(holder) is True
+
+        assert await waiter is False
+        assert runner._release_turn_lease("key-b", 1) is True
+
+    _run(scenario())
+
+
+def test_waiter_started_after_invalidation_remains_valid():
+    """Invalidation rejects only pre-command work, not a later replacement turn."""
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        runner._sessions = {}
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        session_id = "sess-post-stop"
+        runner._session_state("key-b").persistent.run_generation = 1
+        runner._session_state("key-c").persistent.run_generation = 1
+
+        holder = await runner._turn_leases.acquire(
+            session_id, owner_key="key-a", generation=1, timeout=5
+        )
+        runner._session_state("key-a").turn.lease_token = holder
+        runner._session_state("key-a").turn.lease_generation = 1
+        stale = asyncio.create_task(
+            runner._acquire_turn_lease_for_run("key-b", session_id, 1, timeout=5)
+        )
+        await asyncio.sleep(0.02)
+        assert runner._invalidate_turn_lease_waiters(session_key="key-a") is True
+        fresh = asyncio.create_task(
+            runner._acquire_turn_lease_for_run("key-c", session_id, 1, timeout=5)
+        )
+        await asyncio.sleep(0.02)
+        assert runner._turn_leases.release(holder) is True
+
+        assert await stale is False
+        assert runner._release_turn_lease("key-b", 1) is True
+        assert await fresh is True
+        assert runner._release_turn_lease("key-c", 1) is True
+
+    _run(scenario())
+
+
+@pytest.mark.asyncio
+async def test_agent_path_drops_invalidated_alias_before_loading_transcript(
+    monkeypatch, tmp_path
+):
+    """The production acquisition site rejects a pre-/stop alias waiter."""
+    from tests.gateway.test_42039_duplicate_user_message import (
+        _bootstrap,
+        _event,
+        _source,
+    )
+
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner._turn_leases = SessionTurnLeaseRegistry()
+    runner._session_state("key-b").persistent.run_generation = 1
+    holder = await runner._turn_leases.acquire(
+        "sess-dedup", owner_key="key-a", generation=1, timeout=1
+    )
+    runner._session_state("key-a").turn.lease_token = holder
+    runner._session_state("key-a").turn.lease_generation = 1
+    session_env_tokens = object()
+    runner._set_session_env = MagicMock(return_value=session_env_tokens)
+    runner._clear_session_env = MagicMock()
+
+    waiter = asyncio.create_task(
+        runner._handle_message_with_agent(_event(), _source(), "key-b", 1)
+    )
+    for _ in range(100):
+        lease = runner._turn_leases._leases["sess-dedup"]
+        if lease.pending_acquires:
+            break
+        await asyncio.sleep(0)
+    assert runner._turn_leases._leases["sess-dedup"].pending_acquires == 1
+
+    assert runner._invalidate_turn_lease_waiters(session_key="key-a") is True
+    assert runner._turn_leases.release(holder) is True
+
+    result = await waiter
+    assert result == {"final_response": "", "api_calls": 0, "interrupted": True}
+    runner.session_store.load_transcript.assert_not_called()
+    runner._clear_session_env.assert_called_once_with(session_env_tokens)
+    assert runner._release_turn_lease("key-b", 1) is True

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -17,6 +17,7 @@ Covers:
 - registry stays bounded; live and pending leases are never evicted
 - timed-out and cancelled acquire attempts do not pin idle registry entries
 - GatewayRunner._release_turn_lease wiring (bare-runner safe, token-scoped)
+- a waiter invalidated by /stop while blocked is dropped before transcript load
 """
 
 import asyncio
@@ -476,5 +477,40 @@ def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
         assert runner._release_turn_lease("key-a", 1) is False
         # Empty key guard.
         assert runner._release_turn_lease("", 1) is False
+
+    _run(scenario())
+
+
+def test_runner_drops_waiter_invalidated_while_acquiring_turn_lease():
+    """A pre-/stop waiter must not resume into history load/compression."""
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        runner._sessions = {}
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        key = "key-a"
+        session_id = "sess-stop-race"
+        runner._session_state(key).persistent.run_generation = 1
+
+        holder = await runner._turn_leases.acquire(
+            session_id, owner_key="holder", generation=1, timeout=5
+        )
+        waiter = asyncio.create_task(
+            runner._acquire_turn_lease_for_run(
+                key, session_id, 1, timeout=5
+            )
+        )
+        await asyncio.sleep(0.02)
+        assert not waiter.done()
+
+        # /stop invalidates the waiter before the old turn unwinds.
+        runner._session_state(key).persistent.run_generation = 2
+        assert runner._turn_leases.release(holder) is True
+
+        assert await waiter is False
+        # The normal dispatch finally remains responsible for releasing the
+        # stale generation's newly acquired token.
+        assert runner._release_turn_lease(key, 1) is True
 
     _run(scenario())

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -15,6 +15,7 @@ Covers:
   token, never a wedged session, and the degraded token releases nothing
 - registry stays bounded; live leases are never evicted
 - GatewayRunner._release_turn_lease wiring (bare-runner safe, token-scoped)
+- a waiter invalidated by /stop while blocked is dropped before transcript load
 """
 
 import asyncio
@@ -156,5 +157,40 @@ def test_runner_release_turn_lease_is_token_scoped_and_bare_safe():
         assert runner._release_turn_lease("key-a", 1) is False
         # Empty key guard.
         assert runner._release_turn_lease("", 1) is False
+
+    _run(scenario())
+
+
+def test_runner_drops_waiter_invalidated_while_acquiring_turn_lease():
+    """A pre-/stop waiter must not resume into history load/compression."""
+    from gateway.run import GatewayRunner
+
+    async def scenario():
+        runner = object.__new__(GatewayRunner)
+        runner._sessions = {}
+        runner._turn_leases = SessionTurnLeaseRegistry()
+        key = "key-a"
+        session_id = "sess-stop-race"
+        runner._session_state(key).persistent.run_generation = 1
+
+        holder = await runner._turn_leases.acquire(
+            session_id, owner_key="holder", generation=1, timeout=5
+        )
+        waiter = asyncio.create_task(
+            runner._acquire_turn_lease_for_run(
+                key, session_id, 1, timeout=5
+            )
+        )
+        await asyncio.sleep(0.02)
+        assert not waiter.done()
+
+        # /stop invalidates the waiter before the old turn unwinds.
+        runner._session_state(key).persistent.run_generation = 2
+        assert runner._turn_leases.release(holder) is True
+
+        assert await waiter is False
+        # The normal dispatch finally remains responsible for releasing the
+        # stale generation's newly acquired token.
+        assert runner._release_turn_lease(key, 1) is True
 
     _run(scenario())


### PR DESCRIPTION
## What does this PR do?

Prevents a gateway turn invalidated by `/stop` or `/new` while waiting on the resolved-session turn lease from resuming into transcript load or proactive compression.

A turn claims its routing-key slot before entering async setup. If it then blocks on the per-session lease, `/stop` can invalidate that generation and release the active slot while the waiter remains alive. When the old holder exits, the stale waiter previously resumed despite no longer owning the routing key. A newer turn could then collide with that stale compression writer and fail session persistence.

The fix re-checks run-generation ownership after lease acquisition. The token is registered before that check so the existing dispatch `finally` releases it. Stale pre-history exits use generation-guarded running-state cleanup, preserving any newer turn's sentinel or agent; normal exits retain unconditional zombie cleanup for #28686.

## Related Issue

Follow-up to #64934 and #67401.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: re-check generation currency after the resolved-session lease wait and preserve newer running state during a stale unwind.
- `tests/gateway/test_turn_lease.py`: reproduce invalidation while a waiter is blocked and verify its acquired token still releases.
- `tests/gateway/test_session_race_guard.py`: verify stale cleanup cannot clear a newer generation's sentinel/agent state.

## How to Test

1. Start a turn for a session and hold its resolved-session turn lease.
2. Queue a second turn, invalidate its run generation as `/stop` does, then release the holder.
3. Verify the waiter reports interruption before transcript load and its lease token releases.
4. Verify a newer generation's running-agent state survives the stale turn's outer `finally`.

Focused verification:

```text
python -m pytest -q -o addopts='' \
  tests/gateway/test_turn_lease.py \
  tests/gateway/test_session_state_cleanup.py \
  tests/gateway/test_session_race_guard.py \
  tests/gateway/test_pending_drain_no_recursion.py \
  tests/gateway/test_stop_thread_sibling.py \
  tests/gateway/test_compression_interrupt_demotion_56391.py
# 30 passed

python -m ruff check gateway/run.py \
  tests/gateway/test_turn_lease.py \
  tests/gateway/test_session_race_guard.py
# All checks passed

python -m compileall -q gateway
git diff --check HEAD^..HEAD
```

Red/green verification: `test_stale_pre_history_unwind_preserves_newer_generation_state` fails on untouched upstream `main` because the stale unwind removes the newer agent, and passes on this candidate.

The repository-wide `scripts/run_tests.sh` was also attempted. In this local macOS environment the candidate reported 68 failures across 27 unrelated provider/tool suites; untouched upstream `main` reproduced the same baseline cluster with 70 failures. The focused and adjacent gateway suites above remain 30/30 green, so the full-suite checkbox below is intentionally left unchecked pending hermetic CI.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal and documented inline
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — the change uses existing platform-independent async/session primitives
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

N/A — gateway concurrency fix with behavioral regression coverage.
