### PR TITLE
fix(update): preserve --depth 1 on shallow installs during update

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3744,9 +3744,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # against.
         branch = _m()._resolve_update_branch(args)
 
+        # Detect shallow repo — a plain `git fetch` would unshallow it,
+        # dragging in the entire history (the exact cost `--depth 1` avoided).
+        is_shallow = (
+            subprocess.run(
+                git_cmd + ["rev-parse", "--is-shallow-repository"],
+                cwd=_m().PROJECT_ROOT,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+            ).stdout.strip()
+            == "true"
+        )
+        depth_args = ["--depth", "1"] if is_shallow else []
+
         print("→ Fetching updates...")
         fetch_result = subprocess.run(
-            git_cmd + ["fetch", "origin", branch],
+            git_cmd + ["fetch"] + depth_args + ["origin", branch],
             cwd=_m().PROJECT_ROOT,
             capture_output=True,
             text=True, encoding="utf-8", errors="replace",


### PR DESCRIPTION
## Summary

The `--check` path correctly detects shallow repos and appends `--depth 1` to fetch commands (lines 2238-2247), but the actual update path did a bare `git fetch origin branch` without depth args. On shallow installs (the default from the installer), this unshallows the repo and drags in the entire git history.

## Problem

`hermes update` on a shallow git install triggers a full unshallow fetch (missing `--depth 1` in the update path) and shows no progress output while doing it. The terminal sits at "Fetching updates..." for 20+ minutes because it's downloading 179,583+ objects.

Observed on a mainland-China network: 42 MB in ~9 minutes and nowhere near done, because the full repo history was being fetched when only the shallow boundary was needed.

## Root cause

`hermes_cli/update_cmd.py` line 3749 (before this fix):

```python
git_cmd + ["fetch", "origin", branch],   # no --depth 1
```

The `--check` path at line 2238-2247 correctly does:

```python
is_shallow = (subprocess.run(git_cmd + ["rev-parse", "--is-shallow-repository"], ...).stdout.strip() == "true")
deppth_args = ["--depth", "1"] if is_shallow else []
```

But the actual update fetch did not reuse this logic.

## Fix

Added the same shallow detection before the update fetch, and append `depth_args` to the fetch command. When the repo is shallow, `--depth 1` is passed to preserve the boundary. When not shallow, no args are added (full fetch is fine).

## Changes

- `hermes_cli/update_cmd.py`: Add `is_shallow` detection and `depth_args` before the update fetch

Fixes #80049