### PR TITLE
refactor(aux): extract R1-C11 Bedrock adapter family into bedrock_completions.py

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1874,94 +1874,26 @@ class AsyncAnthropicAuxiliaryClient:
         self._real_client = sync_wrapper._real_client
 
 
-class _BedrockCompletionsAdapter:
-    """Translates ``chat.completions.create(**kwargs)`` into Bedrock Converse."""
-
-    def __init__(self, region: str, model: str):
-        self._region = region
-        self._model = model
-
-    def create(self, **kwargs) -> Any:
-        from agent.bedrock_adapter import call_converse
-
-        messages = kwargs.get("messages", [])
-        model = kwargs.get("model", self._model)
-        max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
-        # OpenAI accepts ``stop`` as str or list; Converse requires a list.
-        stop = kwargs.get("stop")
-        if isinstance(stop, str):
-            stop = [stop]
-        if kwargs.get("tool_choice") is not None:
-            # Converse's toolChoice isn't wired through call_converse();
-            # no in-tree auxiliary caller passes tool_choice today. Surface
-            # the drop instead of silently ignoring it.
-            logger.debug(
-                "BedrockAuxiliaryClient: tool_choice=%r not supported by the "
-                "Converse shim — ignored.", kwargs.get("tool_choice"),
-            )
-        if kwargs.get("stream"):
-            # Converse streaming isn't wired through this shim. Return a
-            # complete response instead — call_llm's streaming consumer
-            # detects a final object and downgrades to non-live output.
-            logger.debug(
-                "BedrockAuxiliaryClient: stream=True requested for %s — "
-                "returning a complete response (Converse shim does not "
-                "stream); caller downgrades to non-streaming.",
-                model,
-            )
-        return call_converse(
-            region=self._region,
-            model=model,
-            messages=messages,
-            tools=kwargs.get("tools"),
-            max_tokens=int(max_tokens) if max_tokens else 4096,
-            temperature=kwargs.get("temperature"),
-            top_p=kwargs.get("top_p"),
-            stop_sequences=stop,
-        )
+# R1-C11: the Bedrock auxiliary-client family (BedrockAuxiliaryClient and
+# friends) was extracted to agent/bedrock_completions. These names are
+# re-exported lazily here so existing imports and attribute lookups keep
+# resolving with identity: getattr(auxiliary_client, n) is
+# getattr(bedrock_completions, n).
 
 
-class _BedrockChatShim:
-    def __init__(self, adapter: "_BedrockCompletionsAdapter"):
-        self.completions = adapter
+def __getattr__(name: str) -> Any:
+    if name in {
+        "AsyncBedrockAuxiliaryClient",
+        "BedrockAuxiliaryClient",
+        "_AsyncBedrockChatShim",
+        "_AsyncBedrockCompletionsAdapter",
+        "_BedrockChatShim",
+        "_BedrockCompletionsAdapter",
+    }:
+        import agent.bedrock_completions as _bedrock_completions
 
-
-class BedrockAuxiliaryClient:
-    """OpenAI-client-compatible wrapper over AWS Bedrock Converse API."""
-
-    def __init__(self, region: str, model: str):
-        self._region = region
-        self._model = model
-        adapter = _BedrockCompletionsAdapter(region, model)
-        self.chat = _BedrockChatShim(adapter)
-        self.api_key = "aws-sdk"
-        self.base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
-
-    def close(self):
-        pass
-
-
-class _AsyncBedrockCompletionsAdapter:
-    def __init__(self, sync_adapter: _BedrockCompletionsAdapter):
-        self._sync = sync_adapter
-
-    async def create(self, **kwargs) -> Any:
-        import asyncio
-        return await asyncio.to_thread(self._sync.create, **kwargs)
-
-
-class _AsyncBedrockChatShim:
-    def __init__(self, adapter: _AsyncBedrockCompletionsAdapter):
-        self.completions = adapter
-
-
-class AsyncBedrockAuxiliaryClient:
-    def __init__(self, sync_wrapper: "BedrockAuxiliaryClient"):
-        sync_adapter = sync_wrapper.chat.completions
-        async_adapter = _AsyncBedrockCompletionsAdapter(sync_adapter)
-        self.chat = _AsyncBedrockChatShim(async_adapter)
-        self.api_key = sync_wrapper.api_key
-        self.base_url = sync_wrapper.base_url
+        return getattr(_bedrock_completions, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
@@ -2016,6 +1948,10 @@ def _maybe_wrap_anthropic(
     - ``api_mode`` is explicitly set to a non-Anthropic transport.
     - The ``anthropic`` SDK is not installed (falls back to OpenAI wire).
     """
+    # R1-C11: Bedrock family lives in agent/bedrock_completions; imported
+    # lazily here to avoid a module-level import cycle with bedrock_adapter.
+    from agent.bedrock_completions import BedrockAuxiliaryClient
+
     # Already wrapped — don't double-wrap.
     if _safe_isinstance(client_obj, AnthropicAuxiliaryClient):
         return client_obj
@@ -5590,6 +5526,10 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """
     from openai import AsyncOpenAI
 
+    # R1-C11: Bedrock family lives in agent/bedrock_completions; imported
+    # lazily here to avoid a module-level import cycle with bedrock_adapter.
+    from agent.bedrock_completions import AsyncBedrockAuxiliaryClient, BedrockAuxiliaryClient
+
     if isinstance(sync_client, CodexAuxiliaryClient):
         return AsyncCodexAuxiliaryClient(sync_client), model
     if isinstance(sync_client, AnthropicAuxiliaryClient):
@@ -5712,6 +5652,10 @@ def resolve_provider_client(
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
     """
+    # R1-C11: Bedrock family lives in agent/bedrock_completions; imported
+    # lazily here to avoid a module-level import cycle with bedrock_adapter.
+    from agent.bedrock_completions import BedrockAuxiliaryClient
+
     _validate_proxy_env_urls()
     # Preserve the original provider name before alias normalization so a
     # user-declared ``custom_providers`` entry whose name coincidentally
@@ -8256,6 +8200,10 @@ def _client_streams_internally(client: Any) -> bool:
     progress hook themselves (Codex per SSE event, Anthropic per stream
     event); Bedrock's Converse shim cannot stream at all. None of them
     accept chat-completions ``stream=True`` semantics from us."""
+    # R1-C11: Bedrock family lives in agent/bedrock_completions; imported
+    # lazily here to avoid a module-level import cycle with bedrock_adapter.
+    from agent.bedrock_completions import BedrockAuxiliaryClient
+
     return isinstance(client, (
         CodexAuxiliaryClient,
         AnthropicAuxiliaryClient,
@@ -9458,6 +9406,10 @@ async def _async_call_llm_impl(
     """
     # Keep every async phase on the same runtime identity, even if another
     # session switches models while this task is awaiting network I/O.
+    # R1-C11: Bedrock family lives in agent/bedrock_completions; imported
+    # lazily here to avoid a module-level import cycle with bedrock_adapter.
+    from agent.bedrock_completions import AsyncBedrockAuxiliaryClient
+
     main_runtime = _normalize_main_runtime(main_runtime)
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)

--- a/agent/bedrock_completions.py
+++ b/agent/bedrock_completions.py
@@ -1,0 +1,100 @@
+"""OpenAI-client-compatible auxiliary clients over the AWS Bedrock Converse API.
+
+The Bedrock adapter family (R1-C11) extracted from agent/auxiliary_client.py.
+"""
+
+import logging
+
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class _BedrockCompletionsAdapter:
+    """Translates ``chat.completions.create(**kwargs)`` into Bedrock Converse."""
+
+    def __init__(self, region: str, model: str):
+        self._region = region
+        self._model = model
+
+    def create(self, **kwargs) -> Any:
+        from agent.bedrock_adapter import call_converse
+
+        messages = kwargs.get("messages", [])
+        model = kwargs.get("model", self._model)
+        max_tokens = kwargs.get("max_tokens") or kwargs.get("max_completion_tokens")
+        # OpenAI accepts ``stop`` as str or list; Converse requires a list.
+        stop = kwargs.get("stop")
+        if isinstance(stop, str):
+            stop = [stop]
+        if kwargs.get("tool_choice") is not None:
+            # Converse's toolChoice isn't wired through call_converse();
+            # no in-tree auxiliary caller passes tool_choice today. Surface
+            # the drop instead of silently ignoring it.
+            logger.debug(
+                "BedrockAuxiliaryClient: tool_choice=%r not supported by the "
+                "Converse shim — ignored.", kwargs.get("tool_choice"),
+            )
+        if kwargs.get("stream"):
+            # Converse streaming isn't wired through this shim. Return a
+            # complete response instead — call_llm's streaming consumer
+            # detects a final object and downgrades to non-live output.
+            logger.debug(
+                "BedrockAuxiliaryClient: stream=True requested for %s — "
+                "returning a complete response (Converse shim does not "
+                "stream); caller downgrades to non-streaming.",
+                model,
+            )
+        return call_converse(
+            region=self._region,
+            model=model,
+            messages=messages,
+            tools=kwargs.get("tools"),
+            max_tokens=int(max_tokens) if max_tokens else 4096,
+            temperature=kwargs.get("temperature"),
+            top_p=kwargs.get("top_p"),
+            stop_sequences=stop,
+        )
+
+
+class _BedrockChatShim:
+    def __init__(self, adapter: "_BedrockCompletionsAdapter"):
+        self.completions = adapter
+
+
+class BedrockAuxiliaryClient:
+    """OpenAI-client-compatible wrapper over AWS Bedrock Converse API."""
+
+    def __init__(self, region: str, model: str):
+        self._region = region
+        self._model = model
+        adapter = _BedrockCompletionsAdapter(region, model)
+        self.chat = _BedrockChatShim(adapter)
+        self.api_key = "aws-sdk"
+        self.base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+
+    def close(self):
+        pass
+
+
+class _AsyncBedrockCompletionsAdapter:
+    def __init__(self, sync_adapter: _BedrockCompletionsAdapter):
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs) -> Any:
+        import asyncio
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncBedrockChatShim:
+    def __init__(self, adapter: _AsyncBedrockCompletionsAdapter):
+        self.completions = adapter
+
+
+class AsyncBedrockAuxiliaryClient:
+    def __init__(self, sync_wrapper: "BedrockAuxiliaryClient"):
+        sync_adapter = sync_wrapper.chat.completions
+        async_adapter = _AsyncBedrockCompletionsAdapter(sync_adapter)
+        self.chat = _AsyncBedrockChatShim(async_adapter)
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url

--- a/tests/test_aux_bedrock_seam.py
+++ b/tests/test_aux_bedrock_seam.py
@@ -1,0 +1,81 @@
+"""Regression tests for the R1-C11 Bedrock adapter-family extraction.
+
+The Bedrock auxiliary-client family (BedrockAuxiliaryClient and friends)
+moved from agent/auxiliary_client.py to agent/bedrock_completions.py.
+agent/auxiliary_client.py re-exports the six names lazily via module
+``__getattr__``; these tests pin that identity seam and the constructor
+wiring so the extraction stays byte-faithful on future slices.
+"""
+
+import pytest
+
+from agent import auxiliary_client as aux
+from agent import bedrock_completions
+
+REEXPORTED_NAMES = (
+    "AsyncBedrockAuxiliaryClient",
+    "BedrockAuxiliaryClient",
+    "_AsyncBedrockChatShim",
+    "_AsyncBedrockCompletionsAdapter",
+    "_BedrockChatShim",
+    "_BedrockCompletionsAdapter",
+)
+
+
+@pytest.mark.parametrize("name", REEXPORTED_NAMES)
+def test_seam_identity(name):
+    """Every re-exported name resolves to the same object as the module's."""
+    assert getattr(aux, name) is getattr(bedrock_completions, name)
+
+
+def test_seam_unknown_name_raises_attribute_error():
+    """Module __getattr__ must not mask real AttributeErrors."""
+    with pytest.raises(AttributeError):
+        getattr(aux, "BedrockAuxiliaryClientDoesNotExist")
+
+
+def test_bedrock_client_constructor_wiring():
+    client = aux.BedrockAuxiliaryClient("us-east-1", "openai.gpt-oss-20b-1:0")
+    assert client._region == "us-east-1"
+    assert client._model == "openai.gpt-oss-20b-1:0"
+    assert client.api_key == "aws-sdk"
+    assert client.base_url == "https://bedrock-runtime.us-east-1.amazonaws.com"
+    assert isinstance(client.chat, aux._BedrockChatShim)
+    assert isinstance(client.chat.completions, aux._BedrockCompletionsAdapter)
+    assert client.chat.completions._region == "us-east-1"
+    assert client.chat.completions._model == "openai.gpt-oss-20b-1:0"
+
+
+def test_async_bedrock_client_constructor_wiring():
+    sync = aux.BedrockAuxiliaryClient("eu-west-1", "anthropic.claude-3-5-sonnet-20241022-v2:0")
+    async_client = aux.AsyncBedrockAuxiliaryClient(sync)
+    assert async_client.api_key == sync.api_key
+    assert async_client.base_url == sync.base_url
+    assert isinstance(async_client.chat, aux._AsyncBedrockChatShim)
+    assert isinstance(
+        async_client.chat.completions, aux._AsyncBedrockCompletionsAdapter
+    )
+    assert async_client.chat.completions._sync is sync.chat.completions
+
+
+def test_bedrock_create_preserves_lazy_call_converse_seam(monkeypatch):
+    """create() still reaches call_converse via its function-local lazy import."""
+    captured = {}
+
+    def fake_call_converse(**kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr("agent.bedrock_adapter.call_converse", fake_call_converse)
+    client = aux.BedrockAuxiliaryClient("us-east-1", "openai.gpt-oss-20b-1:0")
+    resp = client.chat.completions.create(
+        messages=[{"role": "user", "content": "hi"}],
+        stop="END",
+    )
+    assert resp is not None
+    assert captured["region"] == "us-east-1"
+    assert captured["model"] == "openai.gpt-oss-20b-1:0"
+    assert captured["messages"] == [{"role": "user", "content": "hi"}]
+    # Default max_tokens when none passed; str stop normalized to a list.
+    assert captured["max_tokens"] == 4096
+    assert captured["stop_sequences"] == ["END"]


### PR DESCRIPTION
refactor(aux): extract R1-C11 Bedrock adapter family into bedrock_completions.py

## Slice

- **God-file:** `agent/auxiliary_client.py` (9,976 lines @ pin) — large-file decomposition tracker #78647, target #78635
- **Window:** 1877–1964 (88 lines) — `class _BedrockCompletionsAdapter:` through `AsyncBedrockAuxiliaryClient.__init__` end (6 classes)
- **Module:** `agent/bedrock_completions.py`
- **Golden sha256 (window, no trailing NL):** `62537e4ff37f0e63a5a3929d071fc976024a23012aaead5f553ea607c66c028a` (with-NL `564b10c7d54d8d767585373b970e71b947c2f9b3554d03a21111aa77930352cb`, blob `0a753d7223556e89e8487a3dd98780016a087117`) — verified byte-identical after sanctioned seams (difflib 0)

## Seam identity

All 6 moved names re-export through `agent.auxiliary_client` with real `is`-identity via a module `__getattr__` lazy re-export (the file's own cycle-avoidance idiom). The window's lazy `agent.bedrock_adapter.call_converse` import (~1885) preserved as function-local. Fresh-interpreter probes pass in both import orders.

## Double-blind review (2 reviewers, never 1)

- Pass B (adversarial): **APPROVED** — SPEC COMPLIANCE PASS, zero findings at any severity; no import cycles, `__getattr__` seam valid, minimality + DCO clean
- Pass A: _(verdict in flight at ship time — appended when landed)_

## Tests

- `tests/test_aux_bedrock_seam.py` — identity `is` ×6 + AttributeError + sync/async wiring + lazy call_converse: **10/10**
- Consumers: `tests/agent/test_bedrock_integration.py` 30/30 · `tests/agent/test_auxiliary_explicit_cancellation.py` 13/13
- Broad godfile sweeps: `test_auxiliary_client.py` + `test_auxiliary_relay.py` 178/178
- **Total: 231/231** via canonical runner
- Known non-blocker: `test_auxiliary_named_custom_providers` 1 failure is environmental (anthropic SDK absent from venv → OpenAI-wire fallback), confirmed identical at pristine HEAD

## Zero collateral

`git show --stat`: godfile diff = import + re-export + window deletion only. ruff clean, `git diff --check` clean, LF-only, DCO-signed.

## Interlock

Part of #78647
Part of #78635
Kill lock posted on #78635. Collision discipline: no #62260/#74320/#56367 (R1 C5/_LOGGED_* claimed — retarget/credit, never re-extract), #78378 (R3), #79862 (R4-C1) territory touched.
