### PR TITLE
fix(weixin,email): stop pollers leaking proxied TCP sockets on fd exhaustion

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -405,9 +405,32 @@ async def _api_post(
     payload: Dict[str, Any],
     token: Optional[str],
     timeout_ms: int,
+    use_client_timeout: bool = False,
 ) -> Dict[str, Any]:
     body = _json_dumps({**payload, "base_info": _base_info()})
     url = f"{base_url.rstrip('/')}/{endpoint}"
+    if use_client_timeout:
+        # getUpdates() long-polls and times out on every idle cycle by
+        # design (no new messages), not as an error path. Cancelling that
+        # in-flight request from the *outside* via asyncio.wait_for() does
+        # not reliably release the underlying connection back to aiohttp's
+        # connector — especially when tunnelled through an HTTP/HTTPS proxy
+        # (e.g. the macOS system proxy picked up via trust_env=True) — so
+        # every idle poll cycle leaked one proxied TCP socket until the
+        # process ran out of file descriptors (#79889). aiohttp's own
+        # ClientTimeout enforces the timeout from *inside* the request's
+        # lifecycle, which does reliably close/release the connection.
+        # Safe here because this path only ever runs inside
+        # self._poll_task, a real asyncio Task — the cron/send path below
+        # still needs the asyncio.wait_for() workaround (see its comment).
+        client_timeout = aiohttp.ClientTimeout(total=timeout_ms / 1000)
+        async with session.post(
+            url, data=body, headers=_headers(token, body), timeout=client_timeout
+        ) as response:
+            raw = await response.text()
+            if not response.ok:
+                raise RuntimeError(f"iLink POST {endpoint} HTTP {response.status}: {raw[:200]}")
+            return json.loads(raw)
     # Use asyncio.wait_for() instead of aiohttp ClientTimeout to avoid
     # "Timeout context manager should be used inside a task" errors when
     # invoked via asyncio.run_coroutine_threadsafe() from cron jobs.
@@ -460,6 +483,7 @@ async def _get_updates(
             payload={"get_updates_buf": sync_buf},
             token=token,
             timeout_ms=timeout_ms,
+            use_client_timeout=True,
         )
     except asyncio.TimeoutError:
         return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -638,7 +638,15 @@ class EmailAdapter(BasePlatformAdapter):
                     self._seen_uids.add(uid)
             # Keep only the most recent UIDs to prevent unbounded growth
             self._trim_seen_uids()
-            imap.logout()
+            try:
+                imap.logout()
+            except Exception:
+                # See _fetch_new_messages() for why logout() can raise before
+                # closing the socket (#79889) — force the close here too.
+                try:
+                    imap.shutdown()
+                except Exception:
+                    pass
             logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
@@ -650,7 +658,10 @@ class EmailAdapter(BasePlatformAdapter):
             try:
                 smtp.login(self._address, self._password)
             finally:
-                smtp.quit()
+                try:
+                    smtp.quit()
+                except Exception:
+                    smtp.close()
             logger.info("[Email] SMTP connection test passed.")
         except Exception as e:
             logger.error("[Email] SMTP connection failed: %s", e)
@@ -785,7 +796,19 @@ class EmailAdapter(BasePlatformAdapter):
                 try:
                     imap.logout()
                 except Exception:
-                    pass
+                    # imaplib.IMAP4.logout() only closes the socket (via its
+                    # internal shutdown()) *after* the LOGOUT command
+                    # round-trip succeeds — any exception during that
+                    # round-trip (timeout, reset, a flaky proxy/VPN hop, all
+                    # more common on macOS corporate networks) propagates
+                    # out before shutdown() runs, leaking the underlying fd.
+                    # This poller runs every EMAIL_POLL_INTERVAL, so each
+                    # failed logout permanently leaked one fd until the
+                    # process ran out of them (#79889). Force the close.
+                    try:
+                        imap.shutdown()
+                    except Exception:
+                        pass
         except Exception as e:
             logger.error("[Email] IMAP fetch error: %s", e)
         return results

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -588,6 +588,30 @@ class _StubResponse:
         return self._body
 
 
+class _StubRequestCM:
+    """Wraps a ``_StubResponse``, honoring an aiohttp ``timeout=`` kwarg.
+
+    Real aiohttp enforces ``ClientTimeout`` from *inside* the request's own
+    lifecycle (see #79889); this mirrors that by raising
+    ``asyncio.TimeoutError`` on ``__aenter__`` when the response's configured
+    ``delay`` would exceed the given timeout, instead of actually sleeping.
+    """
+
+    def __init__(self, response, kwargs):
+        self._response = response
+        self._kwargs = kwargs
+
+    async def __aenter__(self):
+        timeout = self._kwargs.get("timeout")
+        total = getattr(timeout, "total", None) if timeout is not None else None
+        if total is not None and self._response._delay > total:
+            raise asyncio.TimeoutError()
+        return await self._response.__aenter__()
+
+    async def __aexit__(self, *exc):
+        return await self._response.__aexit__(*exc)
+
+
 class _StubSession:
     """Records request kwargs and returns a configurable async-CM response.
 
@@ -603,11 +627,11 @@ class _StubSession:
 
     def post(self, url, **kwargs):
         self.post_calls.append((url, kwargs))
-        return self._response
+        return _StubRequestCM(self._response, kwargs)
 
     def get(self, url, **kwargs):
         self.get_calls.append((url, kwargs))
-        return self._response
+        return _StubRequestCM(self._response, kwargs)
 
 
 class TestWeixinApiTimeout:
@@ -644,6 +668,27 @@ class TestWeixinApiTimeout:
             )
         )
         assert result == {"ret": 0, "msgs": [], "get_updates_buf": "buf-123"}
+
+    def test_get_updates_uses_native_client_timeout(self):
+        # Regression guard for #79889: getUpdates() times out on every idle
+        # long-poll cycle by design, and asyncio.wait_for()-driven external
+        # cancellation doesn't reliably release a proxied connection back to
+        # aiohttp's connector. getUpdates() must therefore let aiohttp's own
+        # ClientTimeout enforce the deadline (use_client_timeout=True) so the
+        # library's own cleanup path releases the connection instead.
+        session = _StubSession(_StubResponse(body='{"ret": 0}'))
+        asyncio.run(
+            weixin._get_updates(
+                session,
+                base_url="https://weixin.example.com",
+                token="tok",
+                sync_buf="buf-123",
+                timeout_ms=5000,
+            )
+        )
+        [(_url, kwargs)] = session.post_calls
+        assert isinstance(kwargs.get("timeout"), weixin.aiohttp.ClientTimeout)
+        assert kwargs["timeout"].total == 5.0
 
 
 class TestWeixinVoiceAlwaysDownloaded:


### PR DESCRIPTION
## What does this PR do?

The weixin and email platform pollers each leaked one file descriptor per poll cycle under proxied/flaky network conditions (common on macOS with a system or corporate proxy), eventually exhausting the process's fd limit and crashing the whole gateway with `EMFILE` (Errno 24) — not just the affected platform.

### Root cause

**Weixin** (`gateway/platforms/weixin.py`): `_poll_loop()` long-polls `getUpdates` with a 35s timeout that fires on *every idle cycle* — that's the normal heartbeat, not an error path. The timeout was enforced with `asyncio.wait_for()` wrapping `session.post()`, i.e. cancelling the in-flight aiohttp request from the *outside*. External cancellation doesn't reliably release the underlying connection back to aiohttp's connector, especially over a proxy tunnel (the macOS system proxy picked up via `trust_env=True`), where the extra CONNECT round-trip widens the window in which cancellation lands mid-handshake. Net effect: roughly one leaked proxied socket per idle poll cycle, forever.

**Email** (`plugins/platforms/email/adapter.py`): `_fetch_new_messages()` opens a fresh `imaplib.IMAP4_SSL` every poll cycle (`EMAIL_POLL_INTERVAL`, default 15s). Its cleanup was `try: imap.logout() except Exception: pass`. `imaplib.IMAP4.logout()` only closes the socket via its own internal `shutdown()` call *after* the LOGOUT round-trip succeeds — any network hiccup during that round-trip (timeout, reset — more common over flaky proxy/VPN paths) raises before `shutdown()` runs, and the bare `except: pass` silently swallowed the leak.

### Fix

1. `_api_post()` gains an opt-in `use_client_timeout` flag that lets aiohttp's own `ClientTimeout` enforce the deadline from *inside* the request's lifecycle (guaranteed cleanup) instead of external `asyncio.wait_for()` cancellation. `_get_updates()` (the long-poll call) now uses it.
2. The email poller (and both `connect()` test-connection paths, same bug class) now fall back to `imap.shutdown()` whenever `logout()` raises, guaranteeing the socket closes either way.

### No regression

- `asyncio.wait_for()` stays the default for every other `_api_post`/`_api_get` caller (sends invoked via `asyncio.run_coroutine_threadsafe()` from cron) — that workaround exists specifically to avoid a previously-fixed "Timeout context manager should be used inside a task" crash, and is untouched.
- `_make_ssl_connector()`'s `keepalive_timeout=2` / `enable_cleanup_closed=True` (prior fixes for #18451 / #69089 CLOSE_WAIT leaks) are unchanged.
- `resolve_proxy_url`, secret-scope reads (#50094, #59739), and the sender-authentication spoof check (GHSA-rxqh-5572-8m77) are untouched.
- Updated the `TestWeixinApiTimeout` stub session to actually honor a `timeout=` kwarg (it previously ignored it silently) so the new path is genuinely exercised, and added a regression test asserting `_get_updates` forwards a real `aiohttp.ClientTimeout`.

## Related Issue

Fixes #79889

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/weixin.py`: add `use_client_timeout` to `_api_post()`; `_get_updates()` opts in.
- `plugins/platforms/email/adapter.py`: force-close via `imap.shutdown()` when `logout()` raises, in the poller and both `connect()` test-connection paths.
- `tests/gateway/test_weixin.py`: stub session now honors `timeout=`; added a regression test locking in the `ClientTimeout` path for `getUpdates`.

## Root Cause Flow

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🔒 Weixin Poll Loop] -->|Idle 35s Long-Poll| B[⚡ session.post via Proxy Tunnel]
    B -->|asyncio.wait_for timeout: EVERY idle cycle| C[💀 External Task Cancel]
    C -->|Connector slot never released| D[🩸 Leaked Proxied Socket]

    E[🔒 Email Poll Loop] -->|Every 15s| F[⚡ imaplib IMAP4_SSL]
    F -->|logout raises before shutdown| G[💀 except: pass swallows it]
    G -->|Socket never closed| D

    D -->|Accumulates over hours| H[🚀 EMFILE Errno 24]
    H --> I[❌ Gateway Crash — All Platforms Down]

    subgraph Fix ["Applied Fix"]
        J[✅ aiohttp Native ClientTimeout] -->|Cleanup from inside request lifecycle| K[Connection Reliably Released]
        L[✅ imap.shutdown Fallback] -->|Guaranteed close on logout failure| K
    end

    C -.->|Replaced by| J
    G -.->|Replaced by| L
```
## Infographic : 

<img width="1024" height="1536" alt="infographic" src="https://github.com/user-attachments/assets/125a02eb-f72d-45e4-adae-7bc7d07391c7" />


## Test plan

- [x] `pytest tests/gateway/test_weixin.py tests/gateway/test_email_robustness.py` — 34 passed
- [x] `pytest tests/gateway/test_weixin_secret_scope.py tests/gateway/test_weixin_typing.py tests/gateway/test_email_secret_scope.py tests/gateway/test_send_multiple_images.py tests/gateway/test_media_metadata_contract.py` — 27 passed
- [ ] Maintainers: soak-test with a real macOS + proxied network (e.g. corporate VPN/system proxy) to confirm `lsof`/fd count stays flat over several hours of idle polling on both platforms