### PR TITLE
fix(agent): surface memory-full / init failures to user instead of silent drop

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1690,7 +1690,7 @@ def init_agent(
                 )
                 agent._memory_store.load_from_disk()
         except Exception:
-            pass  # Memory is optional -- don't break agent init
+            logger.warning("Memory store init failed — agent running without memory", exc_info=True)
     
 
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1730,6 +1730,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_call_id=getattr(tool_call, "id", None),
                         ),
                     )
+                # Surface memory-full / consolidation failure to the user.
+                # Without this the user has no idea writes are being silently
+                # dropped (the tool result is only seen by the model).
+                try:
+                    parsed = json.loads(result) if isinstance(result, str) else result
+                    if isinstance(parsed, dict) and not parsed.get("success"):
+                        usage = parsed.get("usage", "unknown")
+                        agent._emit_warning(
+                            f"⚠️ Memory write rejected ({usage}). "
+                            "Consolidate entries or raise memory.memory_char_limit."
+                        )
+                except Exception:
+                    pass
                 return result
             function_result, function_args, middleware_trace, _execution_blocked, _execution_dispatched = _managed_values(_run_agent_tool_execution_middleware(
                 agent,


### PR DESCRIPTION
## What does this PR do?

When **MEMORY.md** reaches the char limit, the `memory` tool returns an error dict
to the model. The model retries, fails again, eventually gets the "stop retrying"
signal, and proceeds to answer normally — but **the user is never told memory is
full or that writes were silently dropped**.

Two changes:

### 1. Log MemoryStore init failures (agent/agent_init.py:~1693)

Replace bare `except: pass` with `logger.warning(exc_info=True)` so init
failures produce a visible log record instead of silent swallow.

### 2. Surface memory-full to user (agent/tool_executor.py:~1733)

Before `return result` on memory tool writes, check whether the result signals
a consolidation failure (`success=False`) and emit a user-visible warning via
`_emit_warning()` with the current usage ratio. Without this the model silently
retries 3× and then gives up — the user has no clue their instructions were
never persisted.

## Related Issue

Fixes #79472

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Verification

After restart, when memory is near capacity, the user will see:

> ⚠️ Memory write rejected (4,929/5,000 chars). Consolidate entries or raise memory.memory_char_limit.

Instead of silence.

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have tested on my platform: macOS 15.7
