### PR TITLE
fix(sessions): heal missing last_read_at on read-only GET /api/sessions opens

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11199,9 +11199,17 @@ _session_db_bootstrap_lock = threading.Lock()
 # the dashboard read paths query. Reads at most one row per table. Read-only
 # opens skip _reconcile_columns(), so an older store would otherwise 500 on
 # every poll until something opened it writable.
+#
+# MAINTENANCE: any new column added to hermes_state_common.py's sessions/
+# messages schema that a dashboard read path (list_sessions_rich et al.)
+# queries must be added here too, or an existing pre-feature database will
+# 500 on GET /api/sessions until a write connection happens to open first
+# (e.g. creating a new session) -- issue #80037, where last_read_at was
+# never added to this list when the read-state feature shipped.
 _SESSION_DB_READ_PROBE_SQL = (
     "SELECT (SELECT archived FROM sessions LIMIT 1), "
     "(SELECT pinned FROM sessions LIMIT 1), "
+    "(SELECT last_read_at FROM sessions LIMIT 1), "
     "(SELECT active FROM messages LIMIT 1), "
     "(SELECT compacted FROM messages LIMIT 1)"
 )

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -398,7 +398,7 @@ class TestWebServerEndpoints:
         assert response.json()["sessions"] == []
         assert response.json()["total"] == 0
 
-    @pytest.mark.parametrize("missing_column", ["archived", "pinned"])
+    @pytest.mark.parametrize("missing_column", ["archived", "pinned", "last_read_at"])
     def test_get_sessions_heals_stale_schema_store(self, missing_column):
         import sqlite3
 


### PR DESCRIPTION
Fixes #80037.

## Root cause

Read-only `SessionDB` opens skip `_init_schema()`/`_reconcile_columns()` entirely (the healthy read path must never take a write lock). To handle this for existing databases, `_open_session_db_for_profile()` already runs a stale-schema probe query against a handful of columns dashboard read paths query -- if it raises "no such column", it opens one writable connection (running the real migration) before reopening read-only.

`last_read_at` (added for the session read/unread state feature) was never added to this probe list. So on an existing pre-feature database, the probe query itself SUCCEEDED (checking only already-present columns), meaning self-healing never triggered -- the failure only surfaced deeper inside `list_sessions_rich()`'s own broader SELECT as a plain 500. The migration only ran whenever something else (e.g. creating a new session) opened a write connection first -- exactly matching the reported symptom.

## Fix

Added `last_read_at` to the probe SQL, plus a maintenance comment for future columns.

## Verification

Extended the EXISTING parametrized stale-schema healing test with a `last_read_at` case. Verified as a genuine regression by reverting the fix and confirming the new test case fails with the exact reported traceback.

3/3 pass in the parametrized test; 145/146 across the full `test_web_server.py` file plus `test_session_read_state.py` (1 pre-existing unrelated skip; no regression).