### PR TITLE
fix(mcp): accept --create-time flag in stdio watchdog argparse

### DIFF
--- a/tools/mcp_stdio_watchdog.py
+++ b/tools/mcp_stdio_watchdog.py
@@ -105,8 +105,10 @@ def main(argv: list[str] | None = None) -> int:
         description="Parent-death watchdog for a stdio MCP subprocess.",
     )
     parser.add_argument("--ppid", type=int, required=True)
+    parser.add_argument("--create-time", dest="create_time", default=None,
+                        help="ignored (injected by MCP transport; not used by watchdog)")
     parser.add_argument("command", nargs=argparse.REMAINDER)
-    args = parser.parse_args(argv)
+    args, _unknown = parser.parse_known_args(argv)
 
     real_argv = list(args.command)
     if real_argv and real_argv[0] == "--":


### PR DESCRIPTION
## Problem

The MCP SDK transport layer injects `--create-time` into the command line of stdio MCP subprocesses. The watchdog's strict `argparse` parser rejected this unknown flag with:

```
error: unrecognized arguments: --create-time
```

This prevented MCP servers launched via stdio watchdog (e.g. `blender-mcp`) from ever starting — the crash happened before the real command was executed.

## Fix

Two changes in `tools/mcp_stdio_watchdog.py`:

1. **Explicitly register `--create-time`** as an accepted (but ignored) argument, so its presence is documented rather than magic.
2. **Switch `parse_args` → `parse_known_args`** so future unknown flags injected by the MCP transport layer don't crash the watchdog either.

```diff
     parser.add_argument("--ppid", type=int, required=True)
+    parser.add_argument("--create-time", dest="create_time", default=None,
+                        help="ignored (injected by MCP transport; not used by watchdog)")
     parser.add_argument("command", nargs=argparse.REMAINDER)
-    args = parser.parse_args(argv)
+    args, _unknown = parser.parse_known_args(argv)
```

## Test Plan

- [x] Existing watchdog tests pass (`pytest tests/tools/test_mcp_stdio_watchdog.py` — 2 passed)
- [x] `hermes mcp test blender` succeeds with the patched watchdog
- [x] Verified MCP server connects and registers tools after patch applied