### PR TITLE
fix(read_extract): retry anydoc init after failure instead of sticky disable

### DIFF
--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -15,6 +15,7 @@ import os
 import tempfile
 import unittest
 import zipfile
+from unittest import mock
 
 from tools.read_extract import (
     ExtractionError,
@@ -162,6 +163,97 @@ class TestAnydocAbsent(unittest.TestCase):
         self.assertTrue(is_extractable_document("a.ipynb"))
         self.assertTrue(is_extractable_document("a.docx"))
         self.assertTrue(is_extractable_document("a.xlsx"))
+
+
+class TestAnydocInitLifecycle(unittest.TestCase):
+    """First-load lifecycle: one failed load must not disable extraction
+    for the rest of the process, and concurrent first use must not race."""
+
+    def setUp(self):
+        from tools import read_extract
+
+        self.rex = read_extract
+        self._saved_module = read_extract._anydoc_module
+        self._saved_failed_at = read_extract._anydoc_failed_at
+        self._saved_retry = read_extract.ANYDOC_RETRY_SECONDS
+        read_extract._anydoc_module = read_extract._ANYDOC_UNSET
+        read_extract._anydoc_failed_at = None
+
+    def tearDown(self):
+        self.rex._anydoc_module = self._saved_module
+        self.rex._anydoc_failed_at = self._saved_failed_at
+        self.rex.ANYDOC_RETRY_SECONDS = self._saved_retry
+
+    def test_successful_load_is_cached(self):
+        fake = object()
+        calls = []
+
+        def fake_import(name):
+            calls.append(name)
+            return fake
+
+        with mock.patch("importlib.import_module", side_effect=fake_import):
+            self.assertIs(self.rex._anydoc(), fake)
+            self.assertIs(self.rex._anydoc(), fake)
+        self.assertEqual(calls, ["anydoc"])
+
+    def test_failed_load_is_retried_after_cooldown(self):
+        fake = object()
+        calls = []
+
+        def fake_import(name):
+            calls.append(name)
+            if len(calls) == 1:
+                raise ImportError("boom")
+            return fake
+
+        self.rex.ANYDOC_RETRY_SECONDS = 0.0
+        with mock.patch("importlib.import_module", side_effect=fake_import):
+            self.assertIsNone(self.rex._anydoc())
+            self.assertIs(self.rex._anydoc(), fake)
+        self.assertEqual(calls, ["anydoc", "anydoc"])
+
+    def test_failed_load_not_retried_within_cooldown(self):
+        calls = []
+
+        def fake_import(name):
+            calls.append(name)
+            raise ImportError("boom")
+
+        self.rex.ANYDOC_RETRY_SECONDS = 3600.0
+        with mock.patch("importlib.import_module", side_effect=fake_import):
+            self.assertIsNone(self.rex._anydoc())
+            self.assertIsNone(self.rex._anydoc())
+        # One import attempt total, and the handle stays UNSET so a retry
+        # remains possible once the cooldown expires.
+        self.assertEqual(calls, ["anydoc"])
+        self.assertIs(self.rex._anydoc_module, self.rex._ANYDOC_UNSET)
+
+    def test_concurrent_first_load_imports_once(self):
+        import threading
+
+        fake = object()
+        calls = []
+        barrier = threading.Barrier(4)
+
+        def fake_import(name):
+            calls.append(name)
+            return fake
+
+        def worker(out):
+            barrier.wait(5)
+            out.append(self.rex._anydoc())
+
+        with mock.patch("importlib.import_module", side_effect=fake_import):
+            results = []
+            threads = [threading.Thread(target=worker, args=(results,)) for _ in range(3)]
+            for t in threads:
+                t.start()
+            barrier.wait(5)
+            for t in threads:
+                t.join(5)
+        self.assertEqual(calls, ["anydoc"])
+        self.assertEqual(results, [fake, fake, fake])
 
 
 # ---------------------------------------------------------------------------

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 import importlib
 import json
 import posixpath
+import threading
+import time
 import zipfile
 from pathlib import Path
 from typing import Any, Optional
@@ -56,12 +58,32 @@ def _extension(path: str) -> str:
 
 _ANYDOC_UNSET = object()
 _anydoc_module: Any = _ANYDOC_UNSET
+_anydoc_lock = threading.Lock()
+# After a failed first load, wait this long before trying again. The attempt
+# can shell out to pip, so retrying on every call would hammer the network
+# in environments where the install can never succeed.
+ANYDOC_RETRY_SECONDS = 300.0
+_anydoc_failed_at: Optional[float] = None
 
 
 def _anydoc() -> Optional[Any]:
-    """Lazily import the optional anydoc converter; None when unavailable."""
-    global _anydoc_module
-    if _anydoc_module is _ANYDOC_UNSET:
+    """Lazily import the optional anydoc converter; None when unavailable.
+
+    A failed load is retried after :data:`ANYDOC_RETRY_SECONDS` rather than
+    disabling extraction for the rest of the process, so one transient
+    failure (network blip, pip race) does not stick in long-lived workers.
+    """
+    global _anydoc_module, _anydoc_failed_at
+    if _anydoc_module is not _ANYDOC_UNSET:
+        return _anydoc_module
+    with _anydoc_lock:
+        if _anydoc_module is not _ANYDOC_UNSET:
+            return _anydoc_module
+        if (
+            _anydoc_failed_at is not None
+            and time.monotonic() - _anydoc_failed_at < ANYDOC_RETRY_SECONDS
+        ):
+            return None
         try:
             from tools.lazy_deps import ensure as _lazy_ensure
 
@@ -72,7 +94,8 @@ def _anydoc() -> Optional[Any]:
         try:
             _anydoc_module = importlib.import_module("anydoc")
         except Exception:  # ImportError or a broken native binding
-            _anydoc_module = None
+            _anydoc_failed_at = time.monotonic()
+            return None
     return _anydoc_module  # type: ignore[return-value]
 
 


### PR DESCRIPTION
## What does this PR do?

The anydoc wiring from #79781 cached the outcome of the first `_anydoc()` load permanently. Any failure (network blip during the lazy install, missing wheel, pip race, read-only managed store) wrote `_anydoc_module = None`, and nothing ever reset it. Long-lived gateway and desktop workers lost PDF, legacy Office, ODF, RTF, and EPUB extraction for the rest of the process after a single bad first try.

This makes failed loads recoverable and first use race-free:

- Only successful loads are cached for the process lifetime. A failure records a timestamp and returns `None` without touching the module handle, so the next attempt after `ANYDOC_RETRY_SECONDS` (300s) tries again. The cooldown matters because the attempt can shell out to pip: retrying on every call would hammer the network in environments where the install can never succeed.
- A module-level lock serializes first use. Parallel readers can no longer double-install or race a failure into the cache, and the double-checked fast path keeps cached reads lock-free.

Behavior when anydoc is genuinely absent is unchanged: `_anydoc()` returns `None`, covered extensions stay non-extractable, and the stdlib trio is untouched.

## Related Issue

Fixes #80001

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/read_extract.py`: add `_anydoc_lock`, `ANYDOC_RETRY_SECONDS`, and `_anydoc_failed_at`, rewrite `_anydoc()` with the lock, the cooldown-gated retry, and success-only caching, update the docstring.
- `tests/tools/test_read_extract.py`: new `TestAnydocInitLifecycle` class, 4 tests (success cached, failure retried after cooldown, no retry inside cooldown with the handle left UNSET, concurrent first load imports exactly once via a barrier).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_read_extract.py -q`
   - 19 passed, 3 skipped, 0 failed (skips are the real-binding tests, firecrawl-anydoc not installed locally)
2. Manual: in a fresh Python, block the install (`HERMES_DISABLE_LAZY_INSTALLS=1` with anydoc absent), call `read_file` on a PDF, then `pip install firecrawl-anydoc`, set `read_extract.ANYDOC_RETRY_SECONDS = 0`, and read the PDF again. The second read converts. On main, the second read still falls through.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the read_extract suite above and it passes. Full `pytest tests/ -q` not re-run here. Change is isolated to the anydoc load path plus its tests.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - docstring updated in place
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - threading and monotonic clock only, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```shell
# Before: one failed load disables extraction for the process lifetime
_anydoc()  # ImportError during install -> _anydoc_module = None
_anydoc()  # returns None forever, even after a successful pip install

# After: failure cools down, then retries
_anydoc()  # ImportError -> None, _anydoc_failed_at stamped
_anydoc()  # within 300s -> None without re-attempting
_anydoc()  # after 300s -> retries, caches the module on success
```
