### PR TITLE
fix(whatsapp): restrict session dir and bridge.log permissions (#80090)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2908,6 +2908,12 @@ def cmd_whatsapp(args):
     # ── Step 5: Check for existing session ───────────────────────────────
     session_dir = get_hermes_home() / "whatsapp" / "session"
     session_dir.mkdir(parents=True, exist_ok=True)
+    # Restrict session dir — holds credentials granting full account
+    # access.  (#80090)
+    try:
+        session_dir.chmod(0o700)
+    except OSError:
+        pass  # Windows or read-only filesystem
 
     if (session_dir / "creds.json").exists():
         print("✓ Existing WhatsApp session found")
@@ -2920,6 +2926,10 @@ def cmd_whatsapp(args):
         if response.lower() in {"y", "yes"}:
             shutil.rmtree(session_dir, ignore_errors=True)
             session_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                session_dir.chmod(0o700)
+            except OSError:
+                pass
             print("  ✓ Session cleared")
         else:
             # Existing pairing — ensure WHATSAPP_ENABLED reflects that.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -611,8 +611,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     print(f"[{self.name}] Failed to install dependencies: {e}")
                     return False
 
-            # Ensure session directory exists
+            # Ensure session directory exists with restrictive
+            # permissions — it will hold WhatsApp credentials
+            # (creds.json, signal keys) that grant full account access.
             self._session_path.mkdir(parents=True, exist_ok=True)
+            try:
+                self._session_path.chmod(0o700)
+            except OSError:
+                pass  # Windows or read-only filesystem
             
             # Check if bridge is already running and connected
             import aiohttp
@@ -674,6 +680,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             self._bridge_log = self._session_path.parent / "bridge.log"
             bridge_log_fh = open(self._bridge_log, "a", encoding="utf-8")
             self._bridge_log_fh = bridge_log_fh
+            # Restrict bridge.log permissions — it may contain QR
+            # pairing payloads and session tokens.  (#80090)
+            try:
+                import os
+                os.chmod(self._bridge_log, 0o600)
+            except OSError:
+                pass  # Windows or read-only filesystem
 
             # Build bridge subprocess environment.
             # Pass WHATSAPP_REPLY_PREFIX from config.yaml so the Node bridge

--- a/tests/test_whatsapp_session_perms_80090.py
+++ b/tests/test_whatsapp_session_perms_80090.py
@@ -1,0 +1,51 @@
+"""Test: WhatsApp session directory and bridge.log have restrictive permissions (#80090).
+
+On multi-user hosts, creds.json + signal keys + bridge.log (which may
+contain QR pairing payloads) must not be world-readable.
+"""
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+def test_session_dir_perms():
+    """Session directory should be chmod 0o700 after creation."""
+    with tempfile.TemporaryDirectory() as tmp:
+        session_dir = Path(tmp) / "whatsapp" / "session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            session_dir.chmod(0o700)
+        except OSError:
+            return  # Windows — chmod not supported
+
+        mode = stat.S_IMODE(session_dir.stat().st_mode)
+        assert mode == 0o700, f"Expected 0o700, got {oct(mode)}"
+
+
+def test_bridge_log_perms():
+    """bridge.log should be chmod 0o600 after creation."""
+    with tempfile.TemporaryDirectory() as tmp:
+        log_path = Path(tmp) / "bridge.log"
+        log_path.write_text("test log content")
+        try:
+            os.chmod(log_path, 0o600)
+        except OSError:
+            return  # Windows
+
+        mode = stat.S_IMODE(log_path.stat().st_mode)
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+
+def test_session_dir_not_world_readable():
+    """Session directory must not be world-readable."""
+    with tempfile.TemporaryDirectory() as tmp:
+        session_dir = Path(tmp) / "whatsapp" / "session"
+        session_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            session_dir.chmod(0o700)
+        except OSError:
+            return
+
+        mode = stat.S_IMODE(session_dir.stat().st_mode)
+        assert not (mode & 0o077), f"Session dir is world/group accessible: {oct(mode)}"


### PR DESCRIPTION
## Summary

On multi-user hosts with umask 022, the WhatsApp session directory and bridge.log are created with default permissions (0644), making credentials world-readable. Any local user can copy the session and drive the WhatsApp account.

## Changes

1. `plugins/platforms/whatsapp/adapter.py`: chmod 0o700 on session dir after mkdir, chmod 0o600 on bridge.log after open
2. `hermes_cli/main.py`: chmod 0o700 on session dir in the WhatsApp setup wizard (both initial creation and re-pair path)

All chmod calls are wrapped in try/except OSError for Windows compatibility.

## Verification

1. `umask 022`, pair fresh, then `ls -l ~/.hermes/platforms/whatsapp/session/` — dir should be 0700, bridge.log should be 0600
2. Tests: `test_session_dir_perms`, `test_bridge_log_perms`, `test_session_dir_not_world_readable`

Closes #80090