### PR TITLE
feat: DeepSeek server-side web_search on the Responses transport

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -268,6 +268,15 @@ class ResponsesApiTransport(ProviderTransport):
         is_github_responses = params.get("is_github_responses") is True
         is_codex_backend = params.get("is_codex_backend") is True
         is_xai_responses = params.get("is_xai_responses") is True
+        # DeepSeek's /responses surface (api.deepseek.com) runs the built-in
+        # web_search tool server-side on deepseek-v4-flash. Detect it here so
+        # the tools block below can declare the builtin instead of (or in
+        # addition to) Hermes' client-side web_search function.
+        is_deepseek_responses = (
+            str(params.get("provider") or "").strip().lower() == "deepseek"
+            or "api.deepseek.com"
+            in str(params.get("base_url") or params.get("base_url_hostname") or "").lower()
+        ) and "flash" in (model or "").lower()
         replay_encrypted_reasoning = bool(
             params.get("replay_encrypted_reasoning", True)
         )
@@ -327,7 +336,19 @@ class ResponsesApiTransport(ProviderTransport):
         #    is honored, but rename the wire tool to
         #    ``hermes_web_search`` so Grok cannot hijack the name. The alias
         #    is mapped back to ``web_search`` in ``normalize_response``.
-        if is_xai_responses and response_tools:
+        if is_deepseek_responses:
+            # DeepSeek executes its built-in web_search entirely server-side:
+            # swap Hermes' client-side web_search function for the builtin
+            # when one is declared, and declare the builtin outright otherwise
+            # so the model can always search on demand. The response adapter
+            # already normalizes server-side web_search_call items.
+            filtered = [
+                t for t in (response_tools or [])
+                if not (isinstance(t, dict) and t.get("name") == "web_search")
+            ]
+            filtered.append({"type": "web_search"})
+            response_tools = filtered
+        elif is_xai_responses and response_tools:
             has_client_web_search = any(
                 isinstance(t, dict) and t.get("name") == "web_search"
                 for t in response_tools

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -468,6 +468,88 @@ class TestCodexBuildKwargs:
             for t in tools
         )
 
+    # --- DeepSeek server-side web_search (api.deepseek.com /responses) ---
+    # DeepSeek executes its built-in web_search tool entirely server-side on
+    # deepseek-v4-flash (the only model currently supporting the Responses
+    # API). Unlike the xAI 1:1 swap, the builtin is declared outright — even
+    # when no client web_search exists — because DeepSeek models decide
+    # autonomously whether to search (the officially recommended usage), and
+    # a turn without a configured web backend has no client tool to swap.
+
+    def test_deepseek_swaps_client_web_search_for_native_builtin(self, transport):
+        """provider=deepseek + flash model: client web_search is replaced by
+        the server-side builtin; non-conflicting tools are preserved."""
+        messages = [{"role": "user", "content": "Today's weather?"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=[
+                {"type": "function", "function": {
+                    "name": "read_file", "description": "Read a file.",
+                    "parameters": {"type": "object",
+                                   "properties": {"path": {"type": "string"}}}}},
+                {"type": "function", "function": {
+                    "name": "web_search", "description": "Search the web.",
+                    "parameters": {"type": "object",
+                                   "properties": {"query": {"type": "string"}}}}},
+            ],
+            provider="deepseek",
+            base_url="https://api.deepseek.com",
+        )
+        tool_types = [t.get("type") for t in kw.get("tools", [])]
+        assert "web_search" in tool_types, kw.get("tools")
+        names = [t.get("name") for t in kw.get("tools", []) if t.get("type") == "function"]
+        assert "read_file" in names
+        assert "web_search" not in names
+
+    def test_deepseek_declares_native_web_search_without_client_tool(self, transport):
+        """Even with no client web_search declared (e.g. no web backend
+        configured), the DeepSeek builtin is still declared so the model can
+        search on demand."""
+        messages = [{"role": "user", "content": "Today's weather?"}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=[{"type": "function", "function": {
+                "name": "read_file", "description": "Read a file.",
+                "parameters": {"type": "object",
+                               "properties": {"path": {"type": "string"}}}}}],
+            provider="deepseek",
+            base_url="https://api.deepseek.com",
+        )
+        tool_types = [t.get("type") for t in kw.get("tools", [])]
+        assert "web_search" in tool_types, kw.get("tools")
+
+    def test_deepseek_detected_via_hostname_only(self, transport):
+        """api.deepseek.com hostname alone (provider not passed) triggers the
+        builtin declaration, mirroring the xAI hostname-based detection."""
+        messages = [{"role": "user", "content": "Search."}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-flash", messages=messages,
+            tools=None,
+            base_url="https://api.deepseek.com",
+        )
+        tool_types = [t.get("type") for t in kw.get("tools", [])]
+        assert "web_search" in tool_types, kw.get("tools")
+
+    def test_deepseek_non_flash_keeps_client_web_search(self, transport):
+        """Responses API support (incl. web_search) is currently limited to
+        deepseek-v4-flash; non-flash models keep the client tool untouched."""
+        messages = [{"role": "user", "content": "Search."}]
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro", messages=messages,
+            tools=[{"type": "function", "function": {
+                "name": "web_search", "description": "Search the web.",
+                "parameters": {"type": "object",
+                               "properties": {"query": {"type": "string"}}}}}],
+            provider="deepseek",
+            base_url="https://api.deepseek.com",
+        )
+        tools = kw.get("tools", [])
+        assert not any(t.get("type") == "web_search" for t in tools)
+        assert any(
+            t.get("type") == "function" and t.get("name") == "web_search"
+            for t in tools
+        )
+
     # --- Grok reasoning-effort capability allowlist ---
     # api.x.ai 400s with "Model X does not support parameter reasoningEffort"
     # on grok-4 / grok-4-fast / grok-3 / grok-code-fast / grok-4.20-0309-*.


### PR DESCRIPTION
## Summary

DeepSeek's `/responses` endpoint (api.deepseek.com) executes a built-in `web_search` tool **server-side** on `deepseek-v4-flash` — the model performs the search itself and returns `web_search_call` output items (search / open_page / find_in_page) with cited results, exactly like xAI/Grok native search.

Today the Responses transport only injects the native `web_search` builtin for xAI (`is_xai_responses`). DeepSeek users on the Responses API get no server-side search: Hermes falls back to chat-completions mode or the client-side `web_search` function, which requires a separately configured web backend (Tavily/Firecrawl/ddgs...).

This PR mirrors the xAI native-search wiring for DeepSeek: when the transport detects `provider=deepseek` (or `api.deepseek.com` host) with a flash model, it swaps Hermes client-side `web_search` for the built-in `{"type": "web_search"}` tool — and declares the builtin outright even when no client tool exists, because DeepSeek models decide autonomously whether to search (the officially recommended usage, same as their Claude Code integration).

## Why declare outright (vs the xAI 1:1-swap-only rule)

The xAI 1:1 swap exists because a client function literally named `web_search` collides with Grok's native tool and stalls the turn (#48108). DeepSeek has no such collision, and a turn without a configured web backend has no client `web_search` to swap — so the builtin must be declared unconditionally for the capability to exist at all. The DeepSeek docs recommend exactly this model-autonomous search pattern.

## Verification

- **Unit tests**: 4 new tests in `tests/agent/transports/test_codex_transport.py` (swap with client tool, declaration without client tool, hostname-only detection, non-flash models untouched). Full transport suite: 259 passed.
- **Live E2E** (deepseek-v4-flash, real API): question about today's weather returned real-time data with cited sources (China Weather Net, Beijing Meteorological Bureau) with `api_call_count=1`, `tool_call_count=0` — search executed entirely server-side, confirmed via a request-capturing proxy showing `{"type": "web_search"}` in `tools` and `response.web_search_call.completed` in the SSE stream.

## Notes

- Responses API + web_search currently supported on `deepseek-v4-flash` only (v4-pro not yet); non-flash models are untouched by this change.
- Existing xAI behavior is unchanged (all prior tests pass).