### PR TITLE
fix(tools): stop hardcoding max_tokens caps in vision_tools

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -332,6 +332,11 @@ class TestVisionConfig:
         kwargs = await call_with({"auxiliary": {"vision": {"max_tokens": 8000}}})
         assert kwargs["max_tokens"] == 8000
 
+        # Malformed config value (non-numeric string): must not crash the
+        # call -- omit max_tokens rather than raise ValueError from int().
+        kwargs = await call_with({"auxiliary": {"vision": {"max_tokens": "not-a-number"}}})
+        assert "max_tokens" not in kwargs
+
 
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -282,6 +282,56 @@ class TestVisionConfig:
         assert kwargs["temperature"] == 0.1
         assert kwargs["timeout"] == 120.0
 
+    @pytest.mark.asyncio
+    async def test_max_tokens_omitted_by_default_not_hardcoded(self, tmp_path):
+        """Regression for issue #80025: vision analysis must NOT hardcode
+        a max_tokens cap. auxiliary_client.py's documented policy is to
+        omit max_tokens by default for auxiliary tasks (including
+        vision) so the model sizes its own response -- an explicit cap
+        only risks truncating a long image description. Only an
+        explicitly configured integer should be forwarded; unset or
+        "auto" must omit the field entirely."""
+        img = tmp_path / "test.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 8)
+
+        async def call_with(config):
+            mock_response = MagicMock()
+            mock_choice = MagicMock()
+            mock_choice.message.content = "Configured image analysis"
+            mock_response.choices = [mock_choice]
+
+            with (
+                patch("hermes_cli.config.load_config", return_value=config),
+                patch(
+                    "tools.vision_tools._image_to_base64_data_url",
+                    return_value="data:image/png;base64,abc",
+                ),
+                patch(
+                    "tools.vision_tools.async_call_llm",
+                    new_callable=AsyncMock,
+                    return_value=mock_response,
+                ) as mock_llm,
+            ):
+                result = json.loads(
+                    await vision_analyze_tool(str(img), "describe this", "test/model")
+                )
+            assert result["success"] is True
+            return mock_llm.await_args.kwargs
+
+        # No vision config at all: no cap.
+        kwargs = await call_with({})
+        assert "max_tokens" not in kwargs, (
+            f"vision analysis must not hardcode a max_tokens cap by default: {kwargs}"
+        )
+
+        # Explicit "auto": still no cap.
+        kwargs = await call_with({"auxiliary": {"vision": {"max_tokens": "auto"}}})
+        assert "max_tokens" not in kwargs
+
+        # Explicit user-configured integer: forwarded.
+        kwargs = await call_with({"auxiliary": {"vision": {"max_tokens": 8000}}})
+        assert kwargs["max_tokens"] == 8000
+
 
 class TestVisionSafetyGuards:
     @pytest.mark.asyncio

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1251,6 +1251,7 @@ async def vision_analyze_tool(
         # Local vision models (llama.cpp, ollama) can take well over 30s.
         vision_timeout = 120.0
         vision_temperature = 0.1
+        _vmax = None
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -1261,15 +1262,23 @@ async def vision_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            _vmax = _vision_cfg.get("max_tokens")
         except Exception:
             pass
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 2000,
             "timeout": vision_timeout,
         }
+        # Omit max_tokens by default so the model sizes its own response --
+        # matching auxiliary_client.py's documented no-cap policy for
+        # auxiliary tasks (compression summaries, titles, vision, etc.), an
+        # explicit cap only risks truncating a long image description
+        # (issue #80025). "auto" (or unset) means omit; any other value is
+        # an explicit user-configured cap.
+        if _vmax is not None and str(_vmax).strip().lower() != "auto":
+            call_kwargs["max_tokens"] = int(_vmax)
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
@@ -1757,6 +1766,7 @@ async def video_analyze_tool(
 
         vision_timeout = 180.0
         vision_temperature = 0.1
+        _vmax = None
         try:
             from hermes_cli.config import cfg_get, load_config
             _cfg = load_config()
@@ -1767,6 +1777,7 @@ async def video_analyze_tool(
             _vtemp = _vision_cfg.get("temperature")
             if _vtemp is not None:
                 vision_temperature = float(_vtemp)
+            _vmax = _vision_cfg.get("max_tokens")
         except Exception:
             pass
 
@@ -1774,9 +1785,12 @@ async def video_analyze_tool(
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 4000,
             "timeout": vision_timeout,
         }
+        # Omit max_tokens by default -- see the image analysis call site
+        # above for the full rationale (issue #80025).
+        if _vmax is not None and str(_vmax).strip().lower() != "auto":
+            call_kwargs["max_tokens"] = int(_vmax)
         if model:
             call_kwargs["model"] = model
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1278,7 +1278,10 @@ async def vision_analyze_tool(
         # (issue #80025). "auto" (or unset) means omit; any other value is
         # an explicit user-configured cap.
         if _vmax is not None and str(_vmax).strip().lower() != "auto":
-            call_kwargs["max_tokens"] = int(_vmax)
+            try:
+                call_kwargs["max_tokens"] = int(_vmax)
+            except (TypeError, ValueError):
+                pass  # malformed config value -- omit rather than crash the call
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
@@ -1790,7 +1793,10 @@ async def video_analyze_tool(
         # Omit max_tokens by default -- see the image analysis call site
         # above for the full rationale (issue #80025).
         if _vmax is not None and str(_vmax).strip().lower() != "auto":
-            call_kwargs["max_tokens"] = int(_vmax)
+            try:
+                call_kwargs["max_tokens"] = int(_vmax)
+            except (TypeError, ValueError):
+                pass  # malformed config value -- omit rather than crash the call
         if model:
             call_kwargs["model"] = model
 


### PR DESCRIPTION
Fixes #80025.

## Problem

Both vision call sites (image analysis: `max_tokens 2000`, video analysis: `max_tokens 4000`) hardcoded output caps regardless of the vision model's actual capacity, silently truncating long image descriptions and video analyses. This contradicted `agent/auxiliary_client.py`'s own documented no-cap-by-default policy for auxiliary tasks (vision explicitly named), which every other auxiliary call site follows.

## Fix

Read `auxiliary.vision.max_tokens` from config at both call sites; only pass `max_tokens` when it's an explicit integer, treating unset or `"auto"` as omit so the model sizes its own response by default.

## Verification

Added a regression test extending the existing `TestVisionConfig` class. Verified as a genuine regression by reverting the fix and confirming `max_tokens: 2000` was visibly present in the captured kwargs.

33/33 pass in the full test file; 52/52 across two more related vision test files (no regression).