### PR TITLE
fix(tui): repaint full DECSTBM scroll regions

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.test.ts
@@ -199,6 +199,47 @@ describe('LogUpdate.render diff contract', () => {
     expect(hasDecstbm(stdoutOnly(diff))).toBe(true)
   })
 
+  it('repairs fixed cells outside narrow damage after a DECSTBM scroll', () => {
+    const w = 12
+    const h = 6
+    const prev = mkScreen(w, h)
+    const next = mkScreen(w, h)
+    const edge = ['A', 'B', 'C', 'D']
+
+    for (let i = 0; i < edge.length; i++) {
+      const y = i + 1
+      const cell = {
+        char: edge[i]!,
+        styleId: stylePool.none,
+        width: CellWidth.Narrow,
+        hyperlink: undefined
+      }
+
+      setCellAt(prev, w - 1, y, cell)
+      setCellAt(next, w - 1, y, cell)
+    }
+
+    // The ScrollBox dirtied only its narrow inner content. DECSTBM still
+    // shifts every terminal column in the row range, including this fixed
+    // right edge, so LogUpdate must repair outside the original damage.
+    prev.damage = undefined
+    next.damage = { x: 0, y: 1, width: 4, height: 4 }
+
+    const nextFrame: Frame = {
+      ...mkFrame(next, w, h),
+      scrollHint: { top: 1, bottom: 4, delta: 1 }
+    }
+
+    const log = new LogUpdate({ isTTY: true, stylePool })
+    const written = stdoutOnly(log.render(mkFrame(prev, w, h), nextFrame, true, true))
+
+    expect(hasDecstbm(written)).toBe(true)
+
+    for (const char of edge) {
+      expect(written).toContain(char)
+    }
+  })
+
   it('skips DECSTBM when scroll region touches the bottom row', () => {
     const w = 12
     const h = 6

--- a/ui-tui/packages/hermes-ink/src/ink/log-update.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/log-update.ts
@@ -3,7 +3,7 @@ import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi
 import { logForDebugging } from '../utils/debug.js'
 
 import type { Diff, FlickerReason, Frame } from './frame.js'
-import type { Point } from './layout/geometry.js'
+import { type Point, unionRect } from './layout/geometry.js'
 import {
   type Cell,
   cellAt,
@@ -177,6 +177,18 @@ export class LogUpdate {
       // layouts we reserve that lane for status/cursor parking, and scrolling
       // it can leave transient ghosting/bleed artifacts until a later repaint.
       if (top >= 0 && bottom < prev.screen.height - 1 && bottom < next.screen.height - 1) {
+        // DECSTBM scrolls complete terminal rows, not just the ScrollBox's
+        // horizontal bounds. Expand damage across the full screen width so
+        // fixed siblings and borders outside the ScrollBox's narrow damage
+        // are repainted after shiftRows mirrors the hardware operation.
+        const scrollDamage = {
+          x: 0,
+          y: top,
+          width: next.screen.width,
+          height: bottom - top + 1
+        }
+
+        next.screen.damage = next.screen.damage ? unionRect(next.screen.damage, scrollDamage) : scrollDamage
         shiftRows(prev.screen, top, bottom, delta)
         scrollPatch = [
           {


### PR DESCRIPTION
## Summary

- expand DECSTBM scroll damage to the full terminal width
- repaint fixed cells outside a ScrollBox narrow damage rectangle after physical row scrolling
- add a fixed-size scroll-only regression

## Problem

At a fixed terminal size, repeated PageUp/PageDown or wheel scrolling can leave isolated glyphs from previous rows in otherwise blank cells. `/redraw` removes them, but scrolling recreates them.

DECSTBM scrolls complete physical rows across every terminal column. `LogUpdate` mirrored that shift in `prev.screen` while retaining the ScrollBox narrow damage rectangle, so cells outside the rectangle were never repainted even though the terminal moved them.

## Validation

- new regression on unpatched baseline: RED (DECSTBM emitted, fixed edge cells absent from output)
- patched `log-update` suite: 9/9 passed
- TUI typecheck: passed
- production build: passed

This does not change resize handling, Yoga layout, Unicode width, application layout, or session signaling.

Made with [Orca](https://github.com/stablyai/orca) 🐋
