### PR TITLE
fix: show provider account limits in /usage

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -881,6 +881,43 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def resolve_account_usage_target(
+    provider: Optional[str],
+    *,
+    model: Optional[str] = None,
+    base_url: Optional[str] = None,
+    api_key: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve an account-usage target when runtime provider selection is deferred.
+
+    ``auto`` is a routing request, not an account-usage provider. Resolve it through
+    the same runtime provider resolver used by the agent, including the target model
+    and profile-scoped config. Never force a caller-supplied generic key through an
+    auto request: the resolver must choose the matching native credential itself.
+    """
+    normalized = str(provider or "").strip().lower()
+    if normalized not in {"", "auto", "custom"}:
+        return normalized, base_url, api_key
+    try:
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        runtime = resolve_runtime_provider(
+            requested=normalized or None,
+            explicit_base_url=base_url or None,
+            explicit_api_key=api_key if normalized == "custom" else None,
+            target_model=model or None,
+        )
+    except Exception:
+        return normalized or None, base_url, api_key
+
+    resolved_provider = str(runtime.get("provider") or "").strip().lower()
+    if resolved_provider in {"", "auto", "custom"}:
+        return normalized or None, base_url, api_key
+    resolved_base_url = str(runtime.get("base_url") or base_url or "").strip() or None
+    resolved_api_key = runtime.get("api_key") or (api_key if normalized == "custom" else None)
+    return resolved_provider, resolved_base_url, resolved_api_key
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,

--- a/cli.py
+++ b/cli.py
@@ -11296,24 +11296,79 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print()
 
     def _show_usage(self):
-        """Rate limits + session token usage (when a live agent exists) + Nous credits.
+        """Account limits + rate limits + session token usage + Nous credits.
 
-        The Nous credits block is agent-independent (a portal fetch), so it runs even
-        with no live agent — important for the TUI, where /usage runs in a slash-worker
-        subprocess that resumes the session WITHOUT building an agent (self.agent is None),
-        which would otherwise early-return before any credits showed.
+        The account and Nous blocks are agent-independent, so they run even with no
+        live agent — important for a fresh `/usage` invocation before the first API
+        call. Codex credentials are resolved natively when the agent is not built.
         """
-        if not self.agent:
+        agent = self.agent
+        provider = getattr(agent, "provider", None) if agent else None
+        provider = provider or getattr(self, "provider", None)
+        base_url = getattr(agent, "base_url", None) if agent else None
+        base_url = base_url or getattr(self, "base_url", None)
+        api_key = getattr(agent, "api_key", None) if agent else None
+        # A pre-agent CLI may still carry a generic OPENROUTER_API_KEY in
+        # self.api_key. Never send that as a Codex bearer token, or force it
+        # through deferred `auto` routing; native runtime resolution owns both.
+        if (
+            not api_key
+            and str(provider or "").strip().lower() not in {"openai-codex", "auto", ""}
+        ):
+            api_key = getattr(self, "api_key", None)
+
+        from agent.account_usage import (
+            fetch_account_usage,
+            render_account_usage_lines,
+            resolve_account_usage_target,
+        )
+        provider, base_url, api_key = resolve_account_usage_target(
+            provider,
+            model=(getattr(agent, "model", None) if agent else None) or self.model,
+            base_url=base_url,
+            api_key=api_key,
+        )
+        # Account limits are independent of session token counters. Fetch them
+        # before the no-agent/no-call early returns so `/usage` works immediately
+        # after startup, matching the gateway and TUI surfaces.
+        account_snapshot = None
+        if provider:
+            from tools.daemon_pool import DaemonThreadPoolExecutor
+
+            _pool = DaemonThreadPoolExecutor(max_workers=1)
+            try:
+                account_snapshot = _pool.submit(
+                    fetch_account_usage, provider,
+                    base_url=base_url, api_key=api_key,
+                ).result(timeout=10.0)
+            except Exception:
+                account_snapshot = None
+            finally:
+                # Do not wait for a stuck auth refresh/HTTP request after the
+                # user-visible timeout. The worker is allowed to finish in the
+                # background, while `/usage` returns the rest of its report.
+                _pool.shutdown(wait=False, cancel_futures=True)
+        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
+
+        def _print_account_block() -> None:
+            if not account_lines:
+                return
+            print()
+            for line in account_lines:
+                print(line)
+
+        if not agent:
+            _print_account_block()
             if self._print_nous_credits_block():
                 self._print_usage_cta()
             else:
                 print("(._.) No active agent -- send a message first.")
             return
 
-        agent = self.agent
         calls = agent.session_api_calls
 
         if calls == 0:
+            _print_account_block()
             if self._print_nous_credits_block():
                 self._print_usage_cta()
             else:
@@ -11362,28 +11417,9 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         print(f"  Messages:         {msg_count}")
         print(f"  Compressions:     {compressions}")
 
-        # Account limits -- fetched off-thread with a hard timeout so slow
-        # provider APIs don't hang the prompt.
-        provider = getattr(agent, "provider", None) or getattr(self, "provider", None)
-        base_url = getattr(agent, "base_url", None) or getattr(self, "base_url", None)
-        api_key = getattr(agent, "api_key", None) or getattr(self, "api_key", None)
-        # Lazy import — pulls the OpenAI SDK chain, only needed here.
-        from agent.account_usage import fetch_account_usage, render_account_usage_lines
-        account_snapshot = None
-        if provider:
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as _pool:
-                try:
-                    account_snapshot = _pool.submit(
-                        fetch_account_usage, provider,
-                        base_url=base_url, api_key=api_key,
-                    ).result(timeout=10.0)
-                except (concurrent.futures.TimeoutError, Exception):
-                    account_snapshot = None
-        account_lines = [f"  {line}" for line in render_account_usage_lines(account_snapshot)]
-        if account_lines:
-            print()
-            for line in account_lines:
-                print(line)
+        # Account limits were fetched before the no-agent/no-call early returns
+        # above, so the same block is also available after a live session turn.
+        _print_account_block()
 
         # Nous credits magnitudes + monthly-grant gauge (agent-independent — also
         # runs at the no-agent / no-calls early-returns above). See the helper.

--- a/tests/agent/test_account_usage.py
+++ b/tests/agent/test_account_usage.py
@@ -50,6 +50,41 @@ def codex_usage_payload():
     }
 
 
+def test_account_usage_target_resolves_auto_for_target_model(monkeypatch):
+    captured = {}
+    generic_key = "generic-openrouter-key"
+    runtime_key = "test"
+
+    def fake_resolve_runtime_provider(**kwargs):
+        captured.update(kwargs)
+        return {
+            "provider": "openai-codex",
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "api_key": runtime_key,
+        }
+
+    import hermes_cli.runtime_provider as runtime_provider
+
+    monkeypatch.setattr(runtime_provider, "resolve_runtime_provider", fake_resolve_runtime_provider)
+
+    target = account_usage.resolve_account_usage_target(
+        "auto",
+        model="gpt-5.6-luna",
+        api_key=generic_key,
+    )
+
+    assert target == (
+        "openai-codex",
+        "https://chatgpt.com/backend-api/codex",
+        runtime_key,
+    )
+    assert captured == {
+        "requested": "auto",
+        "explicit_base_url": None,
+        "explicit_api_key": None,
+        "target_model": "gpt-5.6-luna",
+    }
+
 def test_codex_usage_prefers_explicit_live_agent_credentials(monkeypatch, codex_usage_payload):
     calls = []
     monkeypatch.setattr(

--- a/tests/cli/test_cli_status_bar.py
+++ b/tests/cli/test_cli_status_bar.py
@@ -196,6 +196,125 @@ class TestCLIStatusBar:
 
 
 class TestCLIUsageReport:
+    def test_show_usage_fetches_account_limits_before_first_api_call(self, capsys):
+        cli_obj = _make_cli(model="gpt-5.6-luna")
+        cli_obj.provider = "openai-codex"
+        cli_obj.base_url = "https://chatgpt.com/backend-api/codex"
+        generic_key = "unrelated-openrouter-key"
+        cli_obj.api_key = generic_key
+
+        with patch("agent.account_usage.fetch_account_usage", return_value=object()) as fetch, \
+             patch(
+                 "agent.account_usage.render_account_usage_lines",
+                 return_value=[
+                     "📈 Account limits",
+                     "Provider: openai-codex (Plus)",
+                 ],
+             ), \
+             patch.object(cli_obj, "_print_nous_credits_block", return_value=False):
+            cli_obj._show_usage()
+
+        output = capsys.readouterr().out
+        fetch.assert_called_once_with(
+            "openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key=None,
+        )
+        assert "📈 Account limits" in output
+        assert "Provider: openai-codex (Plus)" in output
+        assert "No active agent" in output
+
+    def test_show_usage_fetches_account_limits_with_zero_api_calls(self, capsys):
+        cli_obj = _attach_agent(
+            _make_cli(model="gpt-5.6-luna"),
+            prompt_tokens=0,
+            completion_tokens=0,
+            total_tokens=0,
+            api_calls=0,
+            context_tokens=0,
+            context_length=200_000,
+        )
+        cli_obj.agent.provider = "openai-codex"
+        cli_obj.agent.base_url = "https://chatgpt.com/backend-api/codex"
+        codex_credential = "codex-test-credential"
+        cli_obj.agent.api_key = codex_credential
+
+        with patch("agent.account_usage.fetch_account_usage", return_value=object()) as fetch, \
+             patch(
+                 "agent.account_usage.render_account_usage_lines",
+                 return_value=["📈 Account limits"],
+             ), \
+             patch.object(cli_obj, "_print_nous_credits_block", return_value=False):
+            cli_obj._show_usage()
+
+        output = capsys.readouterr().out
+        fetch.assert_called_once_with(
+            "openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key=codex_credential,
+        )
+        assert "📈 Account limits" in output
+        assert "No API calls made yet" in output
+
+    def test_show_usage_resolves_deferred_auto_provider(self):
+        cli_obj = _make_cli(model="gpt-5.6-luna")
+        cli_obj.provider = "auto"
+        cli_obj.base_url = ""
+        generic_key = "generic-openrouter-key"
+        cli_obj.api_key = generic_key
+
+        with patch(
+            "agent.account_usage.resolve_account_usage_target",
+            return_value=("openai-codex", "https://chatgpt.com/backend-api/codex", None),
+        ) as resolve, \
+            patch("agent.account_usage.fetch_account_usage", return_value=None) as fetch, \
+            patch("agent.account_usage.render_account_usage_lines", return_value=[]), \
+            patch.object(cli_obj, "_print_nous_credits_block", return_value=False):
+            cli_obj._show_usage()
+
+        resolve.assert_called_once_with(
+            "auto",
+            model="gpt-5.6-luna",
+            base_url="",
+            api_key=None,
+        )
+        fetch.assert_called_once_with(
+            "openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key=None,
+        )
+
+    def test_show_usage_timeout_does_not_wait_for_worker(self, monkeypatch, capsys):
+        class _TimedOutFuture:
+            def result(self, timeout):
+                raise cli_mod.concurrent.futures.TimeoutError()
+
+        class _Executor:
+            def __init__(self):
+                self.shutdown_args = None
+
+            def submit(self, *args, **kwargs):
+                return _TimedOutFuture()
+
+            def shutdown(self, *, wait, cancel_futures):
+                self.shutdown_args = (wait, cancel_futures)
+
+        executor = _Executor()
+        monkeypatch.setattr(
+            "tools.daemon_pool.DaemonThreadPoolExecutor",
+            lambda max_workers: executor,
+        )
+        cli_obj = _make_cli(model="gpt-5.6-luna")
+        cli_obj.provider = "openai-codex"
+        cli_obj.base_url = "https://chatgpt.com/backend-api/codex"
+
+        with patch("agent.account_usage.render_account_usage_lines", return_value=[]), \
+            patch.object(cli_obj, "_print_nous_credits_block", return_value=False):
+            cli_obj._show_usage()
+
+        assert executor.shutdown_args == (False, True)
+        assert "No active agent" in capsys.readouterr().out
+
     def test_show_usage_omits_cost_reporting(self, capsys):
         cli_obj = _attach_agent(
             _make_cli(),

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -38,6 +38,122 @@ def _neuter_agent_prewarm_timer(request, monkeypatch):
     yield
 
 
+def test_session_usage_includes_account_limits_before_agent(monkeypatch):
+    session = {"agent": None}
+    monkeypatch.setattr(server, "_sess_nowait", lambda _params, _rid: (session, None))
+    monkeypatch.setattr(server, "_session_usage_snapshot", lambda _session: {})
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"provider": "openai-codex", "base_url": ""}},
+    )
+
+    with patch("agent.account_usage.fetch_account_usage", return_value=object()) as fetch, \
+         patch(
+             "agent.account_usage.render_account_usage_lines",
+             return_value=["📈 Account limits", "Provider: openai-codex (Plus)"],
+         ):
+        response = server._methods["session.usage"]("rid", {})
+
+    assert response["result"]["account_lines"] == [
+        "📈 Account limits",
+        "Provider: openai-codex (Plus)",
+    ]
+    fetch.assert_called_once_with("openai-codex", base_url="", api_key=None)
+
+
+def test_session_usage_resolves_auto_provider_in_session_scope(monkeypatch, tmp_path):
+    sid = "usage-profile"
+    session = {
+        "agent": None,
+        "profile_home": str(tmp_path),
+        "model_override": None,
+        "_metadata_mirror": {"provider": "auto", "model": "gpt-5.6-luna"},
+    }
+    server._sessions[sid] = session
+    monkeypatch.setattr(server, "_sess_nowait", lambda _params, _rid: (session, None))
+    monkeypatch.setattr(server, "_session_usage_snapshot", lambda _session: {})
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"provider": "auto", "default": "gpt-5.6-luna"}},
+    )
+    home_token = object()
+    secret_token = object()
+    try:
+        with patch.object(server, "set_hermes_home_override", return_value=home_token) as set_home, \
+            patch.object(server, "reset_hermes_home_override") as reset_home, \
+            patch.object(server, "build_profile_secret_scope", return_value={}) as build_scope, \
+            patch.object(server, "set_secret_scope", return_value=secret_token) as set_scope, \
+            patch.object(server, "reset_secret_scope") as reset_scope, \
+            patch(
+                "agent.account_usage.resolve_account_usage_target",
+                return_value=("openai-codex", "https://chatgpt.com/backend-api/codex", None),
+            ) as resolve, \
+            patch("agent.account_usage.fetch_account_usage", return_value=object()) as fetch, \
+            patch(
+                "agent.account_usage.render_account_usage_lines",
+                return_value=["📈 Account limits"],
+            ):
+            response = server._methods["session.usage"]("rid", {"session_id": sid})
+
+        assert response["result"]["account_lines"] == ["📈 Account limits"]
+        set_home.assert_called_once_with(tmp_path)
+        build_scope.assert_called_once_with(tmp_path)
+        set_scope.assert_called_once_with({})
+        reset_scope.assert_called_once_with(secret_token)
+        reset_home.assert_called_once_with(home_token)
+        resolve.assert_called_once_with(
+            "auto",
+            model="gpt-5.6-luna",
+            base_url=None,
+            api_key=None,
+        )
+        fetch.assert_called_once_with(
+            "openai-codex",
+            base_url="https://chatgpt.com/backend-api/codex",
+            api_key=None,
+        )
+    finally:
+        server._sessions.pop(sid, None)
+
+
+def test_session_usage_rejects_missing_profile_home(monkeypatch, tmp_path):
+    sid = "usage-missing-profile"
+    session = {"agent": None, "profile_home": str(tmp_path / "deleted-profile")}
+    server._sessions[sid] = session
+    try:
+        response = server._methods["session.usage"]("rid", {"session_id": sid})
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert response["error"]["code"] == 5031
+    assert response["error"]["message"] == "profile context unavailable"
+
+
+def test_session_usage_rejects_secret_scope_failure(monkeypatch, tmp_path):
+    sid = "usage-secret-scope-failure"
+    session = {"agent": None, "profile_home": str(tmp_path)}
+    server._sessions[sid] = session
+    home_token = object()
+    try:
+        with patch.object(server, "set_hermes_home_override", return_value=home_token) as set_home, \
+            patch.object(server, "reset_hermes_home_override") as reset_home, \
+            patch.object(
+                server,
+                "build_profile_secret_scope",
+                side_effect=RuntimeError("scope unavailable"),
+            ):
+            response = server._methods["session.usage"]("rid", {"session_id": sid})
+    finally:
+        server._sessions.pop(sid, None)
+
+    assert response["error"]["code"] == 5031
+    assert response["error"]["message"] == "profile context unavailable"
+    set_home.assert_called_once_with(tmp_path)
+    reset_home.assert_called_once_with(home_token)
+
+
 def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
@@ -7774,6 +7890,57 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
             assert "(._.)" not in resp["result"]["output"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_slash_exec_usage_includes_account_and_credit_lines(monkeypatch):
+    server._sessions["sid"] = _session(
+        agent=None,
+        _metadata_mirror={
+            "model": "gpt-5.6-luna",
+            "usage": {
+                "input": 10,
+                "output": 5,
+                "prompt": 10,
+                "completion": 5,
+                "total": 15,
+                "calls": 1,
+                "compressions": 0,
+            },
+        },
+        _metadata_message_count=1,
+    )
+    monkeypatch.setitem(
+        server._methods,
+        "session.usage",
+        lambda rid, params: {
+            "id": rid,
+            "result": {
+                "credits_lines": ["Nous credits: $10 remaining"],
+                "account_lines": [
+                    "📈 Codex account limits",
+                    "5h window: 90% remaining",
+                ],
+            },
+        },
+    )
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "slash.exec",
+                "params": {"command": "usage", "session_id": "sid"},
+            }
+        )
+    finally:
+        server._sessions.pop("sid", None)
+
+    assert isinstance(resp, dict) and "result" in resp
+    output = resp["result"]["output"]
+    assert "Session Token Usage" in output
+    assert "Nous credits: $10 remaining" in output
+    assert "Account limits" in output
+    assert "5h window: 90% remaining" in output
 
 
 def test_prompt_submit_sets_approval_session_key(monkeypatch):

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1270,6 +1270,7 @@ def _(rid, params: dict) -> dict:
 
 
 @method("session.usage")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)
     if err:
@@ -1290,6 +1291,71 @@ def _(rid, params: dict) -> dict:
             usage["credits_lines"] = credits
     except Exception:
         pass
+
+    # Codex/account limits are also agent-independent. Resolve the configured
+    # provider when the session has not built an agent yet, so `/usage` works
+    # immediately after startup instead of returning only the Nous block.
+    try:
+        from agent.account_usage import (
+            fetch_account_usage,
+            render_account_usage_lines,
+            resolve_account_usage_target,
+        )
+
+        provider = getattr(agent, "provider", None) if agent else None
+        base_url = getattr(agent, "base_url", None) if agent else None
+        api_key = getattr(agent, "api_key", None) if agent else None
+        model = getattr(agent, "model", None) if agent else None
+        metadata = _metadata_mirror(session)
+        model = model or metadata.get("model")
+        provider = provider or metadata.get("provider")
+        base_url = base_url or metadata.get("base_url")
+        model_override = session.get("model_override")
+        resume_overrides = session.get("resume_runtime_overrides")
+        if not isinstance(model_override, dict) and isinstance(resume_overrides, dict):
+            model_override = resume_overrides.get("model_override")
+        if isinstance(model_override, dict):
+            model = model or model_override.get("model")
+            provider = provider or model_override.get("provider")
+            base_url = base_url or model_override.get("base_url")
+        if not provider and isinstance(resume_overrides, dict):
+            provider = resume_overrides.get("provider_override")
+
+        cfg = _load_cfg()
+        model_cfg = cfg.get("model", {}) if isinstance(cfg, dict) else {}
+        if isinstance(model_cfg, dict):
+            model = model or model_cfg.get("default") or model_cfg.get("model")
+            provider = provider or model_cfg.get("provider")
+            base_url = base_url or model_cfg.get("base_url")
+        provider = provider or (cfg.get("provider") if isinstance(cfg, dict) else None)
+        if not model:
+            try:
+                model = _resolve_model()
+            except Exception:
+                model = None
+
+        # Do not pass a generic pre-agent key as a Codex bearer token. The
+        # account-usage resolver will select the native OAuth/pool credential.
+        if not agent and str(provider or "").strip().lower() in {"openai-codex", "auto", ""}:
+            api_key = None
+        provider, base_url, api_key = resolve_account_usage_target(
+            provider,
+            model=model,
+            base_url=base_url,
+            api_key=api_key,
+        )
+        if provider:
+            account_snapshot = fetch_account_usage(
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            )
+            account_lines = render_account_usage_lines(account_snapshot)
+            if account_lines:
+                usage["account_lines"] = account_lines
+    except Exception:
+        pass
+
     return _ok(rid, usage)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1404,24 +1404,47 @@ def _profile_home(profile: str | None) -> Path | None:
 
 
 def _profile_scoped(handler):
-    """Bind ``params['profile']``'s HERMES_HOME around a pet RPC handler.
+    """Bind a profile's home and secret scope around a profile-sensitive RPC.
 
-    Pets are per-profile: ``display.pet.*`` lives in the profile's config.yaml and
-    sprites install under its ``pets/`` dir (both resolve via ``get_hermes_home``).
-    The desktop sends ``profile`` on pet calls so config + pets dir resolve to the
-    focused profile even in app-global remote mode, where one backend serves every
-    profile. No-op for the launch profile (own-profile backends already resolve it).
+    App-global clients usually send ``params['profile']``. Session-bound calls
+    such as ``session.usage`` may only send ``session_id``, so fall back to the
+    stored session profile instead of resolving credentials from the launch
+    profile. This keeps account/usage data isolated across profiles.
     """
 
     def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+        params = params if isinstance(params, dict) else {}
+        requested_profile = str(params.get("profile") or "").strip()
+        session = _sessions.get(params.get("session_id") or "")
+        stored_home = (session or {}).get("profile_home")
+        if stored_home:
+            candidate = Path(stored_home)
+            if not candidate.exists():
+                return _err(rid, 5031, "profile context unavailable")
+            home = candidate
+        else:
+            home = _profile_home(requested_profile or None)
+            if home is None and requested_profile and requested_profile != _current_profile_name():
+                return _err(rid, 5031, "profile context unavailable")
         if home is None:
             return handler(rid, params)
-        token = set_hermes_home_override(home)
+
+        try:
+            home_token = set_hermes_home_override(home)
+        except Exception:
+            logger.debug("profile home override unavailable", exc_info=True)
+            return _err(rid, 5031, "profile context unavailable")
+        try:
+            secret_token = set_secret_scope(build_profile_secret_scope(home))
+        except Exception:
+            logger.debug("profile secret scope unavailable", exc_info=True)
+            reset_hermes_home_override(home_token)
+            return _err(rid, 5031, "profile context unavailable")
         try:
             return handler(rid, params)
         finally:
-            reset_hermes_home_override(token)
+            reset_secret_scope(secret_token)
+            reset_hermes_home_override(home_token)
 
     return wrapper
 
@@ -12249,11 +12272,22 @@ _LIVE_SESSION_DIRECT_COMMANDS = frozenset(
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
 
-def _format_live_usage_output(session: dict) -> str:
+def _format_live_usage_output(session: dict, session_id: str | None = None) -> str:
     agent = session.get("agent")
     usage = _session_usage_snapshot(session)
     if agent is None and not usage:
         return "(._.) No active agent -- send a message first."
+    extras: dict = {}
+    if session_id:
+        try:
+            response = _methods["session.usage"](
+                f"usage:{session_id}", {"session_id": session_id}
+            )
+            result = response.get("result") if isinstance(response, dict) else None
+            if isinstance(result, dict):
+                extras = result
+        except Exception:
+            logger.debug("legacy /usage account lookup failed", exc_info=True)
     if session.get("_metadata_message_count") is not None:
         message_count = int(session.get("_metadata_message_count") or 0)
     else:
@@ -12290,6 +12324,12 @@ def _format_live_usage_output(session: dict) -> str:
             f"Compressions:                 {int(usage.get('compressions') or 0):,}",
         ]
     )
+    credits_lines = extras.get("credits_lines") or []
+    if credits_lines:
+        lines.extend(["", "Nous credits", *[str(line) for line in credits_lines]])
+    account_lines = extras.get("account_lines") or []
+    if account_lines:
+        lines.extend(["", "Account limits", *[str(line) for line in account_lines]])
     return "\n".join(lines)
 
 
@@ -12448,7 +12488,7 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     if name == "usage":
         if session is None:
             return "(._.) No active agent -- send a message first."
-        return _format_live_usage_output(session)
+        return _format_live_usage_output(session, sid)
     if name == "history":
         if session is None:
             return "No conversation history yet."

--- a/ui-tui/src/__tests__/usageCommand.test.ts
+++ b/ui-tui/src/__tests__/usageCommand.test.ts
@@ -33,7 +33,8 @@ const buildCtx = (results: Record<string, unknown>) => {
 
   const run = async (arg: string) => {
     usageCommand.run(arg, ctx as any, 'usage')
-    await rpc.mock.results[0]?.value
+    const pending = rpc.mock.results[0]?.value as Promise<unknown> | undefined
+    await pending?.catch(() => undefined)
     await Promise.resolve()
     await Promise.resolve()
   }
@@ -110,6 +111,25 @@ describe('/usage slash command', () => {
     expect(body.toLowerCase()).not.toContain('credits')
   })
 
+  it('shows Codex account limits even before the first API call', async () => {
+    const { panel, run, sys } = buildCtx({
+      'session.usage': baseUsage({ account_lines: ['📈 Account limits', 'Provider: openai-codex (Plus)'] })
+    })
+
+    await run('')
+
+    const sections = panel.mock.calls.find(c => c[0] === 'Account limits')?.[1] as { text?: string }[] | undefined
+    expect((sections ?? []).map(s => s.text ?? '').join('\n')).toContain('Provider: openai-codex (Plus)')
+    expect(printed(sys)).not.toContain('no API calls yet')
+  })
+  it('guards session usage RPC errors', async () => {
+    const failure = new Error('profile context unavailable')
+    const { ctx, run } = buildCtx({ 'session.usage': Promise.reject(failure) })
+
+    await run('')
+
+    expect(ctx.guardedErr).toHaveBeenCalledWith(failure)
+  })
   it('shows the free-models upsell for a free account', async () => {
     const { panel, run } = buildCtx({
       'session.usage': baseUsage({ usage: { available: true, status: 'free', plan_name: null } })

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -643,97 +643,106 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
-    help: 'session usage + Nous credits',
+    help: 'session usage + Nous credits + account limits',
     name: 'usage',
     run: (_arg, ctx) => {
-      ctx.gateway.rpc<SessionUsageResponse>('session.usage', { session_id: ctx.sid }).then(r => {
-        if (ctx.stale()) {
-          return
-        }
+      ctx.gateway
+        .rpc<SessionUsageResponse>('session.usage', { session_id: ctx.sid })
+        .then(r => {
+          if (ctx.stale()) {
+            return
+          }
 
-        const sys = ctx.transcript.sys
+          const sys = ctx.transcript.sys
 
-        if (r) {
-          patchUiState({
-            usage: { calls: r.calls ?? 0, input: r.input ?? 0, output: r.output ?? 0, total: r.total ?? 0 }
-          })
-        }
-
-        // Nous balance block is agent-independent (a portal fetch), so it shows
-        // even with zero API calls or on a resumed session. Prefer the shared
-        // dollar usage model (two-bar view, dollars-only); fall back to the
-        // legacy text lines only when the model is unavailable.
-        const usageModel = r?.usage
-        const barLines = usageBarsText(usageModel)
-        let showedBalance = false
-
-        if (usageModel?.available && (barLines.length || usageModel.status === 'free')) {
-          const sections: PanelSection[] = []
-          const plan = usageModel.plan_name ?? (usageModel.status === 'free' ? 'Free' : null)
-
-          if (plan) {
-            sections.push({
-              text: `Plan: ${plan}${usageModel.renews_display ? ` · renews ${usageModel.renews_display}` : ''}`
+          if (r) {
+            patchUiState({
+              usage: { calls: r.calls ?? 0, input: r.input ?? 0, output: r.output ?? 0, total: r.total ?? 0 }
             })
           }
 
-          if (barLines.length) {
-            sections.push({ text: barLines.join('\n') })
+          // Nous balance block is agent-independent (a portal fetch), so it shows
+          // even with zero API calls or on a resumed session. Prefer the shared
+          // dollar usage model (two-bar view, dollars-only); fall back to the
+          // legacy text lines only when the model is unavailable.
+          const usageModel = r?.usage
+          const barLines = usageBarsText(usageModel)
+          let showedBalance = false
+
+          if (usageModel?.available && (barLines.length || usageModel.status === 'free')) {
+            const sections: PanelSection[] = []
+            const plan = usageModel.plan_name ?? (usageModel.status === 'free' ? 'Free' : null)
+
+            if (plan) {
+              sections.push({
+                text: `Plan: ${plan}${usageModel.renews_display ? ` · renews ${usageModel.renews_display}` : ''}`
+              })
+            }
+
+            if (barLines.length) {
+              sections.push({ text: barLines.join('\n') })
+            }
+
+            if (usageModel.status === 'free') {
+              sections.push({ text: '> Free · free models only. Run /subscription to reach paid models.' })
+            } else if (usageModel.status === 'low') {
+              sections.push({
+                text: `! Low balance · ${usageModel.total_spendable_display ?? 'under $5'} left. Run /topup or /subscription.`
+              })
+            }
+
+            ctx.transcript.panel('Balance', sections)
+            showedBalance = true
+          } else {
+            const creditsLines = r?.credits_lines ?? []
+
+            if (creditsLines.length) {
+              ctx.transcript.panel('Nous balance', [{ text: creditsLines.join('\n') }])
+              showedBalance = true
+            }
           }
 
-          if (usageModel.status === 'free') {
-            sections.push({ text: '> Free · free models only. Run /subscription to reach paid models.' })
-          } else if (usageModel.status === 'low') {
-            sections.push({
-              text: `! Low balance · ${usageModel.total_spendable_display ?? 'under $5'} left. Run /topup or /subscription.`
-            })
-          }
-
-          ctx.transcript.panel('Balance', sections)
-          showedBalance = true
-        } else {
-          const creditsLines = r?.credits_lines ?? []
-
-          if (creditsLines.length) {
-            ctx.transcript.panel('Nous balance', [{ text: creditsLines.join('\n') }])
+          const accountLines = r?.account_lines ?? []
+          if (accountLines.length) {
+            ctx.transcript.panel('Account limits', [{ text: accountLines.join('\n') }])
             showedBalance = true
           }
-        }
 
-        if (!r?.calls) {
-          if (!showedBalance) {
-            sys('no API calls yet')
+          if (!r?.calls) {
+            if (!showedBalance) {
+              sys('no API calls yet')
+            }
+
+            sys(USAGE_CTA)
+
+            return
           }
 
+          const f = (v: number | undefined) => (v ?? 0).toLocaleString()
+
+          const rows: [string, string][] = [
+            ['Model', r.model ?? ''],
+            ['Input tokens', f(r.input)],
+            ['Output tokens', f(r.output)],
+            ['Total tokens', f(r.total)],
+            ['API calls', f(r.calls)]
+          ]
+
+          const sections: PanelSection[] = [{ rows }]
+
+          if (r.context_max) {
+            sections.push({ text: `Context: ${f(r.context_used)} / ${f(r.context_max)} (${r.context_percent}%)` })
+          }
+
+          if (r.compressions) {
+            sections.push({ text: `Compressions: ${r.compressions}` })
+          }
+
+          ctx.transcript.panel('Usage', sections)
+
           sys(USAGE_CTA)
-
-          return
-        }
-
-        const f = (v: number | undefined) => (v ?? 0).toLocaleString()
-
-        const rows: [string, string][] = [
-          ['Model', r.model ?? ''],
-          ['Input tokens', f(r.input)],
-          ['Output tokens', f(r.output)],
-          ['Total tokens', f(r.total)],
-          ['API calls', f(r.calls)]
-        ]
-
-        const sections: PanelSection[] = [{ rows }]
-
-        if (r.context_max) {
-          sections.push({ text: `Context: ${f(r.context_used)} / ${f(r.context_max)} (${r.context_percent}%)` })
-        }
-
-        if (r.compressions) {
-          sections.push({ text: `Compressions: ${r.compressions}` })
-        }
-
-        ctx.transcript.panel('Usage', sections)
-
-        sys(USAGE_CTA)
-      })
+        })
+        .catch(ctx.guardedErr)
     }
   }
 ]

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -270,6 +270,7 @@ export interface SessionUsageResponse {
   cost_status?: 'estimated' | 'exact'
   cost_usd?: number
   credits_lines?: string[]
+  account_lines?: string[]
   input?: number
   model?: string
   output?: number


### PR DESCRIPTION
## Summary
- Show provider account limits from `/usage` before an agent exists or before the first API call.
- Preserve the existing session token usage and Nous credits panels.
- Resolve deferred `auto` routing through the native runtime provider resolver using the session model/config/compute-host metadata.
- Keep Codex OAuth/pool credentials profile-scoped; do not forward generic provider keys as Codex bearer tokens.
- Make the CLI account lookup timeout return without waiting on a stuck worker, using Hermes\u2019 daemon thread pool so abandoned network/auth work cannot hold interpreter exit.
- Render account limits in the TUI and guard rejected `session.usage` RPCs.

## Multi-account scope
Hermes credential pools support multiple accounts for rotation/failover. This PR reports the account selected by the native runtime resolver; it does not aggregate or render every account separately.

## Profile safety
Session-bound usage fails closed when the stored profile directory is unavailable or the profile secret scope cannot be built. It never falls back to the launch profile, and the TUI reports the RPC error through its guarded error path.

## Verification
- PASS: 552 targeted Python tests across the changed CLI, gateway, usage, and account-usage files.
- PASS: 5 TUI Vitest tests.
- PASS: TUI TypeScript typecheck.
- PASS: TUI Prettier check.
- PASS: added-line security scan: zero hardcoded-secret, shell-injection, eval/exec, pickle, or SQL findings.
- PASS: regression coverage for missing profile homes, secret-scope failure, deferred provider resolution, non-blocking timeout, and rejected TUI usage RPCs.
- A prior local full-suite run reported 51 failures across 18 unrelated gateway/tool/environment tests; GitHub currently reports no checks for this fork branch.

## Review follow-up
The implementation includes profile/secret scoping for session-bound usage, session override and compute-host metadata resolution, a genuinely non-blocking daemon-worker timeout, fail-closed scope setup, and guarded TUI RPC error handling.