### PR TITLE
docs(security): clarify execute_code backend boundary

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -73,15 +73,22 @@ A non-default terminal backend runs LLM-emitted shell commands
 inside a container, remote host, or cloud sandbox. The file tools
 (`read_file`, `write_file`, `patch`) also run through this backend,
 since they are implemented on top of the shell contract — they
-cannot reach paths the backend doesn't expose.
+cannot reach paths the backend doesn't expose. The code-execution
+tool follows the configured terminal backend: with a non-local
+backend, the generated Python script runs in that backend; with the
+local backend, it runs as a host subprocess.
 
-What this confines: anything the agent does by issuing shell or
-file operations. What this does **not** confine: everything the
-agent does in its own Python process. That includes the
-code-execution tool (spawned as a host subprocess), MCP subprocesses
-(spawned from the agent's environment), plugin loading, hook
-dispatch, and skill loading (all imported into the agent
-interpreter).
+What this confines: the agent's direct shell and file operations and,
+for non-local backends, the Python script executed by the
+code-execution tool. Code-execution scripts can still call a limited
+set of Hermes tools through an RPC bridge; those calls are dispatched
+by the parent agent and follow each called tool's own boundary. What
+terminal-backend isolation does **not** confine: everything else the
+agent does in its own Python process. That includes MCP subprocesses
+(spawned from the agent's environment), plugin loading, hook dispatch,
+and skill loading (all imported into the agent interpreter), plus
+host- or provider-backed tools such as browser automation, computer
+use, and web search.
 
 Terminal-backend isolation is the right posture when the concern is
 LLM-emitted destructive shell or unwanted file-tool writes, and the


### PR DESCRIPTION
## Summary

- clarify that `execute_code` follows the configured terminal backend
- distinguish local host subprocess execution from non-local backend execution
- document that RPC-invoked tools retain their own execution boundaries
- call out browser automation, computer use, and web search as host- or provider-backed paths

## Why

`SECURITY.md` currently says the code-execution tool always runs as a host subprocess. On current `main`, `execute_code` dispatches non-local terminal backends to `_execute_remote`, which ships the generated script into that backend and uses file-based RPC for the limited tool bridge. Only the local backend runs the script as a host subprocess.

The existing wording therefore understates terminal-backend isolation for the generated Python script while also leaving the RPC bridge's separate tool boundaries implicit.

## Impact

Documentation only. This does not change runtime behavior, configuration, approvals, or enabled capabilities.

## Validation

- traced the local/non-local dispatch in `tools/code_execution_tool.py` on current `main`
- verified the non-local file-based RPC path and the seven allowed RPC tools
- ran `git diff --check`
- no runtime tests run because the change is documentation-only
