### PR TITLE
feat(whatsapp-cloud): port send_location to Cloud backend

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -1259,6 +1259,83 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             reply_to=reply_to,
         )
 
+    # ------------------------------------------------------------------ location
+    async def send_location(
+        self,
+        chat_id: str,
+        latitude: float,
+        longitude: float,
+        *,
+        name: Optional[str] = None,
+        address: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send a native WhatsApp location pin via the Graph API.
+
+        Meta's Cloud API supports ``type: "location"`` with a ``location``
+        object carrying ``latitude``, ``longitude``, and optionally
+        ``name`` and ``address``. Unlike media, this is a single-step
+        send — no upload, no ``media_id``.
+
+        ``reply_to`` quotes the referenced inbound wamid. ``metadata``
+        is accepted for signature parity with the Baileys adapter but
+        has no Cloud API use.
+        """
+        if self._http_client is None:
+            return SendResult(success=False, error="Not connected")
+
+        url = self._graph_url("messages")
+        headers = {
+            "Authorization": f"Bearer {self._access_token}",
+            "Content-Type": "application/json",
+        }
+
+        location_block: Dict[str, Any] = {
+            "latitude": float(latitude),
+            "longitude": float(longitude),
+        }
+        if name:
+            location_block["name"] = name
+        if address:
+            location_block["address"] = address
+
+        payload: Dict[str, Any] = {
+            "messaging_product": "whatsapp",
+            "recipient_type": "individual",
+            "to": chat_id,
+            "type": "location",
+            "location": location_block,
+        }
+        if reply_to:
+            payload["context"] = {"message_id": reply_to}
+
+        try:
+            resp = await self._http_client.post(url, headers=headers, json=payload)
+        except Exception as exc:
+            logger.exception("[whatsapp_cloud] location send failed")
+            return SendResult(success=False, error=str(exc))
+
+        if resp.status_code != 200:
+            try:
+                body = resp.json()
+            except Exception:
+                body = {"raw": resp.text[:500]}
+            error_msg = self._format_graph_error(body, resp.status_code)
+            logger.warning(
+                "[whatsapp_cloud] location send rejected (status=%d): %s",
+                resp.status_code, error_msg,
+            )
+            return SendResult(success=False, error=error_msg)
+
+        try:
+            data = resp.json()
+            ids = data.get("messages") or []
+            wamid = ids[0].get("id") if ids else None
+        except Exception:
+            wamid = None
+        return SendResult(success=True, message_id=wamid)
+
     # ------------------------------------------------------------------ opus conversion
     async def _convert_to_opus(self, mp3_path: str) -> Optional[str]:
         """Convert an MP3 to ``audio/ogg; codecs=opus`` for voice bubbles.
@@ -1936,6 +2013,25 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             # don't carry a caption in Meta's spec, but be defensive.
             inner = raw_message.get(msg_type_str) or {}
             body = str(inner.get("caption") or "")
+        elif msg_type_str == "location":
+            # Inbound location pins. Meta's webhook delivers:
+            #   {type:"location", location:{latitude, longitude, name?, address?}}
+            # Surface the coordinates + optional label as text so the agent
+            # can reason about the location without a separate media download.
+            loc = raw_message.get("location") or {}
+            lat = loc.get("latitude")
+            lng = loc.get("longitude")
+            loc_name = str(loc.get("name") or "").strip()
+            loc_address = str(loc.get("address") or "").strip()
+            parts: list[str] = []
+            if loc_name:
+                parts.append(f"Name: {loc_name}")
+            if loc_address:
+                parts.append(f"Address: {loc_address}")
+            if lat is not None and lng is not None:
+                parts.append(f"Coordinates: {lat}, {lng}")
+                parts.append(f"https://maps.google.com/?q={lat},{lng}")
+            body = " | ".join(parts) if parts else "[Location]"
 
         message_type = {
             "text": MessageType.TEXT,
@@ -1947,7 +2043,7 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "sticker": MessageType.PHOTO,
             "button": MessageType.TEXT,
             "interactive": MessageType.TEXT,
-            "location": MessageType.TEXT,
+            "location": MessageType.LOCATION,
             "contacts": MessageType.TEXT,
         }.get(msg_type_str, MessageType.TEXT)
 

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import Platform
+from gateway.platforms.base import MessageType
 
 
 @pytest.fixture(autouse=True)
@@ -752,6 +753,164 @@ class TestSendVoice:
             _os.unlink(mp3_path)
             if _os.path.exists(opus_path):
                 _os.unlink(opus_path)
+
+
+class TestSendLocation:
+    """send_location — Cloud API ``type: location`` message (parity with B)."""
+
+
+    @pytest.mark.asyncio
+    async def test_send_location_payload_shape(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.loc1"}]}
+            )
+        )
+
+        result = await adapter.send_location(
+            "15551234567", 37.7749, -122.4194,
+            name="Salesforce Tower", address="415 Mission St, San Francisco",
+        )
+        assert result.success is True
+        assert result.message_id == "wamid.loc1"
+
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["messaging_product"] == "whatsapp"
+        assert payload["recipient_type"] == "individual"
+        assert payload["to"] == "15551234567"
+        assert payload["type"] == "location"
+        assert payload["location"]["latitude"] == 37.7749
+        assert payload["location"]["longitude"] == -122.4194
+        assert payload["location"]["name"] == "Salesforce Tower"
+        assert payload["location"]["address"] == "415 Mission St, San Francisco"
+
+    @pytest.mark.asyncio
+    async def test_send_location_minimal_coords_only(self):
+        """Only lat + lng are required; name/address are optional."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.loc2"}]}
+            )
+        )
+
+        result = await adapter.send_location("15551234567", 48.8566, 2.3522)
+        assert result.success is True
+
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["location"] == {"latitude": 48.8566, "longitude": 2.3522}
+        assert "name" not in payload["location"]
+        assert "address" not in payload["location"]
+
+    @pytest.mark.asyncio
+    async def test_send_location_with_reply_to(self):
+        """reply_to sets context.message_id for quoted location messages."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.loc3"}]}
+            )
+        )
+
+        await adapter.send_location(
+            "15551234567", 51.5074, -0.1278, reply_to="wamid.inbound1"
+        )
+        payload = adapter._http_client.post.call_args.kwargs["json"]
+        assert payload["context"] == {"message_id": "wamid.inbound1"}
+
+    @pytest.mark.asyncio
+    async def test_send_location_graph_error_returns_failure(self):
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        error_resp = MagicMock()
+        error_resp.status_code = 400
+        error_resp.json = MagicMock(return_value={
+            "error": {"code": 100, "message": "Invalid location"}
+        })
+        error_resp.text = '{"error":{"code":100,"message":"Invalid location"}}'
+        adapter._http_client.post = AsyncMock(return_value=error_resp)
+
+        result = await adapter.send_location("15551234567", 0.0, 0.0)
+        assert result.success is False
+        assert "graph error 100" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_location_not_connected(self):
+        adapter = _make_adapter()
+        adapter._http_client = None
+
+        result = await adapter.send_location("15551234567", 1.0, 2.0)
+        assert result.success is False
+        assert result.error == "Not connected"
+
+    @pytest.mark.asyncio
+    async def test_send_location_accepts_metadata(self):
+        """metadata kwarg is accepted for signature parity with Baileys."""
+        adapter = _make_adapter()
+        adapter._http_client = MagicMock()
+        adapter._http_client.post = AsyncMock(
+            return_value=_mock_httpx_response(
+                200, {"messages": [{"id": "wamid.loc4"}]}
+            )
+        )
+
+        result = await adapter.send_location(
+            "15551234567", 40.7128, -74.0060, metadata={"key": "value"}
+        )
+        assert result.success is True
+
+
+class TestInboundLocation:
+    """Inbound ``type: location`` messages produce a MessageEvent with
+    coordinates surfaced as text + MessageType.LOCATION (parity with B)."""
+
+    @pytest.mark.asyncio
+    async def test_inbound_location_with_name_address(self):
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+
+        event = await adapter._build_message_event_from_cloud(
+            {"from": "15551234567", "id": "wamid.inbound_loc",
+             "type": "location",
+             "location": {
+                 "latitude": 37.7749, "longitude": -122.4194,
+                 "name": "Salesforce Tower",
+                 "address": "415 Mission St",
+             }},
+            {"15551234567": "Alice"}, {},
+        )
+        assert event is not None
+        assert event.message_type == MessageType.LOCATION
+        assert "Salesforce Tower" in event.text
+        assert "415 Mission St" in event.text
+        assert "37.7749" in event.text
+        assert "-122.4194" in event.text
+        assert "maps.google.com" in event.text
+
+    @pytest.mark.asyncio
+    async def test_inbound_location_coords_only(self):
+        """Location without name/address still surfaces the coordinates."""
+        adapter = _make_adapter()
+        adapter._message_handler = AsyncMock()
+
+        event = await adapter._build_message_event_from_cloud(
+            {"from": "15551234567", "id": "wamid.inbound_loc2",
+             "type": "location",
+             "location": {"latitude": 48.8566, "longitude": 2.3522}},
+            {"15551234567": "Alice"}, {},
+        )
+        assert event is not None
+        assert event.message_type == MessageType.LOCATION
+        assert "48.8566" in event.text
+        assert "2.3522" in event.text
+        assert "maps.google.com" in event.text
+        # No name/address labels when they weren't provided
+        assert "Name:" not in event.text
+        assert "Address:" not in event.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes `GAP_PARTIAL_LOCATION` from the WhatsApp Feature Parity campaign (#79890).

Location pins were previously **Partial (B only)** — the Baileys bridge had `send_location` (`adapter.py:1153` + `bridge.js:1019`) but the Meta Cloud API adapter had no equivalent. This PR ports `send_location` to `gateway/platforms/whatsapp_cloud.py` so the Cloud backend (C) matches the Baileys bridge (B).

## Changes

### Outbound: `send_location` (Cloud API)
- Added `send_location` method to `WhatsAppCloudAdapter` (`whatsapp_cloud.py:1262`)
- Uses Meta's Graph API `type: location` message with `latitude`, `longitude`, optional `name`, `address`, and `reply_to` context support
- Signature parity with the Baileys adapter's `send_location` (`plugins/platforms/whatsapp/adapter.py:1153`)

### Inbound: location message handling
- Previously `type: location` inbound messages mapped to `MessageType.TEXT` with an empty body (`whatsapp_cloud.py:1950`)
- Now maps to `MessageType.LOCATION` with the coordinates, name, address, and a Google Maps link surfaced as the message text (`whatsapp_cloud.py:2016`), so the agent can reason about the location

## Test Plan

- 6 outbound `send_location` tests: payload shape, minimal coords, reply_to, Graph error, not-connected, metadata kwarg
- 2 inbound location tests: with name+address, coords-only
- 63 total tests passing (51 Cloud adapter + 2 native delivery + 8 allowed users + 2 conformance vector)

```
$ python -m pytest tests/gateway/test_whatsapp_cloud.py tests/gateway/test_whatsapp_cloud_allowed_users.py tests/conformance/test_vector_generator.py tests/gateway/test_whatsapp_native_delivery.py -q
63 passed in 2.53s
```

## Evidence anchors

- `gateway/platforms/whatsapp_cloud.py:1262` — `send_location` method
- `gateway/platforms/whatsapp_cloud.py:2016` — inbound location body extraction
- `gateway/platforms/whatsapp_cloud.py:2046` — `MessageType.LOCATION` mapping
- `tests/gateway/test_whatsapp_cloud.py:757` — `TestSendLocation` (6 tests)
- `tests/gateway/test_whatsapp_cloud.py:867` — `TestInboundLocation` (2 tests)

Tracking: WhatsApp Feature Parity campaign #79890, card t_807c73ca