### PR TITLE
feat(whatsapp-cloud): add edit_message for Cloud API text editing

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -588,6 +588,81 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
 
         return SendResult(success=True, message_id=last_message_id)
 
+    # ------------------------------------------------------------------ edit message
+    #
+    # Meta's Cloud API uses the same ``/messages`` endpoint for editing.
+    # When the ``text`` payload includes a ``message_id``, the API edits
+    # that existing message (same phone number scope) instead of sending
+    # a new one.  Edits are supported for up to 30 days after the original
+    # send and the new content must still comply with the original type
+    # constraints (text → text only, etc.).
+    #
+    # https://developers.facebook.com/docs/whatsapp/cloud-api/reference/messages
+
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Edit a previously sent message via the Graph API /messages endpoint.
+
+        Meta's Cloud API supports editing text messages for up to 30 days
+        after the original send.  The edit must be the same type as the
+        original message (text → text); other types (image, video, etc.)
+        cannot be edited into a different type.
+
+        ``chat_id`` is the recipient's WhatsApp ID (``wa_id``); it is
+        required by the base contract but is not sent to Meta's edit
+        endpoint — Meta identifies the target message by ``message_id``
+        alone within our phone-number scope.
+        """
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+        if not content or not content.strip():
+            return SendResult(success=False, error="Empty content")
+
+        url = self._graph_url("messages")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": chat_id,
+            "type": "text",
+            "text": {
+                "body": content,
+                "preview_url": True,
+                "message_id": message_id,
+            },
+        }
+
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception as exc:
+            logger.exception("[whatsapp_cloud] edit_message failed")
+            return SendResult(success=False, error=str(exc))
+
+        if resp.status_code == 200:
+            return SendResult(success=True, message_id=message_id)
+        else:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            error_msg = self._format_graph_error(body, resp.status_code)
+            logger.warning(
+                "[whatsapp_cloud] edit_message rejected (status=%d): %s",
+                resp.status_code,
+                error_msg,
+            )
+            return SendResult(success=False, error=error_msg)
+
     # ------------------------------------------------------------------ typing indicator + read receipts
     #
     # Meta couples these into a single API call: a POST to /messages

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -1400,3 +1400,134 @@ class TestReplyContextResolution:
         assert event.reply_to_text is None
         assert event.reply_to_is_own_message is False
 
+
+# ---------------------------------------------------------------------------
+# edit_message — Cloud API edit text endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestEditMessage:
+    """Outbound edit-message path via Graph API /messages with text.message_id."""
+
+    @pytest.mark.asyncio
+    async def test_edit_includes_body_and_message_id(self):
+        """The edit POST carries the new content and original message_id."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.abc123"}]}
+            )
+        )
+
+        result = await adapter.edit_message(
+            "15551234567", "wamid.abc123", "edited content"
+        )
+
+        assert result.success is True
+        assert result.message_id == "wamid.abc123"
+
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["messaging_product"] == "whatsapp"
+        assert payload["recipient_type"] == "individual"
+        assert payload["to"] == "15551234567"
+        assert payload["type"] == "text"
+        assert payload["text"]["body"] == "edited content"
+        assert payload["text"]["preview_url"] is True
+        assert payload["text"]["message_id"] == "wamid.abc123"
+
+    @pytest.mark.asyncio
+    async def test_edit_requires_connected_client(self):
+        """edit_message returns failure when http_client is None."""
+        adapter = _make_adapter()
+        adapter._http_client = None
+
+        result = await adapter.edit_message(
+            "15551234567", "wamid.abc123", "hi"
+        )
+
+        assert result.success is False
+        assert result.error == "Not connected"
+
+    @pytest.mark.asyncio
+    async def test_edit_rejects_empty_content(self):
+        """edit_message returns failure on empty/whitespace-only content."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+
+        result = await adapter.edit_message(
+            "15551234567", "wamid.abc123", "   "
+        )
+
+        assert result.success is False
+        assert result.error == "Empty content"
+        adapter._http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_edit_failure_status(self):
+        """Non-200 status returns failure with formatted error."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                400, {"error": {"code": 131009, "message": "Parameter value is not valid"}}
+            )
+        )
+
+        result = await adapter.edit_message(
+            "15551234567", "wamid.invalid", "edited"
+        )
+
+        assert result.success is False
+        assert "131009" in result.error
+
+    @pytest.mark.asyncio
+    async def test_edit_network_error(self):
+        """A network-level exception is caught and reported."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(side_effect=ConnectionError("Connection reset"))
+
+        result = await adapter.edit_message(
+            "15551234567", "wamid.abc123", "edited"
+        )
+
+        assert result.success is False
+        assert "Connection reset" in result.error
+
+    @pytest.mark.asyncio
+    async def test_edit_includes_bearer_auth(self):
+        """The edit POST uses the adapter's access token for auth."""
+        adapter = _make_adapter(access_token="my-secret-token")
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.abc123"}]}
+            )
+        )
+
+        await adapter.edit_message("15551234567", "wamid.abc123", "edited")
+
+        headers = adapter._http_client.post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer my-secret-token"
+        assert headers["Content-Type"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_edit_targets_graph_messages(self):
+        """edit_message POSTs to the Graph /messages endpoint."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.abc123"}]}
+            )
+        )
+
+        await adapter.edit_message("15551234567", "wamid.abc123", "edited")
+
+        args, _ = adapter._http_client.post.call_args
+        url = args[0] if args else adapter._http_client.post.call_args.kwargs.get("url")
+        # URL includes the phone-number-ID bucket: .../<phone_id>/messages
+        assert url.endswith("/messages")
+        assert adapter._phone_number_id in url
+


### PR DESCRIPTION
## Summary

Mirrors the Baileys backend's `edit_message` (adapter.py:985 -> bridge.js:862 `/edit`) onto the WhatsApp Cloud adapter. The Cloud API uses the same Graph `/messages` POST endpoint but signals an edit by including the original `message_id` in the `text` object.

Closes **GAP_PARTIAL_EDIT** from the WhatsApp Feature Parity matrix -- Phase 1 (card t_3fb14ad6).

## Changes

- **`gateway/platforms/whatsapp_cloud.py:591-665`** -- New `edit_message()` method. POSTs to `/{version}/{phone-id}/messages` with `text.body` + `text.message_id` to edit the existing message in place. Handles disconnected client, empty content, network exceptions, and non-200 Graph error responses.
- **`tests/gateway/test_whatsapp_cloud.py`** -- 7 conformance tests (TestEditMessage class):
  - Payload shape (body, message_id, auth headers, endpoint URL)
  - Disconnected-client guard
  - Empty/whitespace content rejection
  - 400 Graph error propagation
  - Network exception handling

## Verification

- **50/50 tests passing** (43 existing + 7 new)
- All 7 edit tests verified green on origin/main (commit ff3793fdf)

## Follow-up

1. **Delete messages** remain missing (next card: t_49f91f6b).
2. **Chunked editing** -- if the edited content exceeds 4096 chars, should we split? (Current impl sends as-is; Meta will reject if over text limit, same as initial `send()`.)
3. **Non-text edits** -- Meta restricts editing to same type (text->text). Image/video edit is out of scope for this card.