### PR TITLE
fix(gateway): add cooldown when hygiene compression still exceeds hard limit (#79540)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17196,6 +17196,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                             _reset_hygiene_failure_streak(
                                                 self, session_key
                                             )
+                                    # Compression made progress (rows or tokens
+                                    # reduced) but the session is STILL above the
+                                    # hard message-count limit — record a cooldown
+                                    # so the next inbound message does not
+                                    # immediately re-trigger the same expensive
+                                    # compression that cannot push below the floor
+                                    # (#79540).  Without this guard, every message
+                                    # burns 75-187 s compressing 416→404→416→…
+                                    # forever.
+                                    if (
+                                        not _hyg_aborted
+                                        and _new_count >= _HARD_MSG_LIMIT
+                                        and _hyg_failure_cooldown_seconds >= 0
+                                    ):
+                                        _still_over_cooldown = max(
+                                            _hyg_failure_cooldown_seconds, 60.0
+                                        )
+                                        _record_hygiene_cooldown(
+                                            self,
+                                            session_entry.session_id,
+                                            _still_over_cooldown,
+                                        )
+                                        logger.warning(
+                                            "Session hygiene: compressed %s → %s msgs "
+                                            "but still >= hard limit (%s); "
+                                            "cooling down for %.0fs to avoid "
+                                            "re-trigger loop (#79540)",
+                                            _msg_count, _new_count,
+                                            _HARD_MSG_LIMIT,
+                                            _still_over_cooldown,
+                                        )
                                     if _hyg_aborted:
                                         if _hyg_failure_cooldown_seconds >= 0:
                                             _record_hygiene_cooldown(


### PR DESCRIPTION
## Summary

Fixes #79540. When session-hygiene compression runs successfully but the post-compression message count is still at or above `hygiene_hard_message_limit`, record a cooldown to prevent the next inbound message from immediately re-triggering the same expensive compression.

## Problem

Every inbound message triggers hygiene compression that takes 75-187s, compressing e.g. 416→404 messages. Since 404 >= 400 (the hard limit), the next message re-triggers compression. Infinite loop — the gateway blocks for minutes on every message.

## Root Cause

The existing cooldown mechanism only fires when compression **aborts** (summary generation fails). When compression succeeds but doesn't push `_msg_count` below `_HARD_MSG_LIMIT`, no cooldown is recorded and `_compression_made_progress` returns True (rows reduced), so the failure streak is reset. The next message immediately re-triggers.

## Fix

After the progress check, if `_new_count >= _HARD_MSG_LIMIT` (session still over the hard limit), record a cooldown using the same `_record_hygiene_cooldown` / `_hygiene_cooldown_for_failure` mechanism. Duration: `max(hygiene_failure_cooldown_seconds, 60s)`.

## Changes

- `gateway/run.py`: Add cooldown guard after compression progress check when session remains above hard message-count limit

## Testing

- All 14 existing `test_session_hygiene` tests pass
- Syntax and lint clean
