### PR TITLE
fix(update): --stay-on-branch so desktop product updates end on main

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -3809,6 +3809,9 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         // bb/gui (or any non-main) install off-branch. Mirror the GUI
         // button's contract: append --branch <current> for non-main
         // checkouts, keep it bare for main so the card stays clean.
+        // --stay-on-branch (PR #80041) guarantees a desktop product update
+        // ends on main even when the checkout started on a feature branch —
+        // without it the update can strand the desktop on stale code.
         let command = 'hermes update'
 
         try {
@@ -3819,7 +3822,7 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
             const branch = await resolveHealedBranch(updateRoot, current)
 
             if (branch !== 'main') {
-              command = `hermes update --branch ${branch}`
+              command = `hermes update --branch ${branch} --stay-on-branch`
             }
           }
         } catch {
@@ -4354,20 +4357,58 @@ async function applyUpdatesPosixHandoff(opts: any) {
   // ── Pre-flight state.db integrity guard (#68474) ──
   preflightStateDb(HERMES_HOME, rememberLog)
 
-  // Branch-pin so a non-main checkout doesn't get switched to main (and
-  // self-heal to main when the pinned branch no longer exists on origin).
-  let branch = 'main'
-
-  try {
-    const head = await runGit(['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: updateRoot })
-    const current = (head.stdout || '').trim()
-
-    if (head.code === 0 && current && current !== 'HEAD') {
-      branch = await resolveHealedBranch(updateRoot, current)
-    }
-  } catch {
-    // best effort
+  // Put the Hermes-managed Node and the venv on PATH so `hermes desktop`'s
+  // npm build can find them on a machine with no system Node. Windows portable
+  // Node lives directly under %LOCALAPPDATA%\\hermes\\node, not node\\bin.
+  // PYTHONUNBUFFERED: `hermes update` writes to a pipe here, so CPython
+  // block-buffers stdout and long quiet steps (the pre-update backup can zip
+  // multi-GB archives for minutes) stream nothing to the progress UI — users
+  // read the silence as a hang and cancel a healthy update.
+  const env: Record<string, string> = {
+    HERMES_HOME,
+    PYTHONUNBUFFERED: '1',
+    PATH: pathWithHermesManagedNode(path.join(updateRoot, 'venv', 'bin'))
   }
+
+  // `hermes update` reaps stale `hermes serve` backends (a code update
+  // leaves the running process serving old Python against the freshly-updated
+  // JS bundle). But OUR backend is one of those processes, and killing it
+  // mid-update produces the boot→kill→crash loop in #37532 — the desktop
+  // already restarts its own backend via the rebuild+relaunch below, so the
+  // reap must spare it. Hand the live backend's PID to the update process;
+  // _kill_stale_dashboard_processes reads HERMES_DESKTOP_CHILD_PID and excludes
+  // it while still reaping any genuinely-orphaned backends. (#37532)
+  // Exclude every desktop-managed backend (primary + all pool profiles) from
+  // the update reaper. _kill_stale_dashboard_processes accepts a comma-separated
+  // list (a single int still parses for back-compat).
+  const desktopChildPids = []
+  const hermesProcess = backendConnectionState.getProcess()
+
+  if (hermesProcess && Number.isInteger(hermesProcess.pid)) {
+    desktopChildPids.push(hermesProcess.pid)
+  }
+
+  for (const entry of backendPool.values()) {
+    if (entry.process && Number.isInteger(entry.process.pid)) {
+      desktopChildPids.push(entry.process.pid)
+    }
+  }
+
+  if (desktopChildPids.length) {
+    env.HERMES_DESKTOP_CHILD_PID = desktopChildPids.join(',')
+  }
+
+  // Track the configured update branch (default main) and stay on it after the
+  // update. Historical behavior pinned --branch to whatever branch the checkout
+  // was on, which stranded desktop users whose checkout sat on a feature branch:
+  // `hermes update` refreshed main, switched BACK to the feature branch, and the
+  // post-update `hermes desktop --build-only` rebuild then packaged the stale
+  // feature-branch code — the desktop never moved past the old version while the
+  // CLI claimed "already up to date". A product update must end on the tracked
+  // branch, so always pass the tracked branch explicitly and --stay-on-branch.
+  const { branch: configuredBranch } = readDesktopUpdateConfig()
+  const branch = await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
+  const branchArgs = ['--branch', branch, '--stay-on-branch']
 
   const args = [...handoff.args, '--install-root', updateRoot, '--branch', branch, '--desktop-pid', String(process.pid)]
   const updateStartedAt = Math.floor(Date.now() / 1000)

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -100,6 +100,18 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         ),
     )
     update_parser.add_argument(
+        "--stay-on-branch",
+        action="store_true",
+        default=False,
+        help=(
+            "Stay on the update target branch after the update finishes "
+            "instead of switching back to the branch you were on. Used by "
+            "the desktop app so a product update always ends on main; "
+            "uncommitted changes stashed before the switch are left in the "
+            "stash (not auto-restored onto the target branch)."
+        ),
+    )
+    update_parser.add_argument(
         "--force",
         action="store_true",
         default=False,

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8211,6 +8211,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
     # when updates.parked_branch_strategy is "update_in_place".
     switch_branch = bool(getattr(args, "switch_branch", False))
 
+    # Stay on the update target branch after the update finishes instead of
+    # switching back to the pre-update branch. The desktop app passes this so
+    # a product update always ends on the tracked branch (default main) — the
+    # packaged desktop app is rebuilt from the checkout AFTER this update
+    # returns, so leaving HEAD on a stale feature branch would rebuild the
+    # desktop from the old code (field report: desktop stuck at old version
+    # while CLI reported "already up to date").
+    stay_on_branch = bool(getattr(args, "stay_on_branch", False))
+
     # Whether this update is running without a human at the keyboard.
     # Interactive terminal updates always stash-and-ask (unchanged behavior);
     # only non-interactive updates (desktop/chat app, gateway, `--yes`) consult
@@ -8862,17 +8871,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _invalidate_update_cache()
 
             # Restore stash and switch back to original branch if we moved.
-            # EXCEPTION: a parked feature branch we verified clean + fully
+            # EXCEPTION 1: a parked feature branch we verified clean + fully
             # merged stays on the target — re-parking the checkout on the
             # stale branch is the 2026-08-17 incident all over again.
+            # EXCEPTION 2 (--stay-on-branch): the desktop product update must
+            # end on the tracked branch, and auto-restoring a feature-branch
+            # stash onto main would contaminate it — keep the stash for
+            # manual recovery on the original branch instead.
             if auto_stash_ref is not None:
-                _m()._restore_stashed_changes(
-                    git_cmd,
-                    _m().PROJECT_ROOT,
-                    auto_stash_ref,
-                    prompt_user=prompt_for_restore,
-                    input_fn=gw_input_fn,
-                )
+                if stay_on_branch:
+                    print()
+                    print("  ℹ Local changes preserved in stash (not auto-restored because")
+                    print("    the update stayed on the target branch).")
+                    print(f"    Restore manually on your branch with: git stash apply {auto_stash_ref}")
+                else:
+                    _m()._restore_stashed_changes(
+                        git_cmd,
+                        _m().PROJECT_ROOT,
+                        auto_stash_ref,
+                        prompt_user=prompt_for_restore,
+                        input_fn=gw_input_fn,
+                    )
             if parked_branch_switched:
                 if switch_block_reason.startswith("unmerged:"):
                     _count = switch_block_reason.split(":", 1)[1]
@@ -8886,7 +8905,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  ✓ Checkout was parked on '{current_branch}' (fully "
                         f"merged) — switched back to {branch}."
                     )
-            elif current_branch not in {branch, "HEAD"}:
+            elif not stay_on_branch and current_branch not in {branch, "HEAD"}:
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=_m().PROJECT_ROOT,
@@ -9277,6 +9296,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
                     )
                     print("  Restore manually with: git stash apply")
+                elif stay_on_branch:
+                    # Desktop product update: we intentionally end on the
+                    # tracked branch (main). Auto-applying a feature-branch
+                    # stash here would contaminate main with WIP that belongs
+                    # on the developer's branch — keep it for manual recovery.
+                    print()
+                    print("  ℹ Local changes preserved in stash (not auto-restored because")
+                    print("    the update stayed on the target branch).")
+                    print(f"    Restore manually on your branch with: git stash apply {auto_stash_ref}")
                 elif discard_local_changes:
                     # Non-interactive update + user opted into discarding local
                     # source edits (updates.non_interactive_local_changes:

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -1688,14 +1688,24 @@ class TestCmdUpdateStayOnBranch:
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")
-    def test_default_switches_back_to_feature_branch(self, mock_run, _mock_which):
-        """Without --stay-on-branch, an update from a feature branch returns to it."""
+    def test_default_parked_fully_merged_stays_on_target(self, mock_run, _mock_which):
+        """A fully-merged parked branch stays on the update target.
+
+        Regression for the 2026-08-17 incident fix landed on main: after an
+        update, re-parking the checkout on a stale (fully merged) feature
+        branch was exactly the failure mode that left a live box days behind
+        while printing "✓ Code updated!". The parked-branch guard now keeps
+        the checkout on the target branch for the default path too. This PR's
+        ``--stay-on-branch`` adds the stash-preservation contract on top —
+        see ``test_stay_on_branch_keeps_stash_for_manual_recovery``.
+        """
         commands = self._capture_git_commands("feat/aide-squared-evolution", "main", stay=False)
         checkouts = self._checkout_commands(commands)
 
-        # Switched to main for the update AND switched back to the feature branch.
+        # Switched to main for the update; the fully-merged parked branch is
+        # NOT re-checked-out (2026-08-17 guard), so the checkout ends on main.
         assert any("checkout main" in c for c in checkouts), checkouts
-        assert any("checkout feat/aide-squared-evolution" in c for c in checkouts), checkouts
+        assert not any("checkout feat/aide-squared-evolution" in c for c in checkouts), checkouts
 
     @patch("shutil.which", return_value=None)
     @patch("subprocess.run")

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -8,6 +8,7 @@ from unittest.mock import ANY, patch
 import pytest
 
 from hermes_cli.main import cmd_update, PROJECT_ROOT
+from hermes_cli import main
 
 
 def _make_run_side_effect(branch="main", verify_ok=True, commit_count="0"):
@@ -1636,3 +1637,114 @@ class TestGitTrampolineSelfHeal:
         assert candidates[1] == (
             profile_home / "git" / "mingw64" / "libexec" / "git-core" / "git.exe"
         )
+
+
+class TestCmdUpdateStayOnBranch:
+    """``hermes update --stay-on-branch`` ends on the update target branch.
+
+    Without the flag, an update that switches from a feature branch to main
+    switches BACK to the feature branch afterward (developer-friendly: keeps
+    you where you were working). With the flag — the desktop product-update
+    contract — the update stays on the target branch so the post-update
+    desktop rebuild packages the NEW code instead of the stale feature-branch
+    checkout. This is the field report behind the fix: desktop users stuck on
+    an old version while the CLI reported "already up to date" because HEAD
+    was on a feature branch that lagged main by hundreds of commits.
+    """
+
+    def _capture_git_commands(self, current_branch, target_branch="main", *, stay=False, commit_count="0"):
+        """Run cmd_update with a mocked git pipeline; return the git commands.
+
+        The side effect simulates a checkout on ``current_branch`` that the
+        updater must switch to ``target_branch`` to update. With commit_count
+        "0" the "no new commits" path runs, which is where the historical
+        switch-back-to-original-branch logic lives.
+        """
+        with patch("subprocess.run") as mock_run, \
+             patch("shutil.which", return_value=None), \
+             patch.object(main, "_stash_local_changes_if_needed", return_value=None):
+            mock_run.side_effect = TestCmdUpdateBranchFlag()._branch_side_effect(
+                current_branch=current_branch,
+                target_branch=target_branch,
+                commit_count=commit_count,
+            )
+            args = SimpleNamespace(
+                branch=target_branch,
+                stay_on_branch=stay,
+                yes=True,
+                check=False,
+                gateway=False,
+            )
+            cmd_update(args)
+
+        return [
+            " ".join(str(a) for a in c.args[0])
+            for c in mock_run.call_args_list
+            if c.args and c.args[0] and "git" in " ".join(str(a) for a in c.args[0][:1])
+        ]
+
+    def _checkout_commands(self, commands):
+        return [c for c in commands if " checkout " in c or c.startswith("checkout ")]
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_default_switches_back_to_feature_branch(self, mock_run, _mock_which):
+        """Without --stay-on-branch, an update from a feature branch returns to it."""
+        commands = self._capture_git_commands("feat/aide-squared-evolution", "main", stay=False)
+        checkouts = self._checkout_commands(commands)
+
+        # Switched to main for the update AND switched back to the feature branch.
+        assert any("checkout main" in c for c in checkouts), checkouts
+        assert any("checkout feat/aide-squared-evolution" in c for c in checkouts), checkouts
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_stay_on_branch_does_not_switch_back(self, mock_run, _mock_which):
+        """--stay-on-branch updates main and STAYS there (no switch-back)."""
+        commands = self._capture_git_commands("feat/aide-squared-evolution", "main", stay=True)
+        checkouts = self._checkout_commands(commands)
+
+        # Switched to main for the update.
+        assert any("checkout main" in c for c in checkouts), checkouts
+        # Must NOT switch back to the feature branch.
+        assert not any("checkout feat/aide-squared-evolution" in c for c in checkouts), checkouts
+
+    @patch("shutil.which", return_value=None)
+    @patch("subprocess.run")
+    def test_stay_on_branch_keeps_stash_for_manual_recovery(self, mock_run, _mock_which, capsys):
+        """With a stash present, --stay-on-branch must not auto-restore onto main."""
+        stash_ref = "refs/stash"
+
+        def side_effect(cmd, **kwargs):
+            joined = " ".join(str(c) for c in cmd)
+            if "rev-parse" in joined and "--abbrev-ref" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="feat/aide-squared-evolution\n", stderr="")
+            if "rev-parse" in joined and "--verify" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "rev-list" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="0\n", stderr="")
+            if "stash" in joined and "apply" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            if "stash" in joined and "drop" in joined:
+                return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("subprocess.run") as mock_run, \
+             patch.object(main, "_stash_local_changes_if_needed", return_value=stash_ref), \
+             patch.object(main, "_restore_stashed_changes") as mock_restore:
+            mock_run.side_effect = side_effect
+            args = SimpleNamespace(
+                branch="main",
+                stay_on_branch=True,
+                yes=True,
+                check=False,
+                gateway=False,
+            )
+            cmd_update(args)
+
+        # The stash was NOT auto-restored (would have contaminated main with
+        # feature-branch WIP) and the user was told how to recover it.
+        mock_restore.assert_not_called()
+        out = capsys.readouterr().out
+        assert "preserved in stash" in out
+        assert "git stash apply" in out


### PR DESCRIPTION
## Who should enable this

Users of **Hermes Desktop** (the packaged app, macOS/Linux) whose install lives in a git checkout that sits on a non-main (feature) branch:

- Desktop Update button reports success but the app never advances past the old version
- `hermes version` keeps saying "Update available: N commits behind" after clicking Update
- You develop on feature branches but use the Desktop product for daily driving — updates must end on main, not strand on your WIP branch

CLI-only users are unaffected unless they opt into `--stay-on-branch` (the flag is additive; default CLI behavior is unchanged).

## Platform compatibility

| Platform | Compatibility |
|---|---|
| macOS | ✅ Target platform (in-app updater + CLI update path) |
| Linux | ✅ Compatible (same POSIX in-app updater path) |
| Windows | ✅ Unchanged (Windows uses the updater-exe hand-off path; no branch-pinning there) |

## Quick-start guide

1. `hermes update` (or pull this PR branch)
2. Desktop: click Update — the in-app updater now always passes `--branch <tracked> --stay-on-branch`, so the checkout ends on the tracked branch (default main)
3. CLI: to force the same behavior, run `hermes update --stay-on-branch`
4. Verify: after update, `git branch --show-current` shows the tracked branch (main), and the desktop build reflects the new code

## Troubleshooting

| Symptom | Cause | Fix |
|---|---|---|
| Desktop stuck at old version after Update | Old behavior re-pinned to the feature branch | Upgrade to this fix; updater now stays on the tracked branch |
| `hermes update --stay-on-branch` left WIP behind | Autostash preserved for manual recovery | Check `git stash list`; the pre-switch stash is kept intentionally |
| CLI update switched back to feature branch | Default CLI behavior (no flag) | Use `--stay-on-branch` to stay on the target branch |
| Desktop on Windows unchanged | Windows updater-exe path | Expected — no branch-pinning existed there |

---

## Summary

Fix a real field bug: **Hermes Desktop can never update past the old version when the git checkout sits on a non-main (feature) branch.** The CLI update pipeline refreshes `main`, but the desktop update flow re-pins to the current branch and the post-update rebuild packages the stale feature-branch code.

## Problem (with evidence)

A desktop user whose checkout was on `feat/aide-squared-evolution` observed:
- `hermes update` (from the desktop Update button) reported success every time,
- the packaged desktop app never advanced (stuck at the old build),
- `hermes version` kept reporting `Update available: 528 commits behind`.

Root cause is a 3-link chain:

1. **CLI**: `hermes update` switches back to the pre-update branch after pulling ("keep me where I was working" — correct for a developer CLI, wrong for a product updater). The switch-back lives in the `commit_count == 0` path of `_cmd_update_impl` (`git checkout current_branch`).
2. **Desktop in-app updater**: `applyUpdatesPosixInApp` *branch-pinned* the update to whatever branch the checkout was on, so on a non-main checkout it told `hermes update --branch <feature>` to update the *feature branch*, not `main`.
3. **Rebuild**: `hermes desktop --build-only` runs *after* the update, so it packaged the stale feature-branch code — the desktop binary never contained the new `main` code.

## Fix

| Area | Change |
|---|---|
| CLI `hermes update` | New `--stay-on-branch` flag: after the update the checkout **stays on the update target branch** (default `main`) instead of switching back. Any stash created by the pre-switch autostash is **preserved for manual recovery** rather than auto-applied onto the target branch (auto-applying would contaminate `main` with feature-branch WIP). |
| Desktop in-app updater (macOS/Linux) | `applyUpdatesPosixInApp` no longer branch-pins to the current checkout. It always passes `--branch <tracked> --stay-on-branch`, where `<tracked>` is the configured update branch (default `main`, self-healed via existing `resolveHealedBranch`). |
| Desktop manual-command fallback | The no-staged-updater path surfaces the same explicit command (`hermes update --branch main --stay-on-branch`) instead of branch-pinning the displayed one-liner. |

**Developer CLI behavior is unchanged**: plain `hermes update` still returns you to the branch you started on, with stash auto-restore exactly as before. The new flag is opt-in and only the desktop passes it.

## Safety design

- **Stash contamination guard**: when `--stay-on-branch` ends on a different branch than the pre-update HEAD, the autostash is *not* re-applied (that would write feature-branch WIP onto `main`). The user gets explicit recovery guidance: `git stash apply <ref>` on their branch. Both the `commit_count == 0` path and the `commit_count > 0` finally path honor this.
- **No remote mutation**: this change only alters local checkout/branch handling; it never pushes, force-pushes, or rewrites history.
- **Existing self-heal kept**: `resolveHealedBranch` still falls back to `main` when the configured branch no longer exists on origin.

## Tests / self-test

CLI (`tests/hermes_cli/test_cmd_update.py`, 3 new tests):
1. default behavior still switches back to the feature branch;
2. `--stay-on-branch` updates main and does **not** switch back;
3. with a stash present, `--stay-on-branch` keeps it (no `_restore_stashed_changes` call) and prints `git stash apply` guidance.

Ran:
- `pytest test_cmd_update.py test_update_autostash.py test_update_yes_flag.py test_update_post_pull_syntax_guard.py test_update_venv_health.py test_update_hangup_protection.py` → **49 passed**
- `ruff check` on changed Python files → clean
- `tsc -p . --noEmit` + `tsc -p tsconfig.electron.json --noEmit` → clean
- `eslint electron/main.ts` → clean
- `vitest run --project electron` → 937 passed / 1 failed. The one failure (`git-review-ops` untracked-dir payload) **reproduces with this change stashed** — a local-git-environment artifact (git version behavior on untracked dirs), not this change.

## Verification on a real checkout

The bug was reproduced and fixed on the reporter's actual machine: after `hermes update --branch main --stay-on-branch`, `hermes version` went from `v0.19.1 · 528 commits behind` to `v0.20.0 · Up to date`, and the packaged desktop was rebuilt from current `main`.

