### PR TITLE
fix(update): preserve non-prefixed systemd gateway process

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3248,6 +3248,72 @@ def _cold_start_windows_gateway_after_update() -> None:
         print()
         print(f"  ✓ Starting Windows gateway after update (PID {pid})")
 
+
+def _systemd_service_membership_for_pid(
+    pid: int,
+    *,
+    proc_root: Path = Path("/proc"),
+) -> bool | None:
+    """Classify a PID's systemd service membership from its cgroup.
+
+    Returns ``True`` for service membership, ``False`` when a readable
+    systemd cgroup confirms no service membership, and ``None`` when
+    ownership cannot be determined safely.
+    """
+    try:
+        text = (proc_root / str(pid) / "cgroup").read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+
+    systemd_paths: list[str] = []
+    for line in text.splitlines():
+        parts = line.strip().split(":", 2)
+        if len(parts) != 3:
+            continue
+        hierarchy, controllers, cgroup_path = parts
+        controller_names = controllers.split(",") if controllers else []
+        if not (
+            (hierarchy == "0" and not controllers)
+            or "name=systemd" in controller_names
+        ):
+            continue
+        if not cgroup_path.startswith("/"):
+            return None
+        systemd_paths.append(cgroup_path)
+
+    if not systemd_paths:
+        return None
+    return any(
+        component.endswith(".service")
+        for cgroup_path in systemd_paths
+        for component in cgroup_path.split("/")
+        if component
+    )
+
+
+def _select_update_manual_gateway_pids(
+    candidate_pids,
+    *,
+    known_service_pids,
+    systemd_supported: bool,
+) -> list[int]:
+    """Return update-time gateway PIDs confirmed safe for raw termination."""
+    service_pids = set(known_service_pids)
+    manual_pids: list[int] = []
+    for pid in dict.fromkeys(candidate_pids):
+        if pid in service_pids:
+            continue
+        membership = _systemd_service_membership_for_pid(pid)
+        if membership is True:
+            continue
+        if membership is None and (
+            systemd_supported or sys.platform == "linux"
+        ):
+            continue
+        manual_pids.append(pid)
+    return manual_pids
+
+
 def _for_each_systemd_gateway_unit(
     list_units_stdout: str,
     *,
@@ -4903,7 +4969,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # --- Systemd services (Linux) ---
             # Discover all hermes-gateway* units (default + profiles)
-            if supports_systemd_services():
+            systemd_supported = supports_systemd_services()
+            if systemd_supported:
                 try:
                     _ensure_user_systemd_env()
                 except Exception:
@@ -5230,11 +5297,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
             # --- Manual (non-service) gateways ---
             # Kill any remaining gateway processes not managed by a service.
-            # Exclude PIDs that belong to just-restarted services so we don't
-            # immediately kill the process that systemd/launchd just spawned.
+            # Candidate PIDs are already positive gateway matches. Exclude
+            # known service PIDs, then fail safe on Linux hosts unless the
+            # PID's cgroup confirms it is not service-managed.
+            gateway_pids = find_gateway_pids(all_profiles=True)
             service_pids = _get_service_pids()
-            manual_pids = find_gateway_pids(
-                exclude_pids=service_pids, all_profiles=True
+            manual_pids = _select_update_manual_gateway_pids(
+                gateway_pids,
+                known_service_pids=service_pids,
+                systemd_supported=systemd_supported,
             )
             profile_processes = {
                 proc.pid: proc

--- a/tests/hermes_cli/test_update_gateway_pid_classification.py
+++ b/tests/hermes_cli/test_update_gateway_pid_classification.py
@@ -1,0 +1,167 @@
+"""Regression coverage for update-time gateway PID classification."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import hermes_cli.gateway as gateway
+import hermes_cli.update_cmd as update_cmd
+
+
+def _write_cgroup(proc_root: Path, pid: int, content: str) -> None:
+    pid_dir = proc_root / str(pid)
+    pid_dir.mkdir(parents=True)
+    (pid_dir / "cgroup").write_text(content, encoding="utf-8")
+
+
+def test_cgroup_classifies_custom_named_systemd_service(tmp_path):
+    proc_root = tmp_path / "proc"
+    _write_cgroup(
+        proc_root,
+        101,
+        "0::/system.slice/acme-operations-agent.service\n",
+    )
+
+    assert (
+        update_cmd._systemd_service_membership_for_pid(101, proc_root=proc_root) is True
+    )
+
+
+def test_cgroup_classifies_legacy_named_systemd_service(tmp_path):
+    proc_root = tmp_path / "proc"
+    _write_cgroup(
+        proc_root,
+        105,
+        "12:name=systemd:/system.slice/gaiasignal-agent-hermes.service\n",
+    )
+
+    assert (
+        update_cmd._systemd_service_membership_for_pid(105, proc_root=proc_root) is True
+    )
+
+
+def test_cgroup_classifies_ordinary_manual_gateway(tmp_path):
+    proc_root = tmp_path / "proc"
+    _write_cgroup(
+        proc_root,
+        102,
+        "0::/user.slice/user-1000.slice/session-8.scope\n",
+    )
+
+    assert (
+        update_cmd._systemd_service_membership_for_pid(102, proc_root=proc_root)
+        is False
+    )
+
+
+def test_cgroup_unreadable_or_ambiguous_is_unknown(tmp_path):
+    proc_root = tmp_path / "proc"
+    (proc_root / "103" / "cgroup").mkdir(parents=True)
+    _write_cgroup(proc_root, 104, "7:cpu,cpuacct:/legacy/path\n")
+
+    assert (
+        update_cmd._systemd_service_membership_for_pid(103, proc_root=proc_root) is None
+    )
+    assert (
+        update_cmd._systemd_service_membership_for_pid(104, proc_root=proc_root) is None
+    )
+
+
+def test_update_manual_sweep_only_selects_confirmed_non_service(monkeypatch, tmp_path):
+    proc_root = tmp_path / "proc"
+    _write_cgroup(proc_root, 201, "0::/system.slice/custom-gateway.service\n")
+    _write_cgroup(proc_root, 202, "0::/user.slice/user-1000.slice/session-8.scope\n")
+    (proc_root / "203" / "cgroup").mkdir(parents=True)
+    classify = update_cmd._systemd_service_membership_for_pid
+    monkeypatch.setattr(
+        update_cmd,
+        "_systemd_service_membership_for_pid",
+        lambda pid: classify(pid, proc_root=proc_root),
+    )
+
+    selected = update_cmd._select_update_manual_gateway_pids(
+        [200, 201, 202, 203, 202],
+        known_service_pids={200},
+        systemd_supported=True,
+    )
+
+    assert selected == [202]
+
+
+def test_update_manual_sweep_fails_safe_when_capability_probe_is_false(
+    monkeypatch, tmp_path
+):
+    proc_root = tmp_path / "proc"
+    _write_cgroup(proc_root, 204, "0::/system.slice/custom-gateway.service\n")
+    (proc_root / "205" / "cgroup").mkdir(parents=True)
+    classify = update_cmd._systemd_service_membership_for_pid
+    monkeypatch.setattr(
+        update_cmd,
+        "_systemd_service_membership_for_pid",
+        lambda pid: classify(pid, proc_root=proc_root),
+    )
+
+    selected = update_cmd._select_update_manual_gateway_pids(
+        [204, 205],
+        known_service_pids=set(),
+        systemd_supported=False,
+    )
+
+    assert selected == []
+
+
+def test_update_manual_sweep_preserves_non_systemd_behavior(monkeypatch):
+    classified: list[int] = []
+
+    def classify(pid: int) -> bool:
+        classified.append(pid)
+        return False
+
+    monkeypatch.setattr(
+        update_cmd,
+        "_systemd_service_membership_for_pid",
+        classify,
+    )
+
+    selected = update_cmd._select_update_manual_gateway_pids(
+        [300, 301, 301],
+        known_service_pids={300},
+        systemd_supported=False,
+    )
+
+    assert selected == [301]
+    assert classified == [301]
+
+
+def test_service_pid_discovery_remains_targeted(monkeypatch):
+    calls: list[list[str]] = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        assert "hermes-gateway*" in command
+        assert "--type=service" not in command
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(gateway, "supports_systemd_services", lambda: True)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway._get_service_pids() == set()
+    assert calls == [
+        [
+            "systemctl",
+            "--user",
+            "list-units",
+            "hermes-gateway*",
+            "--plain",
+            "--no-legend",
+            "--no-pager",
+        ],
+        [
+            "systemctl",
+            "list-units",
+            "hermes-gateway*",
+            "--plain",
+            "--no-legend",
+            "--no-pager",
+        ],
+    ]


### PR DESCRIPTION
## Summary

Fixes an updater safety gap for **non-prefixed systemd-managed Hermes gateways**.

`hermes update` already excludes active `hermes-gateway*` service PIDs from its manual-process sweep. A valid gateway run owned by a custom system unit (for example `gaiasignal-agent-hermes.service`) was not in that set, then was rediscovered as a manual process and sent `SIGTERM`.

This focused patch classifies only existing positive `gateway run` candidates at the update manual-sweep boundary using `/proc/<pid>/cgroup`:

- cgroup v2 `0::/...unit.service` and v1 `name=systemd:/...unit.service` => managed service, never raw-SIGTERM;
- confirmed non-service membership => preserves the existing manual-cleanup behavior;
- unreadable/ambiguous cgroup on Linux => fail safe and do not terminate;
- no broad `systemctl` enumeration and no unit-name-prefix trust.

## Why

A real custom systemd service was interrupted by the generic updater and systemd recovered it roughly five seconds later. The update code must not treat system-manager ownership as manual merely because the unit name is outside the standard `hermes-gateway*` convention.

## Verification

Fork branch commit `2ece25503`:

```text
uv sync --extra dev
.venv/bin/python -B -m pytest -p no:cacheprovider -q \
  tests/hermes_cli/test_update_gateway_pid_classification.py \
  tests/hermes_cli/test_update*.py tests/hermes_cli/test_gateway.py
# 162 passed
```

Reviewed/rebased validation commit `02f1a138` on current upstream `8f271272`:

```text
# 164 update + gateway tests passed
.venv/bin/python -B -m ruff check hermes_cli/update_cmd.py \
  tests/hermes_cli/test_update_gateway_pid_classification.py
.venv/bin/python -B -m py_compile hermes_cli/update_cmd.py
git diff --check
```

The new focused coverage verifies custom v2 and legacy v1 service cgroups, normal manual session scopes, unreadable cgroups, a false capability-probe path, non-systemd manual behavior, and preservation of targeted existing service discovery. A read-only check classified the affected live service PID as managed (`True`) without updating or restarting it.

## Scope / safety

- Exactly two files; no dependencies, workflow files, or production changes.
- Independent evaluator and full Consensus Board approved the final two-file change.
- This draft intentionally does **not** authorize local deployment or a service restart.

## Maintainer note

The personal fork is 534 commits behind current `main` because its PAT cannot push inherited workflow-file updates. GitHub compare shows this branch is **ahead by one commit with exactly these two file changes**. Please rebase/cherry-pick the focused patch onto current `main` before merging.

Related context: closed unmerged #5409 added the existing standard-service exclusion; open #20488 and #16349 concern status/profile reporting rather than update-time termination; open #77854 addresses updater-owning standard gateway lifecycle and is currently dirty. No exact duplicate was found.
