### PR TITLE
fix(config): accept JSON-string custom_providers in compat + provider helpers

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1568,8 +1568,21 @@ def get_compatible_custom_providers(
 
     custom_providers = config.get("custom_providers")
     if custom_providers is not None:
+        # `hermes config set` writes list/dict config keys as scalar JSON strings
+        # (double-encoded), so a value loaded from config.yaml may be a JSON
+        # string rather than a native list.  Accept that form here — without
+        # this, custom providers stored via ``config set`` never surface in
+        # /model, the picker, or runtime resolution.
         if not isinstance(custom_providers, list):
-            return []
+            if isinstance(custom_providers, str):
+                try:
+                    custom_providers = json.loads(custom_providers)
+                except Exception:
+                    return []
+                if not isinstance(custom_providers, list):
+                    return []
+            else:
+                return []
         for entry in custom_providers:
             _append_if_new(_normalize_custom_provider_entry(entry))
 
@@ -1593,6 +1606,24 @@ def _coerce_ssl_verify(value: Any) -> Optional[bool]:
     return None
 
 
+def _coerce_custom_providers_list(custom_providers: Any) -> Optional[List[Dict[str, Any]]]:
+    """Coerce ``custom_providers`` to a list of dicts.
+
+    ``hermes config set`` writes list/dict config keys as scalar JSON strings
+    (double-encoded), so the value loaded from config.yaml may be a JSON string
+    rather than a true list.  Return ``None`` when the value cannot be used.
+    """
+    if isinstance(custom_providers, list):
+        return custom_providers
+    if isinstance(custom_providers, str):
+        try:
+            parsed = json.loads(custom_providers)
+        except Exception:
+            return None
+        return parsed if isinstance(parsed, list) else None
+    return None
+
+
 def get_custom_provider_tls_settings(
     base_url: str,
     custom_providers: Optional[List[Dict[str, Any]]] = None,
@@ -1603,8 +1634,9 @@ def get_custom_provider_tls_settings(
         try:
             custom_providers = get_compatible_custom_providers(config)
         except Exception:
-            custom_providers = []
-    if not base_url or not isinstance(custom_providers, list):
+            custom_providers = _coerce_custom_providers_list(custom_providers)
+    custom_providers = _coerce_custom_providers_list(custom_providers)
+    if not base_url or not custom_providers:
         return {}
 
     target_url = normalize_route_base_url(base_url)
@@ -1675,8 +1707,9 @@ def get_custom_provider_extra_headers(
         try:
             custom_providers = get_compatible_custom_providers(config)
         except Exception:
-            custom_providers = []
-    if not base_url or not isinstance(custom_providers, list):
+            custom_providers = _coerce_custom_providers_list(custom_providers)
+    custom_providers = _coerce_custom_providers_list(custom_providers)
+    if not base_url or not custom_providers:
         return {}
 
     target_url = normalize_route_base_url(base_url)
@@ -1747,9 +1780,9 @@ def get_custom_provider_context_length(
         except Exception:
             if config is None:
                 return None
-            raw = config.get("custom_providers")
-            custom_providers = raw if isinstance(raw, list) else []
-    if not isinstance(custom_providers, list):
+            custom_providers = _coerce_custom_providers_list(config.get("custom_providers"))
+    custom_providers = _coerce_custom_providers_list(custom_providers)
+    if not custom_providers:
         return None
 
     target_url = normalize_route_base_url(base_url)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -944,6 +944,53 @@ class TestCustomProviderCompatibility:
             }
         ]
 
+    def test_compatible_custom_providers_accepts_json_string_form(self, tmp_path):
+        """``custom_providers`` written as a scalar JSON string (what `hermes
+        config set` does for list/dict keys) must still resolve to providers.
+
+        Regression: `get_compatible_custom_providers` returned [] for any
+        non-list custom_providers, silently dropping every custom provider from
+        /model and runtime resolution.
+        """
+        import json as _json
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 26,
+                    "custom_providers": _json.dumps(
+                        [
+                            {"name": "acme", "base_url": "https://acme.example.com/v1", "model": "acme/flash", "api_key": "sk-x"},
+                            {"name": "beta", "base_url": "https://beta.example.com/v1", "model": "beta/pro", "api_key": "sk-y"},
+                        ]
+                    ),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        names = [c.get("name") for c in compatible]
+        assert names == ["acme", "beta"]
+
+    def test_compatible_custom_providers_oserror_malformed_json(self, tmp_path):
+        """A non-list, non-JSON custom_providers value must degrade to [] (not raise)."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 26,
+                    "custom_providers": "definitely: not-json[[",
+                }
+            ),
+            encoding="utf-8",
+        )
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+        assert compatible == []
+
 
 class TestInterimAssistantMessageConfig:
     """Test the explicit gateway interim-message config gate."""


### PR DESCRIPTION
## Problem

`hermes config set` serializes list/dict config keys (like `custom_providers` and `fallback_providers`) as **scalar JSON strings** (double-encoded). So `config.yaml` stores:

```yaml
custom_providers: '[{"name": "...", "base_url": "...", "api_key": "..."}]'
```

…as a **string**, not a native list.

`get_compatible_custom_providers()` did `if not isinstance(custom_providers, list): return []`, which **silently dropped every custom provider** from:
- the Telegram/CLI `/model` picker,
- runtime provider resolution,
- per-provider `context_length` / TLS / `extra_headers` overrides.

Net effect: custom OpenAI-compatible endpoints (localhost proxies, aggregators like 9router, self-hosted gateways) configured via `hermes config set` or the provider dashboard disappear from `/model` entirely.

## Fix

- `get_compatible_custom_providers()` now `json.loads` a **string** `custom_providers` back to a list before validating, and degrades to `[]` for malformed JSON rather than raising.
- Added shared `_coerce_custom_providers_list()` and applied it to `get_custom_provider_tls_settings()` / `get_custom_provider_extra_headers()` / `get_custom_provider_context_length()` so those helpers keep working when handed a raw string value.

## Tests

- `test_compatible_custom_providers_accepts_json_string_form` — a JSON-string `custom_providers` resolves to the expected providers.
- `test_compatible_custom_providers_oserror_malformed_json` — malformed string degrades to `[]` without raising.

`pytest tests/hermes_cli/test_config.py tests/hermes_cli/test_custom_provider_model_switch.py tests/hermes_cli/test_user_providers_model_switch.py` → 100 passed.

## Repro / verification

With a config where `custom_providers` is stored as a JSON string (as `hermes config set` writes it), before the fix `get_compatible_custom_providers()` returned `[]`; after, it returns the full provider list and the `/model` picker shows each `custom:<name>` row.