### PR TITLE
fix(cron): skip NUL-bearing remote fallback content in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -331,8 +331,17 @@ def _contains_unsafe_gateway_action(
             return True
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
+            # A NUL-containing path can only come from junk tokenized out of a
+            # binary's decoded contents — never remote-read it (#76762).
+            if "\x00" in os.fspath(script_path):
+                continue
             script_text = read_remote_script(str(script_path))
         if not script_text:
+            continue
+        # Fallback readers return decoded bytes; mirror the local binary check
+        # so machine code (NUL bytes) is "nothing to scan", exactly like a
+        # local binary read (#76762).
+        if "\x00" in script_text:
             continue
         # Relative references inside a script resolve against that script's
         # directory, not the original command's cwd.

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -751,6 +751,43 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    def test_raw_remote_binary_reference_is_skipped(self):
+        """The reusable guard may receive raw remote bytes directly, rather
+        than terminal_tool's pre-filtered reader. NUL-bearing fallback text
+        must still be treated as a binary, not a lifecycle command."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        elf_bytes = (
+            b"\x7fELF\x00\x00\x01\x00/usr/bin/evil\x00"
+            b"\x00hermes gateway restart\x00"
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "/usr/bin/python3 -c 'print(1)'",
+            read_remote_script=lambda _path: elf_bytes.decode(
+                "utf-8", errors="replace"
+            ),
+        )
+        assert result is False
+
+    def test_raw_remote_fallback_still_blocks_real_scripts(self):
+        """Skipping binary fallback text must not allow actual lifecycle
+        commands inside a remotely-read shell script."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /nonexistent/deploy.sh",
+            read_remote_script=lambda path: (
+                "#!/bin/bash\nhermes gateway restart\n"
+                if "deploy.sh" in path
+                else None
+            ),
+        )
+        assert result is True
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""


### PR DESCRIPTION
## Summary

Harden the reusable gateway-lifecycle guard against NUL-bearing remote fallback content:

- Skip the remote-read fallback for referenced script paths containing an embedded NUL byte (machine code tokenized into a bogus path by the recursion).
- Treat NUL-bearing text returned by a remote fallback reader as binary — "nothing to scan" — mirroring the local binary skip, instead of tokenizing machine code and risking false blocks or `ValueError` crashes.
- Real remotely-read shell scripts containing lifecycle commands remain blocked.

## Why

Upstream #77703 fixed the `terminal_tool` path (its `_read_script_in_env` pre-filters binary output); this diff sits on top of that work. However, the reusable `contains_gateway_lifecycle_command_or_referenced_script` API accepts an arbitrary `read_remote_script` callback and can be called directly. Raw NUL-bearing fallback bytes were still treated as shell text, so a binary containing lifecycle-looking strings could false-block a benign command. This makes the guard itself robust regardless of caller pre-filtering.

## Validation

- `pytest tests/hermes_cli/test_gateway_restart_loop.py -q -o 'addopts='` — 86 passed, including two new regressions:
  - raw binary fallback reference is skipped (no false block);
  - a real remote shell script containing a lifecycle command is still blocked.
- Full-repo Python compile + import smoke checks.
- Desktop TypeScript typecheck and Electron platform suite.
- Web check (tests/typecheck/lint) and production build.
- `git diff --check` clean.
- Deployed and verified on the production backend: serve healthy, gateway running, Telegram connected, auth boundary intact.
