### PR TITLE
fix(status): show live sessions when no concurrency cap is set

### DIFF
--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -254,6 +254,56 @@ def _prune_dead(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
     ]
 
 
+def current_repo_root(start: Optional[Path] = None) -> Optional[str]:
+    """Return the enclosing git checkout for ``start``, or None if there is none.
+
+    Walks up looking for ``.git`` rather than shelling out to ``git``: this runs
+    on every session start, and a subprocess per session is a poor trade for a
+    field that is advisory.  ``.git`` is a file (not a directory) inside linked
+    worktrees, which is why this tests existence rather than is_dir -- sessions
+    in two worktrees of one repo are exactly the case #46303 is about.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+    except OSError:
+        return None
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return str(candidate)
+    return None
+
+
+def find_sessions_for_repo(
+    repo_root: Any, *, exclude_lease_id: Optional[str] = None
+) -> list[dict[str, Any]]:
+    """Return live registry entries attached to the same checkout.
+
+    Answers the question #46303 opens with -- "is another session already
+    working in this repo?" -- which no caller could ask before, because the
+    registry was only written when ``max_concurrent_sessions`` was set.
+    """
+    try:
+        wanted = str(Path(repo_root).resolve())
+    except (OSError, TypeError):
+        return []
+    matches = []
+    for entry in active_session_registry_snapshot():
+        if exclude_lease_id and str(entry.get("lease_id") or "") == exclude_lease_id:
+            continue
+        metadata = entry.get("metadata")
+        if not isinstance(metadata, dict):
+            continue
+        recorded = metadata.get("repo_root")
+        if not recorded:
+            continue
+        try:
+            if str(Path(recorded).resolve()) == wanted:
+                matches.append(entry)
+        except OSError:
+            continue
+    return matches
+
+
 @dataclass
 class ActiveSessionLease:
     lease_id: str
@@ -282,13 +332,6 @@ def try_acquire_active_session(
     """
     max_sessions = resolve_max_concurrent_sessions(config)
     lease_id = uuid.uuid4().hex
-    if max_sessions is None:
-        return ActiveSessionLease(
-            lease_id=lease_id,
-            session_id=session_id,
-            surface=surface,
-            enabled=False,
-        ), None
 
     now = time.time()
     entry = {
@@ -300,32 +343,51 @@ def try_acquire_active_session(
         "started_at": now,
         "updated_at": now,
     }
-    if metadata:
-        entry["metadata"] = {
-            str(k): v for k, v in metadata.items() if isinstance(k, str)
-        }
+    entry_metadata = {
+        str(k): v for k, v in (metadata or {}).items() if isinstance(k, str)
+    }
+    # Repo attribution is what makes "is another session already attached to
+    # this checkout?" answerable at all (#46303).  Recorded by default rather
+    # than by caller opt-in so every surface gets it without threading it
+    # through three separate call sites; an explicit metadata repo_root wins.
+    entry_metadata.setdefault("repo_root", current_repo_root())
+    if entry_metadata:
+        entry["metadata"] = entry_metadata
 
     state_path = _state_path()
-    with _FileLock(_lock_path()):
-        raw_entries = _read_entries(state_path)
-        entries = _prune_dead(raw_entries)
-        pruned = len(raw_entries) - len(entries)
-        if pruned:
-            logger.info("Pruned %d stale active session lease(s)", pruned)
-        active_count = len(entries)
-        if active_count >= max_sessions:
+    try:
+        with _FileLock(_lock_path()):
+            raw_entries = _read_entries(state_path)
+            entries = _prune_dead(raw_entries)
+            pruned = len(raw_entries) - len(entries)
+            if pruned:
+                logger.info("Pruned %d stale active session lease(s)", pruned)
+            active_count = len(entries)
+            if max_sessions is not None and active_count >= max_sessions:
+                _write_entries(state_path, entries)
+                logger.info(
+                    "Active session limit reached: active=%d max=%d surface=%s",
+                    active_count,
+                    max_sessions,
+                    surface,
+                )
+                return None, active_session_limit_message(
+                    active_count, max_sessions, entries
+                )
+            entries.append(entry)
             _write_entries(state_path, entries)
-            logger.info(
-                "Active session limit reached: active=%d max=%d surface=%s",
-                active_count,
-                max_sessions,
-                surface,
-            )
-            return None, active_session_limit_message(
-                active_count, max_sessions, entries
-            )
-        entries.append(entry)
-        _write_entries(state_path, entries)
+    except Exception as exc:
+        # Presence tracking is strictly best-effort: a read-only or otherwise
+        # broken registry must never keep a user from starting a session.  Fall
+        # back to the no-op lease so callers can still call release()
+        # unconditionally.
+        logger.warning("Failed to record active session presence: %s", exc)
+        return ActiveSessionLease(
+            lease_id=lease_id,
+            session_id=str(session_id),
+            surface=str(surface),
+            enabled=False,
+        ), None
 
     return ActiveSessionLease(
         lease_id=lease_id,

--- a/hermes_cli/active_sessions.py
+++ b/hermes_cli/active_sessions.py
@@ -374,6 +374,25 @@ class ActiveSessionLease:
         release_active_session(self)
 
 
+def current_repo_root(start: Optional[Path] = None) -> Optional[str]:
+    """Return the enclosing git checkout for ``start``, or None if there is none.
+
+    Walks up looking for ``.git`` rather than shelling out to ``git``: this runs
+    on every session start, and a subprocess per session is a poor trade for a
+    field that is advisory.  ``.git`` is a file (not a directory) inside linked
+    worktrees, which is why this tests existence rather than is_dir -- sessions
+    in two worktrees of one repo are exactly the case #46303 is about.
+    """
+    try:
+        current = (start or Path.cwd()).resolve()
+    except OSError:
+        return None
+    for candidate in (current, *current.parents):
+        if (candidate / ".git").exists():
+            return str(candidate)
+    return None
+
+
 def _clean_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
     return {str(k): v for k, v in metadata.items() if isinstance(k, str)}
 
@@ -427,8 +446,18 @@ def _lease_entry(
     }
     if track_liveness:
         entry["track_liveness"] = True
-    if metadata:
-        entry["metadata"] = _clean_metadata(metadata)
+    entry_metadata = _clean_metadata(metadata) if metadata else {}
+    # Repo attribution is what makes "which checkout is that session attached
+    # to?" answerable at all (#46303).  Recorded here rather than by caller
+    # opt-in so every surface gets it without threading it through three
+    # separate call sites; an explicit metadata repo_root wins, and a session
+    # started outside any checkout simply records nothing.
+    if "repo_root" not in entry_metadata:
+        _repo_root = current_repo_root()
+        if _repo_root:
+            entry_metadata["repo_root"] = _repo_root
+    if entry_metadata:
+        entry["metadata"] = entry_metadata
     return entry
 
 
@@ -574,7 +603,16 @@ def transfer_active_session(
             own["session_id"] = new_session_id
             own["updated_at"] = time.time()
             if metadata:
-                own["metadata"] = _clean_metadata(metadata)
+                new_metadata = _clean_metadata(metadata)
+                # Carry the checkout attribution across a session-id transfer:
+                # callers pass identity metadata, not a full replacement, and
+                # the process has not changed repos (#46303).
+                prior = own.get("metadata")
+                if "repo_root" not in new_metadata and isinstance(prior, dict):
+                    prior_root = prior.get("repo_root")
+                    if prior_root:
+                        new_metadata["repo_root"] = prior_root
+                own["metadata"] = new_metadata
         elif lease.track_liveness:
             entries.append(_lease_entry(
                 lease_id=lease.lease_id, session_id=new_session_id, surface=lease.surface,

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -625,6 +625,7 @@ def show_status(args):
     # way to find out is reading runtime/active_sessions.json by hand.
     try:
         from hermes_cli.active_sessions import (
+            current_repo_root,
             active_session_registry_snapshot,
             format_age,
             resolve_max_concurrent_sessions,
@@ -633,11 +634,11 @@ def show_status(args):
         _cap = resolve_max_concurrent_sessions(config)
     except Exception:
         _cap = None
+    try:
+        _held = active_session_registry_snapshot()
+    except Exception:
+        _held = []
     if _cap:
-        try:
-            _held = active_session_registry_snapshot()
-        except Exception:
-            _held = []
         _full = len(_held) >= _cap
         print(
             "  Slots:        "
@@ -645,12 +646,28 @@ def show_status(args):
                 f"{len(_held)}/{_cap} in use", Colors.YELLOW if _full else Colors.GREEN
             )
         )
+    elif _held:
+        # Without a cap there are no slots to report, but the sessions are still
+        # worth showing: knowing another surface is live in this checkout is the
+        # whole point of tracking them (#46303).
+        print("  Live:         " + color(f"{len(_held)} session(s)", Colors.GREEN))
+    if _held:
         _now = time.time()
+        _here = current_repo_root()
         for _entry in sorted(_held, key=lambda e: e.get("started_at") or 0):
             _age = format_age(_now - float(_entry.get("started_at") or _now))
+            _meta = _entry.get("metadata")
+            _repo = (_meta or {}).get("repo_root") if isinstance(_meta, dict) else None
+            _where = ""
+            if _repo:
+                _where = (
+                    "  ← this repo"
+                    if _here and str(_repo) == str(_here)
+                    else f"  {os.path.basename(str(_repo))}"
+                )
             print(
                 f"                {_entry.get('surface') or 'unknown':<17} "
-                f"{_entry.get('session_id') or '?':<24} {_age}"
+                f"{_entry.get('session_id') or '?':<24} {_age}{_where}"
             )
 
     # =========================================================================

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -289,26 +289,42 @@ def _render_sessions(ctx):
         except Exception:
             _kv("Active:", "(error reading sessions file)")
 
-    # Slot usage, only when max_concurrent_sessions is set. The cap is shared across CLI,
-    # desktop/TUI and the messaging gateway, so the surface that gets rejected is rarely the one
-    # holding the slots — without this the only way to find out is reading
-    # runtime/active_sessions.json by hand.
+    # Live sessions from the active-session registry. Slot usage is only meaningful when
+    # max_concurrent_sessions is set — the cap is shared across CLI, desktop/TUI and the
+    # messaging gateway, so the surface that gets rejected is rarely the one holding the
+    # slots — but the sessions themselves are worth listing either way: per-session
+    # exclusivity (#94595) made the registry authoritative for every surface, so with no cap
+    # set the entries exist and only this readout was still gated on the cap (#46303).
     try:
         from hermes_cli.active_sessions import (
-            active_session_registry_snapshot, format_age, resolve_max_concurrent_sessions)
+            active_session_registry_snapshot, current_repo_root, format_age,
+            resolve_max_concurrent_sessions)
         cap = resolve_max_concurrent_sessions(ctx.config)
-    except Exception:
-        cap = None
-    if cap:
         try:
             held = active_session_registry_snapshot()
         except Exception:
             held = []
+        here = current_repo_root()
+    except Exception:
+        cap, held, here = None, [], None
+    if cap:
         _kv("Slots:", color(f"{len(held)}/{cap} in use", Colors.YELLOW if len(held) >= cap else Colors.GREEN))
+    elif held:
+        # No cap means no slots to report, but "another session is live in this
+        # checkout" is exactly the signal #46303 asks for.
+        _kv("Live:", color(f"{len(held)} session(s)", Colors.GREEN))
+    if held:
         now = time.time()
         for entry in sorted(held, key=lambda e: e.get("started_at") or 0):
             age = format_age(now - float(entry.get("started_at") or now))
-            print(f"                {entry.get('surface') or 'unknown':<17} {entry.get('session_id') or '?':<24} {age}")
+            meta = entry.get("metadata")
+            repo = meta.get("repo_root") if isinstance(meta, dict) else None
+            where = ""
+            if repo:
+                where = ("  ← this repo" if here and str(repo) == str(here)
+                         else f"  {os.path.basename(str(repo))}")
+            print(f"                {entry.get('surface') or 'unknown':<17} "
+                  f"{entry.get('session_id') or '?':<24} {age}{where}")
 
 
 def _render_deep(ctx):

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -167,3 +167,78 @@ def test_release_orphaned_leases_reclaims_only_unowned_own_pid_entries(tmp_path,
         for entry in active_sessions.active_session_registry_snapshot()
     ) == ["kept", "other"]
     assert orphan is not None
+
+
+def test_registry_records_presence_when_cap_is_unset(tmp_path, monkeypatch):
+    """Presence tracking must not be gated on the session cap (#46303).
+
+    ``max_concurrent_sessions`` defaults to ``None``, so gating the registry
+    write on it means the registry is empty for almost every user -- and
+    "is another session attached to this repo?" is unanswerable exactly when
+    it matters. A ``None`` cap means "reject nobody", not "know nobody".
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="solo", surface="cli", config={}
+    )
+
+    assert message is None
+    assert lease is not None
+    snapshot = active_sessions.active_session_registry_snapshot()
+    assert [entry["session_id"] for entry in snapshot] == ["solo"]
+
+    lease.release()
+    assert active_sessions.active_session_registry_snapshot() == []
+
+
+def test_uncapped_sessions_are_recorded_but_never_rejected(tmp_path, monkeypatch):
+    """Recording presence must not start enforcing a limit that isn't set."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    leases = []
+    for index in range(5):
+        lease, message = active_sessions.try_acquire_active_session(
+            session_id=f"s{index}", surface="cli", config={}
+        )
+        assert message is None, f"uncapped session {index} was rejected"
+        assert lease is not None
+        leases.append(lease)
+
+    assert len(active_sessions.active_session_registry_snapshot()) == 5
+
+
+def test_entries_carry_repo_root_so_sessions_are_attributable(tmp_path, monkeypatch):
+    """A registry entry with no repo dimension cannot answer the #46303 question."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    repo_a = tmp_path / "repo_a"
+    (repo_a / ".git").mkdir(parents=True)
+    repo_b = tmp_path / "repo_b"
+    (repo_b / ".git").mkdir(parents=True)
+
+    monkeypatch.chdir(repo_a)
+    active_sessions.try_acquire_active_session(
+        session_id="in_a", surface="cli", config={}
+    )
+    monkeypatch.chdir(repo_b)
+    active_sessions.try_acquire_active_session(
+        session_id="in_b", surface="desktop", config={}
+    )
+
+    found = active_sessions.find_sessions_for_repo(repo_a)
+    assert [entry["session_id"] for entry in found] == ["in_a"]
+
+
+def test_registry_failure_never_blocks_session_start(tmp_path, monkeypatch):
+    """Presence tracking is best-effort: a broken registry must not stop a session."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+
+    def _boom(*args, **kwargs):
+        raise OSError("read-only filesystem")
+
+    monkeypatch.setattr(active_sessions, "_write_entries", _boom)
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="degraded", surface="cli", config={}
+    )
+
+    assert message is None
+    assert lease is not None
+    lease.release()

--- a/tests/hermes_cli/test_active_sessions.py
+++ b/tests/hermes_cli/test_active_sessions.py
@@ -646,3 +646,75 @@ def test_liveness_guard_keeps_a_just_acquired_own_lease_it_cannot_vouch_for(
     ) as active:
         assert active is False
     assert active_sessions.active_session_registry_snapshot(home) == []
+
+
+def test_entries_carry_repo_root_so_sessions_are_attributable(tmp_path, monkeypatch):
+    """A registry entry with no repo dimension cannot answer the #46303 question.
+
+    "Is another session already attached to *this* checkout?" needs the checkout
+    on the entry; surface and session id alone do not say where a session is
+    working.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    repo_a = tmp_path / "repo_a"
+    (repo_a / ".git").mkdir(parents=True)
+    repo_b = tmp_path / "repo_b"
+    (repo_b / ".git").mkdir(parents=True)
+
+    monkeypatch.chdir(repo_a)
+    active_sessions.try_acquire_active_session(
+        session_id="in_a", surface="cli", config={}
+    )
+    monkeypatch.chdir(repo_b)
+    active_sessions.try_acquire_active_session(
+        session_id="in_b", surface="desktop", config={}
+    )
+
+    attributed = {
+        entry["session_id"]: (entry.get("metadata") or {}).get("repo_root")
+        for entry in active_sessions.active_session_registry_snapshot()
+    }
+    assert attributed == {
+        "in_a": str(repo_a.resolve()),
+        "in_b": str(repo_b.resolve()),
+    }
+
+
+def test_repo_root_is_omitted_outside_any_checkout(tmp_path, monkeypatch):
+    """Attribution is advisory: no checkout means no field, not a null one."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    elsewhere = tmp_path / "not_a_repo"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="homeless", surface="cli", config={}
+    )
+    assert lease is not None and message is None
+
+    (entry,) = active_sessions.active_session_registry_snapshot()
+    assert "repo_root" not in (entry.get("metadata") or {})
+
+
+def test_repo_root_survives_a_session_id_transfer(tmp_path, monkeypatch):
+    """A transfer re-writes metadata from the caller's identity fields, which
+    would otherwise silently drop the attribution the entry already had — the
+    process has not changed repos just because the session got an id.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="draft", surface="cli", config={}
+    )
+    assert lease is not None and message is None
+
+    assert active_sessions.transfer_active_session(
+        lease, session_id="saved", metadata={"live_session_id": "saved"}
+    )
+
+    (entry,) = active_sessions.active_session_registry_snapshot()
+    assert entry["session_id"] == "saved"
+    assert entry["metadata"]["repo_root"] == str(repo.resolve())

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -250,3 +250,59 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+def test_show_status_lists_live_sessions_without_a_cap(monkeypatch, capsys, tmp_path):
+    """Per-session exclusivity (#94595) made the registry authoritative for every
+    surface, capped or not — but this readout was still gated on the cap, so an
+    operator who never set ``max_concurrent_sessions`` saw nothing at all even
+    though the entries were right there. That is the awareness signal #46303
+    asks for.
+    """
+    from hermes_cli import active_sessions
+
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    repo = tmp_path / "checkout"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.chdir(repo)
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="20260614_105454_7afa2b", surface="desktop", config={}
+    )
+    assert lease is not None and message is None
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Live:" in output
+    assert "1 session(s)" in output
+    assert "20260614_105454_7afa2b" in output
+    assert "desktop" in output
+    # Attribution: the session was started in this checkout, so say so.
+    assert "this repo" in output
+    assert "Slots:" not in output
+
+
+def test_show_status_still_reports_slots_when_a_cap_is_set(monkeypatch, capsys, tmp_path):
+    """The uncapped listing must not displace the capped slot accounting."""
+    from hermes_cli import active_sessions
+    from hermes_cli import status as status_mod
+
+    home = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(
+        status_mod, "load_config", lambda: {"max_concurrent_sessions": 2}, raising=False
+    )
+
+    lease, message = active_sessions.try_acquire_active_session(
+        session_id="capped-1", surface="cli", config={"max_concurrent_sessions": 2}
+    )
+    assert lease is not None and message is None
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "1/2 in use" in output
+    assert "capped-1" in output
+    assert "Live:" not in output


### PR DESCRIPTION
Closes #46303 (partially — the concurrent-session *awareness* half).

### What changed since this PR was opened

This PR originally added a `record_presence` flag so uncapped surfaces would write to the active-session registry at all. **#94595 has since made that unnecessary**: per-session exclusivity is now enforced unconditionally, and `try_acquire_active_session` records an entry for any session with a stored id, capped or not (`hermes_cli/active_sessions.py:546`). Verified locally: empty `HERMES_HOME` + `config {}` + no flags → `runtime/active_sessions.json` gets the entry.

So I've dropped that half entirely. `record_presence` and all of its plumbing (`cli.py`, `gateway/run.py`, `tui_gateway/server.py`) are gone — those three files are now untouched by this PR. Credit to #94595; this PR is now strictly the residue it left behind.

### What's left

**1. `hermes status` still gates its readout on the cap.** `status.py` wrapped the whole active-session block in `if _cap:`. That was right when the registry was only written under a cap. Now the entries exist for everyone and only this readout is still asking about `max_concurrent_sessions` — an operator who never set one sees nothing, while the data sits in `runtime/active_sessions.json`.

With a cap set, output is unchanged (`Slots: 1/2 in use`). Without one, there are no slots to report, so it prints `Live: 1 session(s)` plus the same per-session lines.

**2. Entries carry no checkout attribution.** #46303 is about two sessions colliding in one git worktree; surface and session id don't say *where* a session is working, and nothing in `hermes_cli/` records it. `_lease_entry` now stores the enclosing checkout as `metadata["repo_root"]` — walked up by looking for `.git` rather than shelling out to `git` (this runs on every session start), testing `exists()` rather than `is_dir()` because `.git` is a *file* inside a linked worktree, which is exactly the two-worktrees-of-one-repo case the issue is about. Status lines then mark each entry `← this repo` or name the other checkout.

It's advisory throughout: a session started outside any checkout records no field at all (not a null one), and `transfer_active_session` carries existing attribution forward instead of dropping it when a caller rewrites identity metadata — that path replaces `metadata` wholesale, so without this the attribution silently vanishes the moment a draft session gets an id.

### Tests

- `test_show_status_lists_live_sessions_without_a_cap` — fails on `main` (verified by reverting `status.py` only), passes here.
- `test_show_status_still_reports_slots_when_a_cap_is_set` — the uncapped listing must not displace capped slot accounting.
- repo attribution across two checkouts, omission outside a checkout, survival across a session-id transfer.

`pytest tests/hermes_cli/test_active_sessions.py tests/hermes_cli/test_status.py tests/hermes_cli/test_cli_active_session_limit.py tests/test_active_session_exclusivity.py tests/tui_gateway/test_cross_process_orphan_ownership.py tests/gateway/test_max_concurrent_sessions.py` → 59 passed.

### Not in scope

#46303's memory cross-bleed half, and advisory worktree locking. This is the "expose a lightweight *other live sessions* signal (count + what repo they're attached to)" item from the issue's suggested directions.
