### PR TITLE
Add Muse community plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ scripts/run_tests.sh
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [computer-use-linux](https://github.com/avifenesh/computer-use-linux) — Linux desktop-control MCP server for Hermes and other MCP hosts, with AT-SPI accessibility trees, Wayland/X11 input, screenshots, and compositor window targeting.
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [Muse](https://github.com/mikeleke/hermes-muse-plugin) — Autonomous reflection, exploration, knowledge distillation, and reusable skill formation for Hermes Agent.
 
 ---
 


### PR DESCRIPTION
## What changed

Adds Muse to the README Community section, linking to the standalone [`mikeleke/hermes-muse-plugin`](https://github.com/mikeleke/hermes-muse-plugin) repository.

## Why

Muse adds an opt-in autonomous growth cycle for Hermes: it reflects on recent sessions, discovers evidence-backed capability gaps, explores them with the user's existing tools, and distills durable memory or reusable skills. The implementation remains external in line with the repository's third-party plugin policy.

## User impact

Users can discover and install the plugin with:

```bash
hermes plugins install mikeleke/hermes-muse-plugin --enable
```

The plugin creates no recurring job during installation and does not elevate tool permissions or bypass Hermes write approval.

## Validation

- Plugin CI passes on Python 3.11, 3.12, and 3.13.
- Tested plugin discovery, `/muse` registration, and `skill_view("muse:muse")` against Hermes Agent v0.20.0.
- Tested real one-shot cron creation and recurring create/status/pause/resume/remove lifecycle against v0.20.0.
- This PR changes one README line only.
