### PR TITLE
docs: fix Baileys typing/read-receipt claims in comparison table

### DIFF
--- a/website/docs/user-guide/messaging/whatsapp-cloud.md
+++ b/website/docs/user-guide/messaging/whatsapp-cloud.md
@@ -402,8 +402,8 @@ This uses your Nous Portal access token instead of needing a separate OpenAI key
 | Groups | Full support | DMs only (v1) |
 | 24h window | No restriction | Hard rule — templates required after |
 | Voice notes (out) | Native | Native with ffmpeg, MP3 fallback otherwise |
-| Read receipts | No | Yes (blue double-checkmarks) |
-| Typing indicator | No | Yes (auto-dismisses on response) |
+| Read receipts | Yes (disabled by default; `send_read_receipts: true` in config) | Yes (blue double-checkmarks) |
+| Typing indicator | Yes (`/typing` endpoint via bridge) | Yes (auto-dismisses on response) |
 | Interactive buttons | Text fallback only | Native (clarify, approval, slash-confirm) |
 | Production use | Risky (Meta can ban) | Designed for it |
 


### PR DESCRIPTION
## Summary

Fixes doc/code conflict identified in WhatsApp parity phase 0 catalog (t_0e530d03).

The whatsapp-cloud.md comparison table claimed Baileys has no typing indicator and no read receipts. Code proves otherwise:

- Typing: plugins/platforms/whatsapp/adapter.py:1268 (send_typing) to bridge.js:1041 (POST /typing)
- Read receipts: plugins/platforms/whatsapp/adapter.py:453-458 (config send_read_receipts) + adapter.py:1357 (_send_read_receipt)

Cloud API rows unchanged (both features present there too).

## Changes

website/docs/user-guide/messaging/whatsapp-cloud.md - 2 cells in comparison table:
- Baileys Read receipts: No -> Yes (disabled by default; send_read_receipts: true in config)
- Baileys Typing indicator: No -> Yes (/typing endpoint via bridge)

Part of WhatsApp Feature Parity campaign #79890 (Phase 1).