### PR TITLE
fix(desktop): remember selected profile across restarts

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9987,6 +9987,9 @@ ipcMain.handle('hermes:connection-config:apply', async (_event, payload) => {
 })
 
 ipcMain.handle('hermes:profile:get', async () => ({ profile: readActiveDesktopProfile() }))
+ipcMain.handle('hermes:profile:remember', async (_event, name) => ({
+  profile: writeActiveDesktopProfile(name)
+}))
 ipcMain.handle('hermes:profile:set', async (_event, name) => {
   const next = writeActiveDesktopProfile(name)
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -102,6 +102,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   },
   profile: {
     get: () => ipcRenderer.invoke('hermes:profile:get'),
+    remember: name => ipcRenderer.invoke('hermes:profile:remember', name),
     set: name => ipcRenderer.invoke('hermes:profile:set', name)
   },
   api: request => ipcRenderer.invoke('hermes:api', request),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -111,6 +111,9 @@ declare global {
       }
       profile: {
         get: () => Promise<DesktopActiveProfile>
+        // Persists the profile used on the next Desktop launch without
+        // interrupting the live gateway workspace switch.
+        remember: (name: string | null) => Promise<DesktopActiveProfile>
         // Persists the desktop's profile choice and relaunches the local
         // backend under the new HERMES_HOME (reloads the window). Pass null to
         // clear the preference.

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -6,7 +6,7 @@ import type { ProfileInfo } from '@/types/hermes'
 
 // Keep profile.ts's side-effecting imports inert: the gateway socket layer and
 // the REST query client must not run for real in a unit test.
-const ensureGatewayForProfile = vi.fn(async () => undefined)
+const ensureGatewayForProfile = vi.fn(async (_profile: string): Promise<void> => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
@@ -19,8 +19,15 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, $profiles, ensureGatewayProfile, prewarmProfileBackend, refreshProfiles } =
-  await import('./profile')
+const {
+  $activeGatewayProfile,
+  $profiles,
+  $showAllProfiles,
+  ensureGatewayProfile,
+  prewarmProfileBackend,
+  refreshProfiles,
+  selectProfile
+} = await import('./profile')
 
 const { $connection } = await import('./session')
 const { invalidateProfileScopedQueries } = await import('@/lib/query-client')
@@ -43,6 +50,7 @@ const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
   ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
 
 const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+const rememberProfile = vi.fn(async (name: string | null) => ({ profile: name }))
 
 beforeEach(() => {
   getConnection.mockReset()
@@ -52,7 +60,9 @@ beforeEach(() => {
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
   $profiles.set([])
-  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+  $showAllProfiles.set(false)
+  rememberProfile.mockClear()
+  vi.stubGlobal('window', { hermesDesktop: { getConnection, profile: { remember: rememberProfile } } })
   vi.mocked(invalidateProfileScopedQueries).mockClear()
   resetStarmapGraph.mockClear()
 })
@@ -107,6 +117,38 @@ describe('ensureGatewayProfile → $connection sync (#46651)', () => {
     expect(getConnection).not.toHaveBeenCalled()
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
     expect($connection.get()?.mode).toBe('remote')
+  })
+})
+
+describe('selectProfile startup preference', () => {
+  it('remembers the selected workspace for the next Desktop launch', async () => {
+    getConnection.mockResolvedValue(localConn({ profile: 'tilly' }))
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly')
+    expect($activeGatewayProfile.get()).toBe('tilly')
+  })
+
+  it('waits for gateway activation before replacing the startup preference', async () => {
+    let resolveGateway!: () => void
+
+    ensureGatewayForProfile.mockImplementationOnce(
+      () =>
+        new Promise<void>(resolve => {
+          resolveGateway = resolve
+        })
+    )
+    getConnection.mockResolvedValue(localConn({ profile: 'tilly' }))
+
+    selectProfile('tilly')
+    await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly'))
+    expect(rememberProfile).not.toHaveBeenCalled()
+
+    resolveGateway()
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -345,7 +345,10 @@ export function selectProfile(name: string): void {
     requestFreshSession()
   }
 
-  void ensureGatewayProfile(target)
+  // The profile rail is a live workspace switch, so it must not call
+  // profile.set() and reload the window. Remember the successful selection for
+  // the next launch through the persistence-only IPC instead.
+  void ensureGatewayProfile(target).then(() => window.hermesDesktop.profile.remember(target))
 }
 
 // Start a fresh session in `name` WITHOUT collapsing the "All profiles" browse


### PR DESCRIPTION
## What does this PR do?

The Desktop profile rail switches the live gateway and session scope, but that successful selection was not saved for the next launch. After a restart, Desktop could return to default and make sessions in the named profile look missing.

This change adds a persistence-only profile IPC that reuses the existing validated active-profile writer without reloading the window. The rail records the selected profile only after its gateway is active, so a failed switch cannot replace the previous startup preference.

The scope is deliberately limited to explicit profile-rail selections. It does not add first-boot heuristics or change updater config handling covered by #64160 and #64195.

## Related Issue

Fixes #79886

Related to #64160 and #64195.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Add a no-reload hermes:profile:remember IPC handler backed by writeActiveDesktopProfile().
- Expose the new method through the preload bridge and renderer type contract.
- Save a profile-rail selection after ensureGatewayProfile() completes.
- Add regression coverage for persistence and asynchronous ordering.

## How to Test

1. Start Desktop with default and at least one named profile.
2. Select the named profile from the profile rail and wait for its sessions to appear.
3. Quit and reopen Desktop.
4. Confirm that Desktop starts in the selected named profile.
5. Run the scoped automated checks listed below.

Automated checks completed:

- ../../node_modules/.bin/vitest run src/store/profile.test.ts (13 tests passed)
- ../../node_modules/.bin/tsc -p . --noEmit
- ../../node_modules/.bin/tsc -p tsconfig.electron.json --noEmit
- ../../node_modules/.bin/eslint electron/main.ts electron/preload.ts src/global.d.ts src/store/profile.ts src/store/profile.test.ts
- ../../node_modules/.bin/prettier --check electron/main.ts electron/preload.ts src/global.d.ts src/store/profile.ts src/store/profile.test.ts
- git diff --check

## Checklist

### Code

- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues and pull requests for duplicates.
- [x] This PR contains only changes related to this bug.
- [ ] I ran pytest tests/ -q. Not run because this patch changes only Desktop TypeScript and Electron files; scoped Desktop checks are listed above.
- [x] I added regression tests for the changed behavior.
- [ ] I completed a patched-binary restart test. The issue was reproduced and the source checks pass on macOS 26.5.2 arm64; this remains unchecked while the PR is a draft.

### Documentation & Housekeeping

- [x] Documentation update: N/A. No user-facing option or configuration key was added.
- [x] cli-config.yaml.example update: N/A. No CLI configuration changed.
- [x] CONTRIBUTING.md or AGENTS.md update: N/A. Existing profile-switch architecture is preserved.
- [x] Cross-platform impact considered. The new handler delegates to the existing cross-platform profile preference writer.
- [x] Tool descriptions and schemas: N/A. No agent tool behavior changed.

## Screenshots / Logs

No private logs are attached. The regression is covered by the profile store test, including the ordering requirement that persistence waits for gateway activation.