### PR TITLE
fix(vision): remove hardcoded max_tokens cap, honor auxiliary.vision.max_tokens config (#80025)

### DIFF
--- a/tests/tools/test_vision_max_tokens_config_80025.py
+++ b/tests/tools/test_vision_max_tokens_config_80025.py
@@ -1,0 +1,85 @@
+"""#80025: vision_tools must not hardcode max_tokens — contradicts
+auxiliary_client.py's own no-cap policy.  Only pass max_tokens when the
+user explicitly configures auxiliary.vision.max_tokens.
+"""
+
+from __future__ import annotations
+
+import inspect
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+# ── Source-level tests (no API calls needed) ──────────────────────────
+
+
+def test_no_hardcoded_max_tokens_in_image_call_site():
+    """The image-analysis call_kwargs block must not contain a literal
+    ``"max_tokens": <int>`` — the cap is silently truncating analyses."""
+    source = Path("tools/vision_tools.py").read_text(encoding="utf-8")
+    # The old hardcoded lines were "max_tokens": 2000 and "max_tokens": 4000.
+    # After the fix, max_tokens only appears inside the conditional guard.
+    assert '"max_tokens": 2000' not in source, (
+        "Hardcoded max_tokens: 2000 still present in vision_tools.py"
+    )
+    assert '"max_tokens": 4000' not in source, (
+        "Hardcoded max_tokens: 4000 still present in vision_tools.py"
+    )
+
+
+def test_max_tokens_is_conditional_on_config():
+    """The call_kwargs dict must NOT include max_tokens by default; it
+    should only be added when _vision_cfg.get('max_tokens') returns a value."""
+    source = Path("tools/vision_tools.py").read_text(encoding="utf-8")
+    # The fix reads _vmax from _vision_cfg and conditionally sets max_tokens.
+    assert "_vmax = _vision_cfg.get" in source, (
+        "vision_tools must read max_tokens from auxiliary.vision config, "
+        "not hardcode it"
+    )
+    assert '"auto"' in source.lower(), (
+        "vision_tools must treat 'auto' as omit (do not pass max_tokens)"
+    )
+
+
+def test_call_kwargs_does_not_include_max_tokens_by_default():
+    """Verify the call_kwargs dict literal in the image path omits
+    max_tokens — it should be added after, conditionally."""
+    source = Path("tools/vision_tools.py").read_text(encoding="utf-8")
+    # Find the image call_kwargs block
+    # The block should have "task", "messages", "temperature", "timeout"
+    # but NOT "max_tokens" in the dict literal.
+    # After the fix, max_tokens is added via call_kwargs["max_tokens"] = ...
+    # only when _vmax is set.
+    lines = source.splitlines()
+    in_call_kwargs = False
+    call_kwargs_lines: list[str] = []
+    for line in lines:
+        if "call_kwargs = {" in line:
+            in_call_kwargs = True
+            call_kwargs_lines = [line]
+            continue
+        if in_call_kwargs:
+            call_kwargs_lines.append(line)
+            if line.strip() == "}":
+                # Check this block — should not contain max_tokens as a
+                # direct key in the dict literal.
+                block = "\n".join(call_kwargs_lines)
+                if '"task": "vision"' in block:
+                    assert '"max_tokens"' not in block, (
+                        "call_kwargs dict literal should not include "
+                        "max_tokens — it must be added conditionally"
+                    )
+                in_call_kwargs = False
+                call_kwargs_lines = []
+
+
+def test_both_image_and_video_paths_are_fixed():
+    """Both the image (line ~1270) and video (line ~1777) call sites must
+    be fixed — the bug report confirms both hardcode caps."""
+    source = Path("tools/vision_tools.py").read_text(encoding="utf-8")
+    # Count occurrences of _vmax — should appear at least twice (image + video).
+    assert source.count("_vmax = _vision_cfg.get") >= 2, (
+        "Both image and video call sites must read max_tokens from config"
+    )

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1263,13 +1263,23 @@ async def vision_analyze_tool(
                 vision_temperature = float(_vtemp)
         except Exception:
             pass
+        # Do NOT hardcode max_tokens — auxiliary_client.py's own policy says
+        # "We do NOT cap output by default" for auxiliary tasks (vision,
+        # compression, etc.).  An explicit cap silently truncates long image
+        # analyses (#80025).  Only pass max_tokens when the user explicitly
+        # configures auxiliary.vision.max_tokens (treat unset/"auto" as omit).
+        _vmax = _vision_cfg.get("max_tokens")
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 2000,
             "timeout": vision_timeout,
         }
+        if _vmax is not None and str(_vmax).strip().lower() != "auto":
+            try:
+                call_kwargs["max_tokens"] = int(_vmax)
+            except (TypeError, ValueError):
+                pass
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
@@ -1770,13 +1780,20 @@ async def video_analyze_tool(
         except Exception:
             pass
 
+        # Do NOT hardcode max_tokens — same rationale as image analysis
+        # above (#80025).  Only pass max_tokens when explicitly configured.
+        _vmax = _vision_cfg.get("max_tokens")
         call_kwargs = {
             "task": "vision",
             "messages": messages,
             "temperature": vision_temperature,
-            "max_tokens": 4000,
             "timeout": vision_timeout,
         }
+        if _vmax is not None and str(_vmax).strip().lower() != "auto":
+            try:
+                call_kwargs["max_tokens"] = int(_vmax)
+            except (TypeError, ValueError):
+                pass
         if model:
             call_kwargs["model"] = model
 


### PR DESCRIPTION
## Summary

`tools/vision_tools.py` hardcoded `max_tokens: 2000` for image analysis and `max_tokens: 4000` for video analysis on every vision call. This silently truncates long image descriptions and video analyses regardless of the vision model's actual capacity.

This contradicts `agent/auxiliary_client.py` (request builder, ~line 7879), which states the policy explicitly:

> "We do NOT cap output by default. Most chat-completions providers treat an omitted max_tokens as use the model's max output, which is what we want for auxiliary tasks (compression summaries, titles, vision, etc.) — an explicit cap only risks truncating a summary."

Vision is named in that comment, yet `vision_tools.py` is the one caller that still hardcodes a cap.

Closes #80025.

## Changes

| File | Change |
|------|--------|
| `tools/vision_tools.py` | Both image (~line 1270) and video (~line 1777) call sites: remove hardcoded `max_tokens`, read `auxiliary.vision.max_tokens` from config. Only pass `max_tokens` when explicitly set; treat unset or `"auto"` as omit. |
| `tests/tools/test_vision_max_tokens_config_80025.py` | 4 new source-level tests: no hardcoded caps, conditional on config, both paths fixed. |

## Design Notes

- **Config-gated**: `auxiliary.vision.max_tokens` in `config.yaml` lets users who want a cap set one. Unset or `"auto"` = omit (model sizes its own response).
- **Consistency**: Matches `auxiliary_client.py`'s own no-cap policy that already applies to compression and titles.
- **Both call sites fixed**: The bug report confirms both image and video paths hardcode caps.

## Test Plan

- [x] `tests/tools/test_vision_max_tokens_config_80025.py` — 4/4 pass
- [x] No hardcoded `"max_tokens": 2000` or `"max_tokens": 4000` remain in source
- [x] Both image and video paths read from `_vision_cfg.get("max_tokens")`

## Adversarial 6-Check — PASS

1. **Diff integrity**: Every change traces to #80025 ✅
2. **Blast radius**: Only the `max_tokens` key in `call_kwargs` — no other behavior changed ✅
3. **Config fallback**: Unset → omit (no cap), `"auto"` → omit, integer → pass through, garbage → silently skip ✅
4. **Type safety**: `int(_vmax)` wrapped in try/except for TypeError/ValueError ✅
5. **Both paths**: Image and video call sites both fixed identically ✅
6. **No regression**: Existing timeout/temperature config reads are untouched ✅