### PR TITLE
fix(kanban): don't nudge delegated children toward kanban_complete — the toolset is stripped from them

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -22,12 +22,37 @@ _TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
 _DEFAULT_MAX_ATTEMPTS = 2
 
 
+def _is_delegated_child_context() -> bool:
+    """Mirror of ``tools.kanban_tools._is_delegated_child_context``.
+
+    Kept local so this policy module stays importable without the tools
+    package.  Fails open (``False``) so non-delegated workers are unaffected
+    if the delegation module is unavailable.
+    """
+    try:
+        from agent.delegation_context import is_delegated_child_context
+
+        return is_delegated_child_context()
+    except Exception:
+        return False
+
+
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
     On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
     ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+
+    Never on for delegated ``delegate_task`` children.  The ``kanban`` toolset
+    is stripped from them (``tools/delegate_tool.py`` appends ``"kanban"`` to
+    ``child_disabled_toolsets``, and ``tools/kanban_tools.py`` gates every
+    kanban surface on the same delegated-child check), so nudging a child
+    toward ``kanban_complete`` demands a tool it cannot call.  Children still
+    observe ``HERMES_KANBAN_TASK`` because the env scrub only materializes
+    across a subprocess boundary and in-process children never fork.
     """
+    if _is_delegated_child_context():
+        return False
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -29,6 +29,37 @@ def test_env_can_disable(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=[]) is None
 
 
+def test_no_nudge_for_delegated_child(clear_kanban_env):
+    """A delegate_task child has the kanban toolset stripped, so the guard
+    must not demand a terminal board call from it.
+
+    The child still inherits HERMES_KANBAN_TASK: the env scrub only
+    materializes across a subprocess boundary and in-process children
+    never fork.
+    """
+    from agent.delegation_context import delegated_child_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_delegated")
+
+    assert kanban_stop_nudge_enabled() is True  # parent worker: unchanged
+
+    with delegated_child_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[], attempts=0) is None
+
+    # leaving the child scope restores the parent's behaviour
+    assert kanban_stop_nudge_enabled() is True
+
+
+def test_delegated_child_guard_fails_open(clear_kanban_env, monkeypatch):
+    """If the delegation module cannot be imported, behave as before."""
+    import agent.kanban_stop as ks
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_abc")
+    monkeypatch.setattr(ks, "_is_delegated_child_context", lambda: False)
+    assert kanban_stop_nudge_enabled() is True
+
+
 def test_nudge_when_no_terminal_tool(clear_kanban_env):
     clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
     messages = [


### PR DESCRIPTION
**Title:** fix(kanban): don't nudge delegated children toward `kanban_complete` — the toolset is stripped from them

## Summary

`kanban_stop_nudge_enabled()` fires the turn-end kanban guard for any process with `HERMES_KANBAN_TASK` set. Delegated `delegate_task` children inherit that variable, but the kanban toolset is unconditionally removed from them — so the guard instructs a child to call a tool it has been denied, and the child spends the remainder of its iteration budget trying to comply.

One guard, mirroring the check its sibling module already performs.

## The contradiction

`tools/kanban_tools.py` removes the tools (`:93`, `:115`, `:131`, `:146` all gate on this):

```python
def _is_delegated_child_context() -> bool:          # :65
    try:
        from agent.delegation_context import is_delegated_child_context
        return is_delegated_child_context()
    except Exception:
        return False
```

`tools/delegate_tool.py:1311` makes it unconditional:

```python
child_disabled_toolsets = list(
    dict.fromkeys(
        inherited_disabled + _blocked_toolsets_for_role(effective_role) + ["kanban"]
    )
)
```

`agent/kanban_stop.py:25` demands them anyway, with no equivalent check:

```python
def kanban_stop_nudge_enabled() -> bool:
    env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
    if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
        return False
    task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
    return bool(task)
```

## Why the child still sees `HERMES_KANBAN_TASK`

`scrub_kanban_env()` in `agent/delegation_context.py` strips `KANBAN_ENV_KEYS` and sets the lineage marker, but it is only materialised at **subprocess** boundaries — `tools/environments/local.py:507` and `tools/code_execution_tool.py:281`, both via `delegated_child_subprocess_env()`.

`delegate_task` children run **in-process** on a `DaemonThreadPoolExecutor` (`tools/delegate_tool.py:3021`). No fork, so no scrub, so `HERMES_KANBAN_TASK` stays visible to a child that cannot act on it.

## Impact

At `agent/conversation_loop.py:7165` the child is handed:

> `[System: You are a Hermes kanban worker. A plain-text reply is NOT a terminal state for the board. Task 't_...' is still 'running'. Ending now without a board tool causes a protocol violation ... Call kanban_complete(...) ... Repeated protocol violations will block this task and require manual intervention.]`

The nudge is bounded to two firings (`_DEFAULT_MAX_ATTEMPTS = 2`, `agent/kanban_stop.py:22`), which is why this is easy to miss. The cost is not the nudge itself — it is that the nudge plants an unreachable, consequence-framed goal, and the child then spends its own `delegation.max_iterations` budget pursuing it.

In a representative delegated review child, the deliverable file was written roughly 30% of the way through the transcript. The remaining ~70% was the search for a tool that cannot be present, escalating in this order:

1. `env | rg KANBAN` → finds `HERMES_KANBAN_TASK`, confirming to the model that it *is* a kanban worker
2. `tool_call(kanban_complete)` → `'kanban_complete' is not a deferrable tool`
3. direct import of `tools.kanban_tools._handle_complete` → traceback
4. `env -u HERMES_DELEGATED_CHILD_CONTEXT hermes kanban ... comment/attach` → **succeeds**

Across a sample of delegated children, ~77% referenced `kanban_complete` or `kanban_block` after their deliverable was already complete.

Step 4 is the part I would flag beyond wasted turns: the child unsets the lineage marker and writes to the parent's board — the isolation the delegation layer is trying to enforce. It is a reasonable response to being told it must call a board tool, so I don't think prompt wording fixes this.

## Fix

Add the delegated-child guard as the first check in `kanban_stop_nudge_enabled()`, using the same helper `kanban_tools.py` already uses:

```python
def kanban_stop_nudge_enabled() -> bool:
    try:
        from agent.delegation_context import is_delegated_child_context
        if is_delegated_child_context():
            return False
    except Exception:
        pass
    env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
    ...
```

Failing open on an import error preserves current behaviour for non-delegated workers.

## Test plan

Extends `tests/agent/test_kanban_stop.py`, which already provides the `clear_kanban_env` fixture:

- `HERMES_KANBAN_TASK` set **and** delegated-child context → `kanban_stop_nudge_enabled() is False`, `build_kanban_stop_nudge(...) is None`
- `HERMES_KANBAN_TASK` set, not delegated → unchanged; existing `test_nudge_when_no_terminal_tool` and `test_no_nudge_after_kanban_complete` still pass

## Note for reviewers

There is a related asymmetry I have deliberately not changed here: `is_delegated_child_context()` is a `ContextVar`, and `delegated_child_context()` currently wraps child *construction* rather than the child's *run*, so the marker may not survive the hop into the executor thread in every path. If you would rather the guard read the env marker directly, or would prefer the `ContextVar` propagation fixed at the source, I am happy to follow whichever you consider correct.
