### PR TITLE
fix(desktop): show quit confirmation when closing window mid-turn

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,7 +159,7 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
-import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor, shouldGuardWindowClose } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -9347,7 +9347,59 @@ function createWindow() {
   mainWindow.on('moved', schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+
+  // On Windows/Linux, closing the last window triggers app.quit() → before-quit,
+  // but by then the renderer's webContents is already destroyed and its entry
+  // has been removed from the active-work map — so the before-quit guard finds
+  // nothing and the app exits silently, killing any turn in flight. Intercept
+  // 'close' instead, while the work data is still live. macOS is excluded: there
+  // closing the primary window is the standard "stay in Dock" gesture.
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+
+    if (!shouldGuardWindowClose(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff, IS_MAC)) {
+      return
+    }
+
+    // Reuse the same latch as the before-quit guard so the two paths never
+    // stack dialogs. Once the user confirms, a second close (or the app.quit()
+    // it triggers) falls through.
+    if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork || quitPromptOpen) {
+      return
+    }
+
+    const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff)
+
+    if (!prompt) {
+      return
+    }
+
+    event.preventDefault()
+    quitPromptOpen = true
+
+    void dialog
+      .showMessageBox(mainWindow!, {
+        buttons: ['Keep Running', 'Quit Anyway'],
+        cancelId: 0,
+        defaultId: 0,
+        detail: prompt.detail,
+        message: prompt.message,
+        type: 'question'
+      })
+      .then(({ response }) => {
+        quitPromptOpen = false
+
+        if (response === 1) {
+          quitConfirmedWithActiveWork = true
+          app.quit()
+        }
+      })
+      .catch(() => {
+        quitPromptOpen = false
+        quitConfirmedWithActiveWork = true
+        app.quit()
+      })
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow

--- a/apps/desktop/electron/quit-guard.test.ts
+++ b/apps/desktop/electron/quit-guard.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { mergeActiveWork, normalizeActiveWork, quitPromptFor, shouldGuardWindowClose } from './quit-guard'
 
 test('normalizeActiveWork drops junk and keeps the count at least the title count', () => {
   assert.deepEqual(normalizeActiveWork(null), { count: 0, titles: [] })
@@ -59,4 +59,25 @@ test('quitPromptFor speaks singular for one chat', () => {
   assert.ok(prompt)
   assert.equal(prompt.message, 'Hermes is still working on 1 chat.')
   assert.ok(prompt.detail.includes('mid-turn'))
+})
+
+// -- shouldGuardWindowClose -------------------------------------------------
+
+test('shouldGuardWindowClose returns true for active work on Windows/Linux', () => {
+  assert.equal(shouldGuardWindowClose({ count: 1, titles: ['Fix login'] }, false, false), true)
+  assert.equal(shouldGuardWindowClose({ count: 3, titles: ['a', 'b', 'c'] }, false, false), true)
+})
+
+test('shouldGuardWindowClose returns false when no work is active', () => {
+  assert.equal(shouldGuardWindowClose({ count: 0, titles: [] }, false, false), false)
+})
+
+test('shouldGuardWindowClose returns false on macOS', () => {
+  // macOS closing the primary window is a "stay in Dock" gesture, not a quit.
+  assert.equal(shouldGuardWindowClose({ count: 2, titles: ['Fix login'] }, false, true), false)
+})
+
+test('shouldGuardWindowClose returns false during a handoff', () => {
+  // Update / swap / uninstall relaunch: the app is replacing itself.
+  assert.equal(shouldGuardWindowClose({ count: 2, titles: ['Fix login'] }, true, false), false)
 })

--- a/apps/desktop/electron/quit-guard.ts
+++ b/apps/desktop/electron/quit-guard.ts
@@ -90,3 +90,29 @@ export function quitPromptFor(work: ActiveWork, quittingForHandoff: boolean): nu
     message: work.count === 1 ? 'Hermes is still working on 1 chat.' : `Hermes is still working on ${work.count} chats.`
   }
 }
+
+/**
+ * Whether a window's 'close' event should be intercepted to show the
+ * active-work confirmation.
+ *
+ * On Windows and Linux, closing the last window triggers app.quit() →
+ * before-quit, but by then the renderer's webContents is already destroyed
+ * and its entry has been removed from the active-work map — so the existing
+ * before-quit guard finds nothing and the app exits silently. Intercepting
+ * 'close' instead catches the guard while the work data is still live.
+ *
+ * macOS is excluded: closing the primary window there is the standard
+ * "window stays in Dock" gesture, not a quit, and prompting on it would
+ * block a normal workflow.
+ */
+export function shouldGuardWindowClose(
+  work: ActiveWork,
+  quittingForHandoff: boolean,
+  isMac: boolean
+): boolean {
+  if (isMac || quittingForHandoff || work.count < 1) {
+    return false
+  }
+
+  return true
+}


### PR DESCRIPTION
## Problem

On Windows and Linux, clicking the window close button (X) while conversations are mid-turn kills the app silently — no confirmation dialog appears.

The existing quit-guard code in `heldQuitForActiveWork()` was wired to `app.on('before-quit')`, but by the time `before-quit` fires the renderer's `webContents` has already been destroyed and its entry removed from `activeWorkByWebContents`. The guard finds an empty map and the app exits without confirmation.

## Root Cause

Electron event order on Windows/Linux when closing the last window:

1. window `close` event — flushes state, allows close
2. window `closed` event — cleans up pet overlay, sets mainWindow=null
3. webContents `destroyed` event — `activeWorkByWebContents.delete(id)` — work data gone
4. `window-all-closed` — calls `app.quit()`
5. `before-quit` — `heldQuitForActiveWork()` finds empty map, no dialog shown

## Fix

Intercept the main window's `close` event instead, while the webContents and active-work data are still live:

1. **`quit-guard.ts`**: Added `shouldGuardWindowClose()` — a pure function that gates on platform (macOS excluded), handoff state, and active work count. Reuses the existing `quitPromptOpen` / `quitConfirmedWithActiveWork` latches so the two paths never stack dialogs.

2. **`quit-guard.test.ts`**: 4 new tests covering all branches of `shouldGuardWindowClose`.

3. **`main.ts`**: Replaced the `close` handler (previously only `schedulePersistWindowState.flush()`) with a full quit-guard that shows `dialog.showMessageBox` before allowing the window to close.

## macOS

macOS is intentionally excluded — closing the primary window there is the standard "stay in Dock" gesture, not a quit. The existing `before-quit` guard remains in place for Cmd+Q and right-click Dock → Quit.

## Testing

- `electron/quit-guard.test.ts`: 12 tests passed (8 existing + 4 new)
- TypeScript compiles cleanly (`tsc -p tsconfig.electron.json --noEmit`)
- No new test failures in the full electron test suite
