### PR TITLE
fix(state): degrade list_sessions_rich on stale read-only profile DBs

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2042,6 +2042,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         self._fts_cjk_available = False
         self._fts_unavailable_warned = False
         self._conn = None
+        # Stale-schema guard for list queries (see _live_session_columns):
+        # None = not probed yet; a set = live sessions columns; probe failures
+        # stay per-call (we do not cache the failure).
+        self._live_session_cols: Optional[set] = None
         # Async token accounting (see queue_token_counts). The condition
         # guards queue + writer state; it is distinct from self._lock so
         # enqueue/flush bookkeeping never contends with SQLite writes.
@@ -5862,6 +5866,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Rows carry token/cost totals — drain queued deltas first so
         # listings (sidebar, /resume, dashboards) show exact counters.
         self.flush_token_counts()
+        # Stale-schema guard: read-only cross-profile opens skip schema
+        # reconciliation, so a dormant profile's state.db can predate this
+        # binary's columns (e.g. last_activity_at). Probe once and degrade
+        # the SQL instead of raising — the desktop sidebar's per-profile
+        # try/except would otherwise swallow the error and silently drop
+        # that whole profile from the session list.
+        live_cols = self._live_session_columns()
+        has_activity_col = "last_activity_at" in live_cols if live_cols is not None else True
         where_clauses = []
         params = []
 
@@ -5991,7 +6003,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 outer_where = (
                     f"{where_sql} AND {combined}" if where_sql else f"WHERE {combined}"
                 )
-            _sel = self._compact_session_cols() if compact_rows else "s.*"
+            _sel = (
+                self._compact_session_cols_live(live_cols) if compact_rows else "s.*"
+            )
             query = f"""
                 WITH RECURSIVE chain(root_id, cur_id) AS (
                     SELECT s.id, s.id FROM sessions s {where_sql}
@@ -6008,7 +6022,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 chain_max AS (
                     SELECT
                         root_id,
-                        MAX({_sql_session_last_active_by_id("cur_id")}) AS effective_last_active
+                        MAX({_sql_session_last_active_by_id("cur_id", has_activity_col=has_activity_col)}) AS effective_last_active
                     FROM chain
                     GROUP BY root_id
                 )
@@ -6020,7 +6034,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
-                    {_sql_session_last_active("s")} AS last_active,
+                    {_sql_session_last_active("s", has_activity_col=has_activity_col)} AS last_active,
                     COALESCE(cm.effective_last_active, s.started_at) AS _effective_last_active
                 FROM sessions s
                 LEFT JOIN chain_max cm ON cm.root_id = s.id
@@ -6033,7 +6047,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # only applies to the outer select.
             params = params + params + id_params + [limit, offset]
         else:
-            _sel = self._compact_session_cols() if compact_rows else "s.*"
+            _sel = (
+                self._compact_session_cols_live(live_cols) if compact_rows else "s.*"
+            )
             query = f"""
                 SELECT {_sel}{prompt_select},
                     COALESCE(
@@ -6043,7 +6059,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                          ORDER BY m.timestamp, m.id LIMIT 1),
                         ''
                     ) AS _preview_raw,
-                    {_sql_session_last_active("s")} AS last_active
+                    {_sql_session_last_active("s", has_activity_col=has_activity_col)} AS last_active
                 FROM sessions s
                 {prompt_join}
                 {where_sql}
@@ -6067,12 +6083,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # back-filled root then projects to its live tip exactly like a row
         # that had made the page on its own. One extra query, bounded by the
         # number of pins (a handful), never N+1 per pin.
-        if include_pinned:
+        if include_pinned and "pinned" in (live_cols or {"pinned"}):
             seen_ids = {s["id"] for s in sessions}
             pinned_where = (
                 f"{where_sql} AND s.pinned = 1" if where_sql else "WHERE s.pinned = 1"
             )
-            _sel = self._compact_session_cols() if compact_rows else "s.*"
+            _sel = (
+                self._compact_session_cols_live(live_cols) if compact_rows else "s.*"
+            )
             pinned_query = f"""
                 SELECT {_sel}{prompt_select},
                     COALESCE(

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -114,7 +114,7 @@ def _ephemeral_child_sql(alias: str = "s") -> str:
     )
 
 
-def _sql_session_last_active(alias: str = "s") -> str:
+def _sql_session_last_active(alias: str = "s", has_activity_col: bool = True) -> str:
     """SQL expression for session recency used by list/status surfaces.
 
     Freshest of ``last_activity_at`` (mid-turn agent activity heartbeat) and
@@ -123,32 +123,51 @@ def _sql_session_last_active(alias: str = "s") -> str:
     Must not prefer a stale heartbeat over a newer message: durable
     heartbeats are rate-limited (~60s), so after a turn writes messages
     ``last_activity_at`` can lag ``MAX(messages.timestamp)``.
+
+    Pass ``has_activity_col=False`` when the live DB predates the
+    ``last_activity_at`` column (read-only cross-profile opens skip schema
+    reconciliation, so a dormant profile's state.db may be older than this
+    binary): the expression then degrades to messages-max + started_at
+    instead of referencing a column SQLite doesn't have.
     """
     msg_max = (
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
         f"WHERE _act_m.session_id = {alias}.id)"
     )
+    activity = (
+        f"SELECT {alias}.last_activity_at AS v UNION ALL " if has_activity_col
+        # See _sql_session_last_active_by_id: UNION ALL needs a non-empty arm.
+        else "SELECT NULL AS v UNION ALL "
+    )
     return (
         f"COALESCE("
         f"(SELECT MAX(_act_v.v) FROM ("
-        f"SELECT {alias}.last_activity_at AS v "
-        f"UNION ALL "
+        f"{activity}"
         f"SELECT {msg_max}"
         f") _act_v), "
         f"{alias}.started_at)"
     )
 
 
-def _sql_session_last_active_by_id(session_id_expr: str) -> str:
+def _sql_session_last_active_by_id(
+    session_id_expr: str, has_activity_col: bool = True
+) -> str:
     """Same freshest-of expression keyed by a session-id SQL expression."""
     msg_max = (
         f"(SELECT MAX(_act_m.timestamp) FROM messages _act_m "
         f"WHERE _act_m.session_id = {session_id_expr})"
     )
-    activity = (
-        f"(SELECT last_activity_at FROM sessions _act_s "
-        f"WHERE _act_s.id = {session_id_expr})"
-    )
+    if has_activity_col:
+        activity = (
+            f"SELECT (SELECT last_activity_at FROM sessions _act_s "
+            f"WHERE _act_s.id = {session_id_expr}) AS v "
+            f"UNION ALL "
+        )
+    else:
+        # UNION ALL requires at least one SELECT; emit a NULL arm so
+        # MAX(_act_v.v) still has a well-formed subquery to scan. The NULL
+        # arm never wins MAX over a real message timestamp.
+        activity = "SELECT NULL AS v UNION ALL "
     started = (
         f"(SELECT started_at FROM sessions _act_s "
         f"WHERE _act_s.id = {session_id_expr})"
@@ -156,8 +175,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     return (
         f"COALESCE("
         f"(SELECT MAX(_act_v.v) FROM ("
-        f"SELECT {activity} AS v "
-        f"UNION ALL "
+        f"{activity}"
         f"SELECT {msg_max}"
         f") _act_v), "
         f"{started})"

--- a/hermes_state_portability.py
+++ b/hermes_state_portability.py
@@ -29,11 +29,56 @@ logger = logging.getLogger("hermes_state")
 class SessionPortabilityMixin:
     """See module docstring — mixin for SessionDB (Port cluster)."""
 
+    def _live_session_columns(self) -> Optional[set]:
+        """Live ``sessions`` column names for this open DB, cached per instance.
+
+        Read-only cross-profile opens skip schema reconciliation on purpose,
+        so a dormant profile's state.db can be older than this binary. List
+        queries intersect the desired projection with this set (when known)
+        so stale DBs degrade (missing column → absent key, i.e. None) instead
+        of raising ``no such column``. Returns None when the probe failed —
+        callers then assume the full schema (normal writable open).
+        """
+        cached = getattr(self, "_live_session_cols", None)
+        if cached is not None:
+            return cached
+        try:
+            with self._read_ctx() as conn:
+                rows = conn.execute('PRAGMA table_info("sessions")').fetchall()
+            self._live_session_cols = {r[1] if not isinstance(r, dict) else r["name"] for r in rows}
+        except Exception:
+            logger.debug("live sessions-column probe failed for %s", self.db_path, exc_info=True)
+            self._live_session_cols = None
+        return self._live_session_cols
+
+    def _compact_session_cols_live(self, live_cols: Optional[set]) -> str:
+        """Compact projection restricted to columns the live DB actually has.
+
+        ``live_cols`` from ``_live_session_columns()``; None means the probe
+        failed and we trust the full declared projection (writable opens are
+        reconciled at startup, so this only matters on read-only paths).
+        """
+        full = self._compact_session_cols()
+        if live_cols is None:
+            return full
+        cols = []
+        for part in full.split(", "):
+            name = part.split(".", 1)[-1]
+            if name in live_cols:
+                cols.append(part)
+        return ", ".join(cols) if cols else "s.*"
+
     @classmethod
     def _compact_session_cols(cls) -> str:
         """SELECT list for compact_rows: every ``sessions`` column declared in
         SCHEMA_SQL except prompt storage internals, aliased with the ``s``
-        prefix used by list_sessions_rich/_get_session_rich_row queries."""
+        prefix used by list_sessions_rich/_get_session_rich_row queries.
+
+        NOTE: this is the code-side contract (what the binary *wants*). The
+        live DB may be older — schema reconciliation is skipped on read-only
+        cross-profile opens — so list queries intersect this projection with
+        ``_live_sessions_columns_sql()`` before composing SQL.
+        """
         if cls._session_compact_cols_sql is None:
             declared = cls._parse_schema_columns(SCHEMA_SQL)["sessions"]
             cls._session_compact_cols_sql = ", ".join(
@@ -175,7 +220,15 @@ class SessionPortabilityMixin:
             return result
         # Same read-your-writes guarantee as list_sessions_rich.
         self.flush_token_counts()
-        _sel = self._compact_session_cols() if compact_rows else "s.*"
+        # Same stale-schema guard as list_sessions_rich: this batch fetch is
+        # the compression-tip projection behind it, so it must honor the same
+        # live-column intersection or the projected tip rows raise on a
+        # dormant profile's older state.db.
+        live_cols = self._live_session_columns()
+        has_activity_col = "last_activity_at" in live_cols if live_cols is not None else True
+        _sel = (
+            self._compact_session_cols_live(live_cols) if compact_rows else "s.*"
+        )
         placeholders = ",".join("?" for _ in ids)
         prompt_select = (
             "" if compact_rows
@@ -194,7 +247,7 @@ class SessionPortabilityMixin:
                      ORDER BY m.timestamp, m.id LIMIT 1),
                     ''
                 ) AS _preview_raw,
-                {_sql_session_last_active("s")} AS last_active
+                {_sql_session_last_active("s", has_activity_col=has_activity_col)} AS last_active
             FROM sessions s
             {prompt_join}
             WHERE s.id IN ({placeholders})

--- a/tests/test_hermes_state_readonly_stale_schema.py
+++ b/tests/test_hermes_state_readonly_stale_schema.py
@@ -1,0 +1,110 @@
+"""Regression: the desktop cross-profile sidebar opens every profile's
+state.db read-only, and read-only opens skip schema reconciliation. A
+dormant profile's DB can therefore be older than the running binary (e.g.
+missing last_activity_at / last_read_at) while the sidebar queries assume
+the current schema. list_sessions_rich must degrade on such DBs instead of
+raising — the sidebar's per-profile try/except swallows the error and
+silently drops the whole profile, which reads as "sessions are gone" in
+the UI.
+"""
+
+import sqlite3
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_common import SCHEMA_SQL
+
+
+def _make_stale_db(tmp_path: Path) -> Path:
+    """A sessions DB with only the pre-heartbeat columns."""
+    db_path = tmp_path / "stale.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            model TEXT,
+            title TEXT,
+            started_at REAL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            archived INTEGER DEFAULT 0,
+            parent_session_id TEXT,
+            model_config TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            timestamp REAL
+        )
+        """
+    )
+    now = time.time()
+    conn.execute(
+        "INSERT INTO sessions (id, source, model, title, started_at, ended_at, "
+        "message_count, archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("sess-1", "tui", "gpt-5.6-sol", "older session", now - 3600, now - 3500, 2, 0),
+    )
+    conn.execute(
+        "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+        ("sess-1", "user", "hello from the past", now - 3600),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class TestStaleSchemaReadOnly:
+    def test_compact_rows_list_degrades_on_stale_db(self, tmp_path):
+        db_path = _make_stale_db(tmp_path)
+        db = SessionDB(db_path=db_path, read_only=True)
+        try:
+            rows = db.list_sessions_rich(
+                limit=10,
+                offset=0,
+                min_message_count=1,
+                compact_rows=True,
+                order_by_last_active=True,
+                include_pinned=True,
+            )
+        finally:
+            db.close()
+        assert [r["id"] for r in rows] == ["sess-1"]
+        # last_active degrades to MAX(messages.timestamp) + started_at fallback.
+        assert rows[0]["last_active"] is not None
+        # Stale columns the binary wants are absent from the row, not errors.
+        assert rows[0].get("last_activity_at") is None
+        assert rows[0].get("last_read_at") is None
+
+    def test_declared_projection_still_applies_when_schema_current(self, tmp_path):
+        # Fresh schema: probe must see every column the mixin declares.
+        db = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            live = db._live_session_columns()
+        finally:
+            db.close()
+        assert live is not None
+        declared = set(db._parse_schema_columns(SCHEMA_SQL)["sessions"].keys())
+        assert declared <= live
+
+    def test_compact_cols_live_intersection(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "fresh.db")
+        try:
+            full = db._compact_session_cols()
+            degraded = db._compact_session_cols_live({"id", "source"})
+            assert "s.last_activity_at" not in degraded
+            assert "s.id" in degraded and "s.source" in degraded
+            assert len(degraded.split(",")) < len(full.split(","))
+        finally:
+            db.close()


### PR DESCRIPTION
## Summary

The desktop sidebar (`GET /api/profiles/sessions/sidebar`) aggregates every profile's `state.db` **read-only**, and read-only opens deliberately skip schema reconciliation. A dormant profile's DB can therefore be older than the running binary, missing columns the list queries select unconditionally (`last_activity_at`, `last_read_at`, `pinned`, …). The sidebar's per-profile `try/except` then swallows the resulting `no such column` error and silently drops the whole profile from the session list — which reads as "all sessions are gone except the active profile's."

## Fix

`list_sessions_rich` now probes the live `sessions` columns once per `SessionDB` instance and **degrades instead of raising** on stale-schema read-only opens:

- **Activity expression** (`_sql_session_last_active` / `_by_id`): falls back to `MAX(messages.timestamp)` + `started_at` when `last_activity_at` is absent. The `UNION ALL` keeps a `NULL` arm so the `MAX` subquery stays well-formed.
- **Compact projection** (`_compact_session_cols_live`): intersected with the live columns, so `compact_rows=True` never selects a column the DB doesn't have.
- **Pinned back-fill**: skipped when the `pinned` column is absent.
- **Compression-tip batch fetch** (`_get_session_rich_rows_batch`): follows the same guard since it backs `list_sessions_rich`'s projection.

Writable opens are unaffected: they still reconcile the schema at startup, so the probe always sees the full column set there.

## Tests

New `tests/test_hermes_state_readonly_stale_schema.py`:

- `compact_rows` listing against a genuinely stale read-only DB returns rows (degraded `last_active`) instead of raising
- fresh-schema DBs still satisfy the declared projection contract
- `_compact_session_cols_live` intersection behavior

Focused suite: 216 passed (state, readonly-preflight, WAL-fallback + new file).

## Repro

```python
db = SessionDB(db_path=stale_db, read_only=True)
db.list_sessions_rich(compact_rows=True, order_by_last_active=True, include_pinned=True)
# before: OperationalError: no such column: last_activity_at
# after:  rows with last_active derived from messages/started_at
```
