### PR TITLE
fix(slack): authorize multiplexed approval callbacks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6650,15 +6650,22 @@ class SlackAdapter(BasePlatformAdapter):
         if not normalized_user_id:
             return False
 
-        runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
+        # Multiplex gateways install closure-based message handlers, so
+        # ``_message_handler.__self__`` cannot recover the runner there. Every
+        # adapter receives an explicit gateway_runner back-reference; prefer it
+        # and retain the bound-handler lookup for older/test integrations.
+        runner = getattr(self, "gateway_runner", None)
+        if runner is None:
+            runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
             try:
-                from gateway.session import SessionSource
-
-                source = SessionSource(
-                    platform=Platform.SLACK,
+                # Use the standard source builder so profile_routes stamps the
+                # routed profile. Interactive authorization must consult the
+                # same per-profile pairing store as normal message intake.
+                source = self.build_source(
                     chat_id=str(channel_id or normalized_user_id),
+                    chat_name="",
                     chat_type="dm" if str(channel_id or "").startswith("D") else "group",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -59,8 +59,9 @@ def _make_adapter():
 
 
 class _AuthRunner:
-    def __init__(self, auth_fn=None):
+    def __init__(self, auth_fn=None, profile_fn=None):
         self._auth_fn = auth_fn or (lambda _source: True)
+        self._profile_fn = profile_fn or (lambda _source: None)
         self.seen_sources = []
 
     async def handle(self, event):
@@ -69,6 +70,9 @@ class _AuthRunner:
     def _is_user_authorized(self, source):
         self.seen_sources.append(source)
         return self._auth_fn(source)
+
+    def _profile_name_for_source(self, source):
+        return self._profile_fn(source)
 
 
 def _attach_auth_runner(adapter, auth_fn=None):
@@ -226,6 +230,45 @@ class TestSlackInteractiveAuth:
         assert runner.seen_sources[0].platform == Platform.SLACK
         assert runner.seen_sources[0].chat_id == "C1"
         assert runner.seen_sources[0].chat_type == "group"
+
+    def test_multiplex_closure_uses_gateway_runner_and_routed_source(self, monkeypatch):
+        adapter = _make_adapter()
+        runner = _AuthRunner(
+            auth_fn=lambda source: source.user_id == "U_OK" and source.profile == "karen",
+            profile_fn=lambda source: "karen" if source.chat_id == "C1" else None,
+        )
+        adapter.gateway_runner = runner  # type: ignore[assignment]
+
+        async def multiplex_handler(_event):
+            return None
+
+        # Multiplex handlers are closures, not bound runner methods. Interactive
+        # auth must use the adapter's explicit gateway_runner back-reference.
+        adapter.set_message_handler(multiplex_handler)
+        assert getattr(adapter._message_handler, "__self__", None) is None
+
+        for name in (
+            "SLACK_ALLOWED_USERS",
+            "SLACK_ALLOW_ALL_USERS",
+            "GATEWAY_ALLOWED_USERS",
+            "GATEWAY_ALLOW_ALL_USERS",
+        ):
+            monkeypatch.delenv(name, raising=False)
+
+        assert adapter._is_interactive_user_authorized(
+            "U_OK",
+            channel_id="C1",
+            user_name="operator",
+            team_id="T1",
+        ) is True
+
+        assert len(runner.seen_sources) == 1
+        source = runner.seen_sources[0]
+        assert source.platform == Platform.SLACK
+        assert source.chat_id == "C1"
+        assert source.chat_type == "group"
+        assert source.scope_id == "T1"
+        assert source.profile == "karen"
 
 
 class TestSlackSlashConfirmAction:


### PR DESCRIPTION
## Summary
- recover Slack interactive authorization from the adapter’s explicit `gateway_runner` back-reference when multiplexing installs closure-based message handlers
- build interactive callback sources through `build_source()` so `profile_routes` selects the correct per-profile pairing store
- preserve the bound-handler fallback for compatibility

## Regression
With `gateway.multiplex_profiles: true`, `_primary_message_handler()` installs a closure. Slack approval callbacks previously tried `_message_handler.__self__`, failed to recover the runner, skipped pairing authorization, and fell back to env-only allowlists. Paired users were rejected as unauthorized in routed channels.

## Tests
- `uv run python -m pytest tests/gateway/test_slack_approval_buttons.py -q` (21 passed)
- `uv run python -m pytest tests/gateway/test_config_driven_access_policy.py tests/gateway/test_slack.py -q` (184 passed)
- `uv run python -m pytest tests/gateway/test_slack_approval_buttons.py tests/gateway/test_config_driven_access_policy.py -q` (44 passed)
- `uv run ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_approval_buttons.py`