### PR TITLE
fix(read_extract): cap anydoc input size before conversion

### DIFF
--- a/tests/tools/test_read_extract.py
+++ b/tests/tools/test_read_extract.py
@@ -133,6 +133,65 @@ class TestAnydocExtraction(unittest.TestCase):
         self.assertEqual(text, "hello\n")
 
 
+class TestAnydocSizeCap(unittest.TestCase):
+    """Oversized inputs must be rejected before anydoc converts them.
+    Uses a fake binding so it runs regardless of local install state."""
+
+    def setUp(self):
+        from tools import read_extract
+
+        self.rex = read_extract
+        self._saved_module = read_extract._anydoc_module
+        self._saved_cap = read_extract.MAX_ANYDOC_BYTES
+        self.tmp = tempfile.mkdtemp(prefix="rex_cap_")
+        self.calls = []
+
+        class _FakeAnydoc:
+            def to_markdown(_self, path):
+                self.calls.append(path)
+                return "converted\n"
+
+        read_extract._anydoc_module = _FakeAnydoc()
+
+    def tearDown(self):
+        import shutil
+
+        self.rex._anydoc_module = self._saved_module
+        self.rex.MAX_ANYDOC_BYTES = self._saved_cap
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name, size):
+        p = os.path.join(self.tmp, name)
+        with open(p, "wb") as fh:
+            fh.write(b"x" * size)
+        return p
+
+    def test_oversized_file_rejected_before_conversion(self):
+        from tools.read_extract import _extract_anydoc
+
+        self.rex.MAX_ANYDOC_BYTES = 10
+        p = self._write("big.pdf", 11)
+        with self.assertRaises(ExtractionError) as ctx:
+            _extract_anydoc(p)
+        self.assertIn("too large", str(ctx.exception))
+        self.assertEqual(self.calls, [])
+
+    def test_file_at_limit_converts(self):
+        from tools.read_extract import _extract_anydoc
+
+        self.rex.MAX_ANYDOC_BYTES = 10
+        p = self._write("ok.pdf", 10)
+        self.assertEqual(_extract_anydoc(p), "converted\n")
+        self.assertEqual(self.calls, [p])
+
+    def test_missing_file_raises_extraction_error(self):
+        from tools.read_extract import _extract_anydoc
+
+        with self.assertRaises(ExtractionError):
+            _extract_anydoc(os.path.join(self.tmp, "gone.pdf"))
+        self.assertEqual(self.calls, [])
+
+
 class TestAnydocAbsent(unittest.TestCase):
     """The absent-dep contract, verified regardless of local install state
     by forcing the cached module handle to None."""

--- a/tools/read_extract.py
+++ b/tools/read_extract.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import os
 import posixpath
 import zipfile
 from pathlib import Path
@@ -32,6 +33,10 @@ ANYDOC_EXTENSIONS = frozenset({
     ".rtf", ".epub", ".pdf",
 })
 MAX_XLSX_BYTES = 50 * 1024 * 1024
+# Refuse to convert huge documents. anydoc loads the whole file through its
+# Rust core with no streaming, and the read_file char budget only applies
+# after conversion, so an unbounded input can pin a tool turn and spike RAM.
+MAX_ANYDOC_BYTES = 50 * 1024 * 1024
 _MAX_XLSX_ROWS_PER_SHEET = 5000
 _MAX_XLSX_COLS = 256
 
@@ -97,6 +102,14 @@ def _extract_anydoc(path: str) -> str:
     mod = _anydoc()
     if mod is None:
         raise ExtractionError(f"Unsupported document type: {path!r}")
+    try:
+        size = os.path.getsize(path)
+    except OSError as exc:
+        raise ExtractionError(str(exc)) from exc
+    if size > MAX_ANYDOC_BYTES:
+        raise ExtractionError(
+            f"Document too large to convert ({size:,} bytes, limit is {MAX_ANYDOC_BYTES:,})"
+        )
     try:
         text = mod.to_markdown(path)
     except OSError as exc:


### PR DESCRIPTION
## What does this PR do?

The anydoc path from #79781 converts every covered file with no resource bound. `_extract_anydoc` hands the path straight to `to_markdown()`, which loads the whole document through the Rust core in one shot, and the read_file char budget only trims the text after conversion has finished. A single large PDF, legacy spreadsheet, or deck can pin a tool turn and spike RAM.

This adds the enforceable half of the bound:

- `_extract_anydoc` stat-checks the input and raises `ExtractionError` when it exceeds `MAX_ANYDOC_BYTES` (50 MB, same scale as the existing `MAX_XLSX_BYTES`). The error routes to the existing read_file fallthrough, so the caller behavior for failures is unchanged.
- No timeout is added, deliberately. The conversion is a synchronous Rust call that Python cannot cancel. A thread-based deadline would bound how long the agent waits but leave the conversion burning RAM in the background, which is the worse failure shape. With the size cap in place, conversion cost is bounded by input size instead.

The stdlib trio and the absent-anydoc contract are untouched.

## Related Issue

Fixes #80003

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/read_extract.py`: add `MAX_ANYDOC_BYTES` (50 MB), size pre-check in `_extract_anydoc` ahead of `to_markdown`, `os.path.getsize` failures map to `ExtractionError`.
- `tests/tools/test_read_extract.py`: new `TestAnydocSizeCap` class, 3 tests against a fake binding so they run without the wheel installed (oversized input rejected before conversion is attempted, input at the limit converts, missing file raises `ExtractionError`).

## How to Test

1. `scripts/run_tests.sh tests/tools/test_read_extract.py -q`
   - 18 passed, 3 skipped, 0 failed (skips are the real-binding tests, firecrawl-anydoc not installed locally)
2. Manual: create a PDF over 50 MB and read it with anydoc installed. On main the turn blocks in conversion. With this change `read_file` returns the fallthrough path immediately.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the read_extract suite above and it passes. Full `pytest tests/ -q` not re-run here. Change is isolated to the anydoc conversion path plus its tests.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - os.path.getsize only, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

```shell
# Before: any size input goes straight to the converter
_extract_anydoc("huge.pdf")  # to_markdown() loads the full file, no bound

# After: oversized input rejected before conversion
_extract_anydoc("huge.pdf")
# ExtractionError: Document too large to convert (52,428,801 bytes, limit is 52,428,800)
```
