### PR TITLE
feat: add fail-closed WhatsApp ownership gate

### DIFF
--- a/docs/whatsapp-ownership-router.md
+++ b/docs/whatsapp-ownership-router.md
@@ -1,0 +1,64 @@
+# WhatsApp inbound ownership router — Hermes side
+
+## Status
+
+Local prototype only. No production configuration, secret, bridge process, or WhatsApp message has been changed or sent.
+
+## Configuration
+
+The adapter accepts an optional `inbound_ownership_router` object in the WhatsApp platform configuration:
+
+```yaml
+inbound_ownership_router:
+  url: https://<authorized-host>/functions/v1/classify-whatsapp-reply
+  token_env: AUTOCRIA_OWNERSHIP_ROUTER_TOKEN
+  timeout_ms: 1500
+  agent_prefixes:
+    - jeffersom
+```
+
+Do not place the secret itself in configuration. `token_env` names the environment variable that contains it.
+
+`jeffersom` is always reserved internally. Values in `agent_prefixes` are additive and cannot remove that priority path.
+
+When the object or URL is absent, existing WhatsApp behavior is preserved. When enabled, the adapter passes a non-secret configuration fingerprint into the bridge and verifies the same fingerprint through `/health`; a bridge with stale URL, token, timeout, or prefix configuration is not silently reused.
+
+## Dispatch behavior
+
+1. Existing Hermes echo suppression runs first.
+2. Groups are not routed through this AutoCria ownership filter.
+3. A word-bounded, case-insensitive `Jeffersom` prefix passes locally without a network request.
+4. Other direct events send only bounded metadata to the classifier.
+5. `jeffersom` passes to the Python adapter queue.
+6. `autocria`, `ambiguous`, invalid responses, authentication/configuration errors, redirects, HTTP failures, network errors, and timeouts are dropped before an agent turn or transcript is created.
+
+The metadata signal contains aliases, current/quoted message IDs, reply category, `hasText`, and `fromOwner`. It excludes the message body and text.
+
+## Transport and secret handling
+
+- Remote endpoints must use HTTPS.
+- HTTP is allowed only for `127.0.0.1`, `localhost`, or IPv6 loopback during local development.
+- Redirects are rejected.
+- A missing token fails closed without transmitting metadata.
+- The bearer token is not logged and is not returned by `/health`; only a fingerprint is exposed.
+- Timeout is bounded to 1–10000 ms.
+
+## Activation
+
+Every production action requires a new specific authorization.
+
+1. Deploy and verify the AutoCria migration and classifier first.
+2. Set `AUTOCRIA_OWNERSHIP_ROUTER_TOKEN` in both authorized runtimes.
+3. Add the configuration above using the verified HTTPS endpoint.
+4. Restart only the affected WhatsApp bridge.
+5. Verify bridge health, configuration fingerprint, and synthetic classification.
+6. Run controlled real-message tests only after separate authorization.
+
+Because the router fails closed, an unavailable classifier blocks non-prefixed direct messages. Explicit `Jeffersom` messages remain available as the local priority path.
+
+## Rollback
+
+1. Remove the `inbound_ownership_router` block or clear its URL. The adapter also clears inherited ownership-router environment variables before launching the bridge.
+2. Restart only the affected bridge.
+3. Verify `/health` reports an empty ownership-router fingerprint and ordinary direct messages queue normally.
+4. Do not delete sessions, migration data, or logs during rollback.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -16,6 +16,7 @@ with different backends via a bridge pattern.
 """
 
 import asyncio
+import json
 import logging
 import os
 import platform
@@ -334,6 +335,73 @@ def _file_content_hash(path: Path) -> str:
         return ""
 
 
+def _ownership_router_config_hash(
+    url: str,
+    token: str,
+    timeout_ms: int,
+    prefixes: list,
+) -> str:
+    """Fingerprint router behavior without exposing its URL or shared secret."""
+    if not url:
+        return ""
+    import hashlib
+
+    payload = json.dumps(
+        {
+            "url": url,
+            "token": token,
+            "timeout_ms": timeout_ms,
+            "prefixes": prefixes,
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _normalize_ownership_router_prefixes(prefixes: object) -> list[str]:
+    """Return up to eight non-empty custom prefixes; Jeffersom is bridge-reserved."""
+    if isinstance(prefixes, str):
+        prefixes = [prefixes]
+    elif not isinstance(prefixes, list):
+        prefixes = []
+    return [str(prefix).strip() for prefix in prefixes if str(prefix).strip()][:8]
+
+
+_OWNERSHIP_ROUTER_ENV_KEYS = (
+    "WHATSAPP_OWNERSHIP_ROUTER_URL",
+    "WHATSAPP_OWNERSHIP_ROUTER_TOKEN",
+    "WHATSAPP_OWNERSHIP_ROUTER_TIMEOUT_MS",
+    "WHATSAPP_OWNERSHIP_ROUTER_PREFIXES",
+    "WHATSAPP_OWNERSHIP_ROUTER_CONFIG_HASH",
+)
+
+
+def _apply_ownership_router_env(
+    env: dict,
+    url: str,
+    token: str,
+    timeout_ms: int,
+    prefixes: list,
+    config_hash: str,
+) -> None:
+    """Replace inherited router variables with the explicit adapter config."""
+    for key in _OWNERSHIP_ROUTER_ENV_KEYS:
+        env.pop(key, None)
+    if not url:
+        return
+    env["WHATSAPP_OWNERSHIP_ROUTER_URL"] = url
+    env["WHATSAPP_OWNERSHIP_ROUTER_TIMEOUT_MS"] = str(timeout_ms)
+    env["WHATSAPP_OWNERSHIP_ROUTER_PREFIXES"] = json.dumps(
+        prefixes,
+        ensure_ascii=False,
+    )
+    if token:
+        env["WHATSAPP_OWNERSHIP_ROUTER_TOKEN"] = token
+    env["WHATSAPP_OWNERSHIP_ROUTER_CONFIG_HASH"] = config_hash
+
+
 def check_whatsapp_requirements() -> bool:
     """
     Check if WhatsApp dependencies are available.
@@ -380,6 +448,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
     - send_read_receipts: Mark accepted inbound WhatsApp messages as read
+    - inbound_ownership_router: Optional metadata-only pre-dispatch ownership router
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
@@ -415,6 +484,25 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._send_read_receipts = (
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
+        )
+        ownership_router = config.extra.get("inbound_ownership_router") or {}
+        if not isinstance(ownership_router, dict):
+            ownership_router = {}
+        self._ownership_router_url = str(ownership_router.get("url") or "").strip()
+        token_env = str(
+            ownership_router.get("token_env") or "AUTOCRIA_OWNERSHIP_ROUTER_TOKEN"
+        ).strip()
+        self._ownership_router_token_env = (
+            token_env if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", token_env)
+            else "AUTOCRIA_OWNERSHIP_ROUTER_TOKEN"
+        )
+        try:
+            timeout_ms = int(ownership_router.get("timeout_ms") or 1500)
+        except (TypeError, ValueError):
+            timeout_ms = 1500
+        self._ownership_router_timeout_ms = max(1, min(timeout_ms, 10000))
+        self._ownership_router_prefixes = _normalize_ownership_router_prefixes(
+            ownership_router.get("agent_prefixes") or []
         )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
@@ -574,6 +662,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
             # Ensure session directory exists
             self._session_path.mkdir(parents=True, exist_ok=True)
+
+            router_token = os.getenv(self._ownership_router_token_env, "")
+            router_config_hash = _ownership_router_config_hash(
+                self._ownership_router_url,
+                router_token,
+                self._ownership_router_timeout_ms,
+                self._ownership_router_prefixes,
+            )
             
             # Check if bridge is already running and connected
             import aiohttp
@@ -599,7 +695,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_router_hash = str(data.get("ownershipRouterConfigHash", ""))
+                                config_matches = (
+                                    running_read_receipts == self._send_read_receipts
+                                    and running_router_hash == router_config_hash
+                                )
                                 if (
                                     running_hash
                                     and disk_hash
@@ -612,11 +712,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                     self._http_session = aiohttp.ClientSession()
                                     self._poll_task = asyncio.create_task(self._poll_messages())
                                     return True
-                                stale_reason = (
-                                    f"running={running_hash or 'unversioned'}, disk={disk_hash}"
-                                    if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
-                                )
+                                if running_hash != disk_hash:
+                                    stale_reason = f"running={running_hash or 'unversioned'}, disk={disk_hash}"
+                                elif running_read_receipts != self._send_read_receipts:
+                                    stale_reason = "send_read_receipts config changed"
+                                else:
+                                    stale_reason = "ownership router config changed"
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
                                 print(f"[{self.name}] Bridge found but not connected (status: {bridge_status}), restarting")
@@ -645,6 +746,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
+            )
+            _apply_ownership_router_env(
+                bridge_env,
+                self._ownership_router_url,
+                router_token,
+                self._ownership_router_timeout_ms,
+                self._ownership_router_prefixes,
+                router_config_hash,
             )
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -30,9 +30,10 @@ import { randomBytes, createHash } from 'crypto';
 import { execFileSync } from 'child_process';
 import { tmpdir } from 'os';
 import qrcode from 'qrcode-terminal';
-import { matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
+import { expandWhatsAppIdentifiers, matchesAllowedUser, parseAllowedUsers } from './allowlist.js';
 import { createOutboundIdTracker } from './outbound_ids.js';
 import { classifyOwnerMessageGate } from './owner_message_gate.js';
+import { applyInboundOwnershipGate } from './inbound_ownership_gate.js';
 import {
   buildPollPayload,
   buildLocationPayload,
@@ -81,6 +82,21 @@ const SEND_READ_RECEIPTS =
   process.env &&
   typeof process.env.WHATSAPP_SEND_READ_RECEIPTS === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_SEND_READ_RECEIPTS.toLowerCase());
+
+const OWNERSHIP_ROUTER_URL = String(process.env.WHATSAPP_OWNERSHIP_ROUTER_URL || '').trim();
+const OWNERSHIP_ROUTER_TOKEN = String(process.env.WHATSAPP_OWNERSHIP_ROUTER_TOKEN || '');
+const OWNERSHIP_ROUTER_CONFIG_HASH = String(process.env.WHATSAPP_OWNERSHIP_ROUTER_CONFIG_HASH || '');
+const OWNERSHIP_ROUTER_TIMEOUT_MS = Math.max(
+  1,
+  Math.min(parseInt(process.env.WHATSAPP_OWNERSHIP_ROUTER_TIMEOUT_MS || '1500', 10) || 1500, 10000),
+);
+let OWNERSHIP_ROUTER_PREFIXES = ['jeffersom'];
+try {
+  const parsedPrefixes = JSON.parse(process.env.WHATSAPP_OWNERSHIP_ROUTER_PREFIXES || '[]');
+  if (Array.isArray(parsedPrefixes) && parsedPrefixes.length) {
+    OWNERSHIP_ROUTER_PREFIXES = parsedPrefixes.slice(0, 8);
+  }
+} catch {}
 
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
@@ -728,6 +744,7 @@ async function startSocket() {
           audio: AUDIO_CACHE_DIR,
         },
       });
+
       event.fromOwner = fromOwner;
 
       // Ignore Hermes' own reply messages in self-chat mode to avoid loops.
@@ -752,6 +769,29 @@ async function startSocket() {
           messageKeys: Object.keys(msg.message || {}),
         });
         continue;
+      }
+
+      // Optional metadata-only ownership gate for multiple automations sharing
+      // this WhatsApp account. It runs after Hermes echo suppression but before
+      // the Python adapter queue, so claimed replies never create agent turns.
+      if (!isGroup && OWNERSHIP_ROUTER_URL) {
+        const ownership = await applyInboundOwnershipGate({
+          config: {
+            url: OWNERSHIP_ROUTER_URL,
+            token: OWNERSHIP_ROUTER_TOKEN,
+            timeoutMs: OWNERSHIP_ROUTER_TIMEOUT_MS,
+            prefixes: OWNERSHIP_ROUTER_PREFIXES,
+          },
+          event,
+          senderAliases: Array.from(expandWhatsAppIdentifiers(senderId, SESSION_DIR)),
+        });
+        if (ownership.action === 'drop') {
+          emitDebugEvent({
+            stage: 'ignored',
+            reason: ownership.reason,
+          });
+          continue;
+        }
       }
 
       messageStore.remember(msg);
@@ -1106,6 +1146,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    ownershipRouterConfigHash: OWNERSHIP_ROUTER_CONFIG_HASH,
   });
 });
 

--- a/scripts/whatsapp-bridge/inbound_ownership_gate.js
+++ b/scripts/whatsapp-bridge/inbound_ownership_gate.js
@@ -1,0 +1,94 @@
+const DEFAULT_TIMEOUT_MS = 1500;
+const DEFAULT_PREFIXES = ['jeffersom'];
+
+export function normalizedPrefixes(prefixes) {
+  const custom = (Array.isArray(prefixes) ? prefixes : [])
+    .map((value) => String(value || '').trim().toLocaleLowerCase('pt-BR'))
+    .filter(Boolean)
+    .slice(0, 8);
+  return [...new Set([...DEFAULT_PREFIXES, ...custom])];
+}
+
+function startsWithExplicitPrefix(body, prefixes) {
+  const text = String(body || '').trimStart().toLocaleLowerCase('pt-BR');
+  return normalizedPrefixes(prefixes).some((prefix) => {
+    if (!text.startsWith(prefix)) return false;
+    const next = text.slice(prefix.length, prefix.length + 1);
+    return !next || /[\s,.:;!?\-]/u.test(next);
+  });
+}
+
+function isSafeRouterUrl(value) {
+  try {
+    const url = new URL(value);
+    if (url.protocol === 'https:') return true;
+    return url.protocol === 'http:' && ['127.0.0.1', 'localhost', '::1', '[::1]'].includes(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+export function buildOwnershipSignal({ event, senderAliases }) {
+  const body = String(event?.body || '').trim();
+  const replyKind = body === '1'
+    ? 'approval_1'
+    : body === '2'
+      ? 'approval_2'
+      : body
+        ? 'text'
+        : 'none';
+  return {
+    senderAliases: [...new Set((senderAliases || []).map((value) => String(value || '').trim()).filter(Boolean))].slice(0, 8),
+    messageId: event?.messageId
+      ? String(event.messageId)
+      : event?.id
+        ? String(event.id)
+        : null,
+    quotedMessageId: event?.quotedMessageId ? String(event.quotedMessageId) : null,
+    replyKind,
+    hasText: Boolean(body),
+    fromOwner: Boolean(event?.fromOwner),
+  };
+}
+
+export async function applyInboundOwnershipGate({ config, event, senderAliases, fetchFn = globalThis.fetch }) {
+  if (!config?.url) return { action: 'pass', reason: 'router_disabled' };
+  if (startsWithExplicitPrefix(event?.body, config.prefixes)) {
+    return { action: 'pass', reason: 'explicit_agent_prefix' };
+  }
+  if (!isSafeRouterUrl(config.url)) {
+    return { action: 'drop', reason: 'invalid_router_url' };
+  }
+  if (!config.token) {
+    return { action: 'drop', reason: 'missing_router_token' };
+  }
+
+  const timeoutMs = Number.isFinite(Number(config.timeoutMs))
+    ? Math.max(1, Math.min(Number(config.timeoutMs), 10000))
+    : DEFAULT_TIMEOUT_MS;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const headers = { 'content-type': 'application/json' };
+    if (config.token) headers.authorization = `Bearer ${config.token}`;
+    const response = await fetchFn(config.url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(buildOwnershipSignal({ event, senderAliases })),
+      signal: controller.signal,
+      redirect: 'error',
+    });
+    if (!response?.ok) return { action: 'drop', reason: 'router_http_error' };
+    const result = await response.json();
+    if (result?.owner === 'jeffersom') return { action: 'pass', reason: 'owned_by_jeffersom' };
+    if (result?.owner === 'autocria') return { action: 'drop', reason: 'owned_by_autocria' };
+    return { action: 'drop', reason: 'router_ambiguous' };
+  } catch (error) {
+    return {
+      action: 'drop',
+      reason: error?.name === 'AbortError' ? 'router_timeout' : 'router_unavailable',
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/scripts/whatsapp-bridge/inbound_ownership_gate.test.mjs
+++ b/scripts/whatsapp-bridge/inbound_ownership_gate.test.mjs
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  applyInboundOwnershipGate,
+  buildOwnershipSignal,
+  normalizedPrefixes,
+} from './inbound_ownership_gate.js';
+
+const baseEvent = {
+  messageId: 'current-1',
+  body: '1',
+  quotedMessageId: 'quoted-1',
+  fromOwner: false,
+};
+
+function config(overrides = {}) {
+  return {
+    url: 'https://router.invalid/classify',
+    token: 'test-token',
+    timeoutMs: 50,
+    prefixes: ['jeffersom'],
+    ...overrides,
+  };
+}
+
+test('disabled router preserves existing behavior', async () => {
+  const result = await applyInboundOwnershipGate({
+    config: null,
+    event: baseEvent,
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => { throw new Error('must not call'); },
+  });
+  assert.deepEqual(result, { action: 'pass', reason: 'router_disabled' });
+});
+
+test('rejects insecure remote router URLs without sending the shared secret', async () => {
+  let called = false;
+  const result = await applyInboundOwnershipGate({
+    config: config({ url: 'http://example.com/classify' }),
+    event: baseEvent,
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => { called = true; },
+  });
+  assert.equal(called, false);
+  assert.deepEqual(result, { action: 'drop', reason: 'invalid_router_url' });
+});
+
+test('missing router token fails closed without sending metadata', async () => {
+  let called = false;
+  const result = await applyInboundOwnershipGate({
+    config: config({ token: '' }),
+    event: baseEvent,
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => {
+      called = true;
+      return { ok: true, json: async () => ({ owner: 'jeffersom' }) };
+    },
+  });
+  assert.equal(called, false);
+  assert.deepEqual(result, { action: 'drop', reason: 'missing_router_token' });
+});
+
+test('allows loopback HTTP router URLs without weakening remote transport', async () => {
+  let calls = 0;
+  const result = await applyInboundOwnershipGate({
+    config: config({ url: 'http://[::1]/classify' }),
+    event: baseEvent,
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => {
+      calls += 1;
+      return { ok: true, json: async () => ({ owner: 'jeffersom' }) };
+    },
+  });
+  assert.deepEqual(result, { action: 'pass', reason: 'owned_by_jeffersom' });
+  assert.equal(calls, 1);
+});
+
+test('Jeffersom prefix bypasses router even during AutoCria flow', async () => {
+  let called = false;
+  const result = await applyInboundOwnershipGate({
+    config: config(),
+    event: { body: '  JeFfErSoM, preciso de ajuda', quotedMessageId: 'auto-1' },
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => { called = true; throw new Error('must not call'); },
+  });
+  assert.equal(called, false);
+  assert.deepEqual(result, { action: 'pass', reason: 'explicit_agent_prefix' });
+});
+
+test('Jeffersom remains reserved when custom prefixes are configured', async () => {
+  let called = false;
+  const result = await applyInboundOwnershipGate({
+    config: config({ prefixes: ['assistant'] }),
+    event: { ...baseEvent, body: 'Jeffersom, status' },
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => { called = true; throw new Error('must not call'); },
+  });
+  assert.equal(called, false);
+  assert.deepEqual(result, { action: 'pass', reason: 'explicit_agent_prefix' });
+});
+
+test('reserved prefix has priority without truncating the eighth custom prefix', () => {
+  const custom = Array.from({ length: 8 }, (_, index) => `custom-${index + 1}`);
+  assert.deepEqual(normalizedPrefixes(custom), ['jeffersom', ...custom]);
+});
+
+test('builds metadata-only signal without the message body', () => {
+  const signal = buildOwnershipSignal({
+    event: { messageId: 'current-2', body: 'private edited answer', quotedMessageId: 'q-1', fromOwner: true },
+    senderAliases: ['5511999999999', '123456789@lid'],
+  });
+  assert.deepEqual(signal, {
+    senderAliases: ['5511999999999', '123456789@lid'],
+    messageId: 'current-2',
+    quotedMessageId: 'q-1',
+    replyKind: 'text',
+    hasText: true,
+    fromOwner: true,
+  });
+  assert.equal('body' in signal, false);
+  assert.equal('text' in signal, false);
+});
+
+test('classifies 1 and 2 as approval signals', () => {
+  assert.equal(buildOwnershipSignal({ event: { body: '1' }, senderAliases: [] }).replyKind, 'approval_1');
+  assert.equal(buildOwnershipSignal({ event: { body: ' 2 ' }, senderAliases: [] }).replyKind, 'approval_2');
+});
+
+test('AutoCria ownership drops before agent dispatch', async () => {
+  const result = await applyInboundOwnershipGate({
+    config: config(),
+    event: baseEvent,
+    senderAliases: ['5511999999999'],
+    fetchFn: async (_url, init) => {
+      const payload = JSON.parse(init.body);
+      assert.equal('body' in payload, false);
+      assert.equal(init.headers.authorization, 'Bearer test-token');
+      assert.equal(init.redirect, 'error');
+      return { ok: true, json: async () => ({ owner: 'autocria', reason: 'quoted_active_session' }) };
+    },
+  });
+  assert.deepEqual(result, { action: 'drop', reason: 'owned_by_autocria' });
+});
+
+test('Jeffersom ownership passes to agent dispatch', async () => {
+  const result = await applyInboundOwnershipGate({
+    config: config(),
+    event: { body: 'status', quotedMessageId: null },
+    senderAliases: ['5511999999999'],
+    fetchFn: async () => ({ ok: true, json: async () => ({ owner: 'jeffersom', reason: 'no_active_session' }) }),
+  });
+  assert.deepEqual(result, { action: 'pass', reason: 'owned_by_jeffersom' });
+});
+
+test('ambiguous, HTTP failure, network error, and timeout fail closed', async () => {
+  const scenarios = [
+    async () => ({ ok: true, json: async () => ({ owner: 'ambiguous', reason: 'multiple_sessions' }) }),
+    async () => ({ ok: false, status: 503, json: async () => ({}) }),
+    async () => { throw new Error('network'); },
+    async (_url, init) => await new Promise((_resolve, reject) => {
+      init.signal.addEventListener('abort', () => reject(Object.assign(new Error('timeout'), { name: 'AbortError' })));
+    }),
+  ];
+  for (const fetchFn of scenarios) {
+    const result = await applyInboundOwnershipGate({
+      config: config({ timeoutMs: 5 }),
+      event: baseEvent,
+      senderAliases: ['5511999999999'],
+      fetchFn,
+    });
+    assert.equal(result.action, 'drop');
+  }
+});

--- a/tests/gateway/test_whatsapp_ownership_router.py
+++ b/tests/gateway/test_whatsapp_ownership_router.py
@@ -1,0 +1,72 @@
+import unittest
+
+from plugins.platforms.whatsapp.adapter import (
+    _apply_ownership_router_env,
+    _ownership_router_config_hash,
+)
+
+
+class OwnershipRouterConfigHashTests(unittest.TestCase):
+    def test_adapter_preserves_eight_custom_prefixes(self):
+        from plugins.platforms.whatsapp.adapter import _normalize_ownership_router_prefixes
+
+        custom = [f"custom-{index}" for index in range(1, 9)]
+        self.assertEqual(_normalize_ownership_router_prefixes(custom), custom)
+
+    def test_hash_is_stable_and_covers_behavior_and_secret(self):
+        base = _ownership_router_config_hash(
+            "https://router.example/classify",
+            "secret-a",
+            1500,
+            ["jeffersom"],
+        )
+        self.assertEqual(len(base), 16)
+        self.assertEqual(
+            base,
+            _ownership_router_config_hash(
+                "https://router.example/classify",
+                "secret-a",
+                1500,
+                ["jeffersom"],
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            _ownership_router_config_hash(
+                "https://router.example/classify",
+                "secret-b",
+                1500,
+                ["jeffersom"],
+            ),
+        )
+        self.assertNotEqual(
+            base,
+            _ownership_router_config_hash(
+                "https://router.example/classify",
+                "secret-a",
+                2500,
+                ["jeffersom"],
+            ),
+        )
+
+    def test_disabled_router_has_empty_fingerprint(self):
+        self.assertEqual(
+            _ownership_router_config_hash("", "unused", 1500, ["jeffersom"]),
+            "",
+        )
+
+    def test_disabled_router_clears_inherited_environment(self):
+        env = {
+            "WHATSAPP_OWNERSHIP_ROUTER_URL": "https://stale.invalid",
+            "WHATSAPP_OWNERSHIP_ROUTER_TOKEN": "stale-token",
+            "WHATSAPP_OWNERSHIP_ROUTER_TIMEOUT_MS": "9999",
+            "WHATSAPP_OWNERSHIP_ROUTER_PREFIXES": '["stale"]',
+            "WHATSAPP_OWNERSHIP_ROUTER_CONFIG_HASH": "stale-hash",
+            "KEEP_ME": "yes",
+        }
+        _apply_ownership_router_env(env, "", "", 1500, ["jeffersom"], "")
+        self.assertEqual(env, {"KEEP_ME": "yes"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- gates inbound WhatsApp traffic before agent dispatch
- sends metadata only to the AutoCria ownership classifier
- fails closed on ambiguity, timeout, invalid responses, or router failure
- reserves the Jeffersom prefix and supports up to eight custom agent prefixes
- fingerprints router configuration without exposing its token

## Validation
- 12/12 bridge ownership tests passed
- 4/4 adapter tests passed via unittest
- Python compile and Node syntax checks passed
- git diff --check passed
- independent pre-commit review: GREEN

## Deployment
Disabled by default. Requires explicit router URL/token configuration. Rollout and rollback are documented in docs/whatsapp-ownership-router.md.