### PR TITLE
fix(web): a benched lazy-install must not disable an importable SDK

### DIFF
--- a/plugins/web/_common.py
+++ b/plugins/web/_common.py
@@ -7,6 +7,9 @@ slots) lazily at call time so monkeypatching the source module keeps working.
 
 from __future__ import annotations
 
+import importlib.util
+import sys
+
 import logging
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
@@ -167,16 +170,71 @@ def titled_rows(raw_results: List[Dict[str, Any]], description_key: str) -> List
     ]
 
 
-def lazy_ensure(feature: str) -> None:
-    """Best-effort ``tools.lazy_deps.ensure``: its own ImportError is benign and swallowed;
-    an install hint (any other error) is re-raised as ImportError."""
+def _sdk_importable(module_name: str) -> bool:
+    """True when ``import <module_name>`` would succeed.
+
+    ``sys.modules`` is checked first: an already-imported module is importable
+    by definition, and ``find_spec`` raises ``ValueError`` on entries with no
+    ``__spec__`` (which is how tests inject a stub SDK).
+    """
+    if module_name in sys.modules:
+        return True
     try:
-        from tools.lazy_deps import ensure as _lazy_ensure
-        _lazy_ensure(feature, prompt=False)
+        return importlib.util.find_spec(module_name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+# Feature -> top-level import the factory actually needs (usually the feature id
+# with its namespace stripped, per the "search.<vendor>" convention).
+_FEATURE_MODULE_PREFIXES = ("search.", "extract.", "export.")
+# Features whose package name is NOT the vendor slug (``exa-py`` ships ``exa_py``).
+_IMPORT_NAME_OVERRIDES = {"search.exa": "exa_py"}
+
+
+def _feature_module(feature: str) -> str:
+    """The importable package a feature's factory needs, from the feature id.
+
+    The override table is consulted first (``search.exa`` -> ``exa_py``) so a
+    vendor whose package name is not its slug is never probed as the wrong
+    module; everything else strips the namespace prefix (``search.parallel`` ->
+    ``parallel``, ``search.firecrawl`` -> ``firecrawl``).
+    """
+    override = _IMPORT_NAME_OVERRIDES.get(feature)
+    if override is not None:
+        return override
+    return feature.split(".", 1)[-1] if feature.startswith(_FEATURE_MODULE_PREFIXES) else feature
+
+
+def lazy_ensure(feature: str) -> None:
+    """Try to install ``feature``'s packages; refuse only when the import would fail.
+
+    The import at the call site is the real gate: whether the SDK can be
+    installed is only interesting when it is not already importable.
+    ``tools.lazy_deps.ensure`` reports an unusable feature with
+    ``FeatureUnavailable`` (a ``RuntimeError``, not an ``ImportError``), so the
+    old ``except ImportError`` never caught the case it was written for, and
+    the broad ``except Exception`` turned "cannot install" into a hard failure
+    even when the SDK would have imported. On a host with
+    ``security.allow_lazy_installs=false`` that made the provider unusable
+    whether or not the package was present.
+
+    So: try to install, and if that is impossible, check whether we needed it.
+    Only a genuinely missing package raises, and it carries the install hint.
+    Unrelated faults still surface as ``ImportError`` for the caller.
+    """
+    try:
+        from tools.lazy_deps import FeatureUnavailable, ensure as _lazy_ensure
     except ImportError:
-        pass
-    except Exception as exc:  # noqa: BLE001
-        raise ImportError(str(exc))
+        return  # lazy-deps helper itself unavailable — let the import decide
+    try:
+        _lazy_ensure(feature, prompt=False)
+    except FeatureUnavailable as exc:
+        if not _sdk_importable(_feature_module(feature)):
+            raise ImportError(str(exc)) from exc
+        # Already importable; nothing needed installing.
+    except Exception as exc:  # noqa: BLE001 — surface real faults as ImportError
+        raise ImportError(str(exc)) from exc
 
 
 def cached_sdk_client(slot: str, env_var: str, missing_key_error: str, feature: str, factory: Callable[[str], Any]) -> Any:

--- a/tests/plugins/web/test_lazy_ensure_importable_sdk.py
+++ b/tests/plugins/web/test_lazy_ensure_importable_sdk.py
@@ -1,0 +1,127 @@
+"""``lazy_ensure`` must not fail when a feature's SDK is already importable.
+
+The helper's contract (docstring and callers) says the import at the call site
+is the real gate: an install that cannot happen is only an error when the
+package is genuinely absent. ``tools.lazy_deps.ensure`` signals an unusable
+feature with ``FeatureUnavailable`` — a ``RuntimeError``, not an
+``ImportError`` — so the pre-split handler never caught it and the broad
+``except Exception`` re-raised it as ``ImportError`` even when the package was
+present. On a host with ``security.allow_lazy_installs=false`` that made the
+provider unusable regardless of whether the SDK was installed.
+
+Ported from the per-provider fix (PR for "a benched lazy-install must not
+disable an importable SDK") to the shared ``plugins/web/_common.lazy_ensure``
+that succeeded it — same contract, every web vendor covered.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from plugins.web import _common
+from tools.lazy_deps import FeatureUnavailable
+
+
+@pytest.fixture
+def fake_parallel_sdk(monkeypatch):
+    """Make ``import parallel`` succeed without installing anything."""
+    module = types.ModuleType("parallel")
+
+    class Parallel:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+    class AsyncParallel:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+    module.Parallel = Parallel
+    module.AsyncParallel = AsyncParallel
+    monkeypatch.setitem(sys.modules, "parallel", module)
+    return module
+
+
+@pytest.fixture
+def fake_exa_sdk(monkeypatch):
+    """Make ``import exa_py`` succeed without installing anything."""
+    module = types.ModuleType("exa_py")
+
+    class Exa:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+    module.Exa = Exa
+    monkeypatch.setitem(sys.modules, "exa_py", module)
+    return module
+
+
+def _deny_lazy_install(*_args, **_kwargs):
+    raise FeatureUnavailable(
+        "search.parallel",
+        ("parallel-web==0.4.2",),
+        "lazy installs disabled (security.allow_lazy_installs=false)",
+    )
+
+
+def _deny_exa_lazy_install(*_args, **_kwargs):
+    raise FeatureUnavailable(
+        "search.exa",
+        ("exa-py==2.10.2",),
+        "lazy installs disabled (security.allow_lazy_installs=false)",
+    )
+
+
+def test_importable_sdk_survives_disabled_lazy_installs(monkeypatch, fake_parallel_sdk):
+    """Feature reported unavailable, but the package imports: not an error."""
+    monkeypatch.setattr("tools.lazy_deps.ensure", _deny_lazy_install)
+
+    _common.lazy_ensure("search.parallel")  # must not raise
+
+    from parallel import Parallel
+
+    assert Parallel(api_key="k").api_key == "k"
+
+
+def test_importable_exa_sdk_survives_disabled_lazy_installs(monkeypatch, fake_exa_sdk):
+    """Same for a vendor whose package name is not its slug: ``exa-py`` imports as ``exa_py``."""
+    monkeypatch.setattr("tools.lazy_deps.ensure", _deny_exa_lazy_install)
+
+    _common.lazy_ensure("search.exa")  # must not raise
+
+    from exa_py import Exa
+
+    assert Exa(api_key="k").api_key == "k"
+
+
+def test_missing_sdk_still_reports_the_install_hint(monkeypatch):
+    """Genuinely absent package keeps the actionable ImportError."""
+    monkeypatch.delitem(sys.modules, "parallel", raising=False)
+    monkeypatch.setattr("tools.lazy_deps.ensure", _deny_lazy_install)
+
+    with pytest.raises(ImportError) as excinfo:
+        _common.lazy_ensure("search.parallel")
+
+    assert "parallel-web" in str(excinfo.value)
+
+
+def test_unrelated_failure_is_still_surfaced(monkeypatch, fake_parallel_sdk):
+    """A non-availability error is a real fault and must not be swallowed."""
+
+    def boom(*_args, **_kwargs):
+        raise OSError("disk exploded")
+
+    monkeypatch.setattr("tools.lazy_deps.ensure", boom)
+
+    with pytest.raises(ImportError, match="disk exploded"):
+        _common.lazy_ensure("search.parallel")
+
+
+def test_absent_helper_degrades_to_the_import(monkeypatch):
+    """Without lazy_deps at all, the call-site import remains the only gate."""
+    monkeypatch.setitem(sys.modules, "tools", types.ModuleType("tools"))
+    monkeypatch.setitem(sys.modules, "tools.lazy_deps", None)  # import raises
+
+    _common.lazy_ensure("search.parallel")  # must not raise, must not install


### PR DESCRIPTION
## Problem

`plugins/web/_common.lazy_ensure` — the helper every web vendor (`search.parallel`, `search.exa`, `search.firecrawl`, …) goes through via `cached_sdk_client` — documents one contract and implements the opposite. Its docstring promises to swallow a benign availability error from the lazy-deps helper and let the subsequent SDK import at the call site be the real gate. The handlers on `main` are:

```python
except ImportError:
    pass                          # never fires
except Exception as exc:
    raise ImportError(str(exc))   # fires for exactly the intended case
```

The root cause is a wrong exception class. `tools.lazy_deps.ensure` signals an unusable feature by raising `FeatureUnavailable`, which subclasses `RuntimeError` — not `ImportError`. So:

- the narrow `except ImportError` arm never matches the error it was written for;
- the broad `except Exception` arm catches `FeatureUnavailable` and converts "cannot install right now" into a hard `ImportError`;
- the import that was supposed to make the decision is never reached.

Practical consequence: on any host with `security.allow_lazy_installs=false`, a web provider is dead whenever `feature_missing()` reports its pin unsatisfied — including when the SDK is importable but installed at a version outside the exact pin (e.g. `parallel-web` 0.4.3 vs the `==0.4.2` pin), or when the module is already present in `sys.modules`. Declining to *install* a package is treated as the package being *absent*.

## Fix

Try the install; if it is impossible, then check whether it was needed at all. Only a genuinely missing package raises, and the raised error keeps the actionable install hint:

```python
try:
    from tools.lazy_deps import FeatureUnavailable, ensure as _lazy_ensure
except ImportError:
    return  # lazy-deps helper itself unavailable — let the import decide
try:
    _lazy_ensure(feature, prompt=False)
except FeatureUnavailable as exc:
    if not _sdk_importable(_feature_module(feature)):
        raise ImportError(str(exc)) from exc
    # Already importable; nothing needed installing.
except Exception as exc:
    raise ImportError(str(exc)) from exc
```

Unrelated faults (an `OSError` from the installer, say) still surface to the caller as `ImportError` rather than being silently swallowed. `_feature_module` maps the feature id to the package the factory imports: the prefix strip covers the vendors whose package name is their slug (`search.parallel` -> `parallel`, `search.firecrawl` -> `firecrawl`), and an override table consulted first covers the ones where it is not (`search.exa` -> `exa_py`, the import name of the `exa-py` SDK), so the probe targets the right module for every vendor.

## Why `sys.modules` is checked before `find_spec`

```python
if module_name in sys.modules:
    return True
try:
    return importlib.util.find_spec(module_name) is not None
except (ImportError, ValueError):
    return False
```

1. An already-imported module is importable by definition; consulting `sys.modules` first is correct and cheaper than a filesystem scan.
2. `importlib.util.find_spec` raises `ValueError` on a module present in `sys.modules` whose `__spec__` is `None`. That is exactly how the existing test suite injects a stub SDK — a bare `types.ModuleType("parallel")` has no `__spec__`. Calling `find_spec` first would raise on precisely the inputs the check needs to answer `True` for. `ValueError` is caught as well, so a malformed entry degrades to "not importable" instead of escaping.

This also explains the pre-existing failure in `tests/tools/test_web_tools_config.py::TestParallelClientConfig`: the suite installs a stub `parallel` module in `sys.modules`, but production code raises before ever looking at it.

## History

This PR originally patched the per-provider `_ensure_parallel_sdk_installed` in `plugins/web/parallel/provider.py`. Upstream since folded that helper into the shared `plugins/web/_common.lazy_ensure` (191cc8d30, 2028dcb91), so the fix was ported to the shared helper — same contract, now covering every web vendor instead of just Parallel. The test module moved accordingly to `tests/plugins/web/test_lazy_ensure_importable_sdk.py`.

## Test evidence

`tests/plugins/web/test_lazy_ensure_importable_sdk.py` (new) covers the distinct paths:

- `test_importable_sdk_survives_disabled_lazy_installs` — `FeatureUnavailable` raised while the package imports fine: not an error.
- `test_importable_exa_sdk_survives_disabled_lazy_installs` — same for `search.exa`, whose package imports as `exa_py`: the prefix strip alone would probe a module no vendor ships.
- `test_missing_sdk_still_reports_the_install_hint` — genuinely absent package still raises `ImportError` carrying `parallel-web`.
- `test_unrelated_failure_is_still_surfaced` — an `OSError` from the installer is not swallowed.
- `test_absent_helper_degrades_to_the_import` — without `tools.lazy_deps` at all, the call-site import remains the only gate.

On the current head (rebased onto `main` @ `564aef294`):

```
tests/plugins/web/test_lazy_ensure_importable_sdk.py    5 passed
tests/plugins/web/test_web_search_provider_plugins.py  34 passed
tests/tools/test_web_tools_config.py                   52 passed
tests/tools/test_web_providers.py                      12 passed
tests/tools/test_web_keyless_fallback.py               42 passed
tests/tools/test_web_keyless_rescue.py                 14 passed
tests/tools/test_lazy_deps.py                          69 passed, 1 skipped
ruff check plugins/web/_common.py tests/plugins/web/test_lazy_ensure_importable_sdk.py
All checks passed!
```

Mutation check — reverting only `plugins/web/_common.py` to its `main` content, with the new tests in place:

```
FAILED tests/plugins/web/test_lazy_ensure_importable_sdk.py::test_importable_sdk_survives_disabled_lazy_installs
FAILED tests/plugins/web/test_lazy_ensure_importable_sdk.py::test_importable_exa_sdk_survives_disabled_lazy_installs
FAILED tests/tools/test_web_tools_config.py::TestParallelClientConfig::test_creates_client_with_key
FAILED tests/tools/test_web_tools_config.py::TestParallelClientConfig::test_singleton_returns_same_instance
```

The two `TestParallelClientConfig` failures are pre-existing on `main` today (`ImportError: Feature 'search.parallel' unavailable: lazy installs disabled (security.allow_lazy_installs=false)…`) and are fixed by this change.

## Context

Found alongside #79839 and #79840 while investigating a single incident; the three are independent fixes in different subsystems and can be reviewed and merged in any order. Touches two files: `plugins/web/_common.py` and the new test module.
