### PR TITLE
refactor(agent): extract extract_content_or_reasoning into auxiliary_text (auxiliary_client.py R5-S1)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9338,60 +9338,7 @@ def _call_llm_impl(
         raise
 
 
-def extract_content_or_reasoning(response) -> str:
-    """Extract content from an LLM response, falling back to reasoning fields.
-
-    Mirrors the main agent loop's behavior when a reasoning model (DeepSeek-R1,
-    Qwen-QwQ, etc.) returns ``content=None`` with reasoning in structured fields.
-
-    Resolution order:
-      1. ``message.content`` — strip inline think/reasoning blocks, check for
-         remaining non-whitespace text.
-      2. ``message.reasoning`` / ``message.reasoning_content`` — direct
-         structured reasoning fields (DeepSeek, Moonshot, NovitaAI, etc.).
-      3. ``message.reasoning_details`` — OpenRouter unified array format.
-
-    Returns the best available text, or ``""`` if nothing found.
-    """
-    import re
-
-    msg = response.choices[0].message
-    content = (msg.content or "").strip()
-
-    if content:
-        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
-        cleaned = re.sub(
-            r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"
-            r".*?"
-            r"</(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>",
-            "", content, flags=re.DOTALL | re.IGNORECASE,
-        ).strip()
-        if cleaned:
-            return cleaned
-
-    # Content is empty or reasoning-only — try structured reasoning fields
-    reasoning_parts: list[str] = []
-    for field in ("reasoning", "reasoning_content"):
-        val = getattr(msg, field, None)
-        if val and isinstance(val, str) and val.strip() and val not in reasoning_parts:
-            reasoning_parts.append(val.strip())
-
-    details = getattr(msg, "reasoning_details", None)
-    if details and isinstance(details, list):
-        for detail in details:
-            if isinstance(detail, dict):
-                summary = (
-                    detail.get("summary")
-                    or detail.get("content")
-                    or detail.get("text")
-                )
-                if summary and summary not in reasoning_parts:
-                    reasoning_parts.append(summary.strip() if isinstance(summary, str) else str(summary))
-
-    if reasoning_parts:
-        return "\n\n".join(reasoning_parts)
-
-    return ""
+from agent.auxiliary_text import extract_content_or_reasoning
 
 
 @_relay_auxiliary_call_async

--- a/agent/auxiliary_text.py
+++ b/agent/auxiliary_text.py
@@ -1,0 +1,54 @@
+def extract_content_or_reasoning(response) -> str:
+    """Extract content from an LLM response, falling back to reasoning fields.
+
+    Mirrors the main agent loop's behavior when a reasoning model (DeepSeek-R1,
+    Qwen-QwQ, etc.) returns ``content=None`` with reasoning in structured fields.
+
+    Resolution order:
+      1. ``message.content`` — strip inline think/reasoning blocks, check for
+         remaining non-whitespace text.
+      2. ``message.reasoning`` / ``message.reasoning_content`` — direct
+         structured reasoning fields (DeepSeek, Moonshot, NovitaAI, etc.).
+      3. ``message.reasoning_details`` — OpenRouter unified array format.
+
+    Returns the best available text, or ``""`` if nothing found.
+    """
+    import re
+
+    msg = response.choices[0].message
+    content = (msg.content or "").strip()
+
+    if content:
+        # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
+        cleaned = re.sub(
+            r"<(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>"
+            r".*?"
+            r"</(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)>",
+            "", content, flags=re.DOTALL | re.IGNORECASE,
+        ).strip()
+        if cleaned:
+            return cleaned
+
+    # Content is empty or reasoning-only — try structured reasoning fields
+    reasoning_parts: list[str] = []
+    for field in ("reasoning", "reasoning_content"):
+        val = getattr(msg, field, None)
+        if val and isinstance(val, str) and val.strip() and val not in reasoning_parts:
+            reasoning_parts.append(val.strip())
+
+    details = getattr(msg, "reasoning_details", None)
+    if details and isinstance(details, list):
+        for detail in details:
+            if isinstance(detail, dict):
+                summary = (
+                    detail.get("summary")
+                    or detail.get("content")
+                    or detail.get("text")
+                )
+                if summary and summary not in reasoning_parts:
+                    reasoning_parts.append(summary.strip() if isinstance(summary, str) else str(summary))
+
+    if reasoning_parts:
+        return "\n\n".join(reasoning_parts)
+
+    return ""


### PR DESCRIPTION
## Summary

`agent/auxiliary_client.py` god-file slice **R5-S1**: extract the pure function `extract_content_or_reasoning` (window 9341–9394, 54 lines) into `agent/auxiliary_text.py`. Part of the repo-wide large-file decomposition (tracker #78647, target #78635).

## What changed and why

- Function moved byte-exact (golden sha256 `58b60b0c5876c0fef8a1b8c3e736e8b72f349dd8baf98cea1279a548e3df58fc`; module content == window slice, zero exceptions)
- PURE LEAF: zero module-level deps (only `re` imported in-body), zero reverse refs, zero open-PR overlap (12/12 PRs scanned in census)
- Re-export line at the old location keeps the name resolvable as `agent.auxiliary_client.extract_content_or_reasoning` with `__func__` identity — direct importers (`agent/oneshot.py:27`, `plugins/teams_pipeline/pipeline.py:20`), the vision_tools lazy path, and tests keep working
- Kill-line math: godfile 9,976 → 9,923 (−54 + 1 re-export line)
- **Double-blind**: 2 blind analysts → R5-CONSENSUS → blind implementer → 2 independent blind witnesses (pass A + adversarial pass B) — both **VERIFIED**, zero failing checks

## Testing

- **47 passed / 0 failed** (4 consumer files: llm_content_none_guard, video_analyze, oneshot, teams_pipeline) in worktree and pristine baseline
- Consumer probe: resolution-order behavior verified (content vs reasoning dicts) via the godfile namespace and via `agent.oneshot`
- Seam identity: `is`-identical, both import orders; standalone module import clean
- py_compile clean · zero top-level imports · LF-only · `git diff --check` clean · DCO signed

## Coordination / interlock

- **Epic:** Part of #78647 · **Target:** Part of #78635
- **Sibling PRs:** auxiliary_client slices R3-S1 (fallback policy) and R4-S1 (anthropic-compat) — disjoint windows, all three consensus-approved
- **Dedup:** leaf window collision-free; later R5 clusters (C-B/C-C/C-E) are gated on open PRs #77518/#63800/#66635/#72637/#78576 per consensus — not touched here
- **Note:** `_is_streaming_rejected_error` (8266–8276) is confirmed dead code (zero callers) — flagged for review during the C-B slice, moved verbatim per doctrine

Part of #78647
Part of #78635
