### PR TITLE
fix(agent): rebuild sanitize_api_messages for immediate tool adjacency

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -28,6 +28,7 @@ import logging
 import re
 import threading
 import time
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -3451,12 +3452,81 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             deduped.append(msg)
         else:
             deduped.append(msg)
+    # Always take the deduped list — mutations are only present when
+    # removed_dupes > 0, but keeping the assignment unconditional makes the
+    # adjacency rebuild below operate on a single known list.
+    messages = deduped
     if removed_dupes:
-        messages = deduped
         _ra().logger.debug(
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Enforce immediate tool adjacency (DeepSeek / Kimi / strict OpenAI-compat).
+    # KAI-ADJACENCY-V1
+    # Steps 1–3 ensure each tool_call_id has some result somewhere and strip
+    # duplicates, but providers that require tool messages to IMMEDIATELY follow
+    # the assistant.tool_calls turn still 400 when a result was parked later
+    # (compression splice, resume, intervening user/assistant). Rebuild on the
+    # per-call copy only — do not rewrite persisted trajectory.
+    # Prefer relocating the real tool result next to its call; stub only when
+    # no matching result remains. Related: #24328; supersedes stale #24374 /
+    # #24330 / #24405 which targeted pre-extraction run_agent.py.
+    tools_by_id: dict = defaultdict(list)
+    non_tool: List[Dict[str, Any]] = []
+    dropped_empty_tool_ids = 0
+    for msg in messages:
+        if msg.get("role") == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            if not cid:
+                dropped_empty_tool_ids += 1
+                continue
+            # Normalize id on the relocated copy so provider string-equality
+            # matches the assistant tool_call id (strip asymmetry scar).
+            if msg.get("tool_call_id") != cid:
+                msg = {**msg, "tool_call_id": cid}
+            tools_by_id[cid].append(msg)
+            continue
+        non_tool.append(msg)
+
+    rebuilt: List[Dict[str, Any]] = []
+    stubs_adjacent = 0
+    for msg in non_tool:
+        if (
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and "tool_calls" in msg
+            and not (isinstance(msg.get("tool_calls"), list) and msg.get("tool_calls"))
+        ):
+            msg = {k: v for k, v in msg.items() if k != "tool_calls"}
+        rebuilt.append(msg)
+        if msg.get("role") != "assistant":
+            continue
+        for tc in msg.get("tool_calls") or []:
+            cid = (_ra().AIAgent._get_tool_call_id_static(tc) or "").strip()
+            if not cid:
+                continue
+            q = tools_by_id.get(cid) or []
+            if q:
+                rebuilt.append(q.pop(0))
+            else:
+                rebuilt.append({
+                    "role": "tool",
+                    "name": _ra().AIAgent._get_tool_call_name_static(tc),
+                    "content": "[Result unavailable — see context summary above]",
+                    "tool_call_id": cid,
+                })
+                stubs_adjacent += 1
+    leftover = sum(len(v) for v in tools_by_id.values())
+    if stubs_adjacent or leftover or dropped_empty_tool_ids:
+        _ra().logger.debug(
+            "Pre-call sanitizer: adjacency pass stubs=%d "
+            "dropped_leftover_tools=%d dropped_empty_tool_ids=%d",
+            stubs_adjacent,
+            leftover,
+            dropped_empty_tool_ids,
+        )
+    messages = rebuilt
     return messages
 
 

--- a/tests/run_agent/test_agent_guardrails.py
+++ b/tests/run_agent/test_agent_guardrails.py
@@ -106,6 +106,110 @@ class TestSanitizeApiMessages:
     def test_empty_list_is_safe(self):
         assert AIAgent._sanitize_api_messages([]) == []
 
+    def test_api_sanitizer_relocates_parked_tool_result(self):
+        """Result with matching id later must move next to assistant.tool_calls.
+
+        Strict providers (DeepSeek / Kimi) reject assistant(tool_calls) followed
+        by a user turn even when a matching tool result exists later. Prefer
+        relocating the real result over stubbing it away.
+        """
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_old",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "second"},
+            {"role": "tool", "tool_call_id": "call_old", "content": "late real result"},
+        ]
+        out = AIAgent._sanitize_api_messages(messages)
+        assistant_idx = next(i for i, m in enumerate(out) if m.get("tool_calls"))
+        assert out[assistant_idx + 1]["role"] == "tool"
+        assert out[assistant_idx + 1]["tool_call_id"] == "call_old"
+        assert out[assistant_idx + 1]["content"] == "late real result"
+        assert any(m.get("role") == "user" and m.get("content") == "second" for m in out)
+
+    def test_api_sanitizer_stubs_when_result_missing_after_user(self):
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_miss",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "second"},
+        ]
+        out = AIAgent._sanitize_api_messages(messages)
+        assistant_idx = next(i for i, m in enumerate(out) if m.get("tool_calls"))
+        assert out[assistant_idx + 1]["role"] == "tool"
+        assert out[assistant_idx + 1]["tool_call_id"] == "call_miss"
+        assert "Result unavailable" in out[assistant_idx + 1]["content"]
+
+    def test_api_sanitizer_emits_tool_results_in_call_order(self):
+        messages = [
+            {"role": "user", "content": "go"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "a", "arguments": "{}"},
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "b", "arguments": "{}"},
+                    },
+                ],
+            },
+            {"role": "tool", "tool_call_id": "call_b", "content": "B"},
+            {"role": "tool", "tool_call_id": "call_a", "content": "A"},
+        ]
+        out = AIAgent._sanitize_api_messages(messages)
+        assistant_idx = next(i for i, m in enumerate(out) if m.get("tool_calls"))
+        assert out[assistant_idx + 1]["tool_call_id"] == "call_a"
+        assert out[assistant_idx + 1]["content"] == "A"
+        assert out[assistant_idx + 2]["tool_call_id"] == "call_b"
+        assert out[assistant_idx + 2]["content"] == "B"
+
+    def test_api_sanitizer_strips_whitespace_tool_call_id_on_relocate(self):
+        messages = [
+            {"role": "user", "content": "first"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_ws",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "user", "content": "second"},
+            {"role": "tool", "tool_call_id": " call_ws ", "content": "padded"},
+        ]
+        out = AIAgent._sanitize_api_messages(messages)
+        assistant_idx = next(i for i, m in enumerate(out) if m.get("tool_calls"))
+        assert out[assistant_idx + 1]["role"] == "tool"
+        assert out[assistant_idx + 1]["tool_call_id"] == "call_ws"
+        assert out[assistant_idx + 1]["content"] == "padded"
+
 
     def test_sdk_object_tool_calls(self):
         tc_obj = types.SimpleNamespace(id="c6", function=types.SimpleNamespace(


### PR DESCRIPTION
## Summary
Strict providers (DeepSeek, Kimi / Moonshot) reject histories where an `assistant` turn with `tool_calls` is not **immediately** followed by the matching `tool` results — even when a result with the same `tool_call_id` exists later (compression splice, resume, intervening user/assistant).

`sanitize_api_messages` already drops true orphans, stubs globally missing ids, and dedups. That still leaves the parked-later shape on the wire.

This adds a final **rebuild** pass on the per-call copy only:
1. Bucket tool results by normalized `tool_call_id`
2. Replay non-tool messages
3. After each `assistant.tool_calls`, emit results in call order (relocate real content; stub only if missing)
4. Drop leftover / empty-id tool messages (debug-counted)

Preserves real tool content instead of stubbing away a late match (unlike the earlier approach in #24374).

## Related
- Fixes #24328
- Supersedes stale / conflicting PRs that targeted pre-extraction `run_agent.py`: #24374, #24330, #24405 (please close as superseded if this lands)

## Test plan
- [x] `python -m pytest tests/run_agent/test_agent_guardrails.py -k SanitizeApiMessages -q`
- New cases: parked result relocated; missing → stub; multi-call order; whitespace `tool_call_id` normalize
