### PR TITLE
docs: compact AGENTS context and enforce budgets

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -88,12 +88,14 @@ runs:
           # die with "cannot iterate over: null", which fails every retry
           # and forces the fail-open path (seen on stacked PRs). The full
           # file list (up to the API's 300-file cap) is on page one.
+          # Include previous_filename so renaming a policy file still classifies
+          # the removed path instead of silently bypassing its test lane.
           CHANGED=""
           for i in 1 2 3; do
             if CHANGED="$(gh api \
               --paginate \
               "repos/${REPO}/compare/${BASE_SHA}...${HEAD_SHA}" \
-              --jq '.files[]?.filename')"; then
+              --jq '.files[]? | (.filename, .previous_filename) | select(. != null)')"; then
               break
             fi
             if [ "$i" = 3 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,214 +2,6 @@
 
 Instructions for AI coding assistants and developers working on the hermes-agent codebase.
 
-**Never give up on the right solution.**
-
-## What Hermes Is
-
-Hermes is a personal AI agent that runs the same agent core across a CLI, a
-messaging gateway (Telegram, Discord, Slack, and ~20 other platforms), a TUI,
-and an Electron desktop app. It learns across sessions (memory + skills),
-delegates to subagents, runs scheduled jobs, and drives a real terminal and
-browser. It is extended primarily through **plugins and skills**, not by
-growing the core.
-
-Two properties shape almost every design decision and are the lens for
-reviewing any change:
-
-- **Per-conversation prompt caching is sacred.** A long-lived conversation
-  reuses a cached prefix every turn. Anything that mutates past context,
-  swaps toolsets, or rebuilds the system prompt mid-conversation invalidates
-  that cache and multiplies the user's cost. We do not do it (the one
-  exception is context compression).
-- **The core is a narrow waist; capability lives at the edges.** Every model
-  tool we add is sent on every API call, so the bar for a new *core* tool is
-  high. Most new capability should arrive as a CLI command + skill, a
-  service-gated tool, or a plugin — not as core surface.
-
-## Contribution Rubric — What We Want / What We Don't
-
-This is the project's intent layer. Use it two ways:
-
-1. **For humans and for your own work** — what gets merged and what gets
-   rejected, so a contribution aims at the target.
-2. **For automated review (the triage sweeper)** — guidance on when a PR is
-   safe to close on the three allowed reasons (`implemented_on_main`,
-   `cannot_reproduce`, `incoherent`) and, just as important, **when NOT to
-   close** one. Taste-based "we don't want this / out of scope" closes are NOT
-   an automated decision — those stay with a human maintainer. The sweeper's
-   job here is to recognize design intent and *avoid wrongly closing a
-   legitimate contribution*, not to make the won't-implement call itself.
-
-Read the balance right: Hermes ships a **lot** — most merges are bug fixes to
-real reported behavior, and the product surface (platforms, channels,
-providers, models, desktop/TUI features) expands aggressively and on purpose.
-The restraint below is aimed squarely at the **core agent + the model tool
-schema**, the one place where every addition is paid for on every API call.
-"Smallest footprint" governs *how a capability is wired into the core*, NOT
-whether the product is allowed to grow. We are expansive at the edges and
-conservative at the waist.
-
-### What we want
-
-- **Fix real bugs, well.** The bulk of what lands is `fix(...)` against an
-  actual reported symptom. A good fix reproduces the symptom on current
-  `main`, points to the exact line where it manifests, and fixes the whole bug
-  class — sibling call paths included — not just the one site the reporter hit.
-- **Expand reach at the edges.** New platform adapters, channels, providers,
-  models, and desktop/TUI/dashboard features are welcome and land routinely,
-  including large ones (a new messaging channel, a session-cap feature, a
-  Windows PTY bridge). Breadth in the product is a goal, not a footprint
-  concern — as long as it integrates with the existing setup/config UX
-  (`hermes tools`, `hermes setup`, auto-install) rather than bolting on a raw
-  env var.
-- **Refactor god-files into clean modules.** Extracting a multi-thousand-line
-  cluster out of `cli.py` / `run_agent.py` / `gateway/run.py` into a focused
-  mixin or module is wanted work, even when the diff is huge and mechanical
-  (large `+N/-N` refactors merge regularly). The "every line traces to the
-  request" test applies to *feature* PRs; a declared refactor's request IS the
-  extraction.
-- **Keep the core narrow.** New *model tools* are the expensive exception —
-  every tool ships on every API call. Prefer, in order: extend existing code →
-  CLI command + skill → service-gated tool (`check_fn`) → plugin → MCP server
-  in the catalog → new core tool (last resort). See "The Footprint Ladder."
-- **Extend, don't duplicate.** Before adding a module/manager/hook, check
-  whether existing infrastructure already covers the use case. When several PRs
-  integrate the same *category*, design one shared interface instead of merging
-  them one at a time (see the ABC + orchestrator note under the Footprint
-  Ladder).
-- **Behavior contracts over snapshots.** Tests should assert how two pieces of
-  data must relate (invariants), not freeze a current value (model lists,
-  config version literals, enumeration counts). See "Don't write
-  change-detector tests."
-- **E2E validation, not just green unit mocks.** For anything touching
-  resolution chains, config propagation, security boundaries, remote
-  backends, or file/network I/O, exercise the real path with real imports
-  against a temp `HERMES_HOME`. Mocks hide integration bugs.
-- **Cache-, alternation-, and invariant-safe.** Preserve prompt caching, strict
-  message role alternation (never two same-role messages in a row; never a
-  synthetic user message injected mid-loop), and a system prompt that is
-  byte-stable for the life of a conversation.
-- **Contributor credit preserved.** Salvage external work by cherry-picking
-  (rebase-merge) so authorship survives in git history; don't reimplement from
-  scratch when you can build on top.
-
-### What we don't want (rejected even when well-built)
-
-- **Speculative infrastructure.** Hooks, callbacks, or extension points with no
-  concrete consumer. Adding a hook is easy; removing one after plugins depend
-  on it is hard. A hook is NOT speculative if a contributor has a real, stated
-  use case — even if the consumer ships separately.
-- **New `HERMES_*` env vars for non-secret config.** `.env` is for secrets
-  only (API keys, tokens, passwords). All behavioral settings — timeouts,
-  thresholds, feature flags, display prefs — go in `config.yaml`. Bridge to an
-  internal env var if the mechanism needs one, but user-facing docs point to
-  `config.yaml`. Reject PRs that tell users to "set X in your .env" unless X
-  is a credential.
-- **A new core tool when terminal + file already do the job, or when a skill
-  would.** If the only barrier is file visibility on a remote backend, fix the
-  mount, not the toolset.
-- **Lazy-reading escape hatches on instructional tools.** No `offset`/`limit`
-  pagination on tools that load content the agent must read fully (skills,
-  prompts, playbooks). Models will read page 1 and skip the rest.
-- **"Fixes" that destroy the feature they secure.** A mitigation that kills the
-  feature's purpose is the wrong mitigation. Read the original commit's intent
-  (`git log -p -S`) before restricting behavior; find a fix that preserves the
-  feature.
-- **Outbound telemetry / usage attribution without opt-in gating.** No new
-  analytics, third-party identifier tagging, or attribution tags until a
-  generic user-facing opt-in (config gate + setup prompt + `hermes tools`
-  toggle) exists. Park behind a label, do not merge.
-- **Change-detector tests, cache-breaking mid-conversation, dead code wired in
-  without E2E proof, and plugins that touch core files.** Plugins live in their
-  own directory and work within the ABCs/hooks we provide; if a plugin needs
-  more, widen the generic plugin surface, don't special-case it in core.
-- **Third-party products / other people's projects integrated into the core
-  tree.** Observability backends, vendor SaaS integrations, analytics dashboards,
-  and similar "someone else's product" plugins do NOT land under `plugins/` in
-  this repo. They place an ongoing maintenance burden on us to keep them working
-  against a fast-moving core, for a backend we don't own. Ship them as a
-  **standalone plugin repo** users install into `~/.hermes/plugins/` (or via a
-  pip entry point), and promote them in the Nous Research Discord
-  (`#plugins-skills-and-skins`). This is a coupling-and-maintenance decision, not
-  a quality bar — the plugin can be excellent and still be a close. PRs that add
-  such a directory to the tree are closed with a pointer to publish it as its own
-  repo.
-
-### Before you call it a bug — verify the premise (and when NOT to close)
-
-The most common reason a well-written PR gets closed is not code quality — it
-is that the change is built on a **wrong premise**, or it treats an
-**intentional design as a gap**. These patterns cut both ways: they tell a
-human reviewer what to scrutinize, and they tell the automated sweeper when a
-PR is NOT safe to close as `implemented_on_main` / `cannot_reproduce` (when in
-doubt, leave it open for a human). They are distilled from real closes.
-
-- **"Intentional design, not a gap."** A limitation that looks like an
-  oversight is often deliberate. Before "fixing" a missing link or a
-  restriction, ask whether the isolation IS the design. Example: profiles are
-  independent islands on purpose — a PR adding live config inheritance from the
-  default profile was closed because coupling profiles together is exactly what
-  the design prevents (the copy-at-creation `--clone` path already covers the
-  legitimate "start from my default" case). Read the original commit's intent
-  (`git log -p -S "<symbol>"`) before assuming something is unfinished.
-- **"The premise doesn't hold against how X actually works."** A PR's
-  justification frequently rests on a wrong mental model of an existing
-  mechanism. Trace the real code/runtime before accepting the rationale. Two
-  real closes: a rate-limit "re-probe during cooldown" PR (the breaker only
-  trips on a *confirmed-empty* account bucket, so re-probing just hammers a
-  bucket we've already proven empty); a usage-accumulation fix whose new branch
-  **never executes at runtime** because an earlier guard already popped the
-  state it depended on. If you can't point to the exact line where the bug
-  manifests AND show the fix changes that line's behavior, you haven't verified
-  the premise.
-- **"This fix was wrong — the absence/omission was deliberate."** Adding the
-  obvious-looking missing piece can break things the omission was protecting.
-  Example: restoring "missing" `__init__.py` files made a test tree importable
-  as a dotted package that shadowed the real plugin, deleting its `register()`
-  at import time. The absence was load-bearing.
-- **"Overreached / resurrected an approach we'd moved past."** Scope creep that
-  supersedes an agreed-on base, or revives a direction the maintainers
-  deliberately closed, gets rejected even when the code works. Keep the change
-  to the narrow piece that was actually agreed; offer the rest as a focused
-  follow-up.
-
-The throughline: **verify the claim AND the intent against the codebase before
-writing or merging a fix.** A confirmed reproduction on current `main` plus a
-line-level account of where the fix acts beats a plausible-sounding rationale
-every time. When in doubt about intent, it is cheaper to ask than to ship a
-fix that fights the design.
-
-### The Footprint Ladder (new capability decision)
-
-Each rung adds more permanent surface than the one above. Choose the highest
-(least-footprint) rung that correctly solves the problem:
-
-1. **Extend existing code** — the capability is a variation of something that
-   already exists. Zero new surface.
-2. **CLI command + skill** — manages config/state/infra expressible as shell
-   commands. The agent runs `hermes <subcommand>` guided by a skill. Zero
-   model-tool footprint. Default choice for subscriptions, scheduled tasks,
-   service setup. Examples: `hermes webhook`, `hermes cron`, `hermes tools`.
-3. **Service-gated tool (`check_fn`)** — needs structured params/returns AND
-   only appears when a prerequisite is configured. Zero footprint otherwise.
-   Examples: Home Assistant tools (gated on token), memory-provider tools.
-4. **Plugin** — third-party/niche/user-specific capability that doesn't ship in
-   core. Lives in `~/.hermes/plugins/` or a pip package, discovered at runtime.
-5. **MCP server (in the catalog)** — if the capability genuinely needs to be a
-   tool (structured I/O the agent invokes) but isn't core-fundamental, prefer
-   building it as an MCP server and adding it to the MCP catalog over growing
-   the core toolset. The agent connects to it through the built-in MCP client;
-   zero permanent core-schema footprint, and it's reusable by any MCP host.
-6. **New core tool** — only when the capability is fundamental, broadly useful
-   to nearly every user, and unreachable via terminal + file (or an MCP server).
-   Examples of correct core tools: terminal, read_file, web_search,
-   browser_navigate.
-
-When 3+ open PRs try to integrate the same *category* of thing (memory
-backends, providers, notifiers), don't merge them one at a time — design an
-ABC + orchestrator, wrap the existing built-in as the first provider, and turn
-the competing PRs into plugins against that interface.
-
 ## Development Environment
 
 ```bash
@@ -221,6 +13,28 @@ source .venv/bin/activate   # or: source venv/bin/activate
 `$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
 main checkout).
 
+## Where the detail lives
+
+`AGENTS.md` is capped at 20,000 chars when loaded into context
+(`CONTEXT_FILE_MAX_CHARS` in `agent/prompt_builder.py`) — anything past that is
+silently head/tail truncated. This file therefore carries only what must be true
+in *every* session. Deep reference material lives in `docs/development/` and is
+read on demand with `read_file`.
+
+| Working on | Read |
+|---|---|
+| `run_agent.py`, `cli.py`, slash commands | `docs/development/architecture-core.md` |
+| `ui-tui/`, `tui_gateway/`, dashboard chat | `docs/development/architecture-tui.md` |
+| `plugins/` (general, memory, model-provider) | `docs/development/plugins.md` |
+| Writing or reviewing a skill | `docs/development/skills-authoring.md` |
+| CLI theming | `docs/development/skins.md` |
+| Curator, cron, kanban | `docs/development/subsystems.md` |
+| `config.yaml` sections, `.env`, loaders | `docs/development/configuration.md` |
+| Test wrapper, isolation, test quality | `docs/development/testing.md` |
+
+Adding a section here? If it is reference material rather than a rule that
+applies to every change, put it in `docs/development/` and link it above.
+
 ## Project Structure
 
 File counts shift constantly — don't treat the tree below as exhaustive.
@@ -230,72 +44,36 @@ entry points you'll actually edit.
 ```
 hermes-agent/
 ├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
-├── model_tools.py        # Tool orchestration, discover_builtin_tools(), handle_function_call()
+├── model_tools.py        # Tool orchestration, handle_function_call()
 ├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
-├── cli.py                # HermesCLI class — interactive CLI orchestrator (~11k LOC)
+├── cli.py                # HermesCLI — interactive CLI orchestrator (~11k LOC)
 ├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
-├── hermes_constants.py   # get_hermes_home(), display_hermes_home() — profile-aware paths
-├── hermes_logging.py     # setup_logging() — agent.log / errors.log / gateway.log (profile-aware)
-├── batch_runner.py       # Parallel batch processing
-├── agent/                # Agent internals (provider adapters, memory, caching, compression, etc.)
-├── hermes_cli/           # CLI subcommands, setup wizard, plugins loader, skin engine
-├── tools/                # Tool implementations — auto-discovered via tools/registry.py
-│   └── environments/     # Terminal backends (local, docker, ssh, modal, daytona, singularity)
+├── hermes_constants.py   # get_hermes_home() / display_hermes_home()
+├── hermes_logging.py     # setup_logging() — profile-aware log files
+├── agent/                # Provider adapters, memory, caching, compression
+├── hermes_cli/           # CLI subcommands, setup wizard, plugins, skin engine
+├── tools/                # Tool impls — auto-discovered via tools/registry.py
+│   └── environments/     # Terminal backends (local, docker, ssh, modal, ...)
 ├── gateway/              # Messaging gateway — run.py + session.py + platforms/
-│   ├── platforms/        # Adapter per platform (telegram, discord, slack, whatsapp,
-│   │                     #   homeassistant, signal, matrix, mattermost, email, sms,
-│   │                     #   dingtalk, wecom, weixin, feishu, qqbot, bluebubbles,
-│   │                     #   yuanbao, webhook, api_server, ...). See ADDING_A_PLATFORM.md.
-│   └── builtin_hooks/    # Extension point for always-registered gateway hooks (none shipped)
-├── plugins/              # Plugin system (see "Plugins" section below)
-│   ├── memory/           # Memory-provider plugins (honcho, mem0, supermemory, ...)
-│   ├── context_engine/   # Context-engine plugins
-│   ├── model-providers/  # Inference backend plugins (openrouter, anthropic, gmi, ...)
-│   ├── kanban/           # Multi-agent board dispatcher + worker plugin
-│   ├── hermes-achievements/  # Gamified achievement tracking
-│   ├── observability/    # Metrics / traces / logs plugin
-│   ├── image_gen/        # Image-generation providers
-│   └── <others>/         # disk-cleanup, google_meet, platforms, spotify,
-│                         #   strike-freedom-cockpit, ...
-├── optional-skills/      # Heavier/niche skills shipped but NOT active by default
+│   └── platforms/        # One adapter per platform. See ADDING_A_PLATFORM.md.
+├── plugins/              # General, memory/, model-providers/, context_engine/,
+│                         #   image_gen/, kanban/, observability/, ...
 ├── skills/               # Built-in skills bundled with the repo
+├── optional-skills/      # Heavier/niche skills, NOT active by default
 ├── ui-tui/               # Ink (React) terminal UI — `hermes --tui`
-│   └── src/              # entry.tsx, app.tsx, gatewayClient.ts + app/components/hooks/lib
 ├── tui_gateway/          # Python JSON-RPC backend for the TUI
-├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains integration)
+├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains)
 ├── cron/                 # Scheduler — jobs.py, scheduler.py
-├── scripts/              # run_tests.sh, release.py, auxiliary scripts
+├── docs/development/     # Deep reference — see the table above
+├── scripts/              # run_tests.sh, release.py
 ├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files as of May 2026)
+└── tests/                # Pytest suite (~17k tests across ~900 files)
 ```
 
 **User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
 **Logs:** `~/.hermes/logs/` — `agent.log` (INFO+), `errors.log` (WARNING+),
 `gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
 Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
-
-## TypeScript Style
-
-Applies to TypeScript across Hermes: desktop, TUI, website, and future TS packages.
-
-- Prefer small nanostores over component state when state is shared, reused, or read by distant UI.
-- Let each feature own its atoms. Chat state belongs near chat, shell state near shell, shared state in `src/store`.
-- Components that render from an atom should use `useStore`. Non-rendering actions should read with `$atom.get()`.
-- Do not pass state through three components when the leaf can subscribe to the atom.
-- Keep persistence beside the atom that owns it.
-- Keep route roots thin. They compose routes and shell; they should not become controllers.
-- No monolithic hooks. A hook should own one narrow job.
-- Prefer colocated action modules over hidden god hooks.
-- If a callback is pure side effect, use the terse void form:
-  `onState={st => void setGatewayState(st)}`.
-- Async UI handlers should make intent explicit:
-  `onClick={() => void save()}`.
-- Prefer interfaces for public props and shared object shapes. Avoid `type X = { ... }` for object props.
-- Extend React primitives for props: `React.ComponentProps<'button'>`, `React.ComponentProps<typeof Dialog>`, `Omit<...>`, `Pick<...>`.
-- Table-driven beats condition ladders when mapping ids, routes, or views.
-- `src/app` owns routes, pages, and page-specific components.
-- `src/store` owns shared atoms.
-- `src/lib` owns shared pure helpers.
 
 ## File Dependency Chain
 
@@ -311,208 +89,11 @@ run_agent.py, cli.py, batch_runner.py, environments/
 
 ---
 
-## AIAgent Class (run_agent.py)
-
-The real `AIAgent.__init__` takes ~60 parameters (credentials, routing, callbacks,
-session context, budget, credential pool, etc.). The signature below is the
-minimum subset you'll usually touch — read `run_agent.py` for the full list.
-
-```python
-class AIAgent:
-    def __init__(self,
-        base_url: str = None,
-        api_key: str = None,
-        provider: str = None,
-        api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
-        model: str = "",                   # empty → resolved from config/provider later
-        max_iterations: int = 500,         # tool-calling iterations (shared with subagents)
-        enabled_toolsets: list = None,
-        disabled_toolsets: list = None,
-        quiet_mode: bool = False,
-        save_trajectories: bool = False,
-        platform: str = None,              # "cli", "telegram", etc.
-        session_id: str = None,
-        skip_context_files: bool = False,
-        skip_memory: bool = False,
-        credential_pool=None,
-        # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
-        # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
-    ): ...
-
-    def chat(self, message: str) -> str:
-        """Simple interface — returns final response string."""
-
-    def run_conversation(self, user_message: str, system_message: str = None,
-                         conversation_history: list = None, task_id: str = None) -> dict:
-        """Full interface — returns dict with final_response + messages."""
-```
-
-### Agent Loop
-
-The core loop is inside `run_conversation()` — entirely synchronous, with
-interrupt checks, budget tracking, and a one-turn grace call:
-
-```python
-while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
-        or self._budget_grace_call:
-    if self._interrupt_requested: break
-    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
-    if response.tool_calls:
-        for tool_call in response.tool_calls:
-            result = handle_function_call(tool_call.name, tool_call.args, task_id)
-            messages.append(tool_result_message(result))
-        api_call_count += 1
-    else:
-        return response.content
-```
-
-Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
-Reasoning content is stored in `assistant_msg["reasoning"]`.
-
----
-
-## CLI Architecture (cli.py)
-
-- **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
-- **KawaiiSpinner** (`agent/display.py`) — animated faces during API calls, `┊` activity feed for tool results
-- `load_cli_config()` in cli.py merges hardcoded defaults + user config YAML
-- **Skin engine** (`hermes_cli/skin_engine.py`) — data-driven CLI theming; initialized from `display.skin` config key at startup; skins customize banner colors, spinner faces/verbs/wings, tool prefix, response box, branding text
-- `process_command()` is a method on `HermesCLI` — dispatches on canonical command name resolved via `resolve_command()` from the central registry
-- Skill slash commands: `agent/skill_commands.py` scans `~/.hermes/skills/`, injects as **user message** (not system prompt) to preserve prompt caching
-
-### Slash Command Registry (`hermes_cli/commands.py`)
-
-All slash commands are defined in a central `COMMAND_REGISTRY` list of `CommandDef` objects. Every downstream consumer derives from this registry automatically:
-
-- **CLI** — `process_command()` resolves aliases via `resolve_command()`, dispatches on canonical name
-- **Gateway** — `GATEWAY_KNOWN_COMMANDS` frozenset for hook emission, `resolve_command()` for dispatch
-- **Gateway help** — `gateway_help_lines()` generates `/help` output
-- **Telegram** — `telegram_bot_commands()` generates the BotCommand menu
-- **Slack** — `slack_subcommand_map()` generates `/hermes` subcommand routing
-- **Autocomplete** — `COMMANDS` flat dict feeds `SlashCommandCompleter`
-- **CLI help** — `COMMANDS_BY_CATEGORY` dict feeds `show_help()`
-
-### Adding a Slash Command
-
-1. Add a `CommandDef` entry to `COMMAND_REGISTRY` in `hermes_cli/commands.py`:
-```python
-CommandDef("mycommand", "Description of what it does", "Session",
-           aliases=("mc",), args_hint="[arg]"),
-```
-2. Add handler in `HermesCLI.process_command()` in `cli.py`:
-```python
-elif canonical == "mycommand":
-    self._handle_mycommand(cmd_original)
-```
-3. If the command is available in the gateway, add a handler in `gateway/run.py`:
-```python
-if canonical == "mycommand":
-    return await self._handle_mycommand(event)
-```
-4. For persistent settings, use `save_config_value()` in `cli.py`
-
-**CommandDef fields:**
-- `name` — canonical name without slash (e.g. `"background"`)
-- `description` — human-readable description
-- `category` — one of `"Session"`, `"Configuration"`, `"Tools & Skills"`, `"Info"`, `"Exit"`
-- `aliases` — tuple of alternative names (e.g. `("bg",)`)
-- `args_hint` — argument placeholder shown in help (e.g. `"<prompt>"`, `"[name]"`)
-- `cli_only` — only available in the interactive CLI
-- `gateway_only` — only available in messaging platforms
-- `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
-
-**Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.
-
----
-
-## TUI Architecture (ui-tui + tui_gateway)
-
-The TUI is a full replacement for the classic (prompt_toolkit) CLI, activated via `hermes --tui` or `HERMES_TUI=1`.
-
-### Process Model
-
-```
-hermes --tui
-  └─ Node (Ink)  ──stdio JSON-RPC──  Python (tui_gateway)
-       │                                  └─ AIAgent + tools + sessions
-       └─ renders transcript, composer, prompts, activity
-```
-
-TypeScript owns the screen. Python owns sessions, tools, model calls, and slash command logic.
-
-### Transport
-
-Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. See `tui_gateway/server.py` for the full method/event catalog.
-
-### Key Surfaces
-
-| Surface | Ink component | Gateway method |
-|---------|---------------|----------------|
-| Chat streaming | `app.tsx` + `messageLine.tsx` | `prompt.submit` → `message.delta/complete` |
-| Tool activity | `thinking.tsx` | `tool.start/progress/complete` |
-| Approvals | `prompts.tsx` | `approval.respond` ← `approval.request` |
-| Clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | `clarify/sudo/secret.respond` |
-| Session picker | `sessionPicker.tsx` | `session.list/resume` |
-| Slash commands | Local handler + fallthrough | `slash.exec` → `_SlashWorker`, `command.dispatch` |
-| Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
-| Theming | `theme.ts` + `branding.tsx` | `gateway.ready` with skin data |
-
-### Slash Command Flow
-
-1. Built-in client commands (`/help`, `/quit`, `/clear`, `/resume`, `/copy`, `/paste`, etc.) handled locally in `app.tsx`
-2. Everything else → `slash.exec` (runs in persistent `_SlashWorker` subprocess) → `command.dispatch` fallback
-
-### Dev Commands
-
-```bash
-cd ui-tui
-npm install       # first time
-npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
-npm start         # production
-npm run build     # full build (hermes-ink + tsc)
-npm run typecheck # typecheck only (tsc --noEmit)
-npm run lint      # eslint
-npm run fmt       # prettier
-npm test          # vitest
-```
-
-### TUI in the Dashboard (`hermes dashboard` → `/chat`)
-
-The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes_cli/pty_bridge.py` + the `@app.websocket("/api/pty")` endpoint in `hermes_cli/web_server.py`.
-
-- Browser loads `web/src/pages/ChatPage.tsx`, which mounts xterm.js's `Terminal` with the WebGL renderer, `@xterm/addon-fit` for container-driven resize, and `@xterm/addon-unicode11` for modern wide-character widths.
-- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST, via query param (browsers can't set `Authorization` on WS upgrade).
-- The server spawns whatever `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL works, native Windows does not).
-- Frames: raw PTY bytes each direction; resize via `\x1b[RESIZE:<cols>;<rows>]` intercepted on the server and applied with `TIOCSWINSZ`.
-
-**Do not re-implement the primary chat experience in React.** The main transcript, composer/input flow (including slash-command behavior), and PTY-backed terminal belong to the embedded `hermes --tui` — anything new you add to Ink shows up in the dashboard automatically. If you find yourself rebuilding the transcript or composer for the dashboard, stop and extend Ink instead.
-
-**Structured React UI around the TUI is allowed when it is not a second chat surface.** Sidebar widgets, inspectors, summaries, status panels, and similar supporting views (e.g. `ChatSidebar`, `ModelPickerDialog`, `ToolCall`) are fine when they complement the embedded TUI rather than replacing the transcript / composer / terminal. Keep their state independent of the PTY child's session and surface their failures non-destructively so the terminal pane keeps working unimpaired.
-
-### Electron Desktop Chat App (`apps/desktop/`)
-
-A **separate** chat surface from both the classic CLI and the dashboard's embedded TUI. It is an Electron + React + nanostore renderer (`@assistant-ui/react`) that talks to a `tui_gateway` backend over JSON-RPC (`requestGateway(method, params)`). The WebSocket/JSON-RPC transport lives in the framework-agnostic `apps/shared` package (`@hermes/shared` — `JsonRpcGatewayClient` + WS URL helpers), which the web dashboard (`web/`) also consumes; **desktop has no build/runtime dependency on the dashboard frontend** — it spawns a headless `hermes serve` backend server (the same gateway `dashboard` serves, minus the browser UI entirely: `serve` sets `headless_backend=True`, so `cmd_dashboard` skips `_build_web_ui` AND exports `HERMES_SERVE_HEADLESS=1` so `mount_spa()` disables the SPA even if a stray `web_dist/` exists — only the JSON-RPC/WS/API surface is reachable). `dashboard` and `serve` share `cmd_dashboard`/`start_server` but are independent surfaces — neither launches the other. The one exception is a backward-compat *fallback*: `serve` is newer, so the desktop spawn (`electron/backend-command.ts` + `backendSupportsServe()` in `electron/main.ts`) detects whether the resolved runtime registers `serve` and, only when it does not (an older managed install / PATH `hermes` the app hasn't updated yet), rewrites the argv to the legacy `dashboard --no-open`. Without that, a new app against an un-upgraded runtime would crash on an unknown subcommand and brick every mid-upgrade user. It does NOT embed `hermes --tui` — it has its own composer, transcript, and slash-command pipeline. For scoped Desktop architecture, state, resolver, transport, and testing rules, read `apps/desktop/AGENTS.md`.
-
-**Slash commands in the desktop app are curated client-side, then dispatched to the backend.** The pipeline:
-
-- **Backend already provides everything.** `tui_gateway/server.py` `commands.catalog` (empty-query list) and `complete.slash` (typed-query completions) both include built-in commands, user `quick_commands`, AND skill-derived commands (`scan_skill_commands()` / `get_skill_commands()`). The desktop app does not need a new RPC to see skills.
-- **The renderer curates via `apps/desktop/src/lib/desktop-slash-commands.ts`.** This is the load-bearing file. It holds `DESKTOP_COMMAND_SPECS` (the built-ins and their Desktop surfaces) plus `NO_DESKTOP_SURFACE` block-lists for terminal-only / messaging-only / picker-owned / settings-owned / advanced commands that should NOT clutter the desktop popover.
-  - `isDesktopSlashCommand(name)` — gates **execution**. Returns true for built-ins AND for any non-built-in (skill / quick command), so typed extension commands run.
-  - `isDesktopSlashSuggestion(name)` — gates **discovery/completion**. Used by BOTH completion paths in `app/chat/composer/hooks/use-slash-completions.ts` (empty-query catalog filter + typed-query `complete.slash` filter) and by `filterDesktopCommandsCatalog`.
-  - `isDesktopSlashExtensionCommand(name)` — true when the command is NOT a known Hermes built-in (i.e. a skill or user quick command). Both suggestion and catalog-filter paths allow extensions through so skill commands surface in the palette. (Added when fixing "skill commands missing from the desktop slash palette" — the curated allow-list was silently dropping every skill/quick command from completions even though they executed fine when typed.)
-- **Dispatch** lives in `app/session/hooks/use-prompt-actions/slash.ts` (`runSlash`): built-ins that the desktop owns (`/skin`, `/help`, `/new`, …) are handled locally or via `commands.catalog`; everything else goes to `slash.exec`, falling back to `command.dispatch` (which the gateway resolves into skill / alias / exec directives). A skill command resolves to `{type: "skill", message}` and is submitted as a normal prompt.
-
-**Rule:** the desktop slash palette's curation is about hiding noise (terminal-only / messaging-only built-ins), NOT about hiding user-activated extensions. Skill commands and `quick_commands` are extensions the backend surfaces — they belong in completions. If you tighten `desktop-slash-commands.ts`, keep `isDesktopSlashExtensionCommand` flowing into both the suggestion and catalog-filter paths. Tests: from `apps/desktop`, run `npx vitest run src/lib/desktop-slash-commands.test.ts` (workspace dependencies are installed at the repo root).
-
----
-
 ## Adding New Tools
 
-Before adding any tool, settle the footprint question first (see "The
-Footprint Ladder" in the Contribution Rubric): most capabilities should NOT
-be core tools. For custom or local-only tools, do **not** edit Hermes core.
-Use the plugin route instead: create `~/.hermes/plugins/<name>/plugin.yaml`
-and `~/.hermes/plugins/<name>/__init__.py`, then register tools with
+For most custom or local-only tools, do **not** edit Hermes core. Use the plugin
+route instead: create `~/.hermes/plugins/<name>/plugin.yaml` and
+`~/.hermes/plugins/<name>/__init__.py`, then register tools with
 `ctx.register_tool(...)`. Plugin toolsets are discovered automatically and can be
 enabled or disabled without touching `tools/` or `toolsets.py`.
 
@@ -589,375 +170,8 @@ Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
    section is handled automatically by the deep-merge and does NOT require
    a version bump.
 
-### Top-level `config.yaml` sections (non-exhaustive):
-
-`model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
-`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
-`auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
-`plugins`, `honcho`.
-
-`auxiliary` holds per-task overrides for side-LLM work (curator, vision,
-embedding, title generation, session_search, etc.) — each task can pin
-its own provider/model/base_url/max_tokens/reasoning_effort. See
-`agent/auxiliary_client.py::_resolve_auto` for resolution order.
-
-`curator` holds the background skill-maintenance config —
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup` (nested).
-
-### .env variables (SECRETS ONLY — API keys, tokens, passwords):
-1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
-```python
-"NEW_API_KEY": {
-    "description": "What it's for",
-    "prompt": "Display name",
-    "url": "https://...",
-    "password": True,
-    "category": "tool",  # provider, tool, messaging, setting
-},
-```
-
-Non-secret settings (timeouts, thresholds, feature flags, paths, display
-preferences) belong in `config.yaml`, not `.env`. If internal code needs an
-env var mirror for backward compatibility, bridge it from `config.yaml` to
-the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
-
-### Config loaders (three paths — know which one you're in):
-
-| Loader | Used by | Location |
-|--------|---------|----------|
-| `load_cli_config()` | CLI mode | `cli.py` — merges CLI-specific defaults + user YAML |
-| `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
-| Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
-
-If you add a new key and the CLI sees it but the gateway doesn't (or vice
-versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
-
-### Working directory:
-- **CLI** — uses the process's current directory (`os.getcwd()`).
-- **Messaging** — uses `terminal.cwd` from `config.yaml`. The gateway bridges this
-  to the `TERMINAL_CWD` env var for child tools. **`MESSAGING_CWD` has been
-  removed** — the config loader prints a deprecation warning if it's set in
-  `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
-  `terminal.cwd` in `config.yaml`.
-
----
-
-## Skin/Theme System
-
-The skin engine (`hermes_cli/skin_engine.py`) provides data-driven CLI visual customization. Skins are **pure data** — no code changes needed to add a new skin.
-
-### Architecture
-
-```
-hermes_cli/skin_engine.py    # SkinConfig dataclass, built-in skins, YAML loader
-~/.hermes/skins/*.yaml       # User-installed custom skins (drop-in)
-```
-
-- `init_skin_from_config()` — called at CLI startup, reads `display.skin` from config
-- `get_active_skin()` — returns cached `SkinConfig` for the current skin
-- `set_active_skin(name)` — switches skin at runtime (used by `/skin` command)
-- `load_skin(name)` — loads from user skins first, then built-ins, then falls back to default
-- Missing skin values inherit from the `default` skin automatically
-
-### What skins customize
-
-| Element | Skin Key | Used By |
-|---------|----------|---------|
-| Banner panel border | `colors.banner_border` | `banner.py` |
-| Banner panel title | `colors.banner_title` | `banner.py` |
-| Banner section headers | `colors.banner_accent` | `banner.py` |
-| Banner dim text | `colors.banner_dim` | `banner.py` |
-| Banner body text | `colors.banner_text` | `banner.py` |
-| Response box border | `colors.response_border` | `cli.py` |
-| Spinner faces (waiting) | `spinner.waiting_faces` | `display.py` |
-| Spinner faces (thinking) | `spinner.thinking_faces` | `display.py` |
-| Spinner verbs | `spinner.thinking_verbs` | `display.py` |
-| Spinner wings (optional) | `spinner.wings` | `display.py` |
-| Tool output prefix | `tool_prefix` | `display.py` |
-| Per-tool emojis | `tool_emojis` | `display.py` → `get_tool_emoji()` |
-| Agent name | `branding.agent_name` | `banner.py`, `cli.py` |
-| Welcome message | `branding.welcome` | `cli.py` |
-| Response box label | `branding.response_label` | `cli.py` |
-| Prompt symbol | `branding.prompt_symbol` | `cli.py` |
-
-### Built-in skins
-
-- `default` — Classic Hermes gold/kawaii (the current look)
-- `ares` — Crimson/bronze war-god theme with custom spinner wings
-- `mono` — Clean grayscale monochrome
-- `slate` — Cool blue developer-focused theme
-
-### Adding a built-in skin
-
-Add to `_BUILTIN_SKINS` dict in `hermes_cli/skin_engine.py`:
-
-```python
-"mytheme": {
-    "name": "mytheme",
-    "description": "Short description",
-    "colors": { ... },
-    "spinner": { ... },
-    "branding": { ... },
-    "tool_prefix": "┊",
-},
-```
-
-### User skins (YAML)
-
-Users create `~/.hermes/skins/<name>.yaml`:
-
-```yaml
-name: cyberpunk
-description: Neon-soaked terminal theme
-
-colors:
-  banner_border: "#FF00FF"
-  banner_title: "#00FFFF"
-  banner_accent: "#FF1493"
-
-spinner:
-  thinking_verbs: ["jacking in", "decrypting", "uploading"]
-  wings:
-    - ["⟨⚡", "⚡⟩"]
-
-branding:
-  agent_name: "Cyber Agent"
-  response_label: " ⚡ Cyber "
-
-tool_prefix: "▏"
-```
-
-Activate with `/skin cyberpunk` or `display.skin: cyberpunk` in config.yaml.
-
----
-
-## Plugins
-
-Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
-repo-shipped plugins can be discovered alongside user-installed ones in
-`~/.hermes/plugins/` and pip-installed entry points.
-
-### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
-
-`PluginManager` discovers plugins from `~/.hermes/plugins/`, `./.hermes/plugins/`,
-and pip entry points. Each plugin exposes a `register(ctx)` function that
-can:
-
-- Register Python-callback lifecycle hooks:
-  `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
-  `on_session_start`, `on_session_end`
-- Register new tools via `ctx.register_tool(...)`
-- Register CLI subcommands via `ctx.register_cli_command(...)` — the
-  plugin's argparse tree is wired into `hermes` at startup so
-  `hermes <pluginname> <subcmd>` works with no change to `main.py`
-
-Hooks are invoked from `model_tools.py` (pre/post tool) and `run_agent.py`
-(lifecycle). **Discovery timing pitfall:** `discover_plugins()` only runs
-as a side effect of importing `model_tools.py`. Code paths that read plugin
-state without importing `model_tools.py` first must call `discover_plugins()`
-explicitly (it's idempotent).
-
-### Memory-provider plugins (`plugins/memory/<name>/`)
-
-Separate discovery system for pluggable memory backends. Current built-in
-providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
-
-Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
-and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
-`sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional
-`post_setup(hermes_home, config)` for setup-wizard integration.
-
-**CLI commands via `plugins/memory/<name>/cli.py`:** if a memory plugin
-defines `register_cli(subparser)`, `discover_plugin_cli_commands()` finds
-it at argparse setup time and wires it into `hermes <plugin>`. The
-framework only exposes CLI commands for the **currently active** memory
-provider (read from `memory.provider` in config.yaml), so disabled
-providers don't clutter `hermes --help`.
-
-**Rule (Teknium, May 2026):** plugins MUST NOT modify core files
-(`run_agent.py`, `cli.py`, `gateway/run.py`, `hermes_cli/main.py`, etc.).
-If a plugin needs a capability the framework doesn't expose, expand the
-generic plugin surface (new hook, new ctx method) — never hardcode
-plugin-specific logic into core. PR #5295 removed 95 lines of hardcoded
-honcho argparse from `main.py` for exactly this reason.
-
-**No new in-tree memory providers (policy, May 2026):** the set of
-built-in memory providers under `plugins/memory/` is closed. New memory
-backends must ship as **standalone plugin repos** that users install
-into `~/.hermes/plugins/` (or via pip entry points) — they implement
-the same `MemoryProvider` ABC, register through the same discovery
-path, and integrate via `hermes memory setup` / `post_setup()` without
-landing in this tree. PRs that add a new directory under
-`plugins/memory/` will be closed with a pointer to publish the
-provider as its own repo. Existing in-tree providers stay; bug fixes
-to them are welcome.
-
-**No new third-party-product plugins in-tree (policy, June 2026):** the
-same rule applies beyond memory providers. Plugins that integrate
-someone else's product or project — observability/metrics backends,
-vendor SaaS connectors, analytics dashboards, paid-service tie-ins —
-must ship as **standalone plugin repos** that users install into
-`~/.hermes/plugins/` (or via pip entry points). They register through
-the existing plugin discovery path and use the ABCs/hooks/ctx surface
-we expose; nothing special is needed in core. The reason is
-maintenance load: every product we absorb into the tree becomes our
-burden to keep working against a fast-moving core, for a backend we
-don't own. Promote standalone plugins in the Nous Research Discord
-(`#plugins-skills-and-skins`). PRs that add such a directory under
-`plugins/` are closed with a pointer to publish it as its own repo —
-this is a coupling decision, not a quality judgment. (The
-`observability/`, `kanban/`, `disk-cleanup/`, etc. directories already
-in the tree are existing precedent, not an invitation to add more
-third-party-product plugins alongside them.)
-
-### Model-provider plugins (`plugins/model-providers/<name>/`)
-
-Every inference backend (openrouter, anthropic, gmi, deepseek, nvidia, …)
-ships as a plugin here. Each plugin's `__init__.py` calls
-`providers.register_provider(ProviderProfile(...))` at module load.
-`providers/__init__.py._discover_providers()` is a **lazy, separate
-discovery system** — scanned on first `get_provider_profile()` or
-`list_providers()` call, NOT by the general PluginManager.
-
-Scan order:
-1. Bundled: `<repo>/plugins/model-providers/<name>/`
-2. User: `$HERMES_HOME/plugins/model-providers/<name>/`
-3. Legacy: `<repo>/providers/<name>.py` (back-compat)
-
-User plugins of the same name override bundled ones — `register_provider()`
-is last-writer-wins. This lets third parties swap out any built-in
-profile without a repo patch.
-
-The general PluginManager records `kind: model-provider` manifests but does
-NOT import them (would double-instantiate `ProviderProfile`). Plugins
-without an explicit `kind:` get auto-coerced via a source-text heuristic
-(`register_provider` + `ProviderProfile` in `__init__.py`).
-
-Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
-
-### Dashboard / context-engine / image-gen plugin directories
-
-`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
-pattern (ABC + orchestrator + per-plugin directory). Context engines
-plug into `agent/context_engine.py`; image-gen providers into
-`agent/image_gen_provider.py`. Reference / docs-companion plugins
-(`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
-`plugin-llm-async-example`) live in the
-[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
-companion repo, not in this tree.
-
----
-
-## Skills
-
-Two parallel surfaces:
-
-- **`skills/`** — built-in skills shipped and loadable by default.
-  Organized by category directories (e.g. `skills/github/`, `skills/mlops/`).
-- **`optional-skills/`** — heavier or niche skills shipped with the repo but
-  NOT active by default. Installed explicitly via
-  `hermes skills install official/<category>/<skill>`. Adapter lives in
-  `tools/skills_hub.py` (`OptionalSkillSource`). Categories include
-  `autonomous-ai-agents`, `blockchain`, `communication`, `creative`,
-  `devops`, `email`, `health`, `mcp`, `migration`, `mlops`, `productivity`,
-  `research`, `security`, `web-development`.
-
-When reviewing skill PRs, check which directory they target — heavy-dep or
-niche skills belong in `optional-skills/`.
-
-### SKILL.md frontmatter
-
-Standard fields: `name`, `description`, `version`, `author`, `license`,
-`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
-`metadata.hermes.tags`, `metadata.hermes.category`,
-`metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
-settings the skill needs — stored under `skills.config.<key>`, prompted
-during setup, injected at load time).
-
-Top-level `tags:` and `category:` are also accepted and mirrored from
-`metadata.hermes.*` by the loader.
-
-### Skill authoring standards (HARDLINE)
-
-Every new or modernized skill — bundled, optional, or contributed —
-must meet these standards before merge. Reviewers reject PRs that
-violate them.
-
-1. **`description` ≤ 60 characters, one sentence, ends with a period.**
-   Long descriptions bloat skill listings and dilute the model's
-   attention when many skills are loaded. State the capability, not
-   the implementation. No marketing words ("powerful",
-   "comprehensive", "seamless", "advanced"). Don't repeat the skill
-   name. Verify with:
-   ```python
-   import re, pathlib
-   m = re.search(r'^description: (.*)$',
-                 pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text(),
-                 re.MULTILINE)
-   assert len(m.group(1)) <= 60, len(m.group(1))
-   ```
-
-2. **Tools referenced in SKILL.md prose must be native Hermes tools or
-   MCP servers the skill explicitly expects.** When the skill needs a
-   capability, point at the proper tool by name in backticks
-   (`` `terminal` ``, `` `web_extract` ``, `` `read_file` ``,
-   `` `patch` ``, `` `search_files` ``, `` `vision_analyze` ``,
-   `` `browser_navigate` ``, `` `delegate_task` ``, etc.). Do NOT
-   name shell utilities the agent already has wrapped — `grep` →
-   `search_files`, `cat`/`head`/`tail` → `read_file`, `sed`/`awk` →
-   `patch`, `find`/`ls` → `search_files target='files'`. If the skill
-   depends on an MCP server, name the MCP server and document the
-   expected setup in `## Prerequisites`. Anything else (third-party
-   CLIs, shell pipelines, etc.) is fair game inside script files but
-   should not be the headline interaction surface in the prose.
-
-3. **`platforms:` gating audited against actual script imports.**
-   Skills that use POSIX-only primitives (`fcntl`, `termios`,
-   `os.setsid`, `os.kill(pid, 0)` for liveness, `/proc`, `/tmp`
-   hardcoded, `signal.SIGKILL`, bash heredocs, `osascript`, `apt`,
-   `systemctl`) must declare their supported platforms. Default
-   posture: try to fix it cross-platform first — `tempfile.gettempdir`,
-   `pathlib.Path`, `psutil.pid_exists`, Python-level filtering instead
-   of `grep`. Gate to a narrower set only when the dependency is
-   genuinely platform-bound.
-
-4. **`author` credits the human contributor first.** For external
-   contributions, the contributor's real name + GitHub handle goes
-   first; "Hermes Agent" is the secondary collaborator. If the
-   contributor's commit shows "Hermes Agent" as author (because they
-   used Hermes to draft the skill), replace it with their actual name
-   — credit the human, not the tool.
-
-5. **SKILL.md body uses the modern section order.** `# <Skill> Skill`
-   title, 2-3 sentence intro stating what it does and doesn't do,
-   `## When to Use`, `## Prerequisites`, `## How to Run`,
-   `## Quick Reference`, `## Procedure`, `## Pitfalls`,
-   `## Verification`. Target ~200 lines for a complex skill,
-   ~100 lines for a simple one. Cut redundant intro fluff, marketing
-   prose, and re-explanations of env vars already in
-   `## Prerequisites`.
-
-6. **Scripts go in `scripts/`, references in `references/`,
-   templates in `templates/`.** Don't expect the model to inline-write
-   parsers, XML walkers, or non-trivial logic every call — ship a
-   helper script. Reference it from SKILL.md by path relative to the
-   skill directory.
-
-7. **Tests live at `tests/skills/test_<skill>_skill.py`** and use only
-   stdlib + pytest + `unittest.mock`. No live network calls. Run via
-   `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`.
-
-8. **`.env.example` additions are isolated to a clearly delimited
-   block.** Don't touch the surrounding file — contributor-supplied
-   `.env.example` versions are usually stale and edits outside the
-   skill's own block must be dropped during salvage.
-
-The full salvage / modernization checklist for external skill PRs
-lives in the `hermes-agent-dev` skill at
-`references/new-skill-pr-salvage.md` — load it before polishing
-contributor skill PRs.
+Full reference — every `config.yaml` section, `.env` policy, the three
+config loaders, and working-directory resolution: `docs/development/configuration.md`.
 
 ---
 
@@ -983,10 +197,9 @@ Enable/disable per platform via `hermes tools` (the curses UI) or the
 ## Delegation (`delegate_task`)
 
 `tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. By default the parent waits for the
-child's summary before continuing its own loop. With `background=true`,
-Hermes returns a delegation id immediately and the result re-enters the
-conversation later through the async-delegation completion queue.
+context + terminal session. Synchronous: the parent waits for the
+child's summary before continuing its own loop — if the parent is
+interrupted, the child is cancelled.
 
 Two shapes:
 
@@ -998,8 +211,7 @@ Two shapes:
 Roles:
 
 - `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
-  `clarify`, `memory`, `send_message`, `cronjob`. Retains `execute_code`
-  (programmatic tool calling).
+  `clarify`, `memory`, `send_message`, `execute_code`.
 - `role="orchestrator"` — retains `delegate_task` so it can spawn its
   own workers. Gated by `delegation.orchestrator_enabled` (default true)
   and bounded by `delegation.max_spawn_depth` (default 2).
@@ -1009,122 +221,17 @@ Key config knobs (under `delegation:` in `config.yaml`):
 `orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
 `max_iterations`.
 
-Durability rule: background `delegate_task` is detached from the current
-turn but still process-local. For work that must survive process restart, use
-`cronjob` or `terminal(background=True, notify_on_complete=True)` instead.
+Synchronicity rule: delegate_task is **not** durable. For long-running
+work that must outlive the current turn, use `cronjob` or
+`terminal(background=True, notify_on_complete=True)` instead.
 
 ---
 
-## Curator (skill lifecycle)
+## Subsystems
 
-Background skill-maintenance system that tracks usage on agent-created
-skills and auto-archives stale ones. Users never lose skills; archives
-go to `~/.hermes/skills/.archive/` and are restorable.
-
-- **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
-  prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
-- **CLI:** `hermes_cli/curator.py` wires `hermes curator <verb>` where
-  verbs are: `status`, `run`, `pause`, `resume`, `pin`, `unpin`,
-  `archive`, `restore`, `prune`, `backup`, `rollback`.
-- **Telemetry:** `tools/skill_usage.py` owns the sidecar
-  `~/.hermes/skills/.usage.json` — per-skill `use_count`, `view_count`,
-  `patch_count`, `last_activity_at`, `state` (active / stale /
-  archived), `pinned`.
-
-Invariants:
-- Curator only touches skills with `created_by: "agent"` provenance —
-  bundled + hub-installed skills are off-limits.
-- Never deletes; max destructive action is archive.
-- Pinned skills are exempt from every auto-transition and from the
-  LLM review pass.
-- `skill_manage(action="delete")` refuses pinned skills; patch/edit/
-  write_file/remove_file go through so the agent can keep improving
-  pinned skills.
-
-Config section (`curator:` in `config.yaml`):
-`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup.*`.
-
-Full user-facing docs: `website/docs/user-guide/features/curator.md`.
-
----
-
-## Cron (scheduled jobs)
-
-`cron/jobs.py` (job store) + `cron/scheduler.py` (tick loop). Agents
-schedule jobs via the `cronjob` tool; users via `hermes cron <verb>`
-(`list`, `add`, `edit`, `pause`, `resume`, `run`, `remove`) or the
-`/cron` slash command.
-
-Supported schedule formats:
-- Duration: `"30m"`, `"2h"`, `"1d"`
-- "every" phrase: `"every 2h"`, `"every monday 9am"`
-- 5-field cron expression: `"0 9 * * *"`
-- ISO timestamp (one-shot): `"2026-06-01T09:00:00Z"`
-
-Per-job fields include `skills` (load specific skills), `model` /
-`provider` overrides, `script` (pre-run data-collection script whose
-stdout is injected into the prompt; `no_agent=True` turns the script
-into the entire job), `context_from` (chain job A's last output into
-job B's prompt), `workdir` (run in a specific directory with its
-`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
-
-Hardening invariants:
-- **3-minute hard interrupt** on cron sessions — runaway agent loops
-  cannot monopolize the scheduler.
-- Catchup window: half the job's period, clamped to 120s–2h.
-- Grace window: 120s for one-shot jobs whose fire time was missed.
-- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
-  across processes.
-- Cron sessions pass `skip_memory=True` by default; memory providers
-  intentionally do not run during cron.
-
-Cron deliveries are **not** mirrored into the target gateway session —
-they land in their own cron session with a header/footer frame so the
-main conversation's message-role alternation stays intact.
-
----
-
-## Kanban (multi-agent work queue)
-
-Durable SQLite-backed board that lets multiple profiles / workers
-collaborate on shared tasks. Users drive it via `hermes kanban <verb>`;
-workers spawned by the dispatcher drive it via a dedicated `kanban_*`
-toolset so their schema footprint is zero when they're not inside a
-kanban task.
-
-- **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
-  `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
-  `unlink`, `comment`, `attach`, `attachments`, `attach-rm`, `complete`,
-  `block`, `unblock`, `archive`, `tail`, plus less-commonly-used `watch`,
-  `stats`, `runs`, `log`, `assignees`, `heartbeat`, `notify-*`,
-  `dispatch`, `daemon`, `gc`.
-- **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
-  `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
-  `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_attach`,
-  `kanban_attach_url`, `kanban_attachments`; profiles that explicitly
-  enable the `kanban` toolset outside a dispatcher-spawned task also get
-  `kanban_list` and `kanban_unblock` for board routing.
-- **Dispatcher:** long-lived loop that (default every 60s) reclaims
-  stale claims, promotes ready tasks, atomically claims, and spawns
-  assigned profiles. Runs **inside the gateway** by default via
-  `kanban.dispatch_in_gateway: true`.
-- **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
-  `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
-  standalone dispatcher deployment).
-
-Isolation model:
-- **Board** is the hard boundary — workers are spawned with
-  `HERMES_KANBAN_BOARD` pinned in their env so they can't see other
-  boards.
-- **Tenant** is a soft namespace *within* a board — one specialist
-  fleet can serve multiple businesses with workspace-path + memory-key
-  isolation.
-- After `kanban.failure_limit` consecutive non-success attempts on the
-  same task (default: 2), the dispatcher auto-blocks it to prevent spin
-  loops.
-
-Full user-facing docs: `website/docs/user-guide/features/kanban.md`.
+Curator (skill lifecycle), cron (scheduled jobs), and kanban (multi-agent
+work queue) each have their own CLI, config section, and invariants.
+See `docs/development/subsystems.md` before changing any of them.
 
 ---
 
@@ -1207,7 +314,7 @@ automatically scope to the active profile.
    a unique credential (bot token, API key), call `acquire_scoped_lock()` from
    `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
    `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
-   See `plugins/platforms/irc/adapter.py` for the canonical pattern.
+   See `gateway/platforms/telegram.py` for the canonical pattern.
 
 6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
    returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
@@ -1281,155 +388,18 @@ def profile_env(tmp_path, monkeypatch):
 
 ## Testing
 
-### Python
-**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
-hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-per-file subprocess isolation via `scripts/run_tests_parallel.py` — no xdist,
-worker count auto-scaled from CPU count). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The
+script enforces hermetic parity with CI (credential vars unset, TZ=UTC,
+LANG=C.UTF-8, subprocess-per-test isolation). Direct `pytest` on a developer
+machine with API keys set diverges from CI in both directions.
 
 ```bash
 scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
-scripts/run_tests.sh tests/agent/test_foo.py -k test_x  # one test (file + -k; the runner is file-granular)
-scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
+scripts/run_tests.sh --no-isolate tests/foo/          # faster, for debugging
 ```
 
-**Flake policy:** the runner auto-retries a failing test FILE once in a fresh
-subprocess (`--file-retries`, default 1; `HERMES_TEST_FILE_RETRIES=0` to
-disable). Pass-on-retry counts as green but is printed in a `⚠ FLAKY` summary
-section with both attempts' output. A FLAKY report is a bug to fix, not noise
-to ignore — timing-sensitive tests must not assume a quiet runner (loose
-wall-clock bounds ≥ 2s, event-based sync, no `assert not _wait_until(...)`
-negative-timing races).
-
-#### Subprocess-per-test-file isolation
-
-Every test file runs in a freshly-spawned Python subprocess via `run_tests_parallel.py`. This means module-level dicts/sets and
-ContextVars from one test file cannot leak into the next.
-
-#### Why the wrapper
-
-|                     | Without wrapper                             | With wrapper                              |
-| ------------------- | ------------------------------------------- | ----------------------------------------- |
-| Provider API keys   | Whatever is in your env (auto-detects pool) | All env vars except a specific few unset. |
-| HOME / `~/.hermes/` | Your real config+auth.json                  | Temp dir per test                         |
-| Timezone            | Local TZ (PDT etc.)                         | UTC                                       |
-| Locale              | Whatever is set                             | C.UTF-8                                   |
-
-### Where to place what tests
-
-The CI change classifier (`scripts/ci/classify_changes.py`) runs specific jobs based on what files changed. A Python test that asserts
-about the contents of `package.json`, `package-lock.json`, `.ts`/`.tsx`
-source, or any other JS-side artifact will not run on a PR that only touches
-those files. This means a regression can go green on a PR and red on `main` (where the
-classifier fails open and runs everything).
-
-Any test that reads or asserts about `package.json`,
-`package-lock.json`, `tsconfig.json`, `.ts`/`.tsx`/`.js`/`.mjs`/`.cjs`
-source files configuration belongs in the JS (vitest) test suite, not in `tests/*.py`.
-
-### Don't write change-detector tests
-
-A test is a **change-detector** if it fails whenever data that is **expected
-to change** gets updated — model catalogs, config version numbers,
-enumeration counts, hardcoded lists of provider models. These tests add no
-behavioral coverage; they just guarantee that routine source updates break
-CI and cost engineering time to "fix."
-
-**Do not write:**
-
-```python
-# catalog snapshot — breaks every model release
-assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
-assert "MiniMax-M2.7" in models
-
-# config version literal — breaks every schema bump
-assert DEFAULT_CONFIG["_config_version"] == 21
-
-# enumeration count — breaks every time a skill/provider is added
-assert len(_PROVIDER_MODELS["huggingface"]) == 8
-```
-
-**Do write:**
-
-```python
-# behavior: does the catalog plumbing work at all?
-assert "gemini" in _PROVIDER_MODELS
-assert len(_PROVIDER_MODELS["gemini"]) >= 1
-
-# behavior: does migration bump the user's version to current latest?
-assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
-
-# invariant: no plan-only model leaks into the legacy list
-assert not (set(moonshot_models) & coding_plan_only_models)
-
-# invariant: every model in the catalog has a context-length entry
-for m in _PROVIDER_MODELS["huggingface"]:
-    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
-```
-
-The rule: if the test reads like a snapshot of current data, delete it. If
-it reads like a contract about how two pieces of data must relate, keep it.
-When a PR adds a new provider/model and you want a test, make the test
-assert the relationship (e.g. "catalog entries all have context lengths"),
-not the specific names.
-
-Reviewers should reject new change-detector tests; authors should convert
-them into invariants before re-requesting review.
-
-### Never read source code in tests
-
-A test that reads a source file's text is testing *the shape of the
-source code*, not its behavior. This is a hard antipattern, banned outright.
-Any test that reads a .py, .ts, .tsx, etc., file is suspect.
-
-**Why it's actively harmful, not just weak:**
-
-- It passes when the implementation is subtly broken (the regex matches a
-  call site that exists but is wired wrong) and fails when a correct
-  refactor changes formatting, variable names, or control flow with
-  identical runtime behavior. Both directions of failure are wrong.
-- It can't be run against a built/bundled/minified artifact, so it silently
-  stops testing anything the moment code moves, gets renamed, or a
-  dependency reformats it.
-- It actively blocks refactors: reviewers see "keeps a pattern intact" tests
-  fail during pure structural cleanup with no behavior change, and either
-  hand-wave the failure (dangerous) or waste time updating regexes that add
-  nothing (waste).
-- It gives false confidence. a green suite full of source-regex tests
-  looks like coverage but has never once executed the code path it claims
-  to guard.
-
-**Do not write:**
-
-```ts
-const source = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8')
-
-test('backend spawn hides the Windows console', () => {
-  assert.match(source, /spawn\(\s*backend\.command,\s*backend\.args[\s\S]{0,300}hiddenWindowsChildOptions/)
-})
-```
-
-**Do write — extract the logic into a small pure/DI-testable function and
-call it for real:**
-
-```ts
-// backend-spawn.ts
-export function hiddenWindowsChildOptions(options: SpawnOptionsLike = {}, isWindows = process.platform === 'win32') {
-  if (!isWindows || 'windowsHide' in options) return options
-  return { ...options, windowsHide: true }
-}
-
-// backend-spawn.test.ts
-test('windowsHide defaults to true on Windows, is left alone elsewhere', () => {
-  assert.equal(hiddenWindowsChildOptions({}, true).windowsHide, true)
-  assert.equal(hiddenWindowsChildOptions({}, false).windowsHide, undefined)
-  assert.equal(hiddenWindowsChildOptions({ windowsHide: false }, true).windowsHide, false)
-})
-```
-
-If the logic lives inline in a god-file (`main.ts`, `cli.py`,
-`gateway/run.py`) and extracting it feels disruptive: that's the actual
-signal to do the extraction, not to regex around it.
+Run the full suite before pushing. Tests must not write to `~/.hermes/`, and
+must not be change-detectors (snapshots of data expected to change). Rationale,
+isolation internals, and the change-detector rule: `docs/development/testing.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,7 +232,8 @@ installs use exact pins. Run `uv lock` after `pyproject.toml` changes.
 ### Testing and evidence
 
 - Always run Python tests through `scripts/run_tests.sh`; it strips credentials,
-  sets hermetic HOME/TZ/locale, and runs each file in a fresh subprocess.
+  preserves the stable real `HOME`, redirects only `HERMES_HOME` to per-test
+  temporary state, pins TZ/locale, and runs each file in a fresh subprocess.
 - Test behavior/invariants, not expected-to-change data or source-text proxies
   for executable behavior. Reading an artifact whose content is itself the
   contract (for example AGENTS/docs/lock/config artifacts) is valid in its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,9 @@ Applies to desktop, TUI, website, and future TypeScript packages.
 - Module-level `get_hermes_home()` values are safe because profile override runs
   before imports. Profile discovery is anchored to `get_default_hermes_root()`:
   normally `~/.hermes`, while custom/Docker roots remain honored.
-- Tests that mock `Path.home()` must also set `HERMES_HOME`. Platform adapters
+- Canonical tests isolate profile state through `HERMES_HOME`; the real `HOME`
+  remains stable. Direct `Path.home() / ".hermes"` access is a bug. Tests that
+  deliberately mock `Path.home()` must also set `HERMES_HOME`. Platform adapters
   using unique credentials must acquire/release scoped token locks.
 
 ### Tools and plugins

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,405 +1,262 @@
 # Hermes Agent - Development Guide
 
-Instructions for AI coding assistants and developers working on the hermes-agent codebase.
+Instructions for AI coding assistants and developers working on the
+`hermes-agent` codebase.
+
+**Never give up on the right solution.**
+
+<!-- The startup context floor is 20,000 characters. Keep this file below
+18,000 characters so headings/wrappers and future edits retain margin. -->
+
+## What Hermes Is
+
+Hermes runs the same personal-agent core across a CLI, messaging gateway, TUI,
+and Electron desktop app. It learns through memory and skills, delegates work,
+runs scheduled jobs, and drives real terminal and browser tools. Capability is
+extended primarily through plugins and skills, not by growing the core.
+
+Two properties govern almost every change:
+
+- **Per-conversation prompt caching is sacred.** Past context, toolsets, and the
+  system-prompt prefix remain byte-stable for a conversation. Compression and
+  narrowly defined explicit invalidation flows are the only established rewrite
+  boundaries; never rebuild prompt state casually mid-session.
+- **The core is a narrow waist; capability lives at the edges.** Product reach
+  should grow, but permanent agent-loop and model-tool-schema surface should not
+  grow when an existing extension path can solve the problem.
+
+## Contribution Contract
+
+This is the normative project intent. Detailed rationale and examples live in
+[`docs/development/contribution-rubric.md`](docs/development/contribution-rubric.md).
+Human setup, submission, and PR workflow live in
+[`CONTRIBUTING.md`](CONTRIBUTING.md); link it rather than duplicating it here.
+Automated triage may close only `implemented_on_main`, `cannot_reproduce`, or
+`incoherent` cases. Taste-based “won't implement” decisions stay with a human;
+when uncertain, leave the contribution open.
+
+### Aim at
+
+- **Real bug fixes.** Reproduce on current `main`, identify the exact runtime
+  line, and fix the whole class through the shared path, including siblings.
+- **Breadth at the edges.** Platforms, channels, providers, models, and UI
+  surfaces are welcome when they integrate through existing setup/config UX.
+- **Declared god-file refactors.** Focused extraction from `cli.py`,
+  `run_agent.py`, or `gateway/run.py` is valid even when mechanically large.
+- **The narrowest working footprint.** New model tools are the expensive last
+  resort because every active schema is paid on every model call.
+- **Extension rather than duplication.** Reuse existing managers, hooks, and
+  interfaces. When several real consumers establish one category, design a
+  shared ABC/orchestrator instead of merging parallel one-offs.
+- **Behavior contracts.** Test relationships and user-visible behavior, not
+  snapshots of catalogs, version literals, counts, or source-text shape.
+- **Real-path validation.** Config propagation, security boundaries, remote
+  backends, and file/network I/O require actual imports and a temp
+  `HERMES_HOME`; mocks alone do not prove the integration.
+- **Cache-, alternation-, and invariant-safe changes.** Never emit two adjacent
+  same-role messages or inject a synthetic user message mid-loop.
+- **Contributor credit.** Salvage external work by cherry-picking/rebase-merging
+  so authorship survives; do not reimplement salvageable work from scratch.
+
+### Reject even when polished
+
+- Speculative hooks, callbacks, or extension points with no concrete consumer.
+  A stated real consumer makes an extension non-speculative.
+- User-facing `HERMES_*` variables for non-secret behavior. Secrets belong in
+  `.env`; timeouts, thresholds, feature flags, paths, and preferences belong in
+  `config.yaml`.
+- A core model tool when existing terminal/file capability, a CLI command plus
+  skill, a service-gated tool, plugin, or MCP server is sufficient.
+- `offset`/`limit` escape hatches on instructional loaders such as skills,
+  prompts, and playbooks; the model must receive those documents completely.
+- Security fixes that destroy the protected feature. Read the original intent
+  before restricting behavior and preserve the useful path.
+- Outbound telemetry, attribution, or third-party identifiers without a generic
+  user opt-in gate exposed through config/setup/tooling.
+- Cache-breaking mid-conversation behavior, dead code wired without E2E proof,
+  change-detector tests, source-text tests, or plugins that special-case
+  themselves in core files.
+- New in-tree integrations for someone else's SaaS/product. Ship them as
+  standalone plugins under `~/.hermes/plugins/` or a pip entry point. Existing
+  integrations may be fixed, but they are not precedent for adding more.
+
+### Verify the premise before fixing it
+
+- Check whether the apparent limitation is intentional isolation. Read history
+  (`git log -p -S`) before coupling profiles, components, or subsystems.
+- Trace runtime reachability. A branch that cannot execute cannot explain the
+  report; point to the line where the symptom manifests and where the fix acts.
+- Treat omissions as potentially load-bearing (for example, package markers can
+  change import/shadowing behavior).
+- Do not overreach or resurrect a direction maintainers intentionally replaced.
+  Keep the PR to the agreed base and offer extras separately.
+
+### Footprint ladder
+
+Stop at the first rung that correctly solves the capability:
+
+1. Extend existing code.
+2. CLI command + skill.
+3. Service-gated tool (`check_fn`).
+4. Plugin.
+5. MCP server in the catalog.
+6. New core model tool, only when fundamental and unavailable through the above.
+
+When three or more contributions target one provider category, build one shared
+ABC/orchestrator, wrap the built-in as its first provider, and adapt competing
+work to that interface.
+
+## Context Budget and Required Reading
+
+`agent/prompt_builder.py` uses an explicit `context_file_max_chars` when set;
+otherwise it derives a model-window budget with a 20,000-character fallback and
+floor. Oversized files are head/tail truncated. Root rules therefore stay here;
+subsystem detail is loaded on demand.
+
+Read the listed reference **before editing or reviewing that area**:
+
+| Area | Required reference |
+|---|---|
+| Contribution design, triage, or policy | [Contribution rubric](docs/development/contribution-rubric.md) |
+| `run_agent.py`, `cli.py`, `model_tools.py`, `toolsets.py`, slash commands | [Core architecture](docs/development/architecture-core.md) |
+| `tools/delegate_tool.py`, subagent orchestration | [Core architecture](docs/development/architecture-core.md) |
+| `ui-tui/`, `tui_gateway/`, dashboard chat | [TUI architecture](docs/development/architecture-tui.md) |
+| `apps/desktop/` | [Desktop guide](apps/desktop/AGENTS.md) and [Desktop design](apps/desktop/DESIGN.md) |
+| Gateway lifecycle or platform adapters | [Gateway internals](website/docs/developer-guide/gateway-internals.md) and [adding a platform](gateway/platforms/ADDING_A_PLATFORM.md) |
+| `plugins/**` or plugin discovery, hooks, and providers | [Plugin system](docs/development/plugins.md) |
+| Bundled or optional skills | [Skills authoring](docs/development/skills-authoring.md) |
+| CLI skins/themes | [Skins](docs/development/skins.md) |
+| Curator, cron, or kanban | [Subsystems](docs/development/subsystems.md) |
+| Config, `.env`, loaders, working directories | [Configuration](docs/development/configuration.md) |
+| Tests, CI isolation, or test quality | [Testing](docs/development/testing.md) |
+| A new built-in model tool | [Adding tools](website/docs/developer-guide/adding-tools.md) |
+
+Root rules remain authoritative. Each listed reference owns its local details
+and procedures; if wording conflicts, root wins. Do not duplicate this contract.
+Keep startup context files below 18,000 characters and progressively loaded
+subdirectory context files below 8,000; move explanations, inventories, and
+tutorials to non-auto-loaded docs.
 
 ## Development Environment
 
 ```bash
-# Prefer .venv; fall back to venv if that's what your checkout has.
+# Prefer .venv; fall back to venv if that is what the checkout has.
 source .venv/bin/activate   # or: source venv/bin/activate
 ```
 
-`scripts/run_tests.sh` probes `.venv` first, then `venv`, then
-`$HOME/.hermes/hermes-agent/venv` (for worktrees that share a venv with the
-main checkout).
-
-## Where the detail lives
-
-`AGENTS.md` is capped at 20,000 chars when loaded into context
-(`CONTEXT_FILE_MAX_CHARS` in `agent/prompt_builder.py`) — anything past that is
-silently head/tail truncated. This file therefore carries only what must be true
-in *every* session. Deep reference material lives in `docs/development/` and is
-read on demand with `read_file`.
-
-| Working on | Read |
-|---|---|
-| `run_agent.py`, `cli.py`, slash commands | `docs/development/architecture-core.md` |
-| `ui-tui/`, `tui_gateway/`, dashboard chat | `docs/development/architecture-tui.md` |
-| `plugins/` (general, memory, model-provider) | `docs/development/plugins.md` |
-| Writing or reviewing a skill | `docs/development/skills-authoring.md` |
-| CLI theming | `docs/development/skins.md` |
-| Curator, cron, kanban | `docs/development/subsystems.md` |
-| `config.yaml` sections, `.env`, loaders | `docs/development/configuration.md` |
-| Test wrapper, isolation, test quality | `docs/development/testing.md` |
-
-Adding a section here? If it is reference material rather than a rule that
-applies to every change, put it in `docs/development/` and link it above.
-
-## Project Structure
-
-File counts shift constantly — don't treat the tree below as exhaustive.
-The canonical source is the filesystem. The notes call out the load-bearing
-entry points you'll actually edit.
-
-```
-hermes-agent/
-├── run_agent.py          # AIAgent class — core conversation loop (~12k LOC)
-├── model_tools.py        # Tool orchestration, handle_function_call()
-├── toolsets.py           # Toolset definitions, _HERMES_CORE_TOOLS list
-├── cli.py                # HermesCLI — interactive CLI orchestrator (~11k LOC)
-├── hermes_state.py       # SessionDB — SQLite session store (FTS5 search)
-├── hermes_constants.py   # get_hermes_home() / display_hermes_home()
-├── hermes_logging.py     # setup_logging() — profile-aware log files
-├── agent/                # Provider adapters, memory, caching, compression
-├── hermes_cli/           # CLI subcommands, setup wizard, plugins, skin engine
-├── tools/                # Tool impls — auto-discovered via tools/registry.py
-│   └── environments/     # Terminal backends (local, docker, ssh, modal, ...)
-├── gateway/              # Messaging gateway — run.py + session.py + platforms/
-│   └── platforms/        # One adapter per platform. See ADDING_A_PLATFORM.md.
-├── plugins/              # General, memory/, model-providers/, context_engine/,
-│                         #   image_gen/, kanban/, observability/, ...
-├── skills/               # Built-in skills bundled with the repo
-├── optional-skills/      # Heavier/niche skills, NOT active by default
-├── ui-tui/               # Ink (React) terminal UI — `hermes --tui`
-├── tui_gateway/          # Python JSON-RPC backend for the TUI
-├── acp_adapter/          # ACP server (VS Code / Zed / JetBrains)
-├── cron/                 # Scheduler — jobs.py, scheduler.py
-├── docs/development/     # Deep reference — see the table above
-├── scripts/              # run_tests.sh, release.py
-├── website/              # Docusaurus docs site
-└── tests/                # Pytest suite (~17k tests across ~900 files)
-```
-
-**User config:** `~/.hermes/config.yaml` (settings), `~/.hermes/.env` (API keys only).
-**Logs:** `~/.hermes/logs/` — `agent.log` (INFO+), `errors.log` (WARNING+),
-`gateway.log` when running the gateway. Profile-aware via `get_hermes_home()`.
-Browse with `hermes logs [--follow] [--level ...] [--session ...]`.
-
-## File Dependency Chain
-
-```
-tools/registry.py  (no deps — imported by all tool files)
-       ↑
-tools/*.py  (each calls registry.register() at import time)
-       ↑
-model_tools.py  (imports tools/registry + triggers tool discovery)
-       ↑
-run_agent.py, cli.py, batch_runner.py, environments/
-```
-
----
-
-## Adding New Tools
-
-For most custom or local-only tools, do **not** edit Hermes core. Use the plugin
-route instead: create `~/.hermes/plugins/<name>/plugin.yaml` and
-`~/.hermes/plugins/<name>/__init__.py`, then register tools with
-`ctx.register_tool(...)`. Plugin toolsets are discovered automatically and can be
-enabled or disabled without touching `tools/` or `toolsets.py`.
-
-Use the built-in route below only when the user is explicitly contributing a new
-core Hermes tool that should ship in the base system.
-
-Built-in/core tools require changes in **2 files**:
-
-**1. Create `tools/your_tool.py`:**
-```python
-import json, os
-from tools.registry import registry
-
-def check_requirements() -> bool:
-    return bool(os.getenv("EXAMPLE_API_KEY"))
-
-def example_tool(param: str, task_id: str = None) -> str:
-    return json.dumps({"success": True, "data": "..."})
-
-registry.register(
-    name="example_tool",
-    toolset="example",
-    schema={"name": "example_tool", "description": "...", "parameters": {...}},
-    handler=lambda args, **kw: example_tool(param=args.get("param", ""), task_id=kw.get("task_id")),
-    check_fn=check_requirements,
-    requires_env=["EXAMPLE_API_KEY"],
-)
-```
-
-**2. Add to `toolsets.py`** — either `_HERMES_CORE_TOOLS` (all platforms) or a new toolset. **This step is required:** auto-discovery imports the tool and registers its schema, but the tool is only *exposed to an agent* if its name appears in a toolset. `_HERMES_CORE_TOOLS` is not dead code — it's the default bundle every platform's base toolset inherits from.
-
-Auto-discovery: any `tools/*.py` file with a top-level `registry.register()` call is imported automatically — no manual import list to maintain. Wiring into a toolset is still a deliberate, manual step.
-
-The registry handles schema collection, dispatch, availability checking, and error wrapping. All handlers MUST return a JSON string.
-
-**Path references in tool schemas**: If the schema description mentions file paths (e.g. default output directories), use `display_hermes_home()` to make them profile-aware. The schema is generated at import time, which is after `_apply_profile_override()` sets `HERMES_HOME`.
-
-**State files**: If a tool stores persistent state (caches, logs, checkpoints), use `get_hermes_home()` for the base directory — never `Path.home() / ".hermes"`. This ensures each profile gets its own state.
-
-**Agent-level tools** (todo, memory): intercepted by `run_agent.py` before `handle_function_call()`. See `tools/todo_tool.py` for the pattern.
-
----
-
-## Dependency Pinning Policy
-
-All dependencies must have upper bounds to limit supply-chain attack surface.
-This policy was established after the litellm compromise (PR #2796, #2810) and
-reinforced after the Mini Shai-Hulud worm campaign (May 2026).
-
-| Source type | Treatment | Example |
-|---|---|---|
-| PyPI package | `>=floor,<next_major` | `"httpx>=0.28.1,<1"` |
-| Git URL | Commit SHA | `git+https://...@<40-char-sha>` |
-| GitHub Actions | Commit SHA + comment | `uses: actions/checkout@<sha>  # v4` |
-| CI-only pip | `==exact` | `pyyaml==6.0.2` |
-
-**When adding a new dependency to `pyproject.toml`:**
-1. Pin to `>=current_version,<next_major` for post-1.0 (e.g. `>=1.5.0,<2`).
-2. For pre-1.0 packages, use `<0.(current_minor + 2)` (e.g. `>=0.29,<0.32`).
-3. Never commit a bare `>=X.Y.Z` without a ceiling — CI and reviewers will reject it.
-4. Run `uv lock` to regenerate `uv.lock` with hashes.
-
-Reference: #2810 (bounds pass), #9801 (SHA pinning + audit CI).
-
----
-
-## Adding Configuration
-
-### config.yaml options:
-1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
-2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
-   ONLY if you need to actively migrate/transform existing user config
-   (renaming keys, changing structure). Adding a new key to an existing
-   section is handled automatically by the deep-merge and does NOT require
-   a version bump.
-
-Full reference — every `config.yaml` section, `.env` policy, the three
-config loaders, and working-directory resolution: `docs/development/configuration.md`.
-
----
-
-## Toolsets
-
-All toolsets are defined in `toolsets.py` as a single `TOOLSETS` dict.
-Each platform's adapter picks a base toolset (e.g. Telegram uses
-`"messaging"`); `_HERMES_CORE_TOOLS` is the default bundle most
-platforms inherit from.
-
-Current toolset keys: `browser`, `clarify`, `code_execution`, `cronjob`,
-`debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`,
-`feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`,
-`messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`,
-`spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`.
-
-Enable/disable per platform via `hermes tools` (the curses UI) or the
-`tools.<platform>.enabled` / `tools.<platform>.disabled` lists in
-`config.yaml`.
-
----
-
-## Delegation (`delegate_task`)
-
-`tools/delegate_tool.py` spawns a subagent with an isolated
-context + terminal session. Synchronous: the parent waits for the
-child's summary before continuing its own loop — if the parent is
-interrupted, the child is cancelled.
-
-Two shapes:
-
-- **Single:** pass `goal` (+ optional `context`, `toolsets`).
-- **Batch (parallel):** pass `tasks: [...]` — each gets its own subagent
-  running concurrently. Concurrency is capped by
-  `delegation.max_concurrent_children` (default 3).
-
-Roles:
-
-- `role="leaf"` (default) — focused worker. Cannot call `delegate_task`,
-  `clarify`, `memory`, `send_message`, `execute_code`.
-- `role="orchestrator"` — retains `delegate_task` so it can spawn its
-  own workers. Gated by `delegation.orchestrator_enabled` (default true)
-  and bounded by `delegation.max_spawn_depth` (default 2).
-
-Key config knobs (under `delegation:` in `config.yaml`):
-`max_concurrent_children`, `max_spawn_depth`, `child_timeout_seconds`,
-`orchestrator_enabled`, `subagent_auto_approve`, `inherit_mcp_toolsets`,
-`max_iterations`.
-
-Synchronicity rule: delegate_task is **not** durable. For long-running
-work that must outlive the current turn, use `cronjob` or
-`terminal(background=True, notify_on_complete=True)` instead.
-
----
-
-## Subsystems
-
-Curator (skill lifecycle), cron (scheduled jobs), and kanban (multi-agent
-work queue) each have their own CLI, config section, and invariants.
-See `docs/development/subsystems.md` before changing any of them.
-
----
-
-## Important Policies
-
-### Prompt Caching Must Not Break
-
-Hermes-Agent ensures caching remains valid throughout a conversation. **Do NOT implement changes that would:**
-- Alter past context mid-conversation
-- Change toolsets mid-conversation
-- Reload memories or rebuild system prompts mid-conversation
-
-Cache-breaking forces dramatically higher costs. The ONLY time we alter context is during context compression.
-
-Slash commands that mutate system-prompt state (skills, tools, memory, etc.)
-must be **cache-aware**: default to deferred invalidation (change takes
-effect next session), with an opt-in `--now` flag for immediate
-invalidation. See `/skills install --now` for the canonical pattern.
-
-### Background Process Notifications (Gateway)
-
-When `terminal(background=true, notify_on_complete=true)` is used, the gateway runs a watcher that
-detects process completion and triggers a new agent turn. Control verbosity of background process
-messages with `display.background_process_notifications`
-in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
-
-- `all` — running-output updates + final message (default)
-- `result` — only the final completion message
-- `error` — only the final message when exit code != 0
-- `off` — no watcher messages at all
-
----
-
-## Profiles: Multi-Instance Support
-
-Hermes supports **profiles** — multiple fully isolated instances, each with its own
-`HERMES_HOME` directory (config, API keys, memory, sessions, skills, gateway, etc.).
-
-The core mechanism: `_apply_profile_override()` in `hermes_cli/main.py` sets
-`HERMES_HOME` before any module imports. All `get_hermes_home()` references
-automatically scope to the active profile.
-
-### Rules for profile-safe code
-
-1. **Use `get_hermes_home()` for all HERMES_HOME paths.** Import from `hermes_constants`.
-   NEVER hardcode `~/.hermes` or `Path.home() / ".hermes"` in code that reads/writes state.
-   ```python
-   # GOOD
-   from hermes_constants import get_hermes_home
-   config_path = get_hermes_home() / "config.yaml"
-
-   # BAD — breaks profiles
-   config_path = Path.home() / ".hermes" / "config.yaml"
-   ```
-
-2. **Use `display_hermes_home()` for user-facing messages.** Import from `hermes_constants`.
-   This returns `~/.hermes` for default or `~/.hermes/profiles/<name>` for profiles.
-   ```python
-   # GOOD
-   from hermes_constants import display_hermes_home
-   print(f"Config saved to {display_hermes_home()}/config.yaml")
-
-   # BAD — shows wrong path for profiles
-   print("Config saved to ~/.hermes/config.yaml")
-   ```
-
-3. **Module-level constants are fine** — they cache `get_hermes_home()` at import time,
-   which is AFTER `_apply_profile_override()` sets the env var. Just use `get_hermes_home()`,
-   not `Path.home() / ".hermes"`.
-
-4. **Tests that mock `Path.home()` must also set `HERMES_HOME`** — since code now uses
-   `get_hermes_home()` (reads env var), not `Path.home() / ".hermes"`:
-   ```python
-   with patch.object(Path, "home", return_value=tmp_path), \
-        patch.dict(os.environ, {"HERMES_HOME": str(tmp_path / ".hermes")}):
-       ...
-   ```
-
-5. **Gateway platform adapters should use token locks** — if the adapter connects with
-   a unique credential (bot token, API key), call `acquire_scoped_lock()` from
-   `gateway.status` in the `connect()`/`start()` method and `release_scoped_lock()` in
-   `disconnect()`/`stop()`. This prevents two profiles from using the same credential.
-   See `gateway/platforms/telegram.py` for the canonical pattern.
-
-6. **Profile operations are HOME-anchored, not HERMES_HOME-anchored** — `_get_profiles_root()`
-   returns `Path.home() / ".hermes" / "profiles"`, NOT `get_hermes_home() / "profiles"`.
-   This is intentional — it lets `hermes -p coder profile list` see all profiles regardless
-   of which one is active.
+`scripts/run_tests.sh` also probes `$HOME/.hermes/hermes-agent/venv`, allowing
+worktrees to share the managed checkout's environment.
+
+Load-bearing root entry points are `run_agent.py` (conversation loop),
+`model_tools.py` (tool orchestration), `toolsets.py` (tool exposure), `cli.py`
+(interactive CLI), and `hermes_state.py` (session store). Inspect the filesystem
+and real definitions/usages rather than trusting a static inventory.
+
+## TypeScript Style
+
+Applies to desktop, TUI, website, and future TypeScript packages.
+
+- Put shared/reused/distant UI state in small feature-owned nanostores; renderers
+  use `useStore`, while non-rendering actions read with `$atom.get()`.
+- Keep persistence beside its owning atom and declare whether the key is global,
+  profile-, connection-, project-, session-, or window-scoped.
+- Do not prop-drill through three components when the leaf can subscribe.
+- Keep route roots thin. Prefer narrow hooks and colocated action modules over
+  controller pages or monolithic hooks.
+- Make side-effect intent explicit: `onState={st => void setState(st)}` and
+  `onClick={() => void save()}`.
+- Prefer interfaces for public props/object shapes and extend React primitives
+  with `React.ComponentProps`, `Omit`, or `Pick`.
+- Prefer table-driven mappings over condition ladders.
+- `src/app` owns routes/pages, `src/store` shared atoms, and `src/lib` shared
+  pure helpers.
+
+## Global Engineering Contracts
+
+### Prompt and conversation state
+
+- Never alter past messages, toolsets, memories, or the system-prompt prefix in
+  a live conversation. Skill mutations default to the next session; only
+  `/skills install|uninstall|reset --now` deliberately uses the established
+  immediate invalidation flow. Do not generalize `--now` to other prompt state.
+- Maintain strict role alternation. Do not manufacture user turns to steer the
+  loop.
+- Preserve the feature while hardening it, and prove resolution chains with real
+  imports instead of wiring dormant code from unit mocks.
+
+### Configuration
+
+- New user-facing behavioral settings go in `config.yaml`; credentials go in
+  `.env`. Legacy, internal, platform, and plugin environment bridges still
+  exist, so do not describe runtime env as secret-only. Adding a config key is
+  deep-merged and does not require a version bump; bump only for migration.
+
+### Profiles (Multi-Instance Support)
+
+- Use `get_hermes_home()` for active-profile state and
+  `display_hermes_home()` in user-facing paths. Never hardcode `~/.hermes` or
+  `Path.home() / ".hermes"` for profile-scoped state.
+- Module-level `get_hermes_home()` values are safe because profile override runs
+  before imports. Profile discovery is anchored to `get_default_hermes_root()`:
+  normally `~/.hermes`, while custom/Docker roots remain honored.
+- Tests that mock `Path.home()` must also set `HERMES_HOME`. Platform adapters
+  using unique credentials must acquire/release scoped token locks.
+
+### Tools and plugins
+
+- Built-in tool modules register with `tools.registry`, return JSON strings, and
+  must also be exposed through `_HERMES_CORE_TOOLS` or another toolset. Use
+  `check_fn` for optional prerequisites.
+- `TOOLSETS` in `toolsets.py` is the built-in registry and
+  `_HERMES_CORE_TOOLS` supplies inherited defaults; `get_all_toolsets()` and
+  `get_toolset_names()` also merge plugin-registered dynamic toolsets. Configure
+  platform choices through `hermes tools`/`platform_toolsets`;
+  `agent.disabled_toolsets` is the final global suppression layer.
+- Tool schema paths use `display_hermes_home()`; persistent tool state uses
+  `get_hermes_home()`.
+- Do not hardcode another tool's name in a schema when that toolset may be
+  disabled. Add conditional cross-references while assembling definitions.
+- Plugins stay behind generic hooks/ABCs and do not modify core files for
+  plugin-specific behavior. New memory backends and third-party products ship
+  as standalone plugin repositories.
+
+### Dependencies
+
+All dependencies have upper bounds: PyPI packages use
+`>=floor,<next-major` (pre-1.0: `<0.(current minor + 2)`), git dependencies use a
+full commit SHA, GitHub Actions use a SHA plus version comment, and CI-only pip
+installs use exact pins. Run `uv lock` after `pyproject.toml` changes.
+
+### Testing and evidence
+
+- Always run Python tests through `scripts/run_tests.sh`; it strips credentials,
+  sets hermetic HOME/TZ/locale, and runs each file in a fresh subprocess.
+- Test behavior/invariants, not expected-to-change data or source-text proxies
+  for executable behavior. Reading an artifact whose content is itself the
+  contract (for example AGENTS/docs/lock/config artifacts) is valid in its
+  appropriate suite. Put JS-artifact tests in Vitest, not Python.
+- File/network/config/security/remote changes require real-path coverage against
+  a temp `HERMES_HOME`. Tests never write to the user's real home.
+- Before claiming completion, run the focused suite and inspect the final diff.
+  See `docs/development/testing.md` for runner and flake policy.
 
 ## Known Pitfalls
 
-### DO NOT hardcode `~/.hermes` paths
-Use `get_hermes_home()` from `hermes_constants` for code paths. Use `display_hermes_home()`
-for user-facing print/log messages. Hardcoding `~/.hermes` breaks profiles — each profile
-has its own `HERMES_HOME` directory. This was the source of 5 bugs fixed in PR #3575.
-
-### DO NOT introduce new `simple_term_menu` usage
-Existing call sites in `hermes_cli/main.py` remain for legacy fallback only;
-the preferred UI is curses (stdlib) because `simple_term_menu` has
-ghost-duplication rendering bugs in tmux/iTerm2 with arrow keys. New
-interactive menus must use `hermes_cli/curses_ui.py` — see
-`hermes_cli/tools_config.py` for the canonical pattern.
-
-### DO NOT use `\033[K` (ANSI erase-to-EOL) in spinner/display code
-Leaks as literal `?[K` text under `prompt_toolkit`'s `patch_stdout`. Use space-padding: `f"\r{line}{' ' * pad}"`.
-
-### `_last_resolved_tool_names` is a process-global in `model_tools.py`
-`_run_single_child()` in `delegate_tool.py` saves and restores this global around subagent execution. If you add new code that reads this global, be aware it may be temporarily stale during child agent runs.
-
-### DO NOT hardcode cross-tool references in schema descriptions
-Tool schema descriptions must not mention tools from other toolsets by name (e.g., `browser_navigate` saying "prefer web_search"). Those tools may be unavailable (missing API keys, disabled toolset), causing the model to hallucinate calls to non-existent tools. If a cross-reference is needed, add it dynamically in `get_tool_definitions()` in `model_tools.py` — see the `browser_navigate` / `execute_code` post-processing blocks for the pattern.
-
-### The gateway has TWO message guards — both must bypass approval/control commands
-When an agent is running, messages pass through two sequential guards:
-(1) **base adapter** (`gateway/platforms/base.py`) queues messages in
-`_pending_messages` when `session_key in self._active_sessions`, and
-(2) **gateway runner** (`gateway/run.py`) intercepts `/stop`, `/new`,
-`/queue`, `/status`, `/approve`, `/deny` before they reach
-`running_agent.interrupt()`. Any new command that must reach the runner
-while the agent is blocked (e.g. approval prompts) MUST bypass BOTH
-guards and be dispatched inline, not via `_process_message_background()`
-(which races session lifecycle).
-
-### Squash merges from stale branches silently revert recent fixes
-Before squash-merging a PR, ensure the branch is up to date with `main`
-(`git fetch origin main && git reset --hard origin/main` in the worktree,
-then re-apply the PR's commits). A stale branch's version of an unrelated
-file will silently overwrite recent fixes on main when squashed. Verify
-with `git diff HEAD~1..HEAD` after merging — unexpected deletions are a
-red flag.
-
-### Don't wire in dead code without E2E validation
-Unused code that was never shipped was dead for a reason. Before wiring an
-unused module into a live code path, E2E test the real resolution chain
-with actual imports (not mocks) against a temp `HERMES_HOME`.
-
-### Tests must not write to `~/.hermes/`
-The `_isolate_hermes_home` autouse fixture in `tests/conftest.py` redirects `HERMES_HOME` to a temp dir. Never hardcode `~/.hermes/` paths in tests.
-
-**Profile tests**: When testing profile features, also mock `Path.home()` so that
-`_get_profiles_root()` and `_get_default_hermes_home()` resolve within the temp dir.
-Use the pattern from `tests/hermes_cli/test_profiles.py`:
-```python
-@pytest.fixture
-def profile_env(tmp_path, monkeypatch):
-    home = tmp_path / ".hermes"
-    home.mkdir()
-    monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    monkeypatch.setenv("HERMES_HOME", str(home))
-    return home
-```
-
----
-
-## Testing
-
-**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The
-script enforces hermetic parity with CI (credential vars unset, TZ=UTC,
-LANG=C.UTF-8, subprocess-per-test isolation). Direct `pytest` on a developer
-machine with API keys set diverges from CI in both directions.
-
-```bash
-scripts/run_tests.sh                                  # full suite, CI-parity
-scripts/run_tests.sh tests/gateway/                   # one directory
-scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
-scripts/run_tests.sh --no-isolate tests/foo/          # faster, for debugging
-```
-
-Run the full suite before pushing. Tests must not write to `~/.hermes/`, and
-must not be change-detectors (snapshots of data expected to change). Rationale,
-isolation internals, and the change-detector rule: `docs/development/testing.md`.
+- **No new `simple_term_menu`.** Legacy call sites remain, but new interactive
+  menus use `hermes_cli/curses_ui.py`.
+- **No `\033[K` in spinner/display code.** It leaks through
+  `prompt_toolkit.patch_stdout`; clear with space padding.
+- **`_last_resolved_tool_names` is process-global.** Delegate execution saves and
+  restores it; code reading it during child execution may observe stale state.
+- **Gateway controls cross two guards.** Approval/control commands must bypass
+  both the base adapter's active-session queue and `gateway/run.py` dispatch,
+  inline rather than through `_process_message_background()`.
+- **Tracked background work needs notification.** Use
+  `terminal(background=True, notify_on_complete=True)` for bounded work; gateway
+  verbosity is controlled by `display.background_process_notifications`.
+- **Stale squash merges can revert unrelated fixes.** Recut on current `main`,
+  preserve contributor commits, and inspect the resulting merge diff.
+- **Missing files may be intentional.** In particular, adding `__init__.py` can
+  make a test directory shadow the real plugin package.
+- **Do not wire dead code without E2E validation.** Reachability through the real
+  CLI/gateway/provider/tool path is the proof.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,9 +205,8 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 # via run_tests_parallel.py, worker count auto-scaled); see AGENTS.md
 scripts/run_tests.sh
 
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
+# Focused run through the same hermetic wrapper:
+scripts/run_tests.sh tests/agent/test_foo.py -v
 ```
 
 ---
@@ -396,8 +395,9 @@ You must still add the tool name to the appropriate list in `toolsets.py`
 registers but is never exposed to the agent. If you introduce a new toolset,
 add it in `toolsets.py` and wire it into the relevant platform presets.
 
-See `AGENTS.md` (section **Adding New Tools**) for profile-aware paths and
-plugin vs core guidance.
+See the `AGENTS.md` **Footprint ladder** and
+`website/docs/developer-guide/adding-tools.md` for profile-aware paths and
+plugin-vs-core guidance.
 
 ---
 
@@ -944,7 +944,7 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `scripts/run_tests.sh` (recommended; same as CI) or `pytest tests/ -v` with the project venv activated
+1. **Run tests**: `scripts/run_tests.sh` (same as CI; pass paths/flags for focused runs)
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
 4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,202 +1,144 @@
 # Desktop Engineering Guide
 
-How to build Hermes Desktop well. This is a judgment guide, not an inventory —
-it teaches the invariants and the reasoning behind them so a change fits the app
-even as files move. Read it with the repository `AGENTS.md` (root rules still
-apply) and [`DESIGN.md`](./DESIGN.md) for the visual and interaction contract.
+Read this with the repository `AGENTS.md` and [`DESIGN.md`](./DESIGN.md).
+Root rules still apply; `DESIGN.md` owns the visual/interaction contract.
 
-When a rule here and the code disagree, trust the code and fix whichever is
-wrong — but never break an invariant to make a change easier.
+<!-- Progressive subdirectory hints cap each file at 8,000 characters. Keep this
+file below 7,500 so future edits retain margin. -->
 
-## What this app is
+## Authority and boundaries
 
-Desktop is its own native chat surface. It is not the browser dashboard and it
-does not embed the TUI. Three parties, each authoritative for one thing:
+Desktop is its own Electron + React chat surface. It is not the dashboard and
+does not embed the TUI.
 
-- **Electron** owns the machine: process lifecycle, native filesystem/git/
-  windows, install/update, and a narrow, typed capability bridge.
-- **The renderer** owns the experience: navigation, presentation, and ephemeral
-  interaction state.
-- **The agent backend** owns the work: sessions, tools, model calls, streaming.
+- **Electron** owns machine facts: process/window lifecycle, native filesystem
+  and git access, install/update, and a narrow typed capability bridge.
+- **The renderer** owns navigation, presentation, and window-local interaction.
+  It never reaches for Node/Electron directly.
+- **The agent backend** owns sessions, tools, model calls, and streaming. Agent
+  behavior stays behind the gateway rather than being reimplemented in React.
 
-Keep the seams clean. The renderer never reaches for Node or Electron directly;
-native power arrives through a deliberate capability, not a general escape hatch.
-Agent behavior lives behind the gateway, never reimplemented in React. When a
-change blurs a seam, that is the smell — fix the seam, don't widen it.
+Put state with the authority allowed to be right. Backend-shaped data in the
+renderer is a cache, Electron owns runtime facts, and components own only local
+presentation. Shared renderer state lives in small feature-owned stores;
+request-shaped server data uses the query layer; hot coordination that must not
+paint stays in refs. Persisted keys declare their scope (global, connection,
+profile, session, project, or window) so one context cannot bleed into another.
 
-## Decide state by authority
+## Identity and reconciliation
 
-The first question for any piece of state is *who is allowed to be right about
-it*, not where it is convenient to store it. Put state with its authority:
+Do not conflate session identities: stable/durable identity keys navigation and
+persisted UI, runtime identity keys live streaming, and lineage identity keys
+state that survives compression. Translate explicitly at boundaries.
 
-- The **backend** is authoritative for anything another Hermes surface can also
-  change. Treat the renderer's copy as a cache of that truth.
-- **Electron** is authoritative for machine and runtime facts.
-- The **renderer** owns only what is purely about this window's presentation.
+The renderer reconciles backend truth:
 
-From that, everything else follows: shared renderer state lives in small stores
-owned by the feature that owns the concern; request-shaped server data that wants
-invalidation lives in the query layer; short-lived interaction detail stays in
-the component; hot coordination that must not paint stays in a ref. Reach for the
-narrowest home that still lets the state be correct. A new global store is a
-claim that many distant surfaces need it — earn that claim.
+- Merge refreshes without dropping live or pinned rows.
+- Paint optimistic direct manipulation from a snapshot; visibly roll back a
+  failed write and let authoritative refresh win.
+- Guard async results with request tokens/generations so stale work cannot
+  overwrite newer intent.
+- Only the foreground selection publishes to the shared view; background work
+  updates its own cache.
+- Coalesce cosmetic churn but flush terminal transitions immediately.
+- Preserve reference identity on no-op updates to avoid expensive rerenders.
 
-Persisted state must declare its scope in its own key: is this global, or does it
-belong to a connection, a profile, a stored session, a project, or a window?
-Getting the scope wrong is how one profile's setting bleeds into another.
+## Switching context
 
-## Identity is not incidental
+A switch re-homes the workspace rather than rebooting everything:
 
-Sessions have more than one identity, and conflating them is a recurring source
-of "session not found" and vanishing history. Reason about which identity a
-surface needs: durable navigation and anything the user pins or persists key off
-the stable/durable identity; live streaming keys off the runtime identity; state
-that must outlive compression keys off the lineage root. Keep the mapping between
-them explicit and translate at the boundary rather than passing the wrong id
-inward.
+- **Connection/mode apply** (local/remote/cloud) keeps the shell mounted, clears
+  gateway-bound stores explicitly, then reconnects. Query invalidation alone is
+  insufficient.
+- **Runtime `HERMES_HOME` change** is a hard re-home: tear down the primary
+  backend, reload/remount the renderer, and reset window-scoped state. Never
+  model it as a soft in-renderer switch.
+- **Live profile swap** changes the active socket while background profiles keep
+  streaming; lists merge, and only explicit user selection starts a fresh draft.
 
-## Server truth is cached, not owned
+After a switch, active socket, profile, connection atoms, REST routing, and
+filesystem routing must agree. Reserve full-screen boot state for a genuinely
+unusable backend.
 
-The renderer paints from a cache of backend truth, so it must reconcile, not
-assume:
+## Resolver and compatibility contract
 
-- **Merge, don't clobber.** A refresh is new information layered over what you
-  already know, not a replacement that can drop live or pinned rows.
-- **Be optimistic, then honest.** Direct manipulation should paint immediately
-  from a snapshot; a failed write rolls back visibly and an authoritative
-  refresh gets the last word.
-- **Guard against the past.** Async results can arrive out of order; a stale
-  response must never overwrite newer intent. Generation counters and request
-  tokens exist for this.
-- **Isolate the foreground.** Only the surface the user is looking at may publish
-  into the shared view; background work updates its own cache quietly.
-- **Coalesce noise, flush signal.** Batch high-frequency cosmetic updates, but
-  let terminal transitions (a turn finishing, needing input, failing) reach the
-  user immediately.
-- **Preserve reference identity on no-ops.** Handing React a fresh array that
-  contains the same data re-renders expensive trees for nothing.
+Every discovery/auth/version/capability policy has one ordered resolver:
 
-## Switching context is a re-home, not a reboot
+1. Express precedence once as data or a pure function.
+2. Validate each candidate at the boundary; existence is not proof.
+3. Failed reads may fall through; failed authoritative writes surface or roll
+   back rather than silently retargeting.
+4. Distinguish missing capability from transient failure.
+5. Bound retries and end with a real recovery action.
 
-Changing profile, connection, or mode is a workspace switch, not a cold start.
-The shell and whatever the user was doing stay put; only the gateway-bound view
-is cleared and repopulated, and the previous context must not leak into the next
-one. Reserve the full-screen boot/connecting experience for a genuinely unusable
-backend.
+Mint a fresh one-time OAuth/WebSocket ticket for every dial; never reuse it or
+fall back to a cached URL. Only confirmed 401/403 or explicitly tagged auth
+rejection means reauthentication. Network, timeout, malformed-response, and
+server failures stay connectivity errors. Only long-lived token/local auth may
+reuse a cached URL as a lower rung. Connection tests exercise the actual
+WebSocket/auth leg, not only an HTTP status probe.
 
-There are three distinct switch shapes, and conflating them is the classic bug:
+Desktop and runtime update on separate clocks. Compatibility fallbacks must be
+narrow, tied to an identified older runtime, preserve the feature, and have a
+test. Do not build a universal extension ABI for one consumer; internal
+registries are composition seams, and Hermes plugin surfaces are not
+interchangeable.
 
-- A **connection/mode apply** (local ↔ remote ↔ cloud) is the soft re-home:
-  shell mounted, gateway-bound stores explicitly wiped, then reconnect. Query
-  invalidation alone cannot evict live session stores — wipe them.
-- A **runtime home change** (switching the underlying `HERMES_HOME` profile) is
-  a hard re-home: the window legitimately reloads and state resets by remount.
-- A **live profile swap** in the same window activates another profile's socket
-  while background profiles keep streaming; lists merge rather than wipe, and
-  only an explicit user selection starts a fresh foreground draft.
+## Backend and transport
 
-Treating a soft switch as hard flickers the app; treating a hard one as soft
-strands stale rows. After any swap, the active socket, active profile, and
-connection atoms must agree, or REST and filesystem calls route to the wrong
-backend.
+The renderer talks to `tui_gateway` over JSON-RPC. Framework-agnostic transport
+lives in `apps/shared` (`@hermes/shared`: `JsonRpcGatewayClient` and WebSocket URL
+helpers), which the web dashboard also consumes; Desktop has no build/runtime
+dependency on the dashboard frontend.
 
-## Cross everything as an observable ladder
+Electron normally spawns headless `hermes serve`. `serve` and `dashboard` share
+backend setup but neither launches the other; headless mode does not build or
+mount the SPA. `backendSupportsServe()` may rewrite the command to legacy
+`dashboard --no-open` only for an older runtime that does not register `serve`.
+Do not broaden that fallback.
 
-Desktop lives at the seams: versions, profiles, local vs remote vs cloud,
-partially installed runtimes, stale caches, older backends. The durable technique
-for all of it is the same — an ordered ladder of candidates:
+## Slash commands and extensions
 
-1. Precedence is written down, in one place, as data or a pure function.
-2. A candidate is trusted only after it is validated at the right boundary.
-   Existence is not proof; probe what you're about to rely on.
-3. A failed *read* falls to the next rung; a failed *authoritative write*
-   surfaces or rolls back rather than silently retargeting.
-4. A missing capability and a transient failure are different: the first may
-   enable a compatibility path or a disabled state; the second should retry.
-5. Retries are bounded and end in a real recovery affordance — never an infinite
-   spinner or a hot loop.
-6. One resolver owns each policy so every caller gets the same answer. Scatter is
-   how two call sites drift apart.
+The backend already exposes built-ins, user `quick_commands`, and skill-derived
+commands through `commands.catalog` and `complete.slash`. Do not add another RPC.
 
-This is the shape of backend discovery, command/version fallbacks, connection and
-auth resolution, workspace-cwd selection, capability detection, and preview
-normalization alike. Learn the shape, not a snapshot of the current rungs.
+`src/lib/desktop-slash-commands.ts` curates Desktop built-ins:
 
-Two auth-flavored corollaries worth naming because they are easy to get wrong:
+- `isDesktopSlashCommand` gates execution and allows non-built-in extensions.
+- `isDesktopSlashSuggestion` gates discovery for both empty-query catalog and
+  typed-query completion paths.
+- `isDesktopSlashExtensionCommand` identifies skills/quick commands. Both the
+  suggestion path and `filterDesktopCommandsCatalog` must allow it through.
 
-- **One-time credentials are never reused.** An OAuth gateway connection mints a
-  fresh WebSocket ticket on every dial and never falls back to the cached URL.
-  Only a confirmed 401/403 (or an explicitly tagged auth rejection) means
-  reauthentication; timeout, network, malformed-response, and server failures
-  remain connectivity errors. Only long-lived token/local auth may reuse a
-  cached URL as a lower rung.
-- **A connection test must exercise the leg you'll actually use.** An HTTP
-  status probe passing while the WebSocket/auth leg fails is a false positive
-  that ships as "it said connected but nothing works."
+Curation hides built-ins with no Desktop surface; it must not hide user-enabled
+extensions. Typed extension commands dispatch through `slash.exec`, then
+`command.dispatch`; a skill result becomes a normal prompt. Desktop-owned
+built-ins remain local or use `commands.catalog`.
 
-## Compatibility without carrying the past forever
+Regression check:
 
-Desktop and its runtime update on separate clocks, so a change can meet an older
-backend. Keep those users working: preserve the current feature, keep the
-fallback narrow and tied to an identified older runtime, and cover it with a
-test. A fallback that quietly degrades the feature it's meant to protect is worse
-than the crash it replaced.
+```bash
+cd apps/desktop
+npx vitest run src/lib/desktop-slash-commands.test.ts
+```
 
-## Keep the waist narrow, grow at the edges
+## Experience and performance
 
-The root contribution rubric governs here too. New capability should arrive at
-the smallest surface that solves it: extend what exists, add a feature locally,
-lean on an existing seam — before you invent a framework. The shell's internal
-registries are composition seams, not a public plugin ABI; do not build a
-universal extension system, a manifest, or a plugin adapter for a single
-consumer. Design a shared contract only once more than one real consumer proves
-its shape. "Plugin" means several unrelated things across Hermes — do not assume
-one surface's extension model runs in another.
+- Background events never navigate, move focus, or open a surface. Offer; do not
+  hijack.
+- Empty, loading, reconnecting, degraded/stale, and exhausted-recovery are
+  distinct states with honest copy and a way out.
+- Focus owns keyboard input; one cancel gesture performs one action.
+- Expensive stateful surfaces remain mounted when hidden; visibility is not
+  lifecycle.
+- Keep hot state local/narrowly derived, avoid per-frame subscriptions in heavy
+  trees, coalesce pointer work, and avoid layout reads immediately after writes.
+  Prove performance with realistic transcripts/content, not an empty demo.
 
-## Respect the person using it
+## Proof before handoff
 
-Design and engineering meet at intent. The user's attention and context are
-sacred:
-
-- Never navigate, move focus, or open a surface because something *happened* in
-  the background. Offer; don't hijack.
-- The states around loading are distinct experiences — empty, loading,
-  reconnecting, degraded/stale, and exhausted-recovery each deserve their own
-  honest copy and their own way out.
-- Keyboard ownership follows focus. The focused surface wins its keys; one
-  cancel gesture does exactly one thing.
-- Expensive, stateful surfaces (terminals, live tools) stay alive when hidden.
-  Visibility is not lifecycle.
-
-## Make it feel instant
-
-Performance is a feature the user feels, especially in drag, resize, scroll,
-typing, streaming, and terminals. The principles are timeless even as the code
-changes: keep hot-path state local or narrowly derived; don't subscribe heavy
-trees to per-frame updates; coalesce pointer work; avoid reading layout right
-after writing style; and don't mount expensive content mid-gesture. Prove speed
-against realistic content — a fast empty demo proves nothing about a long
-transcript. If motion is masking latency, remove the motion, don't tune it.
-
-## Testing as a habit of proof
-
-Test the behavior that would actually break a user, not a snapshot of today's
-data. Favor invariants over frozen values. Exercise the real path for anything
-at a seam — resolver precedence and its failure rungs, identity and scope
-boundaries, optimistic rollback and stale-response ordering, and both sides of a
-local/remote adapter with its profile routing intact. Match how the suite is
-actually run rather than inventing a command; when in doubt, read the scripts.
-
-## The taste test before you hand off
-
-- Does every piece of state live with its authority, at the narrowest scope?
-- Would a background event ever steal the foreground or the user's focus?
-- Does each resolver have one home, a validated ladder, and a bounded, recoverable
-  end?
-- Do local, remote, and profile routing still agree?
-- Does async failure leave a usable UI and a way forward?
-- Do hot interactions stay cheap under realistic load?
-- Does the change pass the [`DESIGN.md`](./DESIGN.md) checklist and update all
-  locales?
-
-If any answer is "not sure," that's the part to go verify.
+Test behavior at seams: resolver fallthrough, identity/scope boundaries,
+optimistic rollback, stale-response ordering, local/remote adapters, and profile
+routing. Confirm that async failure leaves usable UI and recovery, background
+work cannot steal the foreground, hot interactions stay cheap, every locale is
+updated, and the [`DESIGN.md`](./DESIGN.md) checklist passes.

--- a/docs/development/architecture-core.md
+++ b/docs/development/architecture-core.md
@@ -1,0 +1,117 @@
+# Core Architecture — AIAgent & CLI
+
+The conversation loop, the CLI orchestrator, and the slash-command registry.
+Read this before changing `run_agent.py`, `cli.py`, or `hermes_cli/commands.py`.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+## AIAgent Class (run_agent.py)
+
+The real `AIAgent.__init__` takes ~60 parameters (credentials, routing, callbacks,
+session context, budget, credential pool, etc.). The signature below is the
+minimum subset you'll usually touch — read `run_agent.py` for the full list.
+
+```python
+class AIAgent:
+    def __init__(self,
+        base_url: str = None,
+        api_key: str = None,
+        provider: str = None,
+        api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
+        model: str = "",                   # empty → resolved from config/provider later
+        max_iterations: int = 90,          # tool-calling iterations (shared with subagents)
+        enabled_toolsets: list = None,
+        disabled_toolsets: list = None,
+        quiet_mode: bool = False,
+        save_trajectories: bool = False,
+        platform: str = None,              # "cli", "telegram", etc.
+        session_id: str = None,
+        skip_context_files: bool = False,
+        skip_memory: bool = False,
+        credential_pool=None,
+        # ... plus callbacks, thread/user/chat IDs, iteration_budget, fallback_model,
+        # checkpoints config, prefill_messages, service_tier, reasoning_config, etc.
+    ): ...
+
+    def chat(self, message: str) -> str:
+        """Simple interface — returns final response string."""
+
+    def run_conversation(self, user_message: str, system_message: str = None,
+                         conversation_history: list = None, task_id: str = None) -> dict:
+        """Full interface — returns dict with final_response + messages."""
+```
+
+### Agent Loop
+
+The core loop is inside `run_conversation()` — entirely synchronous, with
+interrupt checks, budget tracking, and a one-turn grace call:
+
+```python
+while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
+        or self._budget_grace_call:
+    if self._interrupt_requested: break
+    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
+    if response.tool_calls:
+        for tool_call in response.tool_calls:
+            result = handle_function_call(tool_call.name, tool_call.args, task_id)
+            messages.append(tool_result_message(result))
+        api_call_count += 1
+    else:
+        return response.content
+```
+
+Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
+Reasoning content is stored in `assistant_msg["reasoning"]`.
+## CLI Architecture (cli.py)
+
+- **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
+- **KawaiiSpinner** (`agent/display.py`) — animated faces during API calls, `┊` activity feed for tool results
+- `load_cli_config()` in cli.py merges hardcoded defaults + user config YAML
+- **Skin engine** (`hermes_cli/skin_engine.py`) — data-driven CLI theming; initialized from `display.skin` config key at startup; skins customize banner colors, spinner faces/verbs/wings, tool prefix, response box, branding text
+- `process_command()` is a method on `HermesCLI` — dispatches on canonical command name resolved via `resolve_command()` from the central registry
+- Skill slash commands: `agent/skill_commands.py` scans `~/.hermes/skills/`, injects as **user message** (not system prompt) to preserve prompt caching
+
+### Slash Command Registry (`hermes_cli/commands.py`)
+
+All slash commands are defined in a central `COMMAND_REGISTRY` list of `CommandDef` objects. Every downstream consumer derives from this registry automatically:
+
+- **CLI** — `process_command()` resolves aliases via `resolve_command()`, dispatches on canonical name
+- **Gateway** — `GATEWAY_KNOWN_COMMANDS` frozenset for hook emission, `resolve_command()` for dispatch
+- **Gateway help** — `gateway_help_lines()` generates `/help` output
+- **Telegram** — `telegram_bot_commands()` generates the BotCommand menu
+- **Slack** — `slack_subcommand_map()` generates `/hermes` subcommand routing
+- **Autocomplete** — `COMMANDS` flat dict feeds `SlashCommandCompleter`
+- **CLI help** — `COMMANDS_BY_CATEGORY` dict feeds `show_help()`
+
+### Adding a Slash Command
+
+1. Add a `CommandDef` entry to `COMMAND_REGISTRY` in `hermes_cli/commands.py`:
+```python
+CommandDef("mycommand", "Description of what it does", "Session",
+           aliases=("mc",), args_hint="[arg]"),
+```
+2. Add handler in `HermesCLI.process_command()` in `cli.py`:
+```python
+elif canonical == "mycommand":
+    self._handle_mycommand(cmd_original)
+```
+3. If the command is available in the gateway, add a handler in `gateway/run.py`:
+```python
+if canonical == "mycommand":
+    return await self._handle_mycommand(event)
+```
+4. For persistent settings, use `save_config_value()` in `cli.py`
+
+**CommandDef fields:**
+- `name` — canonical name without slash (e.g. `"background"`)
+- `description` — human-readable description
+- `category` — one of `"Session"`, `"Configuration"`, `"Tools & Skills"`, `"Info"`, `"Exit"`
+- `aliases` — tuple of alternative names (e.g. `("bg",)`)
+- `args_hint` — argument placeholder shown in help (e.g. `"<prompt>"`, `"[name]"`)
+- `cli_only` — only available in the interactive CLI
+- `gateway_only` — only available in messaging platforms
+- `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
+
+**Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.

--- a/docs/development/architecture-core.md
+++ b/docs/development/architecture-core.md
@@ -21,7 +21,7 @@ class AIAgent:
         provider: str = None,
         api_mode: str = None,              # "chat_completions" | "codex_responses" | ...
         model: str = "",                   # empty → resolved from config/provider later
-        max_iterations: int = 90,          # tool-calling iterations (shared with subagents)
+        max_iterations: int = 90,          # per-agent tool-calling iteration cap
         enabled_toolsets: list = None,
         disabled_toolsets: list = None,
         quiet_mode: bool = False,
@@ -64,6 +64,15 @@ while (api_call_count < self.max_iterations and self.iteration_budget.remaining 
 
 Messages follow OpenAI format: `{"role": "system/user/assistant/tool", ...}`.
 Reasoning content is stored in `assistant_msg["reasoning"]`.
+
+## Tool discovery and exposure
+
+`tools/registry.py` is dependency-light and imported by tool modules. Built-in
+tool modules under `tools/` register at import time; `model_tools.py` triggers discovery
+and resolves schemas/dispatch before `run_agent.py`, `cli.py`, `batch_runner.py`,
+and environment consumers use them. Registration alone does not expose a tool:
+the root contract in `AGENTS.md` governs toolset exposure.
+
 ## CLI Architecture (cli.py)
 
 - **Rich** for banner/panels, **prompt_toolkit** for input with autocomplete
@@ -115,3 +124,40 @@ if canonical == "mycommand":
 - `gateway_config_gate` — config dotpath (e.g. `"display.tool_progress_command"`); when set on a `cli_only` command, the command becomes available in the gateway if the config value is truthy. `GATEWAY_KNOWN_COMMANDS` always includes config-gated commands so the gateway can dispatch them; help/menus only show them when the gate is open.
 
 **Adding an alias** requires only adding it to the `aliases` tuple on the existing `CommandDef`. No other file changes needed — dispatch, help text, Telegram menu, Slack mapping, and autocomplete all update automatically.
+
+---
+
+## Delegation (`delegate_task`)
+
+`tools/delegate_tool.py` spawns isolated child conversations with their own
+terminal sessions and toolsets. Top-level model-facing single and batch calls
+dispatch asynchronously automatically; the completed single result or
+consolidated batch re-enters the parent conversation. Do not poll. Direct Python
+callers retain synchronous semantics, and orchestrator-child execution is
+synchronous so that turn can consume worker results.
+
+- Use `goal` for one child or `tasks` for parallel fan-out. Concurrency is
+  bounded by `delegation.max_concurrent_children`.
+- `leaf` children retain `execute_code` but cannot call `delegate_task`,
+  `clarify`, `memory`, `send_message`, or `cronjob`. Orchestrators regain only
+  `delegate_task`, and only when `delegation.orchestrator_enabled` and
+  `max_spawn_depth` allow it.
+- Children know none of the parent conversation; pass every requirement in
+  `context`. Their final summaries are self-reports, so verify paths, URLs, IDs,
+  or other external side effects before claiming success.
+- Delegation is not durable: `/stop`, `/new`, or process exit cancels in-flight
+  children. Use cron or tracked terminal background work for tasks that must
+  survive the session.
+
+The model-facing `background` parameter is retained only for compatibility and
+is ignored. Dynamic schema descriptions in `get_definitions()` expose the
+user's actual concurrency and nesting limits.
+
+Delegation controls live under `delegation`: `max_concurrent_children`,
+`max_spawn_depth`, `child_timeout_seconds`, `orchestrator_enabled`,
+`subagent_auto_approve`, `inherit_mcp_toolsets`, and the per-child independent
+`max_iterations`. A non-positive child timeout disables the wall-clock cap.
+`subagent_auto_approve` removes human review from dangerous child commands; keep
+it disabled unless that non-interactive trust boundary is intentional. Current
+defaults are three concurrent children, depth one (flat delegation), leaf role,
+50 child iterations, and `subagent_auto_approve: false`.

--- a/docs/development/architecture-tui.md
+++ b/docs/development/architecture-tui.md
@@ -1,0 +1,70 @@
+# TUI Architecture (ui-tui + tui_gateway)
+
+The Ink/React terminal UI and its Python JSON-RPC backend.
+Read this before touching anything under `ui-tui/`, `tui_gateway/`, or the dashboard chat page.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+The TUI is a full replacement for the classic (prompt_toolkit) CLI, activated via `hermes --tui` or `HERMES_TUI=1`.
+
+### Process Model
+
+```
+hermes --tui
+  └─ Node (Ink)  ──stdio JSON-RPC──  Python (tui_gateway)
+       │                                  └─ AIAgent + tools + sessions
+       └─ renders transcript, composer, prompts, activity
+```
+
+TypeScript owns the screen. Python owns sessions, tools, model calls, and slash command logic.
+
+### Transport
+
+Newline-delimited JSON-RPC over stdio. Requests from Ink, events from Python. See `tui_gateway/server.py` for the full method/event catalog.
+
+### Key Surfaces
+
+| Surface | Ink component | Gateway method |
+|---------|---------------|----------------|
+| Chat streaming | `app.tsx` + `messageLine.tsx` | `prompt.submit` → `message.delta/complete` |
+| Tool activity | `thinking.tsx` | `tool.start/progress/complete` |
+| Approvals | `prompts.tsx` | `approval.respond` ← `approval.request` |
+| Clarify/sudo/secret | `prompts.tsx`, `maskedPrompt.tsx` | `clarify/sudo/secret.respond` |
+| Session picker | `sessionPicker.tsx` | `session.list/resume` |
+| Slash commands | Local handler + fallthrough | `slash.exec` → `_SlashWorker`, `command.dispatch` |
+| Completions | `useCompletion` hook | `complete.slash`, `complete.path` |
+| Theming | `theme.ts` + `branding.tsx` | `gateway.ready` with skin data |
+
+### Slash Command Flow
+
+1. Built-in client commands (`/help`, `/quit`, `/clear`, `/resume`, `/copy`, `/paste`, etc.) handled locally in `app.tsx`
+2. Everything else → `slash.exec` (runs in persistent `_SlashWorker` subprocess) → `command.dispatch` fallback
+
+### Dev Commands
+
+```bash
+cd ui-tui
+npm install       # first time
+npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
+npm start         # production
+npm run build     # full build (hermes-ink + tsc)
+npm run type-check # typecheck only (tsc --noEmit)
+npm run lint      # eslint
+npm run fmt       # prettier
+npm test          # vitest
+```
+
+### TUI in the Dashboard (`hermes dashboard` → `/chat`)
+
+The dashboard embeds the real `hermes --tui` — **not** a rewrite.  See `hermes_cli/pty_bridge.py` + the `@app.websocket("/api/pty")` endpoint in `hermes_cli/web_server.py`.
+
+- Browser loads `web/src/pages/ChatPage.tsx`, which mounts xterm.js's `Terminal` with the WebGL renderer, `@xterm/addon-fit` for container-driven resize, and `@xterm/addon-unicode11` for modern wide-character widths.
+- `/api/pty?token=…` upgrades to a WebSocket; auth uses the same ephemeral `_SESSION_TOKEN` as REST, via query param (browsers can't set `Authorization` on WS upgrade).
+- The server spawns whatever `hermes --tui` would spawn, through `ptyprocess` (POSIX PTY — WSL works, native Windows does not).
+- Frames: raw PTY bytes each direction; resize via `\x1b[RESIZE:<cols>;<rows>]` intercepted on the server and applied with `TIOCSWINSZ`.
+
+**Do not re-implement the primary chat experience in React.** The main transcript, composer/input flow (including slash-command behavior), and PTY-backed terminal belong to the embedded `hermes --tui` — anything new you add to Ink shows up in the dashboard automatically. If you find yourself rebuilding the transcript or composer for the dashboard, stop and extend Ink instead.
+
+**Structured React UI around the TUI is allowed when it is not a second chat surface.** Sidebar widgets, inspectors, summaries, status panels, and similar supporting views (e.g. `ChatSidebar`, `ModelPickerDialog`, `ToolCall`) are fine when they complement the embedded TUI rather than replacing the transcript / composer / terminal. Keep their state independent of the PTY child's session and surface their failures non-destructively so the terminal pane keeps working unimpaired.

--- a/docs/development/architecture-tui.md
+++ b/docs/development/architecture-tui.md
@@ -50,7 +50,7 @@ npm install       # first time
 npm run dev       # watch mode (rebuilds hermes-ink + tsx --watch)
 npm start         # production
 npm run build     # full build (hermes-ink + tsc)
-npm run type-check # typecheck only (tsc --noEmit)
+npm run typecheck # typecheck only (tsc --noEmit)
 npm run lint      # eslint
 npm run fmt       # prettier
 npm test          # vitest

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -1,0 +1,68 @@
+# Configuration Reference
+
+Full detail on `config.yaml` sections, `.env` policy, the three config loaders,
+and working-directory resolution.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+### config.yaml options:
+1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
+2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
+   ONLY if you need to actively migrate/transform existing user config
+   (renaming keys, changing structure). Adding a new key to an existing
+   section is handled automatically by the deep-merge and does NOT require
+   a version bump.
+
+### Top-level `config.yaml` sections (non-exhaustive):
+
+`model`, `agent`, `terminal`, `compression`, `display`, `stt`, `tts`,
+`memory`, `security`, `delegation`, `smart_model_routing`, `checkpoints`,
+`auxiliary`, `curator`, `skills`, `gateway`, `logging`, `cron`, `profiles`,
+`plugins`, `honcho`.
+
+`auxiliary` holds per-task overrides for side-LLM work (curator, vision,
+embedding, title generation, session_search, etc.) — each task can pin
+its own provider/model/base_url/max_tokens/reasoning_effort. See
+`agent/auxiliary_client.py::_resolve_auto` for resolution order.
+
+`curator` holds the background skill-maintenance config —
+`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
+`archive_after_days`, `backup` (nested).
+
+### .env variables (SECRETS ONLY — API keys, tokens, passwords):
+1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
+```python
+"NEW_API_KEY": {
+    "description": "What it's for",
+    "prompt": "Display name",
+    "url": "https://...",
+    "password": True,
+    "category": "tool",  # provider, tool, messaging, setting
+},
+```
+
+Non-secret settings (timeouts, thresholds, feature flags, paths, display
+preferences) belong in `config.yaml`, not `.env`. If internal code needs an
+env var mirror for backward compatibility, bridge it from `config.yaml` to
+the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
+
+### Config loaders (three paths — know which one you're in):
+
+| Loader | Used by | Location |
+|--------|---------|----------|
+| `load_cli_config()` | CLI mode | `cli.py` — merges CLI-specific defaults + user YAML |
+| `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
+| Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
+
+If you add a new key and the CLI sees it but the gateway doesn't (or vice
+versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
+
+### Working directory:
+- **CLI** — uses the process's current directory (`os.getcwd()`).
+- **Messaging** — uses `terminal.cwd` from `config.yaml`. The gateway bridges this
+  to the `TERMINAL_CWD` env var for child tools. **`MESSAGING_CWD` has been
+  removed** — the config loader prints a deprecation warning if it's set in
+  `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
+  `terminal.cwd` in `config.yaml`.

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -8,9 +8,12 @@ and working-directory resolution.
 ---
 
 ### config.yaml options:
-1. Add documented/defaulted keys to `DEFAULT_CONFIG`, defined in
-   `hermes_cli/config_defaults.py` and re-exported from `hermes_cli/config.py`.
-   It is the primary known-root/default source, not a universal schema:
+
+Both `DEFAULT_CONFIG` and `OPTIONAL_ENV_VARS` are defined in
+`hermes_cli/config_defaults.py` and re-exported from `hermes_cli/config.py`.
+
+1. Add documented/defaulted keys to `DEFAULT_CONFIG`. It is the primary
+   known-root/default source, not a universal schema:
    `_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()` in `hermes_cli/config.py`
    cover intentionally absent, dynamic, or presence-sensitive roots.
 2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
@@ -39,7 +42,10 @@ its own provider/model/base_url/max_tokens/reasoning_effort. See
 
 New credentials (API keys, tokens, passwords) are declared in
 `OPTIONAL_ENV_VARS`; do not add new env-only behavioral configuration:
-1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
+1. Add static entries to `OPTIONAL_ENV_VARS` in
+   `hermes_cli/config_defaults.py` with metadata. `hermes_cli/config.py`
+   re-exports that object and augments it at runtime from discovered model
+   providers and platform plugin manifests:
 ```python
 "NEW_API_KEY": {
     "description": "What it's for",

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -8,7 +8,10 @@ and working-directory resolution.
 ---
 
 ### config.yaml options:
-1. Add to `DEFAULT_CONFIG` in `hermes_cli/config.py`
+1. Add documented/defaulted keys to `DEFAULT_CONFIG` in
+   `hermes_cli/config.py`. It is the primary known-root/default source, not a
+   universal schema: `_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()` cover
+   intentionally absent, dynamic, or presence-sensitive roots.
 2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
    ONLY if you need to actively migrate/transform existing user config
    (renaming keys, changing structure). Adding a new key to an existing
@@ -31,7 +34,10 @@ its own provider/model/base_url/max_tokens/reasoning_effort. See
 `enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
 `archive_after_days`, `backup` (nested).
 
-### .env variables (SECRETS ONLY — API keys, tokens, passwords):
+### .env variables
+
+New credentials (API keys, tokens, passwords) are declared in
+`OPTIONAL_ENV_VARS`; do not add new env-only behavioral configuration:
 1. Add to `OPTIONAL_ENV_VARS` in `hermes_cli/config.py` with metadata:
 ```python
 "NEW_API_KEY": {
@@ -44,9 +50,11 @@ its own provider/model/base_url/max_tokens/reasoning_effort. See
 ```
 
 Non-secret settings (timeouts, thresholds, feature flags, paths, display
-preferences) belong in `config.yaml`, not `.env`. If internal code needs an
-env var mirror for backward compatibility, bridge it from `config.yaml` to
-the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
+preferences) canonically belong in `config.yaml`, not `.env`. Legacy/internal,
+platform, and plugin behavioral env variables still exist (for example
+`HERMES_BACKGROUND_NOTIFICATIONS` and `HERMES_CRON_TIMEOUT`); preserve needed
+compatibility, but bridge new user-facing behavior from config rather than
+presenting runtime env as secret-only.
 
 ### Config loaders (three paths — know which one you're in):
 
@@ -56,8 +64,9 @@ the env var in code (see `gateway_timeout`, `terminal.cwd` → `TERMINAL_CWD`).
 | `load_config()` | `hermes tools`, `hermes setup`, most CLI subcommands | `hermes_cli/config.py` — merges `DEFAULT_CONFIG` + user YAML |
 | Direct YAML load | Gateway runtime | `gateway/run.py` + `gateway/config.py` — reads user YAML raw |
 
-If you add a new key and the CLI sees it but the gateway doesn't (or vice
-versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
+If a new key appears in one surface but not another, trace the actual loader.
+Check `DEFAULT_CONFIG` and the raw/presence-sensitive paths rather than assuming
+one merged schema governs every runtime.
 
 ### Working directory:
 - **CLI** — uses the process's current directory (`os.getcwd()`).
@@ -66,3 +75,16 @@ versa), you're on the wrong loader. Check `DEFAULT_CONFIG` coverage.
   removed** — the config loader prints a deprecation warning if it's set in
   `.env`. Same for `TERMINAL_CWD` in `.env`; the canonical setting is
   `terminal.cwd` in `config.yaml`.
+
+### Background process notifications
+
+`display.background_process_notifications` controls gateway messages for
+tracked background commands:
+
+- `all` — running-output updates and the final message (default)
+- `result` — only the final completion message
+- `error` — only a non-zero-exit final message
+- `off` — no watcher messages
+
+`HERMES_BACKGROUND_NOTIFICATIONS` remains an internal/backward-compatible
+override; user-facing configuration belongs in `config.yaml`.

--- a/docs/development/configuration.md
+++ b/docs/development/configuration.md
@@ -8,10 +8,11 @@ and working-directory resolution.
 ---
 
 ### config.yaml options:
-1. Add documented/defaulted keys to `DEFAULT_CONFIG` in
-   `hermes_cli/config.py`. It is the primary known-root/default source, not a
-   universal schema: `_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()` cover
-   intentionally absent, dynamic, or presence-sensitive roots.
+1. Add documented/defaulted keys to `DEFAULT_CONFIG`, defined in
+   `hermes_cli/config_defaults.py` and re-exported from `hermes_cli/config.py`.
+   It is the primary known-root/default source, not a universal schema:
+   `_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()` in `hermes_cli/config.py`
+   cover intentionally absent, dynamic, or presence-sensitive roots.
 2. Bump `_config_version` (check the current value at the top of `DEFAULT_CONFIG`)
    ONLY if you need to actively migrate/transform existing user config
    (renaming keys, changing structure). Adding a new key to an existing

--- a/docs/development/contribution-rubric.md
+++ b/docs/development/contribution-rubric.md
@@ -1,0 +1,188 @@
+# Contribution Rubric Reference
+
+Detailed rationale and examples behind the compact normative contract in the
+repository `AGENTS.md`. Read this for contribution design, PR review, or
+triage. If wording conflicts, the compact root contract is authoritative.
+
+## How to use this rubric
+
+Use it two ways:
+
+1. **For humans and for your own work** — what gets merged and what gets
+   rejected, so a contribution aims at the target.
+2. **For automated review (the triage sweeper)** — guidance on when a PR is
+   safe to close on the three allowed reasons (`implemented_on_main`,
+   `cannot_reproduce`, `incoherent`) and, just as important, **when NOT to
+   close** one. Taste-based "we don't want this / out of scope" closes are NOT
+   an automated decision — those stay with a human maintainer. The sweeper's
+   job here is to recognize design intent and *avoid wrongly closing a
+   legitimate contribution*, not to make the won't-implement call itself.
+
+Read the balance right: Hermes ships a **lot** — most merges are bug fixes to
+real reported behavior, and the product surface (platforms, channels,
+providers, models, desktop/TUI features) expands aggressively and on purpose.
+The restraint below is aimed squarely at the **core agent + the model tool
+schema**, the one place where every addition is paid for on every API call.
+"Smallest footprint" governs *how a capability is wired into the core*, NOT
+whether the product is allowed to grow. We are expansive at the edges and
+conservative at the waist.
+
+## What we want
+
+- **Fix real bugs, well.** The bulk of what lands is `fix(...)` against an
+  actual reported symptom. A good fix reproduces the symptom on current
+  `main`, points to the exact line where it manifests, and fixes the whole bug
+  class — sibling call paths included — not just the one site the reporter hit.
+- **Expand reach at the edges.** New platform adapters, channels, providers,
+  models, and desktop/TUI/dashboard features are welcome and land routinely,
+  including large ones (a new messaging channel, a session-cap feature, a
+  Windows PTY bridge). Breadth in the product is a goal, not a footprint
+  concern — as long as it integrates with the existing setup/config UX
+  (`hermes tools`, `hermes setup`, auto-install) rather than bolting on a raw
+  env var.
+- **Refactor god-files into clean modules.** Extracting a multi-thousand-line
+  cluster out of `cli.py` / `run_agent.py` / `gateway/run.py` into a focused
+  mixin or module is wanted work, even when the diff is huge and mechanical
+  (large `+N/-N` refactors merge regularly). The "every line traces to the
+  request" test applies to *feature* PRs; a declared refactor's request IS the
+  extraction.
+- **Keep the core narrow.** New *model tools* are the expensive exception —
+  every tool ships on every API call. Prefer, in order: extend existing code →
+  CLI command + skill → service-gated tool (`check_fn`) → plugin → MCP server
+  in the catalog → new core tool (last resort). See "The Footprint Ladder."
+- **Extend, don't duplicate.** Before adding a module/manager/hook, check
+  whether existing infrastructure already covers the use case. When several PRs
+  integrate the same *category*, design one shared interface instead of merging
+  them one at a time (see the ABC + orchestrator note under the Footprint
+  Ladder).
+- **Behavior contracts over snapshots.** Tests should assert how two pieces of
+  data must relate (invariants), not freeze a current value (model lists,
+  config version literals, enumeration counts). See "Don't write
+  change-detector tests."
+- **E2E validation, not just green unit mocks.** For anything touching
+  resolution chains, config propagation, security boundaries, remote
+  backends, or file/network I/O, exercise the real path with real imports
+  against a temp `HERMES_HOME`. Mocks hide integration bugs.
+- **Cache-, alternation-, and invariant-safe.** Preserve prompt caching, strict
+  message role alternation (never two same-role messages in a row; never a
+  synthetic user message injected mid-loop), and a system prompt that is
+  byte-stable for the life of a conversation.
+- **Contributor credit preserved.** Salvage external work by cherry-picking
+  (rebase-merge) so authorship survives in git history; don't reimplement from
+  scratch when you can build on top.
+
+## What we don't want (rejected even when well-built)
+
+- **Speculative infrastructure.** Hooks, callbacks, or extension points with no
+  concrete consumer. Adding a hook is easy; removing one after plugins depend
+  on it is hard. A hook is NOT speculative if a contributor has a real, stated
+  use case — even if the consumer ships separately.
+- **New `HERMES_*` env-only behavior for non-secret config.** Credentials belong
+  in `.env`; new behavioral settings — timeouts, thresholds, feature flags,
+  display prefs — go in `config.yaml`. Legacy/internal/platform/plugin env
+  bridges still exist and may need compatibility, but user-facing docs point to
+  `config.yaml`. Reject new env-only behavior, not the existence of those bridges.
+- **A new core tool when terminal + file already do the job, or when a skill
+  would.** If the only barrier is file visibility on a remote backend, fix the
+  mount, not the toolset.
+- **Lazy-reading escape hatches on instructional tools.** No `offset`/`limit`
+  pagination on tools that load content the agent must read fully (skills,
+  prompts, playbooks). Models will read page 1 and skip the rest.
+- **"Fixes" that destroy the feature they secure.** A mitigation that kills the
+  feature's purpose is the wrong mitigation. Read the original commit's intent
+  (`git log -p -S`) before restricting behavior; find a fix that preserves the
+  feature.
+- **Outbound telemetry / usage attribution without opt-in gating.** No new
+  analytics, third-party identifier tagging, or attribution tags until a
+  generic user-facing opt-in (config gate + setup prompt + `hermes tools`
+  toggle) exists. Park behind a label, do not merge.
+- **Change-detector tests, cache-breaking mid-conversation, dead code wired in
+  without E2E proof, and plugins that touch core files.** Plugins live in their
+  own directory and work within the ABCs/hooks we provide; if a plugin needs
+  more, widen the generic plugin surface, don't special-case it in core.
+- **Third-party products / other people's projects integrated into the core
+  tree.** Observability backends, vendor SaaS integrations, analytics dashboards,
+  and similar "someone else's product" plugins do NOT land under `plugins/` in
+  this repo. They place an ongoing maintenance burden on us to keep them working
+  against a fast-moving core, for a backend we don't own. Ship them as a
+  **standalone plugin repo** users install into `~/.hermes/plugins/` (or via a
+  pip entry point), and promote them in the Nous Research Discord
+  (`#plugins-skills-and-skins`). This is a coupling-and-maintenance decision, not
+  a quality bar — the plugin can be excellent and still be a close. PRs that add
+  such a directory to the tree are closed with a pointer to publish it as its own
+  repo.
+
+## Before you call it a bug — verify the premise (and when NOT to close)
+
+The most common reason a well-written PR gets closed is not code quality — it
+is that the change is built on a **wrong premise**, or it treats an
+**intentional design as a gap**. These patterns cut both ways: they tell a
+human reviewer what to scrutinize, and they tell the automated sweeper when a
+PR is NOT safe to close as `implemented_on_main` / `cannot_reproduce` (when in
+doubt, leave it open for a human). They are distilled from real closes.
+
+- **"Intentional design, not a gap."** A limitation that looks like an
+  oversight is often deliberate. Before "fixing" a missing link or a
+  restriction, ask whether the isolation IS the design. Example: profiles are
+  independent islands on purpose — a PR adding live config inheritance from the
+  default profile was closed because coupling profiles together is exactly what
+  the design prevents (the copy-at-creation `--clone` path already covers the
+  legitimate "start from my default" case). Read the original commit's intent
+  (`git log -p -S "<symbol>"`) before assuming something is unfinished.
+- **"The premise doesn't hold against how X actually works."** A PR's
+  justification frequently rests on a wrong mental model of an existing
+  mechanism. Trace the real code/runtime before accepting the rationale. Two
+  real closes: a rate-limit "re-probe during cooldown" PR (the breaker only
+  trips on a *confirmed-empty* account bucket, so re-probing just hammers a
+  bucket we've already proven empty); a usage-accumulation fix whose new branch
+  **never executes at runtime** because an earlier guard already popped the
+  state it depended on. If you can't point to the exact line where the bug
+  manifests AND show the fix changes that line's behavior, you haven't verified
+  the premise.
+- **"This fix was wrong — the absence/omission was deliberate."** Adding the
+  obvious-looking missing piece can break things the omission was protecting.
+  Example: restoring "missing" `__init__.py` files made a test tree importable
+  as a dotted package that shadowed the real plugin, deleting its `register()`
+  at import time. The absence was load-bearing.
+- **"Overreached / resurrected an approach we'd moved past."** Scope creep that
+  supersedes an agreed-on base, or revives a direction the maintainers
+  deliberately closed, gets rejected even when the code works. Keep the change
+  to the narrow piece that was actually agreed; offer the rest as a focused
+  follow-up.
+
+The throughline: **verify the claim AND the intent against the codebase before
+writing or merging a fix.** A confirmed reproduction on current `main` plus a
+line-level account of where the fix acts beats a plausible-sounding rationale
+every time. When in doubt about intent, it is cheaper to ask than to ship a
+fix that fights the design.
+
+## The Footprint Ladder (new capability decision)
+
+Each rung adds more permanent surface than the one above. Choose the highest
+(least-footprint) rung that correctly solves the problem:
+
+1. **Extend existing code** — the capability is a variation of something that
+   already exists. Zero new surface.
+2. **CLI command + skill** — manages config/state/infra expressible as shell
+   commands. The agent runs `hermes <subcommand>` guided by a skill. Zero
+   model-tool footprint. Default choice for subscriptions, scheduled tasks,
+   service setup. Examples: `hermes webhook`, `hermes cron`, `hermes tools`.
+3. **Service-gated tool (`check_fn`)** — needs structured params/returns AND
+   only appears when a prerequisite is configured. Zero footprint otherwise.
+   Examples: Home Assistant tools (gated on token), memory-provider tools.
+4. **Plugin** — third-party/niche/user-specific capability that doesn't ship in
+   core. Lives in `~/.hermes/plugins/` or a pip package, discovered at runtime.
+5. **MCP server (in the catalog)** — if the capability genuinely needs to be a
+   tool (structured I/O the agent invokes) but isn't core-fundamental, prefer
+   building it as an MCP server and adding it to the MCP catalog over growing
+   the core toolset. The agent connects to it through the built-in MCP client;
+   zero permanent core-schema footprint, and it's reusable by any MCP host.
+6. **New core tool** — only when the capability is fundamental, broadly useful
+   to nearly every user, and unreachable via terminal + file (or an MCP server).
+   Examples of correct core tools: terminal, read_file, web_search,
+   browser_navigate.
+
+When 3+ open PRs try to integrate the same *category* of thing (memory
+backends, providers, notifiers), don't merge them one at a time — design an
+ABC + orchestrator, wrap the existing built-in as the first provider, and turn
+the competing PRs into plugins against that interface.

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -1,0 +1,104 @@
+# Plugin System
+
+General plugins, memory providers, and model providers — three separate discovery paths.
+Read this before adding or reviewing anything under `plugins/`.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
+repo-shipped plugins can be discovered alongside user-installed ones in
+`~/.hermes/plugins/` and pip-installed entry points.
+
+### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
+
+`PluginManager` discovers plugins from `~/.hermes/plugins/`, `./.hermes/plugins/`,
+and pip entry points. Each plugin exposes a `register(ctx)` function that
+can:
+
+- Register Python-callback lifecycle hooks:
+  `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`,
+  `on_session_start`, `on_session_end`
+- Register new tools via `ctx.register_tool(...)`
+- Register CLI subcommands via `ctx.register_cli_command(...)` — the
+  plugin's argparse tree is wired into `hermes` at startup so
+  `hermes <pluginname> <subcmd>` works with no change to `main.py`
+
+Hooks are invoked from `model_tools.py` (pre/post tool) and `run_agent.py`
+(lifecycle). **Discovery timing pitfall:** `discover_plugins()` only runs
+as a side effect of importing `model_tools.py`. Code paths that read plugin
+state without importing `model_tools.py` first must call `discover_plugins()`
+explicitly (it's idempotent).
+
+### Memory-provider plugins (`plugins/memory/<name>/`)
+
+Separate discovery system for pluggable memory backends. Current built-in
+providers include **honcho, mem0, supermemory, byterover, hindsight,
+holographic, openviking, retaindb**.
+
+Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
+and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
+`sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional
+`post_setup(hermes_home, config)` for setup-wizard integration.
+
+**CLI commands via `plugins/memory/<name>/cli.py`:** if a memory plugin
+defines `register_cli(subparser)`, `discover_plugin_cli_commands()` finds
+it at argparse setup time and wires it into `hermes <plugin>`. The
+framework only exposes CLI commands for the **currently active** memory
+provider (read from `memory.provider` in config.yaml), so disabled
+providers don't clutter `hermes --help`.
+
+**Rule (Teknium, May 2026):** plugins MUST NOT modify core files
+(`run_agent.py`, `cli.py`, `gateway/run.py`, `hermes_cli/main.py`, etc.).
+If a plugin needs a capability the framework doesn't expose, expand the
+generic plugin surface (new hook, new ctx method) — never hardcode
+plugin-specific logic into core. PR #5295 removed 95 lines of hardcoded
+honcho argparse from `main.py` for exactly this reason.
+
+**No new in-tree memory providers (policy, May 2026):** the set of
+built-in memory providers under `plugins/memory/` is closed. New memory
+backends must ship as **standalone plugin repos** that users install
+into `~/.hermes/plugins/` (or via pip entry points) — they implement
+the same `MemoryProvider` ABC, register through the same discovery
+path, and integrate via `hermes memory setup` / `post_setup()` without
+landing in this tree. PRs that add a new directory under
+`plugins/memory/` will be closed with a pointer to publish the
+provider as its own repo. Existing in-tree providers stay; bug fixes
+to them are welcome.
+
+### Model-provider plugins (`plugins/model-providers/<name>/`)
+
+Every inference backend (openrouter, anthropic, gmi, deepseek, nvidia, …)
+ships as a plugin here. Each plugin's `__init__.py` calls
+`providers.register_provider(ProviderProfile(...))` at module load.
+`providers/__init__.py._discover_providers()` is a **lazy, separate
+discovery system** — scanned on first `get_provider_profile()` or
+`list_providers()` call, NOT by the general PluginManager.
+
+Scan order:
+1. Bundled: `<repo>/plugins/model-providers/<name>/`
+2. User: `$HERMES_HOME/plugins/model-providers/<name>/`
+3. Legacy: `<repo>/providers/<name>.py` (back-compat)
+
+User plugins of the same name override bundled ones — `register_provider()`
+is last-writer-wins. This lets third parties swap out any built-in
+profile without a repo patch.
+
+The general PluginManager records `kind: model-provider` manifests but does
+NOT import them (would double-instantiate `ProviderProfile`). Plugins
+without an explicit `kind:` get auto-coerced via a source-text heuristic
+(`register_provider` + `ProviderProfile` in `__init__.py`).
+
+Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
+
+### Dashboard / context-engine / image-gen plugin directories
+
+`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
+pattern (ABC + orchestrator + per-plugin directory). Context engines
+plug into `agent/context_engine.py`; image-gen providers into
+`agent/image_gen_provider.py`. Reference / docs-companion plugins
+(`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
+`plugin-llm-async-example`) live in the
+[`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)
+companion repo, not in this tree.

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -7,9 +7,12 @@ Read this before adding or reviewing anything under `plugins/`.
 
 ---
 
-Hermes has two plugin surfaces. Both live under `plugins/` in the repo so
-repo-shipped plugins can be discovered alongside user-installed ones in
-`~/.hermes/plugins/` and pip-installed entry points.
+Hermes has three primary discovery systems: general plugins, memory-provider
+plugins, and model-provider plugins. Their bundled implementations live under
+`plugins/`; the loaders described below also cover the applicable project,
+user, legacy, or pip entry-point locations. Additional provider families use
+their own ABC/orchestrator paths, so do not infer one global plugin-surface
+count from these three primary systems.
 
 ### General plugins (`hermes_cli/plugins.py` + `plugins/<name>/`)
 
@@ -111,12 +114,15 @@ without an explicit `kind:` get auto-coerced via a source-text heuristic
 
 Full authoring guide: `website/docs/developer-guide/model-provider-plugin.md`.
 
-### Dashboard / context-engine / image-gen plugin directories
+### Additional provider families
 
-`plugins/context_engine/`, `plugins/image_gen/`, etc. follow the same
-pattern (ABC + orchestrator + per-plugin directory). Context engines
-plug into `agent/context_engine.py`; image-gen providers into
-`agent/image_gen_provider.py`. Reference / docs-companion plugins
+Dashboard/backend integrations, `plugins/context_engine/`,
+`plugins/image_gen/`, and similar families follow an ABC + orchestrator +
+per-plugin-directory pattern where supported. Context engines plug into
+`agent/context_engine.py`; image-gen providers into
+`agent/image_gen_provider.py`. These are extension families beyond the three
+primary discovery systems above, not evidence for a single exhaustive surface
+count. Reference / docs-companion plugins
 (`example-dashboard`, `strike-freedom-cockpit`, `plugin-llm-example`,
 `plugin-llm-async-example`) live in the
 [`hermes-example-plugins`](https://github.com/NousResearch/hermes-example-plugins)

--- a/docs/development/plugins.md
+++ b/docs/development/plugins.md
@@ -31,11 +31,16 @@ as a side effect of importing `model_tools.py`. Code paths that read plugin
 state without importing `model_tools.py` first must call `discover_plugins()`
 explicitly (it's idempotent).
 
+General user, project, and entry-point plugins are opt-in through
+`plugins.enabled` by default. Explicit built-in or service-gated exceptions
+(for example Spotify) may activate through their own prerequisite/config path;
+do not turn that exception into a claim that every discovered plugin auto-loads.
+
 ### Memory-provider plugins (`plugins/memory/<name>/`)
 
-Separate discovery system for pluggable memory backends. Current built-in
-providers include **honcho, mem0, supermemory, byterover, hindsight,
-holographic, openviking, retaindb**.
+Separate discovery system for pluggable memory backends. Inspect
+`plugins/memory/` for the current built-ins rather than freezing an inventory in
+this guide.
 
 Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
 and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
@@ -66,6 +71,20 @@ landing in this tree. PRs that add a new directory under
 `plugins/memory/` will be closed with a pointer to publish the
 provider as its own repo. Existing in-tree providers stay; bug fixes
 to them are welcome.
+
+**No new third-party-product plugins in-tree (policy, June 2026):** the
+same rule applies beyond memory providers. Plugins that integrate
+someone else's product or project — observability/metrics backends,
+vendor SaaS connectors, analytics dashboards, paid-service tie-ins —
+must ship as **standalone plugin repos** that users install into
+`~/.hermes/plugins/` (or via pip entry points). They register through
+the existing plugin discovery path and use the ABCs/hooks/ctx surface
+we expose; nothing special is needed in core. The reason is
+maintenance load: every product we absorb into the tree becomes our
+burden to keep working against a fast-moving core, for a backend we
+don't own. Promote standalone plugins in the Nous Research Discord
+(`#plugins-skills-and-skins`). PRs that add such a directory under
+`plugins/` are closed.
 
 ### Model-provider plugins (`plugins/model-providers/<name>/`)
 

--- a/docs/development/skills-authoring.md
+++ b/docs/development/skills-authoring.md
@@ -1,0 +1,115 @@
+# Skill Authoring Standards
+
+The hardline standards every bundled, optional, or contributed skill must meet.
+Read this before writing a skill or reviewing a skill PR.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+Two parallel surfaces:
+
+- **`skills/`** — built-in skills shipped and loadable by default.
+  Organized by category directories (e.g. `skills/github/`, `skills/mlops/`).
+- **`optional-skills/`** — heavier or niche skills shipped with the repo but
+  NOT active by default. Installed explicitly via
+  `hermes skills install official/<category>/<skill>`. Adapter lives in
+  `tools/skills_hub.py` (`OptionalSkillSource`). Categories include
+  `autonomous-ai-agents`, `blockchain`, `communication`, `creative`,
+  `devops`, `email`, `health`, `mcp`, `migration`, `mlops`, `productivity`,
+  `research`, `security`, `web-development`.
+
+When reviewing skill PRs, check which directory they target — heavy-dep or
+niche skills belong in `optional-skills/`.
+
+### SKILL.md frontmatter
+
+Standard fields: `name`, `description`, `version`, `author`, `license`,
+`platforms` (OS-gating list: `[macos]`, `[linux, macos]`, ...),
+`metadata.hermes.tags`, `metadata.hermes.category`,
+`metadata.hermes.related_skills`, `metadata.hermes.config` (config.yaml
+settings the skill needs — stored under `skills.config.<key>`, prompted
+during setup, injected at load time).
+
+Top-level `tags:` and `category:` are also accepted and mirrored from
+`metadata.hermes.*` by the loader.
+
+### Skill authoring standards (HARDLINE)
+
+Every new or modernized skill — bundled, optional, or contributed —
+must meet these standards before merge. Reviewers reject PRs that
+violate them.
+
+1. **`description` ≤ 60 characters, one sentence, ends with a period.**
+   Long descriptions bloat skill listings and dilute the model's
+   attention when many skills are loaded. State the capability, not
+   the implementation. No marketing words ("powerful",
+   "comprehensive", "seamless", "advanced"). Don't repeat the skill
+   name. Verify with:
+   ```python
+   import re, pathlib
+   m = re.search(r'^description: (.*)$',
+                 pathlib.Path('skills/<cat>/<name>/SKILL.md').read_text(),
+                 re.MULTILINE)
+   assert len(m.group(1)) <= 60, len(m.group(1))
+   ```
+
+2. **Tools referenced in SKILL.md prose must be native Hermes tools or
+   MCP servers the skill explicitly expects.** When the skill needs a
+   capability, point at the proper tool by name in backticks
+   (`` `terminal` ``, `` `web_extract` ``, `` `read_file` ``,
+   `` `patch` ``, `` `search_files` ``, `` `vision_analyze` ``,
+   `` `browser_navigate` ``, `` `delegate_task` ``, etc.). Do NOT
+   name shell utilities the agent already has wrapped — `grep` →
+   `search_files`, `cat`/`head`/`tail` → `read_file`, `sed`/`awk` →
+   `patch`, `find`/`ls` → `search_files target='files'`. If the skill
+   depends on an MCP server, name the MCP server and document the
+   expected setup in `## Prerequisites`. Anything else (third-party
+   CLIs, shell pipelines, etc.) is fair game inside script files but
+   should not be the headline interaction surface in the prose.
+
+3. **`platforms:` gating audited against actual script imports.**
+   Skills that use POSIX-only primitives (`fcntl`, `termios`,
+   `os.setsid`, `os.kill(pid, 0)` for liveness, `/proc`, `/tmp`
+   hardcoded, `signal.SIGKILL`, bash heredocs, `osascript`, `apt`,
+   `systemctl`) must declare their supported platforms. Default
+   posture: try to fix it cross-platform first — `tempfile.gettempdir`,
+   `pathlib.Path`, `psutil.pid_exists`, Python-level filtering instead
+   of `grep`. Gate to a narrower set only when the dependency is
+   genuinely platform-bound.
+
+4. **`author` credits the human contributor first.** For external
+   contributions, the contributor's real name + GitHub handle goes
+   first; "Hermes Agent" is the secondary collaborator. If the
+   contributor's commit shows "Hermes Agent" as author (because they
+   used Hermes to draft the skill), replace it with their actual name
+   — credit the human, not the tool.
+
+5. **SKILL.md body uses the modern section order.** `# <Skill> Skill`
+   title, 2-3 sentence intro stating what it does and doesn't do,
+   `## When to Use`, `## Prerequisites`, `## How to Run`,
+   `## Quick Reference`, `## Procedure`, `## Pitfalls`,
+   `## Verification`. Target ~200 lines for a complex skill,
+   ~100 lines for a simple one. Cut redundant intro fluff, marketing
+   prose, and re-explanations of env vars already in
+   `## Prerequisites`.
+
+6. **Scripts go in `scripts/`, references in `references/`,
+   templates in `templates/`.** Don't expect the model to inline-write
+   parsers, XML walkers, or non-trivial logic every call — ship a
+   helper script. Reference it from SKILL.md by path relative to the
+   skill directory.
+
+7. **Tests live at `tests/skills/test_<skill>_skill.py`** and use only
+   stdlib + pytest + `unittest.mock`. No live network calls. Run via
+   `scripts/run_tests.sh tests/skills/test_<skill>_skill.py -q`.
+
+8. **`.env.example` additions are isolated to a clearly delimited
+   block.** Don't touch the surrounding file — contributor-supplied
+   `.env.example` versions are usually stale and edits outside the
+   skill's own block must be dropped during salvage.
+
+The full salvage / modernization checklist for external skill PRs
+lives in the `hermes-agent-dev` skill at
+`references/new-skill-pr-salvage.md` — load it before polishing
+contributor skill PRs.

--- a/docs/development/skills-authoring.md
+++ b/docs/development/skills-authoring.md
@@ -109,7 +109,8 @@ violate them.
    `.env.example` versions are usually stale and edits outside the
    skill's own block must be dropped during salvage.
 
-The full salvage / modernization checklist for external skill PRs
-lives in the `hermes-agent-dev` skill at
-`references/new-skill-pr-salvage.md` — load it before polishing
-contributor skill PRs.
+When salvaging an external skill PR, preserve the contributor commit where
+practical, rebase or recut it on current `main`, validate the current skill
+schema and linked files, remove stale generated artifacts, run the repository
+skill validators/docs checks, and inspect the final diff for unrelated drift.
+Do not depend on a private or missing reference to carry this contract.

--- a/docs/development/skins.md
+++ b/docs/development/skins.md
@@ -1,0 +1,92 @@
+# Skin / Theme System
+
+Data-driven CLI theming. Skins are pure data — no code changes needed to add one.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+The skin engine (`hermes_cli/skin_engine.py`) provides data-driven CLI visual customization. Skins are **pure data** — no code changes needed to add a new skin.
+
+### Architecture
+
+```
+hermes_cli/skin_engine.py    # SkinConfig dataclass, built-in skins, YAML loader
+~/.hermes/skins/*.yaml       # User-installed custom skins (drop-in)
+```
+
+- `init_skin_from_config()` — called at CLI startup, reads `display.skin` from config
+- `get_active_skin()` — returns cached `SkinConfig` for the current skin
+- `set_active_skin(name)` — switches skin at runtime (used by `/skin` command)
+- `load_skin(name)` — loads from user skins first, then built-ins, then falls back to default
+- Missing skin values inherit from the `default` skin automatically
+
+### What skins customize
+
+| Element | Skin Key | Used By |
+|---------|----------|---------|
+| Banner panel border | `colors.banner_border` | `banner.py` |
+| Banner panel title | `colors.banner_title` | `banner.py` |
+| Banner section headers | `colors.banner_accent` | `banner.py` |
+| Banner dim text | `colors.banner_dim` | `banner.py` |
+| Banner body text | `colors.banner_text` | `banner.py` |
+| Response box border | `colors.response_border` | `cli.py` |
+| Spinner faces (waiting) | `spinner.waiting_faces` | `display.py` |
+| Spinner faces (thinking) | `spinner.thinking_faces` | `display.py` |
+| Spinner verbs | `spinner.thinking_verbs` | `display.py` |
+| Spinner wings (optional) | `spinner.wings` | `display.py` |
+| Tool output prefix | `tool_prefix` | `display.py` |
+| Per-tool emojis | `tool_emojis` | `display.py` → `get_tool_emoji()` |
+| Agent name | `branding.agent_name` | `banner.py`, `cli.py` |
+| Welcome message | `branding.welcome` | `cli.py` |
+| Response box label | `branding.response_label` | `cli.py` |
+| Prompt symbol | `branding.prompt_symbol` | `cli.py` |
+
+### Built-in skins
+
+- `default` — Classic Hermes gold/kawaii (the current look)
+- `ares` — Crimson/bronze war-god theme with custom spinner wings
+- `mono` — Clean grayscale monochrome
+- `slate` — Cool blue developer-focused theme
+
+### Adding a built-in skin
+
+Add to `_BUILTIN_SKINS` dict in `hermes_cli/skin_engine.py`:
+
+```python
+"mytheme": {
+    "name": "mytheme",
+    "description": "Short description",
+    "colors": { ... },
+    "spinner": { ... },
+    "branding": { ... },
+    "tool_prefix": "┊",
+},
+```
+
+### User skins (YAML)
+
+Users create `~/.hermes/skins/<name>.yaml`:
+
+```yaml
+name: cyberpunk
+description: Neon-soaked terminal theme
+
+colors:
+  banner_border: "#FF00FF"
+  banner_title: "#00FFFF"
+  banner_accent: "#FF1493"
+
+spinner:
+  thinking_verbs: ["jacking in", "decrypting", "uploading"]
+  wings:
+    - ["⟨⚡", "⚡⟩"]
+
+branding:
+  agent_name: "Cyber Agent"
+  response_label: " ⚡ Cyber "
+
+tool_prefix: "▏"
+```
+
+Activate with `/skin cyberpunk` or `display.skin: cyberpunk` in config.yaml.

--- a/docs/development/subsystems.md
+++ b/docs/development/subsystems.md
@@ -1,0 +1,115 @@
+# Subsystems — Curator, Cron, Kanban
+
+Three long-running subsystems with their own CLIs, config sections, and invariants.
+Read the relevant section before changing scheduling, skill lifecycle, or the work queue.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+## Curator (skill lifecycle)
+
+Background skill-maintenance system that tracks usage on agent-created
+skills and auto-archives stale ones. Users never lose skills; archives
+go to `~/.hermes/skills/.archive/` and are restorable.
+
+- **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
+  prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
+- **CLI:** `hermes_cli/curator.py` wires `hermes curator <verb>` where
+  verbs are: `status`, `run`, `pause`, `resume`, `pin`, `unpin`,
+  `archive`, `restore`, `prune`, `backup`, `rollback`.
+- **Telemetry:** `tools/skill_usage.py` owns the sidecar
+  `~/.hermes/skills/.usage.json` — per-skill `use_count`, `view_count`,
+  `patch_count`, `last_activity_at`, `state` (active / stale /
+  archived), `pinned`.
+
+Invariants:
+- Curator only touches skills with `created_by: "agent"` provenance —
+  bundled + hub-installed skills are off-limits.
+- Never deletes; max destructive action is archive.
+- Pinned skills are exempt from every auto-transition and from the
+  LLM review pass.
+- `skill_manage(action="delete")` refuses pinned skills; patch/edit/
+  write_file/remove_file go through so the agent can keep improving
+  pinned skills.
+
+Config section (`curator:` in `config.yaml`):
+`enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
+`archive_after_days`, `backup.*`.
+
+Full user-facing docs: `website/docs/user-guide/features/curator.md`.
+---
+
+## Cron (scheduled jobs)
+
+`cron/jobs.py` (job store) + `cron/scheduler.py` (tick loop). Agents
+schedule jobs via the `cronjob` tool; users via `hermes cron <verb>`
+(`list`, `add`, `edit`, `pause`, `resume`, `run`, `remove`) or the
+`/cron` slash command.
+
+Supported schedule formats:
+- Duration: `"30m"`, `"2h"`, `"1d"`
+- "every" phrase: `"every 2h"`, `"every monday 9am"`
+- 5-field cron expression: `"0 9 * * *"`
+- ISO timestamp (one-shot): `"2026-06-01T09:00:00Z"`
+
+Per-job fields include `skills` (load specific skills), `model` /
+`provider` overrides, `script` (pre-run data-collection script whose
+stdout is injected into the prompt; `no_agent=True` turns the script
+into the entire job), `context_from` (chain job A's last output into
+job B's prompt), `workdir` (run in a specific directory with its
+`AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
+
+Hardening invariants:
+- **3-minute hard interrupt** on cron sessions — runaway agent loops
+  cannot monopolize the scheduler.
+- Catchup window: half the job's period, clamped to 120s–2h.
+- Grace window: 120s for one-shot jobs whose fire time was missed.
+- File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
+  across processes.
+- Cron sessions pass `skip_memory=True` by default; memory providers
+  intentionally do not run during cron.
+
+Cron deliveries are **not** mirrored into the target gateway session —
+they land in their own cron session with a header/footer frame so the
+main conversation's message-role alternation stays intact.
+---
+
+## Kanban (multi-agent work queue)
+
+Durable SQLite-backed board that lets multiple profiles / workers
+collaborate on shared tasks. Users drive it via `hermes kanban <verb>`;
+workers spawned by the dispatcher drive it via a dedicated `kanban_*`
+toolset so their schema footprint is zero when they're not inside a
+kanban task.
+
+- **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
+  `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
+  `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
+  `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
+  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
+- **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
+  `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
+  `kanban_comment`, `kanban_create`, `kanban_link`; profiles that
+  explicitly enable the `kanban` toolset outside a dispatcher-spawned
+  task also get `kanban_list` and `kanban_unblock` for board routing.
+- **Dispatcher:** long-lived loop that (default every 60s) reclaims
+  stale claims, promotes ready tasks, atomically claims, and spawns
+  assigned profiles. Runs **inside the gateway** by default via
+  `kanban.dispatch_in_gateway: true`.
+- **Plugin assets:** `plugins/kanban/dashboard/` (web UI) +
+  `plugins/kanban/systemd/` (`hermes-kanban-dispatcher.service` for
+  standalone dispatcher deployment).
+
+Isolation model:
+- **Board** is the hard boundary — workers are spawned with
+  `HERMES_KANBAN_BOARD` pinned in their env so they can't see other
+  boards.
+- **Tenant** is a soft namespace *within* a board — one specialist
+  fleet can serve multiple businesses with workspace-path + memory-key
+  isolation.
+- After `kanban.failure_limit` consecutive non-success attempts on the
+  same task (default: 2), the dispatcher auto-blocks it to prevent spin
+  loops.
+
+Full user-facing docs: `website/docs/user-guide/features/kanban.md`.

--- a/docs/development/subsystems.md
+++ b/docs/development/subsystems.md
@@ -9,9 +9,9 @@ Read the relevant section before changing scheduling, skill lifecycle, or the wo
 
 ## Curator (skill lifecycle)
 
-Background skill-maintenance system that tracks usage on agent-created
-skills and auto-archives stale ones. Users never lose skills; archives
-go to `~/.hermes/skills/.archive/` and are restorable.
+Background skill-maintenance system that tracks eligible skills and
+auto-archives stale ones. Users never lose skills; archives go to
+`~/.hermes/skills/.archive/` and are restorable.
 
 - **Core:** `agent/curator.py` (review loop, auto-transitions, LLM review
   prompt) + `agent/curator_backup.py` (pre-run tar.gz snapshots).
@@ -24,8 +24,9 @@ go to `~/.hermes/skills/.archive/` and are restorable.
   archived), `pinned`.
 
 Invariants:
-- Curator only touches skills with `created_by: "agent"` provenance —
-  bundled + hub-installed skills are off-limits.
+- Agent-created/adopted local skills are eligible. Bundled built-ins are also
+  eligible when `curator.prune_builtins` is true (the default), except for the
+  small protected set. Hub-installed and external skills remain off-limits.
 - Never deletes; max destructive action is archive.
 - Pinned skills are exempt from every auto-transition and from the
   LLM review pass.
@@ -35,7 +36,7 @@ Invariants:
 
 Config section (`curator:` in `config.yaml`):
 `enabled`, `interval_hours`, `min_idle_hours`, `stale_after_days`,
-`archive_after_days`, `backup.*`.
+`archive_after_days`, `prune_builtins`, `backup.*`.
 
 Full user-facing docs: `website/docs/user-guide/features/curator.md`.
 ---
@@ -61,8 +62,11 @@ job B's prompt), `workdir` (run in a specific directory with its
 `AGENTS.md`/`CLAUDE.md` loaded), and multi-platform delivery.
 
 Hardening invariants:
-- **3-minute hard interrupt** on cron sessions — runaway agent loops
-  cannot monopolize the scheduler.
+- Cron sessions use a **600-second inactivity watchdog by default**; `0`
+  disables it. The watchdog bounds a wedged job rather than imposing a fixed
+  total runtime cap. The legacy `HERMES_CRON_TIMEOUT` bridge remains supported.
+- A pre-run `script` has its own timeout, defaulting to 3,600 seconds, with
+  config/environment resolution separate from the agent inactivity watchdog.
 - Catchup window: half the job's period, clamped to 120s–2h.
 - Grace window: 120s for one-shot jobs whose fire time was missed.
 - File lock at `~/.hermes/cron/.tick.lock` prevents duplicate ticks
@@ -85,14 +89,16 @@ kanban task.
 
 - **CLI:** `hermes_cli/kanban.py` wires `hermes kanban` with verbs
   `init`, `create`, `list` (alias `ls`), `show`, `assign`, `link`,
-  `unlink`, `comment`, `complete`, `block`, `unblock`, `archive`,
-  `tail`, plus less-commonly-used `watch`, `stats`, `runs`, `log`,
-  `assignees`, `heartbeat`, `notify-*`, `dispatch`, `daemon`, `gc`.
+  `unlink`, `comment`, `attach`, `attachments`, `attach-rm`, `complete`,
+  `block`, `unblock`, `archive`, `tail`, plus less-commonly-used `watch`,
+  `stats`, `runs`, `log`, `assignees`, `heartbeat`, `notify-*`,
+  `dispatch`, `daemon`, `gc`.
 - **Worker/orchestrator toolset:** `tools/kanban_tools.py` exposes
   `kanban_show`, `kanban_complete`, `kanban_block`, `kanban_heartbeat`,
-  `kanban_comment`, `kanban_create`, `kanban_link`; profiles that
-  explicitly enable the `kanban` toolset outside a dispatcher-spawned
-  task also get `kanban_list` and `kanban_unblock` for board routing.
+  `kanban_comment`, `kanban_create`, `kanban_link`, `kanban_attach`,
+  `kanban_attach_url`, `kanban_attachments`; profiles that explicitly
+  enable the `kanban` toolset outside a dispatcher-spawned task also get
+  `kanban_list` and `kanban_unblock` for board routing.
 - **Dispatcher:** long-lived loop that (default every 60s) reclaims
   stale claims, promotes ready tasks, atomically claims, and spawns
   assigned profiles. Runs **inside the gateway** by default via

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,0 +1,128 @@
+# Testing Reference
+
+Why the test wrapper exists, how subprocess isolation works, and what makes a test
+a change-detector.
+
+> Extracted from `AGENTS.md`. Load this file when working in this area.
+
+---
+
+**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
+hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
+`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
+on a 16+ core developer machine with API keys set diverges from CI in ways
+that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+
+```bash
+scripts/run_tests.sh                                  # full suite, CI-parity
+scripts/run_tests.sh tests/gateway/                   # one directory
+scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
+scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
+scripts/run_tests.sh --no-isolate tests/foo/          # disable subprocess isolation (faster, for debugging)
+```
+
+### Subprocess-per-test isolation
+
+Every test runs in a freshly-spawned Python subprocess via the in-tree plugin
+at `tests/_isolate_plugin.py`. This means module-level dicts/sets and
+ContextVars from one test cannot leak into the next — the historic
+`_reset_module_state` autouse fixture is gone.
+
+Implementation notes:
+
+- The plugin uses `multiprocessing.get_context("spawn")`, which works on
+  Linux, macOS, and Windows alike (POSIX `fork` is not used).
+- Per-test overhead is ~0.5–1.0s (Python startup + pytest collection). xdist
+  parallelism amortizes this across cores; on a 20-core box the full suite
+  finishes in roughly the same wall time as before, but flake-free.
+- `isolate_timeout` (configured in `pyproject.toml`) caps each test at 30s.
+  Hangs are killed and surfaced as a failure report.
+- Pass `--no-isolate` to disable isolation — useful when debugging a single
+  test interactively, or when you specifically want to verify state leakage.
+- The plugin disables itself in child processes (sentinel envvar
+  `HERMES_ISOLATE_CHILD=1`), so there's no fork-bomb risk.
+
+### Why the wrapper (and why the old "just call pytest" doesn't work)
+
+Five real sources of local-vs-CI drift the script closes:
+
+| | Without wrapper | With wrapper |
+|---|---|---|
+| Provider API keys | Whatever is in your env (auto-detects pool) | All `*_API_KEY`/`*_TOKEN`/etc. unset |
+| HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
+| Timezone | Local TZ (PDT etc.) | UTC |
+| Locale | Whatever is set | C.UTF-8 |
+| xdist workers | `-n auto` = all cores | `-n auto` (safe — subprocess isolation prevents cross-worker flakes) |
+
+`tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
+invocation (including IDE integrations) gets hermetic behavior — but the wrapper
+is belt-and-suspenders.
+
+### Running without the wrapper (only if you must)
+
+If you can't use the wrapper (e.g. inside an IDE that shells pytest directly),
+at minimum activate the venv. The isolation plugin loads automatically from
+`addopts` in `pyproject.toml`, so you get the same per-test process isolation
+either way.
+
+```bash
+source .venv/bin/activate   # or: source venv/bin/activate
+python -m pytest tests/ -q
+```
+
+If you need to bypass isolation for fast feedback while debugging:
+
+```bash
+python -m pytest tests/agent/test_foo.py -q --no-isolate
+```
+
+Always run the full suite before pushing changes.
+
+### Don't write change-detector tests
+
+A test is a **change-detector** if it fails whenever data that is **expected
+to change** gets updated — model catalogs, config version numbers,
+enumeration counts, hardcoded lists of provider models. These tests add no
+behavioral coverage; they just guarantee that routine source updates break
+CI and cost engineering time to "fix."
+
+**Do not write:**
+
+```python
+# catalog snapshot — breaks every model release
+assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
+assert "MiniMax-M2.7" in models
+
+# config version literal — breaks every schema bump
+assert DEFAULT_CONFIG["_config_version"] == 21
+
+# enumeration count — breaks every time a skill/provider is added
+assert len(_PROVIDER_MODELS["huggingface"]) == 8
+```
+
+**Do write:**
+
+```python
+# behavior: does the catalog plumbing work at all?
+assert "gemini" in _PROVIDER_MODELS
+assert len(_PROVIDER_MODELS["gemini"]) >= 1
+
+# behavior: does migration bump the user's version to current latest?
+assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
+
+# invariant: no plan-only model leaks into the legacy list
+assert not (set(moonshot_models) & coding_plan_only_models)
+
+# invariant: every model in the catalog has a context-length entry
+for m in _PROVIDER_MODELS["huggingface"]:
+    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
+```
+
+The rule: if the test reads like a snapshot of current data, delete it. If
+it reads like a contract about how two pieces of data must relate, keep it.
+When a PR adds a new provider/model and you want a test, make the test
+assert the relationship (e.g. "catalog entries all have context lengths"),
+not the specific names.
+
+Reviewers should reject new change-detector tests; authors should convert
+them into invariants before re-requesting review.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -1,128 +1,140 @@
 # Testing Reference
 
-Why the test wrapper exists, how subprocess isolation works, and what makes a test
-a change-detector.
+The CI-parity runner contract, file placement, flake policy, and behavioral test
+standards. Read this file before adding or reviewing tests.
 
-> Extracted from `AGENTS.md`. Load this file when working in this area.
+## Python
 
----
-
-**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script enforces
-hermetic environment parity with CI (unset credential vars, TZ=UTC, LANG=C.UTF-8,
-`-n auto` xdist workers, in-tree subprocess-isolation plugin). Direct `pytest`
-on a 16+ core developer machine with API keys set diverges from CI in ways
-that have caused multiple "works locally, fails in CI" incidents (and the reverse).
+**ALWAYS use `scripts/run_tests.sh`** — do not call `pytest` directly. The script
+enforces hermetic environment parity with CI (unset credential vars, TZ=UTC,
+LANG=C.UTF-8, per-file subprocess isolation via
+`scripts/run_tests_parallel.py` — no xdist, worker count auto-scaled from CPU
+count). Direct `pytest` on a developer machine with API keys set diverges from
+CI in both directions.
 
 ```bash
 scripts/run_tests.sh                                  # full suite, CI-parity
 scripts/run_tests.sh tests/gateway/                   # one directory
-scripts/run_tests.sh tests/agent/test_foo.py::test_x  # one test
+scripts/run_tests.sh tests/agent/test_foo.py -k test_x  # one test (file + -k; runner is file-granular)
 scripts/run_tests.sh -v --tb=long                     # pass-through pytest flags
-scripts/run_tests.sh --no-isolate tests/foo/          # disable subprocess isolation (faster, for debugging)
 ```
 
-### Subprocess-per-test isolation
+**Flake policy:** the runner auto-retries a failing test FILE once in a fresh
+subprocess (`--file-retries`, default 1;
+`HERMES_TEST_FILE_RETRIES=0` disables it). Pass-on-retry counts as green but is
+printed in a `⚠ FLAKY` summary with both attempts. A FLAKY report is a bug to
+fix, not noise: use event-based synchronization, loose wall-clock bounds of at
+least two seconds, and avoid negative-timing races such as
+`assert not _wait_until(...)`.
 
-Every test runs in a freshly-spawned Python subprocess via the in-tree plugin
-at `tests/_isolate_plugin.py`. This means module-level dicts/sets and
-ContextVars from one test cannot leak into the next — the historic
-`_reset_module_state` autouse fixture is gone.
+### Subprocess-per-test-file isolation
 
-Implementation notes:
+Every test file runs in a freshly spawned Python subprocess through
+`scripts/run_tests_parallel.py`. Module-level dicts/sets and ContextVars from
+one test file therefore cannot leak into another.
 
-- The plugin uses `multiprocessing.get_context("spawn")`, which works on
-  Linux, macOS, and Windows alike (POSIX `fork` is not used).
-- Per-test overhead is ~0.5–1.0s (Python startup + pytest collection). xdist
-  parallelism amortizes this across cores; on a 20-core box the full suite
-  finishes in roughly the same wall time as before, but flake-free.
-- `isolate_timeout` (configured in `pyproject.toml`) caps each test at 30s.
-  Hangs are killed and surfaced as a failure report.
-- Pass `--no-isolate` to disable isolation — useful when debugging a single
-  test interactively, or when you specifically want to verify state leakage.
-- The plugin disables itself in child processes (sentinel envvar
-  `HERMES_ISOLATE_CHILD=1`), so there's no fork-bomb risk.
-
-### Why the wrapper (and why the old "just call pytest" doesn't work)
-
-Five real sources of local-vs-CI drift the script closes:
+### Why the wrapper
 
 | | Without wrapper | With wrapper |
 |---|---|---|
-| Provider API keys | Whatever is in your env (auto-detects pool) | All `*_API_KEY`/`*_TOKEN`/etc. unset |
-| HOME / `~/.hermes/` | Your real config+auth.json | Temp dir per test |
-| Timezone | Local TZ (PDT etc.) | UTC |
-| Locale | Whatever is set | C.UTF-8 |
-| xdist workers | `-n auto` = all cores | `-n auto` (safe — subprocess isolation prevents cross-worker flakes) |
+| Provider API keys | Whatever is in the environment | All except a specific few unset |
+| HOME / `~/.hermes/` | Real config and auth state | Temp directory per test |
+| Timezone | Local timezone | UTC |
+| Locale | Host locale | C.UTF-8 |
 
-`tests/conftest.py` also enforces points 1-4 as an autouse fixture so ANY pytest
-invocation (including IDE integrations) gets hermetic behavior — but the wrapper
-is belt-and-suspenders.
+## Where to place tests
 
-### Running without the wrapper (only if you must)
+The CI change classifier (`scripts/ci/classify_changes.py`) selects jobs from
+changed paths. A Python test asserting against `package.json`, lockfiles,
+TypeScript/JavaScript source, or TS config will not run for a frontend-only PR.
+Tests for JS-side artifacts belong in the relevant Vitest suite, not
+`tests/*.py`.
 
-If you can't use the wrapper (e.g. inside an IDE that shells pytest directly),
-at minimum activate the venv. The isolation plugin loads automatically from
-`addopts` in `pyproject.toml`, so you get the same per-test process isolation
-either way.
+## Don't write change-detector tests
 
-```bash
-source .venv/bin/activate   # or: source venv/bin/activate
-python -m pytest tests/ -q
-```
-
-If you need to bypass isolation for fast feedback while debugging:
-
-```bash
-python -m pytest tests/agent/test_foo.py -q --no-isolate
-```
-
-Always run the full suite before pushing changes.
-
-### Don't write change-detector tests
-
-A test is a **change-detector** if it fails whenever data that is **expected
-to change** gets updated — model catalogs, config version numbers,
-enumeration counts, hardcoded lists of provider models. These tests add no
-behavioral coverage; they just guarantee that routine source updates break
-CI and cost engineering time to "fix."
+A change-detector fails whenever data expected to change gets updated — model
+catalogs, config-version literals, enumeration counts, or hardcoded provider
+lists. It adds no behavioral coverage.
 
 **Do not write:**
 
 ```python
-# catalog snapshot — breaks every model release
 assert "gemini-2.5-pro" in _PROVIDER_MODELS["gemini"]
-assert "MiniMax-M2.7" in models
-
-# config version literal — breaks every schema bump
 assert DEFAULT_CONFIG["_config_version"] == 21
-
-# enumeration count — breaks every time a skill/provider is added
 assert len(_PROVIDER_MODELS["huggingface"]) == 8
 ```
 
 **Do write:**
 
 ```python
-# behavior: does the catalog plumbing work at all?
 assert "gemini" in _PROVIDER_MODELS
 assert len(_PROVIDER_MODELS["gemini"]) >= 1
-
-# behavior: does migration bump the user's version to current latest?
 assert raw["_config_version"] == DEFAULT_CONFIG["_config_version"]
-
-# invariant: no plan-only model leaks into the legacy list
 assert not (set(moonshot_models) & coding_plan_only_models)
-
-# invariant: every model in the catalog has a context-length entry
-for m in _PROVIDER_MODELS["huggingface"]:
-    assert m.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
+for model in _PROVIDER_MODELS["huggingface"]:
+    assert model.lower() in DEFAULT_CONTEXT_LENGTHS_LOWER
 ```
 
-The rule: if the test reads like a snapshot of current data, delete it. If
-it reads like a contract about how two pieces of data must relate, keep it.
-When a PR adds a new provider/model and you want a test, make the test
-assert the relationship (e.g. "catalog entries all have context lengths"),
-not the specific names.
+If a test reads like a snapshot of current data, delete it. If it asserts the
+relationship two pieces of data must preserve, keep it.
 
-Reviewers should reject new change-detector tests; authors should convert
-them into invariants before re-requesting review.
+## Do not use source text as a proxy for executable behavior
+
+A test that reads a source file's text tests implementation shape, not behavior.
+It passes when wiring is wrong but a regex still matches, fails on behaviorally
+neutral refactors, cannot test built/minified output, and creates false
+confidence. Tests that read `.py`, `.ts`, `.tsx`, or similar source text are a
+hard antipattern.
+
+Reading an artifact whose contents are themselves the behavior or policy under
+test is different: AGENTS/docs contracts, lockfiles, generated manifests, and
+config artifacts may be read in the suite that owns them. Assert their semantic
+contract, not an incidental formatting snapshot.
+
+**Do not write:**
+
+```ts
+const source = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8')
+
+test('backend spawn hides the Windows console', () => {
+  assert.match(source, /spawn\(\s*backend\.command[\s\S]*windowsHide/)
+})
+```
+
+**Extract and execute the behavior instead:**
+
+```ts
+export function hiddenWindowsChildOptions(
+  options: SpawnOptionsLike = {},
+  isWindows = process.platform === 'win32',
+) {
+  if (!isWindows || 'windowsHide' in options) return options
+  return { ...options, windowsHide: true }
+}
+
+test('windowsHide defaults only on Windows', () => {
+  assert.equal(hiddenWindowsChildOptions({}, true).windowsHide, true)
+  assert.equal(hiddenWindowsChildOptions({}, false).windowsHide, undefined)
+  assert.equal(hiddenWindowsChildOptions({ windowsHide: false }, true).windowsHide, false)
+})
+```
+
+If logic lives inline in a god-file and extraction feels disruptive, that is the
+signal to extract a small pure/DI-testable function rather than regex the file.
+
+## Profile tests
+
+`scripts/run_tests.sh` isolates `HOME` along with credentials, timezone, and
+locale; the `_isolate_hermes_home` autouse fixture separately redirects
+`HERMES_HOME`. Never write to the real `~/.hermes`. Profile-path tests also mock
+`Path.home()` so normal and custom/Docker default-root behavior stay isolated:
+
+```python
+@pytest.fixture
+def profile_env(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+```

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -38,7 +38,7 @@ one test file therefore cannot leak into another.
 | | Without wrapper | With wrapper |
 |---|---|---|
 | Provider API keys | Whatever is in the environment | All except a specific few unset |
-| HOME / `~/.hermes/` | Real config and auth state | Temp directory per test |
+| HOME / `~/.hermes/` | Real config and auth state | Real home (stable); profile state redirected by `HERMES_HOME` |
 | Timezone | Local timezone | UTC |
 | Locale | Host locale | C.UTF-8 |
 
@@ -124,10 +124,12 @@ signal to extract a small pure/DI-testable function rather than regex the file.
 
 ## Profile tests
 
-`scripts/run_tests.sh` isolates `HOME` along with credentials, timezone, and
-locale; the `_isolate_hermes_home` autouse fixture separately redirects
-`HERMES_HOME`. Never write to the real `~/.hermes`. Profile-path tests also mock
-`Path.home()` so normal and custom/Docker default-root behavior stay isolated:
+`scripts/run_tests.sh` preserves the real `HOME` while stripping credentials and
+pinning timezone and locale. The `_hermetic_environment` autouse fixture redirects
+`HERMES_HOME` per test but does **not** redirect `HOME`, because subprocess tests
+depend on a stable home. Never write to the real `~/.hermes`; direct
+`Path.home() / ".hermes"` access is a bug. Tests specifically exercising default
+root discovery may mock `Path.home()`, but must also set `HERMES_HOME`:
 
 ```python
 @pytest.fixture

--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -362,7 +362,7 @@ identifiers are masked in ALL log output, not just your adapter's logs.
 | File | What to update |
 |------|---------------|
 | `README.md` | Platform list in feature table + documentation table |
-| `AGENTS.md` | Gateway description + env var config section |
+| `AGENTS.md` / `docs/development/` | Only when a global invariant or shared architecture changes; do not add per-platform inventory |
 | `website/docs/user-guide/messaging/<platform>.md` | **NEW** — Full setup guide (see existing platform docs for template) |
 | `website/docs/user-guide/messaging/index.md` | Architecture diagram, toolset table, security examples, Next Steps links |
 | `website/docs/reference/environment-variables.md` | All env vars for the platform |
@@ -394,8 +394,8 @@ Optional but valuable:
 After implementing everything, verify with:
 
 ```bash
-# All tests pass
-python -m pytest tests/ -q
+# Focused gateway tests pass through the CI-parity wrapper
+scripts/run_tests.sh tests/gateway/test_<platform>.py -q
 
 # Grep for your platform name to find any missed integration points
 grep -r "telegram\|discord\|whatsapp\|slack" gateway/ tools/ agent/ cron/ hermes_cli/ toolsets.py \

--- a/scripts/check_agents_context.py
+++ b/scripts/check_agents_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Sequence
@@ -40,12 +41,20 @@ def _is_escaped(text: str, index: int) -> bool:
     return backslashes % 2 == 1
 
 
+def _backtick_run_length(text: str, index: int) -> int:
+    end = index
+    while end < len(text) and text[end] == "`":
+        end += 1
+    return end - index
+
+
 def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
-    """Mask fenced/inline code and HTML comments while preserving positions."""
+    """Mask non-navigable Markdown regions while preserving positions."""
     output: list[str] = []
     fence_char: str | None = None
     fence_len = 0
     in_comment = False
+    html_code_tag: str | None = None
     inline_ticks = 0
 
     for line in markdown.splitlines(keepends=True):
@@ -58,15 +67,30 @@ def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
 
         if fence_char is not None:
             output.append("\n" if line.endswith("\n") else "")
-            if marker_char == fence_char and marker_len >= fence_len:
+            marker_tail = stripped[marker_len:].strip()
+            if (
+                marker_char == fence_char
+                and marker_len >= fence_len
+                and not marker_tail
+            ):
                 fence_char = None
                 fence_len = 0
             continue
-        if not in_comment and inline_ticks == 0 and marker_len >= 3:
+        if (
+            not in_comment
+            and html_code_tag is None
+            and inline_ticks == 0
+            and marker_len >= 3
+        ):
             fence_char = marker_char
             fence_len = marker_len
             output.append("\n" if line.endswith("\n") else "")
             continue
+
+        if not in_comment and html_code_tag is None and inline_ticks == 0:
+            if line.startswith("\t") or indent >= 4:
+                output.append("\n" if line.endswith("\n") else "")
+                continue
 
         i = 0
         masked = list(line)
@@ -85,19 +109,37 @@ def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
                 i = end + 3
                 continue
 
-            if inline_ticks:
-                delimiter = "`" * inline_ticks
-                end = line.find(delimiter, i)
-                if end < 0:
+            if html_code_tag is not None:
+                closing = re.search(
+                    rf"</\s*{html_code_tag}\s*>", line[i:], flags=re.IGNORECASE
+                )
+                if closing is None:
                     for j in range(i, len(line)):
                         if line[j] != "\n":
                             masked[j] = " "
                     i = len(line)
                     continue
-                for j in range(i, end + inline_ticks):
+                end = i + closing.end()
+                for j in range(i, end):
                     masked[j] = " "
-                inline_ticks = 0
-                i = end + len(delimiter)
+                html_code_tag = None
+                i = end
+                continue
+
+            if inline_ticks:
+                # Backslash escapes are literal inside a code span; only the
+                # exact run length determines whether this is the closer.
+                if line[i] == "`":
+                    ticks = _backtick_run_length(line, i)
+                    for j in range(i, i + ticks):
+                        masked[j] = " "
+                    i += ticks
+                    if ticks == inline_ticks:
+                        inline_ticks = 0
+                    continue
+                if line[i] != "\n":
+                    masked[i] = " "
+                i += 1
                 continue
 
             if line.startswith("<!--", i):
@@ -114,8 +156,17 @@ def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
                 i = end + 3
                 continue
 
+            html_open = re.match(r"<\s*(pre|code)\b[^>]*>", line[i:], re.IGNORECASE)
+            if html_open is not None:
+                html_code_tag = html_open.group(1).lower()
+                end = i + html_open.end()
+                for j in range(i, end):
+                    masked[j] = " "
+                i = end
+                continue
+
             if line[i] == "`" and not _is_escaped(line, i):
-                ticks = len(line[i:]) - len(line[i:].lstrip("`"))
+                ticks = _backtick_run_length(line, i)
                 inline_ticks = ticks
                 for j in range(i, i + ticks):
                     masked[j] = " "
@@ -128,9 +179,39 @@ def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
         raise ValueError(f"{source}: unterminated fenced code block")
     if in_comment:
         raise ValueError(f"{source}: unterminated HTML comment")
+    if html_code_tag is not None:
+        raise ValueError(f"{source}: unterminated HTML <{html_code_tag}> block")
     if inline_ticks:
         raise ValueError(f"{source}: unterminated inline code span")
     return "".join(output)
+
+
+def _closing_label_index(text: str, opener: int) -> int | None:
+    depth = 1
+    cursor = opener + 1
+    while cursor < len(text):
+        if text[cursor] == "[" and not _is_escaped(text, cursor):
+            depth += 1
+        elif text[cursor] == "]" and not _is_escaped(text, cursor):
+            depth -= 1
+            if depth == 0:
+                return cursor
+        cursor += 1
+    return None
+
+
+def _closing_destination_index(text: str, opener: int, *, source: str) -> int:
+    depth = 1
+    cursor = opener + 1
+    while cursor < len(text):
+        if text[cursor] == "(" and not _is_escaped(text, cursor):
+            depth += 1
+        elif text[cursor] == ")" and not _is_escaped(text, cursor):
+            depth -= 1
+            if depth == 0:
+                return cursor
+        cursor += 1
+    raise ValueError(f"{source}: unterminated Markdown link at character {opener}")
 
 
 def extract_navigable_links(markdown: str, *, source: str) -> list[str]:
@@ -143,6 +224,18 @@ def extract_navigable_links(markdown: str, *, source: str) -> list[str]:
     links: list[str] = []
     i = 0
     while i < len(text):
+        if text.startswith("![", i) and not _is_escaped(text, i):
+            close_label = _closing_label_index(text, i + 1)
+            if close_label is None:
+                i = len(text)
+                continue
+            if close_label + 1 < len(text) and text[close_label + 1] == "(":
+                i = _closing_destination_index(
+                    text, close_label + 1, source=source
+                ) + 1
+            else:
+                i = close_label + 1
+            continue
         if text[i] != "[" or _is_escaped(text, i):
             i += 1
             continue
@@ -150,29 +243,19 @@ def extract_navigable_links(markdown: str, *, source: str) -> list[str]:
             i += 1
             continue
 
-        close_label = i + 1
-        while close_label < len(text):
-            if text[close_label] == "]" and not _is_escaped(text, close_label):
-                break
-            close_label += 1
-        if close_label >= len(text) or close_label + 1 >= len(text) or text[close_label + 1] != "(":
+        close_label = _closing_label_index(text, i)
+        if (
+            close_label is None
+            or close_label + 1 >= len(text)
+            or text[close_label + 1] != "("
+        ):
             i += 1
             continue
 
         cursor = close_label + 2
-        depth = 1
-        destination_end = cursor
-        while destination_end < len(text):
-            char = text[destination_end]
-            if char == "(" and not _is_escaped(text, destination_end):
-                depth += 1
-            elif char == ")" and not _is_escaped(text, destination_end):
-                depth -= 1
-                if depth == 0:
-                    break
-            destination_end += 1
-        if depth:
-            raise ValueError(f"{source}: unterminated Markdown link at character {i}")
+        destination_end = _closing_destination_index(
+            text, close_label + 1, source=source
+        )
 
         raw = text[cursor:destination_end].strip()
         if raw.startswith("<"):
@@ -209,7 +292,11 @@ def _resolve_relative_target(
     source_path: Path,
     destination: str,
 ) -> tuple[str | None, str | None]:
-    parsed = urlsplit(destination)
+    try:
+        parsed = urlsplit(destination)
+    except ValueError:
+        relative_source = source_path.relative_to(repo_root)
+        return None, f"{relative_source} link {destination!r} has malformed URL destination"
     if parsed.scheme or parsed.netloc or destination.startswith("#"):
         return None, None
     relative = unquote(parsed.path)

--- a/scripts/check_agents_context.py
+++ b/scripts/check_agents_context.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Validate repository-owned AGENTS context budgets and navigable links."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+from pathlib import Path
+from typing import Sequence
+from urllib.parse import unquote, urlsplit
+
+MAX_ROOT_CHARS = 18_000
+GOVERNING_FILES = ("AGENTS.md", "apps/desktop/AGENTS.md")
+REQUIRED_REFERENCES = (
+    "CONTRIBUTING.md",
+    "docs/development/contribution-rubric.md",
+    "docs/development/architecture-core.md",
+    "docs/development/architecture-tui.md",
+    "docs/development/configuration.md",
+    "docs/development/plugins.md",
+    "docs/development/skills-authoring.md",
+    "docs/development/skins.md",
+    "docs/development/subsystems.md",
+    "docs/development/testing.md",
+    "apps/desktop/AGENTS.md",
+    "apps/desktop/DESIGN.md",
+    "website/docs/developer-guide/gateway-internals.md",
+    "gateway/platforms/ADDING_A_PLATFORM.md",
+    "website/docs/developer-guide/adding-tools.md",
+)
+
+
+def _is_escaped(text: str, index: int) -> bool:
+    backslashes = 0
+    index -= 1
+    while index >= 0 and text[index] == "\\":
+        backslashes += 1
+        index -= 1
+    return backslashes % 2 == 1
+
+
+def _mask_excluded_markdown(markdown: str, *, source: str) -> str:
+    """Mask fenced/inline code and HTML comments while preserving positions."""
+    output: list[str] = []
+    fence_char: str | None = None
+    fence_len = 0
+    in_comment = False
+    inline_ticks = 0
+
+    for line in markdown.splitlines(keepends=True):
+        stripped = line.lstrip(" ")
+        indent = len(line) - len(stripped)
+        marker_char = stripped[:1]
+        marker_len = 0
+        if indent <= 3 and marker_char in {"`", "~"}:
+            marker_len = len(stripped) - len(stripped.lstrip(marker_char))
+
+        if fence_char is not None:
+            output.append("\n" if line.endswith("\n") else "")
+            if marker_char == fence_char and marker_len >= fence_len:
+                fence_char = None
+                fence_len = 0
+            continue
+        if not in_comment and inline_ticks == 0 and marker_len >= 3:
+            fence_char = marker_char
+            fence_len = marker_len
+            output.append("\n" if line.endswith("\n") else "")
+            continue
+
+        i = 0
+        masked = list(line)
+        while i < len(line):
+            if in_comment:
+                end = line.find("-->", i)
+                if end < 0:
+                    for j in range(i, len(line)):
+                        if line[j] != "\n":
+                            masked[j] = " "
+                    i = len(line)
+                    continue
+                for j in range(i, end + 3):
+                    masked[j] = " "
+                in_comment = False
+                i = end + 3
+                continue
+
+            if inline_ticks:
+                delimiter = "`" * inline_ticks
+                end = line.find(delimiter, i)
+                if end < 0:
+                    for j in range(i, len(line)):
+                        if line[j] != "\n":
+                            masked[j] = " "
+                    i = len(line)
+                    continue
+                for j in range(i, end + inline_ticks):
+                    masked[j] = " "
+                inline_ticks = 0
+                i = end + len(delimiter)
+                continue
+
+            if line.startswith("<!--", i):
+                end = line.find("-->", i + 4)
+                if end < 0:
+                    for j in range(i, len(line)):
+                        if line[j] != "\n":
+                            masked[j] = " "
+                    in_comment = True
+                    i = len(line)
+                    continue
+                for j in range(i, end + 3):
+                    masked[j] = " "
+                i = end + 3
+                continue
+
+            if line[i] == "`" and not _is_escaped(line, i):
+                ticks = len(line[i:]) - len(line[i:].lstrip("`"))
+                inline_ticks = ticks
+                for j in range(i, i + ticks):
+                    masked[j] = " "
+                i += ticks
+                continue
+            i += 1
+        output.append("".join(masked))
+
+    if fence_char is not None:
+        raise ValueError(f"{source}: unterminated fenced code block")
+    if in_comment:
+        raise ValueError(f"{source}: unterminated HTML comment")
+    if inline_ticks:
+        raise ValueError(f"{source}: unterminated inline code span")
+    return "".join(output)
+
+
+def extract_navigable_links(markdown: str, *, source: str) -> list[str]:
+    """Return ordinary inline Markdown link destinations.
+
+    Images, escaped syntax, code spans/blocks, and HTML comments are excluded.
+    Malformed candidate links fail closed instead of being silently ignored.
+    """
+    text = _mask_excluded_markdown(markdown, source=source)
+    links: list[str] = []
+    i = 0
+    while i < len(text):
+        if text[i] != "[" or _is_escaped(text, i):
+            i += 1
+            continue
+        if i > 0 and text[i - 1] == "!" and not _is_escaped(text, i - 1):
+            i += 1
+            continue
+
+        close_label = i + 1
+        while close_label < len(text):
+            if text[close_label] == "]" and not _is_escaped(text, close_label):
+                break
+            close_label += 1
+        if close_label >= len(text) or close_label + 1 >= len(text) or text[close_label + 1] != "(":
+            i += 1
+            continue
+
+        cursor = close_label + 2
+        depth = 1
+        destination_end = cursor
+        while destination_end < len(text):
+            char = text[destination_end]
+            if char == "(" and not _is_escaped(text, destination_end):
+                depth += 1
+            elif char == ")" and not _is_escaped(text, destination_end):
+                depth -= 1
+                if depth == 0:
+                    break
+            destination_end += 1
+        if depth:
+            raise ValueError(f"{source}: unterminated Markdown link at character {i}")
+
+        raw = text[cursor:destination_end].strip()
+        if raw.startswith("<"):
+            angle_end = raw.find(">")
+            if angle_end < 0:
+                raise ValueError(f"{source}: malformed angle-bracket link at character {i}")
+            destination = raw[1:angle_end]
+        else:
+            destination = raw.split(maxsplit=1)[0] if raw else ""
+        if not destination:
+            raise ValueError(f"{source}: empty Markdown link at character {i}")
+        links.append(destination)
+        i = destination_end + 1
+    return links
+
+
+def _tracked_files(repo_root: Path) -> tuple[set[str], str | None]:
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        return {
+            os.fsdecode(item) for item in completed.stdout.split(b"\0") if item
+        }, None
+    except (OSError, subprocess.CalledProcessError) as exc:
+        return set(), f"could not enumerate tracked files: {exc}"
+
+
+def _resolve_relative_target(
+    repo_root: Path,
+    source_path: Path,
+    destination: str,
+) -> tuple[str | None, str | None]:
+    parsed = urlsplit(destination)
+    if parsed.scheme or parsed.netloc or destination.startswith("#"):
+        return None, None
+    relative = unquote(parsed.path)
+    if not relative:
+        return None, None
+    candidate = (source_path.parent / relative).resolve()
+    try:
+        normalized = candidate.relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return None, f"{source_path.relative_to(repo_root)} link {destination!r} escapes repository root"
+    return normalized, None
+
+
+def validate_repository(
+    repo_root: Path,
+    *,
+    max_root_chars: int = MAX_ROOT_CHARS,
+    required_references: Sequence[str] = REQUIRED_REFERENCES,
+) -> list[str]:
+    """Return all repository AGENTS context contract violations."""
+    repo_root = repo_root.resolve()
+    errors: list[str] = []
+    tracked, git_error = _tracked_files(repo_root)
+    if git_error:
+        return [git_error]
+
+    contents: dict[str, str] = {}
+    for relative in GOVERNING_FILES:
+        path = repo_root / relative
+        if relative not in tracked or not path.is_file() or path.is_symlink():
+            errors.append(f"required governing file is missing: {relative}")
+            continue
+        try:
+            contents[relative] = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
+            errors.append(f"could not read {relative}: {exc}")
+
+    root = contents.get("AGENTS.md")
+    if root is not None and len(root) > max_root_chars:
+        errors.append(
+            f"AGENTS.md has {len(root):,} characters; exceeds {max_root_chars:,}-character contract"
+        )
+
+    resolved_root_targets: set[str] = set()
+    for relative, markdown in contents.items():
+        source_path = repo_root / relative
+        try:
+            links = extract_navigable_links(markdown, source=relative)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        for destination in links:
+            normalized, resolution_error = _resolve_relative_target(
+                repo_root, source_path, destination
+            )
+            if resolution_error:
+                errors.append(resolution_error)
+                continue
+            if normalized is None:
+                continue
+            target = repo_root / normalized
+            if (
+                normalized not in tracked
+                or not target.is_file()
+                or target.is_symlink()
+            ):
+                errors.append(
+                    f"{relative} link {destination!r} does not resolve to a tracked regular file"
+                )
+                continue
+            if relative == "AGENTS.md":
+                resolved_root_targets.add(normalized)
+
+    for required in required_references:
+        if required not in resolved_root_targets:
+            errors.append(f"required navigable link is missing: {required}")
+    return errors
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="repository root (default: parent of scripts/)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    repo_root = _parse_args(argv).repo_root.resolve()
+    errors = validate_repository(repo_root)
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1
+    root_chars = len((repo_root / "AGENTS.md").read_text(encoding="utf-8"))
+    print(
+        f"PASS: AGENTS context contract ({root_chars:,}/{MAX_ROOT_CHARS:,} root characters; "
+        f"{len(REQUIRED_REFERENCES)} required links resolved)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/classify_changes.py
+++ b/scripts/ci/classify_changes.py
@@ -33,6 +33,9 @@ must never skip one a change could break:
   or a frontend-only package; an unrecognized path keeps it on.
 * ``skills/`` (incl. ``SKILL.md``) is python-relevant — the skill-doc tests
   read that tree, so a doc-looking edit can still break Python.
+* Any basename case-folding to ``agents.md`` is python-relevant — the
+  context-budget contract reads governing files, while ``python_prod`` remains
+  false for those non-product inputs.
 """
 
 from __future__ import annotations
@@ -47,6 +50,7 @@ _DOCKER_META = ("docker/", ".hadolint.yml", "Dockerfile") # docker setup
 _SITE = ("website/", "skills/", "optional-skills/")  # docs site + skill pages
 # Prose/frontend trees that can't touch Python. skills/ is excluded on purpose.
 _PY_SKIP = ("docs/", "website/") + _FRONTEND
+_PROJECT_CONTEXT_NAMES = {"agents.md"}
 
 # CI-sensitive files: eslint config, workflow files, composite actions.
 # Changes here can influence what code the autofix job executes and pushes to
@@ -80,20 +84,28 @@ def _is_docs(p: str) -> bool:
     return p.endswith((".md", ".mdx")) or p.startswith("docs/") or p.startswith("LICENSE")
 
 
+def _is_project_context(p: str) -> bool:
+    return p.rsplit("/", 1)[-1].casefold() in _PROJECT_CONTEXT_NAMES
+
+
 def _py_irrelevant(p: str) -> bool:
-    return _is_docs(p) or p in _ROOT_NPM or p.startswith(_PY_SKIP) or p.startswith(_DOCKER_META)
+    return not _is_project_context(p) and (
+        _is_docs(p) or p in _ROOT_NPM or p.startswith(_PY_SKIP) or p.startswith(_DOCKER_META)
+    )
 
 
 def _py_test_only(p: str) -> bool:
-    """Is ``p`` inside the test suite (never shipped / imported by the product)?
+    """Is ``p`` a test-only input (never shipped/imported by the product)?
 
     Product jobs (Desktop E2E's ``hermes serve`` backend, the Docker image)
     run installed code — nothing under ``tests/`` is packaged or importable
-    there. scripts/run_tests.sh and run_tests_parallel.py are deliberately
-    NOT test-only: they are runner infrastructure, and a bad edit there can
-    mask real failures, so they stay conservative (python_prod=true).
+    there. Governing AGENTS.md files are exercised by repository-context tests
+    but are likewise not product code. scripts/run_tests.sh and
+    run_tests_parallel.py are deliberately NOT test-only: they are runner
+    infrastructure, and a bad edit there can mask real failures, so they stay
+    conservative (python_prod=true).
     """
-    return p.startswith("tests/")
+    return p.startswith("tests/") or _is_project_context(p)
 
 
 def _is_scan(p: str) -> bool:

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -1,7 +1,8 @@
 # Durable & Background Systems
 
 Four systems run alongside the main conversation loop. Quick reference
-here; full developer notes live in `AGENTS.md`, user-facing docs under
+here; full developer notes live in `docs/development/architecture-core.md`
+and `docs/development/subsystems.md`, with user-facing docs under
 `website/docs/user-guide/features/`.
 
 ### Delegation (`delegate_task`)
@@ -11,11 +12,12 @@ Spawn a subagent with an isolated context + terminal session.
 - **Single:** `delegate_task(goal, context)`.
 - **Batch:** `delegate_task(tasks=[{goal, ...}, ...])` runs children in
   parallel, capped by `delegation.max_concurrent_children` (default 3).
-- **Background:** `delegate_task(background=true)` returns a handle
-  immediately and keeps the parent loop going; the child's result
-  re-enters the conversation as a new turn when it finishes.
-- **Roles:** `leaf` (default; cannot re-delegate) vs `orchestrator`
-  (can spawn its own workers, bounded by `delegation.max_spawn_depth`).
+- **Background:** top-level model-facing calls dispatch asynchronously
+  automatically and re-enter the result later. The model-facing `background`
+  parameter is deprecated and ignored; direct Python/orchestrator paths retain
+  synchronous semantics.
+- **Roles:** `leaf` is the default. The default spawn depth is 1 (flat), so an
+  `orchestrator` role can re-delegate only when configuration raises that cap.
 - **Not durable.** A backgrounded child is still process-local — if the
   parent process exits, the child is lost. For work that must outlive
   the process, use `cronjob` or
@@ -36,11 +38,11 @@ the `cronjob` tool, the `hermes cron` CLI (`list`, `add`, `edit`,
   job), `context_from` (chain job A's output into job B), `workdir`
   (run in a specific dir with its `AGENTS.md` / `CLAUDE.md` loaded),
   multi-platform delivery.
-- **Invariants:** 3-minute hard interrupt per run, `.tick.lock` file
-  prevents duplicate ticks across processes, cron sessions pass
-  `skip_memory=True` by default, and cron deliveries are framed with a
-  header/footer instead of being mirrored into the target gateway
-  session (keeps role alternation intact).
+- **Invariants:** a 600-second inactivity watchdog by default (`0` disables
+  it; legacy `HERMES_CRON_TIMEOUT` remains supported), while pre-run scripts
+  have a separate 3,600-second default timeout. `.tick.lock` prevents duplicate
+  ticks, cron sessions pass `skip_memory=True`, and deliveries are framed rather
+  than mirrored into the target session (preserving role alternation).
 
 User docs: https://hermes-agent.nousresearch.com/docs/user-guide/features/cron
 

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -56,10 +56,11 @@ so nothing is lost.
   `resume`, `pin`, `unpin`, `archive`, `restore`, `list-archived`, `prune`,
   `backup`, `rollback`.
 - **Slash:** `/curator <subcommand>` mirrors the CLI.
-- **Scope:** only touches skills with `created_by: "agent"` provenance.
-  Bundled + hub-installed skills are off-limits. **Never deletes** —
-  max destructive action is archive. Pinned skills are exempt from
-  every auto-transition and every LLM review pass.
+- **Scope:** agent-created skills are eligible. Bundled built-ins are also
+  eligible when `curator.prune_builtins: true` (the default), but skills that are
+  protected, pinned, or referenced by cron jobs remain exempt. Hub-installed
+  skills stay off-limits. **Never deletes** — max destructive action is archive.
+  Pinned skills are exempt from every auto-transition and every LLM review pass.
 - **Cost:** the deterministic inactivity/prune sweep runs for free. The
   aux-model "consolidate overlapping skills into umbrellas" pass is
   **off by default** — opt in with `curator.consolidate: true` or

--- a/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/background-systems.md
@@ -94,9 +94,10 @@ sessions still have zero `kanban_*` schema footprint unless configured.
 - **Dispatcher** runs inside the gateway by default
   (`kanban.dispatch_in_gateway: true`) — reclaims stale claims,
   promotes ready tasks, atomically claims, spawns assigned profiles.
-  Auto-blocks a task after `failure_limit` consecutive spawn failures
-  (default 2; configurable via `kanban.failure_limit` or per-task
-  `max_retries`).
+  Auto-blocks a task after `failure_limit` consecutive non-success outcomes,
+  including `spawn_failed`, `crashed`, and `timed_out` (default 2;
+  configurable via `kanban.failure_limit` or per-task `max_retries`). A
+  successful completion resets the streak.
 - **Isolation:** board is the hard boundary (workers get
   `HERMES_KANBAN_BOARD` pinned in env); tenant is a soft namespace
   within a board for workspace-path + memory-key isolation.

--- a/tests/agent/test_repository_context_budget.py
+++ b/tests/agent/test_repository_context_budget.py
@@ -1,0 +1,60 @@
+"""Runtime budget contract for tracked governing ``AGENTS.md`` files only.
+
+Other recognized context filenames can be intentional templates or fixtures and
+are outside this repository-policy guard.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from agent.prompt_builder import (
+    build_context_files_prompt,
+    drain_truncation_warnings,
+)
+from agent.subdirectory_hints import SubdirectoryHintTracker
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_AGENTS_PATHS = ("AGENTS.md", ":(glob)**/AGENTS.md", "agents.md", ":(glob)**/agents.md")
+
+
+def _repository_agents_files() -> list[Path]:
+    output = subprocess.check_output(
+        ["git", "ls-files", "--", *_AGENTS_PATHS],
+        cwd=_REPO_ROOT,
+        text=True,
+    )
+    return [_REPO_ROOT / relative for relative in output.splitlines()]
+
+
+def test_tracked_repository_agents_files_load_without_truncation():
+    agents_files = set(_repository_agents_files())
+    required = {_REPO_ROOT / "AGENTS.md", _REPO_ROOT / "apps/desktop/AGENTS.md"}
+    assert required <= agents_files, "required governing AGENTS.md files are not tracked"
+
+    root_context_path = _REPO_ROOT / "AGENTS.md"
+    assert root_context_path.is_file(), "repository root AGENTS.md is missing"
+    root_context = root_context_path.read_text(encoding="utf-8").strip()
+
+    drain_truncation_warnings()
+    prompt = build_context_files_prompt(cwd=str(_REPO_ROOT), skip_soul=True)
+    warnings = drain_truncation_warnings()
+    assert f"## AGENTS.md\n\n{root_context}" in prompt, (
+        "repository root AGENTS.md was not loaded in full"
+    )
+    assert not warnings, f"root project context exceeds the startup budget: {warnings}"
+
+    for path in sorted(agents_files):
+        if path.parent == _REPO_ROOT:
+            continue
+        relative = path.relative_to(_REPO_ROOT)
+        assert path.is_file(), f"{relative} is missing"
+        expected = path.read_text(encoding="utf-8").strip()
+        tracker = SubdirectoryHintTracker(working_dir=str(_REPO_ROOT))
+        hint = tracker.check_tool_call("read_file", {"path": str(path.parent / "probe.py")})
+        assert hint is not None, f"{relative} was not discovered"
+        assert expected in hint, f"{relative} was not loaded in full"
+        assert "[...truncated " not in hint, (
+            f"{relative} exceeds the progressive budget"
+        )

--- a/tests/ci/test_classify_changes.py
+++ b/tests/ci/test_classify_changes.py
@@ -68,6 +68,18 @@ CASES = {
     # SKILL.md reads like docs, but the skill-doc tests read skills/, so a
     # skill edit must still run Python.
     "skill md → python + site": (["skills/github/SKILL.md"], _lanes(python=True, site=True)),
+    "root project context → budget contract without product jobs": (
+        ["AGENTS.md"],
+        _lanes(python=True, python_prod=False),
+    ),
+    "frontend project context → budget contract + frontend": (
+        ["apps/desktop/AGENTS.md"],
+        _lanes(python=True, python_prod=False, frontend=True),
+    ),
+    "project context basename is case-insensitive": (
+        ["docs/AgEnTs.Md"],
+        _lanes(python=True, python_prod=False),
+    ),
     "dockerfile → docker meta": (["Dockerfile"], _lanes(docker_meta=True)),
     # install.ps1 is a shell script Python never imports, but it's also not
     # provably prose, so python stays on (fail-open) alongside the Windows lane.

--- a/tests/scripts/test_agents_context_contract.py
+++ b/tests/scripts/test_agents_context_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import subprocess
 from pathlib import Path
 
@@ -265,11 +266,14 @@ def test_documented_test_isolation_preserves_real_home_and_redirects_hermes_home
 
     assert "real `HOME` remains stable" in root_contract
     assert "Direct `Path.home() / \".hermes\"` access is a bug" in root_contract
+    assert "hermetic HOME" not in root_contract
     assert "Real home (stable); profile state redirected by `HERMES_HOME`" in testing_reference
     assert "does **not** redirect `HOME`" in testing_reference
 
 
-def test_configuration_reference_names_default_definition_and_reexport():
+def test_configuration_reference_names_config_data_definitions_and_reexports():
+    from hermes_cli import config, config_defaults
+
     repo_root = Path(__file__).resolve().parents[2]
     reference = " ".join(
         (repo_root / "docs/development/configuration.md")
@@ -277,9 +281,51 @@ def test_configuration_reference_names_default_definition_and_reexport():
         .split()
     )
 
-    assert "defined in `hermes_cli/config_defaults.py`" in reference
-    assert "re-exported from `hermes_cli/config.py`" in reference
+    assert (
+        "Both `DEFAULT_CONFIG` and `OPTIONAL_ENV_VARS` are defined in "
+        "`hermes_cli/config_defaults.py` and re-exported from "
+        "`hermes_cli/config.py`"
+    ) in reference
     assert "`_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()`" in reference
+    assert config.DEFAULT_CONFIG is config_defaults.DEFAULT_CONFIG
+    assert config.OPTIONAL_ENV_VARS is config_defaults.OPTIONAL_ENV_VARS
+
+
+def test_plugin_reference_uses_noncontradictory_discovery_taxonomy():
+    repo_root = Path(__file__).resolve().parents[2]
+    reference = " ".join(
+        (repo_root / "docs/development/plugins.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "three primary discovery systems" in reference
+    assert "two plugin surfaces" not in reference
+    assert "General plugins (`hermes_cli/plugins.py`" in reference
+    assert "Memory-provider plugins (`plugins/memory/<name>/`)" in reference
+    assert "Model-provider plugins (`plugins/model-providers/<name>/`)" in reference
+    assert "Additional provider families" in reference
+
+
+def test_kanban_reference_matches_non_success_outcomes_counted_by_dispatcher():
+    from hermes_cli.kanban_db import _record_task_failure
+
+    repo_root = Path(__file__).resolve().parents[2]
+    reference = " ".join(
+        (
+            repo_root
+            / "skills/autonomous-ai-agents/hermes-agent/references/background-systems.md"
+        )
+        .read_text(encoding="utf-8")
+        .split()
+    )
+    runtime_contract = inspect.getdoc(_record_task_failure) or ""
+
+    assert "consecutive non-success outcomes" in reference
+    assert "consecutive spawn failures" not in reference
+    for outcome in ("spawn_failed", "crashed", "timed_out"):
+        assert outcome in reference
+        assert outcome in runtime_contract
 
 
 def test_curator_reference_documents_builtin_pruning_safeguards():

--- a/tests/scripts/test_agents_context_contract.py
+++ b/tests/scripts/test_agents_context_contract.py
@@ -65,15 +65,32 @@ def test_contract_rejects_one_character_above_root_limit(tmp_path):
     "replacement",
     [
         "![target](target.md)",
+        "![nested [target](target.md)](image.png)",
         "`[target](target.md)`",
         "``[target](target.md)``",
         r"\[target](target.md)",
         "<!-- [target](target.md) -->",
+        "    [target](target.md)",
+        "<pre>\n[target](target.md)\n</pre>",
+        "<code>\n[target](target.md)\n</code>",
         "```markdown\n[target](target.md)\n```",
         "````markdown\n```\n[target](target.md)\n```\n````",
         "~~~~markdown\n[target](target.md)\n~~~~",
     ],
-    ids=["image", "inline-code", "long-inline-code", "escaped", "comment", "fence", "long-fence", "tilde-fence"],
+    ids=[
+        "image",
+        "nested-image-label",
+        "inline-code",
+        "long-inline-code",
+        "escaped",
+        "comment",
+        "indented-code",
+        "html-pre",
+        "html-code",
+        "fence",
+        "long-fence",
+        "tilde-fence",
+    ],
 )
 def test_required_reference_must_be_an_ordinary_navigable_link(tmp_path, replacement):
     repo = _contract_repo(tmp_path)
@@ -105,6 +122,52 @@ def test_link_extractor_ignores_non_links_and_keeps_ordinary_links():
         "https://example.com/x",
         "#local",
     ]
+
+
+def test_invalid_fence_closer_does_not_expose_links_from_fenced_code():
+    markdown = """```
+``` trailing text is not a closer
+[hidden](hidden.md)
+```
+[ordinary](ordinary.md)
+"""
+
+    assert extract_navigable_links(markdown, source="AGENTS.md") == ["ordinary.md"]
+
+
+def test_fence_markers_inside_raw_html_code_do_not_change_parser_state():
+    markdown = """<pre>
+```
+[hidden](hidden.md)
+</pre>
+[ordinary](ordinary.md)
+"""
+
+    assert extract_navigable_links(markdown, source="AGENTS.md") == ["ordinary.md"]
+
+
+@pytest.mark.parametrize("delimiter_length", [1, 2, 3])
+def test_inline_code_closes_only_on_an_exact_backtick_run(delimiter_length):
+    delimiter = "`" * delimiter_length
+    longer_length = 3 if delimiter_length == 1 else delimiter_length + 1
+    longer_run = "`" * longer_length
+    leftover_run = "`" * (longer_length - delimiter_length)
+    markdown = (
+        f"prose {delimiter}opener {longer_run}internal{leftover_run}"
+        f"[hidden](hidden.md) closer{delimiter}\n[ordinary](ordinary.md)\n"
+    )
+
+    assert extract_navigable_links(markdown, source="AGENTS.md") == ["ordinary.md"]
+
+
+@pytest.mark.parametrize("delimiter_length", [1, 2, 3])
+def test_inline_code_exact_closer_is_not_escaped_inside_span(delimiter_length):
+    delimiter = "`" * delimiter_length
+    markdown = (
+        f"prose {delimiter}code\\{delimiter}\n[ordinary](ordinary.md)\n"
+    )
+
+    assert extract_navigable_links(markdown, source="AGENTS.md") == ["ordinary.md"]
 
 
 def test_relative_link_query_and_fragment_are_stripped_for_resolution(tmp_path):
@@ -145,6 +208,17 @@ def test_contract_rejects_invalid_relative_links(tmp_path, target, expected):
     assert any(expected in error and target in error for error in errors)
 
 
+@pytest.mark.parametrize("target", ["http://[", "//["])
+def test_contract_reports_malformed_url_destinations_without_raising(tmp_path, target):
+    repo = _contract_repo(tmp_path)
+    with (repo / "AGENTS.md").open("a", encoding="utf-8") as handle:
+        handle.write(f"\n[bad]({target})\n")
+
+    errors = validate_repository(repo)
+
+    assert f"AGENTS.md link {target!r} has malformed URL destination" in errors
+
+
 def test_contract_requires_root_and_desktop_governing_files(tmp_path):
     repo = _contract_repo(tmp_path)
     (repo / "AGENTS.md").unlink()
@@ -176,3 +250,44 @@ def test_repository_agents_context_contract():
     repo_root = Path(__file__).resolve().parents[2]
 
     assert validate_repository(repo_root) == []
+
+
+def test_documented_test_isolation_preserves_real_home_and_redirects_hermes_home():
+    repo_root = Path(__file__).resolve().parents[2]
+    root_contract = " ".join(
+        (repo_root / "AGENTS.md").read_text(encoding="utf-8").split()
+    )
+    testing_reference = " ".join(
+        (repo_root / "docs/development/testing.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "real `HOME` remains stable" in root_contract
+    assert "Direct `Path.home() / \".hermes\"` access is a bug" in root_contract
+    assert "Real home (stable); profile state redirected by `HERMES_HOME`" in testing_reference
+    assert "does **not** redirect `HOME`" in testing_reference
+
+
+def test_configuration_reference_names_default_definition_and_reexport():
+    repo_root = Path(__file__).resolve().parents[2]
+    reference = " ".join(
+        (repo_root / "docs/development/configuration.md")
+        .read_text(encoding="utf-8")
+        .split()
+    )
+
+    assert "defined in `hermes_cli/config_defaults.py`" in reference
+    assert "re-exported from `hermes_cli/config.py`" in reference
+    assert "`_EXTRA_KNOWN_ROOT_KEYS` and `read_user_config_raw()`" in reference
+
+
+def test_curator_reference_documents_builtin_pruning_safeguards():
+    repo_root = Path(__file__).resolve().parents[2]
+    reference = (
+        repo_root
+        / "skills/autonomous-ai-agents/hermes-agent/references/background-systems.md"
+    ).read_text(encoding="utf-8")
+
+    assert "`curator.prune_builtins: true` (the default)" in reference
+    assert "protected, pinned, or referenced by cron jobs" in reference

--- a/tests/scripts/test_agents_context_contract.py
+++ b/tests/scripts/test_agents_context_contract.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from scripts.check_agents_context import (
+    MAX_ROOT_CHARS,
+    REQUIRED_REFERENCES,
+    extract_navigable_links,
+    validate_repository,
+)
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True, text=True)
+
+
+def _write(repo: Path, relative: str, content: str = "# Reference\n") -> Path:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _contract_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q")
+    for relative in REQUIRED_REFERENCES:
+        _write(repo, relative)
+    links = "\n".join(f"[{relative}]({relative})" for relative in REQUIRED_REFERENCES)
+    _write(repo, "AGENTS.md", f"# Guide\n\n{links}\n")
+    _write(repo, "apps/desktop/AGENTS.md", "# Desktop\n\n[Design](./DESIGN.md)\n")
+    _git(repo, "add", ".")
+    return repo
+
+
+def _root_at_size(repo: Path, size: int) -> None:
+    path = repo / "AGENTS.md"
+    current = path.read_text(encoding="utf-8")
+    assert len(current) <= size
+    path.write_text(current + "x" * (size - len(current)), encoding="utf-8")
+
+
+def test_contract_accepts_exact_root_character_limit_and_resolved_links(tmp_path):
+    repo = _contract_repo(tmp_path)
+    _root_at_size(repo, MAX_ROOT_CHARS)
+    _git(repo, "add", "AGENTS.md")
+
+    assert validate_repository(repo) == []
+
+
+def test_contract_rejects_one_character_above_root_limit(tmp_path):
+    repo = _contract_repo(tmp_path)
+    _root_at_size(repo, MAX_ROOT_CHARS + 1)
+
+    errors = validate_repository(repo)
+
+    assert any("18,001" in error and "18,000" in error for error in errors)
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    [
+        "![target](target.md)",
+        "`[target](target.md)`",
+        "``[target](target.md)``",
+        r"\[target](target.md)",
+        "<!-- [target](target.md) -->",
+        "```markdown\n[target](target.md)\n```",
+        "````markdown\n```\n[target](target.md)\n```\n````",
+        "~~~~markdown\n[target](target.md)\n~~~~",
+    ],
+    ids=["image", "inline-code", "long-inline-code", "escaped", "comment", "fence", "long-fence", "tilde-fence"],
+)
+def test_required_reference_must_be_an_ordinary_navigable_link(tmp_path, replacement):
+    repo = _contract_repo(tmp_path)
+    _write(repo, "target.md")
+    _write(repo, "AGENTS.md", f"# Guide\n\n{replacement}\n")
+    _git(repo, "add", ".")
+
+    errors = validate_repository(repo, required_references=("target.md",))
+
+    assert any("required navigable link is missing: target.md" in error for error in errors)
+
+
+def test_link_extractor_ignores_non_links_and_keeps_ordinary_links():
+    markdown = """
+[ordinary](docs/guide.md#part)
+![image](image.png)
+`[inline](inline.md)`
+\[escaped](escaped.md)
+<!-- [comment](comment.md) -->
+```md
+[fenced](fenced.md)
+```
+[external](https://example.com/x)
+[anchor](#local)
+"""
+
+    assert extract_navigable_links(markdown, source="AGENTS.md") == [
+        "docs/guide.md#part",
+        "https://example.com/x",
+        "#local",
+    ]
+
+
+def test_relative_link_query_and_fragment_are_stripped_for_resolution(tmp_path):
+    repo = _contract_repo(tmp_path)
+    _write(repo, "extra.md")
+    with (repo / "AGENTS.md").open("a", encoding="utf-8") as handle:
+        handle.write("\n[extra](extra.md?plain=1#section)\n")
+    _git(repo, "add", ".")
+
+    assert validate_repository(repo) == []
+
+
+def test_untracked_oversized_agents_fixture_is_outside_repository_contract(tmp_path):
+    repo = _contract_repo(tmp_path)
+    _write(repo, "fixtures/AGENTS.md", "x" * (MAX_ROOT_CHARS + 1))
+
+    assert validate_repository(repo) == []
+
+
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("missing.md", "does not resolve to a tracked regular file"),
+        ("untracked.md", "does not resolve to a tracked regular file"),
+        ("../outside.md", "escapes repository root"),
+        ("docs", "does not resolve to a tracked regular file"),
+    ],
+)
+def test_contract_rejects_invalid_relative_links(tmp_path, target, expected):
+    repo = _contract_repo(tmp_path)
+    if target == "untracked.md":
+        _write(repo, target)
+    with (repo / "AGENTS.md").open("a", encoding="utf-8") as handle:
+        handle.write(f"\n[bad]({target})\n")
+
+    errors = validate_repository(repo)
+
+    assert any(expected in error and target in error for error in errors)
+
+
+def test_contract_requires_root_and_desktop_governing_files(tmp_path):
+    repo = _contract_repo(tmp_path)
+    (repo / "AGENTS.md").unlink()
+    (repo / "apps/desktop/AGENTS.md").unlink()
+
+    errors = validate_repository(repo)
+
+    assert any("required governing file is missing: AGENTS.md" in error for error in errors)
+    assert any("required governing file is missing: apps/desktop/AGENTS.md" in error for error in errors)
+
+
+def test_contract_fails_closed_on_non_repository_and_unreadable_utf8(tmp_path):
+    repo = _contract_repo(tmp_path)
+    (repo / "AGENTS.md").write_bytes(b"\xff")
+    read_errors = validate_repository(repo)
+    not_repo_errors = validate_repository(tmp_path / "not-a-repo")
+
+    assert any("could not read AGENTS.md" in error for error in read_errors)
+    assert any("could not enumerate tracked files" in error for error in not_repo_errors)
+
+
+@pytest.mark.parametrize("content", ["```\n[link](target.md)\n", "<!-- [link](target.md)\n"])
+def test_link_extractor_fails_closed_on_unterminated_exclusions(content):
+    with pytest.raises(ValueError, match="unterminated"):
+        extract_navigable_links(content, source="AGENTS.md")
+
+
+def test_repository_agents_context_contract():
+    repo_root = Path(__file__).resolve().parents[2]
+
+    assert validate_repository(repo_root) == []


### PR DESCRIPTION
## Summary

- Compact the root and desktop AGENTS guidance, moving subsystem detail into progressively loaded development references.
- Add a fail-closed repository context validator and wire context-contract changes into CI classification.
- Correct source-backed guidance for test isolation, config definitions/re-exports, plugin discovery, curator safeguards, and Kanban failure accounting.

## Measured context sizes

- `AGENTS.md`: 74,655 -> 14,452 characters (limit: 18,000).
- `apps/desktop/AGENTS.md`: 10,669 -> 6,873 characters (limit: 8,000).
- Standalone validator: `PASS`, with 15 required navigable links resolved.

## RED -> GREEN history

- First remediation RED: 24 passed / 11 failed, covering indented and raw-HTML code, nested image labels, invalid fence closers, malformed URL destinations, and documentation source contracts.
- First remediation GREEN: 137 passed / 0 failed in the representative bundle.
- Second remediation RED: 37 passed / 4 failed, one for each remaining HOME, OPTIONAL_ENV_VARS, plugin-taxonomy, and Kanban failure-limit accuracy blocker.
- Final GREEN: 41 context-contract tests passed; the final representative bundle passed 139 / 139.

## Validator and documentation edge cases

- Required references cannot be satisfied by images, escaped links, inline code with variable backtick runs, fenced code with variable markers, four-space indented code, raw `<pre>/<code>` blocks, or HTML comments.
- Invalid fence closers preserve parser state; malformed URL destinations fail closed with deterministic errors.
- Exact size boundaries are covered: 17,999 and 18,000 characters accepted; 18,001 rejected.
- Missing governing files, untracked/non-file targets, repository escapes, missing required links, unreadable UTF-8, and unterminated excluded regions are rejected.
- Documentation now preserves stable real `HOME` while redirecting only `HERMES_HOME`, locates `DEFAULT_CONFIG` and `OPTIONAL_ENV_VARS` in `config_defaults.py` with re-exports, uses a noncontradictory plugin taxonomy, and describes `spawn_failed`, `crashed`, and `timed_out` failure-limit outcomes.

## Verification

- Exact reviewed head: `2a61aa1a16381b601ad7df2f9986a5f22f675a77`.
- Independent third review: PASS over all 20 changed files; full diff SHA-256 `e874393135194c6c6643a4899da9abf0b3b426ddab6f7d27f4982cbab841826a`.
- `scripts/run_tests.sh tests/scripts/test_agents_context_contract.py tests/ci/test_classify_changes.py tests/agent/test_prompt_builder.py tests/agent/test_repository_context_budget.py --file-retries 0 -q` -> 139 passed / 0 failed.
- `python3 scripts/check_agents_context.py` -> PASS.
- Ruff, py_compile, YAML parsing, ASCII guard, Docusaurus builds for English and zh-Hans, `git diff --check`, and high-signal changed-line secret scan passed during exact-SHA review.
- Broad-suite caveat: the full repository test suite was not rerun for this narrow documentation/contract change. The focused representative bundle is green; Docusaurus retained pre-existing non-fatal zh-Hans link/anchor warnings.
- Upstream advanced after the reviewed base; a current `git merge-tree --write-tree upstream/main HEAD` completed cleanly without rewriting the reviewed SHA.

## Scope

- PR #72343 is intentionally excluded. Its prompt-builder/system-prompt work has zero changed-path overlap with this 20-file candidate.
- This PR does not merge, deploy, restart, or modify a live checkout.
