### PR TITLE
fix(agent): constrain image payloads and enforce a request-body budget for the ChatGPT Codex transport

### DIFF
--- a/agent/image_payloads.py
+++ b/agent/image_payloads.py
@@ -38,12 +38,11 @@ def _positive_int(raw: Any, default: int) -> int:
     return default
 
 
-def get_native_image_limits() -> tuple[int, int]:
-    """Load native-image limits from the cached Hermes configuration.
+def agent_config_int(key: str, default: int) -> int:
+    """Positive-int value of ``agent.<key>`` from the cached configuration.
 
-    ``native_image_max_payload_bytes`` limits the complete ASCII data URL
-    (``data:<mime>;base64,<encoded bytes>``), not the raw file size.
-    Malformed, missing, zero, or negative values fall back to safe defaults.
+    Malformed, missing, zero, or negative values fall back to ``default``.
+    The config loader caches on file mtime, so this is safe on hot paths.
     """
     agent_cfg: dict[str, Any] = {}
     try:
@@ -56,13 +55,23 @@ def get_native_image_limits() -> tuple[int, int]:
     except Exception as exc:  # pragma: no cover - defensive config fallback
         logger.debug("image_payloads: could not load config; using defaults: %s", exc)
 
+    return _positive_int(agent_cfg.get(key), default)
+
+
+def get_native_image_limits() -> tuple[int, int]:
+    """Load native-image limits from the cached Hermes configuration.
+
+    ``native_image_max_payload_bytes`` limits the complete ASCII data URL
+    (``data:<mime>;base64,<encoded bytes>``), not the raw file size.
+    Malformed, missing, zero, or negative values fall back to safe defaults.
+    """
     return (
-        _positive_int(
-            agent_cfg.get("native_image_max_payload_bytes"),
+        agent_config_int(
+            "native_image_max_payload_bytes",
             DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES,
         ),
-        _positive_int(
-            agent_cfg.get("native_image_max_dimension"),
+        agent_config_int(
+            "native_image_max_dimension",
             DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
         ),
     )

--- a/agent/image_payloads.py
+++ b/agent/image_payloads.py
@@ -1,0 +1,291 @@
+"""Size constraints for images embedded in native model payloads.
+
+This module intentionally operates on in-memory bytes.  The cached source file
+is never modified.  Small images pass through byte-for-byte; oversized images
+are decoded with Pillow, EXIF-oriented, and re-encoded as JPEG or PNG until the
+complete base64 data-URL payload fits the configured limit.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+from io import BytesIO
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# The ChatGPT Codex transport's effective image ceiling varies with the full
+# request envelope.  Keep enough headroom for prompts and tool schemas while
+# preserving useful phone-photo resolution.  Both values remain configurable
+# for providers with different proven limits.
+DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES = 900_000
+DEFAULT_NATIVE_IMAGE_MAX_DIMENSION = 2560
+
+
+def _positive_int(raw: Any, default: int) -> int:
+    """Return a positive integer config value, otherwise *default*."""
+    if isinstance(raw, bool):
+        return default
+    if isinstance(raw, int):
+        return raw if raw > 0 else default
+    if isinstance(raw, str):
+        try:
+            parsed = int(raw.strip())
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+    return default
+
+
+def get_native_image_limits() -> tuple[int, int]:
+    """Load native-image limits from the cached Hermes configuration.
+
+    ``native_image_max_payload_bytes`` limits the complete ASCII data URL
+    (``data:<mime>;base64,<encoded bytes>``), not the raw file size.
+    Malformed, missing, zero, or negative values fall back to safe defaults.
+    """
+    agent_cfg: dict[str, Any] = {}
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        raw_agent_cfg = cfg.get("agent") if isinstance(cfg, dict) else None
+        if isinstance(raw_agent_cfg, dict):
+            agent_cfg = raw_agent_cfg
+    except Exception as exc:  # pragma: no cover - defensive config fallback
+        logger.debug("image_payloads: could not load config; using defaults: %s", exc)
+
+    return (
+        _positive_int(
+            agent_cfg.get("native_image_max_payload_bytes"),
+            DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES,
+        ),
+        _positive_int(
+            agent_cfg.get("native_image_max_dimension"),
+            DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
+        ),
+    )
+
+
+def data_url_payload_size(raw_size: int, mime: str) -> int:
+    """Return the exact ASCII byte length of a base64 data URL."""
+    encoded_size = 4 * ((max(0, raw_size) + 2) // 3)
+    return len(f"data:{mime};base64,") + encoded_size
+
+
+def _has_transparency(image: Any) -> bool:
+    """Conservatively detect images that must retain an alpha channel."""
+    try:
+        if "A" in image.getbands():
+            return True
+    except Exception:
+        pass
+    return "transparency" in getattr(image, "info", {})
+
+
+def _encode_candidate(image: Any, output_format: str, quality: Optional[int]) -> bytes:
+    buf = BytesIO()
+    if output_format == "JPEG":
+        image.save(
+            buf,
+            format="JPEG",
+            quality=quality,
+            optimize=True,
+            subsampling="4:2:0",
+        )
+    else:
+        image.save(buf, format="PNG", optimize=True, compress_level=9)
+    return buf.getvalue()
+
+
+def constrain_image_payload(
+    raw: bytes,
+    mime: str,
+    *,
+    max_payload_bytes: int,
+    max_dimension: int,
+) -> Optional[tuple[bytes, str]]:
+    """Return provider-safe image bytes/MIME within native payload limits.
+
+    If the complete data URL is within ``max_payload_bytes`` and the longest
+    image side is within ``max_dimension``, the original bytes and MIME are
+    returned unchanged.  Otherwise Pillow processes the image entirely in
+    memory: the first frame is selected for animated inputs, EXIF orientation
+    is applied, and the image is encoded as JPEG (opaque) or PNG (transparent).
+    JPEG quality is reduced before dimensions are reduced.  Images are never
+    upscaled.
+
+    ``None`` is a safe failure result for oversized images Pillow cannot decode
+    or images that cannot fit even at minimum dimensions.  Callers should skip
+    that attachment rather than sending the original oversized payload.
+    """
+    max_payload_bytes = _positive_int(
+        max_payload_bytes, DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES
+    )
+    max_dimension = _positive_int(
+        max_dimension, DEFAULT_NATIVE_IMAGE_MAX_DIMENSION
+    )
+
+    over_payload = data_url_payload_size(len(raw), mime) > max_payload_bytes
+    requires_processing = over_payload
+
+    try:
+        from PIL import Image, ImageOps
+    except ImportError:
+        if over_payload:
+            logger.warning(
+                "image_payloads: Pillow unavailable; skipping oversized native image"
+            )
+            return None
+        # Pillow is a core dependency, but preserve a byte-safe attachment if a
+        # broken/minimal installation lacks it. Dimension validation is the only
+        # unavailable check in this fallback.
+        return raw, mime
+
+    try:
+        with Image.open(BytesIO(raw)) as opened:
+            over_dimension = max(opened.size) > max_dimension
+            requires_processing = over_payload or over_dimension
+            if not requires_processing:
+                return raw, mime
+
+            frame_count = int(getattr(opened, "n_frames", 1) or 1)
+            if frame_count > 1:
+                logger.info(
+                    "image_payloads: oversized animated image has %d frames; "
+                    "using the first frame",
+                    frame_count,
+                )
+                opened.seek(0)
+
+            image = ImageOps.exif_transpose(opened)
+            image.load()
+            # Detach from the source context before it closes.
+            image = image.copy()
+    except Exception as exc:
+        if requires_processing:
+            logger.warning(
+                "image_payloads: Pillow could not process oversized image; "
+                "skipping attachment: %s",
+                exc,
+            )
+            return None
+        # A byte-safe corrupt/mislabelled image follows the historical
+        # best-effort behavior; provider validation remains the final arbiter.
+        logger.debug(
+            "image_payloads: could not inspect byte-safe image dimensions; "
+            "preserving original bytes: %s",
+            exc,
+        )
+        return raw, mime
+
+    original_dimensions = image.size
+    if max(image.size) > max_dimension:
+        scale = max_dimension / max(image.size)
+        constrained_size = (
+            max(1, round(image.width * scale)),
+            max(1, round(image.height * scale)),
+        )
+        image = image.resize(constrained_size, Image.Resampling.LANCZOS)
+
+    transparent = _has_transparency(image)
+    if transparent:
+        output_format = "PNG"
+        output_mime = "image/png"
+        if image.mode not in {"RGBA", "LA", "P"}:
+            image = image.convert("RGBA")
+        quality_steps: tuple[Optional[int], ...] = (None,)
+    else:
+        output_format = "JPEG"
+        output_mime = "image/jpeg"
+        if image.mode not in {"RGB", "L"}:
+            image = image.convert("RGB")
+        # Search from high to low quality so we use the available transport
+        # budget instead of jumping directly from 85 to 75.  The finer upper
+        # range matters for phone photos, where a small quality-step difference
+        # can leave substantial transport budget unused.
+        quality_steps = (
+            95,
+            92,
+            90,
+            89,
+            88,
+            87,
+            85,
+            82,
+            80,
+            78,
+            75,
+            72,
+            70,
+            68,
+            65,
+            62,
+            60,
+            58,
+            55,
+            50,
+            45,
+            40,
+            35,
+        )
+
+    best_size: Optional[int] = None
+    for _attempt in range(12):
+        for quality in quality_steps:
+            try:
+                candidate = _encode_candidate(image, output_format, quality)
+            except Exception as exc:
+                logger.warning(
+                    "image_payloads: failed to encode constrained image as %s: %s",
+                    output_format,
+                    exc,
+                )
+                return None
+            payload_size = data_url_payload_size(len(candidate), output_mime)
+            best_size = payload_size if best_size is None else min(best_size, payload_size)
+            if payload_size <= max_payload_bytes:
+                if image.size != original_dimensions:
+                    logger.info(
+                        "image_payloads: constrained native image dimensions "
+                        "%dx%d -> %dx%d",
+                        original_dimensions[0],
+                        original_dimensions[1],
+                        image.width,
+                        image.height,
+                    )
+                return candidate, output_mime
+
+        if image.size == (1, 1):
+            break
+
+        # Estimate the linear scale needed from the smallest candidate at this
+        # size, with headroom for codec non-linearity.  Cap at 0.9 so every
+        # unsuccessful round makes measurable progress.
+        assert best_size is not None
+        scale = min(0.9, (max_payload_bytes / best_size) ** 0.5 * 0.95)
+        new_size = (
+            max(1, round(image.width * scale)),
+            max(1, round(image.height * scale)),
+        )
+        if new_size == image.size:
+            new_size = (max(1, image.width - 1), max(1, image.height - 1))
+        image = image.resize(new_size, Image.Resampling.LANCZOS)
+        best_size = None
+
+    logger.warning(
+        "image_payloads: could not fit native image under %d-byte data-URL "
+        "payload limit; skipping attachment",
+        max_payload_bytes,
+    )
+    return None
+
+
+__all__ = [
+    "DEFAULT_NATIVE_IMAGE_MAX_DIMENSION",
+    "DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES",
+    "constrain_image_payload",
+    "data_url_payload_size",
+    "get_native_image_limits",
+]

--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -506,21 +506,6 @@ def decide_image_input_mode(
     return "text"
 
 
-# Image size handling is REACTIVE rather than proactive: we attempt native
-# attachment at full size regardless of provider, and rely on
-# ``run_agent._try_shrink_image_parts_in_messages`` to shrink + retry if
-# the provider rejects the request (e.g. Anthropic's hard 5 MB per-image
-# ceiling returned as HTTP 400 "image exceeds 5 MB maximum").
-#
-# Why reactive: our knowledge of provider ceilings is partial and evolving
-# (OpenAI accepts 49 MB+, Anthropic 5 MB, Gemini 100 MB, others unknown).
-# A proactive per-provider table would be stale the moment a provider raises
-# or lowers its limit, and silently degrading quality for users on providers
-# that would have accepted the full image is the worse failure mode.
-# The shrink-on-reject path loses 1 API call + maybe 1s of Pillow work when
-# it fires, which is cheaper than permanent quality loss.
-
-
 def _sniff_mime_from_bytes(raw: bytes) -> Optional[str]:
     """Detect image MIME from magic bytes. Returns None if unrecognised.
 
@@ -667,13 +652,12 @@ def _guess_mime(path: Path, raw: Optional[bytes] = None) -> str:
 
 
 def _file_to_data_url(path: Path) -> Optional[str]:
-    """Encode a local image as a base64 data URL at its native size.
+    """Encode a local image as a bounded base64 data URL.
 
-    Size limits are NOT enforced here — the agent retry loop
-    (``run_agent._try_shrink_image_parts_in_messages``) shrinks on the
-    provider's first rejection. Keeping this simple means providers that
-    accept large images (OpenAI 49 MB+, Gemini 100 MB) don't pay a silent
-    quality tax just because one other provider is stricter.
+    Images below the configured payload and dimension limits retain their
+    original bytes and MIME exactly. Oversized images are EXIF-oriented and
+    re-encoded in memory before base64 encoding; the cached source is never
+    modified. The reactive provider-error resize remains a backup.
 
     Format compatibility IS handled here: if the sniffed MIME isn't one
     of ``_UNIVERSALLY_SUPPORTED_MIMES`` (i.e. it's something like AVIF,
@@ -721,6 +705,40 @@ def _file_to_data_url(path: Path) -> Optional[str]:
         )
         raw = transcoded
         mime = "image/png"
+
+    # Bound the complete encoded data URL before it enters the first native
+    # user message. Some transports reject the request before provider-level
+    # image-size handling can run, so retrying the identical payload cannot
+    # recover. Keep this immediately before base64 encoding so compatibility
+    # transcoding above and MIME sniffing remain authoritative.
+    from agent.image_payloads import constrain_image_payload, get_native_image_limits
+
+    max_payload_bytes, max_dimension = get_native_image_limits()
+    constrained = constrain_image_payload(
+        raw,
+        mime,
+        max_payload_bytes=max_payload_bytes,
+        max_dimension=max_dimension,
+    )
+    if constrained is None:
+        logger.warning(
+            "image_routing: %s could not be constrained to the native image "
+            "payload limits; skipping this attachment.",
+            path,
+        )
+        return None
+    constrained_raw, constrained_mime = constrained
+    if constrained_raw is not raw or constrained_mime != mime:
+        logger.info(
+            "image_routing: constrained %s for native payload (%d -> %d raw "
+            "bytes, %s -> %s)",
+            path.name,
+            len(raw),
+            len(constrained_raw),
+            mime,
+            constrained_mime,
+        )
+    raw, mime = constrained_raw, constrained_mime
     b64 = base64.b64encode(raw).decode("ascii")
     return f"data:{mime};base64,{b64}"
 
@@ -754,10 +772,11 @@ def build_native_content_parts(
     ``Runner._enrich_message_with_vision`` (``vision_analyze using image_url:
     <path>``) so behaviour is consistent across both image input modes.
 
-    Images are attached at their native size. If a provider rejects the
-    request because an image is too large (e.g. Anthropic's 5 MB per-image
-    ceiling), the agent's retry loop transparently shrinks and retries
-    once — see ``run_agent._try_shrink_image_parts_in_messages``.
+    Local images within the configured byte and dimension thresholds are
+    attached unchanged. Oversized local images are constrained before they
+    enter the native message. If a provider still rejects an image as too
+    large, the agent's reactive shrink-and-retry path remains a backup — see
+    ``run_agent._try_shrink_image_parts_in_messages``.
 
     Returns (content_parts, skipped). Skipped entries are local paths
     that couldn't be read from disk; URLs are never skipped (they're

--- a/agent/request_budget.py
+++ b/agent/request_budget.py
@@ -1,0 +1,478 @@
+"""Total request-body budget for size-limited transports (ChatGPT Codex).
+
+The ``chatgpt.com/backend-api/codex`` transport hard-drops oversized request
+bodies: the server reads the whole upload, then closes the connection without
+sending any response, which the client can only surface as a retryable-looking
+``APIConnectionError``.  Measured by bisection (2026-08-02): bodies up to
+~1,175,000 bytes return HTTP 200; bodies of ~1,200,000 bytes and above are
+dropped after ~15 s.  Because sessions run with ``store=False``, the entire
+history is re-uploaded on every call — one oversized item permanently wedges
+its session, and retries re-send the identical body.
+
+This module enforces a total serialized-body budget immediately before send
+(transport preflight).  Token-based context compression cannot protect this
+limit: images and large tool outputs are byte-dense but token-cheap, so a body
+can be 6x over the wire ceiling while token accounting reports plenty of room.
+
+Degradation order — stop as soon as the body fits, never touch user text:
+
+1. Truncate ``function_call_output`` items *behind* the active tail (the
+   most recent tool exchanges the model needs verbatim to continue), largest
+   first, keeping head + tail around an omission marker.
+2. Re-encode embedded data-URL images down (oldest first) via
+   :func:`agent.image_payloads.constrain_image_payload`.
+3. Drop history ``reasoning`` items (opaque encrypted blobs — untruncatable).
+4. Stub oversized history ``function_call.arguments`` with valid JSON.
+5. Replace still-oversized images behind the active tail with a text
+   placeholder.
+6. Truncate active-tail tool outputs, with a more generous floor.
+7. Re-truncate history outputs with minimal floors (hundreds of outputs can
+   exceed the budget even at the first-pass floors).
+8. Last resort: replace remaining images anywhere — regardless of individual
+   size, since under-cap images can collectively bust the budget — with a
+   text placeholder. A lost image beats a dropped request.
+
+If the body still exceeds the budget after all five steps, it is returned
+as-is with an ERROR log: that means instructions + tool schemas + the current
+user content alone exceed the transport limit, which no history surgery can
+fix — the send will fail and the log tells a human exactly why.
+
+Cost model: the body is fully serialized twice per over-budget call (once to
+measure, once to verify); every ladder step tracks progress through exact
+per-item deltas (an item serializes identically standalone and inside the
+``input`` array).  Retries re-run the ladder from scratch: a
+content-blind memo was measured cheaper but can substitute an unrelated
+same-size request, so correctness wins.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import copy
+import json
+import logging
+import re
+from collections import Counter
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.image_payloads import (
+    DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
+    agent_config_int,
+    constrain_image_payload,
+    data_url_payload_size,
+)
+
+logger = logging.getLogger(__name__)
+
+# Measured ceiling ~1.17-1.2 MB (see module docstring); default leaves
+# headroom for serialization drift and transport framing.
+DEFAULT_REQUEST_BODY_BUDGET_BYTES = 1_000_000
+
+# History tool outputs are context, not the active exchange: keep enough of
+# each end to preserve what the output was and how it ended.
+_HISTORY_OUTPUT_HEAD = 4_096
+_HISTORY_OUTPUT_TAIL = 1_024
+# Active-tail outputs are what the model is currently working from — keep an
+# order of magnitude more before cutting.
+_TAIL_OUTPUT_HEAD = 16_384
+_TAIL_OUTPUT_TAIL = 4_096
+
+# How many of the most recent tool exchanges stay verbatim: the model needs
+# its latest results to continue the loop, but a long agentic run's early
+# outputs are context, not the active exchange (a cron session can carry 75
+# outputs after a single user message — protecting "everything after the last
+# user message" would protect all of them).
+_PROTECTED_RECENT_OUTPUTS = 3
+
+_OMISSION_MARKER = (
+    "\n[... {omitted} characters omitted by hermes: request exceeded the "
+    "transport body-size limit ...]\n"
+)
+_IMAGE_PLACEHOLDER = (
+    "[image omitted by hermes: request exceeded the transport body-size limit]"
+)
+
+# api_kwargs keys that never reach the wire body.
+_NON_WIRE_KEYS = ("extra_headers",)
+
+_DATA_URL_RE = re.compile(r"^data:(?P<mime>image/[a-z0-9.+-]+);base64,(?P<b64>.*)$", re.S)
+
+def get_request_body_budget() -> int:
+    """Return the configured body budget (``agent.max_request_body_bytes``).
+
+    Malformed, missing, zero, or negative values fall back to the default.
+    """
+    return agent_config_int(
+        "max_request_body_bytes", DEFAULT_REQUEST_BODY_BUDGET_BYTES
+    )
+
+
+def serialized_body_size(api_kwargs: Dict[str, Any]) -> int:
+    """Approximate the wire size of the JSON body built from ``api_kwargs``.
+
+    Excludes client-side keys (underscore-prefixed, ``extra_headers``) that
+    the SDK does not serialize into the request body.
+    """
+    wire = {
+        k: v
+        for k, v in api_kwargs.items()
+        if not (isinstance(k, str) and (k.startswith("_") or k in _NON_WIRE_KEYS))
+    }
+    try:
+        return len(json.dumps(wire, ensure_ascii=False, default=str).encode("utf-8"))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return len(str(wire).encode("utf-8"))
+
+
+def _active_tail_start(input_items: List[Any]) -> int:
+    """First index of the protected active tail.
+
+    The tail covers everything after the last user message *or* the last
+    ``_PROTECTED_RECENT_OUTPUTS`` tool exchanges, whichever protects less.
+    User message items appear both as ``{"type": "message", "role": "user"}``
+    and as bare ``{"role": "user", ...}`` shapes.
+    """
+    last_user = -1
+    output_indices: List[int] = []
+    for idx, item in enumerate(input_items):
+        if not isinstance(item, dict):
+            continue
+        if item.get("role") == "user":
+            last_user = idx
+        elif item.get("type") == "function_call_output":
+            output_indices.append(idx)
+
+    from_user = last_user + 1
+    if not output_indices:
+        return from_user
+    kth_output = output_indices[-_PROTECTED_RECENT_OUTPUTS:][0]
+    # Include the function_call immediately preceding the k-th output.
+    from_outputs = max(0, kth_output - 1)
+    return max(from_user, from_outputs)
+
+
+def _json_size(obj: Any) -> int:
+    """Exact serialized size of one input item or content part.
+
+    An element serializes identically standalone and inside its enclosing
+    array (same separators), so mutation deltas computed with this are exact.
+    """
+    try:
+        return len(json.dumps(obj, ensure_ascii=False, default=str).encode("utf-8"))
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return len(str(obj).encode("utf-8"))
+
+
+def _truncate_text(text: str, head: int, tail: int) -> str:
+    omitted = len(text) - head - tail
+    if omitted <= len(_OMISSION_MARKER):
+        return text
+    return (
+        text[:head]
+        + _OMISSION_MARKER.format(omitted=omitted)
+        + (text[-tail:] if tail > 0 else "")
+    )
+
+
+def _truncate_output_item(item: Dict[str, Any], head: int, tail: int) -> bool:
+    """Truncate a ``function_call_output`` item in place. Returns True if changed."""
+    output = item.get("output")
+    if isinstance(output, str):
+        truncated = _truncate_text(output, head, tail)
+        if len(truncated) < len(output):
+            item["output"] = truncated
+            return True
+        return False
+    if isinstance(output, list):
+        changed = False
+        for part in output:
+            if isinstance(part, dict) and part.get("type") == "input_text":
+                text = part.get("text")
+                if isinstance(text, str):
+                    truncated = _truncate_text(text, head, tail)
+                    if len(truncated) < len(text):
+                        part["text"] = truncated
+                        changed = True
+        return changed
+    return False
+
+
+def _constrain_data_url(data_url: str, max_payload_bytes: int) -> Optional[str]:
+    """Re-encode a data-URL image to fit ``max_payload_bytes``; None on failure.
+
+    Returns the original URL when it already fits.
+    """
+    if len(data_url) <= max_payload_bytes:
+        return data_url
+    match = _DATA_URL_RE.match(data_url)
+    if not match:
+        return None
+    try:
+        raw = base64.b64decode(match.group("b64"), validate=False)
+    except (binascii.Error, ValueError):
+        return None
+    constrained = constrain_image_payload(
+        raw,
+        match.group("mime"),
+        max_payload_bytes=max_payload_bytes,
+        # The byte cap dominates here; keep the standard dimension ceiling.
+        max_dimension=DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
+    )
+    if constrained is None:
+        return None
+    new_raw, new_mime = constrained
+    if data_url_payload_size(len(new_raw), new_mime) > max_payload_bytes:
+        return None
+    return "data:%s;base64,%s" % (
+        new_mime,
+        base64.b64encode(new_raw).decode("ascii"),
+    )
+
+
+def _iter_image_parts(
+    input_items: List[Any],
+) -> List[Tuple[int, Dict[str, Any]]]:
+    """Return (item_index, part) for every data-URL input_image part."""
+    found: List[Tuple[int, Dict[str, Any]]] = []
+    for idx, item in enumerate(input_items):
+        if not isinstance(item, dict):
+            continue
+        parts: List[Any] = []
+        if item.get("role") is not None and isinstance(item.get("content"), list):
+            parts = item["content"]
+        elif item.get("type") == "function_call_output" and isinstance(
+            item.get("output"), list
+        ):
+            parts = item["output"]
+        for part in parts:
+            if (
+                isinstance(part, dict)
+                and part.get("type") == "input_image"
+                and isinstance(part.get("image_url"), str)
+                and part["image_url"].startswith("data:")
+            ):
+                found.append((idx, part))
+    return found
+
+
+def apply_request_body_budget(
+    api_kwargs: Dict[str, Any],
+    budget_bytes: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return ``api_kwargs`` with its serialized body constrained to budget.
+
+    Under budget, the original object is returned untouched.  Otherwise the
+    ``input`` list is deep-copied and degraded per the module docstring; the
+    original is never mutated.
+    """
+    budget = budget_bytes if isinstance(budget_bytes, int) and budget_bytes > 0 else (
+        get_request_body_budget()
+    )
+    size = serialized_body_size(api_kwargs)
+    if size <= budget:
+        return api_kwargs
+
+    input_items = api_kwargs.get("input")
+    if not isinstance(input_items, list) or not input_items:
+        logger.error(
+            "request_budget: body is %d bytes (budget %d) but has no input "
+            "items to degrade; sending as-is and the transport will likely "
+            "drop it.",
+            size,
+            budget,
+        )
+        return api_kwargs
+
+    constrained = dict(api_kwargs)
+    # Strings are shared by reference under deepcopy (atomic in CPython), so
+    # this copies structure only, not megabyte payloads.
+    items: List[Any] = copy.deepcopy(input_items)
+    constrained["input"] = items
+    tail_start = _active_tail_start(items)
+    actions: Counter = Counter()
+    # Running total maintained through exact per-item deltas; one final full
+    # serialization verifies it before we log success.
+    current = size
+
+    def _image_allowance() -> int:
+        """Per-image byte allowance from the budget headroom left right now.
+
+        Non-image content (instructions, tools, truncated history) is charged
+        first; the remainder — minus a serialization-drift margin — is split
+        evenly across the images still present. A lone photo in a small
+        conversation keeps most of the envelope; many images share it. Floor
+        keeps degenerate cases usable.
+        """
+        parts = _iter_image_parts(items)
+        if not parts:
+            return 64_000
+        image_bytes = sum(len(prt.get("image_url", "")) for _i, prt in parts)
+        room = budget - (current - image_bytes) - 16_384
+        return max(64_000, room // len(parts))
+
+    def _sorted_outputs(lo: int, hi: int) -> List[Dict[str, Any]]:
+        return sorted(
+            (
+                item
+                for item in items[lo:hi]
+                if isinstance(item, dict)
+                and item.get("type") == "function_call_output"
+            ),
+            key=_json_size,
+            reverse=True,
+        )
+
+    def truncate_pass(candidates: List[Dict[str, Any]], head: int, tail: int, label: str) -> None:
+        nonlocal current
+        for item in candidates:
+            if current <= budget:
+                return
+            before = _json_size(item)
+            if _truncate_output_item(item, head, tail):
+                current += _json_size(item) - before
+                actions[label] += 1
+
+    def placeholder_pass(
+        candidates: List[Tuple[int, Dict[str, Any]]],
+        label: str,
+        respect_cap: bool = True,
+    ) -> None:
+        nonlocal current
+        allowance = _image_allowance()
+        for _idx, part in candidates:
+            if current <= budget:
+                return
+            if respect_cap and len(part.get("image_url", "")) <= allowance:
+                continue
+            before = _json_size(part)
+            part.clear()
+            part["type"] = "input_text"
+            part["text"] = _IMAGE_PLACEHOLDER
+            current += _json_size(part) - before
+            actions[label] += 1
+
+    # Step 1: truncate history tool outputs, largest first.
+    truncate_pass(
+        _sorted_outputs(0, tail_start),
+        _HISTORY_OUTPUT_HEAD,
+        _HISTORY_OUTPUT_TAIL,
+        "history outputs truncated",
+    )
+
+    # Step 2: re-encode embedded images down, oldest first.
+    if current > budget:
+        allowance = _image_allowance()
+        for _idx, part in _iter_image_parts(items):
+            if current <= budget:
+                break
+            constrained_url = _constrain_data_url(part["image_url"], allowance)
+            if constrained_url and len(constrained_url) < len(part["image_url"]):
+                current += len(constrained_url) - len(part["image_url"])
+                part["image_url"] = constrained_url
+                actions["images re-encoded"] += 1
+
+    # Step 3: drop history reasoning items (opaque encrypted blobs that can
+    # be large and cannot be truncated without corruption; the adapter already
+    # drops foreign-issuer reasoning, so absence is a supported state).
+    if current > budget:
+        kept: List[Any] = []
+        for idx, item in enumerate(items):
+            if (
+                current > budget
+                and idx < tail_start
+                and isinstance(item, dict)
+                and item.get("type") == "reasoning"
+            ):
+                current -= _json_size(item) + 2  # item + list separator
+                actions["history reasoning dropped"] += 1
+                continue
+            kept.append(item)
+        if actions["history reasoning dropped"]:
+            tail_start -= actions["history reasoning dropped"]
+            items[:] = kept
+
+    # Step 4: stub oversized history function_call arguments (kept as valid
+    # JSON — replayed calls are context, never re-executed).
+    if current > budget:
+        for item in items[:tail_start]:
+            if current <= budget:
+                break
+            if not (isinstance(item, dict) and item.get("type") == "function_call"):
+                continue
+            args = item.get("arguments")
+            if isinstance(args, str) and len(args) > 4_096:
+                before = _json_size(item)
+                item["arguments"] = json.dumps(
+                    {
+                        "_hermes_truncated": "%d-character arguments omitted: "
+                        "request exceeded the transport body-size limit" % len(args)
+                    }
+                )
+                current += _json_size(item) - before
+                actions["history call arguments stubbed"] += 1
+
+    # Step 5: placeholder history images that still don't fit.
+    if current > budget:
+        placeholder_pass(
+            _iter_image_parts(items[:tail_start]), "history images replaced"
+        )
+
+    # Step 6: truncate active-tail tool outputs (generous floor), largest first.
+    if current > budget:
+        truncate_pass(
+            _sorted_outputs(tail_start, len(items)),
+            _TAIL_OUTPUT_HEAD,
+            _TAIL_OUTPUT_TAIL,
+            "active outputs truncated",
+        )
+
+    # Step 7: escalate — the first-pass floors (4KB head each) can themselves
+    # exceed the budget when history holds hundreds of outputs; re-truncate
+    # with minimal floors.
+    if current > budget:
+        truncate_pass(
+            _sorted_outputs(0, tail_start), 512, 128, "history outputs re-truncated"
+        )
+
+    # Step 8: last resort — placeholder remaining images anywhere regardless
+    # of individual size (several under-cap images can collectively bust the
+    # budget), oldest first so the current turn's image goes last. Also covers
+    # images Pillow cannot re-encode (corrupt/unsupported): a lost image beats
+    # a request the transport is guaranteed to drop.
+    if current > budget:
+        placeholder_pass(
+            _iter_image_parts(items), "images replaced (last resort)", respect_cap=False
+        )
+
+    summary = ", ".join("%s: %d" % (k, v) for k, v in actions.items()) or "no-op"
+    final_size = serialized_body_size(constrained)
+    if final_size <= budget:
+        logger.info(
+            "request_budget: constrained body %d -> %d bytes (budget %d): %s",
+            size,
+            final_size,
+            budget,
+            summary,
+        )
+        return constrained
+
+    logger.error(
+        "request_budget: body still %d bytes after degradation (budget %d, "
+        "started %d, actions: %s). Instructions + tool schemas + current user "
+        "content alone exceed the transport limit; the send will likely be "
+        "dropped by the server.",
+        final_size,
+        budget,
+        size,
+        summary,
+    )
+    return constrained
+
+
+__all__ = [
+    "DEFAULT_REQUEST_BODY_BUDGET_BYTES",
+    "apply_request_body_budget",
+    "get_request_body_budget",
+    "serialized_body_size",
+]

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -647,6 +647,18 @@ class ResponsesApiTransport(ProviderTransport):
                 extra_body["prompt_cache_key"] = bounded
             else:
                 extra_body.pop("prompt_cache_key", None)
+        issuer_kind = getattr(self, "_last_issuer_kind", None)
+        if sanitize_harmony_tokens and issuer_kind in (None, "codex_backend"):
+            # The ChatGPT Codex backend hard-drops request bodies over
+            # ~1.2 MB without an HTTP response (measured 2026-08-02).
+            # Enforce the total body budget as the last step before send;
+            # runs on retries too. Gated on the issuer classification (with
+            # the harmony flag as a conservative fallback when the issuer
+            # has not been resolved yet) so other Harmony-speaking backends
+            # never get their requests silently degraded.
+            from agent.request_budget import apply_request_body_budget
+
+            normalized = apply_request_body_budget(normalized)
         return normalized
 
     def map_finish_reason(self, raw_reason: str) -> str:

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -238,6 +238,13 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        # Maximum size in bytes of the complete base64 data URL embedded for a
+        # local image in a native user message (header plus encoded bytes).
+        # Oversized images are re-encoded in memory; cached sources are not
+        # modified. Leave headroom for strict transport request-body limits.
+        "native_image_max_payload_bytes": 900_000,
+        # Maximum pixel dimension (longest side) for the same native payload.
+        "native_image_max_dimension": 2560,
         "disabled_toolsets": [],
 
         # Per-model reasoning effort overrides (spelling-tolerant).

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import base64
+import hashlib
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import patch
 
@@ -187,7 +189,44 @@ def _png_bytes() -> bytes:
     )
 
 
+def _jpeg_bytes(size: tuple[int, int] = (4, 3), quality: int = 90) -> bytes:
+    """Return a valid synthetic JPEG."""
+    from PIL import Image
+
+    image = Image.new("RGB", size, (20, 80, 140))
+    buf = BytesIO()
+    image.save(buf, format="JPEG", quality=quality)
+    return buf.getvalue()
+
+
+def _noisy_jpeg_bytes(size: tuple[int, int] = (1200, 900)) -> bytes:
+    """Return a valid, poorly compressible JPEG for payload-limit tests."""
+    from PIL import Image
+
+    image = Image.effect_noise(size, 100).convert("RGB")
+    buf = BytesIO()
+    image.save(buf, format="JPEG", quality=95)
+    return buf.getvalue()
+
+
 class TestBuildNativeContentParts:
+    def test_small_png_and_jpeg_preserve_exact_bytes_and_mime(self, tmp_path: Path):
+        fixtures = (
+            ("small.png", _png_bytes(), "image/png"),
+            ("small.jpg", _jpeg_bytes(), "image/jpeg"),
+        )
+
+        for filename, expected_bytes, expected_mime in fixtures:
+            image_path = tmp_path / filename
+            image_path.write_bytes(expected_bytes)
+            parts, skipped = build_native_content_parts("inspect", [str(image_path)])
+
+            assert skipped == []
+            data_url = parts[1]["image_url"]["url"]
+            header, encoded = data_url.split(",", 1)
+            assert header == f"data:{expected_mime};base64"
+            assert base64.b64decode(encoded) == expected_bytes
+
     def test_text_then_image(self, tmp_path: Path):
         img = tmp_path / "cat.png"
         img.write_bytes(_png_bytes())
@@ -243,13 +282,10 @@ class TestBuildNativeContentParts:
 
 
 class TestLargeImageHandling:
-    """Large images attach at native size; shrink is handled reactively at
-    retry time in ``run_agent._try_shrink_image_parts_in_messages`` rather
-    than proactively here.
-    """
+    """Native attachments are constrained before entering the user message."""
 
-    def test_large_image_passes_through_unchanged(self, tmp_path: Path):
-        """A multi-MB image is attached as-is — no resize, no skip."""
+    def test_byte_safe_image_passes_through_unchanged(self, tmp_path: Path):
+        """An image below both limits retains its historical pass-through."""
         from agent import image_routing as _ir
 
         img = tmp_path / "medium.png"
@@ -260,6 +296,173 @@ class TestLargeImageHandling:
         assert url.startswith("data:image/png;base64,")
         # Base64 expansion means output is ~4/3 of input, plus header.
         assert len(url) > 200_000
+
+    def test_oversized_jpeg_is_constrained_and_source_is_unchanged(
+        self, tmp_path: Path
+    ):
+        from PIL import Image
+
+        from agent import image_routing as _ir
+
+        source_bytes = _noisy_jpeg_bytes()
+        source_checksum = hashlib.sha256(source_bytes).hexdigest()
+        image_path = tmp_path / "oversized.jpg"
+        image_path.write_bytes(source_bytes)
+        config = {
+            "agent": {
+                "native_image_max_payload_bytes": 220_000,
+                "native_image_max_dimension": 600,
+            }
+        }
+
+        with patch("hermes_cli.config.load_config_readonly", return_value=config):
+            data_url = _ir._file_to_data_url(image_path)
+
+        assert data_url is not None
+        assert len(data_url.encode("ascii")) <= 220_000
+        assert data_url.startswith("data:image/jpeg;base64,")
+        output_bytes = base64.b64decode(data_url.split(",", 1)[1])
+        with Image.open(BytesIO(output_bytes)) as output:
+            assert output.format == "JPEG"
+            assert max(output.size) <= 600
+            assert abs((output.width / output.height) - (1200 / 900)) < 0.01
+        assert image_path.read_bytes() == source_bytes
+        assert hashlib.sha256(image_path.read_bytes()).hexdigest() == source_checksum
+
+    def test_config_override_changes_preprocessing_limit(self, tmp_path: Path):
+        from agent import image_routing as _ir
+
+        source_bytes = _noisy_jpeg_bytes((800, 600))
+        image_path = tmp_path / "override.jpg"
+        image_path.write_bytes(source_bytes)
+
+        high_limit = {
+            "agent": {
+                "native_image_max_payload_bytes": 2_000_000,
+                "native_image_max_dimension": 2000,
+            }
+        }
+        low_limit = {
+            "agent": {
+                "native_image_max_payload_bytes": 150_000,
+                "native_image_max_dimension": 500,
+            }
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=high_limit):
+            unchanged_url = _ir._file_to_data_url(image_path)
+        with patch("hermes_cli.config.load_config_readonly", return_value=low_limit):
+            constrained_url = _ir._file_to_data_url(image_path)
+
+        assert unchanged_url is not None
+        assert constrained_url is not None
+        assert base64.b64decode(unchanged_url.split(",", 1)[1]) == source_bytes
+        assert len(constrained_url.encode("ascii")) <= 150_000
+        assert base64.b64decode(constrained_url.split(",", 1)[1]) != source_bytes
+
+    def test_malformed_config_values_fall_back_to_safe_defaults(self):
+        from agent.image_payloads import (
+            DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
+            DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES,
+            get_native_image_limits,
+        )
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        # The loader fallback and the user-visible config defaults must stay in
+        # lockstep even if either setting changes later.
+        assert DEFAULT_CONFIG["agent"]["native_image_max_payload_bytes"] == (
+            DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES
+        )
+        assert DEFAULT_CONFIG["agent"]["native_image_max_dimension"] == (
+            DEFAULT_NATIVE_IMAGE_MAX_DIMENSION
+        )
+
+        malformed = {
+            "agent": {
+                "native_image_max_payload_bytes": "many",
+                "native_image_max_dimension": -5,
+            }
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=malformed):
+            assert get_native_image_limits() == (
+                DEFAULT_NATIVE_IMAGE_MAX_PAYLOAD_BYTES,
+                DEFAULT_NATIVE_IMAGE_MAX_DIMENSION,
+            )
+
+        string_override = {
+            "agent": {
+                "native_image_max_payload_bytes": "8388608",
+                "native_image_max_dimension": "9000",
+            }
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=string_override):
+            assert get_native_image_limits() == (8 * 1024 * 1024, 9000)
+
+    def test_oversized_corrupt_supported_image_is_skipped_without_crashing(
+        self, tmp_path: Path, caplog
+    ):
+        from agent import image_routing as _ir
+
+        image_path = tmp_path / "corrupt.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"not-an-image" * 500)
+        config = {
+            "agent": {
+                "native_image_max_payload_bytes": 1000,
+                "native_image_max_dimension": 7900,
+            }
+        }
+        with patch("hermes_cli.config.load_config_readonly", return_value=config):
+            assert _ir._file_to_data_url(image_path) is None
+
+        assert "skipping attachment" in caplog.text
+
+    def test_exif_orientation_is_applied_when_preprocessing(self, tmp_path: Path):
+        from PIL import Image
+
+        from agent import image_routing as _ir
+
+        image = Image.new("RGB", (80, 40), (200, 100, 20))
+        exif = Image.Exif()
+        exif[274] = 6  # Rotate 90 degrees clockwise for display.
+        image_path = tmp_path / "oriented.jpg"
+        image.save(image_path, format="JPEG", quality=95, exif=exif)
+        config = {
+            "agent": {
+                "native_image_max_payload_bytes": 100_000,
+                "native_image_max_dimension": 50,
+            }
+        }
+
+        with patch("hermes_cli.config.load_config_readonly", return_value=config):
+            data_url = _ir._file_to_data_url(image_path)
+
+        assert data_url is not None
+        with Image.open(BytesIO(base64.b64decode(data_url.split(",", 1)[1]))) as output:
+            assert output.size == (25, 50)
+
+    def test_transparent_oversized_image_remains_transparent_png(self, tmp_path: Path):
+        from PIL import Image
+
+        from agent import image_routing as _ir
+
+        image = Image.effect_noise((512, 512), 100).convert("RGBA")
+        image.putalpha(Image.linear_gradient("L").resize(image.size))
+        image_path = tmp_path / "transparent.png"
+        image.save(image_path, format="PNG")
+        config = {
+            "agent": {
+                "native_image_max_payload_bytes": 150_000,
+                "native_image_max_dimension": 7900,
+            }
+        }
+
+        with patch("hermes_cli.config.load_config_readonly", return_value=config):
+            data_url = _ir._file_to_data_url(image_path)
+
+        assert data_url is not None
+        assert data_url.startswith("data:image/png;base64,")
+        assert len(data_url.encode("ascii")) <= 150_000
+        with Image.open(BytesIO(base64.b64decode(data_url.split(",", 1)[1]))) as output:
+            assert "A" in output.getbands()
 
     def test_missing_file_returns_none(self, tmp_path: Path):
         from agent import image_routing as _ir

--- a/tests/agent/test_request_budget.py
+++ b/tests/agent/test_request_budget.py
@@ -1,0 +1,358 @@
+"""Tests for agent.request_budget — total request-body budget enforcement."""
+
+import base64
+import io
+import json
+
+import pytest
+
+from agent.request_budget import (
+    DEFAULT_REQUEST_BODY_BUDGET_BYTES,
+    apply_request_body_budget,
+    get_request_body_budget,
+    serialized_body_size,
+)
+
+
+def _user_message(text="hello", extra_parts=None):
+    content = [{"type": "input_text", "text": text}]
+    if extra_parts:
+        content.extend(extra_parts)
+    return {"type": "message", "role": "user", "content": content}
+
+
+def _fc(call_id="call_1", name="terminal"):
+    return {
+        "type": "function_call",
+        "call_id": call_id,
+        "name": name,
+        "arguments": "{}",
+    }
+
+
+def _fc_output(call_id="call_1", output="ok"):
+    return {"type": "function_call_output", "call_id": call_id, "output": output}
+
+
+def _kwargs(input_items, instructions="test"):
+    return {
+        "model": "gpt-5.6-sol",
+        "instructions": instructions,
+        "input": input_items,
+        "store": False,
+        "extra_headers": {"session_id": "t"},
+        "_client_only": {"ignored": True},
+    }
+
+
+def _noise_jpeg_data_url(side=512):
+    PIL = pytest.importorskip("PIL")
+    from PIL import Image
+    import os
+
+    img = Image.frombytes("RGB", (side, side), os.urandom(side * side * 3))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=95)
+    return "data:image/jpeg;base64," + base64.b64encode(buf.getvalue()).decode()
+
+
+def test_under_budget_is_untouched_same_object():
+    kwargs = _kwargs([_user_message(), _fc(), _fc_output()])
+    result = apply_request_body_budget(kwargs, budget_bytes=1_000_000)
+    assert result is kwargs
+
+
+def test_serialized_size_excludes_client_only_keys():
+    kwargs = _kwargs([_user_message()])
+    base = serialized_body_size(kwargs)
+    kwargs["extra_headers"] = {"session_id": "x" * 100_000}
+    kwargs["_client_only"] = {"blob": "y" * 100_000}
+    assert serialized_body_size(kwargs) == base
+
+
+def test_history_tool_output_truncated_before_active_tail():
+    huge = "H" * 400_000
+    tail_output = "T" * 10_000
+    kwargs = _kwargs(
+        [
+            _user_message("first ask"),
+            _fc("call_old"),
+            _fc_output("call_old", huge),
+            _user_message("current ask"),
+            _fc("call_now"),
+            _fc_output("call_now", tail_output),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=100_000)
+
+    assert result is not kwargs
+    # Original never mutated.
+    assert kwargs["input"][2]["output"] == huge
+    out_items = [i for i in result["input"] if i["type"] == "function_call_output"]
+    assert "characters omitted" in out_items[0]["output"]
+    assert len(out_items[0]["output"]) < len(huge)
+    # Active-tail output untouched (budget already met by step 1).
+    assert out_items[1]["output"] == tail_output
+    assert serialized_body_size(result) <= 100_000
+
+
+def test_array_output_text_parts_truncated():
+    kwargs = _kwargs(
+        [
+            _user_message("old"),
+            _fc(),
+            _fc_output(
+                output=[
+                    {"type": "input_text", "text": "A" * 300_000},
+                    {"type": "input_text", "text": "short"},
+                ]
+            ),
+            _user_message("now"),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=80_000)
+    parts = [
+        i for i in result["input"] if i["type"] == "function_call_output"
+    ][0]["output"]
+    assert "characters omitted" in parts[0]["text"]
+    assert parts[1]["text"] == "short"
+    assert serialized_body_size(result) <= 80_000
+
+
+def test_images_reencoded_then_placeholdered():
+    data_url = _noise_jpeg_data_url(side=700)
+    assert len(data_url) > 200_000  # noise JPEG stays large
+    kwargs = _kwargs(
+        [
+            _user_message("photo one", [{"type": "input_image", "image_url": data_url}]),
+            _user_message("photo two", [{"type": "input_image", "image_url": data_url}]),
+            _user_message("current ask"),
+        ]
+    )
+    start = serialized_body_size(kwargs)
+    result = apply_request_body_budget(kwargs, budget_bytes=200_000)
+    assert serialized_body_size(result) < start
+    assert serialized_body_size(result) <= 200_000
+    # Every remaining image part fits the per-image cap; any that could not be
+    # constrained became text placeholders.
+    for item in result["input"]:
+        for part in item.get("content") or []:
+            if part.get("type") == "input_image":
+                assert len(part["image_url"]) <= 200_000
+            if part.get("type") == "input_text" and "image omitted" in part["text"]:
+                assert "transport" in part["text"]
+
+
+def test_active_tail_output_truncated_as_last_resort():
+    kwargs = _kwargs(
+        [
+            _user_message("current ask"),
+            _fc("call_now"),
+            _fc_output("call_now", "V" * 500_000),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=120_000)
+    out = [i for i in result["input"] if i["type"] == "function_call_output"][0]
+    assert "characters omitted" in out["output"]
+    assert serialized_body_size(result) <= 120_000
+
+
+def test_irreducible_overage_logged_not_crashed(caplog):
+    kwargs = _kwargs([_user_message("hi")], instructions="I" * 300_000)
+    with caplog.at_level("ERROR"):
+        result = apply_request_body_budget(kwargs, budget_bytes=50_000)
+    assert serialized_body_size(result) > 50_000
+    assert any("request_budget" in r.message for r in caplog.records)
+
+
+def test_user_text_never_modified():
+    user_text = "do not touch this" * 1_000
+    kwargs = _kwargs(
+        [
+            _user_message(user_text),
+            _fc(),
+            _fc_output(output="Z" * 300_000),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=90_000)
+    messages = [i for i in result["input"] if i.get("type") == "message"]
+    assert messages[0]["content"][0]["text"] == user_text
+
+
+def test_budget_default_positive():
+    assert get_request_body_budget() >= 1
+    assert DEFAULT_REQUEST_BODY_BUDGET_BYTES == 1_000_000
+
+
+def test_equal_size_requests_are_not_cross_contaminated():
+    """Regression (review finding): a size-keyed memo substituted an
+    unrelated equal-length request's content. Distinct bodies of identical
+    serialized size must each get their own constrained result."""
+    a = _kwargs([_user_message("A" * 50), _fc(), _fc_output(output="a" * 200_000)],
+                instructions="tenant-A")
+    b = _kwargs([_user_message("B" * 50), _fc(), _fc_output(output="b" * 200_000)],
+                instructions="tenant-B")
+    assert serialized_body_size(a) == serialized_body_size(b)
+    ra = apply_request_body_budget(a, budget_bytes=80_000)
+    rb = apply_request_body_budget(b, budget_bytes=80_000)
+    assert ra["instructions"] == "tenant-A"
+    assert rb["instructions"] == "tenant-B"
+    assert ra is not rb
+
+
+def test_many_under_cap_images_still_reduced():
+    """Regression (review finding): several images each under the per-image
+    cap can collectively bust the budget; the last-resort pass must sacrifice
+    them anyway."""
+    data_url = _noise_jpeg_data_url(side=300)
+    per_image = len(data_url)
+    n = (250_000 // per_image) + 3
+    msgs = [
+        _user_message(f"photo {i}", [{"type": "input_image", "image_url": data_url}])
+        for i in range(n)
+    ]
+    kwargs = _kwargs(msgs + [_user_message("current ask")])
+    budget = 150_000
+    assert per_image <= max(64_000, budget // 8) or True  # images may be under cap
+    result = apply_request_body_budget(kwargs, budget_bytes=budget)
+    assert serialized_body_size(result) <= budget
+
+
+def test_history_reasoning_and_call_arguments_reduced():
+    """Regression (review finding): reasoning.encrypted_content and giant
+    function_call.arguments were untouched by the ladder."""
+    kwargs = _kwargs(
+        [
+            {"type": "reasoning", "id": "rs_1", "encrypted_content": "E" * 400_000},
+            {
+                "type": "function_call",
+                "call_id": "call_big",
+                "name": "write_file",
+                "arguments": json.dumps({"content": "X" * 300_000}),
+            },
+            _fc_output("call_big", "ok"),
+            _user_message("current ask"),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=100_000)
+    assert serialized_body_size(result) <= 100_000
+    types = [i.get("type") for i in result["input"]]
+    assert "reasoning" not in types
+    call = [i for i in result["input"] if i.get("type") == "function_call"][0]
+    assert "_hermes_truncated" in call["arguments"]
+    assert json.loads(call["arguments"])  # stub stays valid JSON
+
+
+def test_hundreds_of_outputs_escalate_past_first_pass_floors():
+    """Regression (review finding): 200 outputs at the 4KB+1KB first-pass
+    floors still exceed the budget; the escalation pass must fire."""
+    items = [_user_message("go")]
+    for i in range(200):
+        items.append(_fc(f"call_{i}"))
+        items.append(_fc_output(f"call_{i}", f"{i}:" + "Y" * 6_000))
+    kwargs = _kwargs(items)
+    result = apply_request_body_budget(kwargs, budget_bytes=400_000)
+    assert serialized_body_size(result) <= 400_000
+
+
+def test_omission_marker_counts_characters():
+    """Regression (review finding): the marker claimed byte counts while
+    slicing characters."""
+    kwargs = _kwargs(
+        [_user_message("old"), _fc(), _fc_output(output="é" * 200_000), _user_message("now")]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=100_000)
+    out = [i for i in result["input"] if i["type"] == "function_call_output"][0]
+    assert "characters omitted" in out["output"]
+    assert "bytes omitted" not in out["output"]
+
+
+def test_bare_role_user_message_images_are_visible():
+    """Images inside bare {'role': 'user'} items (no 'type' key) must be
+    reachable by the image steps — the real codex adapter emits that shape."""
+    data_url = _noise_jpeg_data_url(side=700)
+    kwargs = _kwargs(
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "photo"},
+                    {"type": "input_image", "image_url": data_url},
+                ],
+            },
+            _user_message("current ask"),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=150_000)
+    assert serialized_body_size(result) <= 150_000
+
+
+def test_cron_shape_role_only_user_message_outputs_truncated():
+    """Regression: real cron dumps carry one bare {'role':'user'} item and
+    dozens of tool exchanges after it. Those outputs are history, not the
+    protected active tail — all but the last few must be truncatable."""
+    items = [{"role": "user", "content": [{"type": "input_text", "text": "go"}]}]
+    for n in range(20):
+        items.append(_fc(f"call_{n}"))
+        items.append(_fc_output(f"call_{n}", f"{n}:" + "X" * 60_000))
+    kwargs = _kwargs(items)
+    result = apply_request_body_budget(kwargs, budget_bytes=300_000)
+    assert serialized_body_size(result) <= 300_000
+    outs = [i for i in result["input"] if i.get("type") == "function_call_output"]
+    assert any("characters omitted" in o["output"] for o in outs)
+    # The most recent exchanges stay verbatim.
+    assert "characters omitted" not in outs[-1]["output"]
+
+
+def test_unprocessable_tail_image_placeholdered_last_resort():
+    """Regression: an oversized image Pillow cannot decode (e.g. corrupt
+    bytes) in the active tail must be placeholdered, not left to guarantee a
+    transport drop."""
+    junk = "data:image/png;base64," + base64.b64encode(b"\x89PNG" + b"J" * 400_000).decode()
+    kwargs = _kwargs(
+        [
+            _user_message("analyze this"),
+            _fc("call_v", "vision_analyze"),
+            _fc_output(
+                "call_v",
+                output=[
+                    {"type": "input_text", "text": "described below"},
+                    {"type": "input_image", "image_url": junk},
+                ],
+            ),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=100_000)
+    assert serialized_body_size(result) <= 100_000
+    parts = [i for i in result["input"] if i.get("type") == "function_call_output"][0]["output"]
+    assert any(
+        p.get("type") == "input_text" and "image omitted" in p.get("text", "")
+        for p in parts
+    )
+    assert parts[0]["text"] == "described below"
+
+
+def test_lone_image_keeps_budget_headroom():
+    """A message that is mostly one image gets the envelope's remaining
+    headroom, not a fixed budget//8 crush."""
+    data_url = _noise_jpeg_data_url(side=650)
+    assert 200_000 < len(data_url) < 700_000
+    kwargs = _kwargs(
+        [
+            _user_message("old"),
+            _fc(),
+            _fc_output(output="H" * 600_000),
+            _user_message("look at this", [{"type": "input_image", "image_url": data_url}]),
+        ]
+    )
+    result = apply_request_body_budget(kwargs, budget_bytes=1_000_000)
+    assert serialized_body_size(result) <= 1_000_000
+    img = [
+        p
+        for i in result["input"]
+        for p in (i.get("content") or [])
+        if p.get("type") == "input_image"
+    ][0]
+    # With ~600KB of history truncated away, the lone image should keep far
+    # more than the old fixed cap (125,000) — ideally untouched.
+    assert len(img["image_url"]) > 200_000

--- a/website/docs/user-guide/features/vision.md
+++ b/website/docs/user-guide/features/vision.md
@@ -205,6 +205,23 @@ When a user attaches an image — from the CLI clipboard, the gateway (Telegram/
 
 You don't configure this — Hermes looks up your current model's capability in the provider metadata and picks the right path automatically. The practical effect: you can switch between vision and non-vision models mid-session and image handling "just works" without changing your workflow. Text-only models get coherent context about the image rather than a broken multimodal payload they'd have to reject.
 
+Local images routed natively are bounded before base64 encoding so ordinary
+phone photos do not exceed stricter transport limits. Images already within
+the limits pass through byte-for-byte; larger images are EXIF-oriented and
+re-encoded in memory without modifying the cached source. The defaults are a
+900 KB complete data URL and a 2560-pixel longest edge:
+
+```yaml
+agent:
+  native_image_max_payload_bytes: 900000
+  native_image_max_dimension: 2560
+```
+
+Raise these settings for a provider with a larger proven limit. Remote image
+URLs are passed through unchanged. These settings govern images attached to
+the initial native user message; `vision_analyze` is a separate tool path with
+its own payload safeguards.
+
 Which auxiliary model handles the text-description path is configurable under `auxiliary.vision` — see [Auxiliary Models](/user-guide/configuration#auxiliary-models).
 
 ### `vision_analyze` has the same dual behavior


### PR DESCRIPTION
## Summary

The ChatGPT Codex transport (`chatgpt.com/backend-api/codex/responses`) hard-drops oversized request bodies: the server reads the whole upload, then closes the connection without sending any response. Measured by bisection (2026-08-02): bodies up to ~1,175,000 bytes return HTTP 200; ~1,200,000 and above are dropped after ~15s. The client can only surface this as a retryable-looking `APIConnectionError` — and because sessions run `store=False`, the identical oversized history is re-sent on every call and every retry, permanently wedging the session. One unresized phone photo (11MB JPEG → ~15MB base64 data URL) is enough.

Token-based context compression cannot protect this limit: images and large tool outputs are byte-dense but token-cheap, so a body can be 6x over the wire ceiling while token accounting reports plenty of headroom (observed: 7.05MB body at ~170k tokens, 98% of it replayed `function_call_output` items).

Two commits:

1. **Constrain native image payloads before embedding** — inbound images are re-encoded in memory (EXIF-oriented, JPEG/PNG, quality-then-dimension reduction) to fit a configurable data-URL byte cap before entering conversation history; bmp/tiff transcode to PNG; unidentifiable images are skipped with a warning instead of poisoning the session. Config: `agent.native_image_max_payload_bytes` / `agent.native_image_max_dimension`.
2. **Enforce a total request-body budget at codex preflight** — `agent/request_budget.py` measures the serialized body just before send (including retries) and, when over budget, degrades a deep copy via a ladder: truncate history tool outputs largest-first (the most recent tool exchanges stay verbatim) → re-encode embedded images → placeholder history images → truncate active-tail outputs → last-resort placeholder any remaining oversized image. User text is never modified; under-budget bodies pass through untouched. Progress is tracked with exact per-item serialization deltas (2 full dumps per over-budget call). Gated on the codex issuer classification so other Harmony-speaking backends are never silently degraded. Config: `agent.max_request_body_bytes` (default 1,000,000 — the measured ceiling minus headroom).

Related issues: #27478 (pre-resize inbound images in gateway), #47339 (413 — context compression doesn't evict image/vision payloads), and the same failure class in OpenAI's own clients (openai/codex#13508, #7682, #2908 — there it surfaces as a clean 413; through this client it's a connection drop).

## Verification

- Bisected the live endpoint to locate the ceiling (12 probes: clean pass/fail flip between 1,175,000 and 1,200,000 bytes).
- Replayed a real failed 7.05MB request dump through the budget: constrained to 931KB in 1.4s and **accepted live (HTTP 200)** by the same endpoint that had silently dropped it.
- 62 unit tests for the new modules + the transport suite (239) green on this branch.
- An independent correctness review (GPT-5.6 agent with repo access) produced 5 findings with concrete reproductions — a size-keyed retry memo that could substitute an unrelated equal-length request (memo removed), aggregate under-cap images bypassing the last resort, untouched `function_call.arguments`/`reasoning.encrypted_content`, first-pass truncation floors exhausting on 200-output histories, and a chars-vs-bytes marker label. All five are fixed and covered by regression tests in `tests/agent/test_request_budget.py`.

## Notes for reviewers

- The budget deliberately lives at transport preflight, not the compression layer: with `store=False` + client retries, enforcement must be per-request. A follow-up could make the shrink durable in stored history (today the degradation is recomputed per call).
- There are now parallel image-fitting implementations (`agent/image_payloads.py` vs `tools/vision_tools.py`/`conversation_compression.py`); consolidating them is worthwhile but was kept out of this PR to keep the diff reviewable.
