### PR TITLE
fix(read_file): stop promising anydoc conversion in the tool schema

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2158,7 +2158,7 @@ def _check_file_reqs():
 
 READ_FILE_SCHEMA = {
     "name": "read_file",
-    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text; PDF, legacy Office (.doc/.ppt/.xls), OpenDocument, RTF, and EPUB convert too via the optional anydoc converter (auto-installed on first use). NOTE: Cannot read images or other binary files — use vision_analyze for images.",
+    "description": "Read a text file with line numbers and pagination. Use this instead of cat/head/tail in terminal. Output format: 'LINE_NUM|CONTENT'. Suggests similar filenames if not found. Use offset and limit for large files. Reads exceeding ~100K characters are truncated on a line boundary and return a next_offset; continue with offset to read the rest. Jupyter notebooks (.ipynb), Word documents (.docx), and Excel workbooks (.xlsx) are auto-extracted to readable text; PDF, legacy Office (.doc/.ppt/.xls), OpenDocument, RTF, and EPUB convert too when the optional anydoc converter is available (auto-installed on first use where installs are permitted). NOTE: Cannot read images or other binary files — use vision_analyze for images.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## What does this PR do?

The read_file description from #79781 states that PDF, legacy Office, OpenDocument, RTF, and EPUB "convert too via the optional anydoc converter (auto-installed on first use)", with no qualifier. At runtime conversion depends on the lazy install succeeding, on `security.allow_lazy_installs` / `HERMES_DISABLE_LAZY_INSTALLS`, and on the file being readable from the Hermes host. In offline, locked-down, or remote-backend environments the schema promises a capability the tool does not have, and the model plans around guaranteed conversion only to get a raw-text fallthrough.

This rephrases the sentence to the actual contract: these formats convert when the optional anydoc converter is available, and the auto-install applies where installs are permitted. The string stays static, so tool definitions remain byte-stable for the life of a conversation.

One line, no behavior change.

## Related Issue

Fixes #80008

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/file_tools.py`: reword the anydoc sentence in `READ_FILE_SCHEMA["description"]` to say conversion happens when the optional anydoc converter is available (auto-installed on first use where installs are permitted).

No new tests: the change is a static description string, and a test pinning the exact wording would be a change-detector that breaks on the next legitimate description edit. Existing suites confirm nothing else pinned the old sentence.

## How to Test

1. `scripts/run_tests.sh tests/tools/test_read_extract.py -q`
   - 15 passed, 3 skipped, 0 failed
2. `scripts/run_tests.sh tests/tools/test_file_tools.py -q`
   - 41 passed, 6 failed. All 6 failures (sensitive-path and patch handler cases) fail identically on clean upstream/main on this Windows machine. Verified in a separate worktree.
3. Grep confirms no test or doc pins the old "auto-installed on first use" wording.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the suites above. The 6 file_tools failures reproduce on clean upstream/main and are unrelated.
- [x] I've added tests for my changes - N/A, static string change, change-detector tests are rejected by the repo's testing policy
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - the schema description IS the documentation here
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - string only, no platform surface
- [x] I've updated tool descriptions/schemas if I changed tool behavior - this PR is exactly that

## Screenshots / Logs

```shell
# Before
"PDF, legacy Office (.doc/.ppt/.xls), OpenDocument, RTF, and EPUB convert too
 via the optional anydoc converter (auto-installed on first use)."

# After
"PDF, legacy Office (.doc/.ppt/.xls), OpenDocument, RTF, and EPUB convert too
 when the optional anydoc converter is available
 (auto-installed on first use where installs are permitted)."
```
