### PR TITLE
refactor(kanban): extract stats into stats_mixin (kanban_db.py god-file slice R5)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9491,86 +9491,8 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
 # Stats + SLA helpers
 # ---------------------------------------------------------------------------
 
-def board_stats(conn: sqlite3.Connection) -> dict:
-    """Per-status + per-assignee counts, plus the oldest ``ready`` age in
-    seconds (the clearest staleness signal for a router or HUD).
-    """
-    by_status: dict[str, int] = {}
-    for row in conn.execute(
-        "SELECT status, COUNT(*) AS n FROM tasks "
-        "WHERE status != 'archived' GROUP BY status"
-    ):
-        by_status[row["status"]] = int(row["n"])
-
-    by_assignee: dict[str, dict[str, int]] = {}
-    for row in conn.execute(
-        "SELECT assignee, status, COUNT(*) AS n FROM tasks "
-        "WHERE status != 'archived' AND assignee IS NOT NULL "
-        "GROUP BY assignee, status"
-    ):
-        by_assignee.setdefault(row["assignee"], {})[row["status"]] = int(row["n"])
-
-    oldest_row = conn.execute(
-        "SELECT MIN(created_at) AS ts FROM tasks WHERE status = 'ready'"
-    ).fetchone()
-    now = int(time.time())
-    oldest_ready_age = (
-        (now - int(oldest_row["ts"]))
-        if oldest_row and oldest_row["ts"] is not None else None
-    )
-
-    return {
-        "by_status": by_status,
-        "by_assignee": by_assignee,
-        "oldest_ready_age_seconds": oldest_ready_age,
-        "now": now,
-    }
-
-
-def _to_epoch(val) -> Optional[int]:
-    """Normalise a timestamp to unix epoch seconds.
-
-    Accepts ints (pass-through), numeric strings, and ISO-8601 strings.
-    Returns ``None`` for ``None`` / empty values.
-    """
-    if val is None:
-        return None
-    if isinstance(val, int):
-        return val
-    if isinstance(val, float):
-        return int(val)
-    s = str(val).strip()
-    if not s:
-        return None
-    try:
-        return int(s)
-    except ValueError:
-        pass
-    # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
-    try:
-        from datetime import datetime
-        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
-        return int(dt.timestamp())
-    except (ValueError, OSError):
-        return None
-
-
-def task_age(task: Task) -> dict:
-    """Return age metrics for a single task. All values are seconds or None."""
-    now = int(time.time())
-    _c = _to_epoch(task.created_at)
-    _s = _to_epoch(task.started_at)
-    _co = _to_epoch(task.completed_at)
-    age_since_created = now - _c if _c is not None else None
-    age_since_started = now - _s if _s is not None else None
-    time_to_complete = (
-        _co - (_s or _c) if _co is not None else None
-    )
-    return {
-        "created_age_seconds": age_since_created,
-        "started_age_seconds": age_since_started,
-        "time_to_complete_seconds": time_to_complete,
-    }
+# (moved to hermes_cli/stats_mixin.py — extraction #78632)
+from hermes_cli.stats_mixin import board_stats, task_age, _to_epoch  # noqa: F401
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/stats_mixin.py
+++ b/hermes_cli/stats_mixin.py
@@ -1,0 +1,102 @@
+"""Per-board kanban statistics helpers (god-file decomposition).
+
+Extracted verbatim from ``hermes_cli.kanban_db`` (god-file kill epic
+#78647, region R5, first slice C6 — extraction #78632). Plain function
+module: ``board_stats``, ``_to_epoch``, ``task_age`` are free functions
+taking an explicit ``conn`` / ``task`` parameter — there is no class and
+no ``self`` anywhere. ``kanban_db.py`` re-exports all three names at the
+seam so the module-access callers (``hermes_cli/kanban.py``, the kanban
+dashboard plugin) resolve unchanged.
+
+Import discipline: stdlib only. The ``Task`` annotation in ``task_age``
+is string-lazy under ``from __future__ import annotations``, so this
+module never imports ``hermes_cli.kanban_db`` — no cycle.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from typing import Optional
+
+
+def board_stats(conn: sqlite3.Connection) -> dict:
+    """Per-status + per-assignee counts, plus the oldest ``ready`` age in
+    seconds (the clearest staleness signal for a router or HUD).
+    """
+    by_status: dict[str, int] = {}
+    for row in conn.execute(
+        "SELECT status, COUNT(*) AS n FROM tasks "
+        "WHERE status != 'archived' GROUP BY status"
+    ):
+        by_status[row["status"]] = int(row["n"])
+
+    by_assignee: dict[str, dict[str, int]] = {}
+    for row in conn.execute(
+        "SELECT assignee, status, COUNT(*) AS n FROM tasks "
+        "WHERE status != 'archived' AND assignee IS NOT NULL "
+        "GROUP BY assignee, status"
+    ):
+        by_assignee.setdefault(row["assignee"], {})[row["status"]] = int(row["n"])
+
+    oldest_row = conn.execute(
+        "SELECT MIN(created_at) AS ts FROM tasks WHERE status = 'ready'"
+    ).fetchone()
+    now = int(time.time())
+    oldest_ready_age = (
+        (now - int(oldest_row["ts"]))
+        if oldest_row and oldest_row["ts"] is not None else None
+    )
+
+    return {
+        "by_status": by_status,
+        "by_assignee": by_assignee,
+        "oldest_ready_age_seconds": oldest_ready_age,
+        "now": now,
+    }
+
+
+def _to_epoch(val) -> Optional[int]:
+    """Normalise a timestamp to unix epoch seconds.
+
+    Accepts ints (pass-through), numeric strings, and ISO-8601 strings.
+    Returns ``None`` for ``None`` / empty values.
+    """
+    if val is None:
+        return None
+    if isinstance(val, int):
+        return val
+    if isinstance(val, float):
+        return int(val)
+    s = str(val).strip()
+    if not s:
+        return None
+    try:
+        return int(s)
+    except ValueError:
+        pass
+    # ISO-8601 fallback (e.g. '2026-05-10T15:00:00Z')
+    try:
+        from datetime import datetime
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        return int(dt.timestamp())
+    except (ValueError, OSError):
+        return None
+
+
+def task_age(task: Task) -> dict:
+    """Return age metrics for a single task. All values are seconds or None."""
+    now = int(time.time())
+    _c = _to_epoch(task.created_at)
+    _s = _to_epoch(task.started_at)
+    _co = _to_epoch(task.completed_at)
+    age_since_created = now - _c if _c is not None else None
+    age_since_started = now - _s if _s is not None else None
+    time_to_complete = (
+        _co - (_s or _c) if _co is not None else None
+    )
+    return {
+        "created_age_seconds": age_since_created,
+        "started_age_seconds": age_since_started,
+        "time_to_complete_seconds": time_to_complete,
+    }

--- a/tests/hermes_cli/test_kanban_stats_seam.py
+++ b/tests/hermes_cli/test_kanban_stats_seam.py
@@ -1,0 +1,165 @@
+"""Seam + behaviour tests for the kanban stats extraction (R5-S1).
+
+Covers two things:
+
+1. Seam identity: ``hermes_cli.kanban_db`` re-exports ``board_stats`` /
+   ``task_age`` / ``_to_epoch`` from ``hermes_cli.stats_mixin`` so every
+   module-access caller (``kanban.py``, dashboard plugin) resolves to the
+   SAME function objects — no double definitions, no cycle.
+2. Behaviour of the moved functions themselves, imported directly from
+   the new module: ``board_stats`` aggregation (empty board, mixed
+   statuses, archived exclusion, no-ready ``oldest_ready_age_seconds``)
+   and ``task_age`` created/started/completed permutations.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import stats_mixin
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _set_status(conn, task_id: str, status: str) -> None:
+    """Direct SQL status transition (existing test convention)."""
+    with conn:
+        conn.execute("UPDATE tasks SET status = ? WHERE id = ?", (status, task_id))
+
+
+# ---------------------------------------------------------------------------
+# Seam identity (shim)
+# ---------------------------------------------------------------------------
+
+
+def test_shim_reexports_same_objects():
+    """kanban_db.<name> must BE stats_mixin.<name> — not a copy."""
+    assert kb.board_stats is stats_mixin.board_stats
+    assert kb.task_age is stats_mixin.task_age
+    assert kb._to_epoch is stats_mixin._to_epoch
+
+
+def test_shim_import_roundtrip():
+    """Both modules import cleanly with no cycle (one-way edge only)."""
+    import hermes_cli.kanban_db  # noqa: F401
+    import hermes_cli.stats_mixin  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# board_stats aggregation
+# ---------------------------------------------------------------------------
+
+
+def test_board_stats_empty_board(kanban_home):
+    with kb.connect() as conn:
+        stats = stats_mixin.board_stats(conn)
+    assert stats["by_status"] == {}
+    assert stats["by_assignee"] == {}
+    assert stats["oldest_ready_age_seconds"] is None
+    assert isinstance(stats["now"], int)
+
+
+def test_board_stats_mixed_statuses_and_archived_excluded(kanban_home):
+    with kb.connect() as conn:
+        r1 = kb.create_task(conn, title="r1")
+        r2 = kb.create_task(conn, title="r2")
+        d1 = kb.create_task(conn, title="d1", assignee="alice")
+        w1 = kb.create_task(conn, title="w1", assignee="alice")
+        a1 = kb.create_task(conn, title="a1", assignee="bob")
+        # Default create_task status is "ready" (no parents); transition the mix.
+        _set_status(conn, r1, "ready")
+        _set_status(conn, r2, "ready")
+        _set_status(conn, d1, "done")
+        _set_status(conn, w1, "running")
+        # Archive a1.
+        kb.archive_task(conn, a1)
+
+        stats = stats_mixin.board_stats(conn)
+
+    # Archived tasks are excluded from both rollups.
+    assert stats["by_status"] == {"ready": 2, "done": 1, "running": 1}
+    assert stats["by_assignee"] == {"alice": {"done": 1, "running": 1}}
+    # At least one ready task exists -> oldest_ready_age is a real age.
+    assert stats["oldest_ready_age_seconds"] is not None
+    assert stats["oldest_ready_age_seconds"] >= 0
+
+
+def test_board_stats_oldest_ready_age_absent_without_ready_tasks(kanban_home):
+    with kb.connect() as conn:
+        d1 = kb.create_task(conn, title="only-done")
+        b1 = kb.create_task(conn, title="only-blocked", initial_status="blocked")
+        _set_status(conn, d1, "done")
+        stats = stats_mixin.board_stats(conn)
+    assert stats["oldest_ready_age_seconds"] is None
+    assert stats["by_status"] == {"done": 1, "blocked": 1}
+
+
+# ---------------------------------------------------------------------------
+# task_age permutations
+# ---------------------------------------------------------------------------
+
+
+def test_task_age_created_only(kanban_home):
+    """No started/completed timestamps: only created age is present."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fresh")
+        task = kb.get_task(conn, tid)
+        ages = stats_mixin.task_age(task)
+    assert ages["created_age_seconds"] is not None
+    assert ages["created_age_seconds"] >= 0
+    assert ages["started_age_seconds"] is None
+    assert ages["time_to_complete_seconds"] is None
+
+
+def test_task_age_started_and_completed(kanban_home):
+    """With started+completed set, all three metrics are populated and the
+    time-to-complete is measured from the started timestamp."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ran")
+        # Patch timestamps directly to control the arithmetic.
+        now = int(time.time())
+        with conn:
+            conn.execute(
+                "UPDATE tasks SET started_at = ?, completed_at = ? WHERE id = ?",
+                (now - 60, now - 10, tid),
+            )
+        task = kb.get_task(conn, tid)
+        ages = stats_mixin.task_age(task)
+    assert ages["created_age_seconds"] is not None
+    assert ages["started_age_seconds"] is not None
+    assert ages["time_to_complete_seconds"] is not None
+    assert ages["time_to_complete_seconds"] == 50
+
+
+# ---------------------------------------------------------------------------
+# _to_epoch normalisation (direct)
+# ---------------------------------------------------------------------------
+
+
+def test_to_epoch_normalises_inputs():
+    now = int(time.time())
+    assert stats_mixin._to_epoch(now) == now
+    assert stats_mixin._to_epoch(float(now)) == now
+    assert stats_mixin._to_epoch(str(now)) == now
+    assert stats_mixin._to_epoch("  " + str(now) + "  ") == now
+    assert stats_mixin._to_epoch(None) is None
+    assert stats_mixin._to_epoch("") is None
+    # ISO-8601 with Z suffix round-trips to epoch seconds.
+    iso = datetime.fromtimestamp(now, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    assert stats_mixin._to_epoch(iso) == now
+    # Garbage that is neither numeric nor ISO -> None (no crash).
+    assert stats_mixin._to_epoch("not-a-timestamp") is None


### PR DESCRIPTION
## Summary

kanban_db.py god-file slice **R5**: extract the stats cluster (window 9494–9573, 80 lines) into `hermes_cli/stats_mixin.py`. Part of the repo-wide large-file decomposition (tracker #78647).

## What changed and why

- board_stats / _to_epoch / task_age moved byte-verbatim (all 3 golden hashes verified: `fab841fa…` no-NL, `db10f9db…` sha1, `f2a03e8d…` with-NL)
- Zero pre-R5 deps, zero outgoing edges — the cleanest cluster; shim-only seam, zero caller edits
- Goal-loop contract (HERMES_KANBAN_GOAL_MODE / -Q) preserved — test_kanban_goal_mode.py green
- **Double-blind**: 2 analysts (both agreed cleanest) → consensus → implementer → 2 blind re-reviewers (both APPROVED)

## Testing

- **12 passed** (8 new stats seam + 4 goal-mode regression)
- Plus kanban_db/dashboard/cron-env suites: 65 passed, 3 failures byte-identical to clean pin
- ruff clean · git diff --check clean · LF-only · DCO signed

## Coordination / interlock

- **Epic:** Part of #78647 · **Target:** Part of #78632
- **Sibling PRs:** the 4 other kanban_db slices — disjoint windows
- **Dedup:** no existing PR extracts the stats cluster

Part of #78647
Part of #78632