### PR TITLE
fix(kanban): scope the active_pr respawn guard to the task's own assignee

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6834,7 +6834,7 @@ class DispatchResult:
 
     Reasons: ``"blocker_auth"`` (quota/auth error — also auto-blocked),
     ``"recent_success"`` (completed run within guard window),
-    ``"active_pr"`` (GitHub PR URL in a recent comment)."""
+    ``"active_pr"`` (GitHub PR URL in a recent comment by the assignee)."""
     rate_limited: list[str] = field(default_factory=list)
     """Task ids whose workers bailed on a provider rate-limit / quota wall
     (EX_TEMPFAIL sentinel exit) and were released back to ``ready`` WITHOUT
@@ -8049,8 +8049,11 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
 
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
-        ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        ``_RESPAWN_GUARD_PR_WINDOW`` seconds) **written by the task's own
+        assignee**.  A prior worker already opened a PR; re-spawning risks a
+        duplicate PR on the same task.  A PR link posted by anyone else is
+        context, not evidence, and does not trip the guard.  Tasks with no
+        assignee match on any author, preserving the previous behaviour.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8133,13 +8136,25 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Only the task's OWN assignee counts: another agent linking the PR for
+    #    context is not evidence that this task's worker opened it, and would
+    #    otherwise strand the card for the whole guard window.  Tasks with no
+    #    assignee keep the previous any-author behaviour.
+    assignee_row = conn.execute(
+        "SELECT assignee FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    guard_assignee = ((assignee_row["assignee"] if assignee_row else "") or "").strip()
+
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT author, body FROM task_comments WHERE task_id = ? AND created_at >= ?",
         (task_id, pr_cutoff),
     ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+        if not c["body"] or not _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            continue
+        if guard_assignee and (c["author"] or "").strip() != guard_assignee:
+            continue
+        return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1583,3 +1583,49 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+# ---------------------------------------------------------------------------
+# check_respawn_guard: active_pr authorship
+# ---------------------------------------------------------------------------
+
+
+PR_COMMENT = "Review target: https://github.com/acme/widget/pull/42 please look"
+
+
+def _ready_task(conn, *, assignee):
+    """check_respawn_guard is status-agnostic; the caller filters for ready."""
+    return kb.create_task(conn, title="t", assignee=assignee)
+
+
+def test_active_pr_guard_ignores_other_authors(kanban_home):
+    """A PR link posted by someone other than the assignee is context, not
+    evidence that this task's worker opened a PR."""
+    with kb.connect_closing() as conn:
+        tid = _ready_task(conn, assignee="reviewer")
+        kb.add_comment(conn, tid, "builder", PR_COMMENT)
+        assert kb.check_respawn_guard(conn, tid) != "active_pr"
+
+
+def test_active_pr_guard_fires_for_own_assignee(kanban_home):
+    """Original behaviour preserved: the assignee's own PR link still guards."""
+    with kb.connect_closing() as conn:
+        tid = _ready_task(conn, assignee="builder")
+        kb.add_comment(conn, tid, "builder", PR_COMMENT)
+        assert kb.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_active_pr_guard_matches_any_author_when_unassigned(kanban_home):
+    """Unassigned tasks keep the previous any-author semantics."""
+    with kb.connect_closing() as conn:
+        tid = _ready_task(conn, assignee=None)
+        kb.add_comment(conn, tid, "anyone", PR_COMMENT)
+        assert kb.check_respawn_guard(conn, tid) == "active_pr"
+
+
+def test_active_pr_guard_ignores_non_pr_comment_from_assignee(kanban_home):
+    """A comment without a PR URL never trips the guard."""
+    with kb.connect_closing() as conn:
+        tid = _ready_task(conn, assignee="builder")
+        kb.add_comment(conn, tid, "builder", "no links here, just a status note")
+        assert kb.check_respawn_guard(conn, tid) != "active_pr"


### PR DESCRIPTION
**Title:** fix(kanban): scope the `active_pr` respawn guard to the task's own assignee

## Summary

The `active_pr` respawn guard treats a GitHub PR URL in **any** recent comment as proof that *this task's worker* already opened a PR. It never checks who wrote the comment. When a different agent links a PR for context, the card blocks itself and can never be dispatched again for the duration of the guard window.

This changes the match to require that the comment's author is the task's assignee.

## Current behaviour

`hermes_cli/kanban_db.py:8136`, inside `check_respawn_guard`:

```python
# 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
for c in conn.execute(
    "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
    (task_id, pr_cutoff),
).fetchall():
    if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
        return "active_pr"
```

The intent is right and worth keeping: a worker that already opened a PR should not respawn and open a second one. The comment is explicit that this is about the *prior worker*. But the query selects `body` only — authorship is never consulted, so any commenter's PR link is attributed to the task's worker.

`_RESPAWN_GUARD_PR_WINDOW = 86400` (`:6782`), so a single stray link blocks the card for 24 hours.

## Observed

Three cards on one board accounted for every `active_pr` guard event:

| card | guard events | assignee | author of the PR-URL comment | same? |
|------|-------------:|----------|------------------------------|-------|
| A | 97 | agent-1 | **agent-2** | no |
| B | 79 | agent-1 | **agent-2** | no |
| C | 58 | agent-2 | agent-2 | yes |

Cards A and B are assigned to one agent, but the PR link was posted by a *different* agent dropping context onto the card. Neither card had opened a PR; neither could ever open one. Both were re-evaluated and re-logged once per minute for the full guard window — card A logged an event every 60 seconds for 97 consecutive minutes — and **neither ever ran**. Together they account for ~75% of all guard events observed.

Because the cards never ran, the work they were meant to do went undone and was re-derived later at full cost.

## The workaround it forces

The agents working the board diagnosed this in-band and routed around it. Preserved verbatim in the body of a replacement card:

> *"sibling card [B] is stuck ready under respawn_guarded active_pr (PR URL was put in a **comment** — 24h guard). This card is the live review; body carries the PR link (comments intentionally omit github PR URLs)."*
> *"IMPORTANT: do not put a github.com/.../pull/N URL in comments (dispatcher active_pr guard)."*

It also defeated the idempotency dedupe by suffixing the key with `-v2`.

Both halves are worth fixing: the guard trains agents to keep PR links out of comments — losing them from the audit trail — and makes duplicate cards with mutated keys the path of least resistance.

## Fix

Require that the PR-URL comment was authored by the task's assignee. `task_comments.author` already exists, so this is a query change plus one comparison:

```python
row = conn.execute("SELECT assignee FROM tasks WHERE id = ?", (task_id,)).fetchone()
assignee = ((row["assignee"] if row else "") or "").strip()

pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
for c in conn.execute(
    "SELECT author, body FROM task_comments WHERE task_id = ? AND created_at >= ?",
    (task_id, pr_cutoff),
).fetchall():
    if not c["body"] or not _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
        continue
    if assignee and ((c["author"] or "").strip() != assignee):
        continue          # another agent linked this PR for context
    return "active_pr"
```

When the task has no assignee, behaviour is unchanged — any author still matches — so unassigned boards keep today's semantics.

## What this does and does not fix

Fixes the attribution case (A and B above): a PR link from someone other than the task's worker no longer blocks the task.

**Does not** fix card C, where the assignee did link a PR on its own card and the guard fired as designed. Whether *discussing* a PR should count as *having opened* one is a separate question — it likely wants structured evidence (a recorded PR URL on the run) rather than a regex over free text. I have left that alone deliberately; happy to open it separately if you think it is worth pursuing.

## Test plan

Four cases added to `tests/hermes_cli/test_kanban_db.py`:

- PR URL authored by a non-assignee → guard does **not** return `active_pr` (fails without this change)
- PR URL authored by the assignee → still returns `active_pr` (existing behaviour preserved)
- Task with no assignee, PR URL from any author → still returns `active_pr`
- Comment from the assignee with no PR URL → unchanged

`pytest tests/hermes_cli/test_kanban*.py` → **156 passed, 9 failed**.

Those same 9 fail identically on an unmodified `main` at this commit, so they are pre-existing and
unrelated — the delta from this branch is exactly the 4 new tests. For reference they are:
`test_rate_limit_exit_requeues_without_counting_failure`, `test_connect_works_when_wal_is_silently_refused`,
`test_decompose_with_fanout_creates_children`, `test_decompose_fanout_false_invalid_llm_assignee_uses_default`,
`test_claim_fires_hook`, `test_gateway_create_autosubscribes_on_explicit_board`,
`test_notifier_artifact_delivery_skips_missing_files`, `test_connect_raises_when_kanban_home_is_real_root`,
`test_connect_raises_for_explicit_db_path_under_real_root`. Happy to open a separate issue if they are not
already known.

## Unrelated observation

The guard re-evaluates and re-logs on every dispatcher tick, producing one identical `respawn_guarded` event per minute for as long as the card stays blocked. Collapsing repeats to at most one per `(task, reason)` per hour would make this class of problem visible in the event log rather than burying it under identical rows. Not included here — happy to send it as its own PR if useful.

## Environment

Hermes Agent v0.20.0 (2026.8.3), git install, clean checkout at `origin/main`, Linux, gateway-embedded dispatcher.
