### PR TITLE
fix(agent): handle auxiliary stream stalls and prevent turn ghosting 

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -440,6 +440,42 @@ def _aux_progress_active() -> bool:
     return getattr(_aux_progress, "hook", None) is not None
 
 
+def _anthropic_event_has_content(event: Any) -> bool:
+    event_type = getattr(event, "type", None)
+    if event_type == "content_block_delta":
+        delta = getattr(event, "delta", None)
+        if delta:
+            if getattr(delta, "text", None) or getattr(delta, "thinking", None) or getattr(delta, "partial_json", None):
+                return True
+    return False
+
+
+# Token-bearing Responses/Codex event types consumed by
+# ``agent/codex_runtime.py``. Lifecycle frames (response.created,
+# response.completed, pings) must not reset CompressionCommitFence.
+_CODEX_CONTENT_EVENT_TYPES = frozenset({
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.reasoning_summary_text.delta",
+    "response.text.delta",
+    "response.audio.delta",
+    "response.function_call_arguments.delta",
+    "response.reasoning_text.delta",
+})
+
+
+def _codex_event_has_content(event: Any) -> bool:
+    event_type = event.get("type") if isinstance(event, dict) else getattr(event, "type", None)
+    if event_type in _CODEX_CONTENT_EVENT_TYPES:
+        return True
+    if isinstance(event, dict):
+        delta = event.get("delta")
+        if delta and (delta.get("text") or delta.get("reasoning")):
+            return True
+    return False
+
+
 @contextlib.contextmanager
 def aux_progress_hook(hook):
     """Install *hook* as the current thread's aux forward-progress callback.
@@ -1774,10 +1810,9 @@ class _CodexCompletionsAdapter:
             def _on_each_event(_event: Any) -> None:
                 # Re-check timeout/cancellation per event, matching the
                 # cadence the old in-line ``_check_cancelled()`` used.
-                # Each SSE event is also forward progress for hosts watching
-                # a progress hook (gateway session hygiene): a reasoning
-                # model streaming a long summary must not look hung.
-                _notify_aux_progress()
+                # Only tick progress when the SSE event carries text/content.
+                if _codex_event_has_content(_event):
+                    _notify_aux_progress()
                 _check_cancelled()
 
             event_stream = self._client.responses.create(**stream_kwargs)
@@ -2083,7 +2118,7 @@ class _AnthropicCompletionsAdapter:
             # slow-but-generating summary model. No-op when no hook is
             # installed (None keeps the fast get_final_message path).
             on_stream_event=(
-                (lambda _event: _notify_aux_progress())
+                (lambda _event: _notify_aux_progress() if _anthropic_event_has_content(_event) else None)
                 if _aux_progress_active() else None
             ),
         )
@@ -8747,9 +8782,9 @@ def _obj_get(obj: Any, key: str, default: Any = None) -> Any:
 #      of a total budget (httpx applies the read timeout per stream read), so
 #      a slow-but-generating summary model is never killed mid-generation
 #      while tokens are moving — only a genuinely silent connection dies.
-#   2. Every arriving chunk ticks the progress hook, letting outer watchdogs
-#      (gateway session hygiene) extend their deadlines on liveness instead
-#      of guessing with a fixed wall clock.
+#   2. Content-bearing chunks tick the progress hook, letting outer watchdogs
+#      (gateway session hygiene) extend their deadlines on real tokens instead
+#      of guessing with a fixed wall clock. Keepalives do not reset the clock.
 # A total ceiling still bounds the pathological 1-token-per-idle-window
 # stream; see _aux_stream_total_ceiling().
 
@@ -8906,7 +8941,9 @@ def _aggregate_chat_stream(
 ) -> Any:
     """Consume a chat.completions chunk stream into a complete response.
 
-    Ticks the thread-local aux progress hook on every chunk. Raises
+    Ticks the thread-local aux progress hook only when a chunk carries
+    content, reasoning, or a tool-call fragment — keepalives, role-only
+    pings, and usage trailers do not count as progress. Raises
     TimeoutError when *total_ceiling* seconds elapse before the stream
     finishes — phrased with "timed out" so existing timeout classification
     (``_is_timeout_error``) treats it exactly like a request timeout.
@@ -8947,7 +8984,7 @@ class _ChatStreamAccumulator:
         self.resp_model = model or ""
 
     def feed(self, chunk: Any) -> None:
-        _notify_aux_progress()
+        _made_progress = False
         if (
             self._total_ceiling is not None
             and (time.monotonic() - self._started) >= self._total_ceiling
@@ -8958,6 +8995,9 @@ class _ChatStreamAccumulator:
             )
         self.resp_id = getattr(chunk, "id", None) or self.resp_id
         self.resp_model = getattr(chunk, "model", None) or self.resp_model
+        # Usage is a billing trailer, not a token delta — do not count it
+        # as forward progress; only real content/reasoning/tool-call deltas
+        # should advance CompressionCommitFence._last_progress.
         chunk_usage = getattr(chunk, "usage", None)
         if chunk_usage:
             self.usage = chunk_usage
@@ -8972,13 +9012,16 @@ class _ChatStreamAccumulator:
         piece = getattr(delta, "content", None)
         if piece:
             self.content_parts.append(piece)
+            _made_progress = True
         reasoning_piece = (
             getattr(delta, "reasoning", None)
             or getattr(delta, "reasoning_content", None)
         )
         if reasoning_piece and isinstance(reasoning_piece, str):
             self.reasoning_parts.append(reasoning_piece)
+            _made_progress = True
         for tc in (getattr(delta, "tool_calls", None) or []):
+            _made_progress = True
             idx = getattr(tc, "index", 0) or 0
             acc = self.tool_calls_acc.setdefault(
                 idx, {"id": "", "name": "", "arguments": []}
@@ -8991,6 +9034,9 @@ class _ChatStreamAccumulator:
                     acc["name"] = fn.name
                 if getattr(fn, "arguments", None):
                     acc["arguments"].append(fn.arguments)
+
+        if _made_progress:
+            _notify_aux_progress()
 
     def finish(self) -> Any:
         tool_calls = None

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -38,6 +38,7 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
     recover_rotated_compression_session,
 )
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
 from agent.context_engine import automatic_compaction_status_message
 from agent.iteration_budget import IterationBudget
 from agent.memory_manager import build_memory_context_block
@@ -49,6 +50,21 @@ from agent.model_metadata import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _should_record_compression_timeout_failure(exc: BaseException) -> bool:
+    """Timeout cooldown is for stalled/failed summary calls, not user /stop."""
+    if isinstance(exc, (AuxiliaryExplicitCancellation, InterruptedError)):
+        return False
+    return True
+
+
+def _record_compression_failure_if_stall(agent: Any, exc: BaseException) -> None:
+    if not _should_record_compression_timeout_failure(exc):
+        return
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None and hasattr(compressor, "record_timeout_failure"):
+        compressor.record_timeout_failure(str(exc))
 
 
 def compose_user_api_content(
@@ -827,10 +843,20 @@ def build_turn_context(
                 if _idle_status:
                     agent._emit_status(_idle_status)
                 _idle_input = messages
-                messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_idle_tokens,
-                    task_id=effective_task_id,
-                )
+                try:
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message, approx_tokens=_idle_tokens,
+                        task_id=effective_task_id,
+                    )
+                except (Exception, AuxiliaryExplicitCancellation) as _compress_exc:
+                    logger.warning(
+                        "Idle compaction failed or was interrupted: %s. "
+                        "Proceeding without idle compaction.",
+                        _compress_exc,
+                        exc_info=True,
+                    )
+                    _record_compression_failure_if_stall(agent, _compress_exc)
+                    messages = _idle_input
                 # ``_compress_context`` returns the INPUT list object when it
                 # skips (per-session lock held by another path, failure
                 # cooldown, anti-thrash breaker, codex-native routing). Only
@@ -1001,10 +1027,22 @@ def build_turn_context(
                 _orig_len = len(messages)
                 _orig_tokens = _preflight_tokens
                 _preflight_input = messages
-                messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_preflight_tokens,
-                    task_id=effective_task_id,
-                )
+                try:
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message, approx_tokens=_preflight_tokens,
+                        task_id=effective_task_id,
+                    )
+                except (Exception, AuxiliaryExplicitCancellation) as _compress_exc:
+                    logger.warning(
+                        "Context compression failed or was interrupted: %s. "
+                        "Proceeding without compression for this turn.",
+                        _compress_exc,
+                        exc_info=True,
+                    )
+                    _record_compression_failure_if_stall(agent, _compress_exc)
+                    _preflight_compression_blocked = True
+                    messages = _preflight_input
+                    break
                 if (
                     messages is _preflight_input
                     and compression_skipped_due_to_lock(agent)
@@ -1134,10 +1172,20 @@ def build_turn_context(
                     f"{getattr(_compressor, 'threshold_tokens', 0):,}",
                 )
                 _engine_input = messages
-                messages, active_system_prompt = agent._compress_context(
-                    messages, system_message, approx_tokens=_preflight_tokens,
-                    task_id=effective_task_id,
-                )
+                try:
+                    messages, active_system_prompt = agent._compress_context(
+                        messages, system_message, approx_tokens=_preflight_tokens,
+                        task_id=effective_task_id,
+                    )
+                except (Exception, AuxiliaryExplicitCancellation) as _compress_exc:
+                    logger.warning(
+                        "Engine-driven preflight compression failed or was interrupted: %s. "
+                        "Proceeding without compression.",
+                        _compress_exc,
+                        exc_info=True,
+                    )
+                    _record_compression_failure_if_stall(agent, _compress_exc)
+                    messages = _engine_input
                 # ``_compress_context`` returns the INPUT list object on every
                 # skip path (per-session lock held elsewhere, cooldown,
                 # anti-thrash breaker, codex-native routing) and an engine may

--- a/tests/agent/test_aux_progress_empty_chunks.py
+++ b/tests/agent/test_aux_progress_empty_chunks.py
@@ -1,0 +1,225 @@
+"""Tests that content-free frames do not claim the aux progress hook.
+
+A chunk arriving is *not* a token arriving.  Providers keep a stalled stream
+open with content-free frames (keepalive pings, role-only first deltas, and
+usage-only trailers), and ``CompressionCommitFence`` reads the progress hook
+as "the summary model produced a token" to distinguish a slow model from a
+hung one.  Ticking per-chunk makes a hung stream indistinguishable from a live
+one and renders the hang detector dead code for exactly the failure it exists
+to catch (#78981).
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from agent.auxiliary_client import (
+    _ChatStreamAccumulator,
+    _aggregate_chat_stream,
+    aux_progress_hook,
+)
+from agent.conversation_compression import CompressionCommitFence
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _chunk(content=None, reasoning=None, tool_calls=None):
+    """Minimal chunk with a choice but no real payload by default."""
+    delta = SimpleNamespace(
+        content=content,
+        reasoning=reasoning,
+        reasoning_content=None,
+        tool_calls=tool_calls,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=None)
+    return SimpleNamespace(id=None, model=None, choices=[choice], usage=None)
+
+
+def _keepalive_no_choices():
+    """Keepalive / usage-only trailer: ``choices`` is empty, usage populated."""
+    return SimpleNamespace(
+        id=None, model=None,
+        choices=[],
+        usage=SimpleNamespace(total_tokens=10),
+    )
+
+
+def _keepalive_empty_delta():
+    """Role-only ping: a choice is present but its delta carries nothing."""
+    return _chunk()
+
+
+# ---------------------------------------------------------------------------
+# Content-free frames must NOT tick the hook
+# ---------------------------------------------------------------------------
+
+class TestContentFreeFramesAreNotProgress:
+    """A chunk arriving is not a token arriving.
+
+    Waiters read the hook as "the summary model produced a token" to tell a
+    slow model from a hung one (``CompressionCommitFence``).  Providers keep a
+    stalled stream open with content-free frames, so ticking per-chunk makes a
+    hung stream indistinguishable from a live one.
+    """
+
+    @pytest.mark.parametrize(
+        "factory",
+        [_keepalive_no_choices, _keepalive_empty_delta],
+        ids=["usage-only-trailer", "empty-delta"],
+    )
+    def test_keepalive_frames_do_not_tick(self, factory):
+        """50 content-free frames in a row must produce zero progress ticks."""
+        ticks: list = []
+        with aux_progress_hook(lambda: ticks.append(1)):
+            _aggregate_chat_stream(iter([factory() for _ in range(50)]))
+        assert ticks == [], (
+            f"Expected 0 ticks, got {len(ticks)}; "
+            "content-free frames must not advance the progress clock"
+        )
+
+    @pytest.mark.parametrize(
+        "chunk, label",
+        [
+            (_chunk(content="tok"), "content"),
+            (_chunk(reasoning="thinking"), "reasoning"),
+            (
+                _chunk(tool_calls=[SimpleNamespace(
+                    index=0, id="call_1",
+                    function=SimpleNamespace(name="f", arguments="{}"),
+                )]),
+                "tool_calls",
+            ),
+        ],
+        ids=["content", "reasoning", "tool_calls"],
+    )
+    def test_real_deltas_still_tick(self, chunk, label):
+        """Control: a chunk that actually carries a delta must tick exactly once."""
+        del label
+        ticks: list = []
+        with aux_progress_hook(lambda: ticks.append(1)):
+            _aggregate_chat_stream(iter([chunk]))
+        assert len(ticks) == 1, (
+            f"Expected 1 tick for a real delta, got {len(ticks)}"
+        )
+
+    def test_stalled_stream_lets_the_fence_idle_clock_run(self):
+        """End-to-end against the real fence.
+
+        A stream that delivers keepalive frames and zero tokens must not hold
+        ``seconds_since_progress()`` at zero, or the compression waiter extends
+        its wait to the ceiling instead of failing fast.
+        """
+        fence = CompressionCommitFence()
+
+        def _stalled():
+            for _ in range(10):
+                time.sleep(0.02)
+                yield _keepalive_no_choices()
+
+        with aux_progress_hook(fence.touch_progress):
+            _aggregate_chat_stream(_stalled())
+
+        elapsed = fence.seconds_since_progress()
+        assert elapsed >= 0.15, (
+            f"Expected fence idle clock >= 0.15s after stalled stream, "
+            f"got {elapsed:.3f}s — keepalive frames must not reset progress"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _ChatStreamAccumulator unit-level checks
+# ---------------------------------------------------------------------------
+
+def test_usage_only_chunk_does_not_notify_progress():
+    """Usage trailer (choices=[]) must not fire the progress hook."""
+    aggregator = _ChatStreamAccumulator()
+    with patch("agent.auxiliary_client._notify_aux_progress") as mock_notify:
+        aggregator.feed(
+            SimpleNamespace(
+                usage=SimpleNamespace(total_tokens=10),
+                choices=[],
+            )
+        )
+        mock_notify.assert_not_called()
+
+
+def test_empty_delta_does_not_notify_progress():
+    """Role-only first delta (content/reasoning/tool_calls all None) must not tick."""
+    aggregator = _ChatStreamAccumulator()
+    with patch("agent.auxiliary_client._notify_aux_progress") as mock_notify:
+        aggregator.feed(
+            SimpleNamespace(choices=[
+                SimpleNamespace(delta=SimpleNamespace(
+                    content=None, reasoning=None, tool_calls=None,
+                ))
+            ])
+        )
+        mock_notify.assert_not_called()
+
+
+def test_content_delta_notifies_progress():
+    aggregator = _ChatStreamAccumulator()
+    with patch("agent.auxiliary_client._notify_aux_progress") as mock_notify:
+        aggregator.feed(_chunk(content="hello"))
+        mock_notify.assert_called_once()
+
+
+def test_reasoning_delta_notifies_progress():
+    aggregator = _ChatStreamAccumulator()
+    with patch("agent.auxiliary_client._notify_aux_progress") as mock_notify:
+        aggregator.feed(_chunk(reasoning="let me think"))
+        mock_notify.assert_called_once()
+
+
+def test_tool_call_delta_notifies_progress():
+    aggregator = _ChatStreamAccumulator()
+    with patch("agent.auxiliary_client._notify_aux_progress") as mock_notify:
+        aggregator.feed(_chunk(tool_calls=[SimpleNamespace(
+            index=0, id="c1",
+            function=SimpleNamespace(name="fn", arguments="{}"),
+        )]))
+        mock_notify.assert_called_once()
+
+
+def test_anthropic_ping_event_does_not_tick_progress():
+    from agent.auxiliary_client import _anthropic_event_has_content
+    ping_event = SimpleNamespace(type="ping")
+    assert _anthropic_event_has_content(ping_event) is False
+
+    text_event = SimpleNamespace(
+        type="content_block_delta",
+        delta=SimpleNamespace(text="hello", thinking=None, partial_json=None),
+    )
+    assert _anthropic_event_has_content(text_event) is True
+
+
+def test_codex_keepalive_event_does_not_tick_progress():
+    from agent.auxiliary_client import _codex_event_has_content
+    created_event = SimpleNamespace(type="response.created")
+    assert _codex_event_has_content(created_event) is False
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "response.output_text.delta",
+        "response.reasoning_summary_text.delta",
+    ],
+)
+def test_codex_runtime_text_deltas_count_as_progress(event_type):
+    """Wire names from agent/codex_runtime.py must tick the fence.
+
+    A healthy Codex aux stream emits response.output_text.delta (and
+    response.reasoning_summary_text.delta) for the actual token flow.
+    Matching only the guessed response.text.delta name leaves minutes of
+    live text looking idle, so the 120s abort kills a healthy stream.
+    """
+    from agent.auxiliary_client import _codex_event_has_content
+
+    assert _codex_event_has_content(SimpleNamespace(type=event_type)) is True
+    assert _codex_event_has_content({"type": event_type}) is True
+

--- a/tests/agent/test_compression_interrupt_ghosting.py
+++ b/tests/agent/test_compression_interrupt_ghosting.py
@@ -1,0 +1,216 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.turn_context import (
+    _should_record_compression_timeout_failure,
+    build_turn_context,
+)
+
+
+def test_user_cancel_is_not_a_timeout_failure():
+    assert _should_record_compression_timeout_failure(InterruptedError("stop")) is False
+    assert _should_record_compression_timeout_failure(AuxiliaryExplicitCancellation()) is False
+    assert _should_record_compression_timeout_failure(TimeoutError("stalled")) is True
+    assert _should_record_compression_timeout_failure(RuntimeError("provider boom")) is True
+
+
+def test_compression_interrupt_ghosting():
+    agent = MagicMock()
+    agent.model = "test-model"
+    agent.provider = "test"
+    agent._memory_nudge_interval = 0
+    agent.compression_idle_compact_after_seconds = 0
+
+    # Force compression threshold trigger
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True):
+        with patch("agent.turn_context.estimate_request_tokens_rough", return_value=1000):
+            agent.compression_enabled = True
+            compressor_mock = MagicMock(threshold_tokens=500)
+            compressor_mock.should_defer_preflight_to_real_usage.return_value = False
+            compressor_mock.should_compress.return_value = True
+            compressor_mock.context_length = 4000
+            compressor_mock.last_real_prompt_tokens = 0
+            compressor_mock.last_prompt_tokens = 0
+            compressor_mock.get_active_compression_failure_cooldown.return_value = None
+            agent.context_compressor = compressor_mock
+            agent.max_compression_attempts = 1
+
+            # Mock _compress_context to raise InterruptedError
+            def mock_compress_context(*args, **kwargs):
+                raise InterruptedError("Simulated interrupt")
+
+            agent._compress_context = mock_compress_context
+
+            ctx = build_turn_context(
+                agent=agent,
+                user_message={"role": "user", "content": "hello"},
+                system_message="system prompt",
+                conversation_history=[],
+                task_id="test-task",
+                stream_callback=None,
+                persist_user_message=None,
+                restore_or_build_system_prompt=MagicMock(return_value="system prompt"),
+                install_safe_stdio=MagicMock(),
+                sanitize_surrogates=MagicMock(return_value="hello"),
+                summarize_user_message_for_log=MagicMock(return_value="hello"),
+                set_session_context=MagicMock(),
+                set_current_write_origin=MagicMock(),
+                ra=MagicMock(),
+            )
+
+            # Verification: turn 1 finishes fail-open. A user interrupt is
+            # not a summary-model failure — do not arm the 60s+ timeout ladder.
+            assert ctx is not None
+            assert ctx.preflight_compression_blocked is True
+            assert len(ctx.messages) > 0
+            compressor_mock.record_timeout_failure.assert_not_called()
+
+
+def test_compression_explicit_cancellation_ghosting():
+    """Verify that AuxiliaryExplicitCancellation (subclass of BaseException) is caught safely."""
+    agent = MagicMock()
+    agent.model = "test-model"
+    agent.provider = "test"
+    agent._memory_nudge_interval = 0
+    agent.compression_idle_compact_after_seconds = 0
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True):
+        with patch("agent.turn_context.estimate_request_tokens_rough", return_value=1000):
+            agent.compression_enabled = True
+            compressor_mock = MagicMock(threshold_tokens=500)
+            compressor_mock.should_defer_preflight_to_real_usage.return_value = False
+            compressor_mock.should_compress.return_value = True
+            compressor_mock.context_length = 4000
+            compressor_mock.last_real_prompt_tokens = 0
+            compressor_mock.last_prompt_tokens = 0
+            compressor_mock.get_active_compression_failure_cooldown.return_value = None
+            agent.context_compressor = compressor_mock
+            agent.max_compression_attempts = 1
+
+            # Mock _compress_context to raise AuxiliaryExplicitCancellation (BaseException subclass)
+            def mock_compress_context(*args, **kwargs):
+                raise AuxiliaryExplicitCancellation()
+
+            agent._compress_context = mock_compress_context
+
+            ctx = build_turn_context(
+                agent=agent,
+                user_message={"role": "user", "content": "hello"},
+                system_message="system prompt",
+                conversation_history=[],
+                task_id="test-task-cancellation",
+                stream_callback=None,
+                persist_user_message=None,
+                restore_or_build_system_prompt=MagicMock(return_value="system prompt"),
+                install_safe_stdio=MagicMock(),
+                sanitize_surrogates=MagicMock(return_value="hello"),
+                summarize_user_message_for_log=MagicMock(return_value="hello"),
+                set_session_context=MagicMock(),
+                set_current_write_origin=MagicMock(),
+                ra=MagicMock(),
+            )
+
+            # Verification: BaseException subclass is caught, turn completes
+            # fail-open, and /stop does not embargo later compression.
+            assert ctx is not None
+            assert ctx.preflight_compression_blocked is True
+            assert len(ctx.messages) > 0
+            compressor_mock.record_timeout_failure.assert_not_called()
+
+
+def test_compression_failure_cooldown_prevents_subsequent_turn_retry():
+    agent = MagicMock()
+    agent.model = "test-model"
+    agent.provider = "test"
+    agent._memory_nudge_interval = 0
+    agent.compression_idle_compact_after_seconds = 0
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True):
+        with patch("agent.turn_context.estimate_request_tokens_rough", return_value=1000):
+            agent.compression_enabled = True
+            compressor_mock = MagicMock(threshold_tokens=500)
+            compressor_mock.should_defer_preflight_to_real_usage.return_value = False
+            compressor_mock.should_compress.return_value = True
+            compressor_mock.context_length = 4000
+            compressor_mock.last_real_prompt_tokens = 0
+            compressor_mock.last_prompt_tokens = 0
+            # Active cooldown is now present for turn 2 after previous failure
+            compressor_mock.get_active_compression_failure_cooldown.return_value = {
+                "remaining_seconds": 58.0,
+                "reason": "failure_cooldown",
+            }
+            agent.context_compressor = compressor_mock
+            agent.max_compression_attempts = 1
+            agent._compress_context = MagicMock()
+
+            # Turn 2 execution
+            ctx2 = build_turn_context(
+                agent=agent,
+                user_message={"role": "user", "content": "turn 2 message"},
+                system_message="system prompt",
+                conversation_history=[],
+                task_id="test-task-2",
+                stream_callback=None,
+                persist_user_message=None,
+                restore_or_build_system_prompt=MagicMock(return_value="system prompt"),
+                install_safe_stdio=MagicMock(),
+                sanitize_surrogates=MagicMock(return_value="turn 2 message"),
+                summarize_user_message_for_log=MagicMock(return_value="turn 2 message"),
+                set_session_context=MagicMock(),
+                set_current_write_origin=MagicMock(),
+                ra=MagicMock(),
+            )
+
+            # Verification: turn 2 skips _compress_context due to active failure cooldown
+            assert ctx2 is not None
+            assert len(ctx2.messages) > 0
+            agent._compress_context.assert_not_called()
+
+
+def test_compression_timeout_still_arms_cooldown():
+    """A real stall/timeout must still persist the failure cooldown ladder."""
+    agent = MagicMock()
+    agent.model = "test-model"
+    agent.provider = "test"
+    agent._memory_nudge_interval = 0
+    agent.compression_idle_compact_after_seconds = 0
+
+    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True):
+        with patch("agent.turn_context.estimate_request_tokens_rough", return_value=1000):
+            agent.compression_enabled = True
+            compressor_mock = MagicMock(threshold_tokens=500)
+            compressor_mock.should_defer_preflight_to_real_usage.return_value = False
+            compressor_mock.should_compress.return_value = True
+            compressor_mock.context_length = 4000
+            compressor_mock.last_real_prompt_tokens = 0
+            compressor_mock.last_prompt_tokens = 0
+            compressor_mock.get_active_compression_failure_cooldown.return_value = None
+            agent.context_compressor = compressor_mock
+            agent.max_compression_attempts = 1
+
+            def mock_compress_context(*args, **kwargs):
+                raise TimeoutError("Auxiliary streamed call timed out")
+
+            agent._compress_context = mock_compress_context
+
+            ctx = build_turn_context(
+                agent=agent,
+                user_message={"role": "user", "content": "hello"},
+                system_message="system prompt",
+                conversation_history=[],
+                task_id="test-task-timeout",
+                stream_callback=None,
+                persist_user_message=None,
+                restore_or_build_system_prompt=MagicMock(return_value="system prompt"),
+                install_safe_stdio=MagicMock(),
+                sanitize_surrogates=MagicMock(return_value="hello"),
+                summarize_user_message_for_log=MagicMock(return_value="hello"),
+                set_session_context=MagicMock(),
+                set_current_write_origin=MagicMock(),
+                ra=MagicMock(),
+            )
+
+            assert ctx is not None
+            assert ctx.preflight_compression_blocked is True
+            compressor_mock.record_timeout_failure.assert_called_once()


### PR DESCRIPTION
## What changed & why

I investigated and fixed the "Permanent Session Death" bug (#78981).
The root cause is three intertwined defects in the auxiliary stream
progress-reporting path and the compression call sites.

### 1. False progress signal (`agent/auxiliary_client.py`)

`_ChatStreamAccumulator.feed()` called `_notify_aux_progress()` as its
very first statement, before inspecting the chunk at all. This means every
frame the provider sent — keepalive pings, role-only first deltas, and
usage-only billing trailers (`choices=[]`) — counted as forward progress,
even when the summary model produced zero tokens.

`CompressionCommitFence` documents its `_last_progress` timestamp as
advancing "whenever the streamed summary call produces a token", and the
waiter uses it to distinguish a slow model from a hung one:

```python
since_progress = fence.seconds_since_progress()
if since_progress < idle and waited < ceiling:
    logger.info("Context compression still streaming after %.0fs "
                "(last progress %.1fs ago) - extending wait...", ...)
    continue
```

With a tick per chunk, `since_progress` never grows past the keepalive
interval, the idle branch is never taken, and the hang detector is dead
code for exactly the failure it exists to catch.

**Fix:** the hook now fires only after the delta is parsed and only when
`_made_progress` is True — i.e., when the chunk carries a content,
reasoning, or tool-call fragment. Content-free frames (keepalives,
role-only pings, usage-only trailers) are still accumulated and still
keep the transport alive; they just no longer claim the model produced
something.

### 2. Unhandled interrupt (`agent/turn_context.py`)

When a user interrupted the stalled compression, `InterruptedError`
escaped from `_compress_context()` into `build_turn_context`, then
bubbled up to `gateway/run.py`'s `_handle_message`, which caught it and
silently returned. The user's turn was ghosted with no response.

**Fix:** both `_compress_context()` call sites in `turn_context.py` are
wrapped in `try…except Exception`. On failure the exception is logged,
`_preflight_compression_blocked` is set to `True`, and the turn proceeds
fail-open — the user always gets a response.

### 3. Retry loop on oversized context

After the ghost, the next message immediately retried compression on the
same oversized context and hung again, reproducing the hang on every
subsequent turn.

**Fix:** the `_preflight_compression_blocked` flag set in defect 2
prevents further compression attempts for that turn, breaking the loop.

---

## How to reproduce

**Environment:**
- OS: Windows / Linux (Ubuntu)
- Python: 3.11
- Hermes version: `main`

**Minimal reproducer** (run against unpatched `main`):

```python
"""
Minimal Reproducer for Issue #78981
Run with: uv run python repro.py
"""
from unittest.mock import patch, MagicMock
from agent.turn_context import build_turn_context

def test_repro():
    agent = MagicMock()
    agent.compression_enabled = True
    agent.context_compressor.should_compress.return_value = True
    agent.context_compressor.threshold_tokens = 500
    agent.context_compressor.context_length = 4000
    agent.context_compressor.last_real_prompt_tokens = 0
    agent.max_compression_attempts = 1
    agent._memory_nudge_interval = 0
    agent.compression_idle_compact_after_seconds = 0

    def mock_compress(*args, **kwargs):
        raise InterruptedError("User triggered interrupt during compression")
    agent._compress_context = mock_compress

    print("Running turn context build...")
    try:
        ctx = build_turn_context(
            agent=agent,
            user_message={"role": "user", "content": "hello"},
            system_message="system",
            conversation_history=[],
            task_id="test",
            stream_callback=None,
            persist_user_message=None,
            restore_or_build_system_prompt=MagicMock(return_value="system"),
            install_safe_stdio=MagicMock(),
            sanitize_surrogates=MagicMock(return_value="hello"),
            summarize_user_message_for_log=MagicMock(return_value="hello"),
            set_session_context=MagicMock(),
            set_current_write_origin=MagicMock(),
            ra=MagicMock(),
        )
        print(f"SUCCESS: Block flag: {ctx.preflight_compression_blocked}")
    except InterruptedError:
        print("CRASH: Turn ghosted — session will hang on every next message.")

if __name__ == "__main__":
    with patch("agent.turn_context._should_run_preflight_estimate", return_value=True):
        with patch("agent.turn_context.estimate_request_tokens_rough", return_value=1000):
            test_repro()
```

Expected on **unpatched main**: `CRASH: Turn ghosted`  
Expected **with fix**: `SUCCESS: Block flag: True`

---

## Verification

```
scripts/run_tests.sh tests/agent/test_aux_progress_empty_chunks.py \
                     tests/agent/test_compression_interrupt_ghosting.py -q
```

```
20 passed
```

Adjacent (unchanged paths):

```
scripts/run_tests.sh tests/agent/test_auxiliary_client.py \
                     tests/agent/test_turn_context.py -q
```

```
200 passed
```

Key test cases:
- `test_keepalive_frames_do_not_tick[usage-only-trailer]` — 50 usage-only frames produce zero progress ticks
- `test_keepalive_frames_do_not_tick[empty-delta]` — 50 role-only pings produce zero progress ticks
- `test_stalled_stream_lets_the_fence_idle_clock_run` — a real `CompressionCommitFence` idle clock advances (≥ 0.15 s) when only keepalive frames arrive; without the fix `seconds_since_progress()` stays at 0
- `test_codex_runtime_text_deltas_count_as_progress` — `response.output_text.delta` and `response.reasoning_summary_text.delta` tick (attr + dict)
- `test_compression_interrupt_ghosting` / `test_compression_explicit_cancellation_ghosting` — fail-open, `preflight_compression_blocked=True`, `record_timeout_failure` not called
- `test_compression_timeout_still_arms_cooldown` — a real `TimeoutError` still persists the 60/300/900 ladder

RED (against unpatched `main`, original four):

```
FAILED test_aux_progress_empty_chunks.py::TestContentFreeFramesAreNotProgress::test_keepalive_frames_do_not_tick[usage-only-trailer]
FAILED test_aux_progress_empty_chunks.py::TestContentFreeFramesAreNotProgress::test_keepalive_frames_do_not_tick[empty-delta]
FAILED test_aux_progress_empty_chunks.py::TestContentFreeFramesAreNotProgress::test_stalled_stream_lets_the_fence_idle_clock_run
FAILED test_compression_interrupt_ghosting.py::test_compression_interrupt_ghosting
```

**Platform:** Linux / Windows 11, Python 3.11

## Review follow-up (2026-08-15)

Addressed the requested changes:

1. Codex progress now matches the Responses names this repo consumes (`response.output_text.delta`, `response.reasoning_summary_text.delta`) via one `_CODEX_CONTENT_EVENT_TYPES` frozenset.
2. `/stop` (`InterruptedError` / `AuxiliaryExplicitCancellation`) no longer calls `record_timeout_failure`. A real `TimeoutError` still arms the cooldown.
3. Dropped the out-of-scope desktop/TUI formatting files and the `tests/test_tui_gateway_server.py` rewrite.
4. Moved the usage-trailer comment above the block and removed the trailing whitespace before `if _made_progress:`.

Rebased onto current `main` (one commit).

## Related Issue

Fixes #78981
