### PR TITLE
feat: add phase-one token governance

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1609,12 +1609,33 @@ def init_agent(
     from tools.todo_tool import TodoStore
     agent._todo_store = TodoStore()
     
-    # Load config once for memory, skills, and compression sections
+    # Load config once for memory, skills, compression, and token governance.
     try:
         from hermes_cli.config import load_config_readonly as _load_agent_config
         _agent_cfg = _load_agent_config()
     except Exception:
         _agent_cfg = {}
+
+    agent._token_prompt_budget = None
+    agent._token_governance_contract = None
+    agent._token_governance_config = {}
+    try:
+        _tg = _agent_cfg.get("token_governance", {})
+        if isinstance(_tg, dict) and _tg.get("enabled", False):
+            from agent.token_governance import BudgetPolicy, PromptBudget
+            agent._token_governance_config = dict(_tg)
+            _budget = _tg.get("budget", {}) if isinstance(_tg.get("budget", {}), dict) else {}
+            agent._token_prompt_budget = PromptBudget(BudgetPolicy(
+                api_call_limit=int(_budget.get("api_call_limit", 25)),
+                prompt_token_limit=int(_budget.get("prompt_token_limit", 1_000_000)),
+                absolute_prompt_limit=int(_budget.get("absolute_prompt_limit", 5_000_000)),
+            ))
+    except Exception as _tg_err:
+        # Governance is explicitly enabled: malformed configuration must fail
+        # closed before any model call, never silently disable the contract.
+        agent._token_governance_config = {"enabled": True}
+        agent._token_governance_config_error = str(_tg_err)
+        logger.error("token_governance config invalid; turns will be blocked: %s", _tg_err)
 
     # Codex commentary visibility (display.show_commentary, default true).
     # When true, completed Codex phase=commentary messages are delivered as

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1398,6 +1398,17 @@ def run_conversation(
     # stale prior turn's usage.
     agent._last_turn_usage = None
 
+    # Deterministic zero-token preflight applies to every runtime, including
+    # codex_app_server which otherwise bypasses the normal Hermes loop.
+    _preflight = getattr(agent, "_token_preflight", {"status": "ready"})
+    if _preflight.get("status") != "ready":
+        return {
+            "final_response": json.dumps(_preflight, ensure_ascii=False),
+            "messages": messages,
+            "api_call_count": 0,
+            "end_reason": f"preflight_{_preflight.get('status', 'blocked')}",
+        }
+
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
     # all run inside Codex). Default Hermes path is bypassed entirely.
@@ -3324,6 +3335,28 @@ def run_conversation(
                     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
                     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
                     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+                    # Optional prompt-token budget. It deliberately counts cache
+                    # read/write as prompt processing; input_tokens alone is not
+                    # the consumption denominator. Budget exhaustion prevents a
+                    # subsequent model call after this safe API-call boundary.
+                    _prompt_budget = getattr(agent, "_token_prompt_budget", None)
+                    if _prompt_budget is not None:
+                        _budget_state = _prompt_budget.record(
+                            input_tokens=canonical_usage.input_tokens,
+                            cache_read_tokens=canonical_usage.cache_read_tokens,
+                            cache_write_tokens=canonical_usage.cache_write_tokens,
+                            output_tokens=canonical_usage.output_tokens,
+                        )
+                        agent._token_budget_state = _budget_state
+                        if _budget_state["action"] in {"summarize", "freeze_scope"}:
+                            agent._emit_warning(
+                                f"Token budget: {_budget_state['action']} "
+                                f"({_budget_state['prompt_tokens']:,} prompt tokens)"
+                            )
+                        elif _budget_state["status"] == "budget_exhausted":
+                            agent.iteration_budget = type(agent.iteration_budget)(0)
+                            _turn_exit_reason = "budget_exhausted"
 
                     # Log API call details for debugging/observability
                     _cache_pct = ""

--- a/agent/insights.py
+++ b/agent/insights.py
@@ -29,6 +29,7 @@ from agent.usage_pricing import (
     format_duration_compact,
     has_known_pricing,
 )
+from agent.token_governance import enrich_usage_metrics
 
 
 
@@ -538,7 +539,7 @@ class InsightsEngine:
         date_range_start = min(started_timestamps) if started_timestamps else None
         date_range_end = max(started_timestamps) if started_timestamps else None
 
-        return {
+        overview = {
             "total_sessions": len(sessions),
             "total_messages": total_messages,
             "total_tool_calls": total_tool_calls,
@@ -563,6 +564,22 @@ class InsightsEngine:
             "unknown_cost_sessions": unknown_cost_sessions,
             "included_cost_sessions": included_cost_sessions,
         }
+        canonical = enrich_usage_metrics({
+            "input_tokens": total_input,
+            "output_tokens": total_output,
+            "cache_read_tokens": total_cache_read,
+            "cache_write_tokens": total_cache_write,
+            "api_calls": sum(int(s.get("api_call_count") or 0) for s in sessions),
+        })
+        overview.update({
+            "new_input_tokens": canonical["new_input_tokens"],
+            "cache_input_tokens": canonical["cache_input_tokens"],
+            "prompt_tokens": canonical["prompt_tokens"],
+            "processed_tokens": canonical["processed_tokens"],
+            "avg_prompt_tokens_per_call": canonical["avg_prompt_tokens_per_call"],
+            "cost_unknown": bool(models_without_pricing),
+        })
+        return overview
 
     _GET_MODEL_USAGE_WITH_SOURCE = (
         "SELECT u.session_id, u.model, u.billing_provider, u.billing_base_url,"
@@ -741,6 +758,23 @@ class InsightsEngine:
         for model, data in model_data.items():
             entry = {"model": model, **data}
             entry["sessions"] = len(data["sessions"])
+            canonical = enrich_usage_metrics({
+                "input_tokens": entry["input_tokens"],
+                "output_tokens": entry["output_tokens"],
+                "cache_read_tokens": entry["cache_read_tokens"],
+                "cache_write_tokens": entry["cache_write_tokens"],
+                "api_calls": entry["api_calls"],
+                "cost_status": entry.get("cost_status"),
+                "estimated_cost": entry.get("cost"),
+            })
+            entry.update({
+                "new_input_tokens": canonical["new_input_tokens"],
+                "cache_input_tokens": canonical["cache_input_tokens"],
+                "prompt_tokens": canonical["prompt_tokens"],
+                "processed_tokens": canonical["processed_tokens"],
+                "avg_prompt_tokens_per_call": canonical["avg_prompt_tokens_per_call"],
+                "cost_unknown": not bool(entry.get("has_pricing")),
+            })
             # Models that surfaced only via tool-call attribution (no token
             # rows) won't have these set by _accumulate — default them so the
             # output shape is uniform for downstream/JSON consumers.

--- a/agent/token_governance.py
+++ b/agent/token_governance.py
@@ -1,0 +1,307 @@
+"""Deterministic first-stage controls for token-efficient complex tasks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+def enrich_usage_metrics(row: Mapping[str, Any]) -> dict[str, Any]:
+    """Return canonical prompt/processed counters without dropping legacy keys."""
+    result = dict(row)
+    new_input = int(row.get("input_tokens") or row.get("new_input_tokens") or 0)
+    cache_read = int(row.get("cache_read_tokens") or 0)
+    cache_write = int(row.get("cache_write_tokens") or 0)
+    output = int(row.get("output_tokens") or 0)
+    api_calls = int(row.get("api_calls") or row.get("api_call_count") or 0)
+    cache_input = cache_read + cache_write
+    prompt = new_input + cache_input
+    result.update(
+        new_input_tokens=new_input,
+        cache_input_tokens=cache_input,
+        prompt_tokens=prompt,
+        processed_tokens=prompt + output,
+        avg_prompt_tokens_per_call=(prompt / api_calls if api_calls else None),
+    )
+    cost_status = row.get("cost_status")
+    result["cost_unknown"] = cost_status == "unknown" or (
+        cost_status in (None, "") and row.get("estimated_cost") is None
+        and row.get("estimated_cost_usd") is None
+    )
+    return result
+
+
+def _canonical_json(value: Mapping[str, Any]) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _contract_hash(contract: Mapping[str, Any]) -> str:
+    payload = {k: v for k, v in contract.items() if k != "contract_hash"}
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def build_task_contract(
+    *,
+    task_id: str,
+    requirement_id: str,
+    revision: int,
+    original_request: str,
+    business_goal: str,
+    acceptance_criteria: Sequence[Mapping[str, Any]],
+    in_scope: Sequence[str] = (),
+    out_of_scope: Sequence[str] = (),
+    constraints: Sequence[str] = (),
+    protected_assets: Sequence[str] = (),
+    authority: Mapping[str, bool] | None = None,
+) -> dict[str, Any]:
+    contract = {
+        "task_id": task_id,
+        "requirement_id": requirement_id,
+        "revision": int(revision),
+        "original_request": original_request,
+        "business_goal": business_goal,
+        "in_scope": list(in_scope),
+        "out_of_scope": list(out_of_scope),
+        "acceptance_criteria": [dict(item) for item in acceptance_criteria],
+        "constraints": list(constraints),
+        "protected_assets": list(protected_assets),
+        "authority": dict(authority or {
+            "may_edit_code": True,
+            "may_commit": False,
+            "may_push": False,
+            "may_deploy": False,
+            "may_delete": False,
+        }),
+        "success_definition": "所有验收标准通过",
+        "contract_version": 1,
+    }
+    contract["contract_hash"] = _contract_hash(contract)
+    return contract
+
+
+_AUTHORITY_FIELDS = (
+    "may_edit_code", "may_commit", "may_push", "may_deploy", "may_delete",
+)
+
+
+def validate_task_contract(contract: Mapping[str, Any]) -> dict[str, Any]:
+    required = {
+        "task_id", "requirement_id", "revision", "original_request",
+        "business_goal", "acceptance_criteria", "authority", "contract_hash",
+    }
+    missing = sorted(required - set(contract))
+    if missing:
+        return {"valid": False, "reason": "missing_fields", "missing": missing}
+    if not isinstance(contract.get("original_request"), str) or not contract["original_request"]:
+        return {"valid": False, "reason": "original_request_missing"}
+    if not isinstance(contract.get("revision"), int) or isinstance(contract.get("revision"), bool) or contract["revision"] < 1:
+        return {"valid": False, "reason": "revision_invalid"}
+    if not isinstance(contract.get("business_goal"), str) or not contract["business_goal"]:
+        return {"valid": False, "reason": "business_goal_invalid"}
+    criteria = contract.get("acceptance_criteria")
+    if not isinstance(criteria, list):
+        return {"valid": False, "reason": "acceptance_criteria_invalid"}
+    criterion_ids: set[str] = set()
+    for item in criteria:
+        if not isinstance(item, Mapping):
+            return {"valid": False, "reason": "acceptance_criteria_invalid"}
+        criterion_id = item.get("id")
+        if not isinstance(criterion_id, str) or not criterion_id or criterion_id in criterion_ids:
+            return {"valid": False, "reason": "acceptance_criteria_invalid"}
+        if not isinstance(item.get("requirement"), str) or not item["requirement"]:
+            return {"valid": False, "reason": "acceptance_criteria_invalid"}
+        if not isinstance(item.get("verification"), str) or not item["verification"]:
+            return {"valid": False, "reason": "acceptance_criteria_invalid"}
+        criterion_ids.add(criterion_id)
+    authority = contract.get("authority")
+    if not isinstance(authority, Mapping) or set(authority) != set(_AUTHORITY_FIELDS):
+        return {"valid": False, "reason": "authority_invalid"}
+    if any(type(authority[field]) is not bool for field in _AUTHORITY_FIELDS):
+        return {"valid": False, "reason": "authority_invalid"}
+    for field in ("in_scope", "out_of_scope", "constraints", "protected_assets"):
+        value = contract.get(field, [])
+        if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+            return {"valid": False, "reason": f"{field}_invalid"}
+    if _contract_hash(contract) != contract.get("contract_hash"):
+        return {"valid": False, "reason": "contract_hash_mismatch"}
+    return {"valid": True, "reason": None}
+
+
+@dataclass(frozen=True)
+class BudgetPolicy:
+    api_call_limit: int
+    prompt_token_limit: int
+    absolute_prompt_limit: int
+    summarize_ratio: float = 0.70
+    freeze_scope_ratio: float = 0.85
+
+
+class PromptBudget:
+    """Per-stage prompt budget using input + cache read + cache write."""
+
+    def __init__(self, policy: BudgetPolicy):
+        self.policy = policy
+        self.api_calls = 0
+        self.prompt_tokens = 0
+        self.processed_tokens = 0
+
+    def record(self, *, input_tokens: int, cache_read_tokens: int,
+               cache_write_tokens: int, output_tokens: int) -> dict[str, Any]:
+        prompt = int(input_tokens) + int(cache_read_tokens) + int(cache_write_tokens)
+        self.api_calls += 1
+        self.prompt_tokens += prompt
+        self.processed_tokens += prompt + int(output_tokens)
+        ratio = self.prompt_tokens / self.policy.prompt_token_limit
+        status = "active"
+        action = "continue"
+        if self.prompt_tokens > self.policy.absolute_prompt_limit:
+            status, action = "budget_exhausted", "pause"
+        elif self.prompt_tokens >= self.policy.prompt_token_limit or self.api_calls >= self.policy.api_call_limit:
+            status, action = "budget_exhausted", "handoff"
+        elif ratio >= self.policy.freeze_scope_ratio:
+            action = "freeze_scope"
+        elif ratio >= self.policy.summarize_ratio:
+            action = "summarize"
+        return {
+            "status": status,
+            "action": action,
+            "api_calls": self.api_calls,
+            "prompt_tokens": self.prompt_tokens,
+            "processed_tokens": self.processed_tokens,
+            "prompt_ratio": ratio,
+        }
+
+
+def _git_probe(workspace: Path) -> tuple[bool, str | None, bool | None]:
+    try:
+        top = subprocess.run(
+            ["git", "-C", str(workspace), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if top.returncode != 0:
+            return False, None, None
+        branch = subprocess.run(
+            ["git", "-C", str(workspace), "branch", "--show-current"],
+            capture_output=True, text=True, timeout=5, check=False,
+        ).stdout.strip() or None
+        dirty = bool(subprocess.run(
+            ["git", "-C", str(workspace), "status", "--porcelain"],
+            capture_output=True, text=True, timeout=5, check=False,
+        ).stdout.strip())
+        return True, branch, dirty
+    except (OSError, subprocess.SubprocessError):
+        return False, None, None
+
+
+def preflight_workspace(
+    workspace: str | os.PathLike[str], *,
+    required_files: Sequence[str] = (),
+    test_commands: Sequence[str] = (),
+    dependencies_complete: bool = True,
+    revision: int | None = None,
+    current_revision: int | None = None,
+    successful_artifact: bool = False,
+    active_run: bool = False,
+    require_git: bool = False,
+) -> dict[str, Any]:
+    path = Path(workspace)
+    exists = path.is_dir()
+    files = [p for p in path.rglob("*") if p.is_file()] if exists else []
+    git_repo, branch, dirty = _git_probe(path) if exists else (False, None, None)
+    missing = [name for name in required_files if not (path / name).exists()] if exists else list(required_files)
+    status, block_reason = "ready", None
+    if not exists:
+        status, block_reason = "blocked", "workspace_missing"
+    elif not files:
+        status, block_reason = "blocked", "workspace_empty"
+        missing.append("workspace_empty")
+    elif current_revision is not None and revision is not None and revision < current_revision:
+        status, block_reason = "superseded", "revision_superseded"
+    elif successful_artifact:
+        status, block_reason = "duplicate", "successful_artifact_exists"
+    elif active_run:
+        status, block_reason = "blocked", "active_run_exists"
+    elif not dependencies_complete:
+        status, block_reason = "blocked", "dependencies_incomplete"
+    elif require_git and not git_repo:
+        status, block_reason = "blocked", "git_repository_required"
+    elif missing:
+        status, block_reason = "blocked", "required_files_missing"
+    return {
+        "status": status,
+        "workspace_exists": exists,
+        "workspace_file_count": len(files),
+        "git_repository": git_repo,
+        "git_branch": branch,
+        "git_dirty": dirty,
+        "test_commands": list(test_commands),
+        "missing": sorted(set(missing)),
+        "block_reason": block_reason,
+    }
+
+
+def write_handoff(
+    path: str | os.PathLike[str], *,
+    contract: Mapping[str, Any],
+    stage_completed: str,
+    next_stage: str,
+    acceptance_traceability: Sequence[Mapping[str, Any]],
+    alignment: Mapping[str, Any],
+    confirmed_facts: Sequence[Any] = (),
+    decisions: Sequence[Any] = (),
+    completed_actions: Sequence[Any] = (),
+    artifacts: Sequence[Any] = (),
+    tests: Sequence[Any] = (),
+    open_issues: Sequence[Any] = (),
+    risks: Sequence[Any] = (),
+    next_actions: Sequence[Any] = (),
+) -> Path:
+    valid = validate_task_contract(contract)
+    if not valid["valid"]:
+        raise ValueError(valid["reason"])
+    payload = {
+        "task_id": contract["task_id"],
+        "revision": contract["revision"],
+        "contract_hash": contract["contract_hash"],
+        "stage_completed": stage_completed,
+        "confirmed_facts": list(confirmed_facts),
+        "decisions": list(decisions),
+        "completed_actions": list(completed_actions),
+        "artifacts": list(artifacts),
+        "tests": list(tests),
+        "open_issues": list(open_issues),
+        "risks": list(risks),
+        "next_stage": next_stage,
+        "next_actions": list(next_actions),
+        "acceptance_traceability": [dict(item) for item in acceptance_traceability],
+        "alignment": dict(alignment),
+    }
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    return destination
+
+
+def validate_handoff(handoff: Mapping[str, Any], contract: Mapping[str, Any]) -> dict[str, Any]:
+    contract_result = validate_task_contract(contract)
+    if not contract_result["valid"]:
+        return contract_result
+    for key in ("task_id", "revision", "contract_hash"):
+        if handoff.get(key) != contract.get(key):
+            return {"valid": False, "reason": f"{key}_mismatch"}
+    alignment = handoff.get("alignment") or {}
+    if alignment.get("status") != "aligned":
+        return {"valid": False, "reason": "alignment_not_aligned"}
+    if alignment.get("criteria_missing") or alignment.get("out_of_scope_changes") or alignment.get("unapproved_goals"):
+        return {"valid": False, "reason": "alignment_gate_failed"}
+    expected = {item.get("id") for item in contract.get("acceptance_criteria", [])}
+    traced = {item.get("criterion_id") for item in handoff.get("acceptance_traceability", [])}
+    missing = sorted(x for x in expected - traced if x)
+    if missing:
+        return {"valid": False, "reason": "criteria_untracked", "missing": missing}
+    return {"valid": True, "reason": None}

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -24,7 +24,9 @@ move-and-name refactor with no semantic change.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
 import threading
 import time
 import uuid
@@ -657,6 +659,77 @@ def build_turn_context(
         # fresh staged input.
         if not isinstance(pending_cli_message, dict) or pending_cli_message.get("_db_persisted"):
             agent._pending_cli_user_message = None
+
+    # Deterministic zero-token governance preflight. This is deliberately after
+    # the task/turn ids and current user message exist, but before idle/preflight
+    # compression and pre_llm_call plugins — all of those may call an auxiliary
+    # model. Non-ready status is carried into the loop for a structured exit.
+    _token_preflight = {"status": "ready"}
+    _tg = getattr(agent, "_token_governance_config", {})
+    if isinstance(_tg, dict) and _tg:
+        try:
+            from agent.token_governance import preflight_workspace, validate_task_contract
+            _config_error = getattr(agent, "_token_governance_config_error", "")
+            if _config_error:
+                _token_preflight = {
+                    "status": "blocked",
+                    "block_reason": "token_governance_config_invalid",
+                    "error": _config_error,
+                    "missing": [],
+                }
+            _contract_path = _tg.get("contract_path")
+            if _token_preflight["status"] == "ready" and not _contract_path:
+                _token_preflight = {
+                    "status": "blocked",
+                    "block_reason": "task_contract_missing",
+                    "missing": ["contract_path"],
+                }
+            if _token_preflight["status"] == "ready" and _contract_path:
+                with open(os.path.expanduser(str(_contract_path)), encoding="utf-8") as _contract_file:
+                    agent._token_governance_contract = json.load(_contract_file)
+                _contract_result = validate_task_contract(agent._token_governance_contract)
+                if not _contract_result["valid"]:
+                    _token_preflight = {
+                        "status": "blocked",
+                        "block_reason": _contract_result["reason"],
+                        "missing": _contract_result.get("missing", []),
+                    }
+            _preflight_cfg = _tg.get("preflight", {}) if isinstance(_tg.get("preflight", {}), dict) else {}
+            if _preflight_cfg.get("enabled", False) and _token_preflight["status"] == "ready":
+                _token_preflight = preflight_workspace(
+                    _preflight_cfg.get("workspace") or os.getcwd(),
+                    required_files=_preflight_cfg.get("required_files", ()),
+                    test_commands=_preflight_cfg.get("test_commands", ()),
+                    dependencies_complete=bool(_preflight_cfg.get("dependencies_complete", True)),
+                    revision=_preflight_cfg.get("revision"),
+                    current_revision=_preflight_cfg.get("current_revision"),
+                    successful_artifact=bool(_preflight_cfg.get("successful_artifact", False)),
+                    active_run=bool(_preflight_cfg.get("active_run", False)),
+                    require_git=bool(_preflight_cfg.get("require_git", False)),
+                )
+        except Exception as _tg_err:
+            _token_preflight = {
+                "status": "blocked",
+                "block_reason": "token_governance_preflight_error",
+                "error": str(_tg_err),
+                "missing": [],
+            }
+    agent._token_preflight = _token_preflight
+    if _token_preflight.get("status") != "ready":
+        # Skip every remaining prologue step that can invoke an auxiliary model
+        # (compression, pre_llm_call hooks, external-memory prefetch). The loop
+        # consumes this structured status and returns with api_call_count=0.
+        return TurnContext(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            conversation_history=conversation_history,
+            active_system_prompt=active_system_prompt,
+            effective_task_id=effective_task_id,
+            turn_id=turn_id,
+            current_turn_user_idx=current_turn_user_idx,
+            should_review_memory=should_review_memory,
+        )
 
     # ── Idle-triggered compaction (opt-in; ``idle_compact_after_seconds``) ──
     # When a session resumes after a long idle gap, compact the accumulated

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -95,8 +95,13 @@ def finalize_turn(
         api_call_count >= agent.max_iterations
         or agent.iteration_budget.remaining <= 0
     )
+    governance_budget_exhausted = (
+        isinstance(getattr(agent, "_token_budget_state", None), dict)
+        and agent._token_budget_state.get("status") == "budget_exhausted"
+    )
     budget_fallback_eligible = (
         budget_exhausted
+        and not governance_budget_exhausted
         and not interrupted
         and not failed
         and str(_turn_exit_reason) in {"unknown", "budget_exhausted"}

--- a/docs/token-governance-phase1.example.yaml
+++ b/docs/token-governance-phase1.example.yaml
@@ -1,0 +1,22 @@
+# Hermes 全局 Token 治理第一阶段配置示例
+# 默认不启用，保证现有行为向后兼容。经用户批准部署后再写入各 Profile config.yaml。
+token_governance:
+  enabled: true
+  contract_path: "C:/path/to/task-contract.r1.json"
+  budget:
+    api_call_limit: 25
+    prompt_token_limit: 1000000
+    absolute_prompt_limit: 5000000
+  preflight:
+    enabled: true
+    workspace: "C:/path/to/project"
+    required_files: []
+    test_commands: []
+    dependencies_complete: true
+    revision: 1
+    current_revision: 1
+    successful_artifact: false
+    active_run: false
+    require_git: true
+# 长工具输出外置复用Hermes现有 tools/tool_result_storage.py，
+# 由上下文窗口自动缩放预算，无需新增开关。

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1564,13 +1564,8 @@ def _print_tui_exit_summary(
         cache_read_tokens = int(session.get("cache_read_tokens") or 0)
         cache_write_tokens = int(session.get("cache_write_tokens") or 0)
         reasoning_tokens = int(session.get("reasoning_tokens") or 0)
-        total_tokens = (
-            input_tokens
-            + output_tokens
-            + cache_read_tokens
-            + cache_write_tokens
-            + reasoning_tokens
-        )
+        prompt_tokens = input_tokens + cache_read_tokens + cache_write_tokens
+        total_tokens = prompt_tokens + output_tokens
     except Exception:
         return
     finally:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -14025,6 +14025,7 @@ def _aux_usage_rows(db, cutoff: float) -> List[Dict[str, Any]]:
                    SUM(u.input_tokens) as input_tokens,
                    SUM(u.output_tokens) as output_tokens,
                    SUM(u.cache_read_tokens) as cache_read_tokens,
+                   SUM(u.cache_write_tokens) as cache_write_tokens,
                    SUM(u.reasoning_tokens) as reasoning_tokens,
                    COALESCE(SUM(u.estimated_cost_usd), 0) as estimated_cost,
                    COUNT(DISTINCT u.session_id) as sessions,
@@ -14041,6 +14042,12 @@ def _aux_usage_rows(db, cutoff: float) -> List[Dict[str, Any]]:
         # Table predates the task column (older DB opened by newer code) —
         # aux breakdown is simply unavailable.
         return []
+
+
+def _enrich_usage_row(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach canonical prompt/processed metrics while preserving old fields."""
+    from agent.token_governance import enrich_usage_metrics
+    return enrich_usage_metrics(row)
 
 
 def _merge_aux_into_by_model(
@@ -14073,6 +14080,8 @@ def _merge_aux_into_by_model(
             merged[model] = target
         target["input_tokens"] = (target.get("input_tokens") or 0) + (aux.get("input_tokens") or 0)
         target["output_tokens"] = (target.get("output_tokens") or 0) + (aux.get("output_tokens") or 0)
+        target["cache_read_tokens"] = (target.get("cache_read_tokens") or 0) + (aux.get("cache_read_tokens") or 0)
+        target["cache_write_tokens"] = (target.get("cache_write_tokens") or 0) + (aux.get("cache_write_tokens") or 0)
         target["estimated_cost"] = (target.get("estimated_cost") or 0) + (aux.get("estimated_cost") or 0)
         target["api_calls"] = (target.get("api_calls") or 0) + (aux.get("api_calls") or 0)
         tasks = target.setdefault("aux_tasks", [])
@@ -14080,12 +14089,14 @@ def _merge_aux_into_by_model(
             "task": aux.get("task") or "",
             "input_tokens": aux.get("input_tokens") or 0,
             "output_tokens": aux.get("output_tokens") or 0,
+            "cache_read_tokens": aux.get("cache_read_tokens") or 0,
+            "cache_write_tokens": aux.get("cache_write_tokens") or 0,
             "estimated_cost": aux.get("estimated_cost") or 0,
             "api_calls": aux.get("api_calls") or 0,
         })
-    result = list(merged.values())
+    result = [_enrich_usage_row(row) for row in merged.values()]
     result.sort(
-        key=lambda r: (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0),
+        key=lambda r: r.get("prompt_tokens") or 0,
         reverse=True,
     )
     return result
@@ -14100,20 +14111,24 @@ def _aux_task_summary(aux_rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "task": task,
             "input_tokens": 0,
             "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
             "estimated_cost": 0,
             "api_calls": 0,
             "models": [],
         })
         d["input_tokens"] += aux.get("input_tokens") or 0
         d["output_tokens"] += aux.get("output_tokens") or 0
+        d["cache_read_tokens"] += aux.get("cache_read_tokens") or 0
+        d["cache_write_tokens"] += aux.get("cache_write_tokens") or 0
         d["estimated_cost"] += aux.get("estimated_cost") or 0
         d["api_calls"] += aux.get("api_calls") or 0
         model = aux.get("model") or "unknown"
         if model not in d["models"]:
             d["models"].append(model)
-    result = list(by_task.values())
+    result = [_enrich_usage_row(row) for row in by_task.values()]
     result.sort(
-        key=lambda r: (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0),
+        key=lambda r: r.get("prompt_tokens") or 0,
         reverse=True,
     )
     return result
@@ -14130,6 +14145,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    SUM(reasoning_tokens) as reasoning_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
@@ -14138,19 +14154,21 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ?
             GROUP BY day ORDER BY day
         """, (cutoff,))
-        daily = [dict(r) for r in cur.fetchall()]
+        daily = [_enrich_usage_row(dict(r)) for r in cur.fetchall()]
 
         cur2 = db._conn.execute("""
             SELECT model,
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
+                   SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COUNT(*) as sessions,
                    SUM(COALESCE(api_call_count, 0)) as api_calls
             FROM sessions WHERE started_at > ? AND model IS NOT NULL
             GROUP BY model ORDER BY SUM(input_tokens) + SUM(output_tokens) DESC
         """, (cutoff,))
-        by_model = [dict(r) for r in cur2.fetchall()]
+        by_model = [_enrich_usage_row(dict(r)) for r in cur2.fetchall()]
 
         # Fold in auxiliary usage (vision, compression, title_generation, ...)
         # recorded per (model, task) in session_model_usage. Aux calls never
@@ -14164,6 +14182,7 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             SELECT SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
+                   SUM(cache_write_tokens) as total_cache_write,
                    SUM(reasoning_tokens) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
@@ -14172,6 +14191,14 @@ def _get_usage_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ?
         """, (cutoff,))
         totals = dict(cur3.fetchone())
+        totals.update(_enrich_usage_row({
+            "input_tokens": totals.get("total_input"),
+            "output_tokens": totals.get("total_output"),
+            "cache_read_tokens": totals.get("total_cache_read"),
+            "cache_write_tokens": totals.get("total_cache_write"),
+            "api_calls": totals.get("total_api_calls"),
+            "estimated_cost": totals.get("total_estimated_cost"),
+        }))
         usage = InsightsEngine(db).get_usage_breakdown(days=days)
 
         return {
@@ -14219,6 +14246,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                    SUM(input_tokens) as input_tokens,
                    SUM(output_tokens) as output_tokens,
                    SUM(cache_read_tokens) as cache_read_tokens,
+                   SUM(cache_write_tokens) as cache_write_tokens,
                    SUM(reasoning_tokens) as reasoning_tokens,
                    COALESCE(SUM(estimated_cost_usd), 0) as estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as actual_cost,
@@ -14244,6 +14272,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 "input_tokens": aux.get("input_tokens") or 0,
                 "output_tokens": aux.get("output_tokens") or 0,
                 "cache_read_tokens": aux.get("cache_read_tokens") or 0,
+                "cache_write_tokens": aux.get("cache_write_tokens") or 0,
                 "reasoning_tokens": aux.get("reasoning_tokens") or 0,
                 "estimated_cost": aux.get("estimated_cost") or 0,
                 "actual_cost": 0,
@@ -14279,6 +14308,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                             "input_tokens",
                             "output_tokens",
                             "cache_read_tokens",
+                            "cache_write_tokens",
                             "reasoning_tokens",
                             "estimated_cost",
                             "actual_cost",
@@ -14290,7 +14320,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                         continue
                     target["sessions"] = (target.get("sessions") or 0) + (row.get("sessions") or 0)
                     target["last_used_at"] = max(target.get("last_used_at") or 0, row.get("last_used_at") or 0)
-                    total_tokens = (target.get("input_tokens") or 0) + (target.get("output_tokens") or 0)
+                    total_tokens = _enrich_usage_row(target)["processed_tokens"]
                     sessions = target.get("sessions") or 0
                     target["avg_tokens_per_session"] = total_tokens / sessions if sessions else 0
                 rows.append(target)
@@ -14303,6 +14333,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                             "input_tokens",
                             "output_tokens",
                             "cache_read_tokens",
+                            "cache_write_tokens",
                             "reasoning_tokens",
                             "estimated_cost",
                             "actual_cost",
@@ -14315,7 +14346,7 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 rows.extend(model_rows)
 
         rows.sort(
-            key=lambda r: (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0),
+            key=lambda r: _enrich_usage_row(r)["prompt_tokens"],
             reverse=True,
         )
 
@@ -14339,13 +14370,10 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
             except Exception:
                 pass
 
-            models.append({
+            model_row = _enrich_usage_row(row)
+            model_row.update({
                 "model": model_name,
                 "provider": provider,
-                "input_tokens": row["input_tokens"],
-                "output_tokens": row["output_tokens"],
-                "cache_read_tokens": row["cache_read_tokens"],
-                "reasoning_tokens": row["reasoning_tokens"],
                 "estimated_cost": row["estimated_cost"],
                 "actual_cost": row["actual_cost"],
                 "sessions": row["sessions"],
@@ -14355,12 +14383,14 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
                 "avg_tokens_per_session": row["avg_tokens_per_session"],
                 "capabilities": caps,
             })
+            models.append(model_row)
 
         totals_cur = db._conn.execute("""
             SELECT COUNT(DISTINCT model) as distinct_models,
                    SUM(input_tokens) as total_input,
                    SUM(output_tokens) as total_output,
                    SUM(cache_read_tokens) as total_cache_read,
+                   SUM(cache_write_tokens) as total_cache_write,
                    SUM(reasoning_tokens) as total_reasoning,
                    COALESCE(SUM(estimated_cost_usd), 0) as total_estimated_cost,
                    COALESCE(SUM(actual_cost_usd), 0) as total_actual_cost,
@@ -14369,6 +14399,13 @@ def _get_models_analytics(days: int = 30, profile: Optional[str] = None):
             FROM sessions WHERE started_at > ? AND model IS NOT NULL AND model != ''
         """, (cutoff,))
         totals = dict(totals_cur.fetchone())
+        totals.update(_enrich_usage_row({
+            "input_tokens": totals.get("total_input"),
+            "output_tokens": totals.get("total_output"),
+            "cache_read_tokens": totals.get("total_cache_read"),
+            "cache_write_tokens": totals.get("total_cache_write"),
+            "api_calls": totals.get("total_api_calls"),
+        }))
 
         return {
             "models": models,

--- a/tests/agent/test_token_governance.py
+++ b/tests/agent/test_token_governance.py
@@ -1,0 +1,121 @@
+import json
+
+import pytest
+
+from agent.token_governance import (
+    BudgetPolicy,
+    PromptBudget,
+    build_task_contract,
+    enrich_usage_metrics,
+    preflight_workspace,
+    validate_handoff,
+    validate_task_contract,
+    write_handoff,
+)
+
+
+def test_usage_metrics_count_cache_as_prompt_and_processed():
+    metrics = enrich_usage_metrics({
+        "input_tokens": 10,
+        "cache_read_tokens": 30,
+        "cache_write_tokens": 5,
+        "output_tokens": 7,
+        "api_calls": 2,
+    })
+    assert metrics["new_input_tokens"] == 10
+    assert metrics["cache_input_tokens"] == 35
+    assert metrics["prompt_tokens"] == 45
+    assert metrics["processed_tokens"] == 52
+    assert metrics["avg_prompt_tokens_per_call"] == 22.5
+
+
+def test_task_contract_preserves_original_request_and_detects_tampering(tmp_path):
+    original = "完整原始要求\n不得摘要。"
+    contract = build_task_contract(
+        task_id="T-1",
+        requirement_id="R-1",
+        revision=1,
+        original_request=original,
+        business_goal="解决业务问题",
+        acceptance_criteria=[{"id": "AC-01", "requirement": "保持原文", "verification": "哈希"}],
+    )
+    assert contract["original_request"] == original
+    assert validate_task_contract(contract)["valid"] is True
+    contract["original_request"] = "被改写"
+    result = validate_task_contract(contract)
+    assert result["valid"] is False
+    assert result["reason"] == "contract_hash_mismatch"
+
+
+def test_task_contract_rejects_invalid_authority_and_criteria():
+    contract = build_task_contract(
+        task_id="T-1", requirement_id="R-1", revision=1,
+        original_request="原文", business_goal="目标",
+        acceptance_criteria=[{"id": "AC-01", "requirement": "要求", "verification": "测试"}],
+    )
+    contract["authority"]["may_push"] = "false"
+    contract["contract_hash"] = __import__("hashlib").sha256(
+        json.dumps({k: v for k, v in contract.items() if k != "contract_hash"}, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    assert validate_task_contract(contract)["reason"] == "authority_invalid"
+
+    contract = build_task_contract(
+        task_id="T-1", requirement_id="R-1", revision=1,
+        original_request="原文", business_goal="目标",
+        acceptance_criteria=[{"id": "AC-01", "requirement": "", "verification": "测试"}],
+    )
+    assert validate_task_contract(contract)["reason"] == "acceptance_criteria_invalid"
+
+
+def test_prompt_budget_thresholds_use_prompt_not_new_input():
+    budget = PromptBudget(BudgetPolicy(api_call_limit=10, prompt_token_limit=1000, absolute_prompt_limit=2000))
+    assert budget.record(input_tokens=10, cache_read_tokens=690, cache_write_tokens=0, output_tokens=1)["action"] == "summarize"
+    assert budget.record(input_tokens=0, cache_read_tokens=150, cache_write_tokens=0, output_tokens=1)["action"] == "freeze_scope"
+    result = budget.record(input_tokens=0, cache_read_tokens=150, cache_write_tokens=0, output_tokens=1)
+    assert result["action"] == "handoff"
+    assert result["status"] == "budget_exhausted"
+
+
+def test_prompt_budget_absolute_limit_pauses():
+    budget = PromptBudget(BudgetPolicy(api_call_limit=80, prompt_token_limit=5000, absolute_prompt_limit=5500))
+    result = budget.record(input_tokens=0, cache_read_tokens=5600, cache_write_tokens=0, output_tokens=0)
+    assert result["action"] == "pause"
+    assert result["status"] == "budget_exhausted"
+
+
+def test_preflight_empty_workspace_blocks_without_model(tmp_path):
+    result = preflight_workspace(tmp_path)
+    assert result["status"] == "blocked"
+    assert result["workspace_file_count"] == 0
+    assert "workspace_empty" in result["missing"]
+
+
+def test_preflight_superseded_revision_blocks(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')", encoding="utf-8")
+    result = preflight_workspace(tmp_path, revision=1, current_revision=2)
+    assert result["status"] == "superseded"
+    assert result["block_reason"] == "revision_superseded"
+
+
+def test_preflight_active_run_and_duplicate_are_zero_token_outcomes(tmp_path):
+    (tmp_path / "app.py").write_text("print('ok')", encoding="utf-8")
+    assert preflight_workspace(tmp_path, active_run=True)["status"] == "blocked"
+    assert preflight_workspace(tmp_path, successful_artifact=True)["status"] == "duplicate"
+
+
+def test_handoff_requires_contract_alignment_and_traceability(tmp_path):
+    contract = build_task_contract(
+        task_id="T-1", requirement_id="R-1", revision=1,
+        original_request="原文", business_goal="目标",
+        acceptance_criteria=[{"id": "AC-01", "requirement": "要求", "verification": "测试"}],
+    )
+    trace = [{"criterion_id": "AC-01", "implementation": ["a.py"], "evidence": ["test.log"], "status": "passed"}]
+    path = write_handoff(
+        tmp_path / "handoff.json", contract=contract, stage_completed="Discovery",
+        next_stage="Planning", acceptance_traceability=trace,
+        alignment={"status": "aligned", "criteria_covered": ["AC-01"], "criteria_missing": [], "out_of_scope_changes": [], "unapproved_goals": []},
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert validate_handoff(payload, contract)["valid"] is True
+    payload["alignment"]["status"] = "deviated"
+    assert validate_handoff(payload, contract)["valid"] is False

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -240,6 +240,50 @@ def test_prefetch_runs_for_substantive_user_message():
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 
+def test_token_governance_missing_contract_fails_closed(tmp_path):
+    agent = _FakeAgent()
+    agent._token_governance_config = {
+        "enabled": True,
+        "preflight": {"enabled": True, "workspace": str(tmp_path)},
+    }
+
+    _build(agent)
+
+    assert agent._token_preflight["status"] == "blocked"
+    assert agent._token_preflight["block_reason"] == "task_contract_missing"
+
+
+def test_token_governance_preflight_blocks_before_auxiliary_work(tmp_path):
+    from agent.token_governance import build_task_contract
+    agent, mm = _agent_with_memory_manager()
+    contract = build_task_contract(
+        task_id="T", requirement_id="R", revision=1,
+        original_request="request", business_goal="goal", acceptance_criteria=[],
+    )
+    contract_path = tmp_path / "contract.json"
+    contract_path.write_text(__import__("json").dumps(contract), encoding="utf-8")
+    (tmp_path / "empty").mkdir()
+    agent._token_governance_config = {
+        "enabled": True,
+        "contract_path": str(contract_path),
+        "preflight": {"enabled": True, "workspace": str(tmp_path / "empty")},
+    }
+    agent.compression_enabled = True
+    compressor = MagicMock()
+    compressor.protect_first_n = 2
+    compressor.protect_last_n = 2
+    compressor.threshold_tokens = 1
+    agent.context_compressor = compressor
+
+    ctx = _build(agent, user_message="substantive task requiring memory")
+
+    assert agent._token_preflight["status"] == "blocked"
+    assert agent._token_preflight["block_reason"] == "workspace_empty"
+    mm.prefetch_all.assert_not_called()
+    compressor.should_compress.assert_not_called()
+    assert ctx.plugin_user_context == ""
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -165,6 +165,26 @@ def test_pending_response_does_not_mask_later_terminal_exit(
     assert agent._handle_max_iterations_called is False
 
 
+def test_governance_budget_exhaustion_never_calls_summary_model(monkeypatch):
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    agent = _LimitAgent()
+    agent._token_budget_state = {
+        "status": "budget_exhausted",
+        "action": "handoff",
+        "prompt_tokens": 1_000_000,
+    }
+
+    result = _finalize(
+        agent,
+        final_response=None,
+        exit_reason="budget_exhausted",
+    )
+
+    assert agent._handle_max_iterations_called is False
+    assert result["turn_exit_reason"] == "budget_exhausted"
+    assert result["completed"] is False
+
+
 def test_pending_response_records_kanban_timeout(monkeypatch):
     monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
     monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")

--- a/tests/hermes_cli/test_token_governance_analytics.py
+++ b/tests/hermes_cli/test_token_governance_analytics.py
@@ -1,0 +1,57 @@
+import json
+import sqlite3
+
+from hermes_cli import web_server
+
+
+def _make_db(tmp_path):
+    db = tmp_path / "state.db"
+    conn = sqlite3.connect(db)
+    conn.row_factory = sqlite3.Row
+    conn.execute("""
+        CREATE TABLE sessions (
+          model TEXT, billing_provider TEXT, input_tokens INTEGER,
+          output_tokens INTEGER, cache_read_tokens INTEGER,
+          cache_write_tokens INTEGER, reasoning_tokens INTEGER,
+          estimated_cost_usd REAL, actual_cost_usd REAL,
+          api_call_count INTEGER, tool_call_count INTEGER, started_at REAL
+        )
+    """)
+    conn.execute("""
+        INSERT INTO sessions VALUES
+        ('m','p',10,7,30,5,2,NULL,NULL,2,0,9999999999)
+    """)
+    conn.commit()
+    return conn
+
+
+def test_usage_dashboard_enrichment_uses_cache_in_prompt():
+    row = web_server._enrich_usage_row({
+        "input_tokens": 100,
+        "output_tokens": 5,
+        "cache_read_tokens": 200,
+        "cache_write_tokens": 20,
+        "api_calls": 4,
+    })
+    assert row["prompt_tokens"] == 320
+    assert row["processed_tokens"] == 325
+    assert row["avg_prompt_tokens_per_call"] == 80
+
+
+def test_models_analytics_propagates_cache_write_and_prompt(monkeypatch, tmp_path):
+    conn = _make_db(tmp_path)
+    class DB:
+        _conn = conn
+        def close(self):
+            pass
+    monkeypatch.setattr(web_server, "_open_session_db_for_profile", lambda *a, **k: DB())
+    monkeypatch.setattr(web_server, "_aux_usage_rows", lambda *a, **k: [])
+
+    result = web_server._get_models_analytics(1)
+
+    model = result["models"][0]
+    assert model["cache_write_tokens"] == 5
+    assert model["prompt_tokens"] == 45
+    assert model["processed_tokens"] == 52
+    assert result["totals"]["total_cache_write"] == 5
+    assert result["totals"]["prompt_tokens"] == 45

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1564,6 +1564,25 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    # Subagents inherit token-governance only when the parent explicitly
+    # enabled it. Disabled governance leaves historical child behaviour intact.
+    _parent_tg = getattr(parent_agent, "_token_governance_config", {})
+    if isinstance(_parent_tg, dict) and _parent_tg.get("enabled", False):
+        from agent.token_governance import BudgetPolicy, PromptBudget
+        _sub_budget = _parent_tg.get("subagent_budget", {})
+        if not isinstance(_sub_budget, dict):
+            raise ValueError("token_governance.subagent_budget must be a mapping")
+        try:
+            _child_policy = BudgetPolicy(
+                api_call_limit=min(int(max_iterations), int(_sub_budget.get("api_call_limit", 20))),
+                prompt_token_limit=int(_sub_budget.get("prompt_token_limit", 500_000)),
+                absolute_prompt_limit=int(_sub_budget.get("absolute_prompt_limit", 500_000)),
+            )
+            if min(_child_policy.api_call_limit, _child_policy.prompt_token_limit, _child_policy.absolute_prompt_limit) <= 0:
+                raise ValueError("subagent token budgets must be positive")
+            child._token_prompt_budget = PromptBudget(_child_policy)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid token_governance.subagent_budget: {exc}") from exc
     child._parent_turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
     # Stable sidebar marker: delegate subagent sessions must stay out of
     # session pickers even when a parent delete orphans them (parent_session_id

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2052,11 +2052,18 @@ export interface ManagedFileWriteResponse {
 export interface AnalyticsDailyEntry {
   day: string;
   input_tokens: number;
+  new_input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
+  cache_input_tokens: number;
+  prompt_tokens: number;
+  processed_tokens: number;
+  avg_prompt_tokens_per_call: number;
   reasoning_tokens: number;
   estimated_cost: number;
   actual_cost: number;
+  cost_unknown: boolean;
   sessions: number;
   api_calls: number;
 }
@@ -2064,7 +2071,15 @@ export interface AnalyticsDailyEntry {
 export interface AnalyticsModelEntry {
   model: string;
   input_tokens: number;
+  new_input_tokens: number;
   output_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number;
+  cache_input_tokens: number;
+  prompt_tokens: number;
+  processed_tokens: number;
+  avg_prompt_tokens_per_call: number;
+  cost_unknown: boolean;
   estimated_cost: number;
   sessions: number;
   api_calls: number;
@@ -2093,6 +2108,13 @@ export interface AnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
+    new_input_tokens: number;
+    cache_input_tokens: number;
+    prompt_tokens: number;
+    processed_tokens: number;
+    avg_prompt_tokens_per_call: number;
+    cost_unknown: boolean;
     total_reasoning: number;
     total_estimated_cost: number;
     total_actual_cost: number;
@@ -2140,6 +2162,12 @@ export interface ModelsAnalyticsModelEntry {
   input_tokens: number;
   output_tokens: number;
   cache_read_tokens: number;
+  cache_write_tokens: number;
+  cache_input_tokens: number;
+  prompt_tokens: number;
+  processed_tokens: number;
+  avg_prompt_tokens_per_call: number;
+  cost_unknown: boolean;
   reasoning_tokens: number;
   estimated_cost: number;
   actual_cost: number;
@@ -2165,6 +2193,13 @@ export interface ModelsAnalyticsResponse {
     total_input: number;
     total_output: number;
     total_cache_read: number;
+    total_cache_write: number;
+    new_input_tokens: number;
+    cache_input_tokens: number;
+    prompt_tokens: number;
+    processed_tokens: number;
+    avg_prompt_tokens_per_call: number;
+    cost_unknown: boolean;
     total_reasoning: number;
     total_estimated_cost: number;
     total_actual_cost: number;

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -132,7 +132,7 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
   if (daily.length === 0) return null;
 
   const maxTokens = Math.max(
-    ...daily.map((d) => d.input_tokens + d.output_tokens),
+    ...daily.map((d) => d.processed_tokens),
     1,
   );
 
@@ -168,9 +168,9 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
           style={{ height: CHART_HEIGHT_PX }}
         >
           {daily.map((d) => {
-            const total = d.input_tokens + d.output_tokens;
+            const total = d.processed_tokens;
             const inputH = Math.round(
-              (d.input_tokens / maxTokens) * CHART_HEIGHT_PX,
+              (d.prompt_tokens / maxTokens) * CHART_HEIGHT_PX,
             );
             const outputH = Math.round(
               (d.output_tokens / maxTokens) * CHART_HEIGHT_PX,
@@ -185,13 +185,19 @@ function TokenBarChart({ daily }: { daily: AnalyticsDailyEntry[] }) {
                   <div className="font-mondwest normal-case bg-card border border-border px-2.5 py-1.5 text-xs text-foreground shadow-lg whitespace-nowrap">
                     <div className="font-medium">{formatDate(d.day)}</div>
                     <div>
-                      {t.analytics.input}: {formatTokens(d.input_tokens)}
+                      New input: {formatTokens(d.new_input_tokens)}
+                    </div>
+                    <div>
+                      Cache input: {formatTokens(d.cache_input_tokens)}
+                    </div>
+                    <div>
+                      Prompt: {formatTokens(d.prompt_tokens)}
                     </div>
                     <div>
                       {t.analytics.output}: {formatTokens(d.output_tokens)}
                     </div>
                     <div>
-                      {t.analytics.total}: {formatTokens(total)}
+                      Processed: {formatTokens(total)}
                     </div>
                   </div>
                 </div>
@@ -255,7 +261,9 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.date} col="day" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.input} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label="New input" col="new_input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label="Cache input" col="cache_input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
+                <SortHeader label="Prompt" col="prompt_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
                 <SortHeader label={t.analytics.output} col="output_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
@@ -272,9 +280,15 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
                       {d.sessions}
                     </td>
                   <td className="text-right py-2 px-4">
+                    {formatTokens(d.new_input_tokens)}
+                  </td>
+                  <td className="text-right py-2 px-4">
+                    {formatTokens(d.cache_input_tokens)}
+                  </td>
+                  <td className="text-right py-2 px-4">
                     <span style={{ color: "var(--series-input-token)" }}>
-                        {formatTokens(d.input_tokens)}
-                      </span>
+                      {formatTokens(d.prompt_tokens)}
+                    </span>
                   </td>
                   <td className="text-right py-2 pl-4">
                     <span style={{ color: "var(--series-output-token)" }}>
@@ -293,7 +307,7 @@ function DailyTable({ daily }: { daily: AnalyticsDailyEntry[] }) {
 
 function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
   const { t } = useI18n();
-  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "input_tokens", "desc");
+  const { sorted, sortKey, sortDir, toggle } = useTableSort(models, "prompt_tokens", "desc");
 
   if (models.length === 0) return null;
 
@@ -314,7 +328,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
               <tr className="border-b border-border text-muted-foreground text-xs">
                 <SortHeader label={t.analytics.model} col="model" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-left py-2 pr-4 font-medium" />
                 <SortHeader label={t.sessions.title} col="sessions" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 px-4 font-medium" />
-                <SortHeader label={t.analytics.tokens} col="input_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
+                <SortHeader label="Prompt / Output" col="prompt_tokens" sortKey={sortKey} sortDir={sortDir} toggle={toggle} className="text-right py-2 pl-4 font-medium" />
               </tr>
             </thead>
             <tbody>
@@ -331,7 +345,7 @@ function ModelTable({ models }: { models: AnalyticsModelEntry[] }) {
                   </td>
                   <td className="text-right py-2 pl-4">
                     <span style={{ color: "var(--series-input-token)" }}>
-                      {formatTokens(m.input_tokens)}
+                      {formatTokens(m.prompt_tokens)}
                     </span>
                     {" / "}
                     <span style={{ color: "var(--series-output-token)" }}>
@@ -494,13 +508,10 @@ export default function AnalyticsPage() {
               </h2>
               <p>
                 The token, cost, and per-day analytics on this page are a
-                local debug estimate. They only count successful main-agent
-                responses with a usable <span className="font-mono">usage</span>{" "}
-                block, and silently exclude auxiliary calls (context
-                compression, title generation, vision, session search, web
-                extract, smart approvals, MCP routing, plugin LLM access)
-                plus provider-side retries and fallback attempts. Cache
-                writes are missing entirely.
+                local debug estimate. It counts recorded main-agent and known
+                auxiliary usage, but provider-side retries or calls that do not
+                return a usable <span className="font-mono">usage</span> block
+                can still be absent.
               </p>
               <p>
                 On models with heavy auxiliary traffic (Kimi K2.6, MiniMax
@@ -544,18 +555,28 @@ export default function AnalyticsPage() {
                 <Stats
                   items={[
                     {
-                      label: t.analytics.totalTokens,
-                      value: formatTokens(
-                        data.totals.total_input + data.totals.total_output,
-                      ),
+                      label: "Processed tokens",
+                      value: formatTokens(data.totals.processed_tokens),
                     },
                     {
-                      label: t.analytics.input,
-                      value: formatTokens(data.totals.total_input),
+                      label: "New input",
+                      value: formatTokens(data.totals.new_input_tokens),
+                    },
+                    {
+                      label: "Cache input",
+                      value: formatTokens(data.totals.cache_input_tokens),
+                    },
+                    {
+                      label: "Prompt tokens",
+                      value: formatTokens(data.totals.prompt_tokens),
                     },
                     {
                       label: t.analytics.output,
                       value: formatTokens(data.totals.total_output),
+                    },
+                    {
+                      label: "Avg prompt / API call",
+                      value: formatTokens(data.totals.avg_prompt_tokens_per_call),
                     },
                     {
                       label: t.analytics.totalSessions,


### PR DESCRIPTION
## Summary
- add canonical Prompt and Processed token analytics
- add immutable task contract validation and deterministic zero-token preflight
- add prompt/API budgets, handoff validation, and fail-closed subagent budgets
- reuse existing bounded tool-result storage
- keep token governance disabled by default for backward compatibility

## Verification
- 121 focused Python tests passed on committed HEAD
- Web TypeScript typecheck passed
- independent verifier passed all remediation checks
- same-HEAD/same-interpreter baseline comparison found no reproducible candidate regression

## Scope
Phase 1 only. No deployment, production config changes, or phase 2/3 behavior.