### PR TITLE
fix(desktop): resolve live gateway in slash-completions fetcher

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts
@@ -21,6 +21,7 @@ import {
   peekCachedSlashCompletion
 } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
+import { $gateway } from '@/store/gateway'
 import { $sessions } from '@/store/session'
 
 import type { CompletionEntry, CompletionPayload } from './use-live-completion-adapter'
@@ -72,10 +73,17 @@ export function useSlashCompletions(options: {
   const { gateway, skinThemes, activeSkin } = options
   const enabled = Boolean(gateway)
   const epoch = useStore($slashCompletionsEpoch)
+  // Live active gateway: profile switches SWAP the gateway object
+  // (store/gateway.ts activeGateway()), so a mount-time prop is stale for
+  // sessions that outlive a switch. Subscribing recreates the fetcher on swap.
+  const currentGateway = useStore($gateway)
 
   const fetcher = useCallback(
     async (query: string): Promise<CompletionPayload> => {
-      if (!gateway) {
+      // Prefer the LIVE active gateway; fall back to the mount-time prop.
+      const gw = currentGateway ?? gateway
+
+      if (!gw) {
         return { items: [], query }
       }
 
@@ -143,7 +151,7 @@ export function useSlashCompletions(options: {
       try {
         if (!query) {
           const catalog = filterDesktopCommandsCatalog(
-            await cachedSlashCompletion('catalog', () => gateway.request<CommandsCatalogLike>('commands.catalog'))
+            await cachedSlashCompletion('catalog', () => gw.request<CommandsCatalogLike>('commands.catalog'))
           )
 
           // Prefer the categorized layout so the popover renders section headers
@@ -184,7 +192,7 @@ export function useSlashCompletions(options: {
         }
 
         const result = await cachedSlashCompletion(`slash:${text.toLowerCase()}`, () =>
-          gateway.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text })
+          gw.request<{ items?: CompletionEntry[]; replace_from?: number }>('complete.slash', { text })
         )
 
         // Arg-completion items (replace_from > 1) carry just the arg stub —
@@ -249,7 +257,7 @@ export function useSlashCompletions(options: {
         return { items: [], query }
       }
     },
-    [gateway, skinThemes, activeSkin]
+    [gateway, currentGateway, skinThemes, activeSkin]
   )
 
   const toItem = useCallback((entry: CompletionEntry, index: number): Unstable_TriggerItem => {


### PR DESCRIPTION
## Summary

Fixes the desktop app showing an **empty slash-command catalog in pre-existing sessions after a profile switch-back**.

**Symptom:** Open a session, type `/` → full command list. Switch to another profile, switch back, return to the *same* session → typing `/` shows nothing (no commands at all, including native ones). A **new** session, or hitting **reload session** on the affected one, immediately shows the full catalog.

## Root cause

The slash-completions catalog is fetched by `useSlashCompletions`, which captures the `gateway` prop in its `useCallback` fetcher closure **at session mount** (`use-slash-completions.ts:252`).

Profile switches **swap** the active gateway object (`store/gateway.ts` → `activeGateway()`), rather than repointing the same instance. After a switch-back, the pre-existing session still holds the **stale gateway reference** from mount time; its `gateway.request('commands.catalog')` RPC fails against the swapped connection, and the `catch` at `use-slash-completions.ts:248` silently returns `{ items: [], query }`.

The cache invalidation on profile change (`slash-completion-cache.ts:99-107`) is correct — it bumps `$slashCompletionsEpoch` — but that only re-renders the hook; it does **not** recreate the fetcher closure with a fresh gateway, because the stale `gateway` object is unchanged from the dependency perspective.

## Fix

Subscribe to the **live active gateway** via the existing `$gateway` store and route the fetcher's RPCs through it, falling back to the mount-time prop:

- Import `$gateway` from `@/store/gateway`
- `const currentGateway = useStore($gateway)` — re-renders the hook on any gateway swap
- `const gw = currentGateway ?? gateway` inside the fetcher; both `commands.catalog` and `complete.slash` go through `gw`
- Add `currentGateway` to the `useCallback` deps so the fetcher is recreated when the active profile changes

A new session / reload-session already worked because they re-mount the hook with the current gateway prop — this fix makes the same true for sessions that outlive a profile switch.

## Files changed

- `apps/desktop/src/app/chat/composer/hooks/use-slash-completions.ts` — resolve live gateway in the fetcher (+ deps)

## Testing

- **Unit:** extend `use-slash-completions.test.tsx` — mount with gateway A, swap `$gateway` to B, assert the next catalog fetch calls B's `request`, not A's
- **Manual:** open session → switch profile → switch back → `/` in the pre-existing session shows the full catalog without reload
- **Regression:** single-profile desktop (no gateway swaps) unaffected — fetcher is only recreated when `$gateway` actually changes

## Notes

- Related to the known stale-profile-reference class documented at `store/profile.ts:230-238` (activating a background profile left `$connection` describing the primary).
- No backend / config / skill changes required — this is purely a renderer closure issue.
- Repro environment: v0.17.0 (build `36cb5ae`, 2026-08-04), Windows, 12-profile multiplex desktop.