### PR TITLE
fix(sessions): heal stale profile schemas on read

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -47,6 +47,7 @@ _cron_profile_home = late("_cron_profile_home")
 _disable_unselected_skills = late("_disable_unselected_skills")
 _fallback_profile_dicts = late("_fallback_profile_dicts")
 _hub_action_name = late("_hub_action_name")
+_open_session_db_for_profile = late("_open_session_db_for_profile")
 _profile_setup_command = late("_profile_setup_command")
 _profile_to_dict = late("_profile_to_dict")
 _resolve_profile_dir = late("_resolve_profile_dir")
@@ -75,7 +76,7 @@ def get_profiles_sessions(
     exclude_sources: str = None,
     full: bool = False,
 ):
-    """Unified, read-only session list aggregated across ALL profiles.
+    """Unified session list aggregated across ALL profiles.
 
     Intentionally process-light: this opens each profile's ``state.db`` directly
     from disk — it does NOT spawn a dashboard backend per profile. Each returned
@@ -92,7 +93,6 @@ def get_profiles_sessions(
     if order not in ("created", "recent"):
         raise HTTPException(status_code=400, detail="order must be one of: created, recent")
 
-    from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
     targets: List[Tuple[str, Path]] = []
@@ -132,10 +132,9 @@ def get_profiles_sessions(
         if not db_path.exists():
             continue
         try:
-            # Read-only: this loop runs on every sidebar refresh, so it must
-            # never DDL/write-lock another profile's live DB (see SessionDB
-            # read_only docstring).
-            db = SessionDB(db_path=db_path, read_only=True)
+            # Healthy stores stay read-only on every refresh. Older stores get
+            # one writable schema reconciliation before reopening read-only.
+            db = _open_session_db_for_profile(name, read_only=True)
         except Exception as exc:
             errors.append({"profile": name, "error": str(exc)})
             continue
@@ -217,8 +216,9 @@ def get_profiles_sessions_sidebar(
     ``/api/profiles/sessions`` calls they reopened every profile's ``state.db``
     three times and re-counted each refresh. This opens each DB once and runs
     the three filtered queries together, returning the three windows in one
-    payload. Read-only and process-light, same row projection and 300s active
-    heuristic as ``/api/profiles/sessions``.
+    payload. Healthy stores stay read-only and process-light; an older store
+    gets one schema reconciliation before the read is retried. Uses the same
+    row projection and 300s active heuristic as ``/api/profiles/sessions``.
 
     The caller passes the source taxonomy (``recents_exclude`` /
     ``messaging_exclude`` CSV, ``source=cron`` is implicit) so this stays
@@ -226,7 +226,6 @@ def get_profiles_sessions_sidebar(
     ``min_messages=1`` / ``archived=exclude`` / recency order, matching the
     desktop's per-slice calls.
     """
-    from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
     # cron + messaging are cross-profile; recents is scoped to recents_profile.
@@ -290,7 +289,7 @@ def get_profiles_sessions_sidebar(
         if not db_path.exists():
             continue
         try:
-            db = SessionDB(db_path=db_path, read_only=True)
+            db = _open_session_db_for_profile(name, read_only=True)
         except Exception as exc:
             errors.append({"profile": name, "error": str(exc)})
             continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11195,16 +11195,29 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
 # query raises "no such table: sessions".
 _session_db_bootstrap_lock = threading.Lock()
 
-# Stale-schema probe for read-only opens: compiled against the newest columns
-# the dashboard read paths query. Reads at most one row per table. Read-only
-# opens skip _reconcile_columns(), so an older store would otherwise 500 on
-# every poll until something opened it writable.
-_SESSION_DB_READ_PROBE_SQL = (
-    "SELECT (SELECT archived FROM sessions LIMIT 1), "
-    "(SELECT pinned FROM sessions LIMIT 1), "
-    "(SELECT active FROM messages LIMIT 1), "
-    "(SELECT compacted FROM messages LIMIT 1)"
-)
+# Read-only opens skip _reconcile_columns(), so probe every table and column
+# declared in SCHEMA_SQL before serving dashboard reads. Deriving these probes
+# from the schema keeps future column additions on the existing self-heal path.
+@functools.lru_cache(maxsize=1)
+def _session_db_read_probe_sqls() -> Tuple[str, ...]:
+    from hermes_state_common import SCHEMA_SQL
+    from hermes_state_schema import SessionSchemaMixin
+
+    def _quote(identifier: str) -> str:
+        return '"' + identifier.replace('"', '""') + '"'
+
+    expected = SessionSchemaMixin._parse_schema_columns(SCHEMA_SQL)
+    probes: List[str] = []
+    for table_name, columns in expected.items():
+        safe_table = _quote(table_name)
+        safe_columns = [
+            f"{safe_table}.{_quote(column)}" for column in columns
+        ]
+        probes.append(
+            f"SELECT {', '.join(safe_columns)} "
+            f"FROM {safe_table} LIMIT 0"
+        )
+    return tuple(probes)
 
 
 def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
@@ -11250,7 +11263,8 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
         conn = getattr(db, "_conn", None)
         if conn is not None:
             try:
-                conn.execute(_SESSION_DB_READ_PROBE_SQL).fetchone()
+                for probe_sql in _session_db_read_probe_sqls():
+                    conn.execute(probe_sql)
             except BaseException:
                 db.close()
                 raise

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -398,7 +398,10 @@ class TestWebServerEndpoints:
         assert response.json()["sessions"] == []
         assert response.json()["total"] == 0
 
-    @pytest.mark.parametrize("missing_column", ["archived", "pinned"])
+    @pytest.mark.parametrize(
+        "missing_column",
+        ["archived", "pinned", "last_read_at", "profile_name"],
+    )
     def test_get_sessions_heals_stale_schema_store(self, missing_column):
         import sqlite3
 
@@ -433,6 +436,63 @@ class TestWebServerEndpoints:
         finally:
             healed.close()
         assert missing_column in columns
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/api/profiles/sessions?profile=legacy&limit=50&offset=0",
+            (
+                "/api/profiles/sessions/sidebar?recents_profile=legacy"
+                "&recents_limit=50"
+            ),
+        ],
+    )
+    def test_profile_session_lists_heal_stale_schema_store(self, endpoint):
+        import sqlite3
+
+        from hermes_cli import profiles as profiles_mod
+        from hermes_state import SessionDB
+
+        profile_home = profiles_mod.get_profile_dir("legacy")
+        profile_home.mkdir(parents=True)
+        db_path = profile_home / "state.db"
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session("stale-profile-schema", source="cli")
+            seed.append_message(
+                "stale-profile-schema",
+                role="user",
+                content="hello",
+            )
+        finally:
+            seed.close()
+
+        legacy = sqlite3.connect(str(db_path))
+        try:
+            legacy.execute("ALTER TABLE sessions DROP COLUMN last_read_at")
+            legacy.commit()
+        finally:
+            legacy.close()
+
+        response = self.client.get(endpoint)
+
+        assert response.status_code == 200
+        payload = response.json()
+        if "/sidebar" in endpoint:
+            sessions = payload["recents"]["sessions"]
+        else:
+            sessions = payload["sessions"]
+        assert [row["id"] for row in sessions] == ["stale-profile-schema"]
+        assert payload["errors"] == []
+
+        healed = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1] for row in healed.execute("PRAGMA table_info(sessions)")
+            }
+        finally:
+            healed.close()
+        assert "last_read_at" in columns
 
     def test_get_sessions_zero_byte_store_returns_empty_list(self):
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop reads every profile's `state.db` in read-only mode when it builds the session list. Read-only opens skip schema reconciliation. The existing probe checked four named columns, so an older profile without `sessions.last_read_at` passed the probe and failed later with `no such column: s.last_read_at`. The cross-profile list and batched sidebar routes also opened `SessionDB` directly. They caught that failure and returned an empty list, which made intact sessions appear missing after an update or restart.

This change derives cached `LIMIT 0` probes from every table and column declared in `SCHEMA_SQL`. A current database remains read-only. A stale profile follows the existing one-time writable reconciliation path and is reopened read-only. Both cross-profile session routes now use that shared helper.

## Related Issue

Fixes #79531

This follows the direction introduced in #42487. The commit retains liuhao1024's credit and extends the fix to the current shared helper and the Desktop sidebar route. The reproduction and schema analysis from wangyi0177-eng in #79531 helped isolate the `last_read_at` case.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

`hermes_cli/web_server.py` now builds the read-only probes from `SCHEMA_SQL` and uses the existing writable reconciliation path when any declared table or column is missing.

`hermes_cli/web_routers/profiles.py` now routes both `/api/profiles/sessions` and `/api/profiles/sessions/sidebar` through `_open_session_db_for_profile`.

`tests/hermes_cli/test_web_server.py` covers missing `last_read_at` and `profile_name` columns, plus both cross-profile session endpoints.

## How to Test

1. Create a named profile database with the current `SessionDB`, add one session and one message, then remove `sessions.last_read_at` to model a database created before that column was added.
2. Request `/api/sessions`, `/api/profiles/sessions`, and `/api/profiles/sessions/sidebar`. Each route should return the existing session, and `PRAGMA table_info(sessions)` should show that `last_read_at` was restored.
3. Run the focused test and compatibility commands listed below.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Relevant documentation is unchanged; docstrings were updated where behavior changed
- [x] No config keys were added or changed
- [x] No contributor workflow or architecture document changed
- [x] I considered Windows and macOS compatibility
- [x] No tool descriptions or schemas changed

## Screenshots / Logs

```text
python -m pytest tests/hermes_cli/test_web_server.py -q
143 passed

python -m pytest tests/hermes_cli/test_dashboard_param_clamps.py -q
9 passed

python -m pytest tests/test_web_server_sessiondb_eventloop.py -q
3 passed

python scripts/check-windows-footguns.py --all
No Windows footguns found (917 files scanned)

git diff --check origin/main...HEAD
clean
```

I also started `scripts/run_tests.sh`. At 28.8%, the runner had reported 7,630 passing checks and 12 failures, so I stopped the run. The failures were outside the modified files and came from missing optional SDKs, the live-system signal guard, credential-routing expectations, and a network isolation test. The focused web server tests above all pass on the rebased commit.
