### PR TITLE
fix(email): surface IMAP fetch failures through the fatal-error hook (#80016)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -526,6 +526,11 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
 
+        # Track the last IMAP fetch attempt so the poll loop can distinguish
+        # "checked, nothing new" from "the check itself failed" (#80016).
+        self._last_fetch_failed: bool = False
+        self._last_fetch_error: str = ""
+
         # Map chat_id (sender email) -> last subject + message-id for threading
         self._thread_context: Dict[str, Dict[str, str]] = {}
 
@@ -689,6 +694,22 @@ class EmailAdapter(BasePlatformAdapter):
         # Run IMAP operations in a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
         messages = await loop.run_in_executor(None, self._fetch_new_messages)
+        if self._last_fetch_failed:
+            # The IMAP check itself failed (connect/login/select/search/fetch),
+            # not just an empty inbox. Surface it through the fatal-error hook
+            # so the gateway's existing reconnect/backoff/status machinery
+            # re-establishes the mailbox instead of silently treating every
+            # failed check as "nothing new" (#80016). The handler runs in a
+            # detached task (gateway/run.py), so awaiting it from our own poll
+            # task is safe even though teardown cancels this task.
+            self._last_fetch_failed = False
+            self._set_fatal_error(
+                "email_imap_fetch_failed",
+                self._last_fetch_error or "IMAP fetch failed",
+                retryable=True,
+            )
+            await self._notify_fatal_error()
+            return
         for msg_data in messages:
             await self._dispatch_message(msg_data)
 
@@ -788,6 +809,8 @@ class EmailAdapter(BasePlatformAdapter):
                     pass
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
+            self._last_fetch_failed = True
+            self._last_fetch_error = str(e)
         return results
 
     @staticmethod

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -581,6 +581,31 @@ class TestPollLoop(unittest.TestCase):
         self.assertEqual(len(dispatched), 1)
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
 
+    def test_check_inbox_notifies_fatal_error_on_fetch_failure(self):
+        """A failed IMAP check must surface through the fatal-error hook so
+        the gateway's reconnect/backoff machinery learns email is unhealthy
+        instead of silently treating the failed check as an empty inbox
+        (#80016)."""
+        import asyncio
+        adapter = self._make_adapter()
+        notified = []
+
+        async def mock_fatal_handler(adapter):
+            notified.append(adapter)
+
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+
+        mock_imap = MagicMock()
+        mock_imap.login.side_effect = Exception("read operation timed out")
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            asyncio.run(adapter._check_inbox())
+
+        self.assertEqual(len(notified), 1)
+        self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_failed")
+        self.assertTrue(adapter.fatal_error_retryable)
+        self.assertIn("read operation timed out", adapter.fatal_error_message)
+
 
 class TestSendEmailStandalone(unittest.TestCase):
     """Test the standalone _send_email function in send_message_tool."""


### PR DESCRIPTION
## Summary

`plugins/platforms/email/adapter.py::_fetch_new_messages()` wrapped the entire IMAP connect/login/select/search/fetch sequence in a single bare `except Exception` that logged `[Email] IMAP fetch error: %s` and returned an empty list — byte-for-byte identical to what a genuinely empty inbox returns. The caller (`_check_inbox`) therefore cannot distinguish "checked, nothing new" from "the check itself failed."

Critically, the adapter never invoked its fatal-error hook (`self._fatal_error_handler`, wired via `set_fatal_error_handler`), so the gateway's existing reconnect/backoff/status machinery (`_handle_adapter_fatal_error` in `gateway/run.py`) never learned the mailbox was unreachable. Extended outages produced zero reconnect attempts, zero platform-status change, and required a manual gateway restart.

## Fix

- `_fetch_new_messages()` now records the failure (`_last_fetch_failed` / `_last_fetch_error`) instead of silently returning an empty list.
- `_check_inbox()` (async, on the event loop) observes the flag and, on failure, sets a retryable fatal error (`email_imap_fetch_failed`) and notifies the gateway fatal-error handler. The gateway then tears the adapter down and queues the platform for background reconnection with backoff — the same path a startup connection failure takes.

The fatal handler runs in a detached shielded task (per `gateway/run.py` design), so awaiting it from the adapter's own poll task is safe even though teardown cancels that task.

## Tests

- New regression test `test_check_inbox_notifies_fatal_error_on_fetch_failure` verifies the fatal-error handler is invoked with a retryable `email_imap_fetch_failed` code when IMAP login fails.
- `tests/gateway/test_email.py`, `tests/gateway/test_email_robustness.py`, `tests/gateway/test_email_secret_scope.py`: 43 passed.

Closes #80016
