### PR TITLE
fix(windows): pass CREATE_NO_WINDOW when scanning for gateway PIDs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -23,6 +23,7 @@ from gateway.restart import (
     GATEWAY_SERVICE_RESTART_EXIT_CODE,
     parse_restart_drain_timeout,
 )
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.config import (
     get_env_value,
     get_hermes_home,
@@ -391,6 +392,11 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                         encoding="utf-8",
                         errors="ignore",
                         timeout=10,
+                        # Without CREATE_NO_WINDOW this pops a console window
+                        # on every scan. ``hermes gateway status`` runs one,
+                        # and anything polling gateway liveness runs one per
+                        # poll, so the flash is constant on Windows.
+                        creationflags=windows_hide_flags(),
                     )
                 except (OSError, subprocess.TimeoutExpired):
                     result = None
@@ -416,6 +422,9 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                         encoding="utf-8",
                         errors="ignore",
                         timeout=15,
+                        # Same as the wmic branch above — and this is the path
+                        # modern Windows 11 actually takes, since wmic is gone.
+                        creationflags=windows_hide_flags(),
                     )
                 except (OSError, subprocess.TimeoutExpired):
                     return []


### PR DESCRIPTION
## Problem

`_scan_gateway_pids()` in `hermes_cli/gateway.py` shells out to read the Windows process table — `wmic`, or PowerShell's `Get-CimInstance` on Windows 11 where wmic has been removed — but neither call passes `creationflags`.

This is the one Windows subprocess path in the codebase that skips `windows_hide_flags()`. Everywhere else already does it, for exactly this reason:

- `hermes_cli/gateway_windows.py` passes `CREATE_NO_WINDOW` to `schtasks` with the comment *"avoids a flashing console window when the CLI is itself hosted in a TUI"*
- `hermes_cli/_subprocess_compat.py` documents the helper as covering *"Console-window flashes — every `subprocess.Popen` of a `.exe` on Windows spawns a cmd window briefly unless `CREATE_NO_WINDOW` is passed"*

It matters because this scan is on a hot path: `hermes gateway status` runs one, and anything polling gateway liveness runs one per poll. When the caller has no console of its own — the gateway runs under `pythonw.exe`, and GUI hosts have none either — Windows gives the child a brand-new **visible** console rather than an inherited one.

## Change

Pass `creationflags=windows_hide_flags()` to both the wmic and the PowerShell invocation. The helper returns `0` on non-Windows, and both call sites are already inside `if is_windows():`, so there is no POSIX impact.

## Testing

- `tests/hermes_cli/test_gateway_windows.py` + `tests/hermes_cli/test_gateway_service.py`: **34 passed, 1 skipped** on Windows 11
- `tests/hermes_cli/test_gateway.py` has 6 failures on Windows, but they are **pre-existing and unrelated** — they monkeypatch `os.geteuid`, which does not exist on Windows. Verified they fail identically with this commit reverted.

## A note on what I could and could not verify

I could not capture a before/after screenshot of the visible flash. Measuring this from an automated harness turned out to be unreliable, and I would rather say so than overclaim:

- Counting `conhost.exe` processes is **not** a proxy for a visible window. `CREATE_NO_WINDOW` actually *increases* the conhost count in some setups, because the child is denied the inherited console and gets its own headless one — which is the desired outcome, not a regression.
- When the parent already owns a console, both variants are flash-free (the child just inherits it), so the difference is invisible from a normal terminal.
- In my process tree everything was already spawned hidden, so even a console-less parent (`pythonw.exe`) produced no visible window in either variant when I enumerated top-level windows with `IsWindowVisible`.

So the justification here is Win32 semantics plus consistency with the rest of the codebase, not a captured repro. If a maintainer on a Windows box with an interactive desktop session can confirm the flash on `hermes gateway status` before/after, that would settle it.

## Relationship to #42544

Related but **not a fix** for it. That issue is about the terminal tool's git-bash spawns, where `CREATE_NO_WINDOW` is reportedly insufficient because MSYS2's `bash.exe` allocates its own console. This PR only removes the same class of flash from the gateway PID scan, which is plain `wmic`/`powershell.exe` and does not have that complication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017eGq5qoHF6es7Vwh7qRFeh
