### PR TITLE
fix(agent): strip _moa_prepared_request before dispatching to native client (#78382)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -506,6 +506,15 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
         # MoA is a virtual chat-completions provider backed by the
         # in-process MoAClient facade. Do not rebuild a request-local
         # OpenAI client from the virtual runtime metadata.
+        #
+        # After a client replacement (credential rotation /
+        # dead-connection cleanup / fallback+restore), agent.client may
+        # become a native OpenAI client while agent.provider stays
+        # "moa".  Pop the MoA-internal key so the native SDK does not
+        # reject it as an unexpected kwarg.  The MoAClient facade
+        # already handles a missing key by falling through to its
+        # normal resolution path.  (#78382)
+        api_kwargs.pop("_moa_prepared_request", None)
         return agent.client.chat.completions.create(**api_kwargs)
     request_client = make_client("chat_completion_request")
     return request_client.chat.completions.create(**api_kwargs)

--- a/tests/test_moa_prepared_request_leak_78382.py
+++ b/tests/test_moa_prepared_request_leak_78382.py
@@ -1,0 +1,67 @@
+"""Test: _moa_prepared_request does not leak to native OpenAI clients (#78382).
+
+After a client replacement (credential rotation / fallback / dead-connection
+cleanup), agent.client may become a native OpenAI client while agent.provider
+stays "moa".  The dispatch must strip the MoA-internal key so the native SDK
+does not reject it.
+"""
+import types
+from unittest.mock import MagicMock, patch
+
+from agent.chat_completion_helpers import _dispatch_nonstreaming_api_request
+
+
+class _FakeNativeClient:
+    """Mimics a native OpenAI client whose create() rejects unknown kwargs."""
+
+    def __init__(self):
+        self.chat = types.SimpleNamespace()
+        self.chat.completions = types.SimpleNamespace()
+        self.chat.completions.create = MagicMock(return_value="native-response")
+
+
+def _make_agent(provider="moa"):
+    agent = MagicMock()
+    agent.provider = provider
+    agent.client = _FakeNativeClient()
+    agent.api_mode = "chat_completions"
+    return agent
+
+
+def test_moa_key_stripped_from_native_client():
+    """_moa_prepared_request must not reach a native OpenAI client."""
+    agent = _make_agent(provider="moa")
+    api_kwargs = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hi"}],
+        "_moa_prepared_request": {"messages": [], "model": "x"},
+    }
+
+    # Patch make_client to return a factory that returns our fake client
+    def _make_client(label=None):
+        return agent.client
+
+    _dispatch_nonstreaming_api_request(agent, api_kwargs, make_client=_make_client)
+
+    # The native client should NOT have received the MoA-internal key.
+    call_kwargs = agent.client.chat.completions.create.call_args[1]
+    assert "_moa_prepared_request" not in call_kwargs, (
+        f"_moa_prepared_request leaked to native client: {call_kwargs.keys()}"
+    )
+
+
+def test_no_moa_key_when_absent():
+    """Normal non-MoA call should work without the key present."""
+    agent = _make_agent(provider="openai")
+    api_kwargs = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+
+    def _make_client(label=None):
+        return agent.client
+
+    _dispatch_nonstreaming_api_request(agent, api_kwargs, make_client=_make_client)
+    call_kwargs = agent.client.chat.completions.create.call_args[1]
+    assert "_moa_prepared_request" not in call_kwargs
+    assert call_kwargs["model"] == "gpt-4"


### PR DESCRIPTION
## Summary

After a client replacement (credential rotation, dead-connection cleanup, or fallback+restore via `_replace_primary_openai_client`), `agent.client` becomes a native OpenAI client while `agent.provider` stays `"moa"`. The `_moa_prepared_request` key was passed through to the native SDK at `chat_completion_helpers.py:509`, causing `TypeError: Completions.create() got an unexpected keyword argument _moa_prepared_request` on every turn.

## Fix

Pop `_moa_prepared_request` from `api_kwargs` at the dispatch point before calling `agent.client.chat.completions.create()`. The `MoAClient.create()` facade already handles a missing key by falling through to its normal resolution path (moa_loop.py:1852), so the fix is safe for both the real facade and replaced native clients.

## Test

- `test_moa_key_stripped_from_native_client` — verifies the key is removed before reaching a native client
- `test_no_moa_key_when_absent` — verifies normal non-MoA calls work without the key

## Root cause

`conversation_loop.py:2326-2327` injects `_moa_prepared_request` into `api_kwargs` when `agent.provider == "moa"`. After client replacement, the provider stays "moa" but the client is native — the key leaks through.

Closes #78382