### PR TITLE
fix(config): preserve dotted keys under open-dict leaf containers (#80006)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -989,6 +989,18 @@ def get_missing_env_vars(required_only: bool = False) -> List[Dict[str, Any]]:
     return missing
 
 
+# Sub-tree names whose immediate children are user-supplied keys that may
+# legitimately contain dots (e.g. Matrix room IDs ``!abc:server.tld``).
+# ``_set_nested`` stops splitting the dotted path after crossing one of
+# these segments and treats the remainder as a single opaque key.  Keep
+# the list narrow — adding a name here changes the meaning of every
+# ``hermes config set <name>.<anything>`` invocation that contains a dot
+# in ``<anything>``.
+_OPEN_DICT_LEAF_CONTAINERS = frozenset({
+    "channel_prompts",
+})
+
+
 def _set_nested(config, dotted_key: str, value):
     """Set a value at an arbitrarily nested dotted key path.
 
@@ -1010,8 +1022,25 @@ def _set_nested(config, dotted_key: str, value):
     replaced any non-dict value (including lists) with ``{}``, silently
     destroying list-typed config like ``custom_providers`` whenever a
     caller used an indexed path.
+
+    Open-dict containers (#80006): certain sub-trees are flat dicts whose
+    *keys* may themselves contain dots (e.g. ``matrix.channel_prompts``
+    keyed by Matrix room IDs like ``!abc:server.tld``).  A naive
+    ``split(".")`` would slice the room ID into nested path segments and
+    silently write the value into a wrong nested shape.  When the path
+    crosses one of these container names, everything after the container
+    segment is treated as a single opaque key.
     """
     parts = dotted_key.split(".")
+    # Find the earliest open-dict container segment; everything after it
+    # is the user-supplied key, dots and all.  The container's position
+    # varies by platform (``matrix.channel_prompts`` vs top-level
+    # ``channel_prompts``), so match by name regardless of depth.
+    for idx, part in enumerate(parts[:-1]):
+        if part in _OPEN_DICT_LEAF_CONTAINERS:
+            # Re-partition: path to the container, then one opaque key.
+            parts = parts[: idx + 1] + [".".join(parts[idx + 1 :])]
+            break
     current = config
     for part in parts[:-1]:
         if isinstance(current, list):

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -723,3 +723,83 @@ class TestMalformedYAMLConfigPreservation:
         assert "Cannot parse" in captured.out or "Cannot parse" in captured.err
         raw = _read_config(_isolated_hermes_home)
         assert raw == self.BROKEN_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Open-dict leaf containers — keys containing dots must not be split
+# ---------------------------------------------------------------------------
+
+class TestOpenDictLeafContainers:
+    """``channel_prompts`` and similar flat-dict subtrees are keyed by
+    user-supplied identifiers that may legitimately contain dots (Matrix
+    room IDs like ``!abc:server.tld``, bridged-channel IDs, etc.).
+
+    A naive ``split(".")`` on the dotted path slices the identifier into
+    nested path segments and silently writes the value into a wrong
+    nested shape — the user sees ``✓ Set …`` but the runtime reads no
+    value.  ``_set_nested`` must stop splitting after crossing a known
+    open-dict container name and treat the remainder as a single opaque
+    key.
+    """
+
+    def _write_config(self, tmp_path, body):
+        (tmp_path / "config.yaml").write_text(body)
+
+    def test_matrix_room_id_with_dots_lands_as_single_key(self, _isolated_hermes_home):
+        """matrix.channel_prompts.!abc:server.tld writes ONE key, not nested."""
+        self._write_config(_isolated_hermes_home, "matrix:\n  channel_prompts: {}\n")
+
+        set_config_value(
+            "matrix.channel_prompts.!TestRoom:chat.changwt.cc",
+            "be brief",
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        # The full room ID is preserved as one key under channel_prompts.
+        assert reloaded["matrix"]["channel_prompts"] == {
+            "!TestRoom:chat.changwt.cc": "be brief",
+        }
+
+    def test_channel_prompts_value_replaces_existing_room_id_entry(self, _isolated_hermes_home):
+        """Re-setting the same room ID replaces the value in place."""
+        self._write_config(_isolated_hermes_home, (
+            "matrix:\n"
+            "  channel_prompts:\n"
+            "    '!OldRoom:example.org': old prompt\n"
+        ))
+
+        set_config_value(
+            "matrix.channel_prompts.!OldRoom:example.org",
+            "new prompt",
+        )
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["matrix"]["channel_prompts"] == {
+            "!OldRoom:example.org": "new prompt",
+        }
+
+    def test_top_level_channel_prompts_also_protects_dotted_key(self, _isolated_hermes_home):
+        """The protection is keyed by container NAME, not by full path —
+        a top-level ``channel_prompts.<dotted>`` is protected too."""
+        self._write_config(_isolated_hermes_home, "channel_prompts: {}\n")
+
+        set_config_value("channel_prompts.!abc:example.org", "hi")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["channel_prompts"] == {"!abc:example.org": "hi"}
+
+    def test_other_dotted_keys_still_split_normally(self, _isolated_hermes_home):
+        """The open-dict protection must NOT leak into other paths —
+        ordinary nested keys like ``model.provider`` keep splitting."""
+        self._write_config(_isolated_hermes_home, "model:\n  default: x\n")
+
+        set_config_value("model.provider", "anthropic")
+
+        import yaml
+        reloaded = yaml.safe_load(_read_config(_isolated_hermes_home))
+        assert reloaded["model"]["provider"] == "anthropic"
+        # The original sibling is preserved.
+        assert reloaded["model"]["default"] == "x"


### PR DESCRIPTION
Closes #80006.

## What

`hermes config set` silently misroutes values when the target key is a flat dict whose *keys* legitimately contain dots. The canonical case is `channel_prompts` — declared as `{}` per-platform in `config_defaults.py` so users can populate it with room/channel IDs — where a Matrix room ID like `!abc:server.tld` was being sliced by `_set_nested` into nested path segments:

```bash
$ hermes config set matrix.channel_prompts.!TestRoom:chat.changwt.cc "be brief"
✓ Set matrix.channel_prompts.!TestRoom:chat.changwt.cc = be brief  # ← lies
```

```yaml
# Written (before fix):
matrix:
  channel_prompts:
    '!TestRoom:chat':
      changwt:
        cc: be brief    # ← runtime reads matrix.channel_prompts['!TestRoom:chat.changwt.cc'], gets nothing

# Written (after fix):
matrix:
  channel_prompts:
    '!TestRoom:chat.changwt.cc': be brief
```

The user sees `✓` and the runtime reads nothing. Silent config breakage.

## Fix

Add a narrow allowlist `_OPEN_DICT_LEAF_CONTAINERS` (currently just `channel_prompts`). When `_set_nested` crosses one of these segments, it stops splitting and treats the remainder of the dotted path as a single opaque key.

The list is intentionally narrow — adding a name to it changes the meaning of every `hermes config set <name>.<anything>` invocation that contains a dot, so future expansion should be deliberate.

## Why not a broader YAML-aware fix

- #33613 proposes a general YAML-aware `config set` redesign — that is the right long-term answer but a much bigger change. This PR is the smallest fix for the concrete reported bug.
- #76974 covers the *list-creation* side of the same "_set_nested doesn't know what shape the user means" problem class. The two fixes are independent; this PR does not attempt to also fix #76974 (out of scope, would balloon the diff).

## Tests

4 new regression tests in `TestOpenDictLeafContainers` (`tests/hermes_cli/test_set_config_value.py`):

- `test_matrix_room_id_with_dots_lands_as_single_key` — the original bug shape
- `test_channel_prompts_value_replaces_existing_room_id_entry` — idempotent re-set
- `test_top_level_channel_prompts_also_protects_dotted_key` — protection is keyed by container *name*, not full path
- `test_other_dotted_keys_still_split_normally` — sibling paths (model.provider) keep existing split behavior

```
$ ./venv/bin/python -m pytest tests/hermes_cli/test_set_config_value.py -q
86 passed in 2.61s
```

Full file (existing 82 + new 4) green. E2E verified by invoking `set_config_value("matrix.channel_prompts.!TestRoom:chat.changwt.cc", ...)` against a fresh `HERMES_HOME` and inspecting the resulting `config.yaml` — the full room ID lands as a single opaque key.

## Notes

- The PR template's duplicate-check was run before starting: searched open + closed PRs for "channel_prompts config set", "matrix room id dots", "_set_nested dotted key" — no prior art. Nearest neighbors are #33613 (broader redesign, feature-shaped) and #76974 (list-creation, separate bug).