### PR TITLE
fix(gateway): interrupt every in-flight API turn on shutdown, not just /v1/runs

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1448,6 +1448,15 @@ class APIServerAdapter(BasePlatformAdapter):
         # (the /v1/runs path tracks its own in-flight set via
         # _active_run_tasks).
         self._inflight_agent_runs: int = 0
+        # Every agent currently inside _run_agent(), i.e. exactly the turns
+        # counted by _inflight_agent_runs above.  Shutdown needs the whole
+        # adapter-owned set, so this is deliberately NOT _active_run_agents:
+        # that one is run_id-keyed and scoped to the public /v1/runs stop API,
+        # and only /v1/runs has a run_id at all.  Keyed by id() because the
+        # other six agent-entry paths have no stable identifier of their own;
+        # the dict holds a strong reference for the life of the turn, so an
+        # id() can never be recycled while it is still registered.
+        self._shutdown_interruptible_agents: Dict[int, Any] = {}
         # Back-reference to the owning GatewayRunner (set by gateway/run.py)
         # so /api/platforms/{platform}/events can resolve sibling adapters.
         # BasePlatformAdapter declares the class-level default of None.
@@ -1473,6 +1482,52 @@ class APIServerAdapter(BasePlatformAdapter):
             )
         except Exception:
             return 0
+
+    def interrupt_active_runs(self, reason: str) -> int:
+        """Cooperatively interrupt every adapter-owned agent during shutdown.
+
+        The gateway drain accounts for API-server work through
+        ``active_agent_work_count()``, but those agents are owned by this
+        adapter rather than ``GatewayRunner._running_agents``, so
+        ``GatewayRunner._interrupt_running_agents()`` never reaches them: the
+        turn runs to the drain timeout with no cooperative interrupt and is
+        then amputated by the post-interrupt tool-subprocess kill.
+
+        Cover the same set the drain waits on, so accounting and interrupt
+        agree:
+
+        * ``_active_run_agents`` — the ``/v1/runs`` agents counted through
+          ``_active_run_tasks``.
+        * ``_shutdown_interruptible_agents`` — every ``_run_agent()`` turn
+          counted through ``_inflight_agent_runs``, i.e. both session-chat
+          routes, ``/v1/chat/completions`` and ``/v1/responses`` in their
+          streaming and non-streaming forms.
+
+        ``_pending_agent_requests`` is intentionally not covered: it counts
+        admitted requests that have not constructed an agent yet, so there is
+        no object to interrupt.
+
+        Returns the number of agents that accepted an interrupt.
+        """
+        agents: Dict[int, Any] = {}
+        for agent in list(self._active_run_agents.values()):
+            if agent is not None:
+                agents[id(agent)] = agent
+        for agent in list(self._shutdown_interruptible_agents.values()):
+            if agent is not None:
+                # Dedupe by object identity — the two registries are disjoint
+                # today (/v1/runs runs its own lifecycle, not _run_agent), but
+                # an agent published to both must still be interrupted once.
+                agents[id(agent)] = agent
+
+        interrupted = 0
+        for agent in agents.values():
+            try:
+                if request_hard_interrupt(agent, reason):
+                    interrupted += 1
+            except Exception as exc:
+                logger.debug("[api_server] failed interrupting active agent: %s", exc)
+        return interrupted
 
     @staticmethod
     def _gateway_is_draining() -> bool:
@@ -6041,6 +6096,13 @@ class APIServerAdapter(BasePlatformAdapter):
                     # runs its own agent lifecycle and doesn't go through
                     # TurnRunner, so it needs its own baseline.
                     _publish_turn_process_ownership(agent, effective_task_id)
+                    # Shutdown interrupt coverage (#63529).  Registering here,
+                    # once, covers every _run_agent() caller — the same reason
+                    # the _ProviderAuthResolutionError handler below lives here
+                    # rather than in each route.  Only two callers pass
+                    # ``agent_ref``, and only /v1/runs has a run_id, so neither
+                    # is a usable hook for the rest.
+                    self._shutdown_interruptible_agents[id(agent)] = agent
                     result = agent.run_conversation(
                         user_message=user_message,
                         conversation_history=conversation_history,
@@ -6170,6 +6232,11 @@ class APIServerAdapter(BasePlatformAdapter):
                     # in gateway/run.py's _run_sync_with_timeout_lifecycle.
                     if agent is not None:
                         _clear_turn_process_ownership(agent)
+                        # Symmetric with the registration above: the turn is
+                        # over, so it must not be interrupted by a later
+                        # shutdown.  pop() is a no-op when _create_agent
+                        # succeeded but the turn never reached registration.
+                        self._shutdown_interruptible_agents.pop(id(agent), None)
                     clear_session_vars(tokens)
 
         self._activate_admitted_request()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7365,6 +7365,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception:
             return 0
 
+    def _interrupt_api_server_runs(self, reason: str) -> int:
+        """Interrupt API-server agents that are not in ``_running_agents``.
+
+        Counterpart of ``_active_api_run_count()``: that method folds
+        adapter-owned API work into the shutdown drain, so this one must reach
+        the same agents when the drain times out. Duck-typed on the adapter so
+        an older adapter (or a minimal test double for this class) without the
+        hook is simply skipped rather than raising mid-shutdown.
+        """
+        try:
+            adapter = getattr(self, "adapters", {}).get(Platform.API_SERVER)
+            helper = getattr(adapter, "interrupt_active_runs", None)
+            return max(0, int(helper(reason))) if callable(helper) else 0
+        except Exception as exc:
+            logger.debug("Failed interrupting api_server runs during shutdown: %s", exc)
+            return 0
+
     # ── scale-to-zero idle detection / dormant-quiesce (Phase 0) ──────────────
     # The gateway-side BEHAVIOUR that consumes the relay scale-to-zero primitives
     # (gateway-gateway Phase 5). Pure logic lives in gateway/scale_to_zero.py; the
@@ -9194,6 +9211,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.debug("Interrupted running agent for session %s during shutdown", session_key)
             except Exception as e:
                 logger.debug("Failed interrupting agent during shutdown: %s", e)
+        # API-server / desk turns are adapter-owned and never enter
+        # _running_agents, so the loop above cannot see them even though
+        # _drain_active_agents() waited for them (#63529).
+        interrupted_api = self._interrupt_api_server_runs(reason)
+        if interrupted_api:
+            logger.debug("Interrupted %d api_server run(s) during shutdown", interrupted_api)
 
     async def _notify_active_sessions_of_shutdown(self) -> None:
         """Send shutdown/restart notifications to active chats and home channels.
@@ -12861,7 +12884,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _INTERRUPT_REASON_GATEWAY_RESTART if self._restart_requested else _INTERRUPT_REASON_GATEWAY_SHUTDOWN
                 )
                 interrupt_deadline = asyncio.get_running_loop().time() + 5.0
-                while self._running_agents and asyncio.get_running_loop().time() < interrupt_deadline:
+                # Wait on API-server work too. The interrupt is cooperative:
+                # without this the settle window closes the instant
+                # _running_agents is empty, and an API turn that was just asked
+                # to stop gets its tool subprocesses killed below before it can
+                # unwind — the exact amputation this interrupt exists to avoid.
+                while (
+                    self._running_agents or self._active_api_run_count()
+                ) and asyncio.get_running_loop().time() < interrupt_deadline:
                     self._update_runtime_status("draining")
                     await asyncio.sleep(0.1)
 

--- a/tests/gateway/test_api_server_active_work_drain.py
+++ b/tests/gateway/test_api_server_active_work_drain.py
@@ -8,6 +8,7 @@ turns once the gateway starts draining.
 """
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -17,7 +18,13 @@ from aiohttp.test_utils import TestClient, TestServer
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.api_server import APIServerAdapter
+from gateway.run import _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+from hermes_state import SessionDB
 from tests.gateway.restart_test_helpers import make_restart_runner
+
+# Safety net so a regression parks the executor thread forever instead of
+# hanging CI.  No assertion below depends on elapsed time.
+_TURN_UNBLOCK_TIMEOUT = 30.0
 
 
 class _RunTask:
@@ -165,5 +172,323 @@ class TestDrainAdmission:
                     assert response.status == 503
                     assert response.headers["Retry-After"] == "1"
                     assert payload["error"]["code"] == "gateway_draining"
+
+
+# ---------------------------------------------------------------------------
+# Shutdown interrupt coverage (#63529)
+#
+# The drain ACCOUNTS for every API turn (`active_agent_work_count()` sums
+# `_pending_agent_requests` + `_inflight_agent_runs` + live `_active_run_tasks`)
+# but `GatewayRunner._interrupt_running_agents()` only walked
+# `self._running_agents`, which no API turn ever enters.  So an API turn held
+# the drain open for the full timeout and was then amputated by
+# `_kill_tool_subprocesses("post-interrupt")` with no cooperative interrupt.
+#
+# `/v1/runs` is only one of seven API agent-entry points.  The other six all
+# funnel through `_run_agent()` — both session-chat routes and
+# `/v1/chat/completions` + `/v1/responses` in streaming and non-streaming form
+# — and none of them has a run_id, so `_active_run_agents` cannot reach them.
+# ---------------------------------------------------------------------------
+
+
+def _parked_agent(loop, started: asyncio.Event, release: threading.Event) -> MagicMock:
+    """A mock agent whose turn parks inside ``run_conversation`` until released.
+
+    ``request_hard_interrupt`` falls back to ``agent.interrupt(reason)`` for an
+    unspecced ``MagicMock`` — ``inspect.getattr_static`` refuses to invent
+    ``hard_interrupt`` on a ``__getattr__`` proxy — which is exactly the ABI
+    teknium1's review asked this regression to verify.
+    """
+    agent = MagicMock()
+    agent.session_id = None
+    agent.session_prompt_tokens = 0
+    agent.session_completion_tokens = 0
+    agent.session_total_tokens = 0
+    agent._last_compaction_in_place = False
+    agent._hermes_api_runtime = {}
+
+    def _park(user_message=None, conversation_history=None, task_id=None):
+        loop.call_soon_threadsafe(started.set)
+        release.wait(_TURN_UNBLOCK_TIMEOUT)
+        return {"final_response": "done", "messages": [], "api_calls": 0, "tools": []}
+
+    agent.run_conversation.side_effect = _park
+    # A real agent unwinds its turn on interrupt; releasing here models that so
+    # the parked executor thread can finish.
+    agent.interrupt.side_effect = lambda *_a, **_k: release.set()
+    return agent
+
+
+class _SettlingApiAdapter:
+    """API adapter double whose work clears a few polls AFTER it is interrupted.
+
+    The poll count is the deterministic quantity under test: it makes "the
+    settle window kept polling API work" observable without timing anything.
+    """
+
+    def __init__(self, polls_to_settle: int = 3):
+        self._polls_to_settle = polls_to_settle
+        self.interrupt_reasons: list = []
+
+    def active_agent_work_count(self) -> int:
+        if not self.interrupt_reasons:
+            return 1
+        if self._polls_to_settle > 0:
+            self._polls_to_settle -= 1
+            return 1
+        return 0
+
+    def interrupt_active_runs(self, reason: str) -> int:
+        self.interrupt_reasons.append(reason)
+        return 1
+
+    @property
+    def settled(self) -> bool:
+        """Non-consuming view of the same state, safe to read from a spy."""
+        return bool(self.interrupt_reasons) and self._polls_to_settle == 0
+
+
+def _make_async_noop():
+    async def _noop(*args, **kwargs):
+        return None
+
+    return _noop
+
+
+class TestRunAgentRegistersForShutdownInterrupt:
+    @pytest.mark.asyncio
+    async def test_run_agent_registers_and_unregisters_the_agent(self):
+        """One registration inside ``_run_agent`` covers all six of its callers.
+
+        Only two callers pass ``agent_ref``, and that lands in a caller-local
+        list rather than any registry, so it is not a usable hook.
+        """
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.session_id = None
+        agent.session_prompt_tokens = 0
+        agent.session_completion_tokens = 0
+        agent.session_total_tokens = 0
+        agent._last_compaction_in_place = False
+        observed = {}
+
+        def _record(user_message=None, conversation_history=None, task_id=None):
+            observed["during"] = dict(adapter._shutdown_interruptible_agents)
+            return {"final_response": "done", "messages": [], "api_calls": 0, "tools": []}
+
+        agent.run_conversation.side_effect = _record
+
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            await adapter._run_agent(
+                user_message="hello",
+                conversation_history=[],
+                session_id="s1",
+            )
+
+        assert list(observed["during"].values()) == [agent]
+        assert adapter._shutdown_interruptible_agents == {}
+
+    @pytest.mark.asyncio
+    async def test_agent_is_unregistered_when_the_turn_raises(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        agent.run_conversation.side_effect = RuntimeError("boom")
+
+        with patch.object(adapter, "_create_agent", return_value=agent):
+            with pytest.raises(RuntimeError):
+                await adapter._run_agent(
+                    user_message="hello",
+                    conversation_history=[],
+                    session_id="s1",
+                )
+
+        assert adapter._shutdown_interruptible_agents == {}
+
+
+class TestInterruptActiveRuns:
+    def test_interrupts_v1_runs_agents(self):
+        """The ``/v1/runs`` coverage #63963 established stays green."""
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        agent = MagicMock()
+        adapter._active_run_agents = {"run-1": agent}
+
+        assert adapter.interrupt_active_runs("gateway shutdown") == 1
+        agent.interrupt.assert_called_once_with("gateway shutdown")
+
+    def test_interrupts_each_agent_exactly_once_across_both_registries(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        shared = MagicMock()
+        run_only = MagicMock()
+        turn_only = MagicMock()
+        adapter._active_run_agents = {"run-1": run_only, "run-2": shared}
+        adapter._shutdown_interruptible_agents = {
+            id(shared): shared,
+            id(turn_only): turn_only,
+        }
+
+        assert adapter.interrupt_active_runs("gateway shutdown") == 3
+        shared.interrupt.assert_called_once_with("gateway shutdown")
+        run_only.interrupt.assert_called_once_with("gateway shutdown")
+        turn_only.interrupt.assert_called_once_with("gateway shutdown")
+
+    def test_one_bad_agent_does_not_strand_the_others(self):
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        exploding = MagicMock()
+        exploding.interrupt.side_effect = RuntimeError("already torn down")
+        no_abi = object()  # exposes neither hard_interrupt nor interrupt
+        healthy = MagicMock()
+        adapter._shutdown_interruptible_agents = {
+            id(exploding): exploding,
+            id(no_abi): no_abi,
+            id(healthy): healthy,
+        }
+
+        assert adapter.interrupt_active_runs("gateway shutdown") == 1
+        healthy.interrupt.assert_called_once_with("gateway shutdown")
+
+
+class TestShutdownInterruptReachesEveryApiTurn:
+    @pytest.mark.asyncio
+    async def test_chat_completions_turn_is_interrupted(self):
+        """A non-``/v1/runs`` API turn, end to end through the real handler.
+
+        This is teknium1's named acceptance criterion on #63963: the drain
+        counts this turn, so the shutdown interrupt must reach it.
+        """
+        runner, _adapter = make_restart_runner()
+        api = APIServerAdapter(PlatformConfig(enabled=True))
+        runner.adapters = {Platform.API_SERVER: api}
+        app = _make_admission_app(api)
+
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        release = threading.Event()
+        agent = _parked_agent(loop, started, release)
+
+        try:
+            with patch.object(api, "_create_agent", return_value=agent):
+                async with TestClient(TestServer(app)) as client:
+                    request = asyncio.ensure_future(
+                        client.post(
+                            "/v1/chat/completions",
+                            json={"messages": [{"role": "user", "content": "hi"}]},
+                        )
+                    )
+                    await asyncio.wait_for(started.wait(), _TURN_UNBLOCK_TIMEOUT)
+
+                    # The drain sees this turn ...
+                    assert runner._active_api_run_count() == 1
+                    # ... and it is not in _running_agents, so only the API
+                    # hook can reach it.
+                    assert runner._running_agents == {}
+
+                    runner._interrupt_running_agents(_INTERRUPT_REASON_GATEWAY_SHUTDOWN)
+
+                    agent.interrupt.assert_called_once_with(
+                        _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    )
+                    response = await asyncio.wait_for(request, _TURN_UNBLOCK_TIMEOUT)
+                    assert response.status == 200
+        finally:
+            release.set()
+
+        assert api._shutdown_interruptible_agents == {}
+
+    @pytest.mark.asyncio
+    async def test_session_chat_sse_turn_is_interrupted(self, tmp_path):
+        """The SSE session-chat route is a second, differently shaped caller."""
+        runner, _adapter = make_restart_runner()
+        api = APIServerAdapter(PlatformConfig(enabled=True))
+        session_db = SessionDB(tmp_path / "state.db")
+        api._session_db = session_db
+        runner.adapters = {Platform.API_SERVER: api}
+        app = _make_admission_app(api)
+        session_id = session_db.create_session("sse-session", "api_server")
+
+        loop = asyncio.get_running_loop()
+        started = asyncio.Event()
+        release = threading.Event()
+        agent = _parked_agent(loop, started, release)
+
+        try:
+            with patch.object(api, "_create_agent", return_value=agent):
+                async with TestClient(TestServer(app)) as client:
+                    request = asyncio.ensure_future(
+                        client.post(
+                            f"/api/sessions/{session_id}/chat/stream",
+                            json={"message": "hi"},
+                        )
+                    )
+                    await asyncio.wait_for(started.wait(), _TURN_UNBLOCK_TIMEOUT)
+
+                    assert runner._active_api_run_count() == 1
+                    assert runner._running_agents == {}
+
+                    runner._interrupt_running_agents(_INTERRUPT_REASON_GATEWAY_SHUTDOWN)
+
+                    agent.interrupt.assert_called_once_with(
+                        _INTERRUPT_REASON_GATEWAY_SHUTDOWN
+                    )
+                    response = await asyncio.wait_for(request, _TURN_UNBLOCK_TIMEOUT)
+                    assert response.status == 200
+                    await asyncio.wait_for(response.text(), _TURN_UNBLOCK_TIMEOUT)
+        finally:
+            release.set()
+            close = getattr(session_db, "close", None)
+            if callable(close):
+                close()
+
+        assert api._shutdown_interruptible_agents == {}
+
+    def test_interrupt_running_agents_is_a_noop_without_an_api_adapter(self):
+        """The hook is duck-typed — an adapterless runner must not raise."""
+        runner, _adapter = make_restart_runner()
+        runner.adapters = {}
+
+        runner._interrupt_running_agents(_INTERRUPT_REASON_GATEWAY_SHUTDOWN)
+
+        assert runner._interrupt_api_server_runs("x") == 0
+
+
+class TestShutdownSettleWindow:
+    @pytest.mark.asyncio
+    async def test_settle_window_waits_for_interrupted_api_work(self, monkeypatch):
+        """The interrupt is cooperative, so the settle window must poll API work.
+
+        Otherwise the window closes the instant ``_running_agents`` is empty —
+        which it always is for API turns — and the post-interrupt tool kill
+        lands on a turn that was asked to stop microseconds earlier.
+        """
+        import tools.browser_tool as _bt
+        import tools.process_registry as _pr
+        import tools.terminal_tool as _tt
+
+        runner, adapter = make_restart_runner()
+        runner._restart_drain_timeout = 0.01  # force the drain-timeout path
+        adapter.disconnect = _make_async_noop()
+        api = _SettlingApiAdapter()
+        runner.adapters = {Platform.TELEGRAM: adapter, Platform.API_SERVER: api}
+
+        settled_at_kill: list = []
+
+        def _spy_kill_all(task_id=None):
+            settled_at_kill.append(api.settled)
+            return 0
+
+        monkeypatch.setattr(_pr.process_registry, "kill_all", _spy_kill_all)
+        monkeypatch.setattr(_tt, "cleanup_all_environments", lambda: None)
+        monkeypatch.setattr(_bt, "cleanup_all_browsers", lambda: None)
+
+        with patch("gateway.status.remove_pid_file"), \
+             patch("gateway.status.write_runtime_status"), \
+             patch("cron.scheduler.mark_job_run"):
+            await runner.stop()
+
+        assert api.interrupt_reasons == [_INTERRUPT_REASON_GATEWAY_SHUTDOWN]
+        assert settled_at_kill, "post-interrupt tool kill never ran"
+        assert settled_at_kill[0] is True, (
+            "post-interrupt tool kill ran while the interrupted API turn was "
+            "still unwinding"
+        )
 
 


### PR DESCRIPTION
supersedes #63963

@necoweb3 found this bug and got the architecture right. Two parts of #63963 are kept here essentially as written, with credit:

- the duck-typed `GatewayRunner._interrupt_api_server_runs()` hook, called from `_interrupt_running_agents()` — an adapter without the hook is skipped rather than raising mid-shutdown;
- folding `_active_api_run_count()` into the 5s settle window after the interrupt.

What this PR adds is the coverage teknium1's review asked for. #63963 has been open 23 days with that one review unanswered, so rather than let the fix sit, this ships the superset.

## What does this PR do?

The shutdown drain **accounts for** API-server work but never **interrupts** it.

`_drain_active_agents()` folds `_active_api_run_count()` into both its wait loop and its `timed_out` verdict. `_interrupt_running_agents()` iterates `self._running_agents` only — a dict no API turn ever enters, because the API server owns its own agent lifecycle. The repo states the gap against itself, in `gateway/run.py` directly above the drain loop:

```python
# API-server / desk sessions have the same structural gap (#63529).
```

**User-visible symptom:** every gateway restart (`/restart`, `/update`, SIGUSR1 — they all funnel through the same `stop()`) with a live API or desktop turn burns the full drain timeout, then runs `_kill_tool_subprocesses("post-interrupt")`, which amputates the turn's tool subprocesses. No cooperative interrupt, no chance to unwind. "It hung, then I lost my work."

### Seven entry points, not one

| # | Entry point | Counted by | Agent reachable via | Covered by #63963 | Covered here |
|---|---|---|---|---|---|
| 1 | `POST /v1/runs` (`_handle_runs`) | `_active_run_tasks` | `_active_run_agents[run_id]` | ✅ | ✅ |
| 2 | `POST /api/sessions/{id}/chat` (`_handle_session_chat`) | `_inflight_agent_runs` | — | ❌ | ✅ |
| 3 | `POST /api/sessions/{id}/chat/stream` (`_handle_session_chat_stream`) | `_inflight_agent_runs` | — | ❌ | ✅ |
| 4 | `POST /v1/chat/completions`, streaming (`_handle_chat_completions`) | `_inflight_agent_runs` | caller-local `agent_ref` list | ❌ | ✅ |
| 5 | `POST /v1/chat/completions`, non-streaming | `_inflight_agent_runs` | — | ❌ | ✅ |
| 6 | `POST /v1/responses`, streaming (`_handle_responses`) | `_inflight_agent_runs` | caller-local `agent_ref` list | ❌ | ✅ |
| 7 | `POST /v1/responses`, non-streaming | `_inflight_agent_runs` | — | ❌ | ✅ |

Rows 2–7 are the six `_run_agent()` callers. `_inflight_agent_runs += 1 / -= 1` wraps every one of them, so they all hold the drain open — and none of them has a `run_id`, so the run_id-keyed `_active_run_agents` structurally cannot reach them. Only rows 4 and 6 pass `agent_ref`, and that lands in a caller-local one-element list, never a registry, so it is not a usable hook either.

That is broader than the review note, which named the synchronous session-chat path specifically.

### The approach: one registration site

Rather than touch six call sites, register at the single unconditional agent-creation point inside `_run_agent`'s inner `_run`, immediately beside the existing `_publish_turn_process_ownership(agent, effective_task_id)` call, and unregister in the **same existing `finally`** that already calls `_clear_turn_process_ownership(agent)`. One symmetric pair, six callers covered, mirroring a lifecycle idiom already accepted in that exact function — and the same "handle it here, once, covers every `_run_agent()` caller" reasoning the `_ProviderAuthResolutionError` branch a few lines below already uses.

The new registry is deliberately **not** `_active_run_agents`:

- `_active_run_agents` is `run_id`-keyed and scoped to the public `POST /v1/runs/{run_id}/stop` API; shutdown needs everything, and six of the seven paths have no `run_id`.
- Keeping them separate also avoids colliding with #58856, which relocates `_active_run_agents[run_id] = agent` into `_run_agent` for its own purposes. `interrupt_active_runs()` dedupes by object identity, so if that lands and an agent ends up in both registries, it is still interrupted exactly once.

`_pending_agent_requests` is deliberately not covered, and the docstring says so: it counts admitted requests that have not constructed an agent yet, so there is no object to interrupt.

Cron is out of scope here — cron agents live in `cron/scheduler.py`'s own module-level registry keyed by `job_id`, entirely outside this adapter, and #43085 covers that surface.

## teknium1's `### Suggested changes` on #63963, as an acceptance checklist

> - Track interruptable agents for every `_run_agent()` path included in `_inflight_agent_runs`, and interrupt that complete adapter-owned set during shutdown.

✅ One registration inside `_run_agent` covers all six callers by construction — `_inflight_agent_runs` and the registry are incremented/populated around the same body, so they cannot drift. `interrupt_active_runs()` walks that registry unioned with `_active_run_agents`, deduped by identity.

> - Add a timeout regression for a non-`/v1/runs` API turn that verifies `agent.interrupt()` is called.

✅ Two of them, both end-to-end through the real aiohttp handlers with the turn genuinely parked inside `run_conversation` on an executor thread: `test_chat_completions_turn_is_interrupted` and `test_session_chat_sse_turn_is_interrupted`. Each asserts the drain sees the turn (`_active_api_run_count() == 1`), that it is *not* in `_running_agents`, and then that `agent.interrupt` is called exactly once with the shutdown reason.

(`request_hard_interrupt()` is used rather than a bare `agent.interrupt(reason)`, matching `_interrupt_running_agents` and the `/v1/runs` stop handler. For an unspecced mock it falls through to `agent.interrupt(reason)`, so the assertion above is on the exact ABI named in the review.)

## Related Issue

Context: #63529 (closed — its accounting half landed; this is the interrupt half). Not auto-closing it.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py`
  - `__init__`: add `_shutdown_interruptible_agents`, an adapter-owned registry of agents currently inside `_run_agent()`, keyed by `id()`. It holds a strong reference for the life of the turn, so an `id()` cannot be recycled while registered.
  - `_run_agent()` inner `_run()`: register beside `_publish_turn_process_ownership()`; unregister in the existing `finally` beside `_clear_turn_process_ownership()`. `pop(..., None)` is a no-op if `_create_agent` succeeded but the turn never reached registration.
  - new `interrupt_active_runs(reason) -> int`: walks `_active_run_agents` ∪ `_shutdown_interruptible_agents`, dedupes by object identity, calls `request_hard_interrupt` per agent, swallows and logs per-agent failures so one torn-down agent cannot strand the rest, and returns the number that accepted an interrupt.
- `gateway/run.py`
  - new `_interrupt_api_server_runs(reason)` — duck-typed adapter hook (from #63963).
  - `_interrupt_running_agents()` calls it after its `_running_agents` loop (from #63963).
  - the post-interrupt settle window now polls `_active_api_run_count()` as well as `_running_agents` (from #63963).
- `tests/gateway/test_api_server_active_work_drain.py` — 9 new tests.

## How to Test

```
pytest tests/gateway/test_api_server_active_work_drain.py -v
```

14 passed (5 pre-existing + 9 new).

**Red-before / green-after.** Every hunk was reverted independently against clean `origin/main` and the tests re-run in their final location:

| Production state | Result |
|---|---|
| both prod files at `origin/main` | **9 failed**, 5 passed — all 9 new tests red, no pre-existing test disturbed |
| `api_server.py` fixed, `run.py` at `origin/main` | **4 failed**, 10 passed |
| `run.py` fixed, `api_server.py` at `origin/main` | **7 failed**, 7 passed |
| full fix, **settle-window hunk alone** reverted | **1 failed**, 13 passed |
| full fix | **14 passed** |

The last row but one is the point: the settle-window change is independently load-bearing, not a cosmetic tag-along. `test_settle_window_waits_for_interrupted_api_work` drives the real `runner.stop()` down its drain-timeout path and asserts, via a deterministic poll counter rather than any wall-clock measurement, that the post-interrupt tool kill ran only *after* the interrupted API work had settled.

Adjacent suites, all green on this branch:

```
pytest tests/gateway/test_gateway_shutdown.py tests/gateway/test_cron_active_work_drain.py \
       tests/gateway/test_restart_resume_pending.py tests/gateway/test_clean_shutdown_marker.py \
       tests/agent/test_interrupt_compat.py          # 52 passed
pytest tests/gateway/test_api_server.py tests/gateway/test_session_api.py \
       tests/gateway/test_api_server_runs.py         # 127 passed
```

Manual: start the gateway with the API server enabled, send a long-running turn to `POST /v1/chat/completions` (non-streaming) or to the desktop app, then `/restart`. Before: the drain runs to its full timeout and the turn's tool subprocesses are killed from under it. After: the turn is interrupted cooperatively as soon as the drain times out, and the settle window lets it unwind before the tool kill.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the touched file plus the adjacent gateway/API/shutdown suites (179 tests, all green); the full suite is not green on a stock local checkout, so I did not claim it
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing docs describe this internal shutdown path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure in-process Python (dict bookkeeping, asyncio); no paths, no signals, no subprocess behavior touched
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- **#63963** — superseded, with credit above. Same diagnosis; this widens the fix from 1 of 7 entry points to 7 of 7 and answers the review that has been open on it since 07-16.
- **#58856** — orthogonal. It adds approval/stop support to the session-chat stream and relocates `_active_run_agents[run_id]` into `_run_agent` for that. This PR deliberately does not touch `_active_run_agents`, and its identity dedupe means the two compose without conflict whichever lands first.
- **#43085** — the cron-side counterpart of the same structural gap, in `cron/scheduler.py`. Disjoint registry, disjoint population; intentionally not folded in here.
