### PR TITLE
fix(slack): make native plan cards read-only

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3857,6 +3857,99 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=_profile,
         )
 
+    def _record_slack_plan_tool_completion(
+        self,
+        *,
+        event_type: str,
+        tool_name: Optional[str],
+        is_error: bool,
+        result: Any,
+        source: SessionSource,
+        session_key: Optional[str],
+        session_id: str,
+        loop: Optional[asyncio.AbstractEventLoop],
+    ) -> Optional[Dict[str, Any]]:
+        """Persist and wake the Slack todo projection from a sync callback."""
+        if (
+            event_type != "tool.completed"
+            or tool_name != "todo"
+            or is_error
+            or source.platform != Platform.SLACK
+        ):
+            return None
+        adapter = self._adapter_for_source(source)
+        if adapter is None or not getattr(adapter, "_plan_cards_enabled", False):
+            return None
+        try:
+            from plugins.platforms.slack.plan_cards import parse_todo_result
+
+            todos = parse_todo_result(result)
+            if todos is None:
+                return None
+            resolved_key = session_key or self._session_key_for_source(source)
+            state = adapter.record_desired_plan_snapshot(
+                session_key=resolved_key,
+                session_id=session_id,
+                team_id=str(getattr(source, "scope_id", None) or ""),
+                channel_id=str(source.chat_id or ""),
+                thread_ts=str(getattr(source, "thread_id", None) or ""),
+                route_user_id=str(getattr(source, "user_id", None) or ""),
+                chat_type=str(getattr(source, "chat_type", None) or "group"),
+                todos=todos,
+            )
+            if not state:
+                return None
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(adapter.request_plan_reconcile)
+            return state
+        except Exception:
+            logger.warning(
+                "Slack plan-card todo projection failed; normal response continues",
+                exc_info=True,
+            )
+            return None
+
+    async def _validate_slack_plan_action_after_claim(
+        self,
+        event: MessageEvent,
+        claimed_session_key: str,
+    ) -> bool:
+        """Revalidate trusted Slack action metadata while session ownership is held."""
+        metadata = (getattr(event, "metadata", None) or {}).get("slack_plan_action")
+        if not metadata:
+            return True
+        if event.source.platform != Platform.SLACK or not getattr(event, "internal", False):
+            return False
+        adapter = self._adapter_for_source(event.source)
+        valid = bool(
+            adapter
+            and callable(getattr(adapter, "validate_plan_action_metadata", None))
+            and adapter.validate_plan_action_metadata(metadata)
+        )
+        expected_key = str(metadata.get("session_key") or "")
+        expected_session_id = str(metadata.get("session_id") or "")
+        if valid and expected_key != claimed_session_key:
+            valid = False
+        if valid:
+            current_session_id = await asyncio.to_thread(
+                self._lookup_session_id_under_store_lock,
+                self.session_store,
+                claimed_session_key,
+            )
+            valid = str(current_session_id or "") == expected_session_id
+        if valid:
+            return True
+        if adapter is not None:
+            try:
+                await adapter.send(
+                    event.source.chat_id,
+                    "This plan card is stale. Refresh it and try again.",
+                    metadata=self._thread_metadata_for_source(event.source),
+                )
+            except Exception:
+                logger.debug("Failed to send stale Slack plan-card notice", exc_info=True)
+        return False
+
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
         if source.platform != Platform.TELEGRAM or source.chat_type != "dm":
@@ -11407,6 +11500,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _run_generation = self._begin_session_run_generation(_quick_key)
 
         try:
+            if not await self._validate_slack_plan_action_after_claim(event, _quick_key):
+                return None
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
@@ -19151,6 +19246,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
+            # Native Slack plan projection is independent of progress display.
+            # Persist synchronously before any log/off/no-queue early return,
+            # then wake Slack reconciliation on the gateway loop.
+            try:
+                self._record_slack_plan_tool_completion(
+                    event_type=event_type,
+                    tool_name=tool_name,
+                    is_error=bool(kwargs.get("is_error")),
+                    result=kwargs.get("result"),
+                    source=source,
+                    session_key=session_key,
+                    session_id=session_id,
+                    loop=_voice_ack_loop,
+                )
+            except Exception:
+                logger.warning(
+                    "Slack plan-card bridge failed; normal tool progress continues",
+                    exc_info=True,
+                )
             # Live status line (Slack's assistant status): stash the current
             # tool phrase on the adapter; the _keep_typing refresh renders it
             # within a couple of seconds. Handled before every other gate

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -70,6 +70,7 @@ try:  # sibling module; support both package and flat plugin-dir import
         PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
+        _is_slack_human_user_id,
         build_plan_blocks,
         is_interactive_user_task,
         is_user_task_id,
@@ -86,6 +87,7 @@ except ImportError:  # pragma: no cover - plugin loaded outside package context
         PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
+        _is_slack_human_user_id,
         build_plan_blocks,
         is_interactive_user_task,
         is_user_task_id,
@@ -4771,7 +4773,10 @@ class SlackAdapter(BasePlatformAdapter):
     @staticmethod
     def _plan_interaction_owner_matches(state: Dict[str, Any], user_id: str) -> bool:
         route_user_id = str(state.get("route_user_id") or "")
-        return not route_user_id or route_user_id == str(user_id or "")
+        return (
+            _is_slack_human_user_id(route_user_id)
+            and route_user_id == str(user_id or "")
+        )
 
     @staticmethod
     def _plan_action_dedupe_id(body: Dict[str, Any], action: Dict[str, Any]) -> str:
@@ -4883,7 +4888,12 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=str(state.get("thread_ts") or "") or None,
         ):
             return
-        if not self._plan_interaction_owner_matches(state, str(user.get("id") or "")):
+        if (
+            action_id != "hermes_plan_refresh"
+            and not self._plan_interaction_owner_matches(
+                state, str(user.get("id") or "")
+            )
+        ):
             return
         dedupe_id = self._plan_action_dedupe_id(body, action)
         if not self._plan_store.consume_action_id(dedupe_id):

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4831,7 +4831,9 @@ class SlackAdapter(BasePlatformAdapter):
         prompt = (
             "[Trusted Slack plan action]\n"
             "Use the todo tool to apply exactly this structured change to the current full todo list. "
-            "Preserve every task not named by the action.\n"
+            "Preserve every task not named by the action. Set each named task to the exact status "
+            "specified by its *_task_status field. For add_task_ids, create exactly one Todo with "
+            "the supplied ID, add_task_content, and add_task_status.\n"
             + json.dumps(changes, ensure_ascii=False, sort_keys=True)
         )
         await self.handle_message(MessageEvent(
@@ -4957,7 +4959,7 @@ class SlackAdapter(BasePlatformAdapter):
             task_id = str(selected.get("value") or "")
             eligible_cancel = {
                 task["id"] for task in tasks
-                if is_user_task_id(task["id"]) and task["status"] == "pending"
+                if is_user_task_id(task["id"]) and task["status"] == "in_progress"
             }
             if task_id in eligible_cancel:
                 await self._dispatch_plan_action_event(
@@ -4965,7 +4967,10 @@ class SlackAdapter(BasePlatformAdapter):
                     body=body,
                     action_kind=PLAN_ACTION_CANCEL,
                     action_dedupe_id=dedupe_id,
-                    changes={"cancel_task_ids": [task_id]},
+                    changes={
+                        "cancel_task_ids": [task_id],
+                        "cancel_task_status": "cancelled",
+                    },
                 )
             return
         if action_id == "hermes_plan_complete":
@@ -4982,7 +4987,7 @@ class SlackAdapter(BasePlatformAdapter):
             eligible = {
                 task["id"] for task in tasks
                 if is_user_task_id(task["id"])
-                and task["status"] in {"pending", "completed"}
+                and task["status"] in {"in_progress", "completed"}
             }
             completed = {
                 task["id"] for task in tasks
@@ -5001,7 +5006,9 @@ class SlackAdapter(BasePlatformAdapter):
                 action_dedupe_id=dedupe_id,
                 changes={
                     "complete_task_ids": complete_ids,
+                    "complete_task_status": "completed",
                     "reopen_task_ids": reopen_ids,
+                    "reopen_task_status": "in_progress",
                 },
             )
 
@@ -5029,7 +5036,11 @@ class SlackAdapter(BasePlatformAdapter):
         content = str((((values.get("task") or {}).get("content") or {}).get("value")) or "").strip()
         if not content or len(content) > MAX_USER_TASK_CONTENT_LENGTH:
             return
-        validated_metadata = {**payload, "add_task_content": content}
+        validated_metadata = {
+            **payload,
+            "add_task_content": content,
+            "add_task_status": "in_progress",
+        }
         state = self._plan_store.validate_action(validated_metadata)
         if not state:
             return
@@ -5069,6 +5080,7 @@ class SlackAdapter(BasePlatformAdapter):
             changes={
                 "add_task_ids": list(payload["add_task_ids"]),
                 "add_task_content": content,
+                "add_task_status": "in_progress",
             },
         )
 

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -58,6 +58,7 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_video_from_bytes,
 )
+from tools.todo_tool import MAX_TODO_ITEMS
 
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks
@@ -4904,7 +4905,8 @@ class SlackAdapter(BasePlatformAdapter):
             if not secret:
                 return
             if (
-                sum(is_interactive_user_task(task) for task in tasks)
+                len(tasks) >= MAX_TODO_ITEMS
+                or sum(is_interactive_user_task(task) for task in tasks)
                 >= MAX_INTERACTIVE_TASKS
             ):
                 return

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -17,6 +17,7 @@ import os
 import random
 import re
 import time
+import uuid
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -61,24 +62,45 @@ from gateway.platforms.base import (
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks
     from .plan_cards import (
+        MAX_INTERACTIVE_TASKS,
+        MAX_USER_TASK_CONTENT_LENGTH,
+        PLAN_ACTION_ADD_USER_TASK,
+        PLAN_ACTION_CANCEL,
+        PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
         build_plan_blocks,
+        is_interactive_user_task,
+        is_user_task_id,
         sign_private_metadata,
         verify_private_metadata,
     )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks  # type: ignore
     from plan_cards import (  # type: ignore
+        MAX_INTERACTIVE_TASKS,
+        MAX_USER_TASK_CONTENT_LENGTH,
+        PLAN_ACTION_ADD_USER_TASK,
+        PLAN_ACTION_CANCEL,
+        PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
         build_plan_blocks,
+        is_interactive_user_task,
+        is_user_task_id,
         sign_private_metadata,
         verify_private_metadata,
     )
 
 
 logger = logging.getLogger(__name__)
+
+
+def _profile_from_hermes_home(home: Any) -> Optional[str]:
+    path = _Path(home)
+    if path.parent.name == "profiles" and path.name:
+        return path.name
+    return None
 
 
 class _PlanRetryPersistenceError(RuntimeError):
@@ -533,7 +555,9 @@ class SlackAdapter(BasePlatformAdapter):
             default=False,
         )
         from hermes_constants import get_hermes_home
-        self._plan_store = PlanCardStore(get_hermes_home())
+        plan_home = get_hermes_home()
+        self._plan_profile = _profile_from_hermes_home(plan_home)
+        self._plan_store = PlanCardStore(plan_home)
         self._plan_reconcile_task: Optional[asyncio.Task] = None
         self._plan_reconcile_generation = 0
         self._plan_reconcile_stopping = True
@@ -4032,6 +4056,9 @@ class SlackAdapter(BasePlatformAdapter):
         channel_id: str = "",
         user_name: Optional[str] = None,
         team_id: str = "",
+        profile: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        fail_closed_on_lookup_error: bool = False,
     ) -> bool:
         """Return whether a Slack interactive caller may perform gated actions."""
         normalized_user_id = str(user_id or "").strip()
@@ -4041,6 +4068,17 @@ class SlackAdapter(BasePlatformAdapter):
         runner = getattr(getattr(self, "_message_handler", None), "__self__", None)
         auth_fn = getattr(runner, "_is_user_authorized", None)
         if callable(auth_fn):
+            if profile:
+                try:
+                    pairing_stores = getattr(runner, "pairing_stores", None)
+                    if (
+                        not isinstance(pairing_stores, dict)
+                        or profile not in pairing_stores
+                        or pairing_stores[profile] is None
+                    ):
+                        return False
+                except Exception:
+                    return False
             try:
                 from gateway.session import SessionSource
 
@@ -4050,10 +4088,14 @@ class SlackAdapter(BasePlatformAdapter):
                     chat_type="dm" if str(channel_id or "").startswith("D") else "group",
                     user_id=normalized_user_id,
                     user_name=str(user_name).strip() if user_name else None,
+                    thread_id=thread_id,
                     scope_id=str(team_id) if team_id else None,
+                    profile=profile,
                 )
                 return bool(auth_fn(source))
             except Exception:
+                if fail_closed_on_lookup_error:
+                    return False
                 logger.debug(
                     "[Slack] Falling back to env-only interactive auth for user %s",
                     normalized_user_id,
@@ -4128,6 +4170,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "thread_ts": thread_ts,
                 "route_user_id": route_user_id,
                 "chat_type": chat_type,
+                "profile": self._plan_profile,
             },
             todos,
         )
@@ -4142,6 +4185,7 @@ class SlackAdapter(BasePlatformAdapter):
             "message_ts": state.get("message_ts", ""),
             "route_user_id": state.get("route_user_id", ""),
             "chat_type": state.get("chat_type", "group"),
+            "profile": state.get("profile"),
         }
         return build_plan_blocks(
             state.get("last_desired_snapshot") or [],
@@ -4651,7 +4695,45 @@ class SlackAdapter(BasePlatformAdapter):
             self._plan_reconcile_task = None
 
     def validate_plan_action_metadata(self, metadata: Dict[str, Any]) -> bool:
-        return self._plan_store.validate_action(metadata) is not None
+        try:
+            state = self._plan_store.validate_action(metadata)
+        except Exception:
+            logger.warning(
+                "[Slack] Claim-time plan action state lookup failed",
+                exc_info=True,
+            )
+            return False
+        if not state:
+            return False
+        if state.get("profile") != self._plan_profile:
+            return False
+        action_user_id = metadata.get("action_user_id")
+        if (
+            not isinstance(action_user_id, str)
+            or not action_user_id
+            or action_user_id != action_user_id.strip()
+        ):
+            return False
+        channel_id = str(state.get("channel_id") or "")
+        team_id = str(state.get("team_id") or "")
+        if not channel_id or not team_id:
+            return False
+        try:
+            return self._is_interactive_user_authorized(
+                action_user_id,
+                channel_id=channel_id,
+                user_name=None,
+                team_id=team_id,
+                profile=state.get("profile"),
+                thread_id=str(state.get("thread_ts") or "") or None,
+                fail_closed_on_lookup_error=True,
+            )
+        except Exception:
+            logger.warning(
+                "[Slack] Claim-time plan action authorization lookup failed",
+                exc_info=True,
+            )
+            return False
 
     def _plan_state_from_interaction(
         self,
@@ -4664,6 +4746,8 @@ class SlackAdapter(BasePlatformAdapter):
         message_ts = str(message.get("ts") or "")
         state = self._plan_store.lookup_route(team_id, channel_id, message_ts)
         if not state:
+            return None
+        if state.get("profile") != self._plan_profile:
             return None
         if (
             team_id != str(state.get("team_id") or "")
@@ -4710,6 +4794,8 @@ class SlackAdapter(BasePlatformAdapter):
         *,
         state: Dict[str, Any],
         body: Dict[str, Any],
+        action_kind: str,
+        action_dedupe_id: str,
         changes: Dict[str, Any],
     ) -> None:
         task_ids = sorted({
@@ -4724,10 +4810,13 @@ class SlackAdapter(BasePlatformAdapter):
             "team_id": state["team_id"],
             "channel_id": state["channel_id"],
             "thread_ts": state.get("thread_ts", ""),
+            "profile": state.get("profile"),
             "message_ts": state["message_ts"],
             "revision": state["desired_revision"],
             "snapshot_hash": state["desired_hash"],
             "task_ids": task_ids,
+            "action_kind": action_kind,
+            "action_dedupe_id": action_dedupe_id,
             "action_user_id": str((body.get("user") or {}).get("id") or ""),
             **changes,
         }
@@ -4738,6 +4827,7 @@ class SlackAdapter(BasePlatformAdapter):
             thread_id=str(state.get("thread_ts") or "") or None,
             scope_id=str(state.get("team_id") or "") or None,
         )
+        source.profile = state.get("profile")
         prompt = (
             "[Trusted Slack plan action]\n"
             "Use the todo tool to apply exactly this structured change to the current full todo list. "
@@ -4767,34 +4857,59 @@ class SlackAdapter(BasePlatformAdapter):
     async def _handle_plan_action_after_ack(self, body, action) -> None:
         if not self._plan_cards_enabled:
             return
+        action_id = str(action.get("action_id") or "")
+        if action_id not in {
+            "hermes_plan_complete",
+            "hermes_plan_cancel",
+            "hermes_plan_add",
+            "hermes_plan_refresh",
+        }:
+            return
         team_id = self._event_team_id({}, body)
         channel_id = str((body.get("channel") or {}).get("id") or "")
+        state = self._plan_state_from_interaction(body, action)
+        if not state:
+            return
         user = body.get("user") or {}
         if not self._is_interactive_user_authorized(
             str(user.get("id") or ""),
             channel_id=channel_id,
             user_name=user.get("name"),
             team_id=team_id,
+            profile=state.get("profile"),
+            thread_id=str(state.get("thread_ts") or "") or None,
         ):
-            return
-        state = self._plan_state_from_interaction(body, action)
-        if not state:
             return
         if not self._plan_interaction_owner_matches(state, str(user.get("id") or "")):
             return
         dedupe_id = self._plan_action_dedupe_id(body, action)
         if not self._plan_store.consume_action_id(dedupe_id):
             return
-        action_id = str(action.get("action_id") or "")
         tasks = state.get("last_desired_snapshot") or []
         if action_id == "hermes_plan_refresh":
             self._plan_store.request_refresh(state["session_key"])
             self.request_plan_reconcile()
             return
+        snapshot_ids = [str(task.get("id") or "") for task in tasks]
+        if (
+            len(snapshot_ids) != len(set(snapshot_ids))
+            or sum(is_interactive_user_task(task) for task in tasks)
+            > MAX_INTERACTIVE_TASKS
+        ):
+            return
         if action_id == "hermes_plan_add":
             secret = self._plan_signing_secret()
             if not secret:
                 return
+            if (
+                sum(is_interactive_user_task(task) for task in tasks)
+                >= MAX_INTERACTIVE_TASKS
+            ):
+                return
+            existing_ids = set(snapshot_ids)
+            generated_id = f"user:{uuid.uuid4()}"
+            while generated_id in existing_ids:
+                generated_id = f"user:{uuid.uuid4()}"
             payload = {
                 "session_key": state["session_key"],
                 "session_id": state["session_id"],
@@ -4804,7 +4919,12 @@ class SlackAdapter(BasePlatformAdapter):
                 "message_ts": state["message_ts"],
                 "revision": state["desired_revision"],
                 "snapshot_hash": state["desired_hash"],
-                "task_ids": [],
+                "profile": state.get("profile"),
+                "task_ids": [generated_id],
+                "action_kind": PLAN_ACTION_ADD_USER_TASK,
+                "add_task_ids": [generated_id],
+                "action_user_id": str(user.get("id") or ""),
+                "action_dedupe_id": dedupe_id,
             }
             private_metadata = sign_private_metadata(payload, secret)
             if not private_metadata:
@@ -4815,17 +4935,18 @@ class SlackAdapter(BasePlatformAdapter):
                     "type": "modal",
                     "callback_id": "hermes_plan_add_task",
                     "private_metadata": private_metadata,
-                    "title": {"type": "plain_text", "text": "Add task"},
+                    "title": {"type": "plain_text", "text": "Add user task"},
                     "submit": {"type": "plain_text", "text": "Add"},
                     "close": {"type": "plain_text", "text": "Cancel"},
                     "blocks": [{
                         "type": "input",
                         "block_id": "task",
-                        "label": {"type": "plain_text", "text": "Task"},
+                        "label": {"type": "plain_text", "text": "User task"},
                         "element": {
                             "type": "plain_text_input",
                             "action_id": "content",
                             "multiline": True,
+                            "max_length": MAX_USER_TASK_CONTENT_LENGTH,
                         },
                     }],
                 },
@@ -4836,21 +4957,37 @@ class SlackAdapter(BasePlatformAdapter):
             task_id = str(selected.get("value") or "")
             eligible_cancel = {
                 task["id"] for task in tasks
-                if task["status"] not in {"completed", "cancelled"}
+                if is_user_task_id(task["id"]) and task["status"] == "pending"
             }
             if task_id in eligible_cancel:
                 await self._dispatch_plan_action_event(
-                    state=state, body=body, changes={"cancel_task_ids": [task_id]}
+                    state=state,
+                    body=body,
+                    action_kind=PLAN_ACTION_CANCEL,
+                    action_dedupe_id=dedupe_id,
+                    changes={"cancel_task_ids": [task_id]},
                 )
             return
         if action_id == "hermes_plan_complete":
-            selected = {
-                str(option.get("value") or "")
-                for option in action.get("selected_options") or []
-                if option.get("value")
+            raw_selected = action.get("selected_options")
+            if not isinstance(raw_selected, list) or any(
+                not isinstance(option, dict) or not option.get("value")
+                for option in raw_selected
+            ):
+                return
+            selected_ids = [str(option["value"]) for option in raw_selected]
+            if len(selected_ids) != len(set(selected_ids)):
+                return
+            selected = set(selected_ids)
+            eligible = {
+                task["id"] for task in tasks
+                if is_user_task_id(task["id"])
+                and task["status"] in {"pending", "completed"}
             }
-            eligible = {task["id"] for task in tasks if task["status"] != "cancelled"}
-            completed = {task["id"] for task in tasks if task["status"] == "completed"}
+            completed = {
+                task["id"] for task in tasks
+                if is_user_task_id(task["id"]) and task["status"] == "completed"
+            }
             if not selected.issubset(eligible):
                 return
             complete_ids = sorted(selected - completed)
@@ -4860,6 +4997,8 @@ class SlackAdapter(BasePlatformAdapter):
             await self._dispatch_plan_action_event(
                 state=state,
                 body=body,
+                action_kind=PLAN_ACTION_COMPLETE_REOPEN,
+                action_dedupe_id=dedupe_id,
                 changes={
                     "complete_task_ids": complete_ids,
                     "reopen_task_ids": reopen_ids,
@@ -4882,19 +5021,31 @@ class SlackAdapter(BasePlatformAdapter):
         )
         if not payload:
             return
-        state = self._plan_store.validate_action(payload)
+        user = body.get("user") or {}
+        user_id = str(user.get("id") or "")
+        if user_id != str(payload.get("action_user_id") or ""):
+            return
+        values = ((body.get("view") or {}).get("state") or {}).get("values") or {}
+        content = str((((values.get("task") or {}).get("content") or {}).get("value")) or "").strip()
+        if not content or len(content) > MAX_USER_TASK_CONTENT_LENGTH:
+            return
+        validated_metadata = {**payload, "add_task_content": content}
+        state = self._plan_store.validate_action(validated_metadata)
         if not state:
             return
-        user = body.get("user") or {}
+        if state.get("profile") != self._plan_profile:
+            return
         if not self._is_interactive_user_authorized(
-            str(user.get("id") or ""),
+            user_id,
             channel_id=str(state.get("channel_id") or ""),
             user_name=user.get("name"),
             team_id=str(state.get("team_id") or ""),
+            profile=state.get("profile"),
+            thread_id=str(state.get("thread_ts") or "") or None,
         ):
             return
         if not self._plan_interaction_owner_matches(
-            state, str(user.get("id") or "")
+            state, user_id
         ):
             return
         view_body = body.get("view") or {}
@@ -4903,21 +5054,22 @@ class SlackAdapter(BasePlatformAdapter):
                 "view_submission",
                 str(view_body.get("id") or ""),
                 str(view_body.get("hash") or ""),
-                str(user.get("id") or ""),
+                user_id,
                 str(payload.get("session_key") or ""),
                 str(payload.get("revision") or ""),
             )).encode("utf-8")
         ).hexdigest()
         if not self._plan_store.consume_action_id(dedupe_id):
             return
-        values = ((body.get("view") or {}).get("state") or {}).get("values") or {}
-        content = str((((values.get("task") or {}).get("content") or {}).get("value")) or "").strip()
-        if not content:
-            return
         await self._dispatch_plan_action_event(
             state=state,
             body=body,
-            changes={"add_task_content": content},
+            action_kind=PLAN_ACTION_ADD_USER_TASK,
+            action_dedupe_id=str(payload.get("action_dedupe_id") or ""),
+            changes={
+                "add_task_ids": list(payload["add_task_ids"]),
+                "add_task_content": content,
+            },
         )
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -10,9 +10,11 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
+import hashlib
 import json
 import logging
 import os
+import random
 import re
 import time
 from dataclasses import dataclass, field
@@ -38,6 +40,7 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from agent.secret_scope import UnscopedSecretError, get_secret
 from gateway.config import Platform, PlatformConfig
+from utils import is_truthy_value
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -57,11 +60,30 @@ from gateway.platforms.base import (
 
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks
+    from .plan_cards import (
+        PlanCardStore,
+        _RetryScheduleKind,
+        build_plan_blocks,
+        sign_private_metadata,
+        verify_private_metadata,
+    )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks  # type: ignore
+    from plan_cards import (  # type: ignore
+        PlanCardStore,
+        _RetryScheduleKind,
+        build_plan_blocks,
+        sign_private_metadata,
+        verify_private_metadata,
+    )
 
 
 logger = logging.getLogger(__name__)
+
+
+class _PlanRetryPersistenceError(RuntimeError):
+    """Signal retry state could not be made durable for the sole worker."""
+
 
 # ContextVar carrying the user_id of the slash-command invoker.
 # Set in _handle_slash_command, read in send() to match the correct
@@ -502,6 +524,20 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_watchdog_task: Optional[asyncio.Task] = None
         self._socket_reconnect_lock = asyncio.Lock()
         self._socket_watchdog_interval_s = 15.0
+        # Native plan cards are a Slack-only cached projection of Hermes todo.
+        # The upstream default is intentionally off.
+        self._plan_cards_enabled = is_truthy_value(
+            self.config.extra.get("native_plan_cards")
+            if isinstance(self.config.extra, dict)
+            else None,
+            default=False,
+        )
+        from hermes_constants import get_hermes_home
+        self._plan_store = PlanCardStore(get_hermes_home())
+        self._plan_reconcile_task: Optional[asyncio.Task] = None
+        self._plan_reconcile_generation = 0
+        self._plan_reconcile_stopping = True
+        self._plan_reconcile_wakeup = asyncio.Event()
 
     def _start_socket_mode_handler(self) -> None:
         """Start the Slack Socket Mode background task."""
@@ -1035,6 +1071,7 @@ class SlackAdapter(BasePlatformAdapter):
                 return False
             lock_acquired = True
             self._running = False
+            await self._stop_plan_reconcile_worker()
 
             # Tear down any prior reconnect state before flipping ``_running``
             # back on. We must cancel + await the existing watchdog (not just
@@ -1221,6 +1258,17 @@ class SlackAdapter(BasePlatformAdapter):
 
             self._app.action("hermes_feedback")(self._handle_feedback_action)
 
+            # Always register these ACK handlers so controls posted before a
+            # config rollback do not time out or retry after the feature is off.
+            for _action_id in (
+                "hermes_plan_complete",
+                "hermes_plan_cancel",
+                "hermes_plan_add",
+                "hermes_plan_refresh",
+            ):
+                self._app.action(_action_id)(self._handle_plan_action)
+            self._app.view("hermes_plan_add_task")(self._handle_plan_add_view)
+
             # Register plugin-provided Block Kit action handlers.
             #
             # Plugins call ``ctx.register_slack_action_handler(action_id, cb)``
@@ -1283,6 +1331,7 @@ class SlackAdapter(BasePlatformAdapter):
                 self._start_socket_mode_handler()
                 self._running = True
                 self._ensure_socket_watchdog()
+                self._start_plan_reconcile_worker()
             except Exception:
                 self._running = False
                 try:
@@ -1351,7 +1400,9 @@ class SlackAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Slack."""
+        self._plan_reconcile_stopping = True
         self._running = False
+        await self._stop_plan_reconcile_worker()
 
         watchdog_task = self._socket_watchdog_task
         self._socket_watchdog_task = None
@@ -1377,6 +1428,12 @@ class SlackAdapter(BasePlatformAdapter):
         self._release_platform_lock()
 
         logger.info("[Slack] Disconnected")
+
+    async def cancel_background_tasks(self) -> None:
+        """Stop generation-owned plan work before generic background cleanup."""
+        self._plan_reconcile_stopping = True
+        await self._stop_plan_reconcile_worker()
+        await super().cancel_background_tasks()
 
     @staticmethod
     def _metadata_team_id(metadata: Optional[Dict[str, Any]]) -> str:
@@ -4033,6 +4090,836 @@ class SlackAdapter(BasePlatformAdapter):
             return True
         return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
+    def _plan_signing_secret(self) -> Optional[bytes]:
+        override = getattr(self, "_plan_signing_secret_override", ...)
+        if override is not ...:
+            return str(override).encode("utf-8") if override else None
+        try:
+            value = get_secret("SLACK_SIGNING_SECRET")
+        except UnscopedSecretError:
+            value = None
+        except Exception:
+            value = None
+        if not value and isinstance(self.config.extra, dict):
+            value = self.config.extra.get("native_plan_cards_signing_secret")
+        return str(value).encode("utf-8") if value else None
+
+    def record_desired_plan_snapshot(
+        self,
+        *,
+        session_key: str,
+        session_id: str,
+        team_id: str,
+        channel_id: str,
+        thread_ts: str,
+        route_user_id: str,
+        chat_type: str,
+        todos: List[Dict[str, Any]],
+    ) -> Optional[Dict[str, Any]]:
+        """Synchronously persist a desired projection before Slack I/O."""
+        if not self._plan_cards_enabled:
+            return None
+        return self._plan_store.record_desired_snapshot(
+            {
+                "session_key": session_key,
+                "session_id": session_id,
+                "team_id": team_id,
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "route_user_id": route_user_id,
+                "chat_type": chat_type,
+            },
+            todos,
+        )
+
+    def _render_plan_state(self, state: Dict[str, Any]):
+        context = {
+            "session_key": state.get("session_key", ""),
+            "session_id": state.get("session_id", ""),
+            "team_id": state.get("team_id", ""),
+            "channel_id": state.get("channel_id", ""),
+            "thread_ts": state.get("thread_ts", ""),
+            "message_ts": state.get("message_ts", ""),
+            "route_user_id": state.get("route_user_id", ""),
+            "chat_type": state.get("chat_type", "group"),
+        }
+        return build_plan_blocks(
+            state.get("last_desired_snapshot") or [],
+            revision=int(state.get("desired_revision") or 0),
+            snapshot_hash=str(state.get("desired_hash") or ""),
+            signing_secret=self._plan_signing_secret(),
+            action_context=context,
+        )
+
+    @staticmethod
+    def _plan_error_text(exc: Exception) -> str:
+        response = getattr(exc, "response", None)
+        if response is not None:
+            try:
+                return str(response.get("error") or response)
+            except Exception:
+                pass
+        return str(exc)
+
+    @classmethod
+    def _is_native_plan_unsupported(cls, exc: Exception) -> bool:
+        text = cls._plan_error_text(exc).lower()
+        return "invalid_blocks" in text or "unsupported" in text
+
+    @classmethod
+    def _is_plan_message_missing(cls, exc: Exception) -> bool:
+        text = cls._plan_error_text(exc).lower()
+        return any(token in text for token in (
+            "message_not_found", "cant_update_message", "not_found", "update_not_found"
+        ))
+
+    async def _apply_plan_blocks(
+        self,
+        *,
+        generation: int,
+        state: Dict[str, Any],
+        text: str,
+        blocks: List[Dict[str, Any]],
+    ) -> str:
+        if not self._plan_generation_active(generation):
+            raise asyncio.CancelledError
+        client = self._get_client(state["channel_id"], team_id=state.get("team_id") or None)
+        message_ts = str(state.get("message_ts") or "")
+        if message_ts:
+            result = await client.chat_update(
+                channel=state["channel_id"],
+                ts=message_ts,
+                text=text,
+                blocks=blocks,
+            )
+            return str(result.get("ts") or message_ts)
+        kwargs: Dict[str, Any] = {
+            "channel": state["channel_id"],
+            "text": text,
+            "blocks": blocks,
+            "client_msg_id": state["client_msg_id"],
+        }
+        if state.get("thread_ts"):
+            kwargs["thread_ts"] = state["thread_ts"]
+        result = await client.chat_postMessage(**kwargs)
+        return str(result.get("ts") or "")
+
+    async def _apply_rendered_plan(
+        self,
+        generation: int,
+        state: Dict[str, Any],
+        rendered,
+    ) -> str:
+        try:
+            return await self._apply_plan_blocks(
+                generation=generation,
+                state=state,
+                text=rendered.text,
+                blocks=rendered.native_blocks,
+            )
+        except Exception as native_exc:
+            if not self._is_native_plan_unsupported(native_exc):
+                raise
+            return await self._apply_plan_blocks(
+                generation=generation,
+                state=state,
+                text=rendered.text,
+                blocks=rendered.fallback_blocks,
+            )
+
+    async def _read_back_plan_anchor(
+        self,
+        generation: int,
+        anchor: Dict[str, Any],
+    ) -> Tuple[Optional[str], bool]:
+        """Perform one bounded Slack history read for an attempted create."""
+        client_msg_id = str(anchor.get("client_msg_id") or "")
+        if not client_msg_id:
+            return None, True
+        if not self._plan_generation_active(generation):
+            raise asyncio.CancelledError
+        try:
+            client = self._get_client(
+                anchor["channel_id"], team_id=anchor.get("team_id") or None
+            )
+            if anchor.get("thread_ts"):
+                response = await client.conversations_replies(
+                    channel=anchor["channel_id"],
+                    ts=anchor["thread_ts"],
+                    limit=100,
+                )
+            else:
+                response = await client.conversations_history(
+                    channel=anchor["channel_id"],
+                    limit=100,
+                )
+            expected_user = str(
+                self._team_bot_user_ids.get(str(anchor.get("team_id") or "")) or ""
+            )
+            for message in response.get("messages") or []:
+                if str(message.get("client_msg_id") or "") != client_msg_id:
+                    continue
+                message_user = str(message.get("user") or "")
+                if expected_user and message_user and message_user != expected_user:
+                    continue
+                message_ts = str(message.get("ts") or "")
+                if message_ts:
+                    return message_ts, True
+            return None, True
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Plan-card create recovery read unavailable for %s/%s: %s; "
+                "retrying with the same client_msg_id",
+                anchor.get("channel_id", ""),
+                anchor.get("thread_ts", ""),
+                exc,
+            )
+            return None, False
+
+    async def _neutralize_orphaned_plan_message(
+        self,
+        generation: int,
+        state: Dict[str, Any],
+        message_ts: str,
+    ) -> bool:
+        """Best-effort delete or neutralize a retired/conflicting card."""
+        if not self._plan_generation_active(generation):
+            raise asyncio.CancelledError
+        try:
+            client = self._get_client(
+                state["channel_id"], team_id=state.get("team_id") or None
+            )
+            try:
+                await client.chat_delete(channel=state["channel_id"], ts=message_ts)
+            except Exception:
+                if not self._plan_generation_active(generation):
+                    raise asyncio.CancelledError
+                await client.chat_update(
+                    channel=state["channel_id"],
+                    ts=message_ts,
+                    text="This Hermes plan card is no longer active.",
+                    blocks=[],
+                )
+            return True
+        except Exception:
+            logger.debug(
+                "[Slack] Failed to neutralize orphaned plan card %s",
+                message_ts,
+                exc_info=True,
+            )
+            return False
+
+    def _queue_retired_orphan(
+        self,
+        session_key: str,
+        state: Dict[str, Any],
+        message_ts: str,
+    ) -> None:
+        added = self._plan_store.retire_orphan_anchor(
+            session_key,
+            {**state, "message_ts": str(message_ts)},
+        )
+        if added:
+            return
+        persisted = self._plan_store.get_session(session_key)
+        identity = (
+            str(state.get("team_id") or ""),
+            str(state.get("channel_id") or ""),
+            str(message_ts),
+            str(state.get("client_msg_id") or ""),
+        )
+        if not persisted or not any(
+            (
+                str(anchor.get("team_id") or ""),
+                str(anchor.get("channel_id") or ""),
+                str(anchor.get("message_ts") or ""),
+                str(anchor.get("client_msg_id") or ""),
+            ) == identity
+            for anchor in persisted.get("retired_anchors") or []
+        ):
+            raise RuntimeError("Slack plan-card orphan lineage was not persisted")
+
+    async def _cleanup_retired_plan_anchors(
+        self,
+        generation: int,
+        session_key: str,
+    ) -> bool:
+        all_clean = True
+        for anchor in self._plan_store.list_retired(session_key):
+            anchor_id = str(anchor.get("anchor_id") or "")
+            message_ts = str(anchor.get("message_ts") or "")
+            if not message_ts and anchor.get("client_msg_id") and anchor.get("create_attempted_at"):
+                recovered_ts, readable = await self._read_back_plan_anchor(
+                    generation, anchor
+                )
+                if not self._plan_generation_active(generation):
+                    raise asyncio.CancelledError
+                if recovered_ts:
+                    outcome = self._plan_store.record_create_result(
+                        session_key,
+                        expected_route=anchor,
+                        client_msg_id=str(anchor.get("client_msg_id") or ""),
+                        message_ts=recovered_ts,
+                    )
+                    if outcome == "retired":
+                        message_ts = recovered_ts
+                    elif outcome == "conflict":
+                        self._queue_retired_orphan(session_key, anchor, recovered_ts)
+                        self._plan_store.complete_retired_cleanup(session_key, anchor_id)
+                        all_clean = False
+                        continue
+                else:
+                    self._mark_retired_plan_retry(session_key, anchor_id)
+                    all_clean = False
+                    continue
+            if not message_ts:
+                self._plan_store.complete_retired_cleanup(session_key, anchor_id)
+                continue
+            cleaned = await self._neutralize_orphaned_plan_message(
+                generation, anchor, message_ts
+            )
+            if not self._plan_generation_active(generation):
+                raise asyncio.CancelledError
+            if cleaned:
+                self._plan_store.complete_retired_cleanup(session_key, anchor_id)
+            else:
+                self._mark_retired_plan_retry(session_key, anchor_id)
+                all_clean = False
+        return all_clean
+
+    def _plan_generation_active(self, generation: int) -> bool:
+        return (
+            self._plan_cards_enabled
+            and self._running
+            and not self._plan_reconcile_stopping
+            and generation == self._plan_reconcile_generation
+            and asyncio.current_task() is self._plan_reconcile_task
+        )
+
+    async def _reconcile_plan_session(
+        self,
+        generation: int,
+        session_key: str,
+    ) -> bool:
+        """Reconcile one durable session from the generation-owned worker."""
+        if not self._app:
+            return False
+        try:
+            for _attempt in range(8):
+                if not self._plan_generation_active(generation):
+                    return False
+                retired_clean = await self._cleanup_retired_plan_anchors(
+                    generation, session_key
+                )
+                state = self._plan_store.get_session(session_key)
+                if not state:
+                    return False
+                desired_revision = int(state.get("desired_revision") or 0)
+                if desired_revision <= int(state.get("applied_revision") or 0):
+                    return retired_clean
+                if float(state.get("next_retry_at") or 0) > time.time():
+                    return retired_clean
+                if state.get("message_ts") and state.get("applied_hash") == state.get("desired_hash"):
+                    if self._plan_store.mark_applied(
+                        session_key,
+                        revision=desired_revision,
+                        snapshot_hash=state["desired_hash"],
+                        message_ts=state["message_ts"],
+                        expected_message_ts=str(state.get("message_ts") or ""),
+                        expected_client_msg_id=str(state.get("client_msg_id") or ""),
+                    ):
+                        return retired_clean
+                    continue
+
+                if not state.get("message_ts"):
+                    prepared = self._plan_store.prepare_create(
+                        session_key, expected_route=state
+                    )
+                    if not prepared:
+                        continue
+                    state = prepared
+                    if prepared.get("was_attempted"):
+                        recovered_ts, _readable = await self._read_back_plan_anchor(
+                            generation, state
+                        )
+                        if recovered_ts:
+                            if not self._plan_generation_active(generation):
+                                return False
+                            outcome = self._plan_store.record_create_result(
+                                session_key,
+                                expected_route=state,
+                                client_msg_id=str(state.get("client_msg_id") or ""),
+                                message_ts=recovered_ts,
+                            )
+                            if outcome in {"current", "retired"}:
+                                continue
+                            if outcome == "conflict":
+                                self._queue_retired_orphan(
+                                    session_key, state, recovered_ts
+                                )
+                                continue
+
+                rendered = self._render_plan_state(state)
+                expected_message_ts = str(state.get("message_ts") or "")
+                creating_anchor = not bool(expected_message_ts)
+                try:
+                    try:
+                        message_ts = await self._apply_rendered_plan(
+                            generation, state, rendered
+                        )
+                    except Exception as apply_exc:
+                        if not self._plan_generation_active(generation):
+                            raise asyncio.CancelledError
+                        if expected_message_ts and self._is_plan_message_missing(apply_exc):
+                            self._plan_store.reset_missing_anchor(
+                                session_key, expected_message_ts=expected_message_ts
+                            )
+                            continue
+                        raise
+                    if not message_ts:
+                        raise RuntimeError("Slack plan-card response did not include a message ts")
+                    client_msg_id = str(state.get("client_msg_id") or "")
+                    if creating_anchor:
+                        try:
+                            create_outcome = self._plan_store.record_create_result(
+                                session_key,
+                                expected_route=state,
+                                client_msg_id=client_msg_id,
+                                message_ts=message_ts,
+                            )
+                            if create_outcome in {"conflict", "route_changed"}:
+                                self._queue_retired_orphan(
+                                    session_key, state, message_ts
+                                )
+                        except Exception:
+                            logger.error(
+                                "[Slack] Created plan card %s but failed to persist its lineage for %s",
+                                message_ts,
+                                session_key,
+                                exc_info=True,
+                            )
+                            raise
+                    if not self._plan_generation_active(generation):
+                        return False
+                    if self._plan_store.mark_applied(
+                        session_key,
+                        revision=desired_revision,
+                        snapshot_hash=state["desired_hash"],
+                        message_ts=message_ts,
+                        rendered_revision=desired_revision,
+                        expected_message_ts=expected_message_ts,
+                        expected_client_msg_id=client_msg_id,
+                    ):
+                        return retired_clean
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    if not self._plan_generation_active(generation):
+                        raise asyncio.CancelledError
+                    logger.warning(
+                        "[Slack] Plan-card reconciliation failed for %s: %s",
+                        session_key, exc, exc_info=True,
+                    )
+                    self._mark_plan_retry(session_key)
+                    return False
+            self.request_plan_reconcile()
+            return False
+        except asyncio.CancelledError:
+            raise
+        except _PlanRetryPersistenceError:
+            raise
+        except Exception:
+            logger.warning(
+                "[Slack] Plan-card reconciliation crashed for %s",
+                session_key, exc_info=True,
+            )
+            if self._plan_generation_active(generation):
+                self._mark_plan_retry(session_key)
+            return False
+
+    def _mark_plan_retry(self, session_key: str) -> None:
+        try:
+            self._plan_store.mark_retry(session_key)
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Failed to persist plan-card retry metadata for %s",
+                session_key,
+                exc_info=True,
+            )
+            raise _PlanRetryPersistenceError(session_key) from exc
+
+    def _mark_retired_plan_retry(self, session_key: str, anchor_id: str) -> None:
+        try:
+            self._plan_store.mark_retired_retry(session_key, anchor_id)
+        except Exception as exc:
+            logger.warning(
+                "[Slack] Failed to persist retired plan-card retry metadata for %s/%s",
+                session_key,
+                anchor_id,
+                exc_info=True,
+            )
+            raise _PlanRetryPersistenceError(session_key) from exc
+
+    def request_plan_reconcile(self) -> None:
+        if not self._plan_cards_enabled:
+            return
+        self._plan_reconcile_wakeup.set()
+
+    async def _plan_reconcile_worker(self, generation: int) -> None:
+        error_count = 0
+        while self._plan_generation_active(generation):
+            try:
+                self._plan_reconcile_wakeup.clear()
+                dirty = self._plan_store.list_dirty()
+                for state in dirty:
+                    if not self._plan_generation_active(generation):
+                        return
+                    await self._reconcile_plan_session(
+                        generation,
+                        str(state.get("session_key") or ""),
+                    )
+                if not self._plan_generation_active(generation):
+                    return
+                if self._plan_reconcile_wakeup.is_set():
+                    error_count = 0
+                    continue
+                retry_schedule = self._plan_store.retry_schedule()
+                error_count = 0
+                if self._plan_reconcile_wakeup.is_set():
+                    continue
+                if retry_schedule.kind is _RetryScheduleKind.DUE_NOW:
+                    continue
+                if retry_schedule.kind is _RetryScheduleKind.NO_WORK:
+                    await self._plan_reconcile_wakeup.wait()
+                else:
+                    retry_delay = max(
+                        0.0,
+                        float(retry_schedule.deadline or 0) - time.time(),
+                    )
+                    if retry_delay <= 0:
+                        continue
+                    try:
+                        await asyncio.wait_for(
+                            self._plan_reconcile_wakeup.wait(), timeout=retry_delay
+                        )
+                    except asyncio.TimeoutError:
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                if not self._plan_generation_active(generation):
+                    return
+                error_count += 1
+                delay = min(5.0, 0.1 * (2 ** min(error_count - 1, 8)))
+                delay += random.uniform(0, delay * 0.2)
+                logger.warning(
+                    "[Slack] Plan reconcile worker iteration failed; retrying in %.2fs",
+                    delay,
+                    exc_info=True,
+                )
+                try:
+                    await asyncio.wait_for(
+                        self._plan_reconcile_wakeup.wait(), timeout=delay
+                    )
+                except asyncio.TimeoutError:
+                    pass
+
+    def _start_plan_reconcile_worker(self) -> None:
+        if not self._plan_cards_enabled or not self._running:
+            return
+        task = self._plan_reconcile_task
+        if task is not None and not task.done():
+            self.request_plan_reconcile()
+            return
+        self._plan_reconcile_generation += 1
+        self._plan_reconcile_stopping = False
+        generation = self._plan_reconcile_generation
+        self._plan_reconcile_task = asyncio.create_task(
+            self._plan_reconcile_worker(generation)
+        )
+        self.request_plan_reconcile()
+
+    async def _stop_plan_reconcile_worker(self) -> None:
+        self._plan_reconcile_stopping = True
+        self._plan_reconcile_wakeup.set()
+        task = self._plan_reconcile_task
+        if task is None:
+            return
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        if self._plan_reconcile_task is task:
+            self._plan_reconcile_task = None
+
+    def validate_plan_action_metadata(self, metadata: Dict[str, Any]) -> bool:
+        return self._plan_store.validate_action(metadata) is not None
+
+    def _plan_state_from_interaction(
+        self,
+        body: Dict[str, Any],
+        action: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        team_id = self._event_team_id({}, body)
+        channel_id = str((body.get("channel") or {}).get("id") or "")
+        message = body.get("message") or {}
+        message_ts = str(message.get("ts") or "")
+        state = self._plan_store.lookup_route(team_id, channel_id, message_ts)
+        if not state:
+            return None
+        if (
+            team_id != str(state.get("team_id") or "")
+            or channel_id != str(state.get("channel_id") or "")
+            or message_ts != str(state.get("message_ts") or "")
+        ):
+            return None
+        body_thread = str(message.get("thread_ts") or "")
+        if body_thread != str(state.get("thread_ts") or ""):
+            return None
+        block_id = str(action.get("block_id") or "")
+        expected_prefix = (
+            f"hermes-plan-controls-r{int(state.get('applied_render_revision') or 0)}-"
+            f"{str(state.get('desired_hash') or '')[:10]}"
+        )
+        if block_id != expected_prefix:
+            return None
+        return state
+
+    @staticmethod
+    def _plan_interaction_owner_matches(state: Dict[str, Any], user_id: str) -> bool:
+        route_user_id = str(state.get("route_user_id") or "")
+        return not route_user_id or route_user_id == str(user_id or "")
+
+    @staticmethod
+    def _plan_action_dedupe_id(body: Dict[str, Any], action: Dict[str, Any]) -> str:
+        action_ts = str(action.get("action_ts") or "")
+        if not action_ts:
+            actions = body.get("actions") or []
+            if actions and isinstance(actions[0], dict):
+                action_ts = str(actions[0].get("action_ts") or "")
+        pieces = (
+            str((body.get("team") or {}).get("id") or body.get("team_id") or ""),
+            str((body.get("channel") or {}).get("id") or ""),
+            str((body.get("message") or {}).get("ts") or ""),
+            str((body.get("user") or {}).get("id") or ""),
+            str(action.get("action_id") or ""),
+            action_ts or str(body.get("trigger_id") or ""),
+        )
+        return hashlib.sha256("\x1f".join(pieces).encode("utf-8")).hexdigest()
+
+    async def _dispatch_plan_action_event(
+        self,
+        *,
+        state: Dict[str, Any],
+        body: Dict[str, Any],
+        changes: Dict[str, Any],
+    ) -> None:
+        task_ids = sorted({
+            str(task_id)
+            for key, value in changes.items()
+            if key.endswith("task_ids")
+            for task_id in (value or [])
+        })
+        trusted = {
+            "session_key": state["session_key"],
+            "session_id": state["session_id"],
+            "team_id": state["team_id"],
+            "channel_id": state["channel_id"],
+            "thread_ts": state.get("thread_ts", ""),
+            "message_ts": state["message_ts"],
+            "revision": state["desired_revision"],
+            "snapshot_hash": state["desired_hash"],
+            "task_ids": task_ids,
+            "action_user_id": str((body.get("user") or {}).get("id") or ""),
+            **changes,
+        }
+        source = self.build_source(
+            chat_id=state["channel_id"],
+            chat_type=str(state.get("chat_type") or "group"),
+            user_id=str(state.get("route_user_id") or "") or None,
+            thread_id=str(state.get("thread_ts") or "") or None,
+            scope_id=str(state.get("team_id") or "") or None,
+        )
+        prompt = (
+            "[Trusted Slack plan action]\n"
+            "Use the todo tool to apply exactly this structured change to the current full todo list. "
+            "Preserve every task not named by the action.\n"
+            + json.dumps(changes, ensure_ascii=False, sort_keys=True)
+        )
+        await self.handle_message(MessageEvent(
+            text=prompt,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=str(state.get("message_ts") or ""),
+            internal=True,
+            metadata={
+                "slack_plan_action": trusted,
+                "gateway_session_id": str(state.get("session_id") or ""),
+            },
+        ))
+
+    async def _handle_plan_action(self, ack, body, action) -> None:
+        """Ack immediately and isolate all plan-card interaction failures."""
+        await ack()
+        try:
+            await self._handle_plan_action_after_ack(body, action)
+        except Exception:
+            logger.warning("[Slack] Plan-card action failed", exc_info=True)
+
+    async def _handle_plan_action_after_ack(self, body, action) -> None:
+        if not self._plan_cards_enabled:
+            return
+        team_id = self._event_team_id({}, body)
+        channel_id = str((body.get("channel") or {}).get("id") or "")
+        user = body.get("user") or {}
+        if not self._is_interactive_user_authorized(
+            str(user.get("id") or ""),
+            channel_id=channel_id,
+            user_name=user.get("name"),
+            team_id=team_id,
+        ):
+            return
+        state = self._plan_state_from_interaction(body, action)
+        if not state:
+            return
+        if not self._plan_interaction_owner_matches(state, str(user.get("id") or "")):
+            return
+        dedupe_id = self._plan_action_dedupe_id(body, action)
+        if not self._plan_store.consume_action_id(dedupe_id):
+            return
+        action_id = str(action.get("action_id") or "")
+        tasks = state.get("last_desired_snapshot") or []
+        if action_id == "hermes_plan_refresh":
+            self._plan_store.request_refresh(state["session_key"])
+            self.request_plan_reconcile()
+            return
+        if action_id == "hermes_plan_add":
+            secret = self._plan_signing_secret()
+            if not secret:
+                return
+            payload = {
+                "session_key": state["session_key"],
+                "session_id": state["session_id"],
+                "team_id": state["team_id"],
+                "channel_id": state["channel_id"],
+                "thread_ts": state.get("thread_ts", ""),
+                "message_ts": state["message_ts"],
+                "revision": state["desired_revision"],
+                "snapshot_hash": state["desired_hash"],
+                "task_ids": [],
+            }
+            private_metadata = sign_private_metadata(payload, secret)
+            if not private_metadata:
+                return
+            await self._get_client(channel_id, team_id=team_id or None).views_open(
+                trigger_id=body.get("trigger_id"),
+                view={
+                    "type": "modal",
+                    "callback_id": "hermes_plan_add_task",
+                    "private_metadata": private_metadata,
+                    "title": {"type": "plain_text", "text": "Add task"},
+                    "submit": {"type": "plain_text", "text": "Add"},
+                    "close": {"type": "plain_text", "text": "Cancel"},
+                    "blocks": [{
+                        "type": "input",
+                        "block_id": "task",
+                        "label": {"type": "plain_text", "text": "Task"},
+                        "element": {
+                            "type": "plain_text_input",
+                            "action_id": "content",
+                            "multiline": True,
+                        },
+                    }],
+                },
+            )
+            return
+        if action_id == "hermes_plan_cancel":
+            selected = action.get("selected_option") or {}
+            task_id = str(selected.get("value") or "")
+            eligible_cancel = {
+                task["id"] for task in tasks
+                if task["status"] not in {"completed", "cancelled"}
+            }
+            if task_id in eligible_cancel:
+                await self._dispatch_plan_action_event(
+                    state=state, body=body, changes={"cancel_task_ids": [task_id]}
+                )
+            return
+        if action_id == "hermes_plan_complete":
+            selected = {
+                str(option.get("value") or "")
+                for option in action.get("selected_options") or []
+                if option.get("value")
+            }
+            eligible = {task["id"] for task in tasks if task["status"] != "cancelled"}
+            completed = {task["id"] for task in tasks if task["status"] == "completed"}
+            if not selected.issubset(eligible):
+                return
+            complete_ids = sorted(selected - completed)
+            reopen_ids = sorted(completed - selected)
+            if not complete_ids and not reopen_ids:
+                return
+            await self._dispatch_plan_action_event(
+                state=state,
+                body=body,
+                changes={
+                    "complete_task_ids": complete_ids,
+                    "reopen_task_ids": reopen_ids,
+                },
+            )
+
+    async def _handle_plan_add_view(self, ack, body, view=None, client=None) -> None:
+        await ack()
+        try:
+            await self._handle_plan_add_view_after_ack(body)
+        except Exception:
+            logger.warning("[Slack] Plan-card modal submission failed", exc_info=True)
+
+    async def _handle_plan_add_view_after_ack(self, body) -> None:
+        if not self._plan_cards_enabled:
+            return
+        payload = verify_private_metadata(
+            str((body.get("view") or {}).get("private_metadata") or ""),
+            self._plan_signing_secret(),
+        )
+        if not payload:
+            return
+        state = self._plan_store.validate_action(payload)
+        if not state:
+            return
+        user = body.get("user") or {}
+        if not self._is_interactive_user_authorized(
+            str(user.get("id") or ""),
+            channel_id=str(state.get("channel_id") or ""),
+            user_name=user.get("name"),
+            team_id=str(state.get("team_id") or ""),
+        ):
+            return
+        if not self._plan_interaction_owner_matches(
+            state, str(user.get("id") or "")
+        ):
+            return
+        view_body = body.get("view") or {}
+        dedupe_id = hashlib.sha256(
+            "\x1f".join((
+                "view_submission",
+                str(view_body.get("id") or ""),
+                str(view_body.get("hash") or ""),
+                str(user.get("id") or ""),
+                str(payload.get("session_key") or ""),
+                str(payload.get("revision") or ""),
+            )).encode("utf-8")
+        ).hexdigest()
+        if not self._plan_store.consume_action_id(dedupe_id):
+            return
+        values = ((body.get("view") or {}).get("state") or {}).get("values") or {}
+        content = str((((values.get("task") or {}).get("content") or {}).get("value")) or "").strip()
+        if not content:
+            return
+        await self._dispatch_plan_action_event(
+            state=state,
+            body=body,
+            changes={"add_task_content": content},
+        )
+
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:
         """Handle a slash-confirm button click from Block Kit."""
         await ack()
@@ -5091,20 +5978,19 @@ def interactive_setup() -> None:
 
 
 def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
-    """Translate ``config.yaml`` ``slack:`` keys into ``SLACK_*`` env vars.
+    """Apply recognized ``config.yaml`` ``slack:`` keys.
 
     Implements the ``apply_yaml_config_fn`` contract (#24849). Mirrors the
     legacy ``slack_cfg`` block that used to live in
-    ``gateway/config.py::load_gateway_config()`` before this migration.
+    ``gateway/config.py::load_gateway_config()`` before this migration, while
+    also seeding the native plan-card settings consumed from
+    ``PlatformConfig.extra``.
 
     The SlackAdapter reads its runtime configuration via ``os.getenv()``
-    throughout the connect / handle code paths, so rather than rewrite those
-    call sites to read from ``PlatformConfig.extra``, this hook keeps the
-    existing env-driven model and owns the YAML→env translation here, next to
-    the adapter that consumes it. Env vars take precedence over YAML — every
-    assignment is guarded by ``not os.getenv(...)`` so explicit env vars
-    survive a config.yaml update. Returns ``None`` because no extras are
-    seeded into ``PlatformConfig.extra`` directly (everything flows through env).
+    for the legacy settings below, so this hook keeps their existing YAML→env
+    translation and env-over-YAML precedence. Native plan-card settings are
+    intentionally returned as a narrow extras dict instead; unknown Slack keys
+    are not bridged and secrets are not copied into the process environment.
     """
     if "require_mention" in slack_cfg and not os.getenv("SLACK_REQUIRE_MENTION"):
         os.environ["SLACK_REQUIRE_MENTION"] = str(slack_cfg["require_mention"]).lower()
@@ -5124,7 +6010,15 @@ def _apply_yaml_config(yaml_cfg: dict, slack_cfg: dict) -> dict | None:
         if isinstance(ac, list):
             ac = ",".join(str(v) for v in ac)
         os.environ["SLACK_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    extras = {
+        key: slack_cfg[key]
+        for key in (
+            "native_plan_cards",
+            "native_plan_cards_signing_secret",
+        )
+        if key in slack_cfg
+    }
+    return extras or None
 
 
 def _is_connected(config) -> bool:
@@ -5158,11 +6052,10 @@ def register(ctx) -> None:
         # Interactive setup wizard — replaces hermes_cli/setup.py::_setup_slack
         # and the static _PLATFORMS["slack"] dict in hermes_cli/gateway.py.
         setup_fn=interactive_setup,
-        # YAML→env config bridge — owns the translation of config.yaml slack:
-        # keys (require_mention, strict_mention, allow_bots,
-        # free_response_channels, reactions, allowed_channels) into SLACK_*
-        # env vars that the adapter reads via os.getenv(). Replaces the
-        # hardcoded block in gateway/config.py. Hook contract: #24849.
+        # Slack YAML bridge — translates the legacy env-driven settings into
+        # SLACK_* and returns only the recognized native plan-card settings for
+        # PlatformConfig.extra. Replaces the hardcoded block in
+        # gateway/config.py. Hook contract: #24849.
         apply_yaml_config_fn=_apply_yaml_config,
         # Auth env vars for _is_user_authorized() integration
         allowed_users_env="SLACK_ALLOWED_USERS",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -10,14 +10,12 @@ Uses slack-bolt (Python) with Socket Mode for:
 
 import asyncio
 import contextvars
-import hashlib
 import json
 import logging
 import os
 import random
 import re
 import time
-import uuid
 from dataclasses import dataclass, field
 from typing import Dict, Optional, Any, Tuple, List
 
@@ -58,45 +56,27 @@ from gateway.platforms.base import (
     cache_document_from_bytes,
     cache_video_from_bytes,
 )
-from tools.todo_tool import MAX_TODO_ITEMS
-
 try:  # sibling module; support both package and flat plugin-dir import
     from .block_kit import render_blocks
     from .plan_cards import (
-        MAX_INTERACTIVE_TASKS,
-        MAX_USER_TASK_CONTENT_LENGTH,
-        PLAN_ACTION_ADD_USER_TASK,
-        PLAN_ACTION_CANCEL,
-        PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
-        _is_slack_human_user_id,
         build_plan_blocks,
-        is_interactive_user_task,
-        is_user_task_id,
-        sign_private_metadata,
-        verify_private_metadata,
     )
 except ImportError:  # pragma: no cover - plugin loaded outside package context
     from block_kit import render_blocks  # type: ignore
     from plan_cards import (  # type: ignore
-        MAX_INTERACTIVE_TASKS,
-        MAX_USER_TASK_CONTENT_LENGTH,
-        PLAN_ACTION_ADD_USER_TASK,
-        PLAN_ACTION_CANCEL,
-        PLAN_ACTION_COMPLETE_REOPEN,
         PlanCardStore,
         _RetryScheduleKind,
-        _is_slack_human_user_id,
         build_plan_blocks,
-        is_interactive_user_task,
-        is_user_task_id,
-        sign_private_metadata,
-        verify_private_metadata,
     )
 
 
 logger = logging.getLogger(__name__)
+
+_PLAN_CARD_READ_ONLY_MESSAGE = (
+    "This Plan Card is now read-only; use Clarify or reply in Slack."
+)
 
 
 def _profile_from_hermes_home(home: Any) -> Optional[str]:
@@ -1285,8 +1265,8 @@ class SlackAdapter(BasePlatformAdapter):
 
             self._app.action("hermes_feedback")(self._handle_feedback_action)
 
-            # Always register these ACK handlers so controls posted before a
-            # config rollback do not time out or retry after the feature is off.
+            # Keep compatibility ACK handlers for cards posted before Plan
+            # Cards became read-only. They only return a migration notice.
             for _action_id in (
                 "hermes_plan_complete",
                 "hermes_plan_cancel",
@@ -4135,20 +4115,6 @@ class SlackAdapter(BasePlatformAdapter):
             return True
         return _env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
-    def _plan_signing_secret(self) -> Optional[bytes]:
-        override = getattr(self, "_plan_signing_secret_override", ...)
-        if override is not ...:
-            return str(override).encode("utf-8") if override else None
-        try:
-            value = get_secret("SLACK_SIGNING_SECRET")
-        except UnscopedSecretError:
-            value = None
-        except Exception:
-            value = None
-        if not value and isinstance(self.config.extra, dict):
-            value = self.config.extra.get("native_plan_cards_signing_secret")
-        return str(value).encode("utf-8") if value else None
-
     def record_desired_plan_snapshot(
         self,
         *,
@@ -4179,23 +4145,10 @@ class SlackAdapter(BasePlatformAdapter):
         )
 
     def _render_plan_state(self, state: Dict[str, Any]):
-        context = {
-            "session_key": state.get("session_key", ""),
-            "session_id": state.get("session_id", ""),
-            "team_id": state.get("team_id", ""),
-            "channel_id": state.get("channel_id", ""),
-            "thread_ts": state.get("thread_ts", ""),
-            "message_ts": state.get("message_ts", ""),
-            "route_user_id": state.get("route_user_id", ""),
-            "chat_type": state.get("chat_type", "group"),
-            "profile": state.get("profile"),
-        }
         return build_plan_blocks(
             state.get("last_desired_snapshot") or [],
             revision=int(state.get("desired_revision") or 0),
             snapshot_hash=str(state.get("desired_hash") or ""),
-            signing_secret=self._plan_signing_secret(),
-            action_context=context,
         )
 
     @staticmethod
@@ -4698,402 +4651,62 @@ class SlackAdapter(BasePlatformAdapter):
             self._plan_reconcile_task = None
 
     def validate_plan_action_metadata(self, metadata: Dict[str, Any]) -> bool:
-        try:
-            state = self._plan_store.validate_action(metadata)
-        except Exception:
-            logger.warning(
-                "[Slack] Claim-time plan action state lookup failed",
-                exc_info=True,
-            )
-            return False
-        if not state:
-            return False
-        if state.get("profile") != self._plan_profile:
-            return False
-        action_user_id = metadata.get("action_user_id")
-        if (
-            not isinstance(action_user_id, str)
-            or not action_user_id
-            or action_user_id != action_user_id.strip()
-        ):
-            return False
-        channel_id = str(state.get("channel_id") or "")
-        team_id = str(state.get("team_id") or "")
-        if not channel_id or not team_id:
-            return False
-        try:
-            return self._is_interactive_user_authorized(
-                action_user_id,
-                channel_id=channel_id,
-                user_name=None,
-                team_id=team_id,
-                profile=state.get("profile"),
-                thread_id=str(state.get("thread_ts") or "") or None,
-                fail_closed_on_lookup_error=True,
-            )
-        except Exception:
-            logger.warning(
-                "[Slack] Claim-time plan action authorization lookup failed",
-                exc_info=True,
-            )
-            return False
-
-    def _plan_state_from_interaction(
-        self,
-        body: Dict[str, Any],
-        action: Dict[str, Any],
-    ) -> Optional[Dict[str, Any]]:
-        team_id = self._event_team_id({}, body)
-        channel_id = str((body.get("channel") or {}).get("id") or "")
-        message = body.get("message") or {}
-        message_ts = str(message.get("ts") or "")
-        state = self._plan_store.lookup_route(team_id, channel_id, message_ts)
-        if not state:
-            return None
-        if state.get("profile") != self._plan_profile:
-            return None
-        if (
-            team_id != str(state.get("team_id") or "")
-            or channel_id != str(state.get("channel_id") or "")
-            or message_ts != str(state.get("message_ts") or "")
-        ):
-            return None
-        body_thread = str(message.get("thread_ts") or "")
-        if body_thread != str(state.get("thread_ts") or ""):
-            return None
-        block_id = str(action.get("block_id") or "")
-        expected_prefix = (
-            f"hermes-plan-controls-r{int(state.get('applied_render_revision') or 0)}-"
-            f"{str(state.get('desired_hash') or '')[:10]}"
-        )
-        if block_id != expected_prefix:
-            return None
-        return state
-
-    @staticmethod
-    def _plan_interaction_owner_matches(state: Dict[str, Any], user_id: str) -> bool:
-        route_user_id = str(state.get("route_user_id") or "")
-        return (
-            _is_slack_human_user_id(route_user_id)
-            and route_user_id == str(user_id or "")
-        )
-
-    @staticmethod
-    def _plan_action_dedupe_id(body: Dict[str, Any], action: Dict[str, Any]) -> str:
-        action_ts = str(action.get("action_ts") or "")
-        if not action_ts:
-            actions = body.get("actions") or []
-            if actions and isinstance(actions[0], dict):
-                action_ts = str(actions[0].get("action_ts") or "")
-        pieces = (
-            str((body.get("team") or {}).get("id") or body.get("team_id") or ""),
-            str((body.get("channel") or {}).get("id") or ""),
-            str((body.get("message") or {}).get("ts") or ""),
-            str((body.get("user") or {}).get("id") or ""),
-            str(action.get("action_id") or ""),
-            action_ts or str(body.get("trigger_id") or ""),
-        )
-        return hashlib.sha256("\x1f".join(pieces).encode("utf-8")).hexdigest()
-
-    async def _dispatch_plan_action_event(
-        self,
-        *,
-        state: Dict[str, Any],
-        body: Dict[str, Any],
-        action_kind: str,
-        action_dedupe_id: str,
-        changes: Dict[str, Any],
-    ) -> None:
-        task_ids = sorted({
-            str(task_id)
-            for key, value in changes.items()
-            if key.endswith("task_ids")
-            for task_id in (value or [])
-        })
-        trusted = {
-            "session_key": state["session_key"],
-            "session_id": state["session_id"],
-            "team_id": state["team_id"],
-            "channel_id": state["channel_id"],
-            "thread_ts": state.get("thread_ts", ""),
-            "profile": state.get("profile"),
-            "message_ts": state["message_ts"],
-            "revision": state["desired_revision"],
-            "snapshot_hash": state["desired_hash"],
-            "task_ids": task_ids,
-            "action_kind": action_kind,
-            "action_dedupe_id": action_dedupe_id,
-            "action_user_id": str((body.get("user") or {}).get("id") or ""),
-            **changes,
-        }
-        source = self.build_source(
-            chat_id=state["channel_id"],
-            chat_type=str(state.get("chat_type") or "group"),
-            user_id=str(state.get("route_user_id") or "") or None,
-            thread_id=str(state.get("thread_ts") or "") or None,
-            scope_id=str(state.get("team_id") or "") or None,
-        )
-        source.profile = state.get("profile")
-        prompt = (
-            "[Trusted Slack plan action]\n"
-            "Use the todo tool to apply exactly this structured change to the current full todo list. "
-            "Preserve every task not named by the action. Set each named task to the exact status "
-            "specified by its *_task_status field. For add_task_ids, create exactly one Todo with "
-            "the supplied ID, add_task_content, and add_task_status.\n"
-            + json.dumps(changes, ensure_ascii=False, sort_keys=True)
-        )
-        await self.handle_message(MessageEvent(
-            text=prompt,
-            message_type=MessageType.TEXT,
-            source=source,
-            message_id=str(state.get("message_ts") or ""),
-            internal=True,
-            metadata={
-                "slack_plan_action": trusted,
-                "gateway_session_id": str(state.get("session_id") or ""),
-            },
-        ))
+        # Internal plan-action events may still be queued from a gateway that
+        # posted interactive cards before this read-only renderer shipped.
+        # They are no longer valid mutation requests.
+        return False
 
     async def _handle_plan_action(self, ack, body, action) -> None:
-        """Ack immediately and isolate all plan-card interaction failures."""
+        """Acknowledge legacy controls and fail closed without mutating state."""
         await ack()
         try:
-            await self._handle_plan_action_after_ack(body, action)
+            action_id = str(action.get("action_id") or "")
+            if action_id not in {
+                "hermes_plan_complete",
+                "hermes_plan_cancel",
+                "hermes_plan_add",
+                "hermes_plan_refresh",
+            }:
+                return
+            team_id = self._event_team_id({}, body)
+            channel_id = str((body.get("channel") or {}).get("id") or "")
+            user_id = str((body.get("user") or {}).get("id") or "")
+            message = body.get("message") or {}
+            action_ts = str(action.get("action_ts") or "")
+            if not action_ts:
+                actions = body.get("actions") or []
+                if actions and isinstance(actions[0], dict):
+                    action_ts = str(actions[0].get("action_ts") or "")
+            dedupe_key = "\x1f".join((
+                "legacy-plan-action",
+                team_id,
+                channel_id,
+                str(message.get("ts") or ""),
+                user_id,
+                action_id,
+                action_ts or str(body.get("trigger_id") or ""),
+            ))
+            if self._dedup.is_duplicate(dedupe_key) or not channel_id or not user_id:
+                return
+            kwargs = {
+                "channel": channel_id,
+                "user": user_id,
+                "text": _PLAN_CARD_READ_ONLY_MESSAGE,
+                "mrkdwn": True,
+            }
+            thread_ts = str(message.get("thread_ts") or "")
+            if thread_ts:
+                kwargs["thread_ts"] = thread_ts
+            await self._get_client(
+                channel_id, team_id=team_id or None
+            ).chat_postEphemeral(**kwargs)
         except Exception:
-            logger.warning("[Slack] Plan-card action failed", exc_info=True)
-
-    async def _handle_plan_action_after_ack(self, body, action) -> None:
-        if not self._plan_cards_enabled:
-            return
-        action_id = str(action.get("action_id") or "")
-        if action_id not in {
-            "hermes_plan_complete",
-            "hermes_plan_cancel",
-            "hermes_plan_add",
-            "hermes_plan_refresh",
-        }:
-            return
-        team_id = self._event_team_id({}, body)
-        channel_id = str((body.get("channel") or {}).get("id") or "")
-        state = self._plan_state_from_interaction(body, action)
-        if not state:
-            return
-        user = body.get("user") or {}
-        if not self._is_interactive_user_authorized(
-            str(user.get("id") or ""),
-            channel_id=channel_id,
-            user_name=user.get("name"),
-            team_id=team_id,
-            profile=state.get("profile"),
-            thread_id=str(state.get("thread_ts") or "") or None,
-        ):
-            return
-        if (
-            action_id != "hermes_plan_refresh"
-            and not self._plan_interaction_owner_matches(
-                state, str(user.get("id") or "")
-            )
-        ):
-            return
-        dedupe_id = self._plan_action_dedupe_id(body, action)
-        if not self._plan_store.consume_action_id(dedupe_id):
-            return
-        tasks = state.get("last_desired_snapshot") or []
-        if action_id == "hermes_plan_refresh":
-            self._plan_store.request_refresh(state["session_key"])
-            self.request_plan_reconcile()
-            return
-        snapshot_ids = [str(task.get("id") or "") for task in tasks]
-        if (
-            len(snapshot_ids) != len(set(snapshot_ids))
-            or sum(is_interactive_user_task(task) for task in tasks)
-            > MAX_INTERACTIVE_TASKS
-        ):
-            return
-        if action_id == "hermes_plan_add":
-            secret = self._plan_signing_secret()
-            if not secret:
-                return
-            if (
-                len(tasks) >= MAX_TODO_ITEMS
-                or sum(is_interactive_user_task(task) for task in tasks)
-                >= MAX_INTERACTIVE_TASKS
-            ):
-                return
-            existing_ids = set(snapshot_ids)
-            generated_id = f"user:{uuid.uuid4()}"
-            while generated_id in existing_ids:
-                generated_id = f"user:{uuid.uuid4()}"
-            payload = {
-                "session_key": state["session_key"],
-                "session_id": state["session_id"],
-                "team_id": state["team_id"],
-                "channel_id": state["channel_id"],
-                "thread_ts": state.get("thread_ts", ""),
-                "message_ts": state["message_ts"],
-                "revision": state["desired_revision"],
-                "snapshot_hash": state["desired_hash"],
-                "profile": state.get("profile"),
-                "task_ids": [generated_id],
-                "action_kind": PLAN_ACTION_ADD_USER_TASK,
-                "add_task_ids": [generated_id],
-                "action_user_id": str(user.get("id") or ""),
-                "action_dedupe_id": dedupe_id,
-            }
-            private_metadata = sign_private_metadata(payload, secret)
-            if not private_metadata:
-                return
-            await self._get_client(channel_id, team_id=team_id or None).views_open(
-                trigger_id=body.get("trigger_id"),
-                view={
-                    "type": "modal",
-                    "callback_id": "hermes_plan_add_task",
-                    "private_metadata": private_metadata,
-                    "title": {"type": "plain_text", "text": "Add user task"},
-                    "submit": {"type": "plain_text", "text": "Add"},
-                    "close": {"type": "plain_text", "text": "Cancel"},
-                    "blocks": [{
-                        "type": "input",
-                        "block_id": "task",
-                        "label": {"type": "plain_text", "text": "User task"},
-                        "element": {
-                            "type": "plain_text_input",
-                            "action_id": "content",
-                            "multiline": True,
-                            "max_length": MAX_USER_TASK_CONTENT_LENGTH,
-                        },
-                    }],
-                },
-            )
-            return
-        if action_id == "hermes_plan_cancel":
-            selected = action.get("selected_option") or {}
-            task_id = str(selected.get("value") or "")
-            eligible_cancel = {
-                task["id"] for task in tasks
-                if is_user_task_id(task["id"]) and task["status"] == "in_progress"
-            }
-            if task_id in eligible_cancel:
-                await self._dispatch_plan_action_event(
-                    state=state,
-                    body=body,
-                    action_kind=PLAN_ACTION_CANCEL,
-                    action_dedupe_id=dedupe_id,
-                    changes={
-                        "cancel_task_ids": [task_id],
-                        "cancel_task_status": "cancelled",
-                    },
-                )
-            return
-        if action_id == "hermes_plan_complete":
-            raw_selected = action.get("selected_options")
-            if not isinstance(raw_selected, list) or any(
-                not isinstance(option, dict) or not option.get("value")
-                for option in raw_selected
-            ):
-                return
-            selected_ids = [str(option["value"]) for option in raw_selected]
-            if len(selected_ids) != len(set(selected_ids)):
-                return
-            selected = set(selected_ids)
-            eligible = {
-                task["id"] for task in tasks
-                if is_user_task_id(task["id"])
-                and task["status"] in {"in_progress", "completed"}
-            }
-            completed = {
-                task["id"] for task in tasks
-                if is_user_task_id(task["id"]) and task["status"] == "completed"
-            }
-            if not selected.issubset(eligible):
-                return
-            complete_ids = sorted(selected - completed)
-            reopen_ids = sorted(completed - selected)
-            if not complete_ids and not reopen_ids:
-                return
-            await self._dispatch_plan_action_event(
-                state=state,
-                body=body,
-                action_kind=PLAN_ACTION_COMPLETE_REOPEN,
-                action_dedupe_id=dedupe_id,
-                changes={
-                    "complete_task_ids": complete_ids,
-                    "complete_task_status": "completed",
-                    "reopen_task_ids": reopen_ids,
-                    "reopen_task_status": "in_progress",
-                },
-            )
+            logger.warning("[Slack] Legacy Plan Card notice failed", exc_info=True)
 
     async def _handle_plan_add_view(self, ack, body, view=None, client=None) -> None:
-        await ack()
-        try:
-            await self._handle_plan_add_view_after_ack(body)
-        except Exception:
-            logger.warning("[Slack] Plan-card modal submission failed", exc_info=True)
-
-    async def _handle_plan_add_view_after_ack(self, body) -> None:
-        if not self._plan_cards_enabled:
-            return
-        payload = verify_private_metadata(
-            str((body.get("view") or {}).get("private_metadata") or ""),
-            self._plan_signing_secret(),
-        )
-        if not payload:
-            return
-        user = body.get("user") or {}
-        user_id = str(user.get("id") or "")
-        if user_id != str(payload.get("action_user_id") or ""):
-            return
-        values = ((body.get("view") or {}).get("state") or {}).get("values") or {}
-        content = str((((values.get("task") or {}).get("content") or {}).get("value")) or "").strip()
-        if not content or len(content) > MAX_USER_TASK_CONTENT_LENGTH:
-            return
-        validated_metadata = {
-            **payload,
-            "add_task_content": content,
-            "add_task_status": "in_progress",
-        }
-        state = self._plan_store.validate_action(validated_metadata)
-        if not state:
-            return
-        if state.get("profile") != self._plan_profile:
-            return
-        if not self._is_interactive_user_authorized(
-            user_id,
-            channel_id=str(state.get("channel_id") or ""),
-            user_name=user.get("name"),
-            team_id=str(state.get("team_id") or ""),
-            profile=state.get("profile"),
-            thread_id=str(state.get("thread_ts") or "") or None,
-        ):
-            return
-        if not self._plan_interaction_owner_matches(
-            state, user_id
-        ):
-            return
-        view_body = body.get("view") or {}
-        dedupe_id = hashlib.sha256(
-            "\x1f".join((
-                "view_submission",
-                str(view_body.get("id") or ""),
-                str(view_body.get("hash") or ""),
-                user_id,
-                str(payload.get("session_key") or ""),
-                str(payload.get("revision") or ""),
-            )).encode("utf-8")
-        ).hexdigest()
-        if not self._plan_store.consume_action_id(dedupe_id):
-            return
-        await self._dispatch_plan_action_event(
-            state=state,
-            body=body,
-            action_kind=PLAN_ACTION_ADD_USER_TASK,
-            action_dedupe_id=str(payload.get("action_dedupe_id") or ""),
-            changes={
-                "add_task_ids": list(payload["add_task_ids"]),
-                "add_task_content": content,
-                "add_task_status": "in_progress",
-            },
+        await ack(
+            response_action="errors",
+            errors={"task": _PLAN_CARD_READ_ONLY_MESSAGE},
         )
 
     async def _handle_slash_confirm_action(self, ack, body, action) -> None:

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -30,7 +30,7 @@ MAX_USER_TASK_CONTENT_LENGTH = 3000
 MAX_NATIVE_TASK_TITLE_LENGTH = 3000
 MAX_ACTION_DEDUPE_IDS = 512
 USER_TASK_ID_PREFIX = "user:"
-INTERACTIVE_USER_TASK_STATUSES = frozenset({"pending", "completed"})
+INTERACTIVE_USER_TASK_STATUSES = frozenset({"in_progress", "completed"})
 PLAN_ACTION_COMPLETE_REOPEN = "complete_reopen"
 PLAN_ACTION_CANCEL = "cancel"
 PLAN_ACTION_ADD_USER_TASK = "add_user_task"
@@ -236,7 +236,7 @@ def _control_blocks(
     cancel_options = [
         {"text": _plain_text(task["content"][:75]), "value": task["id"]}
         for task in user_tasks
-        if task["status"] == "pending"
+        if task["status"] == "in_progress"
     ]
     if cancel_options and not over_capacity:
         elements.append({
@@ -984,17 +984,24 @@ class PlanCardStore:
                 return None
             change_keys = {
                 "complete_task_ids", "reopen_task_ids", "cancel_task_ids",
-                "add_task_ids", "add_task_content",
+                "add_task_ids", "add_task_content", "complete_task_status",
+                "reopen_task_status", "cancel_task_status", "add_task_status",
             }
 
             if action_kind == PLAN_ACTION_COMPLETE_REOPEN:
                 if any(key in metadata for key in change_keys - {
                     "complete_task_ids", "reopen_task_ids",
+                    "complete_task_status", "reopen_task_status",
                 }):
                     return None
                 complete_ids = id_list("complete_task_ids")
                 reopen_ids = id_list("reopen_task_ids")
-                if complete_ids is None or reopen_ids is None:
+                if (
+                    complete_ids is None
+                    or reopen_ids is None
+                    or metadata.get("complete_task_status") != "completed"
+                    or metadata.get("reopen_task_status") != "in_progress"
+                ):
                     return None
                 combined = complete_ids + reopen_ids
                 if not combined or len(combined) != len(set(combined)):
@@ -1004,7 +1011,7 @@ class PlanCardStore:
                 if any(
                     not is_user_task_id(task_id)
                     or task_id not in by_id
-                    or by_id[task_id]["status"] != "pending"
+                    or by_id[task_id]["status"] != "in_progress"
                     for task_id in complete_ids
                 ):
                     return None
@@ -1016,21 +1023,28 @@ class PlanCardStore:
                 ):
                     return None
             elif action_kind == PLAN_ACTION_CANCEL:
-                if any(key in metadata for key in change_keys - {"cancel_task_ids"}):
+                if any(key in metadata for key in change_keys - {
+                    "cancel_task_ids", "cancel_task_status",
+                }):
                     return None
                 cancel_ids = id_list("cancel_task_ids")
-                if cancel_ids is None or len(cancel_ids) != 1 or task_ids != cancel_ids:
+                if (
+                    cancel_ids is None
+                    or len(cancel_ids) != 1
+                    or task_ids != cancel_ids
+                    or metadata.get("cancel_task_status") != "cancelled"
+                ):
                     return None
                 task_id = cancel_ids[0]
                 if (
                     not is_user_task_id(task_id)
                     or task_id not in by_id
-                    or by_id[task_id]["status"] != "pending"
+                    or by_id[task_id]["status"] != "in_progress"
                 ):
                     return None
             else:
                 if any(key in metadata for key in change_keys - {
-                    "add_task_ids", "add_task_content",
+                    "add_task_ids", "add_task_content", "add_task_status",
                 }):
                     return None
                 add_ids = id_list("add_task_ids")
@@ -1042,6 +1056,7 @@ class PlanCardStore:
                     or not is_user_task_id(add_ids[0])
                     or add_ids[0] in by_id
                     or user_task_count >= MAX_INTERACTIVE_TASKS
+                    or metadata.get("add_task_status") != "in_progress"
                     or not isinstance(content, str)
                     or not content.strip()
                     or len(content) > MAX_USER_TASK_CONTENT_LENGTH

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -26,7 +26,20 @@ from typing import Any, Iterator, Mapping, Optional, Sequence
 
 STATE_VERSION = 1
 MAX_INTERACTIVE_TASKS = 10
+MAX_USER_TASK_CONTENT_LENGTH = 3000
+MAX_NATIVE_TASK_TITLE_LENGTH = 3000
 MAX_ACTION_DEDUPE_IDS = 512
+USER_TASK_ID_PREFIX = "user:"
+INTERACTIVE_USER_TASK_STATUSES = frozenset({"pending", "completed"})
+PLAN_ACTION_COMPLETE_REOPEN = "complete_reopen"
+PLAN_ACTION_CANCEL = "cancel"
+PLAN_ACTION_ADD_USER_TASK = "add_user_task"
+PLAN_MUTATION_ACTIONS = frozenset({
+    PLAN_ACTION_COMPLETE_REOPEN,
+    PLAN_ACTION_CANCEL,
+    PLAN_ACTION_ADD_USER_TASK,
+})
+_NATIVE_TITLE_TRUNCATION_SUFFIX = "... [truncated]"
 _STATUS_LABELS = {
     "pending": "Pending",
     "in_progress": "In progress",
@@ -58,20 +71,33 @@ def _json_loads_prefix(value: str) -> Any:
         return data
 
 
+def is_user_task_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and value.startswith(USER_TASK_ID_PREFIX)
+        and len(value) > len(USER_TASK_ID_PREFIX)
+    )
+
+
+def is_interactive_user_task(task: Mapping[str, Any]) -> bool:
+    return (
+        is_user_task_id(task.get("id"))
+        and task.get("status") in INTERACTIVE_USER_TASK_STATUSES
+    )
+
+
 def normalize_todos(todos: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
     normalized: list[dict[str, str]] = []
-    seen: set[str] = set()
     for item in todos:
         if not isinstance(item, Mapping):
             continue
-        task_id = str(item.get("id") or "").strip()
-        if not task_id or task_id in seen:
+        task_id = str(item.get("id") or "")
+        if not task_id:
             continue
         content = str(item.get("content") or "").strip() or "(no description)"
         status = str(item.get("status") or "pending").strip().lower()
         if status not in _NATIVE_STATUSES:
             status = "pending"
-        seen.add(task_id)
         normalized.append({"id": task_id, "content": content, "status": status})
     return normalized
 
@@ -157,6 +183,16 @@ def _plain_text(text: str) -> dict[str, Any]:
     return {"type": "plain_text", "text": text[:3000], "emoji": True}
 
 
+def _native_task_title(task: Mapping[str, str]) -> str:
+    title = task["content"]
+    if task["status"] == "cancelled":
+        title = f"[cancelled] {title}"
+    if len(title) <= MAX_NATIVE_TASK_TITLE_LENGTH:
+        return title
+    prefix_length = MAX_NATIVE_TASK_TITLE_LENGTH - len(_NATIVE_TITLE_TRUNCATION_SUFFIX)
+    return title[:prefix_length] + _NATIVE_TITLE_TRUNCATION_SUFFIX
+
+
 def _control_blocks(
     todos: list[dict[str, str]],
     *,
@@ -165,22 +201,23 @@ def _control_blocks(
     signing_secret: Optional[bytes],
     action_context: Optional[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
-    if len(todos) > MAX_INTERACTIVE_TASKS:
-        return []
     base = dict(action_context or {})
     base.update({"revision": revision, "snapshot_hash": desired_hash})
     encoded = encode_action_value(base)
-    completed = {task["id"] for task in todos if task["status"] == "completed"}
+    user_tasks = [task for task in todos if is_interactive_user_task(task)]
+    over_capacity = len(user_tasks) > MAX_INTERACTIVE_TASKS
+    completed = {
+        task["id"] for task in user_tasks if task["status"] == "completed"
+    }
     checkbox_options = [
         {
             "text": _plain_text(task["content"][:75]),
             "value": task["id"],
         }
-        for task in todos
-        if task["status"] != "cancelled"
+        for task in user_tasks
     ]
     elements: list[dict[str, Any]] = []
-    if checkbox_options:
+    if checkbox_options and not over_capacity:
         checkbox: dict[str, Any] = {
             "type": "checkboxes",
             "action_id": "hermes_plan_complete",
@@ -198,21 +235,25 @@ def _control_blocks(
         elements.append(checkbox)
     cancel_options = [
         {"text": _plain_text(task["content"][:75]), "value": task["id"]}
-        for task in todos
-        if task["status"] not in {"completed", "cancelled"}
+        for task in user_tasks
+        if task["status"] == "pending"
     ]
-    if cancel_options:
+    if cancel_options and not over_capacity:
         elements.append({
             "type": "static_select",
             "action_id": "hermes_plan_cancel",
             "placeholder": _plain_text("Cancel task"),
             "options": cancel_options,
         })
-    if signing_secret:
+    if (
+        signing_secret
+        and not over_capacity
+        and len(user_tasks) < MAX_INTERACTIVE_TASKS
+    ):
         elements.append({
             "type": "button",
             "action_id": "hermes_plan_add",
-            "text": _plain_text("Add task"),
+            "text": _plain_text("Add user task"),
             "value": encoded,
         })
     elements.append({
@@ -242,15 +283,12 @@ def build_plan_blocks(
     count = len(tasks)
     text = f"Hermes plan: {count} task{'s' if count != 1 else ''}"
     native_tasks = []
-    for task in tasks:
-        title = task["content"]
-        if task["status"] == "cancelled":
-            title = f"[cancelled] {title}"
+    for index, task in enumerate(tasks):
         native_tasks.append({
             "type": "task_card",
-            "block_id": f"hermes-task-{task['id'][:80]}-r{revision}-{snapshot_hash[:8]}",
+            "block_id": f"hermes-task-{index}-{task['id'][:70]}-r{revision}-{snapshot_hash[:8]}",
             "task_id": task["id"],
-            "title": title[:3000],
+            "title": _native_task_title(task),
             "status": _NATIVE_STATUSES[task["status"]],
         })
     native = [{
@@ -271,31 +309,41 @@ def build_plan_blocks(
     for task in tasks:
         label = _STATUS_LABELS[task["status"]]
         lines.append(f"• *{label}* `{task['id']}` — {task['content']}")
-    if count > MAX_INTERACTIVE_TASKS:
+    user_task_count = sum(is_interactive_user_task(task) for task in tasks)
+    if user_task_count > MAX_INTERACTIVE_TASKS:
         lines.append(
-            f"_Interactive controls unavailable: this plan has {count} tasks; "
-            f"the safe control limit is {MAX_INTERACTIVE_TASKS}._"
+            f"_User task mutation controls unavailable: this plan has {user_task_count} "
+            f"mutable user tasks; the safe control limit is {MAX_INTERACTIVE_TASKS}. Refresh remains available._"
         )
-    chunks: list[str] = []
-    current = ""
-    for line in lines:
-        candidate = f"{current}\n{line}".strip()
-        if current and len(candidate) > 2900:
-            chunks.append(current)
-            current = line
-        else:
-            current = candidate
-    if current:
-        chunks.append(current)
+    fallback_text = "\n".join(lines)
+    chunks = [
+        fallback_text[index:index + 3000]
+        for index in range(0, len(fallback_text), 3000)
+    ]
+    control_blocks = _control_blocks(
+        tasks,
+        revision=revision,
+        desired_hash=snapshot_hash,
+        signing_secret=signing_secret,
+        action_context=action_context,
+    )
+    max_fallback_blocks = 50
+    if len(control_blocks) > max_fallback_blocks:
+        control_blocks = []
+    text_block_budget = max_fallback_blocks - len(control_blocks)
+    truncated = len(chunks) > text_block_budget
+    section_limit = text_block_budget
+    if truncated and text_block_budget:
+        section_limit -= 1
     fallback = [
         {
             "type": "section",
             "block_id": f"hermes-plan-fallback-r{revision}-{index}-{snapshot_hash[:8]}",
-            "text": {"type": "mrkdwn", "text": chunk[:3000]},
+            "text": {"type": "mrkdwn", "text": chunk},
         }
-        for index, chunk in enumerate(chunks[:49])
+        for index, chunk in enumerate(chunks[:section_limit])
     ]
-    if len(chunks) > 49:
+    if truncated and text_block_budget:
         fallback.append({
             "type": "context",
             "block_id": f"hermes-plan-overflow-r{revision}-{snapshot_hash[:8]}",
@@ -307,19 +355,17 @@ def build_plan_blocks(
                 ),
             }],
         })
-    if count <= MAX_INTERACTIVE_TASKS:
-        fallback.extend(_control_blocks(
-            tasks,
-            revision=revision,
-            desired_hash=snapshot_hash,
-            signing_secret=signing_secret,
-            action_context=action_context,
-        ))
+    if len(fallback) + len(control_blocks) <= max_fallback_blocks:
+        fallback.extend(control_blocks)
     return RenderedPlan(text=text, native_blocks=native, fallback_blocks=fallback)
 
 
 class PlanCardStore:
-    """Cross-process durable store for desired/applied Slack projections."""
+    """Native Slack plugin authority for its current desired Todo projection.
+
+    This is durable Slack projection state, not a replacement for or claim of
+    authority over the core TodoStore.
+    """
 
     def __init__(self, hermes_home: Path | str):
         root = Path(hermes_home)
@@ -409,7 +455,7 @@ class PlanCardStore:
         defaults = {"chat_type": "group"}
         for key in (
             "session_key", "session_id", "team_id", "channel_id",
-            "thread_ts", "route_user_id", "chat_type",
+            "thread_ts", "route_user_id", "chat_type", "profile",
         ):
             default = defaults.get(key, "")
             left_value = str(left.get(key) or "") if key in left else default
@@ -428,6 +474,7 @@ class PlanCardStore:
             "channel_id": str(state.get("channel_id") or ""),
             "thread_ts": str(state.get("thread_ts") or ""),
             "route_user_id": str(state.get("route_user_id") or ""),
+            "profile": state.get("profile"),
             "chat_type": (
                 str(state.get("chat_type") or "")
                 if "chat_type" in state
@@ -476,6 +523,9 @@ class PlanCardStore:
             new_thread_ts = route_value("thread_ts")
             new_route_user_id = route_value("route_user_id")
             new_chat_type = route_value("chat_type", "group")
+            new_profile = route.get("profile") if "profile" in route else prior.get("profile")
+            if new_profile is not None:
+                new_profile = str(new_profile)
             prior_chat_type = (
                 str(prior.get("chat_type") or "")
                 if "chat_type" in prior
@@ -488,6 +538,7 @@ class PlanCardStore:
                 new_thread_ts != str(prior.get("thread_ts") or ""),
                 new_route_user_id != str(prior.get("route_user_id") or ""),
                 new_chat_type != prior_chat_type,
+                str(new_profile or "") != str(prior.get("profile") or ""),
             ))
             retired_anchors = list(prior.get("retired_anchors") or [])
             if route_changed:
@@ -509,6 +560,7 @@ class PlanCardStore:
                 "thread_ts": new_thread_ts,
                 "route_user_id": new_route_user_id,
                 "chat_type": new_chat_type,
+                "profile": new_profile,
                 "message_ts": "" if route_changed else prior_message_ts,
                 "client_msg_id": "" if route_changed else str(prior.get("client_msg_id") or ""),
                 "create_attempted_at": 0 if route_changed else float(prior.get("create_attempted_at") or 0),
@@ -877,15 +929,124 @@ class PlanCardStore:
                 "team_id": state.get("team_id"),
                 "channel_id": state.get("channel_id"),
                 "thread_ts": state.get("thread_ts"),
+                "profile": state.get("profile"),
                 "message_ts": state.get("message_ts"),
                 "revision": state.get("desired_revision"),
                 "snapshot_hash": state.get("desired_hash"),
             }
             if any(str(metadata.get(key)) != str(expected) for key, expected in comparisons.items()):
                 return None
-            task_ids = {task["id"] for task in state.get("last_desired_snapshot") or []}
-            if not set(metadata.get("task_ids") or []).issubset(task_ids):
+            action_kind = metadata.get("action_kind")
+            if action_kind not in PLAN_MUTATION_ACTIONS:
                 return None
+            action_user_id = str(metadata.get("action_user_id") or "")
+            if not action_user_id:
+                return None
+            route_user_id = str(state.get("route_user_id") or "")
+            if route_user_id and action_user_id != route_user_id:
+                return None
+            action_dedupe_id = str(metadata.get("action_dedupe_id") or "")
+            if not action_dedupe_id or action_dedupe_id not in {
+                str(value) for value in data.get("action_ids") or []
+            }:
+                return None
+
+            snapshot = state.get("last_desired_snapshot")
+            if not isinstance(snapshot, list) or any(
+                not isinstance(task, Mapping) for task in snapshot
+            ):
+                return None
+            tasks = normalize_todos(snapshot)
+            if len(tasks) != len(snapshot):
+                return None
+            snapshot_ids = [task["id"] for task in tasks]
+            if len(snapshot_ids) != len(set(snapshot_ids)):
+                return None
+            if snapshot_hash(tasks) != str(state.get("desired_hash") or ""):
+                return None
+            by_id = {task["id"]: task for task in tasks}
+            user_task_count = sum(is_interactive_user_task(task) for task in tasks)
+            if user_task_count > MAX_INTERACTIVE_TASKS:
+                return None
+
+            def id_list(key: str) -> Optional[list[str]]:
+                value = metadata.get(key)
+                if not isinstance(value, list) or any(
+                    not isinstance(task_id, str) or not task_id for task_id in value
+                ):
+                    return None
+                if len(value) != len(set(value)):
+                    return None
+                return value
+
+            task_ids = id_list("task_ids")
+            if task_ids is None:
+                return None
+            change_keys = {
+                "complete_task_ids", "reopen_task_ids", "cancel_task_ids",
+                "add_task_ids", "add_task_content",
+            }
+
+            if action_kind == PLAN_ACTION_COMPLETE_REOPEN:
+                if any(key in metadata for key in change_keys - {
+                    "complete_task_ids", "reopen_task_ids",
+                }):
+                    return None
+                complete_ids = id_list("complete_task_ids")
+                reopen_ids = id_list("reopen_task_ids")
+                if complete_ids is None or reopen_ids is None:
+                    return None
+                combined = complete_ids + reopen_ids
+                if not combined or len(combined) != len(set(combined)):
+                    return None
+                if task_ids != sorted(combined):
+                    return None
+                if any(
+                    not is_user_task_id(task_id)
+                    or task_id not in by_id
+                    or by_id[task_id]["status"] != "pending"
+                    for task_id in complete_ids
+                ):
+                    return None
+                if any(
+                    not is_user_task_id(task_id)
+                    or task_id not in by_id
+                    or by_id[task_id]["status"] != "completed"
+                    for task_id in reopen_ids
+                ):
+                    return None
+            elif action_kind == PLAN_ACTION_CANCEL:
+                if any(key in metadata for key in change_keys - {"cancel_task_ids"}):
+                    return None
+                cancel_ids = id_list("cancel_task_ids")
+                if cancel_ids is None or len(cancel_ids) != 1 or task_ids != cancel_ids:
+                    return None
+                task_id = cancel_ids[0]
+                if (
+                    not is_user_task_id(task_id)
+                    or task_id not in by_id
+                    or by_id[task_id]["status"] != "pending"
+                ):
+                    return None
+            else:
+                if any(key in metadata for key in change_keys - {
+                    "add_task_ids", "add_task_content",
+                }):
+                    return None
+                add_ids = id_list("add_task_ids")
+                content = metadata.get("add_task_content")
+                if (
+                    add_ids is None
+                    or len(add_ids) != 1
+                    or task_ids != add_ids
+                    or not is_user_task_id(add_ids[0])
+                    or add_ids[0] in by_id
+                    or user_task_count >= MAX_INTERACTIVE_TASKS
+                    or not isinstance(content, str)
+                    or not content.strip()
+                    or len(content) > MAX_USER_TASK_CONTENT_LENGTH
+                ):
+                    return None
             return dict(state)
 
     def consume_action_id(self, action_id: str) -> bool:
@@ -904,14 +1065,21 @@ class PlanCardStore:
 
 __all__ = [
     "MAX_INTERACTIVE_TASKS",
+    "MAX_USER_TASK_CONTENT_LENGTH",
+    "PLAN_ACTION_ADD_USER_TASK",
+    "PLAN_ACTION_CANCEL",
+    "PLAN_ACTION_COMPLETE_REOPEN",
     "PlanCardStore",
     "RenderedPlan",
     "build_plan_blocks",
     "decode_action_value",
     "encode_action_value",
+    "is_interactive_user_task",
+    "is_user_task_id",
     "normalize_todos",
     "parse_todo_result",
     "sign_private_metadata",
     "snapshot_hash",
+    "USER_TASK_ID_PREFIX",
     "verify_private_metadata",
 ]

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -81,6 +81,15 @@ def is_user_task_id(value: Any) -> bool:
     )
 
 
+def _is_slack_human_user_id(value: Any) -> bool:
+    user_id = str(value or "")
+    return (
+        len(user_id) > 1
+        and user_id == user_id.strip()
+        and user_id.startswith(("U", "W"))
+    )
+
+
 def is_interactive_user_task(task: Mapping[str, Any]) -> bool:
     return (
         is_user_task_id(task.get("id"))
@@ -206,6 +215,7 @@ def _control_blocks(
     base = dict(action_context or {})
     base.update({"revision": revision, "snapshot_hash": desired_hash})
     encoded = encode_action_value(base)
+    has_mutation_owner = _is_slack_human_user_id(base.get("route_user_id"))
     user_tasks = [task for task in todos if is_interactive_user_task(task)]
     over_capacity = len(user_tasks) > MAX_INTERACTIVE_TASKS
     completed = {
@@ -219,7 +229,7 @@ def _control_blocks(
         for task in user_tasks
     ]
     elements: list[dict[str, Any]] = []
-    if checkbox_options and not over_capacity:
+    if has_mutation_owner and checkbox_options and not over_capacity:
         checkbox: dict[str, Any] = {
             "type": "checkboxes",
             "action_id": "hermes_plan_complete",
@@ -240,7 +250,7 @@ def _control_blocks(
         for task in user_tasks
         if task["status"] == "in_progress"
     ]
-    if cancel_options and not over_capacity:
+    if has_mutation_owner and cancel_options and not over_capacity:
         elements.append({
             "type": "static_select",
             "action_id": "hermes_plan_cancel",
@@ -249,6 +259,7 @@ def _control_blocks(
         })
     if (
         signing_secret
+        and has_mutation_owner
         and not over_capacity
         and len(user_tasks) < MAX_INTERACTIVE_TASKS
         and len(todos) < MAX_TODO_ITEMS
@@ -946,7 +957,10 @@ class PlanCardStore:
             if not action_user_id:
                 return None
             route_user_id = str(state.get("route_user_id") or "")
-            if route_user_id and action_user_id != route_user_id:
+            if (
+                not _is_slack_human_user_id(route_user_id)
+                or action_user_id != route_user_id
+            ):
                 return None
             action_dedupe_id = str(metadata.get("action_dedupe_id") or "")
             if not action_dedupe_id or action_dedupe_id not in {

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -23,6 +23,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Optional, Sequence
 
+from tools.todo_tool import MAX_TODO_ITEMS
+
 
 STATE_VERSION = 1
 MAX_INTERACTIVE_TASKS = 10
@@ -249,6 +251,7 @@ def _control_blocks(
         signing_secret
         and not over_capacity
         and len(user_tasks) < MAX_INTERACTIVE_TASKS
+        and len(todos) < MAX_TODO_ITEMS
     ):
         elements.append({
             "type": "button",
@@ -1055,6 +1058,7 @@ class PlanCardStore:
                     or task_ids != add_ids
                     or not is_user_task_id(add_ids[0])
                     or add_ids[0] in by_id
+                    or len(tasks) >= MAX_TODO_ITEMS
                     or user_task_count >= MAX_INTERACTIVE_TASKS
                     or metadata.get("add_task_status") != "in_progress"
                     or not isinstance(content, str)

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -1,0 +1,917 @@
+"""Native Slack plan-card rendering and durable projection state.
+
+The todo tool remains authoritative. This module only stores the latest desired
+Slack projection, the last applied projection, and the reverse route needed to
+validate interactive payloads.
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import hmac
+import json
+import os
+import random
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterator, Mapping, Optional, Sequence
+
+
+STATE_VERSION = 1
+MAX_INTERACTIVE_TASKS = 10
+MAX_ACTION_DEDUPE_IDS = 512
+_STATUS_LABELS = {
+    "pending": "Pending",
+    "in_progress": "In progress",
+    "completed": "Completed",
+    "cancelled": "Cancelled",
+}
+_NATIVE_STATUSES = {
+    "pending": "pending",
+    "in_progress": "in_progress",
+    "completed": "complete",
+    "cancelled": "error",
+}
+_path_locks: dict[str, threading.Lock] = {}
+_path_locks_guard = threading.Lock()
+
+
+def _path_thread_lock(path: Path) -> threading.Lock:
+    key = str(path.resolve())
+    with _path_locks_guard:
+        return _path_locks.setdefault(key, threading.Lock())
+
+
+def _json_loads_prefix(value: str) -> Any:
+    text = value.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        data, _ = json.JSONDecoder().raw_decode(text)
+        return data
+
+
+def normalize_todos(todos: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
+    normalized: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for item in todos:
+        if not isinstance(item, Mapping):
+            continue
+        task_id = str(item.get("id") or "").strip()
+        if not task_id or task_id in seen:
+            continue
+        content = str(item.get("content") or "").strip() or "(no description)"
+        status = str(item.get("status") or "pending").strip().lower()
+        if status not in _NATIVE_STATUSES:
+            status = "pending"
+        seen.add(task_id)
+        normalized.append({"id": task_id, "content": content, "status": status})
+    return normalized
+
+
+def parse_todo_result(result: Any) -> Optional[list[dict[str, str]]]:
+    """Return the full normalized todo list from a successful tool result."""
+    if not isinstance(result, str) or not result.strip():
+        return None
+    try:
+        data = _json_loads_prefix(result)
+    except Exception:
+        return None
+    if not isinstance(data, dict) or data.get("error") or not isinstance(data.get("todos"), list):
+        return None
+    return normalize_todos(data["todos"])
+
+
+def snapshot_hash(todos: Sequence[Mapping[str, Any]]) -> str:
+    payload = json.dumps(normalize_todos(todos), ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def encode_action_value(payload: Mapping[str, Any]) -> str:
+    raw = json.dumps(dict(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def decode_action_value(value: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        padded = value + "=" * (-len(value) % 4)
+        decoded = json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
+    except Exception:
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def sign_private_metadata(payload: Mapping[str, Any], secret: Optional[bytes]) -> Optional[str]:
+    if not secret:
+        return None
+    body = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
+    signature = hmac.new(secret, body.encode("utf-8"), hashlib.sha256).hexdigest()
+    return json.dumps({"payload": dict(payload), "signature": signature}, separators=(",", ":"))
+
+
+def verify_private_metadata(value: Any, secret: Optional[bytes]) -> Optional[dict[str, Any]]:
+    if not secret or not isinstance(value, str):
+        return None
+    try:
+        envelope = json.loads(value)
+        payload = envelope["payload"]
+        signature = str(envelope["signature"])
+        body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        expected = hmac.new(secret, body.encode("utf-8"), hashlib.sha256).hexdigest()
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or not hmac.compare_digest(signature, expected):
+        return None
+    return payload
+
+
+@dataclass(frozen=True)
+class RenderedPlan:
+    text: str
+    native_blocks: list[dict[str, Any]]
+    fallback_blocks: list[dict[str, Any]]
+
+
+class _RetryScheduleKind(Enum):
+    NO_WORK = "no_work"
+    DUE_NOW = "due_now"
+    DUE_AT = "due_at"
+
+
+@dataclass(frozen=True)
+class _RetrySchedule:
+    kind: _RetryScheduleKind
+    deadline: Optional[float] = None
+
+
+def _plain_text(text: str) -> dict[str, Any]:
+    return {"type": "plain_text", "text": text[:3000], "emoji": True}
+
+
+def _control_blocks(
+    todos: list[dict[str, str]],
+    *,
+    revision: int,
+    desired_hash: str,
+    signing_secret: Optional[bytes],
+    action_context: Optional[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    if len(todos) > MAX_INTERACTIVE_TASKS:
+        return []
+    base = dict(action_context or {})
+    base.update({"revision": revision, "snapshot_hash": desired_hash})
+    encoded = encode_action_value(base)
+    completed = {task["id"] for task in todos if task["status"] == "completed"}
+    checkbox_options = [
+        {
+            "text": _plain_text(task["content"][:75]),
+            "value": task["id"],
+        }
+        for task in todos
+        if task["status"] != "cancelled"
+    ]
+    elements: list[dict[str, Any]] = []
+    if checkbox_options:
+        checkbox: dict[str, Any] = {
+            "type": "checkboxes",
+            "action_id": "hermes_plan_complete",
+            "options": checkbox_options,
+            "confirm": {
+                "title": _plain_text("Update tasks"),
+                "text": _plain_text("Complete checked tasks and reopen unchecked tasks?"),
+                "confirm": _plain_text("Update"),
+                "deny": _plain_text("Back"),
+            },
+        }
+        selected = [option for option in checkbox_options if option["value"] in completed]
+        if selected:
+            checkbox["initial_options"] = selected
+        elements.append(checkbox)
+    cancel_options = [
+        {"text": _plain_text(task["content"][:75]), "value": task["id"]}
+        for task in todos
+        if task["status"] not in {"completed", "cancelled"}
+    ]
+    if cancel_options:
+        elements.append({
+            "type": "static_select",
+            "action_id": "hermes_plan_cancel",
+            "placeholder": _plain_text("Cancel task"),
+            "options": cancel_options,
+        })
+    if signing_secret:
+        elements.append({
+            "type": "button",
+            "action_id": "hermes_plan_add",
+            "text": _plain_text("Add task"),
+            "value": encoded,
+        })
+    elements.append({
+        "type": "button",
+        "action_id": "hermes_plan_refresh",
+        "text": _plain_text("Refresh"),
+        "value": encoded,
+    })
+    if not elements:
+        return []
+    return [{
+        "type": "actions",
+        "block_id": f"hermes-plan-controls-r{revision}-{desired_hash[:10]}",
+        "elements": elements,
+    }]
+
+
+def build_plan_blocks(
+    todos: Sequence[Mapping[str, Any]],
+    *,
+    revision: int,
+    snapshot_hash: str,
+    signing_secret: Optional[bytes],
+    action_context: Optional[Mapping[str, Any]] = None,
+) -> RenderedPlan:
+    tasks = normalize_todos(todos)
+    count = len(tasks)
+    text = f"Hermes plan: {count} task{'s' if count != 1 else ''}"
+    native_tasks = []
+    for task in tasks:
+        title = task["content"]
+        if task["status"] == "cancelled":
+            title = f"[cancelled] {title}"
+        native_tasks.append({
+            "type": "task_card",
+            "block_id": f"hermes-task-{task['id'][:80]}-r{revision}-{snapshot_hash[:8]}",
+            "task_id": task["id"],
+            "title": title[:3000],
+            "status": _NATIVE_STATUSES[task["status"]],
+        })
+    native = [{
+        "type": "plan",
+        "block_id": f"hermes-plan-r{revision}-{snapshot_hash[:10]}",
+        "title": "Hermes plan",
+        "tasks": native_tasks,
+    }]
+    native.extend(_control_blocks(
+        tasks,
+        revision=revision,
+        desired_hash=snapshot_hash,
+        signing_secret=signing_secret,
+        action_context=action_context,
+    ))
+
+    lines = [f"*Hermes plan* ({count} tasks)"]
+    for task in tasks:
+        label = _STATUS_LABELS[task["status"]]
+        lines.append(f"• *{label}* `{task['id']}` — {task['content']}")
+    if count > MAX_INTERACTIVE_TASKS:
+        lines.append(
+            f"_Interactive controls unavailable: this plan has {count} tasks; "
+            f"the safe control limit is {MAX_INTERACTIVE_TASKS}._"
+        )
+    chunks: list[str] = []
+    current = ""
+    for line in lines:
+        candidate = f"{current}\n{line}".strip()
+        if current and len(candidate) > 2900:
+            chunks.append(current)
+            current = line
+        else:
+            current = candidate
+    if current:
+        chunks.append(current)
+    fallback = [
+        {
+            "type": "section",
+            "block_id": f"hermes-plan-fallback-r{revision}-{index}-{snapshot_hash[:8]}",
+            "text": {"type": "mrkdwn", "text": chunk[:3000]},
+        }
+        for index, chunk in enumerate(chunks[:49])
+    ]
+    if len(chunks) > 49:
+        fallback.append({
+            "type": "context",
+            "block_id": f"hermes-plan-overflow-r{revision}-{snapshot_hash[:8]}",
+            "elements": [{
+                "type": "mrkdwn",
+                "text": (
+                    "Slack display truncated this plan because it exceeds block/text limits. "
+                    "The complete task truth remains in Hermes todo."
+                ),
+            }],
+        })
+    if count <= MAX_INTERACTIVE_TASKS:
+        fallback.extend(_control_blocks(
+            tasks,
+            revision=revision,
+            desired_hash=snapshot_hash,
+            signing_secret=signing_secret,
+            action_context=action_context,
+        ))
+    return RenderedPlan(text=text, native_blocks=native, fallback_blocks=fallback)
+
+
+class PlanCardStore:
+    """Cross-process durable store for desired/applied Slack projections."""
+
+    def __init__(self, hermes_home: Path | str):
+        root = Path(hermes_home)
+        self.state_path = root / "gateway" / "slack_plan_cards.json"
+        self.lock_path = root / "gateway" / "slack_plan_cards.lock"
+
+    @contextlib.contextmanager
+    def _locked(self) -> Iterator[None]:
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        thread_lock = _path_thread_lock(self.lock_path)
+        with thread_lock:
+            handle = self.lock_path.open("a+b")
+            try:
+                handle.seek(0, os.SEEK_END)
+                if handle.tell() == 0:
+                    handle.write(b"\0")
+                    handle.flush()
+                    os.fsync(handle.fileno())
+                handle.seek(0)
+                if os.name == "nt":  # pragma: no cover - exercised on Windows CI
+                    import msvcrt
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+                else:
+                    import fcntl
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+                yield
+            finally:
+                try:
+                    if os.name == "nt":  # pragma: no cover
+                        import msvcrt
+                        handle.seek(0)
+                        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                    else:
+                        import fcntl
+                        fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+                finally:
+                    handle.close()
+
+    def _read_unlocked(self, *, strict: bool = False) -> dict[str, Any]:
+        if not self.state_path.exists():
+            return {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": []}
+        try:
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict) or not isinstance(data.get("sessions"), dict):
+                raise ValueError("invalid root")
+            data.setdefault("routes", {})
+            data.setdefault("action_ids", [])
+            return data
+        except Exception as exc:
+            if strict:
+                raise ValueError(f"Slack plan-card state is corrupt: {exc}") from exc
+            return {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": [], "_corrupt": True}
+
+    def _write_unlocked(self, data: Mapping[str, Any]) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{self.state_path.name}.", dir=self.state_path.parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(tmp_name, self.state_path)
+            if hasattr(os, "O_DIRECTORY"):
+                dir_fd = os.open(self.state_path.parent, os.O_RDONLY | os.O_DIRECTORY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+
+    def _quarantine_corrupt_unlocked(self) -> None:
+        if not self.state_path.exists():
+            return
+        suffix = f".corrupt.{int(time.time() * 1000)}.{os.getpid()}"
+        os.replace(self.state_path, self.state_path.with_name(self.state_path.name + suffix))
+
+    @staticmethod
+    def _route_key(team_id: str, channel_id: str, message_ts: str) -> str:
+        return "\x1f".join((str(team_id), str(channel_id), str(message_ts)))
+
+    @staticmethod
+    def _route_matches(left: Mapping[str, Any], right: Mapping[str, Any]) -> bool:
+        defaults = {"chat_type": "group"}
+        for key in (
+            "session_key", "session_id", "team_id", "channel_id",
+            "thread_ts", "route_user_id", "chat_type",
+        ):
+            default = defaults.get(key, "")
+            left_value = str(left.get(key) or "") if key in left else default
+            right_value = str(right.get(key) or "") if key in right else default
+            if left_value != right_value:
+                return False
+        return True
+
+    @staticmethod
+    def _retired_anchor_from_state(state: Mapping[str, Any]) -> dict[str, Any]:
+        return {
+            "anchor_id": str(uuid.uuid4()),
+            "session_key": str(state.get("session_key") or ""),
+            "session_id": str(state.get("session_id") or ""),
+            "team_id": str(state.get("team_id") or ""),
+            "channel_id": str(state.get("channel_id") or ""),
+            "thread_ts": str(state.get("thread_ts") or ""),
+            "route_user_id": str(state.get("route_user_id") or ""),
+            "chat_type": (
+                str(state.get("chat_type") or "")
+                if "chat_type" in state
+                else "group"
+            ),
+            "message_ts": str(state.get("message_ts") or ""),
+            "client_msg_id": str(state.get("client_msg_id") or ""),
+            "create_attempted_at": float(state.get("create_attempted_at") or 0),
+            "retry_count": 0,
+            "next_retry_at": 0,
+            "retired_at": time.time(),
+        }
+
+    def record_desired_snapshot(
+        self,
+        route: Mapping[str, Any],
+        todos: Sequence[Mapping[str, Any]],
+    ) -> dict[str, Any]:
+        session_key = str(route.get("session_key") or "").strip()
+        if not session_key:
+            raise ValueError("session_key is required")
+        normalized = normalize_todos(todos)
+        desired_hash = snapshot_hash(normalized)
+        now = time.time()
+        with self._locked():
+            try:
+                data = self._read_unlocked(strict=True)
+            except ValueError:
+                # Todo is authoritative. Quarantine unreadable projection state
+                # and rebuild from this full successful snapshot; interactive
+                # reads remain fail-closed until this recovery write occurs.
+                self._quarantine_corrupt_unlocked()
+                data = {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": []}
+            prior = dict(data["sessions"].get(session_key) or {})
+            prior_message_ts = str(prior.get("message_ts") or "")
+            def route_value(key: str, default: str = "") -> str:
+                if key in route:
+                    return str(route.get(key) or "")
+                if key in prior:
+                    return str(prior.get(key) or "")
+                return default
+
+            new_session_id = route_value("session_id")
+            new_team_id = route_value("team_id")
+            new_channel_id = route_value("channel_id")
+            new_thread_ts = route_value("thread_ts")
+            new_route_user_id = route_value("route_user_id")
+            new_chat_type = route_value("chat_type", "group")
+            prior_chat_type = (
+                str(prior.get("chat_type") or "")
+                if "chat_type" in prior
+                else "group"
+            )
+            route_changed = bool(prior) and any((
+                new_session_id != str(prior.get("session_id") or ""),
+                new_team_id != str(prior.get("team_id") or ""),
+                new_channel_id != str(prior.get("channel_id") or ""),
+                new_thread_ts != str(prior.get("thread_ts") or ""),
+                new_route_user_id != str(prior.get("route_user_id") or ""),
+                new_chat_type != prior_chat_type,
+            ))
+            retired_anchors = list(prior.get("retired_anchors") or [])
+            if route_changed:
+                if prior_message_ts:
+                    data["routes"].pop(self._route_key(
+                        prior.get("team_id", ""),
+                        prior.get("channel_id", ""),
+                        prior_message_ts,
+                    ), None)
+                if prior_message_ts or float(prior.get("create_attempted_at") or 0):
+                    retired_anchors.append(self._retired_anchor_from_state(prior))
+            revision = int(prior.get("desired_revision") or 0) + 1
+            state = {
+                **prior,
+                "session_key": session_key,
+                "session_id": new_session_id,
+                "team_id": new_team_id,
+                "channel_id": new_channel_id,
+                "thread_ts": new_thread_ts,
+                "route_user_id": new_route_user_id,
+                "chat_type": new_chat_type,
+                "message_ts": "" if route_changed else prior_message_ts,
+                "client_msg_id": "" if route_changed else str(prior.get("client_msg_id") or ""),
+                "create_attempted_at": 0 if route_changed else float(prior.get("create_attempted_at") or 0),
+                "retired_anchors": retired_anchors,
+                "desired_revision": revision,
+                "applied_revision": int(prior.get("applied_revision") or 0),
+                "desired_hash": desired_hash,
+                "applied_hash": str(prior.get("applied_hash") or ""),
+                "applied_render_revision": int(prior.get("applied_render_revision") or 0),
+                "last_desired_snapshot": normalized,
+                "retry_count": 0,
+                "next_retry_at": 0,
+                "updated_at": now,
+            }
+            data["sessions"][session_key] = state
+            self._write_unlocked(data)
+            return dict(state)
+
+    def get_session(self, session_key: str) -> Optional[dict[str, Any]]:
+        with self._locked():
+            data = self._read_unlocked()
+            if data.get("_corrupt"):
+                return None
+            state = data["sessions"].get(str(session_key))
+            return dict(state) if isinstance(state, dict) else None
+
+    def list_dirty(self, *, now: Optional[float] = None) -> list[dict[str, Any]]:
+        current = time.time() if now is None else now
+        with self._locked():
+            data = self._read_unlocked()
+            if data.get("_corrupt"):
+                return []
+            dirty = []
+            for state in data["sessions"].values():
+                current_due = (
+                    int(state.get("desired_revision") or 0)
+                    > int(state.get("applied_revision") or 0)
+                    and float(state.get("next_retry_at") or 0) <= current
+                )
+                retired_due = any(
+                    float(anchor.get("next_retry_at") or 0) <= current
+                    for anchor in state.get("retired_anchors") or []
+                )
+                if current_due or retired_due:
+                    dirty.append(dict(state))
+            return dirty
+
+    def retry_schedule(self, *, now: Optional[float] = None) -> _RetrySchedule:
+        """Return the complete current/retired retry schedule snapshot."""
+        current = time.time() if now is None else now
+        earliest: Optional[float] = None
+        due_now = False
+        with self._locked():
+            data = self._read_unlocked()
+            if data.get("_corrupt"):
+                return _RetrySchedule(_RetryScheduleKind.NO_WORK)
+            for state in data["sessions"].values():
+                if int(state.get("desired_revision") or 0) > int(
+                    state.get("applied_revision") or 0
+                ):
+                    deadline = float(state.get("next_retry_at") or 0)
+                    if deadline <= current:
+                        due_now = True
+                    else:
+                        earliest = deadline if earliest is None else min(earliest, deadline)
+                for anchor in state.get("retired_anchors") or []:
+                    deadline = float(anchor.get("next_retry_at") or 0)
+                    if deadline <= current:
+                        due_now = True
+                    else:
+                        earliest = deadline if earliest is None else min(earliest, deadline)
+        if due_now:
+            return _RetrySchedule(_RetryScheduleKind.DUE_NOW)
+        if earliest is not None:
+            return _RetrySchedule(_RetryScheduleKind.DUE_AT, earliest)
+        return _RetrySchedule(_RetryScheduleKind.NO_WORK)
+
+    def prepare_create(
+        self,
+        session_key: str,
+        *,
+        expected_route: Mapping[str, Any],
+    ) -> Optional[dict[str, Any]]:
+        """Persist one UUID create identity and attempt marker before Slack I/O."""
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if (
+                not isinstance(state, dict)
+                or not self._route_matches(state, expected_route)
+                or str(state.get("message_ts") or "")
+            ):
+                return None
+            was_attempted = bool(float(state.get("create_attempted_at") or 0))
+            client_msg_id = str(state.get("client_msg_id") or "")
+            if not client_msg_id:
+                client_msg_id = str(uuid.uuid4())
+                state["client_msg_id"] = client_msg_id
+            state["create_attempted_at"] = time.time()
+            state["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return {**state, "was_attempted": was_attempted}
+
+    def mark_applied(
+        self,
+        session_key: str,
+        *,
+        revision: int,
+        snapshot_hash: str,
+        message_ts: str,
+        rendered_revision: Optional[int] = None,
+        expected_message_ts: Optional[str] = None,
+        expected_client_msg_id: Optional[str] = None,
+    ) -> bool:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict) or int(state.get("desired_revision") or 0) != int(revision):
+                return False
+            current_ts = str(state.get("message_ts") or "")
+            result_ts = str(message_ts or "")
+            if expected_client_msg_id is not None and str(state.get("client_msg_id") or "") != str(expected_client_msg_id):
+                return False
+            if expected_message_ts is not None and current_ts != str(expected_message_ts):
+                same_idempotent_result = (
+                    current_ts == result_ts
+                    and bool(expected_client_msg_id)
+                    and str(state.get("client_msg_id") or "") == str(expected_client_msg_id)
+                )
+                if not same_idempotent_result:
+                    return False
+            old_ts = str(state.get("message_ts") or "")
+            if old_ts:
+                data["routes"].pop(self._route_key(state.get("team_id", ""), state.get("channel_id", ""), old_ts), None)
+            state["message_ts"] = str(message_ts)
+            if expected_client_msg_id:
+                state["client_msg_id"] = str(expected_client_msg_id)
+            state["applied_revision"] = int(revision)
+            state["applied_hash"] = str(snapshot_hash)
+            if rendered_revision is not None or not int(state.get("applied_render_revision") or 0):
+                state["applied_render_revision"] = int(
+                    revision if rendered_revision is None else rendered_revision
+                )
+            state["retry_count"] = 0
+            state["next_retry_at"] = 0
+            state["updated_at"] = time.time()
+            data["routes"][self._route_key(state.get("team_id", ""), state.get("channel_id", ""), message_ts)] = session_key
+            self._write_unlocked(data)
+            return True
+
+    def record_create_result(
+        self,
+        session_key: str,
+        *,
+        expected_route: Mapping[str, Any],
+        client_msg_id: str,
+        message_ts: str,
+    ) -> str:
+        """Route a completed create to the matching current or retired generation."""
+        created_ts = str(message_ts or "")
+        if not created_ts:
+            return "route_changed"
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return "route_changed"
+            if (
+                self._route_matches(state, expected_route)
+                and str(state.get("client_msg_id") or "") == str(client_msg_id)
+            ):
+                current_ts = str(state.get("message_ts") or "")
+                if current_ts and current_ts != created_ts:
+                    return "conflict"
+                route_key = self._route_key(
+                    state.get("team_id", ""), state.get("channel_id", ""), created_ts
+                )
+                route_owner = str(data["routes"].get(route_key) or "")
+                if route_owner and route_owner != session_key:
+                    return "conflict"
+                state["message_ts"] = created_ts
+                state["updated_at"] = time.time()
+                data["routes"][route_key] = session_key
+                self._write_unlocked(data)
+                return "current"
+            for anchor in state.get("retired_anchors") or []:
+                if (
+                    self._route_matches(anchor, expected_route)
+                    and str(anchor.get("client_msg_id") or "") == str(client_msg_id)
+                ):
+                    retired_ts = str(anchor.get("message_ts") or "")
+                    if retired_ts and retired_ts != created_ts:
+                        return "conflict"
+                    anchor["message_ts"] = created_ts
+                    anchor["updated_at"] = time.time()
+                    self._write_unlocked(data)
+                    return "retired"
+            return "route_changed"
+
+    def reset_missing_anchor(self, session_key: str, *, expected_message_ts: str) -> bool:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict) or str(state.get("message_ts") or "") != str(expected_message_ts):
+                return False
+            data["routes"].pop(self._route_key(
+                state.get("team_id", ""), state.get("channel_id", ""), expected_message_ts
+            ), None)
+            state["message_ts"] = ""
+            state["client_msg_id"] = ""
+            state["create_attempted_at"] = 0
+            state["applied_hash"] = ""
+            state["applied_render_revision"] = 0
+            state["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return True
+
+    def list_retired(self, session_key: str, *, now: Optional[float] = None) -> list[dict[str, Any]]:
+        current = time.time() if now is None else now
+        with self._locked():
+            data = self._read_unlocked()
+            state = data.get("sessions", {}).get(session_key)
+            if not isinstance(state, dict):
+                return []
+            return [
+                dict(anchor) for anchor in state.get("retired_anchors") or []
+                if float(anchor.get("next_retry_at") or 0) <= current
+            ]
+
+    def mark_retired_retry(
+        self,
+        session_key: str,
+        anchor_id: str,
+        *,
+        base_seconds: float = 1.0,
+        max_seconds: float = 60.0,
+    ) -> None:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return
+            for anchor in state.get("retired_anchors") or []:
+                if str(anchor.get("anchor_id") or "") != str(anchor_id):
+                    continue
+                count = int(anchor.get("retry_count") or 0) + 1
+                delay = min(max_seconds, base_seconds * (2 ** min(count - 1, 8)))
+                anchor["retry_count"] = count
+                anchor["next_retry_at"] = time.time() + delay + random.uniform(0, delay * 0.2)
+                self._write_unlocked(data)
+                return
+
+    def complete_retired_cleanup(self, session_key: str, anchor_id: str) -> bool:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return False
+            before = list(state.get("retired_anchors") or [])
+            after = [
+                anchor for anchor in before
+                if str(anchor.get("anchor_id") or "") != str(anchor_id)
+            ]
+            if len(after) == len(before):
+                return False
+            state["retired_anchors"] = after
+            state["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return True
+
+    def retire_orphan_anchor(
+        self,
+        session_key: str,
+        anchor: Mapping[str, Any],
+    ) -> bool:
+        """Durably queue a conflict-created remote message for cleanup."""
+        message_ts = str(anchor.get("message_ts") or "")
+        if not message_ts:
+            return False
+        identity = (
+            str(anchor.get("team_id") or ""),
+            str(anchor.get("channel_id") or ""),
+            message_ts,
+            str(anchor.get("client_msg_id") or ""),
+        )
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return False
+            retired = state.setdefault("retired_anchors", [])
+            for existing in retired:
+                existing_identity = (
+                    str(existing.get("team_id") or ""),
+                    str(existing.get("channel_id") or ""),
+                    str(existing.get("message_ts") or ""),
+                    str(existing.get("client_msg_id") or ""),
+                )
+                if existing_identity == identity:
+                    return False
+            candidate = self._retired_anchor_from_state({
+                **anchor,
+                "session_key": str(anchor.get("session_key") or session_key),
+            })
+            candidate["message_ts"] = message_ts
+            candidate["client_msg_id"] = str(anchor.get("client_msg_id") or "")
+            retired.append(candidate)
+            state["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return True
+
+    def mark_retry(self, session_key: str, *, base_seconds: float = 1.0, max_seconds: float = 60.0) -> None:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return
+            count = int(state.get("retry_count") or 0) + 1
+            delay = min(max_seconds, base_seconds * (2 ** min(count - 1, 8)))
+            state["retry_count"] = count
+            state["next_retry_at"] = time.time() + delay + random.uniform(0, delay * 0.2)
+            self._write_unlocked(data)
+
+    def request_refresh(self, session_key: str) -> Optional[dict[str, Any]]:
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return None
+            state["desired_revision"] = int(state.get("desired_revision") or 0) + 1
+            state["applied_hash"] = ""
+            state["next_retry_at"] = 0
+            state["updated_at"] = time.time()
+            self._write_unlocked(data)
+            return dict(state)
+
+    def lookup_route(self, team_id: str, channel_id: str, message_ts: str) -> Optional[dict[str, Any]]:
+        with self._locked():
+            data = self._read_unlocked()
+            if data.get("_corrupt"):
+                return None
+            session_key = data["routes"].get(self._route_key(team_id, channel_id, message_ts))
+            state = data["sessions"].get(session_key) if session_key else None
+            return dict(state) if isinstance(state, dict) else None
+
+    def validate_action(self, metadata: Mapping[str, Any]) -> Optional[dict[str, Any]]:
+        required = ("session_key", "session_id", "team_id", "channel_id", "message_ts", "revision", "snapshot_hash")
+        if any(metadata.get(key) in (None, "") for key in required):
+            return None
+        with self._locked():
+            data = self._read_unlocked()
+            if data.get("_corrupt"):
+                return None
+            route_key = self._route_key(
+                str(metadata["team_id"]),
+                str(metadata["channel_id"]),
+                str(metadata["message_ts"]),
+            )
+            session_key = str(data["routes"].get(route_key) or "")
+            state = data["sessions"].get(session_key)
+            if not isinstance(state, dict):
+                return None
+            comparisons = {
+                "session_key": state.get("session_key"),
+                "session_id": state.get("session_id"),
+                "team_id": state.get("team_id"),
+                "channel_id": state.get("channel_id"),
+                "thread_ts": state.get("thread_ts"),
+                "message_ts": state.get("message_ts"),
+                "revision": state.get("desired_revision"),
+                "snapshot_hash": state.get("desired_hash"),
+            }
+            if any(str(metadata.get(key)) != str(expected) for key, expected in comparisons.items()):
+                return None
+            task_ids = {task["id"] for task in state.get("last_desired_snapshot") or []}
+            if not set(metadata.get("task_ids") or []).issubset(task_ids):
+                return None
+            return dict(state)
+
+    def consume_action_id(self, action_id: str) -> bool:
+        if not action_id:
+            return False
+        with self._locked():
+            data = self._read_unlocked(strict=True)
+            ids = [str(value) for value in data.get("action_ids") or []]
+            if action_id in ids:
+                return False
+            ids.append(action_id)
+            data["action_ids"] = ids[-MAX_ACTION_DEDUPE_IDS:]
+            self._write_unlocked(data)
+            return True
+
+
+__all__ = [
+    "MAX_INTERACTIVE_TASKS",
+    "PlanCardStore",
+    "RenderedPlan",
+    "build_plan_blocks",
+    "decode_action_value",
+    "encode_action_value",
+    "normalize_todos",
+    "parse_todo_result",
+    "sign_private_metadata",
+    "snapshot_hash",
+    "verify_private_metadata",
+]

--- a/plugins/platforms/slack/plan_cards.py
+++ b/plugins/platforms/slack/plan_cards.py
@@ -1,16 +1,13 @@
-"""Native Slack plan-card rendering and durable projection state.
+"""Native read-only Slack plan-card rendering and durable projection state.
 
-The todo tool remains authoritative. This module only stores the latest desired
-Slack projection, the last applied projection, and the reverse route needed to
-validate interactive payloads.
+The todo tool remains authoritative. This module stores the latest desired
+Slack projection, the last applied projection, and stable message anchors.
 """
 
 from __future__ import annotations
 
-import base64
 import contextlib
 import hashlib
-import hmac
 import json
 import os
 import random
@@ -23,24 +20,8 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Iterator, Mapping, Optional, Sequence
 
-from tools.todo_tool import MAX_TODO_ITEMS
-
-
 STATE_VERSION = 1
-MAX_INTERACTIVE_TASKS = 10
-MAX_USER_TASK_CONTENT_LENGTH = 3000
 MAX_NATIVE_TASK_TITLE_LENGTH = 3000
-MAX_ACTION_DEDUPE_IDS = 512
-USER_TASK_ID_PREFIX = "user:"
-INTERACTIVE_USER_TASK_STATUSES = frozenset({"in_progress", "completed"})
-PLAN_ACTION_COMPLETE_REOPEN = "complete_reopen"
-PLAN_ACTION_CANCEL = "cancel"
-PLAN_ACTION_ADD_USER_TASK = "add_user_task"
-PLAN_MUTATION_ACTIONS = frozenset({
-    PLAN_ACTION_COMPLETE_REOPEN,
-    PLAN_ACTION_CANCEL,
-    PLAN_ACTION_ADD_USER_TASK,
-})
 _NATIVE_TITLE_TRUNCATION_SUFFIX = "... [truncated]"
 _STATUS_LABELS = {
     "pending": "Pending",
@@ -71,30 +52,6 @@ def _json_loads_prefix(value: str) -> Any:
     except json.JSONDecodeError:
         data, _ = json.JSONDecoder().raw_decode(text)
         return data
-
-
-def is_user_task_id(value: Any) -> bool:
-    return (
-        isinstance(value, str)
-        and value.startswith(USER_TASK_ID_PREFIX)
-        and len(value) > len(USER_TASK_ID_PREFIX)
-    )
-
-
-def _is_slack_human_user_id(value: Any) -> bool:
-    user_id = str(value or "")
-    return (
-        len(user_id) > 1
-        and user_id == user_id.strip()
-        and user_id.startswith(("U", "W"))
-    )
-
-
-def is_interactive_user_task(task: Mapping[str, Any]) -> bool:
-    return (
-        is_user_task_id(task.get("id"))
-        and task.get("status") in INTERACTIVE_USER_TASK_STATUSES
-    )
 
 
 def normalize_todos(todos: Sequence[Mapping[str, Any]]) -> list[dict[str, str]]:
@@ -131,46 +88,6 @@ def snapshot_hash(todos: Sequence[Mapping[str, Any]]) -> str:
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
-def encode_action_value(payload: Mapping[str, Any]) -> str:
-    raw = json.dumps(dict(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
-
-
-def decode_action_value(value: Any) -> Optional[dict[str, Any]]:
-    if not isinstance(value, str) or not value:
-        return None
-    try:
-        padded = value + "=" * (-len(value) % 4)
-        decoded = json.loads(base64.urlsafe_b64decode(padded.encode("ascii")))
-    except Exception:
-        return None
-    return decoded if isinstance(decoded, dict) else None
-
-
-def sign_private_metadata(payload: Mapping[str, Any], secret: Optional[bytes]) -> Optional[str]:
-    if not secret:
-        return None
-    body = json.dumps(dict(payload), sort_keys=True, separators=(",", ":"))
-    signature = hmac.new(secret, body.encode("utf-8"), hashlib.sha256).hexdigest()
-    return json.dumps({"payload": dict(payload), "signature": signature}, separators=(",", ":"))
-
-
-def verify_private_metadata(value: Any, secret: Optional[bytes]) -> Optional[dict[str, Any]]:
-    if not secret or not isinstance(value, str):
-        return None
-    try:
-        envelope = json.loads(value)
-        payload = envelope["payload"]
-        signature = str(envelope["signature"])
-        body = json.dumps(payload, sort_keys=True, separators=(",", ":"))
-        expected = hmac.new(secret, body.encode("utf-8"), hashlib.sha256).hexdigest()
-    except Exception:
-        return None
-    if not isinstance(payload, dict) or not hmac.compare_digest(signature, expected):
-        return None
-    return payload
-
-
 @dataclass(frozen=True)
 class RenderedPlan:
     text: str
@@ -190,10 +107,6 @@ class _RetrySchedule:
     deadline: Optional[float] = None
 
 
-def _plain_text(text: str) -> dict[str, Any]:
-    return {"type": "plain_text", "text": text[:3000], "emoji": True}
-
-
 def _native_task_title(task: Mapping[str, str]) -> str:
     title = task["content"]
     if task["status"] == "cancelled":
@@ -204,94 +117,11 @@ def _native_task_title(task: Mapping[str, str]) -> str:
     return title[:prefix_length] + _NATIVE_TITLE_TRUNCATION_SUFFIX
 
 
-def _control_blocks(
-    todos: list[dict[str, str]],
-    *,
-    revision: int,
-    desired_hash: str,
-    signing_secret: Optional[bytes],
-    action_context: Optional[Mapping[str, Any]],
-) -> list[dict[str, Any]]:
-    base = dict(action_context or {})
-    base.update({"revision": revision, "snapshot_hash": desired_hash})
-    encoded = encode_action_value(base)
-    has_mutation_owner = _is_slack_human_user_id(base.get("route_user_id"))
-    user_tasks = [task for task in todos if is_interactive_user_task(task)]
-    over_capacity = len(user_tasks) > MAX_INTERACTIVE_TASKS
-    completed = {
-        task["id"] for task in user_tasks if task["status"] == "completed"
-    }
-    checkbox_options = [
-        {
-            "text": _plain_text(task["content"][:75]),
-            "value": task["id"],
-        }
-        for task in user_tasks
-    ]
-    elements: list[dict[str, Any]] = []
-    if has_mutation_owner and checkbox_options and not over_capacity:
-        checkbox: dict[str, Any] = {
-            "type": "checkboxes",
-            "action_id": "hermes_plan_complete",
-            "options": checkbox_options,
-            "confirm": {
-                "title": _plain_text("Update tasks"),
-                "text": _plain_text("Complete checked tasks and reopen unchecked tasks?"),
-                "confirm": _plain_text("Update"),
-                "deny": _plain_text("Back"),
-            },
-        }
-        selected = [option for option in checkbox_options if option["value"] in completed]
-        if selected:
-            checkbox["initial_options"] = selected
-        elements.append(checkbox)
-    cancel_options = [
-        {"text": _plain_text(task["content"][:75]), "value": task["id"]}
-        for task in user_tasks
-        if task["status"] == "in_progress"
-    ]
-    if has_mutation_owner and cancel_options and not over_capacity:
-        elements.append({
-            "type": "static_select",
-            "action_id": "hermes_plan_cancel",
-            "placeholder": _plain_text("Cancel task"),
-            "options": cancel_options,
-        })
-    if (
-        signing_secret
-        and has_mutation_owner
-        and not over_capacity
-        and len(user_tasks) < MAX_INTERACTIVE_TASKS
-        and len(todos) < MAX_TODO_ITEMS
-    ):
-        elements.append({
-            "type": "button",
-            "action_id": "hermes_plan_add",
-            "text": _plain_text("Add user task"),
-            "value": encoded,
-        })
-    elements.append({
-        "type": "button",
-        "action_id": "hermes_plan_refresh",
-        "text": _plain_text("Refresh"),
-        "value": encoded,
-    })
-    if not elements:
-        return []
-    return [{
-        "type": "actions",
-        "block_id": f"hermes-plan-controls-r{revision}-{desired_hash[:10]}",
-        "elements": elements,
-    }]
-
-
 def build_plan_blocks(
     todos: Sequence[Mapping[str, Any]],
     *,
     revision: int,
     snapshot_hash: str,
-    signing_secret: Optional[bytes],
-    action_context: Optional[Mapping[str, Any]] = None,
 ) -> RenderedPlan:
     tasks = normalize_todos(todos)
     count = len(tasks)
@@ -311,40 +141,17 @@ def build_plan_blocks(
         "title": "Hermes plan",
         "tasks": native_tasks,
     }]
-    native.extend(_control_blocks(
-        tasks,
-        revision=revision,
-        desired_hash=snapshot_hash,
-        signing_secret=signing_secret,
-        action_context=action_context,
-    ))
-
     lines = [f"*Hermes plan* ({count} tasks)"]
     for task in tasks:
         label = _STATUS_LABELS[task["status"]]
         lines.append(f"• *{label}* `{task['id']}` — {task['content']}")
-    user_task_count = sum(is_interactive_user_task(task) for task in tasks)
-    if user_task_count > MAX_INTERACTIVE_TASKS:
-        lines.append(
-            f"_User task mutation controls unavailable: this plan has {user_task_count} "
-            f"mutable user tasks; the safe control limit is {MAX_INTERACTIVE_TASKS}. Refresh remains available._"
-        )
     fallback_text = "\n".join(lines)
     chunks = [
         fallback_text[index:index + 3000]
         for index in range(0, len(fallback_text), 3000)
     ]
-    control_blocks = _control_blocks(
-        tasks,
-        revision=revision,
-        desired_hash=snapshot_hash,
-        signing_secret=signing_secret,
-        action_context=action_context,
-    )
     max_fallback_blocks = 50
-    if len(control_blocks) > max_fallback_blocks:
-        control_blocks = []
-    text_block_budget = max_fallback_blocks - len(control_blocks)
+    text_block_budget = max_fallback_blocks
     truncated = len(chunks) > text_block_budget
     section_limit = text_block_budget
     if truncated and text_block_budget:
@@ -369,8 +176,6 @@ def build_plan_blocks(
                 ),
             }],
         })
-    if len(fallback) + len(control_blocks) <= max_fallback_blocks:
-        fallback.extend(control_blocks)
     return RenderedPlan(text=text, native_blocks=native, fallback_blocks=fallback)
 
 
@@ -420,18 +225,18 @@ class PlanCardStore:
 
     def _read_unlocked(self, *, strict: bool = False) -> dict[str, Any]:
         if not self.state_path.exists():
-            return {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": []}
+            return {"version": STATE_VERSION, "sessions": {}, "routes": {}}
         try:
             data = json.loads(self.state_path.read_text(encoding="utf-8"))
             if not isinstance(data, dict) or not isinstance(data.get("sessions"), dict):
                 raise ValueError("invalid root")
             data.setdefault("routes", {})
-            data.setdefault("action_ids", [])
+            data.pop("action_ids", None)
             return data
         except Exception as exc:
             if strict:
                 raise ValueError(f"Slack plan-card state is corrupt: {exc}") from exc
-            return {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": [], "_corrupt": True}
+            return {"version": STATE_VERSION, "sessions": {}, "routes": {}, "_corrupt": True}
 
     def _write_unlocked(self, data: Mapping[str, Any]) -> None:
         self.state_path.parent.mkdir(parents=True, exist_ok=True)
@@ -518,10 +323,9 @@ class PlanCardStore:
                 data = self._read_unlocked(strict=True)
             except ValueError:
                 # Todo is authoritative. Quarantine unreadable projection state
-                # and rebuild from this full successful snapshot; interactive
-                # reads remain fail-closed until this recovery write occurs.
+                # and rebuild from this full successful snapshot.
                 self._quarantine_corrupt_unlocked()
-                data = {"version": STATE_VERSION, "sessions": {}, "routes": {}, "action_ids": []}
+                data = {"version": STATE_VERSION, "sessions": {}, "routes": {}}
             prior = dict(data["sessions"].get(session_key) or {})
             prior_message_ts = str(prior.get("message_ts") or "")
             def route_value(key: str, default: str = "") -> str:
@@ -898,19 +702,6 @@ class PlanCardStore:
             state["next_retry_at"] = time.time() + delay + random.uniform(0, delay * 0.2)
             self._write_unlocked(data)
 
-    def request_refresh(self, session_key: str) -> Optional[dict[str, Any]]:
-        with self._locked():
-            data = self._read_unlocked(strict=True)
-            state = data["sessions"].get(session_key)
-            if not isinstance(state, dict):
-                return None
-            state["desired_revision"] = int(state.get("desired_revision") or 0) + 1
-            state["applied_hash"] = ""
-            state["next_retry_at"] = 0
-            state["updated_at"] = time.time()
-            self._write_unlocked(data)
-            return dict(state)
-
     def lookup_route(self, team_id: str, channel_id: str, message_ts: str) -> Optional[dict[str, Any]]:
         with self._locked():
             data = self._read_unlocked()
@@ -920,199 +711,11 @@ class PlanCardStore:
             state = data["sessions"].get(session_key) if session_key else None
             return dict(state) if isinstance(state, dict) else None
 
-    def validate_action(self, metadata: Mapping[str, Any]) -> Optional[dict[str, Any]]:
-        required = ("session_key", "session_id", "team_id", "channel_id", "message_ts", "revision", "snapshot_hash")
-        if any(metadata.get(key) in (None, "") for key in required):
-            return None
-        with self._locked():
-            data = self._read_unlocked()
-            if data.get("_corrupt"):
-                return None
-            route_key = self._route_key(
-                str(metadata["team_id"]),
-                str(metadata["channel_id"]),
-                str(metadata["message_ts"]),
-            )
-            session_key = str(data["routes"].get(route_key) or "")
-            state = data["sessions"].get(session_key)
-            if not isinstance(state, dict):
-                return None
-            comparisons = {
-                "session_key": state.get("session_key"),
-                "session_id": state.get("session_id"),
-                "team_id": state.get("team_id"),
-                "channel_id": state.get("channel_id"),
-                "thread_ts": state.get("thread_ts"),
-                "profile": state.get("profile"),
-                "message_ts": state.get("message_ts"),
-                "revision": state.get("desired_revision"),
-                "snapshot_hash": state.get("desired_hash"),
-            }
-            if any(str(metadata.get(key)) != str(expected) for key, expected in comparisons.items()):
-                return None
-            action_kind = metadata.get("action_kind")
-            if action_kind not in PLAN_MUTATION_ACTIONS:
-                return None
-            action_user_id = str(metadata.get("action_user_id") or "")
-            if not action_user_id:
-                return None
-            route_user_id = str(state.get("route_user_id") or "")
-            if (
-                not _is_slack_human_user_id(route_user_id)
-                or action_user_id != route_user_id
-            ):
-                return None
-            action_dedupe_id = str(metadata.get("action_dedupe_id") or "")
-            if not action_dedupe_id or action_dedupe_id not in {
-                str(value) for value in data.get("action_ids") or []
-            }:
-                return None
-
-            snapshot = state.get("last_desired_snapshot")
-            if not isinstance(snapshot, list) or any(
-                not isinstance(task, Mapping) for task in snapshot
-            ):
-                return None
-            tasks = normalize_todos(snapshot)
-            if len(tasks) != len(snapshot):
-                return None
-            snapshot_ids = [task["id"] for task in tasks]
-            if len(snapshot_ids) != len(set(snapshot_ids)):
-                return None
-            if snapshot_hash(tasks) != str(state.get("desired_hash") or ""):
-                return None
-            by_id = {task["id"]: task for task in tasks}
-            user_task_count = sum(is_interactive_user_task(task) for task in tasks)
-            if user_task_count > MAX_INTERACTIVE_TASKS:
-                return None
-
-            def id_list(key: str) -> Optional[list[str]]:
-                value = metadata.get(key)
-                if not isinstance(value, list) or any(
-                    not isinstance(task_id, str) or not task_id for task_id in value
-                ):
-                    return None
-                if len(value) != len(set(value)):
-                    return None
-                return value
-
-            task_ids = id_list("task_ids")
-            if task_ids is None:
-                return None
-            change_keys = {
-                "complete_task_ids", "reopen_task_ids", "cancel_task_ids",
-                "add_task_ids", "add_task_content", "complete_task_status",
-                "reopen_task_status", "cancel_task_status", "add_task_status",
-            }
-
-            if action_kind == PLAN_ACTION_COMPLETE_REOPEN:
-                if any(key in metadata for key in change_keys - {
-                    "complete_task_ids", "reopen_task_ids",
-                    "complete_task_status", "reopen_task_status",
-                }):
-                    return None
-                complete_ids = id_list("complete_task_ids")
-                reopen_ids = id_list("reopen_task_ids")
-                if (
-                    complete_ids is None
-                    or reopen_ids is None
-                    or metadata.get("complete_task_status") != "completed"
-                    or metadata.get("reopen_task_status") != "in_progress"
-                ):
-                    return None
-                combined = complete_ids + reopen_ids
-                if not combined or len(combined) != len(set(combined)):
-                    return None
-                if task_ids != sorted(combined):
-                    return None
-                if any(
-                    not is_user_task_id(task_id)
-                    or task_id not in by_id
-                    or by_id[task_id]["status"] != "in_progress"
-                    for task_id in complete_ids
-                ):
-                    return None
-                if any(
-                    not is_user_task_id(task_id)
-                    or task_id not in by_id
-                    or by_id[task_id]["status"] != "completed"
-                    for task_id in reopen_ids
-                ):
-                    return None
-            elif action_kind == PLAN_ACTION_CANCEL:
-                if any(key in metadata for key in change_keys - {
-                    "cancel_task_ids", "cancel_task_status",
-                }):
-                    return None
-                cancel_ids = id_list("cancel_task_ids")
-                if (
-                    cancel_ids is None
-                    or len(cancel_ids) != 1
-                    or task_ids != cancel_ids
-                    or metadata.get("cancel_task_status") != "cancelled"
-                ):
-                    return None
-                task_id = cancel_ids[0]
-                if (
-                    not is_user_task_id(task_id)
-                    or task_id not in by_id
-                    or by_id[task_id]["status"] != "in_progress"
-                ):
-                    return None
-            else:
-                if any(key in metadata for key in change_keys - {
-                    "add_task_ids", "add_task_content", "add_task_status",
-                }):
-                    return None
-                add_ids = id_list("add_task_ids")
-                content = metadata.get("add_task_content")
-                if (
-                    add_ids is None
-                    or len(add_ids) != 1
-                    or task_ids != add_ids
-                    or not is_user_task_id(add_ids[0])
-                    or add_ids[0] in by_id
-                    or len(tasks) >= MAX_TODO_ITEMS
-                    or user_task_count >= MAX_INTERACTIVE_TASKS
-                    or metadata.get("add_task_status") != "in_progress"
-                    or not isinstance(content, str)
-                    or not content.strip()
-                    or len(content) > MAX_USER_TASK_CONTENT_LENGTH
-                ):
-                    return None
-            return dict(state)
-
-    def consume_action_id(self, action_id: str) -> bool:
-        if not action_id:
-            return False
-        with self._locked():
-            data = self._read_unlocked(strict=True)
-            ids = [str(value) for value in data.get("action_ids") or []]
-            if action_id in ids:
-                return False
-            ids.append(action_id)
-            data["action_ids"] = ids[-MAX_ACTION_DEDUPE_IDS:]
-            self._write_unlocked(data)
-            return True
-
-
 __all__ = [
-    "MAX_INTERACTIVE_TASKS",
-    "MAX_USER_TASK_CONTENT_LENGTH",
-    "PLAN_ACTION_ADD_USER_TASK",
-    "PLAN_ACTION_CANCEL",
-    "PLAN_ACTION_COMPLETE_REOPEN",
     "PlanCardStore",
     "RenderedPlan",
     "build_plan_blocks",
-    "decode_action_value",
-    "encode_action_value",
-    "is_interactive_user_task",
-    "is_user_task_id",
     "normalize_todos",
     "parse_todo_result",
-    "sign_private_metadata",
     "snapshot_hash",
-    "USER_TASK_ID_PREFIX",
-    "verify_private_metadata",
 ]

--- a/plugins/platforms/slack/plugin.yaml
+++ b/plugins/platforms/slack/plugin.yaml
@@ -29,6 +29,10 @@ optional_env:
     description: "Allow any Slack user to trigger the bot (dev only)"
     prompt: "Allow all users? (true/false)"
     password: false
+  - name: SLACK_SIGNING_SECRET
+    description: "Slack app signing secret used to authenticate plan-card modal metadata"
+    prompt: "Slack Signing Secret (optional)"
+    password: true
   - name: SLACK_HOME_CHANNEL
     description: "Default channel ID for cron / notification delivery (starts with C)"
     prompt: "Home channel ID"

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1573,6 +1573,118 @@ class TestLoadGatewayConfig:
             "C01ABC": "Code review mode",
         }
 
+    def test_bridges_slack_native_plan_cards_from_top_level_yaml(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            "  native_plan_cards: true\n"
+            "  unrecognized_plan_setting: should-not-bridge\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.SLACK].extra
+        assert extra["native_plan_cards"] is True
+        assert "unrecognized_plan_setting" not in extra
+
+    def test_slack_native_plan_signing_secret_stays_in_extra(self, tmp_path, monkeypatch, caplog):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        secret = "plan-signing-secret-" + "a" * 44
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n"
+            f"  native_plan_cards_signing_secret: {secret}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+        monkeypatch.delenv("SLACK_NATIVE_PLAN_CARDS_SIGNING_SECRET", raising=False)
+
+        config = load_gateway_config()
+
+        assert (
+            config.platforms[Platform.SLACK].extra[
+                "native_plan_cards_signing_secret"
+            ]
+            == secret
+        )
+        assert secret not in os.environ.values()
+        assert secret not in caplog.text
+
+    def test_slack_native_plan_cards_false_remains_false(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  native_plan_cards: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.platforms[Platform.SLACK].extra["native_plan_cards"] is False
+
+    def test_absent_slack_native_plan_keys_stay_absent(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "slack:\n  require_mention: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("SLACK_REQUIRE_MENTION", raising=False)
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.SLACK].extra
+        assert "native_plan_cards" not in extra
+        assert "native_plan_cards_signing_secret" not in extra
+        assert os.environ["SLACK_REQUIRE_MENTION"] == "true"
+
+    def test_nested_slack_native_plan_extra_still_loads(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    extra:\n"
+            "      native_plan_cards: true\n"
+            "      native_plan_cards_signing_secret: nested-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.SLACK].extra
+        assert extra["native_plan_cards"] is True
+        assert extra["native_plan_cards_signing_secret"] == "nested-secret"
+
+    def test_nested_slack_native_plan_extra_keeps_existing_precedence(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "platforms:\n"
+            "  slack:\n"
+            "    extra:\n"
+            "      native_plan_cards: false\n"
+            "      native_plan_cards_signing_secret: nested-secret\n"
+            "slack:\n"
+            "  native_plan_cards: true\n"
+            "  native_plan_cards_signing_secret: top-level-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        extra = config.platforms[Platform.SLACK].extra
+        assert extra["native_plan_cards"] is True
+        assert extra["native_plan_cards_signing_secret"] == "top-level-secret"
+
     def test_bridges_feishu_allow_bots_from_config_yaml_to_env(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"
         hermes_home.mkdir()

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -898,6 +898,9 @@ class TestSlackProxyBehavior:
 
                 return decorator
 
+            def view(self, callback_id):
+                return self.action(callback_id)
+
         class FakeSocketModeHandler:
             def __init__(self, app, app_token, proxy=None):
                 self.app = app
@@ -992,6 +995,9 @@ class TestSlackProxyBehavior:
                     return fn
 
                 return decorator
+
+            def view(self, callback_id):
+                return self.action(callback_id)
 
         class FakeSocketModeHandler:
             def __init__(self, app, app_token, proxy=None):

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -638,9 +638,9 @@ async def test_hash_dedupe_keeps_existing_card_actions_valid(tmp_path) -> None:
     adapter = _adapter(tmp_path)
     client = adapter._team_clients["T1"]
     client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
-    first = _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
+    first = _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
     assert await _reconcile(adapter, "sk", first["desired_revision"])
-    same = _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
+    same = _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
     assert await _reconcile(adapter, "sk", same["desired_revision"])
     client.chat_update.assert_not_awaited()
 
@@ -1714,7 +1714,7 @@ async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_
     adapter = _adapter(tmp_path)
     _state(adapter, [
         {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:a", "content": "A", "status": "pending"},
+        {"id": "user:a", "content": "A", "status": "in_progress"},
         {"id": "user:b", "content": "B", "status": "completed"},
     ])
     adapter._plan_store.mark_applied(
@@ -1759,9 +1759,13 @@ async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_
     assert trusted["action_kind"] == "complete_reopen"
     assert trusted["task_ids"] == ["user:a", "user:b"]
     assert trusted["complete_task_ids"] == ["user:a"]
+    assert trusted["complete_task_status"] == "completed"
     assert trusted["reopen_task_ids"] == ["user:b"]
+    assert trusted["reopen_task_status"] == "in_progress"
     assert trusted["revision"] == 1
     assert "todo" in event.text.lower()
+    assert '"complete_task_status": "completed"' in event.text
+    assert '"reopen_task_status": "in_progress"' in event.text
     assert adapter.validate_plan_action_metadata(trusted)
 
     await adapter._handle_plan_action(ack, body, action)
@@ -1804,8 +1808,12 @@ async def test_plan_action_rejects_mixed_duplicate_and_ineligible_ids_atomically
         },
         {
             "action_id": "hermes_plan_complete", "block_id": block_id,
+            "selected_options": [{"value": "user:pending"}],
+        },
+        {
+            "action_id": "hermes_plan_complete", "block_id": block_id,
             "selected_options": [
-                {"value": "user:pending"}, {"value": "user:pending"},
+                {"value": "user:active"}, {"value": "user:active"},
             ],
         },
         {
@@ -1818,7 +1826,7 @@ async def test_plan_action_rejects_mixed_duplicate_and_ineligible_ids_atomically
         },
         {
             "action_id": "hermes_plan_cancel", "block_id": block_id,
-            "selected_option": {"value": "user:active"},
+            "selected_option": {"value": "user:pending"},
         },
     )):
         body["actions"][0]["action_ts"] = f"invalid-{index}"
@@ -1830,19 +1838,20 @@ async def test_plan_action_rejects_mixed_duplicate_and_ineligible_ids_atomically
     body["actions"][0]["action_ts"] = "valid-cancel"
     await adapter._handle_plan_action(AsyncMock(), body, {
         "action_id": "hermes_plan_cancel", "block_id": block_id,
-        "selected_option": {"value": "user:pending"},
+        "selected_option": {"value": "user:active"},
     })
     await asyncio.sleep(0)
     assert len(events) == 1
     assert events[0].metadata["slack_plan_action"]["action_kind"] == "cancel"
-    assert events[0].metadata["slack_plan_action"]["cancel_task_ids"] == ["user:pending"]
+    assert events[0].metadata["slack_plan_action"]["cancel_task_ids"] == ["user:active"]
+    assert events[0].metadata["slack_plan_action"]["cancel_task_status"] == "cancelled"
 
 
 def test_adapter_claim_validator_rejects_direct_forged_plan_metadata(tmp_path) -> None:
     adapter = _adapter(tmp_path)
     state = _state(adapter, [
         {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:a", "content": "User", "status": "pending"},
+        {"id": "user:a", "content": "User", "status": "in_progress"},
     ])
     assert adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -1857,15 +1866,19 @@ def test_adapter_claim_validator_rejects_direct_forged_plan_metadata(tmp_path) -
     assert not adapter.validate_plan_action_metadata({
         **base, "action_kind": "complete_reopen",
         "task_ids": ["agent:a", "user:a"],
-        "complete_task_ids": ["agent:a", "user:a"], "reopen_task_ids": [],
+        "complete_task_ids": ["agent:a", "user:a"],
+        "complete_task_status": "completed", "reopen_task_ids": [],
+        "reopen_task_status": "in_progress",
     })
     assert not adapter.validate_plan_action_metadata({
         **base, "action_kind": "complete_reopen", "task_ids": ["agent:a"],
-        "complete_task_ids": [], "reopen_task_ids": ["agent:a"],
+        "complete_task_ids": [], "complete_task_status": "completed",
+        "reopen_task_ids": ["agent:a"], "reopen_task_status": "in_progress",
     })
     assert not adapter.validate_plan_action_metadata({
         **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
         "add_task_ids": ["user:replacement"], "add_task_content": "New",
+        "add_task_status": "in_progress",
     })
 
 
@@ -1906,7 +1919,7 @@ async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_p
     adapter = _adapter(tmp_path)
     _state(
         adapter,
-        [{"id": "user:a", "content": "A", "status": "pending"}],
+        [{"id": "user:a", "content": "A", "status": "in_progress"}],
         route_user_id="U-owner",
         chat_type=chat_type,
     )
@@ -1948,7 +1961,7 @@ async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_p
 @pytest.mark.parametrize("invalid_field", ["team", "channel", "message", "thread", "block"])
 async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path, invalid_field) -> None:
     adapter = _adapter(tmp_path)
-    _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
+    _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
     state = adapter._plan_store.get_session("sk")
     adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -1982,7 +1995,7 @@ async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path,
 @pytest.mark.asyncio
 async def test_plan_action_queues_silently_when_original_session_is_busy(tmp_path) -> None:
     adapter = _adapter(tmp_path)
-    _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
+    _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
     state = adapter._plan_store.get_session("sk")
     adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -2084,7 +2097,10 @@ async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) 
     assert trusted["add_task_ids"] == [generated_id]
     assert trusted["task_ids"] == [generated_id]
     assert trusted["add_task_content"] == "New task"
-    assert generated_id in events[0].text
+    assert trusted["add_task_status"] == "in_progress"
+    assert f'"add_task_ids": ["{generated_id}"]' in events[0].text
+    assert '"add_task_content": "New task"' in events[0].text
+    assert '"add_task_status": "in_progress"' in events[0].text
 
     await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
     assert len(events) == 1
@@ -2097,18 +2113,18 @@ async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) 
 
 
 @pytest.mark.asyncio
-async def test_inactive_user_tasks_do_not_block_pending_action_or_add_modal(tmp_path) -> None:
+async def test_future_user_tasks_do_not_block_active_action_or_add_modal(tmp_path) -> None:
     adapter = _adapter(tmp_path)
-    inactive = [
+    read_only = [
         {
-            "id": f"user:inactive-{index}",
+            "id": f"user:read-only-{index}",
             "content": str(index),
-            "status": "cancelled" if index % 2 else "in_progress",
+            "status": "cancelled" if index % 2 else "pending",
         }
         for index in range(15)
     ]
-    state = _state(adapter, inactive + [
-        {"id": "user:pending", "content": "Pending", "status": "pending"},
+    state = _state(adapter, read_only + [
+        {"id": "user:active", "content": "Active", "status": "in_progress"},
     ])
     assert adapter._plan_store.mark_applied(
         "sk", revision=state["desired_revision"],
@@ -2131,11 +2147,11 @@ async def test_inactive_user_tasks_do_not_block_pending_action_or_add_modal(tmp_
     block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
     await adapter._handle_plan_action(AsyncMock(), body, {
         "action_id": "hermes_plan_complete", "block_id": block_id,
-        "selected_options": [{"value": "user:pending"}],
+        "selected_options": [{"value": "user:active"}],
     })
     await asyncio.sleep(0)
     assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["complete_task_ids"] == ["user:pending"]
+    assert events[0].metadata["slack_plan_action"]["complete_task_ids"] == ["user:active"]
 
     body["actions"][0]["action_ts"] = "add"
     await adapter._handle_plan_action(AsyncMock(), body, {
@@ -2203,6 +2219,7 @@ async def test_add_modal_keeps_validated_lineage_across_concurrent_route_change(
     assert trusted["revision"] == original["desired_revision"]
     assert trusted["snapshot_hash"] == original["desired_hash"]
     assert trusted["add_task_ids"] == ["user:new"]
+    assert trusted["add_task_status"] == "in_progress"
 
     runner = object.__new__(GatewayRunner)
     runner.adapters = {events[0].source.platform: adapter}

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -14,7 +14,11 @@ from gateway.platforms.base import MessageEvent
 from gateway.run import GatewayRunner
 from gateway.session import build_session_key
 from plugins.platforms.slack.adapter import SlackAdapter
-from plugins.platforms.slack.plan_cards import sign_private_metadata
+from plugins.platforms.slack.plan_cards import (
+    is_user_task_id,
+    sign_private_metadata,
+    verify_private_metadata,
+)
 
 
 def _adapter(
@@ -35,6 +39,30 @@ def _adapter(
     adapter._channel_team = {"C1": "T1"}
     adapter._plan_signing_secret_override = secret
     return adapter
+
+
+@pytest.mark.parametrize(
+    ("relative_home", "expected_profile"),
+    [
+        ((".hermes",), None),
+        (("hermes-root", "profiles", "secondary"), "secondary"),
+        (("profiles",), None),
+    ],
+)
+def test_adapter_derives_profile_only_from_profile_home_shape(
+    tmp_path, relative_home, expected_profile
+) -> None:
+    home = tmp_path.joinpath(*relative_home)
+    config = PlatformConfig(
+        enabled=True,
+        token="xoxb-test",
+        extra={"native_plan_cards": True},
+    )
+    with patch("hermes_constants.get_hermes_home", return_value=home):
+        adapter = SlackAdapter(config)
+
+    assert adapter._plan_profile == expected_profile
+    assert adapter._plan_store.state_path == home / "gateway" / "slack_plan_cards.json"
 
 
 def _state(
@@ -610,9 +638,9 @@ async def test_hash_dedupe_keeps_existing_card_actions_valid(tmp_path) -> None:
     adapter = _adapter(tmp_path)
     client = adapter._team_clients["T1"]
     client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
-    first = _state(adapter)
+    first = _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
     assert await _reconcile(adapter, "sk", first["desired_revision"])
-    same = _state(adapter)
+    same = _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
     assert await _reconcile(adapter, "sk", same["desired_revision"])
     client.chat_update.assert_not_awaited()
 
@@ -629,7 +657,7 @@ async def test_hash_dedupe_keeps_existing_card_actions_valid(tmp_path) -> None:
     }, {
         "action_id": "hermes_plan_complete",
         "block_id": "hermes-plan-controls-r1-" + first["desired_hash"][:10],
-        "selected_options": [{"value": "a"}],
+        "selected_options": [{"value": "user:a"}],
     })
     await asyncio.sleep(0)
     assert len(events) == 1
@@ -1685,8 +1713,9 @@ async def test_stale_schedule_applies_latest_and_refresh_forces_update(tmp_path)
 async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_event(tmp_path) -> None:
     adapter = _adapter(tmp_path)
     _state(adapter, [
-        {"id": "a", "content": "A", "status": "pending"},
-        {"id": "b", "content": "B", "status": "completed"},
+        {"id": "agent:a", "content": "Agent", "status": "pending"},
+        {"id": "user:a", "content": "A", "status": "pending"},
+        {"id": "user:b", "content": "B", "status": "completed"},
     ])
     adapter._plan_store.mark_applied(
         "sk",
@@ -1712,7 +1741,7 @@ async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_
     action = {
         "action_id": "hermes_plan_complete",
         "block_id": "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10],
-        "selected_options": [{"value": "a"}],
+        "selected_options": [{"value": "user:a"}],
     }
 
     await adapter._handle_plan_action(ack, body, action)
@@ -1727,13 +1756,117 @@ async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_
     assert event.metadata["gateway_session_id"] == "sid"
     trusted = event.metadata["slack_plan_action"]
     assert trusted["action_user_id"] == "U-owner"
-    assert trusted["complete_task_ids"] == ["a"]
-    assert trusted["reopen_task_ids"] == ["b"]
+    assert trusted["action_kind"] == "complete_reopen"
+    assert trusted["task_ids"] == ["user:a", "user:b"]
+    assert trusted["complete_task_ids"] == ["user:a"]
+    assert trusted["reopen_task_ids"] == ["user:b"]
     assert trusted["revision"] == 1
     assert "todo" in event.text.lower()
+    assert adapter.validate_plan_action_metadata(trusted)
 
     await adapter._handle_plan_action(ack, body, action)
     assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_action_rejects_mixed_duplicate_and_ineligible_ids_atomically(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter, [
+        {"id": "agent:a", "content": "Agent", "status": "pending"},
+        {"id": "user:pending", "content": "Pending", "status": "pending"},
+        {"id": "user:done", "content": "Done", "status": "completed"},
+        {"id": "user:active", "content": "Active", "status": "in_progress"},
+    ])
+    state = adapter._plan_store.get_session("sk")
+    adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "mixed"}],
+    }
+    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
+
+    for index, action in enumerate((
+        {
+            "action_id": "hermes_plan_complete", "block_id": block_id,
+            "selected_options": [
+                {"value": "user:pending"}, {"value": "agent:a"},
+            ],
+        },
+        {
+            "action_id": "hermes_plan_complete", "block_id": block_id,
+            "selected_options": [
+                {"value": "user:pending"}, {"value": "user:pending"},
+            ],
+        },
+        {
+            "action_id": "hermes_plan_complete", "block_id": block_id,
+            "selected_options": [{"value": "user:missing"}],
+        },
+        {
+            "action_id": "hermes_plan_cancel", "block_id": block_id,
+            "selected_option": {"value": "agent:a"},
+        },
+        {
+            "action_id": "hermes_plan_cancel", "block_id": block_id,
+            "selected_option": {"value": "user:active"},
+        },
+    )):
+        body["actions"][0]["action_ts"] = f"invalid-{index}"
+        await adapter._handle_plan_action(AsyncMock(), body, action)
+
+    await asyncio.sleep(0)
+    assert events == []
+
+    body["actions"][0]["action_ts"] = "valid-cancel"
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_cancel", "block_id": block_id,
+        "selected_option": {"value": "user:pending"},
+    })
+    await asyncio.sleep(0)
+    assert len(events) == 1
+    assert events[0].metadata["slack_plan_action"]["action_kind"] == "cancel"
+    assert events[0].metadata["slack_plan_action"]["cancel_task_ids"] == ["user:pending"]
+
+
+def test_adapter_claim_validator_rejects_direct_forged_plan_metadata(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter, [
+        {"id": "agent:a", "content": "Agent", "status": "pending"},
+        {"id": "user:a", "content": "User", "status": "pending"},
+    ])
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    base = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0", "message_ts": "20.0",
+        "revision": 1, "snapshot_hash": state["desired_hash"],
+        "action_user_id": "U-owner", "action_dedupe_id": "dedupe",
+    }
+    assert adapter._plan_store.consume_action_id("dedupe")
+    assert not adapter.validate_plan_action_metadata({
+        **base, "action_kind": "complete_reopen",
+        "task_ids": ["agent:a", "user:a"],
+        "complete_task_ids": ["agent:a", "user:a"], "reopen_task_ids": [],
+    })
+    assert not adapter.validate_plan_action_metadata({
+        **base, "action_kind": "complete_reopen", "task_ids": ["agent:a"],
+        "complete_task_ids": [], "reopen_task_ids": ["agent:a"],
+    })
+    assert not adapter.validate_plan_action_metadata({
+        **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
+        "add_task_ids": ["user:replacement"], "add_task_content": "New",
+    })
 
 
 @pytest.mark.asyncio
@@ -1771,7 +1904,12 @@ async def test_plan_action_rejects_wrong_route_or_unauthorized_user(tmp_path) ->
 @pytest.mark.parametrize("chat_type", ["group", "dm"])
 async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_path, chat_type) -> None:
     adapter = _adapter(tmp_path)
-    _state(adapter, route_user_id="U-owner", chat_type=chat_type)
+    _state(
+        adapter,
+        [{"id": "user:a", "content": "A", "status": "pending"}],
+        route_user_id="U-owner",
+        chat_type=chat_type,
+    )
     state = adapter._plan_store.get_session("sk")
     adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -1791,7 +1929,7 @@ async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_p
     action = {
         "action_id": "hermes_plan_complete",
         "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-        "selected_options": [{"value": "a"}],
+        "selected_options": [{"value": "user:a"}],
     }
     await adapter._handle_plan_action(AsyncMock(), body, action)
     await asyncio.sleep(0)
@@ -1810,7 +1948,7 @@ async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_p
 @pytest.mark.parametrize("invalid_field", ["team", "channel", "message", "thread", "block"])
 async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path, invalid_field) -> None:
     adapter = _adapter(tmp_path)
-    _state(adapter)
+    _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
     state = adapter._plan_store.get_session("sk")
     adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -1836,7 +1974,7 @@ async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path,
 
     await adapter._handle_plan_action(AsyncMock(), body, {
         "action_id": "hermes_plan_complete", "block_id": block_id,
-        "selected_options": [{"value": "a"}],
+        "selected_options": [{"value": "user:a"}],
     })
     adapter._message_handler.assert_not_awaited()
 
@@ -1844,7 +1982,7 @@ async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path,
 @pytest.mark.asyncio
 async def test_plan_action_queues_silently_when_original_session_is_busy(tmp_path) -> None:
     adapter = _adapter(tmp_path)
-    _state(adapter)
+    _state(adapter, [{"id": "user:a", "content": "A", "status": "pending"}])
     state = adapter._plan_store.get_session("sk")
     adapter._plan_store.mark_applied(
         "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
@@ -1866,7 +2004,7 @@ async def test_plan_action_queues_silently_when_original_session_is_busy(tmp_pat
     action = {
         "action_id": "hermes_plan_complete",
         "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-        "selected_options": [{"value": "a"}],
+        "selected_options": [{"value": "user:a"}],
     }
 
     await adapter._handle_plan_action(AsyncMock(), body, action)
@@ -1899,8 +2037,18 @@ async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) 
     })
     view = client.views_open.call_args.kwargs["view"]
     assert view["callback_id"] == "hermes_plan_add_task"
+    assert view["title"]["text"] == "Add user task"
     envelope = json.loads(view["private_metadata"])
     assert envelope["signature"]
+    payload = verify_private_metadata(view["private_metadata"], b"signing-secret")
+    generated_id = payload["add_task_ids"][0]
+    assert is_user_task_id(generated_id)
+    assert payload["task_ids"] == [generated_id]
+    assert payload["action_kind"] == "add_user_task"
+    assert payload["action_user_id"] == "U-owner"
+    assert generated_id not in {
+        task["id"] for task in adapter._plan_store.get_session("sk")["last_desired_snapshot"]
+    }
 
     events = []
     async def handle(event):
@@ -1931,16 +2079,69 @@ async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) 
     await asyncio.sleep(0)
     assert ack.await_count == 1
     assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["add_task_content"] == "New task"
+    trusted = events[0].metadata["slack_plan_action"]
+    assert trusted["action_kind"] == "add_user_task"
+    assert trusted["add_task_ids"] == [generated_id]
+    assert trusted["task_ids"] == [generated_id]
+    assert trusted["add_task_content"] == "New task"
+    assert generated_id in events[0].text
 
     await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
     assert len(events) == 1
 
     tampered = json.loads(view["private_metadata"])
-    tampered["payload"]["revision"] = 99
+    tampered["payload"]["add_task_ids"] = ["user:replacement"]
     submit_body["view"]["private_metadata"] = json.dumps(tampered)
     await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
     assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_inactive_user_tasks_do_not_block_pending_action_or_add_modal(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    inactive = [
+        {
+            "id": f"user:inactive-{index}",
+            "content": str(index),
+            "status": "cancelled" if index % 2 else "in_progress",
+        }
+        for index in range(15)
+    ]
+    state = _state(adapter, inactive + [
+        {"id": "user:pending", "content": "Pending", "status": "pending"},
+    ])
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    body = {
+        "trigger_id": "trigger", "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "complete"}],
+    }
+    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_complete", "block_id": block_id,
+        "selected_options": [{"value": "user:pending"}],
+    })
+    await asyncio.sleep(0)
+    assert len(events) == 1
+    assert events[0].metadata["slack_plan_action"]["complete_task_ids"] == ["user:pending"]
+
+    body["actions"][0]["action_ts"] = "add"
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_add", "block_id": block_id,
+    })
+    client.views_open.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1955,9 +2156,12 @@ async def test_add_modal_keeps_validated_lineage_across_concurrent_route_change(
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
         "channel_id": "C1", "thread_ts": "10.0", "message_ts": "20.0",
         "revision": original["desired_revision"],
-        "snapshot_hash": original["desired_hash"], "task_ids": [],
+        "snapshot_hash": original["desired_hash"], "task_ids": ["user:new"],
+        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
+        "action_user_id": "U-owner", "action_dedupe_id": "open-dedupe",
     }
     private_metadata = sign_private_metadata(payload, b"signing-secret")
+    assert adapter._plan_store.consume_action_id("open-dedupe")
     adapter._is_interactive_user_authorized = MagicMock(return_value=True)
     events = []
 
@@ -1998,6 +2202,7 @@ async def test_add_modal_keeps_validated_lineage_across_concurrent_route_change(
     assert trusted["thread_ts"] == "10.0"
     assert trusted["revision"] == original["desired_revision"]
     assert trusted["snapshot_hash"] == original["desired_hash"]
+    assert trusted["add_task_ids"] == ["user:new"]
 
     runner = object.__new__(GatewayRunner)
     runner.adapters = {events[0].source.platform: adapter}

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -19,6 +19,7 @@ from plugins.platforms.slack.plan_cards import (
     sign_private_metadata,
     verify_private_metadata,
 )
+from tools.todo_tool import MAX_TODO_ITEMS
 
 
 def _adapter(
@@ -2158,6 +2159,99 @@ async def test_future_user_tasks_do_not_block_active_action_or_add_modal(tmp_pat
         "action_id": "hermes_plan_add", "block_id": block_id,
     })
     client.views_open.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("count", "opens_modal"),
+    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
+)
+async def test_add_modal_preflight_follows_authoritative_todo_capacity(
+    tmp_path, count: int, opens_modal: bool,
+) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter, [
+        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
+        for index in range(count)
+    ])
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    await adapter._handle_plan_action(AsyncMock(), {
+        "trigger_id": "trigger", "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"},
+        "actions": [{"action_ts": f"capacity-{count}"}],
+    }, {
+        "action_id": "hermes_plan_add",
+        "block_id": (
+            f"hermes-plan-controls-r{state['desired_revision']}-"
+            f"{state['desired_hash'][:10]}"
+        ),
+    })
+    assert (client.views_open.await_count == 1) is opens_modal
+
+
+@pytest.mark.asyncio
+async def test_add_modal_submission_fails_after_desired_snapshot_reaches_todo_capacity(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    original = _state(adapter, [
+        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
+        for index in range(MAX_TODO_ITEMS - 1)
+    ])
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=original["desired_revision"],
+        snapshot_hash=original["desired_hash"], message_ts="20.0",
+    )
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    action_body = {
+        "trigger_id": "trigger", "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "open"}],
+    }
+    await adapter._handle_plan_action(AsyncMock(), action_body, {
+        "action_id": "hermes_plan_add",
+        "block_id": (
+            f"hermes-plan-controls-r{original['desired_revision']}-"
+            f"{original['desired_hash'][:10]}"
+        ),
+    })
+    view = client.views_open.call_args.kwargs["view"]
+
+    adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
+        thread_ts="10.0", route_user_id="U-owner", chat_type="group",
+        todos=[
+            {"id": f"agent:{index}", "content": str(index), "status": "pending"}
+            for index in range(MAX_TODO_ITEMS)
+        ],
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    await adapter._handle_plan_add_view(AsyncMock(), {
+        "team": {"id": "T1"}, "user": {"id": "U-owner"},
+        "view": {
+            "id": "V-capacity", "hash": "H-capacity",
+            "private_metadata": view["private_metadata"],
+            "state": {"values": {"task": {"content": {"value": "Too late"}}}},
+        },
+    })
+    await asyncio.sleep(0)
+    assert events == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -1959,6 +1959,240 @@ async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_p
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action_id", "selection"),
+    [
+        ("hermes_plan_complete", {"selected_options": [{"value": "user:a"}]}),
+        ("hermes_plan_cancel", {"selected_option": {"value": "user:a"}}),
+        ("hermes_plan_add", {}),
+    ],
+)
+async def test_same_channel_unrelated_allowlisted_user_cannot_mutate_owner_card(
+    tmp_path, action_id, selection,
+) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(
+        adapter,
+        [{"id": "user:a", "content": "A", "status": "in_progress"}],
+    )
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    body = {
+        "trigger_id": "trigger",
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-other"},
+        "actions": [{"action_ts": action_id}],
+    }
+    action = {
+        "action_id": action_id,
+        "block_id": (
+            f"hermes-plan-controls-r{state['desired_revision']}-"
+            f"{state['desired_hash'][:10]}"
+        ),
+        **selection,
+    }
+
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    await asyncio.sleep(0)
+
+    assert events == []
+    client.views_open.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_empty_owner_route_is_read_only_but_refresh_remains_available(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(
+        adapter,
+        [{"id": "user:a", "content": "A", "status": "in_progress"}],
+        route_user_id="",
+    )
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    rendered = adapter._render_plan_state(adapter._plan_store.get_session("sk"))
+    assert [
+        element["action_id"]
+        for block in rendered.native_blocks
+        if block["type"] == "actions"
+        for element in block["elements"]
+    ] == ["hermes_plan_refresh"]
+
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    body = {
+        "trigger_id": "trigger",
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-allowlisted"},
+        "actions": [{"action_ts": "empty-owner"}],
+    }
+    block_id = (
+        f"hermes-plan-controls-r{state['desired_revision']}-"
+        f"{state['desired_hash'][:10]}"
+    )
+    for index, action in enumerate((
+        {
+            "action_id": "hermes_plan_complete",
+            "selected_options": [{"value": "user:a"}],
+        },
+        {
+            "action_id": "hermes_plan_cancel",
+            "selected_option": {"value": "user:a"},
+        },
+        {"action_id": "hermes_plan_add"},
+    )):
+        body["actions"][0]["action_ts"] = f"empty-owner-{index}"
+        await adapter._handle_plan_action(
+            AsyncMock(), body, {**action, "block_id": block_id}
+        )
+
+    assert events == []
+    client.views_open.assert_not_awaited()
+    before_refresh = adapter._plan_store.get_session("sk")["desired_revision"]
+    body["actions"][0]["action_ts"] = "empty-owner-refresh"
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_refresh", "block_id": block_id,
+    })
+    assert adapter._plan_store.get_session("sk")["desired_revision"] == before_refresh + 1
+
+
+@pytest.mark.asyncio
+async def test_route_owner_change_reanchors_and_only_new_owner_can_use_new_card(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    old = _state(
+        adapter,
+        [{"id": "user:a", "content": "A", "status": "in_progress"}],
+        route_user_id="U-owner",
+    )
+    old_create = adapter._plan_store.prepare_create("sk", expected_route=old)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=old["desired_revision"], snapshot_hash=old["desired_hash"],
+        message_ts="20.0", expected_message_ts="",
+        expected_client_msg_id=old_create["client_msg_id"],
+    )
+
+    new = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
+        thread_ts="10.0", route_user_id="U-new", chat_type="group",
+        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
+    )
+    assert new["message_ts"] == ""
+    assert new["retired_anchors"][0]["message_ts"] == "20.0"
+    assert new["retired_anchors"][0]["route_user_id"] == "U-owner"
+    assert adapter._plan_store.lookup_route("T1", "C1", "20.0") is None
+    new_create = adapter._plan_store.prepare_create("sk", expected_route=new)
+    assert new_create["client_msg_id"] != old_create["client_msg_id"]
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=new["desired_revision"], snapshot_hash=new["desired_hash"],
+        message_ts="30.0", rendered_revision=new["desired_revision"],
+        expected_message_ts="",
+        expected_client_msg_id=new_create["client_msg_id"],
+    )
+
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    action = {
+        "action_id": "hermes_plan_complete",
+        "block_id": (
+            f"hermes-plan-controls-r{new['desired_revision']}-"
+            f"{new['desired_hash'][:10]}"
+        ),
+        "selected_options": [{"value": "user:a"}],
+    }
+    body = {
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"},
+        "actions": [{"action_ts": "old-card"}],
+    }
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    body["message"]["ts"] = "30.0"
+    body["actions"][0]["action_ts"] = "old-owner-new-card"
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    assert events == []
+
+    body["user"]["id"] = "U-new"
+    body["actions"][0]["action_ts"] = "new-owner-new-card"
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    await asyncio.sleep(0)
+    assert len(events) == 1
+    assert events[0].metadata["slack_plan_action"]["action_user_id"] == "U-new"
+
+
+@pytest.mark.asyncio
+async def test_wildcard_allowlist_does_not_bypass_exact_plan_owner(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(
+        adapter,
+        [{"id": "user:a", "content": "A", "status": "in_progress"}],
+        route_user_id="U-owner",
+    )
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    body = {
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-other"},
+        "actions": [{"action_ts": "wildcard"}],
+    }
+    action = {
+        "action_id": "hermes_plan_complete",
+        "block_id": (
+            f"hermes-plan-controls-r{state['desired_revision']}-"
+            f"{state['desired_hash'][:10]}"
+        ),
+        "selected_options": [{"value": "user:a"}],
+    }
+
+    with patch.dict("os.environ", {"SLACK_ALLOWED_USERS": "*"}, clear=False):
+        assert adapter._is_interactive_user_authorized(
+            "U-other", channel_id="C1", team_id="T1", thread_id="10.0"
+        )
+        await adapter._handle_plan_action(AsyncMock(), body, action)
+
+    await asyncio.sleep(0)
+    assert events == []
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("invalid_field", ["team", "channel", "message", "thread", "block"])
 async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path, invalid_field) -> None:
     adapter = _adapter(tmp_path)

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -1,0 +1,2166 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent import secret_scope
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import MessageEvent
+from gateway.run import GatewayRunner
+from gateway.session import build_session_key
+from plugins.platforms.slack.adapter import SlackAdapter
+from plugins.platforms.slack.plan_cards import sign_private_metadata
+
+
+def _adapter(
+    tmp_path,
+    *,
+    secret: str | None = "signing-secret",
+    enabled: bool = True,
+) -> SlackAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        token="xoxb-test",
+        extra={"native_plan_cards": enabled},
+    )
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._channel_team = {"C1": "T1"}
+    adapter._plan_signing_secret_override = secret
+    return adapter
+
+
+def _state(
+    adapter: SlackAdapter,
+    todos=None,
+    *,
+    route_user_id: str = "U-owner",
+    chat_type: str = "group",
+):
+    return adapter.record_desired_plan_snapshot(
+        session_key="sk",
+        session_id="sid",
+        team_id="T1",
+        channel_id="C1",
+        thread_ts="10.0",
+        route_user_id=route_user_id,
+        chat_type=chat_type,
+        todos=todos or [{"id": "a", "content": "A", "status": "pending"}],
+    )
+
+
+def _converged_state_with_retired_anchor(adapter: SlackAdapter):
+    first = _state(adapter)
+    first_create = adapter._plan_store.prepare_create("sk", expected_route=first)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=first["desired_revision"], snapshot_hash=first["desired_hash"],
+        message_ts="20.0", expected_message_ts="",
+        expected_client_msg_id=first_create["client_msg_id"],
+    )
+    moved = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    moved_create = adapter._plan_store.prepare_create("sk", expected_route=moved)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=moved["desired_revision"], snapshot_hash=moved["desired_hash"],
+        message_ts="30.0", expected_message_ts="",
+        expected_client_msg_id=moved_create["client_msg_id"],
+    )
+    return adapter._plan_store.list_retired("sk")[0]
+
+
+async def _reconcile(
+    adapter: SlackAdapter,
+    session_key: str,
+    _scheduled_revision: int | None = None,
+) -> bool:
+    """Drive the adapter-owned worker until this session settles once."""
+    before = adapter._plan_store.get_session(session_key) or {}
+    before_retry = int(before.get("retry_count") or 0)
+    adapter._running = True
+    adapter._start_plan_reconcile_worker()
+    adapter.request_plan_reconcile()
+    result = False
+    for _ in range(200):
+        state = adapter._plan_store.get_session(session_key) or {}
+        dirty_keys = {
+            str(item.get("session_key") or "")
+            for item in adapter._plan_store.list_dirty()
+        }
+        if session_key not in dirty_keys:
+            result = bool(state) and (
+                int(state.get("applied_revision") or 0)
+                >= int(state.get("desired_revision") or 0)
+                and not state.get("retired_anchors")
+            )
+            break
+        if int(state.get("retry_count") or 0) > before_retry:
+            break
+        await asyncio.sleep(0.005)
+    await adapter._stop_plan_reconcile_worker()
+    return result
+
+
+def test_plan_wake_is_event_only_and_adapter_has_one_worker_field(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    source = inspect.getsource(SlackAdapter.request_plan_reconcile)
+    assert "create_task" not in source
+    assert "reconcile_plan_card" not in source
+    assert not hasattr(adapter, "_plan_reconcile_tasks")
+    assert not hasattr(adapter, "_plan_reconcile_locks")
+    assert hasattr(adapter, "_plan_reconcile_task")
+
+    adapter.request_plan_reconcile()
+    assert adapter._plan_reconcile_task is None
+    assert adapter._plan_reconcile_wakeup.is_set()
+
+
+@pytest.mark.asyncio
+async def test_plan_worker_serializes_all_session_slack_io(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._running = True
+    _state(adapter)
+    adapter.record_desired_plan_snapshot(
+        session_key="other", session_id="sid-2", team_id="T1", channel_id="C1",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "B", "status": "pending"}],
+    )
+    active = 0
+    max_active = 0
+
+    async def post(**kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return {"ts": "20.0" if kwargs.get("thread_ts") == "10.0" else "21.0"}
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=post)
+    for _ in range(10):
+        adapter.request_plan_reconcile()
+    adapter._start_plan_reconcile_worker()
+    for _ in range(100):
+        if not adapter._plan_store.list_dirty():
+            break
+        await asyncio.sleep(0.01)
+    await adapter.disconnect()
+
+    assert max_active == 1
+    assert adapter._plan_store.list_dirty() == []
+
+
+@pytest.mark.asyncio
+async def test_start_reuses_one_worker_then_reconnect_advances_generation(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._running = True
+
+    adapter._start_plan_reconcile_worker()
+    first_task = adapter._plan_reconcile_task
+    first_generation = adapter._plan_reconcile_generation
+    adapter._start_plan_reconcile_worker()
+
+    assert adapter._plan_reconcile_task is first_task
+    assert adapter._plan_reconcile_generation == first_generation
+
+    await adapter._stop_plan_reconcile_worker()
+    adapter._start_plan_reconcile_worker()
+    assert adapter._plan_reconcile_task is not first_task
+    assert adapter._plan_reconcile_generation == first_generation + 1
+    await adapter._stop_plan_reconcile_worker()
+
+
+@pytest.mark.asyncio
+async def test_old_queued_wake_after_reconnect_only_wakes_new_worker(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    adapter._running = True
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(
+        return_value={"ts": "20.0"}
+    )
+
+    adapter._start_plan_reconcile_worker()
+    old_generation = adapter._plan_reconcile_generation
+    queued_old_wake = adapter.request_plan_reconcile
+    await adapter._stop_plan_reconcile_worker()
+    assert adapter._plan_reconcile_task is None
+
+    adapter._start_plan_reconcile_worker()
+    assert adapter._plan_reconcile_generation == old_generation + 1
+    queued_old_wake()
+    for _ in range(100):
+        persisted = adapter._plan_store.get_session("sk")
+        if persisted["applied_revision"] == state["desired_revision"]:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    adapter._team_clients["T1"].chat_postMessage.assert_awaited_once()
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "20.0"
+
+
+@pytest.mark.asyncio
+async def test_wake_at_quiescent_boundary_is_not_lost(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._running = True
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    original_list_dirty = adapter._plan_store.list_dirty
+    first_scan = True
+
+    def list_dirty(*args, **kwargs):
+        nonlocal first_scan
+        if first_scan:
+            first_scan = False
+            _state(adapter)
+            adapter.request_plan_reconcile()
+            return []
+        return original_list_dirty(*args, **kwargs)
+
+    adapter._plan_store.list_dirty = MagicMock(side_effect=list_dirty)
+    adapter._start_plan_reconcile_worker()
+    for _ in range(100):
+        state = adapter._plan_store.get_session("sk")
+        if state and state["applied_revision"] == state["desired_revision"]:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_postMessage.assert_awaited_once()
+    state = adapter._plan_store.get_session("sk")
+    assert state["applied_revision"] == state["desired_revision"]
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_single_worker_and_blocks_post_return_commit(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_post(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return {"ts": "20.0"}
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=blocked_post)
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    assert not disconnect.done()
+    release.set()
+    await disconnect
+
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["desired_revision"] == state["desired_revision"]
+    assert persisted["applied_revision"] == 0
+    assert persisted["message_ts"] == "20.0"
+    assert adapter._plan_reconcile_task is None
+    assert type(adapter._plan_store)(tmp_path).get_session("sk")["message_ts"] == "20.0"
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(return_value={"ts": "30.0"})
+    adapter._team_clients["T1"].chat_update = AsyncMock(return_value={"ts": "20.0"})
+    adapter._app = MagicMock()
+    adapter._running = True
+    adapter._start_plan_reconcile_worker()
+    for _ in range(100):
+        persisted = adapter._plan_store.get_session("sk")
+        if persisted["applied_revision"] == state["desired_revision"]:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+    adapter._team_clients["T1"].chat_postMessage.assert_not_awaited()
+    adapter._team_clients["T1"].chat_update.assert_awaited_once()
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "20.0"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_create_route_change_persists_retired_lineage_before_return(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_post(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return {"ts": "20.0"}
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=blocked_post)
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    moved = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    release.set()
+    await disconnect
+
+    persisted = type(adapter._plan_store)(tmp_path).get_session("sk")
+    assert persisted["channel_id"] == "C2"
+    assert persisted["message_ts"] == ""
+    assert [anchor["message_ts"] for anchor in persisted["retired_anchors"]] == ["20.0"]
+
+    restarted = _adapter(tmp_path)
+    client = restarted._team_clients["T1"]
+    client.chat_delete = AsyncMock()
+    client.chat_postMessage = AsyncMock(return_value={"ts": "30.0"})
+    restarted._running = True
+    restarted._start_plan_reconcile_worker()
+    for _ in range(100):
+        current = restarted._plan_store.get_session("sk")
+        if current["applied_revision"] == moved["desired_revision"]:
+            break
+        await asyncio.sleep(0.01)
+    await restarted._stop_plan_reconcile_worker()
+
+    client.chat_delete.assert_awaited_once_with(channel="C1", ts="20.0")
+    client.chat_postMessage.assert_awaited_once()
+    assert client.chat_postMessage.call_args.kwargs["channel"] == "C2"
+    assert restarted._plan_store.get_session("sk")["message_ts"] == "30.0"
+
+
+@pytest.mark.asyncio
+async def test_create_lineage_store_failure_recovers_by_client_id_without_duplicate(
+    tmp_path, caplog
+) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_post(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return {"ts": "20.0"}
+
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(side_effect=blocked_post)
+    client.chat_delete = AsyncMock()
+    adapter._plan_store.record_create_result = MagicMock(
+        side_effect=OSError("disk unavailable")
+    )
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    with caplog.at_level("ERROR", logger="plugins.platforms.slack.adapter"):
+        release.set()
+        await disconnect
+
+    persisted = type(adapter._plan_store)(tmp_path).get_session("sk")
+    assert persisted["message_ts"] == ""
+    assert persisted["client_msg_id"]
+    assert persisted["applied_revision"] == 0
+    client.chat_delete.assert_not_awaited()
+    assert "failed to persist its lineage" in caplog.text
+
+    restarted = _adapter(tmp_path)
+    recovered_client = restarted._team_clients["T1"]
+    recovered_client.conversations_replies = AsyncMock(return_value={"messages": [{
+        "ts": "20.0", "client_msg_id": persisted["client_msg_id"],
+    }]})
+    recovered_client.chat_postMessage = AsyncMock(return_value={"ts": "21.0"})
+    recovered_client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+    assert await _reconcile(restarted, "sk", state["desired_revision"])
+
+    recovered_client.chat_postMessage.assert_not_awaited()
+    assert restarted._plan_store.get_session("sk")["message_ts"] == "20.0"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_blocks_retry_commit_after_cancelled_apply_returns(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_post(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        raise RuntimeError("timeout")
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=blocked_post)
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    release.set()
+    await disconnect
+
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["retry_count"] == 0
+    assert persisted["applied_revision"] == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_blocks_missing_anchor_reset_after_cancelled_update(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    first = _state(adapter)
+    prepared = adapter._plan_store.prepare_create("sk", expected_route=first)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=first["desired_revision"], snapshot_hash=first["desired_hash"],
+        message_ts="20.0", expected_message_ts="",
+        expected_client_msg_id=prepared["client_msg_id"],
+    )
+    _state(adapter, [{"id": "a", "content": "changed", "status": "pending"}])
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_update(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        raise RuntimeError("message_not_found")
+
+    adapter._team_clients["T1"].chat_update = AsyncMock(side_effect=blocked_update)
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    release.set()
+    await disconnect
+
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["message_ts"] == "20.0"
+    assert persisted["client_msg_id"] == prepared["client_msg_id"]
+    assert persisted["retry_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_disconnect_blocks_retired_retry_after_cancelled_readback(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    first = _state(adapter)
+    adapter._plan_store.prepare_create("sk", expected_route=first)
+    adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_history(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return {"messages": []}
+
+    adapter._team_clients["T1"].conversations_replies = AsyncMock(
+        side_effect=blocked_history
+    )
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    disconnect = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    release.set()
+    await disconnect
+
+    retired = adapter._plan_store.get_session("sk")["retired_anchors"]
+    assert len(retired) == 1
+    assert retired[0]["retry_count"] == 0
+    assert retired[0]["next_retry_at"] == 0
+
+
+@pytest.mark.asyncio
+async def test_conflict_is_retired_before_cleanup_and_cancel_keeps_it(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._running = True
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+
+    async def post(**_kwargs):
+        competing = type(adapter._plan_store)(tmp_path)
+        prepared = competing.get_session("sk")
+        assert competing.record_create_result(
+            "sk", expected_route=prepared,
+            client_msg_id=prepared["client_msg_id"], message_ts="30.0",
+        ) == "current"
+        return {"ts": "20.0"}
+
+    async def blocked_delete(**_kwargs):
+        retired = adapter._plan_store.get_session("sk")["retired_anchors"]
+        assert [anchor["message_ts"] for anchor in retired] == ["20.0"]
+        cleanup_started.set()
+        await release_cleanup.wait()
+
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(side_effect=post)
+    client.chat_delete = AsyncMock(side_effect=blocked_delete)
+    adapter._start_plan_reconcile_worker()
+    await cleanup_started.wait()
+    await adapter.disconnect()
+
+    assert [
+        anchor["message_ts"]
+        for anchor in adapter._plan_store.get_session("sk")["retired_anchors"]
+    ] == ["20.0"]
+
+
+@pytest.mark.asyncio
+async def test_conflict_retirement_store_failure_prevents_remote_cleanup(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._running = True
+    client = adapter._team_clients["T1"]
+
+    async def post(**_kwargs):
+        competing = type(adapter._plan_store)(tmp_path)
+        prepared = competing.get_session("sk")
+        assert competing.record_create_result(
+            "sk", expected_route=prepared,
+            client_msg_id=prepared["client_msg_id"], message_ts="30.0",
+        ) == "current"
+        return {"ts": "20.0"}
+
+    client.chat_postMessage = AsyncMock(side_effect=post)
+    client.chat_delete = AsyncMock()
+    client.chat_update = AsyncMock()
+    adapter._plan_store.retire_orphan_anchor = MagicMock(side_effect=OSError("disk"))
+
+    adapter._start_plan_reconcile_worker()
+    for _ in range(100):
+        if adapter._plan_reconcile_task and adapter._plan_reconcile_task.done():
+            break
+        if adapter._plan_store.get_session("sk")["retry_count"]:
+            break
+        await asyncio.sleep(0.01)
+    await adapter.disconnect()
+
+    client.chat_delete.assert_not_awaited()
+    client.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_creates_updates_and_dedupes_hash(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+
+    first = _state(adapter)
+    assert await _reconcile(adapter, "sk", first["desired_revision"])
+    client.chat_postMessage.assert_awaited_once()
+    posted = client.chat_postMessage.call_args.kwargs
+    assert posted["thread_ts"] == "10.0"
+    assert posted["blocks"][0]["type"] == "plan"
+
+    same = _state(adapter)
+    assert await _reconcile(adapter, "sk", same["desired_revision"])
+    client.chat_update.assert_not_awaited()
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["applied_revision"] == same["desired_revision"]
+    assert persisted["applied_render_revision"] == first["desired_revision"]
+
+    changed = _state(adapter, [{"id": "a", "content": "A", "status": "completed"}])
+    assert await _reconcile(adapter, "sk", changed["desired_revision"])
+    client.chat_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_hash_dedupe_keeps_existing_card_actions_valid(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    first = _state(adapter)
+    assert await _reconcile(adapter, "sk", first["desired_revision"])
+    same = _state(adapter)
+    assert await _reconcile(adapter, "sk", same["desired_revision"])
+    client.chat_update.assert_not_awaited()
+
+    events = []
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    await adapter._handle_plan_action(AsyncMock(), {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "same-hash"}],
+    }, {
+        "action_id": "hermes_plan_complete",
+        "block_id": "hermes-plan-controls-r1-" + first["desired_hash"][:10],
+        "selected_options": [{"value": "a"}],
+    })
+    await asyncio.sleep(0)
+    assert len(events) == 1
+    assert events[0].metadata["slack_plan_action"]["revision"] == same["desired_revision"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_native_failure_falls_back_and_missing_update_reanchors(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    first = _state(adapter)
+    await _reconcile(adapter, "sk", first["desired_revision"])
+
+    changed = _state(adapter, [{"id": "a", "content": "changed", "status": "pending"}])
+    client.chat_update = AsyncMock(side_effect=[RuntimeError("invalid_blocks"), {"ts": "20.0"}])
+    assert await _reconcile(adapter, "sk", changed["desired_revision"])
+    assert client.chat_update.await_count == 2
+    assert client.chat_update.call_args_list[1].kwargs["blocks"][0]["type"] == "section"
+
+    newer = _state(adapter, [{"id": "b", "content": "new", "status": "pending"}])
+    client.chat_update = AsyncMock(side_effect=RuntimeError("message_not_found"))
+    client.chat_postMessage.reset_mock()
+    client.chat_postMessage.return_value = {"ts": "30.0"}
+    assert await _reconcile(adapter, "sk", newer["desired_revision"])
+    client.chat_postMessage.assert_awaited_once()
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "30.0"
+
+
+@pytest.mark.asyncio
+async def test_inflight_stale_create_adopts_anchor_and_updates_latest_without_duplicate(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    post_started = asyncio.Event()
+    release_post = asyncio.Event()
+
+    async def delayed_post(**_kwargs):
+        post_started.set()
+        await release_post.wait()
+        return {"ts": "20.0"}
+
+    client.chat_postMessage = AsyncMock(side_effect=delayed_post)
+    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+    first = _state(adapter)
+    reconcile = asyncio.create_task(
+        _reconcile(adapter, "sk", first["desired_revision"])
+    )
+    await post_started.wait()
+    latest = _state(adapter, [{"id": "b", "content": "Latest", "status": "pending"}])
+    release_post.set()
+
+    assert await reconcile
+    assert await _reconcile(adapter, "sk", latest["desired_revision"])
+    client.chat_postMessage.assert_awaited_once()
+    client.chat_update.assert_awaited_once()
+    assert client.chat_update.call_args.kwargs["ts"] == "20.0"
+    assert client.chat_update.call_args.kwargs["blocks"][0]["tasks"][0]["task_id"] == "b"
+
+    restarted = type(adapter._plan_store)(tmp_path)
+    state = restarted.get_session("sk")
+    assert state["message_ts"] == "20.0"
+    assert state["applied_revision"] == latest["desired_revision"]
+    assert restarted.lookup_route("T1", "C1", "20.0")["session_key"] == "sk"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("thread_ts", ["10.0", ""])
+async def test_restart_recovers_attempted_create_by_client_msg_id_before_post(tmp_path, thread_ts) -> None:
+    adapter = _adapter(tmp_path)
+    state = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
+        thread_ts=thread_ts, route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "a", "content": "A", "status": "pending"}],
+    )
+    prepared = adapter._plan_store.prepare_create("sk", expected_route=state)
+    client = adapter._team_clients["T1"]
+    recovered = {
+        "ts": "20.0", "client_msg_id": prepared["client_msg_id"], "user": "U-bot",
+    }
+    client.conversations_replies = AsyncMock(return_value={"messages": [recovered]})
+    client.conversations_history = AsyncMock(return_value={"messages": [recovered]})
+    client.chat_postMessage = AsyncMock()
+    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+    adapter._team_bot_user_ids = {"T1": "U-bot"}
+
+    assert await _reconcile(adapter, "sk", state["desired_revision"])
+    client.chat_postMessage.assert_not_awaited()
+    client.chat_update.assert_awaited_once()
+    if thread_ts:
+        client.conversations_replies.assert_awaited_once()
+        client.conversations_history.assert_not_awaited()
+    else:
+        client.conversations_history.assert_awaited_once()
+        client.conversations_replies.assert_not_awaited()
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "20.0"
+
+
+@pytest.mark.asyncio
+async def test_unavailable_readback_posts_with_same_persisted_client_msg_id(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    prepared = adapter._plan_store.prepare_create("sk", expected_route=state)
+    client = adapter._team_clients["T1"]
+    client.conversations_replies = AsyncMock(side_effect=RuntimeError("missing_scope"))
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+
+    assert await _reconcile(adapter, "sk", state["desired_revision"])
+    assert client.chat_postMessage.call_args.kwargs["client_msg_id"] == prepared["client_msg_id"]
+    assert adapter._plan_store.get_session("sk")["client_msg_id"] == prepared["client_msg_id"]
+
+
+@pytest.mark.asyncio
+async def test_same_revision_dual_create_uses_one_uuid_and_one_anchor(tmp_path) -> None:
+    first_adapter = _adapter(tmp_path)
+    second_adapter = _adapter(tmp_path)
+    client = AsyncMock()
+    first_adapter._team_clients = second_adapter._team_clients = {"T1": client}
+    client.conversations_replies = AsyncMock(return_value={"messages": []})
+    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+    client.chat_delete = AsyncMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    post_ids = []
+
+    async def idempotent_post(**kwargs):
+        post_ids.append(kwargs["client_msg_id"])
+        if len(post_ids) == 2:
+            started.set()
+        await release.wait()
+        return {"ts": "20.0"}
+
+    client.chat_postMessage = AsyncMock(side_effect=idempotent_post)
+    state = _state(first_adapter)
+    first = asyncio.create_task(_reconcile(first_adapter, "sk", state["desired_revision"]))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(_reconcile(second_adapter, "sk", state["desired_revision"]))
+    await started.wait()
+    latest = _state(first_adapter, [{"id": "b", "content": "Latest", "status": "pending"}])
+    release.set()
+
+    assert all(await asyncio.gather(first, second))
+    assert len(set(post_ids)) == 1
+    assert client.chat_delete.await_count == 0
+    stored = first_adapter._plan_store.get_session("sk")
+    assert stored["message_ts"] == "20.0"
+    assert stored["applied_revision"] == latest["desired_revision"]
+    assert first_adapter._plan_store.lookup_route("T1", "C1", "20.0")["session_key"] == "sk"
+    assert client.chat_update.call_args.kwargs["blocks"][0]["tasks"][0]["task_id"] == "b"
+
+
+@pytest.mark.asyncio
+async def test_non_idempotent_dual_create_cleans_conflicting_loser(tmp_path) -> None:
+    first_adapter = _adapter(tmp_path)
+    second_adapter = _adapter(tmp_path)
+    client = AsyncMock()
+    first_adapter._team_clients = second_adapter._team_clients = {"T1": client}
+    client.conversations_replies = AsyncMock(return_value={"messages": []})
+    client.chat_delete = AsyncMock()
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def non_idempotent_post(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        result_ts = f"2{call_count}.0"
+        if call_count == 2:
+            started.set()
+        await release.wait()
+        return {"ts": result_ts}
+
+    client.chat_postMessage = AsyncMock(side_effect=non_idempotent_post)
+    state = _state(first_adapter)
+    first = asyncio.create_task(_reconcile(first_adapter, "sk", state["desired_revision"]))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(_reconcile(second_adapter, "sk", state["desired_revision"]))
+    await started.wait()
+    release.set()
+
+    assert all(await asyncio.gather(first, second))
+    stored = first_adapter._plan_store.get_session("sk")
+    assert stored["message_ts"] in {"21.0", "22.0"}
+    assert client.chat_delete.await_count == 1
+    loser_ts = client.chat_delete.call_args.kwargs["ts"]
+    assert loser_ts != stored["message_ts"]
+    assert first_adapter._plan_store.lookup_route("T1", "C1", loser_ts) is None
+
+
+@pytest.mark.asyncio
+async def test_conflicting_create_cleanup_failure_is_retired_and_retried_after_restart(tmp_path) -> None:
+    first_adapter = _adapter(tmp_path)
+    second_adapter = _adapter(tmp_path)
+    client = AsyncMock()
+    first_adapter._team_clients = second_adapter._team_clients = {"T1": client}
+    client.conversations_replies = AsyncMock(return_value={"messages": []})
+    client.chat_delete = AsyncMock(side_effect=RuntimeError("delete failed"))
+    client.chat_update = AsyncMock(side_effect=RuntimeError("neutralize failed"))
+    started = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def non_idempotent_post(**_kwargs):
+        nonlocal call_count
+        call_count += 1
+        result_ts = f"4{call_count}.0"
+        if call_count == 2:
+            started.set()
+        await release.wait()
+        return {"ts": result_ts}
+
+    client.chat_postMessage = AsyncMock(side_effect=non_idempotent_post)
+    state = _state(first_adapter)
+    first = asyncio.create_task(_reconcile(first_adapter, "sk", state["desired_revision"]))
+    await asyncio.sleep(0)
+    second = asyncio.create_task(_reconcile(second_adapter, "sk", state["desired_revision"]))
+    await started.wait()
+    release.set()
+    await asyncio.gather(first, second)
+
+    persisted = first_adapter._plan_store.get_session("sk")
+    assert len(persisted["retired_anchors"]) == 1
+    loser = persisted["retired_anchors"][0]
+    assert loser["message_ts"] != persisted["message_ts"]
+    assert loser["client_msg_id"] == persisted["client_msg_id"]
+
+    restarted = _adapter(tmp_path)
+    restarted_client = restarted._team_clients["T1"]
+    restarted_client.chat_delete = AsyncMock()
+    with patch(
+        "plugins.platforms.slack.plan_cards.time.time",
+        return_value=time.time() + 120,
+    ):
+        assert await _reconcile(restarted, "sk", state["desired_revision"])
+    restarted_client.chat_delete.assert_awaited_once_with(channel="C1", ts=loser["message_ts"])
+    assert restarted._plan_store.get_session("sk")["retired_anchors"] == []
+
+
+@pytest.mark.asyncio
+async def test_readback_conflict_cleanup_failure_retires_recovered_loser(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    prepared = adapter._plan_store.prepare_create("sk", expected_route=state)
+    client = adapter._team_clients["T1"]
+
+    async def conflicting_readback(**_kwargs):
+        competing = type(adapter._plan_store)(tmp_path)
+        assert competing.record_create_result(
+            "sk", expected_route=prepared,
+            client_msg_id=prepared["client_msg_id"], message_ts="20.0",
+        ) == "current"
+        return {"messages": [{
+            "ts": "21.0", "client_msg_id": prepared["client_msg_id"],
+        }]}
+
+    async def update_by_ts(**kwargs):
+        if kwargs["ts"] == "21.0":
+            raise RuntimeError("neutralize failed")
+        return {"ts": kwargs["ts"]}
+
+    client.conversations_replies = AsyncMock(side_effect=conflicting_readback)
+    client.chat_delete = AsyncMock(side_effect=RuntimeError("delete failed"))
+    client.chat_update = AsyncMock(side_effect=update_by_ts)
+
+    assert not await _reconcile(adapter, "sk", state["desired_revision"])
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["message_ts"] == "20.0"
+    assert [anchor["message_ts"] for anchor in persisted["retired_anchors"]] == ["21.0"]
+
+
+@pytest.mark.asyncio
+async def test_thread_to_non_thread_route_uses_new_uuid_and_history_recovery(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    store = adapter._plan_store
+    threaded = _state(adapter)
+    prepared = store.prepare_create("sk", expected_route=threaded)
+    assert store.mark_applied(
+        "sk", revision=threaded["desired_revision"], snapshot_hash=threaded["desired_hash"],
+        message_ts="20.0", rendered_revision=threaded["desired_revision"],
+        expected_message_ts="", expected_client_msg_id=prepared["client_msg_id"],
+    )
+    moved = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
+        thread_ts="", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    next_generation = store.prepare_create("sk", expected_route=moved)
+    client = adapter._team_clients["T1"]
+    client.chat_delete = AsyncMock()
+    client.conversations_history = AsyncMock(return_value={"messages": [{
+        "ts": "30.0", "client_msg_id": next_generation["client_msg_id"],
+    }]})
+    client.conversations_replies = AsyncMock()
+    client.chat_postMessage = AsyncMock()
+    client.chat_update = AsyncMock(return_value={"ts": "30.0"})
+
+    assert await _reconcile(adapter, "sk", moved["desired_revision"])
+    client.conversations_history.assert_awaited_once()
+    client.conversations_replies.assert_not_awaited()
+    client.chat_postMessage.assert_not_awaited()
+    assert store.get_session("sk")["client_msg_id"] == next_generation["client_msg_id"]
+    assert next_generation["client_msg_id"] != prepared["client_msg_id"]
+
+
+@pytest.mark.asyncio
+async def test_inflight_stale_update_converges_latest_on_existing_anchor(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    first = _state(adapter)
+    assert await _reconcile(adapter, "sk", first["desired_revision"])
+
+    update_started = asyncio.Event()
+    release_update = asyncio.Event()
+
+    async def delayed_update(**_kwargs):
+        update_started.set()
+        await release_update.wait()
+        return {"ts": "20.0"}
+
+    client.chat_update = AsyncMock(side_effect=delayed_update)
+    stale = _state(adapter, [{"id": "b", "content": "Stale", "status": "pending"}])
+    reconcile = asyncio.create_task(
+        _reconcile(adapter, "sk", stale["desired_revision"])
+    )
+    await update_started.wait()
+    latest = _state(adapter, [{"id": "c", "content": "Latest", "status": "pending"}])
+    release_update.set()
+
+    assert await reconcile
+    assert client.chat_postMessage.await_count == 1
+    assert client.chat_update.await_count == 2
+    assert client.chat_update.call_args.kwargs["blocks"][0]["tasks"][0]["task_id"] == "c"
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == latest["desired_revision"]
+
+
+@pytest.mark.asyncio
+async def test_stale_create_cleans_up_orphan_when_other_process_anchor_wins(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    post_started = asyncio.Event()
+    release_post = asyncio.Event()
+
+    async def delayed_post(**_kwargs):
+        post_started.set()
+        await release_post.wait()
+        return {"ts": "20.0"}
+
+    client.chat_postMessage = AsyncMock(side_effect=delayed_post)
+    client.chat_update = AsyncMock(return_value={"ts": "30.0"})
+    client.chat_delete = AsyncMock()
+    first = _state(adapter)
+    reconcile = asyncio.create_task(
+        _reconcile(adapter, "sk", first["desired_revision"])
+    )
+    await post_started.wait()
+    latest = _state(adapter, [{"id": "b", "content": "Latest", "status": "pending"}])
+    competing_store = type(adapter._plan_store)(tmp_path)
+    assert competing_store.record_create_result(
+        "sk", expected_route=latest,
+        client_msg_id=latest["client_msg_id"], message_ts="30.0",
+    ) == "current"
+    release_post.set()
+
+    assert await reconcile
+    client.chat_postMessage.assert_awaited_once()
+    client.chat_delete.assert_awaited_once_with(channel="C1", ts="20.0")
+    client.chat_update.assert_awaited_once()
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "30.0"
+
+
+@pytest.mark.asyncio
+async def test_stale_create_cleans_up_orphan_when_route_changes(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    post_started = asyncio.Event()
+    release_post = asyncio.Event()
+
+    async def delayed_post(**_kwargs):
+        post_started.set()
+        await release_post.wait()
+        return {"ts": "20.0"}
+
+    client.chat_postMessage = AsyncMock(side_effect=delayed_post)
+    client.chat_delete = AsyncMock()
+    first = _state(adapter)
+    reconcile = asyncio.create_task(
+        _reconcile(adapter, "sk", first["desired_revision"])
+    )
+    await post_started.wait()
+    latest = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    release_post.set()
+
+    assert await reconcile
+    assert client.chat_postMessage.await_count == 2
+    assert client.chat_postMessage.call_args_list[0].kwargs["channel"] == "C1"
+    assert client.chat_postMessage.call_args_list[1].kwargs["channel"] == "C2"
+    client.chat_delete.assert_awaited_once_with(channel="C1", ts="20.0")
+    state = adapter._plan_store.get_session("sk")
+    assert state["channel_id"] == "C2"
+    assert state["applied_revision"] == latest["desired_revision"]
+
+
+@pytest.mark.asyncio
+async def test_retired_cleanup_failure_is_retried_after_adapter_restart(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(side_effect=[{"ts": "20.0"}, {"ts": "30.0"}])
+    first = _state(adapter)
+    assert await _reconcile(adapter, "sk", first["desired_revision"])
+    moved = adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    client.chat_delete = AsyncMock(side_effect=RuntimeError("delete failed"))
+    client.chat_update = AsyncMock(side_effect=RuntimeError("neutralize failed"))
+
+    assert not await _reconcile(adapter, "sk", moved["desired_revision"])
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["message_ts"] == "30.0"
+    assert persisted["retired_anchors"][0]["message_ts"] == "20.0"
+    assert persisted["retired_anchors"][0]["retry_count"] == 1
+
+    restarted = _adapter(tmp_path)
+    restarted_client = restarted._team_clients["T1"]
+    restarted_client.chat_delete = AsyncMock()
+    with patch(
+        "plugins.platforms.slack.plan_cards.time.time",
+        return_value=time.time() + 120,
+    ):
+        assert await _reconcile(restarted, "sk", moved["desired_revision"])
+    restarted_client.chat_delete.assert_awaited_once_with(channel="C1", ts="20.0")
+    assert restarted._plan_store.get_session("sk")["retired_anchors"] == []
+
+
+@pytest.mark.asyncio
+async def test_transient_failure_keeps_dirty_for_worker_retry(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=RuntimeError("timeout"))
+    assert not await _reconcile(adapter, "sk", state["desired_revision"])
+    persisted = adapter._plan_store.get_session("sk")
+    assert persisted["desired_revision"] > persisted["applied_revision"]
+    assert persisted["retry_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_apply_and_retry_store_failure_uses_worker_backoff_then_wake_recovers(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(
+        side_effect=[RuntimeError("timeout"), {"ts": "20.0"}]
+    )
+    client.conversations_replies = AsyncMock(return_value={"messages": []})
+    retry_failed = asyncio.Event()
+
+    def fail_retry(_session_key):
+        retry_failed.set()
+        raise OSError("disk unavailable")
+
+    adapter._plan_store.mark_retry = MagicMock(side_effect=fail_retry)
+    adapter._plan_store.retry_schedule = MagicMock(
+        wraps=adapter._plan_store.retry_schedule
+    )
+    adapter._running = True
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await retry_failed.wait()
+        await asyncio.sleep(0)
+
+        assert adapter._plan_reconcile_task is worker
+        assert adapter._plan_store.retry_schedule.call_count == 0
+
+        adapter._plan_store.mark_retry = MagicMock()
+        adapter.request_plan_reconcile()
+        for _ in range(50):
+            if client.chat_postMessage.await_count == 2:
+                break
+            await asyncio.sleep(0.01)
+        await adapter._stop_plan_reconcile_worker()
+
+    assert client.chat_postMessage.await_count == 2
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == 1
+
+
+@pytest.mark.asyncio
+async def test_session_crash_and_retry_store_failure_reaches_same_worker_backoff(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    crashed = asyncio.Event()
+
+    original_cleanup = adapter._cleanup_retired_plan_anchors
+    cleanup_calls = 0
+
+    async def cleanup_side_effect(generation, session_key):
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        if cleanup_calls == 1:
+            crashed.set()
+            raise RuntimeError("unexpected session failure")
+        return await original_cleanup(generation, session_key)
+
+    adapter._cleanup_retired_plan_anchors = AsyncMock(
+        side_effect=cleanup_side_effect
+    )
+    retry_failed = asyncio.Event()
+
+    def fail_retry(_session_key):
+        retry_failed.set()
+        raise OSError("disk unavailable")
+
+    adapter._plan_store.mark_retry = MagicMock(side_effect=fail_retry)
+    adapter._plan_store.retry_schedule = MagicMock(
+        wraps=adapter._plan_store.retry_schedule
+    )
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(
+        return_value={"ts": "20.0"}
+    )
+    adapter._running = True
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await crashed.wait()
+        await retry_failed.wait()
+        await asyncio.sleep(0)
+
+        assert adapter._plan_reconcile_task is worker
+        assert adapter._plan_store.retry_schedule.call_count == 0
+
+        adapter._plan_store.mark_retry = MagicMock()
+        adapter.request_plan_reconcile()
+        for _ in range(50):
+            if adapter._plan_store.get_session("sk")["applied_revision"] == 1:
+                break
+            await asyncio.sleep(0.01)
+        await adapter._stop_plan_reconcile_worker()
+
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == 1
+
+
+@pytest.mark.asyncio
+async def test_persistent_retry_store_failure_is_rate_bounded_and_disconnects(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(
+        side_effect=RuntimeError("timeout")
+    )
+    adapter._team_clients["T1"].conversations_replies = AsyncMock(
+        return_value={"messages": []}
+    )
+    adapter._plan_store.mark_retry = MagicMock(
+        side_effect=OSError("disk unavailable")
+    )
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await asyncio.sleep(0.36)
+
+        assert adapter._plan_reconcile_task is worker
+        assert worker is not None and not worker.done()
+        assert 2 <= adapter._plan_store.mark_retry.call_count <= 4
+        await asyncio.wait_for(adapter.disconnect(), timeout=0.2)
+
+    assert worker.done()
+    assert adapter._plan_reconcile_task is None
+
+
+@pytest.mark.asyncio
+async def test_retired_cleanup_and_retry_persistence_double_failure_uses_worker_backoff(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _converged_state_with_retired_anchor(adapter)
+    client = adapter._team_clients["T1"]
+    client.chat_delete = AsyncMock(side_effect=[RuntimeError("delete failed"), None])
+    client.chat_update = AsyncMock(side_effect=RuntimeError("neutralize failed"))
+    retry_persistence_failed = asyncio.Event()
+
+    def fail_retired_retry(*_args, **_kwargs):
+        retry_persistence_failed.set()
+        raise OSError("disk unavailable")
+
+    adapter._plan_store.mark_retired_retry = MagicMock(
+        side_effect=fail_retired_retry
+    )
+    adapter._plan_store.mark_retry = MagicMock(
+        wraps=adapter._plan_store.mark_retry
+    )
+    adapter._running = True
+
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await retry_persistence_failed.wait()
+        for _ in range(50):
+            if not adapter._plan_store.get_session("sk")["retired_anchors"]:
+                break
+            await asyncio.sleep(0.01)
+        await adapter._stop_plan_reconcile_worker()
+
+    assert adapter._plan_reconcile_task is None
+    assert worker is not None
+    assert adapter._plan_store.get_session("sk")["retired_anchors"] == []
+    assert client.chat_delete.await_count == 2
+    adapter._plan_store.mark_retry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persistent_retired_retry_persistence_failure_is_rate_bounded_and_disconnects(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _converged_state_with_retired_anchor(adapter)
+    client = adapter._team_clients["T1"]
+    client.chat_delete = AsyncMock(side_effect=RuntimeError("delete failed"))
+    client.chat_update = AsyncMock(side_effect=RuntimeError("neutralize failed"))
+    adapter._plan_store.mark_retired_retry = MagicMock(
+        side_effect=OSError("disk unavailable")
+    )
+    adapter._plan_store.mark_retry = MagicMock(
+        wraps=adapter._plan_store.mark_retry
+    )
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await asyncio.sleep(0.36)
+
+        assert adapter._plan_reconcile_task is worker
+        assert worker is not None and not worker.done()
+        assert 2 <= adapter._plan_store.mark_retired_retry.call_count <= 4
+        adapter._plan_store.mark_retry.assert_not_called()
+        await asyncio.wait_for(adapter.disconnect(), timeout=0.2)
+
+    assert worker.done()
+    assert adapter._plan_reconcile_task is None
+
+
+@pytest.mark.asyncio
+async def test_apply_failure_with_persisted_retry_uses_exact_deadline(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(
+        side_effect=[RuntimeError("timeout"), {"ts": "20.0"}]
+    )
+    client.conversations_replies = AsyncMock(return_value={"messages": []})
+    original_mark_retry = adapter._plan_store.mark_retry
+
+    def short_retry(session_key):
+        return original_mark_retry(
+            session_key, base_seconds=0.03, max_seconds=0.03
+        )
+
+    adapter._plan_store.mark_retry = MagicMock(side_effect=short_retry)
+    adapter._plan_store.list_dirty = MagicMock(wraps=adapter._plan_store.list_dirty)
+    adapter._running = True
+    started = time.monotonic()
+    with patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        for _ in range(50):
+            if client.chat_postMessage.await_count == 2:
+                break
+            await asyncio.sleep(0.01)
+        elapsed = time.monotonic() - started
+        await adapter._stop_plan_reconcile_worker()
+
+    assert client.chat_postMessage.await_count == 2
+    assert elapsed >= 0.02
+    assert adapter._plan_store.list_dirty.call_count <= 3
+
+
+@pytest.mark.asyncio
+async def test_startup_worker_reconciles_dirty_state_and_disconnect_stops_it(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    state = _state(adapter)
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    adapter._plan_reconcile_interval_s = 0.01
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+
+    adapter._start_plan_reconcile_worker()
+    for _ in range(50):
+        if adapter._plan_store.get_session("sk")["applied_revision"] == state["desired_revision"]:
+            break
+        await asyncio.sleep(0.01)
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == state["desired_revision"]
+
+    await adapter.disconnect()
+    assert adapter._plan_reconcile_task is None
+    adapter._stop_socket_mode_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_background_tasks_stops_blocked_plan_worker_before_base_cleanup(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._running = True
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def blocked_post(**_kwargs):
+        started.set()
+        try:
+            await release.wait()
+        except asyncio.CancelledError:
+            await release.wait()
+        return {"ts": "20.0"}
+
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(side_effect=blocked_post)
+    adapter._start_plan_reconcile_worker()
+    await started.wait()
+    cancelling = asyncio.create_task(adapter.cancel_background_tasks())
+    await asyncio.sleep(0)
+    assert adapter._plan_reconcile_stopping is True
+    release.set()
+    await cancelling
+
+    assert adapter._plan_reconcile_task is None
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == 0
+    assert adapter._plan_store.get_session("sk")["message_ts"] == "20.0"
+
+
+@pytest.mark.asyncio
+async def test_cancel_then_disconnect_is_idempotent_for_plan_worker(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    adapter._start_plan_reconcile_worker()
+
+    await adapter.cancel_background_tasks()
+    await adapter.disconnect()
+
+    assert adapter._plan_reconcile_task is None
+    adapter._stop_socket_mode_handler.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_idle_worker_waits_without_fixed_interval_rescans(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._running = True
+    adapter._plan_reconcile_interval_s = 0.01
+    adapter._plan_store.list_dirty = MagicMock(wraps=adapter._plan_store.list_dirty)
+    adapter._plan_store.retry_schedule = MagicMock(
+        wraps=adapter._plan_store.retry_schedule
+    )
+
+    adapter._start_plan_reconcile_worker()
+    await asyncio.sleep(0.05)
+    await adapter._stop_plan_reconcile_worker()
+
+    assert adapter._plan_store.list_dirty.call_count == 1
+    assert adapter._plan_store.retry_schedule.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_due_now_after_stale_dirty_scan_immediately_rescans_then_quiesces(
+    tmp_path,
+) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    original_list_dirty = adapter._plan_store.list_dirty
+    calls = 0
+
+    def stale_once(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return []
+        return original_list_dirty(*args, **kwargs)
+
+    adapter._plan_store.list_dirty = MagicMock(side_effect=stale_once)
+    adapter._plan_reconcile_wakeup.wait = AsyncMock(
+        wraps=adapter._plan_reconcile_wakeup.wait
+    )
+    adapter._team_clients["T1"].chat_postMessage = AsyncMock(
+        return_value={"ts": "20.0"}
+    )
+    adapter._running = True
+
+    adapter._start_plan_reconcile_worker()
+    for _ in range(50):
+        if adapter._plan_store.get_session("sk")["applied_revision"] == 1:
+            break
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0)
+    await adapter._stop_plan_reconcile_worker()
+
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == 1
+    assert adapter._plan_store.list_dirty.call_count == 2
+    assert adapter._plan_reconcile_wakeup.wait.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_current_retry_runs_at_earliest_deadline(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    with patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0):
+        adapter._plan_store.mark_retry("sk", base_seconds=0.03, max_seconds=0.03)
+    adapter._running = True
+    adapter._plan_reconcile_interval_s = 1.0
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+
+    adapter._start_plan_reconcile_worker()
+    for _ in range(50):
+        if client.chat_postMessage.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_postMessage.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_retired_retry_runs_at_earliest_deadline(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    first = _state(adapter)
+    prepared = adapter._plan_store.prepare_create("sk", expected_route=first)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=first["desired_revision"], snapshot_hash=first["desired_hash"],
+        message_ts="20.0", expected_message_ts="",
+        expected_client_msg_id=prepared["client_msg_id"],
+    )
+    adapter.record_desired_plan_snapshot(
+        session_key="sk", session_id="sid-2", team_id="T1", channel_id="C2",
+        thread_ts="11.0", route_user_id="U-owner", chat_type="group",
+        todos=[{"id": "b", "content": "Moved", "status": "pending"}],
+    )
+    retired = adapter._plan_store.list_retired("sk")[0]
+    with patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0):
+        adapter._plan_store.mark_retry("sk", base_seconds=1, max_seconds=1)
+        adapter._plan_store.mark_retired_retry(
+            "sk", retired["anchor_id"], base_seconds=0.03, max_seconds=0.03
+        )
+    adapter._running = True
+    client = adapter._team_clients["T1"]
+    client.chat_delete = AsyncMock()
+
+    adapter._start_plan_reconcile_worker()
+    for _ in range(50):
+        if client.chat_delete.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_delete.assert_awaited_once_with(channel="C1", ts="20.0")
+
+
+@pytest.mark.asyncio
+async def test_new_snapshot_wake_preempts_long_retry_deadline(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    with patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0):
+        adapter._plan_store.mark_retry("sk", base_seconds=10, max_seconds=10)
+    adapter._running = True
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    adapter._start_plan_reconcile_worker()
+    await asyncio.sleep(0.02)
+    client.chat_postMessage.assert_not_awaited()
+
+    _state(adapter, [{"id": "b", "content": "New", "status": "pending"}])
+    adapter.request_plan_reconcile()
+    for _ in range(50):
+        if client.chat_postMessage.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_postMessage.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_many_converged_sessions_get_one_quiescent_scan(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    for index in range(50):
+        key = f"sk-{index}"
+        state = adapter._plan_store.record_desired_snapshot({
+            "session_key": key, "session_id": f"sid-{index}", "team_id": "T1",
+            "channel_id": "C1", "thread_ts": "",
+        }, [{"id": "a", "content": "A", "status": "pending"}])
+        assert adapter._plan_store.mark_applied(
+            key, revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
+            message_ts=f"20.{index}",
+        )
+    adapter._running = True
+    adapter._plan_reconcile_interval_s = 0.01
+    adapter._plan_store.list_dirty = MagicMock(wraps=adapter._plan_store.list_dirty)
+    adapter._plan_store.retry_schedule = MagicMock(
+        wraps=adapter._plan_store.retry_schedule
+    )
+
+    adapter._start_plan_reconcile_worker()
+    await asyncio.sleep(0.05)
+    await adapter._stop_plan_reconcile_worker()
+
+    assert adapter._plan_store.list_dirty.call_count == 1
+    assert adapter._plan_store.retry_schedule.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_recovers_from_transient_list_error_on_wake_same_task(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    original = adapter._plan_store.list_dirty
+    failed = asyncio.Event()
+    calls = 0
+
+    def flaky_list_dirty(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            failed.set()
+            raise OSError("transient lock error")
+        return original(*args, **kwargs)
+
+    adapter._plan_store.list_dirty = MagicMock(side_effect=flaky_list_dirty)
+    adapter._running = True
+    adapter._start_plan_reconcile_worker()
+    worker = adapter._plan_reconcile_task
+    await failed.wait()
+    _state(adapter)
+    adapter.request_plan_reconcile()
+    for _ in range(50):
+        if client.chat_postMessage.await_count:
+            break
+        await asyncio.sleep(0.01)
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_postMessage.assert_awaited_once()
+    assert worker is not None
+    assert calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_worker_recovers_from_transient_deadline_error_on_wake(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    original = adapter._plan_store.retry_schedule
+    failed = asyncio.Event()
+    calls = 0
+
+    def flaky_deadline(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            failed.set()
+            raise OSError("transient read error")
+        return original(*args, **kwargs)
+
+    adapter._plan_store.retry_schedule = MagicMock(side_effect=flaky_deadline)
+    adapter._running = True
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    adapter._start_plan_reconcile_worker()
+    worker = adapter._plan_reconcile_task
+    await failed.wait()
+    _state(adapter)
+    adapter.request_plan_reconcile()
+    for _ in range(50):
+        if client.chat_postMessage.await_count:
+            break
+        await asyncio.sleep(0.01)
+    assert adapter._plan_reconcile_task is worker
+    await adapter._stop_plan_reconcile_worker()
+
+    client.chat_postMessage.assert_awaited_once()
+    assert calls >= 2
+
+
+@pytest.mark.asyncio
+async def test_persistent_worker_error_is_rate_bounded_without_replacement(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    adapter._plan_store.list_dirty = MagicMock(side_effect=OSError("persistent"))
+    adapter._running = True
+    with patch("plugins.platforms.slack.adapter.random.uniform", return_value=0):
+        adapter._start_plan_reconcile_worker()
+        worker = adapter._plan_reconcile_task
+        await asyncio.sleep(0.36)
+        assert adapter._plan_reconcile_task is worker
+        assert worker is not None and not worker.done()
+        assert 2 <= adapter._plan_store.list_dirty.call_count <= 4
+        await adapter._stop_plan_reconcile_worker()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_worker_error_backoff_exits_same_task(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    failed = asyncio.Event()
+
+    def fail_list_dirty():
+        failed.set()
+        raise OSError("persistent")
+
+    adapter._plan_store.list_dirty = MagicMock(side_effect=fail_list_dirty)
+    adapter._running = True
+    adapter._stop_socket_mode_handler = AsyncMock()
+    adapter._release_platform_lock = MagicMock()
+    adapter._start_plan_reconcile_worker()
+    worker = adapter._plan_reconcile_task
+    await failed.wait()
+
+    await asyncio.wait_for(adapter.disconnect(), timeout=0.2)
+
+    assert worker is not None and worker.done()
+    assert adapter._plan_reconcile_task is None
+
+
+@pytest.mark.asyncio
+async def test_stale_schedule_applies_latest_and_refresh_forces_update(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    client = adapter._team_clients["T1"]
+    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
+    first = _state(adapter)
+    second = _state(adapter, [{"id": "b", "content": "latest", "status": "pending"}])
+    assert await _reconcile(adapter, "sk", first["desired_revision"])
+    assert adapter._plan_store.get_session("sk")["applied_revision"] == second["desired_revision"]
+
+    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
+    refreshed = adapter._plan_store.request_refresh("sk")
+    assert refreshed["desired_revision"] == second["desired_revision"] + 1
+    assert await _reconcile(adapter, "sk")
+    client.chat_update.assert_awaited_once()
+    assert (
+        client.chat_update.call_args.kwargs["blocks"][0]["block_id"]
+        != f"hermes-plan-r{second['desired_revision']}-{second['desired_hash'][:10]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_event(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter, [
+        {"id": "a", "content": "A", "status": "pending"},
+        {"id": "b", "content": "B", "status": "completed"},
+    ])
+    adapter._plan_store.mark_applied(
+        "sk",
+        revision=1,
+        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
+        message_ts="20.0",
+    )
+    events: list[MessageEvent] = []
+
+    async def handle(event: MessageEvent):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    ack = AsyncMock()
+    body = {
+        "team": {"id": "T1"},
+        "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner", "name": "owner"},
+        "actions": [{"action_ts": "99.1"}],
+    }
+    action = {
+        "action_id": "hermes_plan_complete",
+        "block_id": "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10],
+        "selected_options": [{"value": "a"}],
+    }
+
+    await adapter._handle_plan_action(ack, body, action)
+    await asyncio.sleep(0)
+    assert ack.await_count == 1
+    assert len(events) == 1
+    event = events[0]
+    assert event.internal is True
+    assert event.source.chat_id == "C1"
+    assert event.source.thread_id == "10.0"
+    assert event.source.user_id == "U-owner"
+    assert event.metadata["gateway_session_id"] == "sid"
+    trusted = event.metadata["slack_plan_action"]
+    assert trusted["action_user_id"] == "U-owner"
+    assert trusted["complete_task_ids"] == ["a"]
+    assert trusted["reopen_task_ids"] == ["b"]
+    assert trusted["revision"] == 1
+    assert "todo" in event.text.lower()
+
+    await adapter._handle_plan_action(ack, body, action)
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_plan_action_rejects_wrong_route_or_unauthorized_user(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._plan_store.mark_applied(
+        "sk", revision=1,
+        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
+        message_ts="20.0",
+    )
+    adapter.set_message_handler(AsyncMock())
+    ack = AsyncMock()
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "WRONG"},
+        "message": {"ts": "20.0"}, "user": {"id": "U1"},
+        "actions": [{"action_ts": "1"}],
+    }
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    block_id = "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10]
+    await adapter._handle_plan_action(ack, body, {
+        "action_id": "hermes_plan_refresh", "block_id": block_id,
+    })
+    adapter._message_handler.assert_not_awaited()
+
+    body["channel"]["id"] = "C1"
+    adapter._is_interactive_user_authorized.return_value = False
+    await adapter._handle_plan_action(ack, body, {
+        "action_id": "hermes_plan_refresh", "block_id": block_id,
+    })
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("chat_type", ["group", "dm"])
+async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_path, chat_type) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter, route_user_id="U-owner", chat_type=chat_type)
+    state = adapter._plan_store.get_session("sk")
+    adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-other"}, "actions": [{"action_ts": f"other-{chat_type}"}],
+    }
+    action = {
+        "action_id": "hermes_plan_complete",
+        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
+        "selected_options": [{"value": "a"}],
+    }
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    await asyncio.sleep(0)
+    assert events == []
+
+    body["user"]["id"] = "U-owner"
+    body["actions"][0]["action_ts"] = f"owner-{chat_type}"
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    await asyncio.sleep(0)
+    assert len(events) == 1
+    assert events[0].source.user_id == "U-owner"
+    assert events[0].source.chat_type == chat_type
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_field", ["team", "channel", "message", "thread", "block"])
+async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path, invalid_field) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    state = adapter._plan_store.get_session("sk")
+    adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    adapter.set_message_handler(AsyncMock())
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U1"}, "actions": [{"action_ts": invalid_field}],
+    }
+    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
+    if invalid_field == "team":
+        body["team"]["id"] = "WRONG"
+    elif invalid_field == "channel":
+        body["channel"]["id"] = "WRONG"
+    elif invalid_field == "message":
+        body["message"]["ts"] = "WRONG"
+    elif invalid_field == "thread":
+        body["message"]["thread_ts"] = "WRONG"
+    else:
+        block_id = "hermes-plan-controls-r0-stale"
+
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_complete", "block_id": block_id,
+        "selected_options": [{"value": "a"}],
+    })
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plan_action_queues_silently_when_original_session_is_busy(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    state = adapter._plan_store.get_session("sk")
+    adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    adapter.set_message_handler(AsyncMock())
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    adapter.set_busy_session_handler(AsyncMock(return_value=False))
+    source = adapter.build_source(
+        chat_id="C1", chat_type="group", user_id="U-owner",
+        thread_id="10.0", scope_id="T1",
+    )
+    session_key = build_session_key(source)
+    adapter._active_sessions[session_key] = asyncio.Event()
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "busy"}],
+    }
+    action = {
+        "action_id": "hermes_plan_complete",
+        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
+        "selected_options": [{"value": "a"}],
+    }
+
+    await adapter._handle_plan_action(AsyncMock(), body, action)
+    await asyncio.sleep(0)
+    assert adapter._pending_messages[session_key].internal is True
+    adapter._message_handler.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    _state(adapter)
+    adapter._plan_store.mark_applied(
+        "sk", revision=1,
+        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
+        message_ts="20.0",
+    )
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    body = {
+        "trigger_id": "trigger",
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "1"}],
+    }
+    block_id = "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10]
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_add", "block_id": block_id,
+    })
+    view = client.views_open.call_args.kwargs["view"]
+    assert view["callback_id"] == "hermes_plan_add_task"
+    envelope = json.loads(view["private_metadata"])
+    assert envelope["signature"]
+
+    events = []
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    rejected_body = {
+        "team": {"id": "T1"}, "user": {"id": "U-other"},
+        "view": {
+            "id": "V-other", "hash": "H-other",
+            "private_metadata": view["private_metadata"],
+            "state": {"values": {"task": {"content": {"value": "Wrong owner"}}}},
+        },
+    }
+    await adapter._handle_plan_add_view(AsyncMock(), rejected_body, AsyncMock())
+    await asyncio.sleep(0)
+    assert events == []
+
+    submit_body = {
+        "team": {"id": "T1"}, "user": {"id": "U-owner"},
+        "view": {
+            "private_metadata": view["private_metadata"],
+            "state": {"values": {"task": {"content": {"value": "New task"}}}},
+        },
+    }
+    ack = AsyncMock()
+    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
+    await asyncio.sleep(0)
+    assert ack.await_count == 1
+    assert len(events) == 1
+    assert events[0].metadata["slack_plan_action"]["add_task_content"] == "New task"
+
+    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
+    assert len(events) == 1
+
+    tampered = json.loads(view["private_metadata"])
+    tampered["payload"]["revision"] = 99
+    submit_body["view"]["private_metadata"] = json.dumps(tampered)
+    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_add_modal_keeps_validated_lineage_across_concurrent_route_change(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    original = _state(adapter)
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=original["desired_revision"],
+        snapshot_hash=original["desired_hash"], message_ts="20.0",
+    )
+    payload = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0", "message_ts": "20.0",
+        "revision": original["desired_revision"],
+        "snapshot_hash": original["desired_hash"], "task_ids": [],
+    }
+    private_metadata = sign_private_metadata(payload, b"signing-secret")
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    events = []
+
+    async def handle(event):
+        events.append(event)
+
+    adapter.set_message_handler(handle)
+    validate = adapter._plan_store.validate_action
+    changed = False
+
+    def validate_then_change(metadata):
+        nonlocal changed
+        validated = validate(metadata)
+        if validated and not changed:
+            changed = True
+            adapter.record_desired_plan_snapshot(
+                session_key="sk", session_id="sid-new", team_id="T1",
+                channel_id="C2", thread_ts="11.0", route_user_id="U-owner",
+                chat_type="group",
+                todos=[{"id": "b", "content": "New", "status": "pending"}],
+            )
+        return validated
+
+    adapter._plan_store.validate_action = MagicMock(side_effect=validate_then_change)
+    await adapter._handle_plan_add_view(AsyncMock(), {
+        "team": {"id": "T1"}, "user": {"id": "U-owner"},
+        "view": {
+            "id": "V-race", "hash": "H-race", "private_metadata": private_metadata,
+            "state": {"values": {"task": {"content": {"value": "Old modal"}}}},
+        },
+    })
+    await asyncio.sleep(0)
+
+    assert len(events) == 1
+    trusted = events[0].metadata["slack_plan_action"]
+    assert trusted["session_id"] == "sid"
+    assert trusted["channel_id"] == "C1"
+    assert trusted["thread_ts"] == "10.0"
+    assert trusted["revision"] == original["desired_revision"]
+    assert trusted["snapshot_hash"] == original["desired_hash"]
+
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {events[0].source.platform: adapter}
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {
+        "sk": type("Entry", (), {"session_id": "sid-new"})()
+    }
+    adapter.send = AsyncMock()
+    assert not await runner._validate_slack_plan_action_after_claim(events[0], "sk")
+    adapter.send.assert_awaited_once()
+
+
+def test_add_control_unavailable_without_signing_secret(tmp_path) -> None:
+    adapter = _adapter(tmp_path, secret=None)
+    state = _state(adapter)
+    rendered = adapter._render_plan_state(state)
+    action_ids = [
+        element["action_id"]
+        for block in rendered.native_blocks
+        if block["type"] == "actions"
+        for element in block["elements"]
+    ]
+    assert "hermes_plan_add" not in action_ids
+
+
+@pytest.mark.asyncio
+async def test_crafted_add_action_is_rejected_without_signing_secret(tmp_path) -> None:
+    adapter = _adapter(tmp_path, secret=None)
+    _state(adapter)
+    state = adapter._plan_store.get_session("sk")
+    adapter._plan_store.mark_applied(
+        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    client = adapter._team_clients["T1"]
+    client.views_open = AsyncMock()
+    await adapter._handle_plan_action(AsyncMock(), {
+        "trigger_id": "trigger", "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U-owner"}, "actions": [{"action_ts": "no-secret"}],
+    }, {
+        "action_id": "hermes_plan_add",
+        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
+    })
+    client.views_open.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_disabled_plan_handlers_ack_without_mutation(tmp_path) -> None:
+    adapter = _adapter(tmp_path, enabled=False)
+    adapter.set_message_handler(AsyncMock())
+    ack = AsyncMock()
+
+    await adapter._handle_plan_action(ack, {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0"}, "user": {"id": "U1"},
+    }, {"action_id": "hermes_plan_refresh", "block_id": "stale"})
+    await adapter._handle_plan_add_view(ack, {
+        "team": {"id": "T1"}, "user": {"id": "U1"}, "view": {},
+    })
+
+    assert ack.await_count == 2
+    adapter._message_handler.assert_not_awaited()
+    assert adapter._plan_store.list_dirty() == []
+    assert adapter._plan_reconcile_task is None
+
+
+def test_feature_gate_defaults_off_and_coerces_false_string(tmp_path) -> None:
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        assert SlackAdapter(PlatformConfig(enabled=True, token="x", extra={}))._plan_cards_enabled is False
+        assert SlackAdapter(PlatformConfig(
+            enabled=True, token="x", extra={"native_plan_cards": "false"}
+        ))._plan_cards_enabled is False
+
+
+def test_loaded_config_constructs_enabled_adapter_with_signing_key(
+    tmp_path, monkeypatch
+) -> None:
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    secret = "loaded-plan-signing-secret"
+    (hermes_home / "config.yaml").write_text(
+        "slack:\n"
+        "  native_plan_cards: true\n"
+        f"  native_plan_cards_signing_secret: {secret}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
+
+    config = load_gateway_config()
+    adapter = SlackAdapter(config.platforms[Platform.SLACK])
+
+    assert adapter._plan_cards_enabled is True
+    assert adapter._plan_signing_secret() == secret.encode("utf-8")
+
+
+def _adapter_with_config_signing_secret(tmp_path, secret: str | None) -> SlackAdapter:
+    extra = {}
+    if secret is not None:
+        extra["native_plan_cards_signing_secret"] = secret
+    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
+        return SlackAdapter(PlatformConfig(enabled=True, token="x", extra=extra))
+
+
+def test_unscoped_multiplex_signing_secret_uses_adapter_config_not_global_env(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
+    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
+    was_multiplex_active = secret_scope.is_multiplex_active()
+    scope_token = secret_scope.set_secret_scope(None)
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert adapter._plan_signing_secret() == b"adapter-local-secret"
+    finally:
+        secret_scope.reset_secret_scope(scope_token)
+        secret_scope.set_multiplex_active(was_multiplex_active)
+
+
+def test_unscoped_multiplex_signing_secret_fails_closed_without_adapter_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
+    adapter = _adapter_with_config_signing_secret(tmp_path, None)
+    was_multiplex_active = secret_scope.is_multiplex_active()
+    scope_token = secret_scope.set_secret_scope(None)
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert adapter._plan_signing_secret() is None
+    finally:
+        secret_scope.reset_secret_scope(scope_token)
+        secret_scope.set_multiplex_active(was_multiplex_active)
+
+
+def test_scoped_signing_secret_takes_priority_over_adapter_config(
+    tmp_path, monkeypatch
+) -> None:
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
+    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
+    was_multiplex_active = secret_scope.is_multiplex_active()
+    scope_token = secret_scope.set_secret_scope(
+        {"SLACK_SIGNING_SECRET": "properly-scoped-secret"}
+    )
+    secret_scope.set_multiplex_active(True)
+    try:
+        assert adapter._plan_signing_secret() == b"properly-scoped-secret"
+    finally:
+        secret_scope.reset_secret_scope(scope_token)
+        secret_scope.set_multiplex_active(was_multiplex_active)
+
+
+def test_signing_secret_store_failure_uses_adapter_config(tmp_path) -> None:
+    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
+
+    with patch(
+        "plugins.platforms.slack.adapter.get_secret",
+        side_effect=RuntimeError("secret store unavailable"),
+    ):
+        assert adapter._plan_signing_secret() == b"adapter-local-secret"
+
+
+def test_plan_signing_secret_has_no_direct_process_env_fallback() -> None:
+    source = inspect.getsource(SlackAdapter._plan_signing_secret)
+
+    assert "os.getenv" not in source

--- a/tests/gateway/test_slack_plan_card_adapter.py
+++ b/tests/gateway/test_slack_plan_card_adapter.py
@@ -2,30 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-import json
 import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from agent import secret_scope
-from gateway.config import Platform, PlatformConfig, load_gateway_config
-from gateway.platforms.base import MessageEvent
-from gateway.run import GatewayRunner
-from gateway.session import build_session_key
+from gateway.config import PlatformConfig
 from plugins.platforms.slack.adapter import SlackAdapter
-from plugins.platforms.slack.plan_cards import (
-    is_user_task_id,
-    sign_private_metadata,
-    verify_private_metadata,
-)
-from tools.todo_tool import MAX_TODO_ITEMS
 
 
 def _adapter(
     tmp_path,
     *,
-    secret: str | None = "signing-secret",
     enabled: bool = True,
 ) -> SlackAdapter:
     config = PlatformConfig(
@@ -38,7 +26,6 @@ def _adapter(
     adapter._app = MagicMock()
     adapter._team_clients = {"T1": AsyncMock()}
     adapter._channel_team = {"C1": "T1"}
-    adapter._plan_signing_secret_override = secret
     return adapter
 
 
@@ -81,7 +68,11 @@ def _state(
         thread_ts="10.0",
         route_user_id=route_user_id,
         chat_type=chat_type,
-        todos=todos or [{"id": "a", "content": "A", "status": "pending"}],
+        todos=(
+            todos
+            if todos is not None
+            else [{"id": "a", "content": "A", "status": "pending"}]
+        ),
     )
 
 
@@ -634,35 +625,6 @@ async def test_reconcile_creates_updates_and_dedupes_hash(tmp_path) -> None:
     client.chat_update.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_hash_dedupe_keeps_existing_card_actions_valid(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    client = adapter._team_clients["T1"]
-    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
-    first = _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
-    assert await _reconcile(adapter, "sk", first["desired_revision"])
-    same = _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
-    assert await _reconcile(adapter, "sk", same["desired_revision"])
-    client.chat_update.assert_not_awaited()
-
-    events = []
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    await adapter._handle_plan_action(AsyncMock(), {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "same-hash"}],
-    }, {
-        "action_id": "hermes_plan_complete",
-        "block_id": "hermes-plan-controls-r1-" + first["desired_hash"][:10],
-        "selected_options": [{"value": "user:a"}],
-    })
-    await asyncio.sleep(0)
-    assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["revision"] == same["desired_revision"]
 
 
 @pytest.mark.asyncio
@@ -1690,1027 +1652,133 @@ async def test_disconnect_during_worker_error_backoff_exits_same_task(tmp_path) 
 
 
 @pytest.mark.asyncio
-async def test_stale_schedule_applies_latest_and_refresh_forces_update(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    client = adapter._team_clients["T1"]
-    client.chat_postMessage = AsyncMock(return_value={"ts": "20.0"})
-    first = _state(adapter)
-    second = _state(adapter, [{"id": "b", "content": "latest", "status": "pending"}])
-    assert await _reconcile(adapter, "sk", first["desired_revision"])
-    assert adapter._plan_store.get_session("sk")["applied_revision"] == second["desired_revision"]
-
-    client.chat_update = AsyncMock(return_value={"ts": "20.0"})
-    refreshed = adapter._plan_store.request_refresh("sk")
-    assert refreshed["desired_revision"] == second["desired_revision"] + 1
-    assert await _reconcile(adapter, "sk")
-    client.chat_update.assert_awaited_once()
-    assert (
-        client.chat_update.call_args.kwargs["blocks"][0]["block_id"]
-        != f"hermes-plan-r{second['desired_revision']}-{second['desired_hash'][:10]}"
-    )
-
-
-@pytest.mark.asyncio
-async def test_plan_action_acks_authorizes_validates_dedupes_and_emits_internal_event(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
+@pytest.mark.parametrize("enabled", [True, False])
+@pytest.mark.parametrize(
+    "action_id",
+    [
+        "hermes_plan_complete",
+        "hermes_plan_cancel",
+        "hermes_plan_add",
+        "hermes_plan_refresh",
+    ],
+)
+async def test_legacy_plan_actions_ack_read_only_without_dispatch_or_state_mutation(
+    tmp_path, enabled, action_id,
+) -> None:
+    adapter = _adapter(tmp_path, enabled=enabled)
     _state(adapter, [
-        {"id": "agent:a", "content": "Agent", "status": "pending"},
         {"id": "user:a", "content": "A", "status": "in_progress"},
         {"id": "user:b", "content": "B", "status": "completed"},
     ])
-    adapter._plan_store.mark_applied(
-        "sk",
-        revision=1,
-        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
-        message_ts="20.0",
-    )
-    events: list[MessageEvent] = []
-
-    async def handle(event: MessageEvent):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    ack = AsyncMock()
-    body = {
-        "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner", "name": "owner"},
-        "actions": [{"action_ts": "99.1"}],
-    }
-    action = {
-        "action_id": "hermes_plan_complete",
-        "block_id": "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10],
-        "selected_options": [{"value": "user:a"}],
-    }
-
-    await adapter._handle_plan_action(ack, body, action)
-    await asyncio.sleep(0)
-    assert ack.await_count == 1
-    assert len(events) == 1
-    event = events[0]
-    assert event.internal is True
-    assert event.source.chat_id == "C1"
-    assert event.source.thread_id == "10.0"
-    assert event.source.user_id == "U-owner"
-    assert event.metadata["gateway_session_id"] == "sid"
-    trusted = event.metadata["slack_plan_action"]
-    assert trusted["action_user_id"] == "U-owner"
-    assert trusted["action_kind"] == "complete_reopen"
-    assert trusted["task_ids"] == ["user:a", "user:b"]
-    assert trusted["complete_task_ids"] == ["user:a"]
-    assert trusted["complete_task_status"] == "completed"
-    assert trusted["reopen_task_ids"] == ["user:b"]
-    assert trusted["reopen_task_status"] == "in_progress"
-    assert trusted["revision"] == 1
-    assert "todo" in event.text.lower()
-    assert '"complete_task_status": "completed"' in event.text
-    assert '"reopen_task_status": "in_progress"' in event.text
-    assert adapter.validate_plan_action_metadata(trusted)
-
-    await adapter._handle_plan_action(ack, body, action)
-    assert len(events) == 1
-
-
-@pytest.mark.asyncio
-async def test_plan_action_rejects_mixed_duplicate_and_ineligible_ids_atomically(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    _state(adapter, [
-        {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:pending", "content": "Pending", "status": "pending"},
-        {"id": "user:done", "content": "Done", "status": "completed"},
-        {"id": "user:active", "content": "Active", "status": "in_progress"},
-    ])
-    state = adapter._plan_store.get_session("sk")
-    adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "mixed"}],
-    }
-    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
-
-    for index, action in enumerate((
-        {
-            "action_id": "hermes_plan_complete", "block_id": block_id,
-            "selected_options": [
-                {"value": "user:pending"}, {"value": "agent:a"},
-            ],
-        },
-        {
-            "action_id": "hermes_plan_complete", "block_id": block_id,
-            "selected_options": [{"value": "user:pending"}],
-        },
-        {
-            "action_id": "hermes_plan_complete", "block_id": block_id,
-            "selected_options": [
-                {"value": "user:active"}, {"value": "user:active"},
-            ],
-        },
-        {
-            "action_id": "hermes_plan_complete", "block_id": block_id,
-            "selected_options": [{"value": "user:missing"}],
-        },
-        {
-            "action_id": "hermes_plan_cancel", "block_id": block_id,
-            "selected_option": {"value": "agent:a"},
-        },
-        {
-            "action_id": "hermes_plan_cancel", "block_id": block_id,
-            "selected_option": {"value": "user:pending"},
-        },
-    )):
-        body["actions"][0]["action_ts"] = f"invalid-{index}"
-        await adapter._handle_plan_action(AsyncMock(), body, action)
-
-    await asyncio.sleep(0)
-    assert events == []
-
-    body["actions"][0]["action_ts"] = "valid-cancel"
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_cancel", "block_id": block_id,
-        "selected_option": {"value": "user:active"},
-    })
-    await asyncio.sleep(0)
-    assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["action_kind"] == "cancel"
-    assert events[0].metadata["slack_plan_action"]["cancel_task_ids"] == ["user:active"]
-    assert events[0].metadata["slack_plan_action"]["cancel_task_status"] == "cancelled"
-
-
-def test_adapter_claim_validator_rejects_direct_forged_plan_metadata(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    state = _state(adapter, [
-        {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:a", "content": "User", "status": "in_progress"},
-    ])
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    base = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "message_ts": "20.0",
-        "revision": 1, "snapshot_hash": state["desired_hash"],
-        "action_user_id": "U-owner", "action_dedupe_id": "dedupe",
-    }
-    assert adapter._plan_store.consume_action_id("dedupe")
-    assert not adapter.validate_plan_action_metadata({
-        **base, "action_kind": "complete_reopen",
-        "task_ids": ["agent:a", "user:a"],
-        "complete_task_ids": ["agent:a", "user:a"],
-        "complete_task_status": "completed", "reopen_task_ids": [],
-        "reopen_task_status": "in_progress",
-    })
-    assert not adapter.validate_plan_action_metadata({
-        **base, "action_kind": "complete_reopen", "task_ids": ["agent:a"],
-        "complete_task_ids": [], "complete_task_status": "completed",
-        "reopen_task_ids": ["agent:a"], "reopen_task_status": "in_progress",
-    })
-    assert not adapter.validate_plan_action_metadata({
-        **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
-        "add_task_ids": ["user:replacement"], "add_task_content": "New",
-        "add_task_status": "in_progress",
-    })
-
-
-@pytest.mark.asyncio
-async def test_plan_action_rejects_wrong_route_or_unauthorized_user(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    _state(adapter)
-    adapter._plan_store.mark_applied(
-        "sk", revision=1,
-        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
-        message_ts="20.0",
-    )
+    state_path = adapter._plan_store.state_path
+    before = state_path.read_bytes() if state_path.exists() else None
     adapter.set_message_handler(AsyncMock())
-    ack = AsyncMock()
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "WRONG"},
-        "message": {"ts": "20.0"}, "user": {"id": "U1"},
-        "actions": [{"action_ts": "1"}],
-    }
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    block_id = "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10]
-    await adapter._handle_plan_action(ack, body, {
-        "action_id": "hermes_plan_refresh", "block_id": block_id,
-    })
-    adapter._message_handler.assert_not_awaited()
-
-    body["channel"]["id"] = "C1"
-    adapter._is_interactive_user_authorized.return_value = False
-    await adapter._handle_plan_action(ack, body, {
-        "action_id": "hermes_plan_refresh", "block_id": block_id,
-    })
-    adapter._message_handler.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("chat_type", ["group", "dm"])
-async def test_plan_action_requires_persisted_route_owner_for_group_and_dm(tmp_path, chat_type) -> None:
-    adapter = _adapter(tmp_path)
-    _state(
-        adapter,
-        [{"id": "user:a", "content": "A", "status": "in_progress"}],
-        route_user_id="U-owner",
-        chat_type=chat_type,
-    )
-    state = adapter._plan_store.get_session("sk")
-    adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-other"}, "actions": [{"action_ts": f"other-{chat_type}"}],
-    }
-    action = {
-        "action_id": "hermes_plan_complete",
-        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-        "selected_options": [{"value": "user:a"}],
-    }
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    await asyncio.sleep(0)
-    assert events == []
-
-    body["user"]["id"] = "U-owner"
-    body["actions"][0]["action_ts"] = f"owner-{chat_type}"
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    await asyncio.sleep(0)
-    assert len(events) == 1
-    assert events[0].source.user_id == "U-owner"
-    assert events[0].source.chat_type == chat_type
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("action_id", "selection"),
-    [
-        ("hermes_plan_complete", {"selected_options": [{"value": "user:a"}]}),
-        ("hermes_plan_cancel", {"selected_option": {"value": "user:a"}}),
-        ("hermes_plan_add", {}),
-    ],
-)
-async def test_same_channel_unrelated_allowlisted_user_cannot_mutate_owner_card(
-    tmp_path, action_id, selection,
-) -> None:
-    adapter = _adapter(tmp_path)
-    state = _state(
-        adapter,
-        [{"id": "user:a", "content": "A", "status": "in_progress"}],
-    )
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
     client = adapter._team_clients["T1"]
+    client.chat_postEphemeral = AsyncMock(return_value={"message_ts": "notice"})
     client.views_open = AsyncMock()
+    ack = AsyncMock()
     body = {
         "trigger_id": "trigger",
         "team": {"id": "T1"},
         "channel": {"id": "C1"},
         "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-other"},
-        "actions": [{"action_ts": action_id}],
+        "user": {"id": "U-owner"},
+        "actions": [{"action_ts": "legacy-action"}],
     }
     action = {
         "action_id": action_id,
-        "block_id": (
-            f"hermes-plan-controls-r{state['desired_revision']}-"
-            f"{state['desired_hash'][:10]}"
-        ),
-        **selection,
+        "block_id": "hermes-plan-controls-r1-legacy",
+        "selected_options": [{"value": "user:a"}],
+        "selected_option": {"value": "user:a"},
     }
 
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    await asyncio.sleep(0)
+    await adapter._handle_plan_action(ack, body, action)
+    await adapter._handle_plan_action(ack, body, action)
 
-    assert events == []
+    assert ack.await_count == 2
+    client.chat_postEphemeral.assert_awaited_once()
+    notice = client.chat_postEphemeral.call_args.kwargs
+    assert notice["channel"] == "C1"
+    assert notice["user"] == "U-owner"
+    assert notice["thread_ts"] == "10.0"
+    assert "read-only" in notice["text"]
+    assert "Clarify or reply in Slack" in notice["text"]
     client.views_open.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_empty_owner_route_is_read_only_but_refresh_remains_available(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    state = _state(
-        adapter,
-        [{"id": "user:a", "content": "A", "status": "in_progress"}],
-        route_user_id="",
-    )
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    rendered = adapter._render_plan_state(adapter._plan_store.get_session("sk"))
-    assert [
-        element["action_id"]
-        for block in rendered.native_blocks
-        if block["type"] == "actions"
-        for element in block["elements"]
-    ] == ["hermes_plan_refresh"]
-
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    body = {
-        "trigger_id": "trigger",
-        "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-allowlisted"},
-        "actions": [{"action_ts": "empty-owner"}],
-    }
-    block_id = (
-        f"hermes-plan-controls-r{state['desired_revision']}-"
-        f"{state['desired_hash'][:10]}"
-    )
-    for index, action in enumerate((
-        {
-            "action_id": "hermes_plan_complete",
-            "selected_options": [{"value": "user:a"}],
-        },
-        {
-            "action_id": "hermes_plan_cancel",
-            "selected_option": {"value": "user:a"},
-        },
-        {"action_id": "hermes_plan_add"},
-    )):
-        body["actions"][0]["action_ts"] = f"empty-owner-{index}"
-        await adapter._handle_plan_action(
-            AsyncMock(), body, {**action, "block_id": block_id}
-        )
-
-    assert events == []
-    client.views_open.assert_not_awaited()
-    before_refresh = adapter._plan_store.get_session("sk")["desired_revision"]
-    body["actions"][0]["action_ts"] = "empty-owner-refresh"
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_refresh", "block_id": block_id,
-    })
-    assert adapter._plan_store.get_session("sk")["desired_revision"] == before_refresh + 1
-
-
-@pytest.mark.asyncio
-async def test_route_owner_change_reanchors_and_only_new_owner_can_use_new_card(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    old = _state(
-        adapter,
-        [{"id": "user:a", "content": "A", "status": "in_progress"}],
-        route_user_id="U-owner",
-    )
-    old_create = adapter._plan_store.prepare_create("sk", expected_route=old)
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=old["desired_revision"], snapshot_hash=old["desired_hash"],
-        message_ts="20.0", expected_message_ts="",
-        expected_client_msg_id=old_create["client_msg_id"],
-    )
-
-    new = adapter.record_desired_plan_snapshot(
-        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
-        thread_ts="10.0", route_user_id="U-new", chat_type="group",
-        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
-    )
-    assert new["message_ts"] == ""
-    assert new["retired_anchors"][0]["message_ts"] == "20.0"
-    assert new["retired_anchors"][0]["route_user_id"] == "U-owner"
-    assert adapter._plan_store.lookup_route("T1", "C1", "20.0") is None
-    new_create = adapter._plan_store.prepare_create("sk", expected_route=new)
-    assert new_create["client_msg_id"] != old_create["client_msg_id"]
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=new["desired_revision"], snapshot_hash=new["desired_hash"],
-        message_ts="30.0", rendered_revision=new["desired_revision"],
-        expected_message_ts="",
-        expected_client_msg_id=new_create["client_msg_id"],
-    )
-
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    action = {
-        "action_id": "hermes_plan_complete",
-        "block_id": (
-            f"hermes-plan-controls-r{new['desired_revision']}-"
-            f"{new['desired_hash'][:10]}"
-        ),
-        "selected_options": [{"value": "user:a"}],
-    }
-    body = {
-        "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"},
-        "actions": [{"action_ts": "old-card"}],
-    }
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    body["message"]["ts"] = "30.0"
-    body["actions"][0]["action_ts"] = "old-owner-new-card"
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    assert events == []
-
-    body["user"]["id"] = "U-new"
-    body["actions"][0]["action_ts"] = "new-owner-new-card"
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    await asyncio.sleep(0)
-    assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["action_user_id"] == "U-new"
-
-
-@pytest.mark.asyncio
-async def test_wildcard_allowlist_does_not_bypass_exact_plan_owner(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    state = _state(
-        adapter,
-        [{"id": "user:a", "content": "A", "status": "in_progress"}],
-        route_user_id="U-owner",
-    )
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    body = {
-        "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-other"},
-        "actions": [{"action_ts": "wildcard"}],
-    }
-    action = {
-        "action_id": "hermes_plan_complete",
-        "block_id": (
-            f"hermes-plan-controls-r{state['desired_revision']}-"
-            f"{state['desired_hash'][:10]}"
-        ),
-        "selected_options": [{"value": "user:a"}],
-    }
-
-    with patch.dict("os.environ", {"SLACK_ALLOWED_USERS": "*"}, clear=False):
-        assert adapter._is_interactive_user_authorized(
-            "U-other", channel_id="C1", team_id="T1", thread_id="10.0"
-        )
-        await adapter._handle_plan_action(AsyncMock(), body, action)
-
-    await asyncio.sleep(0)
-    assert events == []
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("invalid_field", ["team", "channel", "message", "thread", "block"])
-async def test_plan_action_rejects_each_stale_or_wrong_route_dimension(tmp_path, invalid_field) -> None:
-    adapter = _adapter(tmp_path)
-    _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
-    state = adapter._plan_store.get_session("sk")
-    adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    adapter.set_message_handler(AsyncMock())
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U1"}, "actions": [{"action_ts": invalid_field}],
-    }
-    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
-    if invalid_field == "team":
-        body["team"]["id"] = "WRONG"
-    elif invalid_field == "channel":
-        body["channel"]["id"] = "WRONG"
-    elif invalid_field == "message":
-        body["message"]["ts"] = "WRONG"
-    elif invalid_field == "thread":
-        body["message"]["thread_ts"] = "WRONG"
-    else:
-        block_id = "hermes-plan-controls-r0-stale"
-
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_complete", "block_id": block_id,
-        "selected_options": [{"value": "user:a"}],
-    })
     adapter._message_handler.assert_not_awaited()
+    after = state_path.read_bytes() if state_path.exists() else None
+    assert after == before
 
 
 @pytest.mark.asyncio
-async def test_plan_action_queues_silently_when_original_session_is_busy(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    _state(adapter, [{"id": "user:a", "content": "A", "status": "in_progress"}])
-    state = adapter._plan_store.get_session("sk")
-    adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    adapter.set_message_handler(AsyncMock())
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    adapter.set_busy_session_handler(AsyncMock(return_value=False))
-    source = adapter.build_source(
-        chat_id="C1", chat_type="group", user_id="U-owner",
-        thread_id="10.0", scope_id="T1",
-    )
-    session_key = build_session_key(source)
-    adapter._active_sessions[session_key] = asyncio.Event()
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "busy"}],
-    }
-    action = {
-        "action_id": "hermes_plan_complete",
-        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-        "selected_options": [{"value": "user:a"}],
-    }
-
-    await adapter._handle_plan_action(AsyncMock(), body, action)
-    await asyncio.sleep(0)
-    assert adapter._pending_messages[session_key].internal is True
-    adapter._message_handler.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_add_modal_is_signed_and_submission_tamper_fails_closed(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    _state(adapter)
-    adapter._plan_store.mark_applied(
-        "sk", revision=1,
-        snapshot_hash=adapter._plan_store.get_session("sk")["desired_hash"],
-        message_ts="20.0",
-    )
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    body = {
-        "trigger_id": "trigger",
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "1"}],
-    }
-    block_id = "hermes-plan-controls-r1-" + adapter._plan_store.get_session("sk")["desired_hash"][:10]
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_add", "block_id": block_id,
-    })
-    view = client.views_open.call_args.kwargs["view"]
-    assert view["callback_id"] == "hermes_plan_add_task"
-    assert view["title"]["text"] == "Add user task"
-    envelope = json.loads(view["private_metadata"])
-    assert envelope["signature"]
-    payload = verify_private_metadata(view["private_metadata"], b"signing-secret")
-    generated_id = payload["add_task_ids"][0]
-    assert is_user_task_id(generated_id)
-    assert payload["task_ids"] == [generated_id]
-    assert payload["action_kind"] == "add_user_task"
-    assert payload["action_user_id"] == "U-owner"
-    assert generated_id not in {
-        task["id"] for task in adapter._plan_store.get_session("sk")["last_desired_snapshot"]
-    }
-
-    events = []
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    rejected_body = {
-        "team": {"id": "T1"}, "user": {"id": "U-other"},
-        "view": {
-            "id": "V-other", "hash": "H-other",
-            "private_metadata": view["private_metadata"],
-            "state": {"values": {"task": {"content": {"value": "Wrong owner"}}}},
-        },
-    }
-    await adapter._handle_plan_add_view(AsyncMock(), rejected_body, AsyncMock())
-    await asyncio.sleep(0)
-    assert events == []
-
-    submit_body = {
-        "team": {"id": "T1"}, "user": {"id": "U-owner"},
-        "view": {
-            "private_metadata": view["private_metadata"],
-            "state": {"values": {"task": {"content": {"value": "New task"}}}},
-        },
-    }
-    ack = AsyncMock()
-    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
-    await asyncio.sleep(0)
-    assert ack.await_count == 1
-    assert len(events) == 1
-    trusted = events[0].metadata["slack_plan_action"]
-    assert trusted["action_kind"] == "add_user_task"
-    assert trusted["add_task_ids"] == [generated_id]
-    assert trusted["task_ids"] == [generated_id]
-    assert trusted["add_task_content"] == "New task"
-    assert trusted["add_task_status"] == "in_progress"
-    assert f'"add_task_ids": ["{generated_id}"]' in events[0].text
-    assert '"add_task_content": "New task"' in events[0].text
-    assert '"add_task_status": "in_progress"' in events[0].text
-
-    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
-    assert len(events) == 1
-
-    tampered = json.loads(view["private_metadata"])
-    tampered["payload"]["add_task_ids"] = ["user:replacement"]
-    submit_body["view"]["private_metadata"] = json.dumps(tampered)
-    await adapter._handle_plan_add_view(ack, submit_body, AsyncMock())
-    assert len(events) == 1
-
-
-@pytest.mark.asyncio
-async def test_future_user_tasks_do_not_block_active_action_or_add_modal(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    read_only = [
-        {
-            "id": f"user:read-only-{index}",
-            "content": str(index),
-            "status": "cancelled" if index % 2 else "pending",
-        }
-        for index in range(15)
-    ]
-    state = _state(adapter, read_only + [
-        {"id": "user:active", "content": "Active", "status": "in_progress"},
-    ])
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    body = {
-        "trigger_id": "trigger", "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "complete"}],
-    }
-    block_id = "hermes-plan-controls-r1-" + state["desired_hash"][:10]
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_complete", "block_id": block_id,
-        "selected_options": [{"value": "user:active"}],
-    })
-    await asyncio.sleep(0)
-    assert len(events) == 1
-    assert events[0].metadata["slack_plan_action"]["complete_task_ids"] == ["user:active"]
-
-    body["actions"][0]["action_ts"] = "add"
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_add", "block_id": block_id,
-    })
-    client.views_open.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("count", "opens_modal"),
-    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
-)
-async def test_add_modal_preflight_follows_authoritative_todo_capacity(
-    tmp_path, count: int, opens_modal: bool,
-) -> None:
-    adapter = _adapter(tmp_path)
-    state = _state(adapter, [
-        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
-        for index in range(count)
-    ])
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    await adapter._handle_plan_action(AsyncMock(), {
-        "trigger_id": "trigger", "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"},
-        "actions": [{"action_ts": f"capacity-{count}"}],
-    }, {
-        "action_id": "hermes_plan_add",
-        "block_id": (
-            f"hermes-plan-controls-r{state['desired_revision']}-"
-            f"{state['desired_hash'][:10]}"
-        ),
-    })
-    assert (client.views_open.await_count == 1) is opens_modal
-
-
-@pytest.mark.asyncio
-async def test_add_modal_submission_fails_after_desired_snapshot_reaches_todo_capacity(
+async def test_legacy_plan_modal_submission_acks_read_only_without_dispatch_or_mutation(
     tmp_path,
 ) -> None:
     adapter = _adapter(tmp_path)
-    original = _state(adapter, [
-        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
-        for index in range(MAX_TODO_ITEMS - 1)
-    ])
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=original["desired_revision"],
-        snapshot_hash=original["desired_hash"], message_ts="20.0",
-    )
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    action_body = {
-        "trigger_id": "trigger", "team": {"id": "T1"},
-        "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "open"}],
-    }
-    await adapter._handle_plan_action(AsyncMock(), action_body, {
-        "action_id": "hermes_plan_add",
-        "block_id": (
-            f"hermes-plan-controls-r{original['desired_revision']}-"
-            f"{original['desired_hash'][:10]}"
-        ),
-    })
-    view = client.views_open.call_args.kwargs["view"]
-
-    adapter.record_desired_plan_snapshot(
-        session_key="sk", session_id="sid", team_id="T1", channel_id="C1",
-        thread_ts="10.0", route_user_id="U-owner", chat_type="group",
-        todos=[
-            {"id": f"agent:{index}", "content": str(index), "status": "pending"}
-            for index in range(MAX_TODO_ITEMS)
-        ],
-    )
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    await adapter._handle_plan_add_view(AsyncMock(), {
-        "team": {"id": "T1"}, "user": {"id": "U-owner"},
-        "view": {
-            "id": "V-capacity", "hash": "H-capacity",
-            "private_metadata": view["private_metadata"],
-            "state": {"values": {"task": {"content": {"value": "Too late"}}}},
-        },
-    })
-    await asyncio.sleep(0)
-    assert events == []
-
-
-@pytest.mark.asyncio
-async def test_add_modal_keeps_validated_lineage_across_concurrent_route_change(tmp_path) -> None:
-    adapter = _adapter(tmp_path)
-    original = _state(adapter)
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=original["desired_revision"],
-        snapshot_hash=original["desired_hash"], message_ts="20.0",
-    )
-    payload = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "message_ts": "20.0",
-        "revision": original["desired_revision"],
-        "snapshot_hash": original["desired_hash"], "task_ids": ["user:new"],
-        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "action_user_id": "U-owner", "action_dedupe_id": "open-dedupe",
-    }
-    private_metadata = sign_private_metadata(payload, b"signing-secret")
-    assert adapter._plan_store.consume_action_id("open-dedupe")
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    events = []
-
-    async def handle(event):
-        events.append(event)
-
-    adapter.set_message_handler(handle)
-    validate = adapter._plan_store.validate_action
-    changed = False
-
-    def validate_then_change(metadata):
-        nonlocal changed
-        validated = validate(metadata)
-        if validated and not changed:
-            changed = True
-            adapter.record_desired_plan_snapshot(
-                session_key="sk", session_id="sid-new", team_id="T1",
-                channel_id="C2", thread_ts="11.0", route_user_id="U-owner",
-                chat_type="group",
-                todos=[{"id": "b", "content": "New", "status": "pending"}],
-            )
-        return validated
-
-    adapter._plan_store.validate_action = MagicMock(side_effect=validate_then_change)
-    await adapter._handle_plan_add_view(AsyncMock(), {
-        "team": {"id": "T1"}, "user": {"id": "U-owner"},
-        "view": {
-            "id": "V-race", "hash": "H-race", "private_metadata": private_metadata,
-            "state": {"values": {"task": {"content": {"value": "Old modal"}}}},
-        },
-    })
-    await asyncio.sleep(0)
-
-    assert len(events) == 1
-    trusted = events[0].metadata["slack_plan_action"]
-    assert trusted["session_id"] == "sid"
-    assert trusted["channel_id"] == "C1"
-    assert trusted["thread_ts"] == "10.0"
-    assert trusted["revision"] == original["desired_revision"]
-    assert trusted["snapshot_hash"] == original["desired_hash"]
-    assert trusted["add_task_ids"] == ["user:new"]
-    assert trusted["add_task_status"] == "in_progress"
-
-    runner = object.__new__(GatewayRunner)
-    runner.adapters = {events[0].source.platform: adapter}
-    runner.session_store = MagicMock()
-    runner.session_store._entries = {
-        "sk": type("Entry", (), {"session_id": "sid-new"})()
-    }
-    adapter.send = AsyncMock()
-    assert not await runner._validate_slack_plan_action_after_claim(events[0], "sk")
-    adapter.send.assert_awaited_once()
-
-
-def test_add_control_unavailable_without_signing_secret(tmp_path) -> None:
-    adapter = _adapter(tmp_path, secret=None)
-    state = _state(adapter)
-    rendered = adapter._render_plan_state(state)
-    action_ids = [
-        element["action_id"]
-        for block in rendered.native_blocks
-        if block["type"] == "actions"
-        for element in block["elements"]
-    ]
-    assert "hermes_plan_add" not in action_ids
-
-
-@pytest.mark.asyncio
-async def test_crafted_add_action_is_rejected_without_signing_secret(tmp_path) -> None:
-    adapter = _adapter(tmp_path, secret=None)
     _state(adapter)
-    state = adapter._plan_store.get_session("sk")
-    adapter._plan_store.mark_applied(
-        "sk", revision=1, snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    client = adapter._team_clients["T1"]
-    client.views_open = AsyncMock()
-    await adapter._handle_plan_action(AsyncMock(), {
-        "trigger_id": "trigger", "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U-owner"}, "actions": [{"action_ts": "no-secret"}],
-    }, {
-        "action_id": "hermes_plan_add",
-        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-    })
-    client.views_open.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_disabled_plan_handlers_ack_without_mutation(tmp_path) -> None:
-    adapter = _adapter(tmp_path, enabled=False)
+    before = adapter._plan_store.state_path.read_bytes()
     adapter.set_message_handler(AsyncMock())
     ack = AsyncMock()
+    body = {
+        "user": {"id": "U-owner"},
+        "view": {
+            "id": "V1",
+            "hash": "H1",
+            "private_metadata": "legacy-signed-or-tampered-data",
+            "state": {"values": {"task": {"content": {"value": "New task"}}}},
+        },
+    }
 
-    await adapter._handle_plan_action(ack, {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0"}, "user": {"id": "U1"},
-    }, {"action_id": "hermes_plan_refresh", "block_id": "stale"})
-    await adapter._handle_plan_add_view(ack, {
-        "team": {"id": "T1"}, "user": {"id": "U1"}, "view": {},
-    })
+    await adapter._handle_plan_add_view(ack, body, AsyncMock())
+    await adapter._handle_plan_add_view(ack, body, AsyncMock())
 
     assert ack.await_count == 2
+    for call in ack.await_args_list:
+        assert call.kwargs["response_action"] == "errors"
+        assert "read-only" in call.kwargs["errors"]["task"]
+        assert "Clarify or reply in Slack" in call.kwargs["errors"]["task"]
     adapter._message_handler.assert_not_awaited()
-    assert adapter._plan_store.list_dirty() == []
-    assert adapter._plan_reconcile_task is None
+    assert adapter._plan_store.state_path.read_bytes() == before
+
+
+def test_legacy_internal_plan_action_metadata_always_fails_closed(tmp_path) -> None:
+    adapter = _adapter(tmp_path)
+    assert not adapter.validate_plan_action_metadata({
+        "session_key": "sk",
+        "session_id": "sid",
+        "action_kind": "complete_reopen",
+    })
+
+
+@pytest.mark.parametrize("route_user_id", ["", "U-owner", "B-bot"])
+@pytest.mark.parametrize("count", [0, 1, 10, 100])
+def test_adapter_render_is_read_only_for_all_owner_and_capacity_combinations(
+    tmp_path, route_user_id, count,
+) -> None:
+    adapter = _adapter(tmp_path)
+    statuses = ("pending", "in_progress", "completed", "cancelled")
+    state = _state(
+        adapter,
+        [
+            {
+                "id": f"task-{index}",
+                "content": f"Task {index}",
+                "status": statuses[index % len(statuses)],
+            }
+            for index in range(count)
+        ],
+        route_user_id=route_user_id,
+    )
+    rendered = adapter._render_plan_state(state)
+
+    assert all(block["type"] != "actions" for block in rendered.native_blocks)
+    assert all(block["type"] != "actions" for block in rendered.fallback_blocks)
 
 
 def test_feature_gate_defaults_off_and_coerces_false_string(tmp_path) -> None:
     with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
-        assert SlackAdapter(PlatformConfig(enabled=True, token="x", extra={}))._plan_cards_enabled is False
+        assert SlackAdapter(
+            PlatformConfig(enabled=True, token="x", extra={})
+        )._plan_cards_enabled is False
         assert SlackAdapter(PlatformConfig(
             enabled=True, token="x", extra={"native_plan_cards": "false"}
         ))._plan_cards_enabled is False
-
-
-def test_loaded_config_constructs_enabled_adapter_with_signing_key(
-    tmp_path, monkeypatch
-) -> None:
-    hermes_home = tmp_path / ".hermes"
-    hermes_home.mkdir()
-    secret = "loaded-plan-signing-secret"
-    (hermes_home / "config.yaml").write_text(
-        "slack:\n"
-        "  native_plan_cards: true\n"
-        f"  native_plan_cards_signing_secret: {secret}\n",
-        encoding="utf-8",
-    )
-    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
-    monkeypatch.delenv("SLACK_SIGNING_SECRET", raising=False)
-
-    config = load_gateway_config()
-    adapter = SlackAdapter(config.platforms[Platform.SLACK])
-
-    assert adapter._plan_cards_enabled is True
-    assert adapter._plan_signing_secret() == secret.encode("utf-8")
-
-
-def _adapter_with_config_signing_secret(tmp_path, secret: str | None) -> SlackAdapter:
-    extra = {}
-    if secret is not None:
-        extra["native_plan_cards_signing_secret"] = secret
-    with patch("hermes_constants.get_hermes_home", return_value=tmp_path):
-        return SlackAdapter(PlatformConfig(enabled=True, token="x", extra=extra))
-
-
-def test_unscoped_multiplex_signing_secret_uses_adapter_config_not_global_env(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
-    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
-    was_multiplex_active = secret_scope.is_multiplex_active()
-    scope_token = secret_scope.set_secret_scope(None)
-    secret_scope.set_multiplex_active(True)
-    try:
-        assert adapter._plan_signing_secret() == b"adapter-local-secret"
-    finally:
-        secret_scope.reset_secret_scope(scope_token)
-        secret_scope.set_multiplex_active(was_multiplex_active)
-
-
-def test_unscoped_multiplex_signing_secret_fails_closed_without_adapter_config(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
-    adapter = _adapter_with_config_signing_secret(tmp_path, None)
-    was_multiplex_active = secret_scope.is_multiplex_active()
-    scope_token = secret_scope.set_secret_scope(None)
-    secret_scope.set_multiplex_active(True)
-    try:
-        assert adapter._plan_signing_secret() is None
-    finally:
-        secret_scope.reset_secret_scope(scope_token)
-        secret_scope.set_multiplex_active(was_multiplex_active)
-
-
-def test_scoped_signing_secret_takes_priority_over_adapter_config(
-    tmp_path, monkeypatch
-) -> None:
-    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret-from-other-profile")
-    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
-    was_multiplex_active = secret_scope.is_multiplex_active()
-    scope_token = secret_scope.set_secret_scope(
-        {"SLACK_SIGNING_SECRET": "properly-scoped-secret"}
-    )
-    secret_scope.set_multiplex_active(True)
-    try:
-        assert adapter._plan_signing_secret() == b"properly-scoped-secret"
-    finally:
-        secret_scope.reset_secret_scope(scope_token)
-        secret_scope.set_multiplex_active(was_multiplex_active)
-
-
-def test_signing_secret_store_failure_uses_adapter_config(tmp_path) -> None:
-    adapter = _adapter_with_config_signing_secret(tmp_path, "adapter-local-secret")
-
-    with patch(
-        "plugins.platforms.slack.adapter.get_secret",
-        side_effect=RuntimeError("secret store unavailable"),
-    ):
-        assert adapter._plan_signing_secret() == b"adapter-local-secret"
-
-
-def test_plan_signing_secret_has_no_direct_process_env_fallback() -> None:
-    source = inspect.getsource(SlackAdapter._plan_signing_secret)
-
-    assert "os.getenv" not in source

--- a/tests/gateway/test_slack_plan_card_gateway.py
+++ b/tests/gateway/test_slack_plan_card_gateway.py
@@ -63,7 +63,7 @@ async def _ingress_plan_event(
         thread_ts="10.0",
         route_user_id="U1",
         chat_type="group",
-        todos=[{"id": "user:a", "content": "A", "status": "pending"}],
+        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
     )
     assert adapter._plan_store.mark_applied(
         "sk", revision=state["desired_revision"],
@@ -310,7 +310,7 @@ async def test_claim_time_rejects_current_ineligible_task_status(tmp_path) -> No
         thread_ts="10.0",
         route_user_id="U1",
         chat_type="group",
-        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
+        todos=[{"id": "user:a", "content": "A", "status": "pending"}],
     )
     assert adapter._plan_store.mark_applied(
         "sk", revision=current["desired_revision"],

--- a/tests/gateway/test_slack_plan_card_gateway.py
+++ b/tests/gateway/test_slack_plan_card_gateway.py
@@ -298,6 +298,26 @@ async def test_claim_time_rechecks_current_actor_authorization(tmp_path) -> None
 
 
 @pytest.mark.asyncio
+async def test_claim_time_rejects_forged_metadata_from_unrelated_user(tmp_path) -> None:
+    adapter = _real_adapter(tmp_path)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    event = await _ingress_plan_event(adapter)
+    forged = {
+        **event.metadata["slack_plan_action"],
+        "action_user_id": "U-unrelated",
+    }
+
+    assert adapter._plan_store.validate_action(forged) is None
+    assert not adapter.validate_plan_action_metadata(forged)
+
+    event.metadata["slack_plan_action"] = forged
+    adapter.send = AsyncMock()
+    runner = _runner(adapter)
+    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_claim_time_rejects_current_ineligible_task_status(tmp_path) -> None:
     adapter = _real_adapter(tmp_path)
     adapter._is_interactive_user_authorized = MagicMock(return_value=True)

--- a/tests/gateway/test_slack_plan_card_gateway.py
+++ b/tests/gateway/test_slack_plan_card_gateway.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
 from gateway.run import GatewayRunner
+from plugins.platforms.slack.adapter import SlackAdapter
 
 
 def _source(platform=Platform.SLACK) -> SessionSource:
@@ -28,7 +30,87 @@ def _runner(adapter) -> GatewayRunner:
     runner.config = MagicMock()
     runner.session_store = MagicMock()
     runner.session_store._entries = {"sk": SimpleNamespace(session_id="sid")}
+    profile = getattr(adapter, "_plan_profile", None)
+    runner._profile_adapters = (
+        {profile: {Platform.SLACK: adapter}} if profile else {}
+    )
     return runner
+
+
+def _real_adapter(tmp_path, *, home=None) -> SlackAdapter:
+    config = PlatformConfig(
+        enabled=True,
+        token="xoxb-test",
+        extra={"native_plan_cards": True},
+    )
+    with patch("hermes_constants.get_hermes_home", return_value=home or tmp_path):
+        adapter = SlackAdapter(config)
+    adapter._plan_signing_secret_override = "signing-secret"
+    return adapter
+
+
+async def _ingress_plan_event(
+    adapter: SlackAdapter,
+    *,
+    handler=None,
+    expect_event: bool = True,
+) -> MessageEvent | None:
+    state = adapter.record_desired_plan_snapshot(
+        session_key="sk",
+        session_id="sid",
+        team_id="T1",
+        channel_id="C1",
+        thread_ts="10.0",
+        route_user_id="U1",
+        chat_type="group",
+        todos=[{"id": "user:a", "content": "A", "status": "pending"}],
+    )
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    if handler is None:
+        events = []
+
+        async def handle(event):
+            events.append(event)
+
+        adapter.set_message_handler(handle)
+    else:
+        adapter.set_message_handler(handler)
+        events = handler.__self__.events
+    body = {
+        "team": {"id": "T1"}, "channel": {"id": "C1"},
+        "message": {"ts": "20.0", "thread_ts": "10.0"},
+        "user": {"id": "U1"}, "actions": [{"action_ts": "ingress"}],
+    }
+    await adapter._handle_plan_action(AsyncMock(), body, {
+        "action_id": "hermes_plan_complete",
+        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
+        "selected_options": [{"value": "user:a"}],
+    })
+    await asyncio.sleep(0)
+    assert len(events) == (1 if expect_event else 0)
+    return events[0] if events else None
+
+
+class _ProfileAuthorizationRunner:
+    def __init__(self) -> None:
+        self.events = []
+        self.sources = []
+        self.pairing_store = MagicMock()
+        self.pairing_store.is_approved.return_value = True
+        self.secondary_pairing_store = MagicMock()
+        self.secondary_pairing_store.is_approved.return_value = True
+        self.pairing_stores = {"secondary": self.secondary_pairing_store}
+
+    def _is_user_authorized(self, source) -> bool:
+        self.sources.append(source)
+        store = self.pairing_stores.get(source.profile, self.pairing_store)
+        return bool(store.is_approved(source.platform.value, source.user_id))
+
+    async def handle(self, event) -> None:
+        self.events.append(event)
 
 
 def test_todo_completion_persists_before_threadsafe_wake_without_coroutine() -> None:
@@ -152,6 +234,112 @@ async def test_runner_revalidates_stale_action_and_sends_notice() -> None:
     adapter.send.reset_mock()
     assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
     adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_claim_time_rechecks_current_actor_authorization(tmp_path) -> None:
+    default_adapter = _real_adapter(tmp_path / "default")
+    assert default_adapter._plan_profile is None
+
+    missing_adapter = _real_adapter(
+        tmp_path,
+        home=tmp_path / "missing-root" / "profiles" / "secondary",
+    )
+    missing_authorization = _ProfileAuthorizationRunner()
+    missing_authorization.pairing_stores = {}
+    await _ingress_plan_event(
+        missing_adapter,
+        handler=missing_authorization.handle,
+        expect_event=False,
+    )
+    assert missing_authorization.events == []
+    assert missing_authorization.sources == []
+    missing_authorization.pairing_store.is_approved.assert_not_called()
+
+    adapter = _real_adapter(
+        tmp_path,
+        home=tmp_path / "hermes-root" / "profiles" / "secondary",
+    )
+    authorization = _ProfileAuthorizationRunner()
+    event = await _ingress_plan_event(adapter, handler=authorization.handle)
+    assert authorization.sources[-1].profile == "secondary"
+    assert authorization.sources[-1].thread_id == "10.0"
+    assert event.metadata["slack_plan_action"]["profile"] == "secondary"
+    assert adapter._plan_store.get_session("sk")["profile"] == "secondary"
+    missing_profile = dict(event.metadata["slack_plan_action"])
+    missing_profile.pop("profile")
+    assert adapter._plan_store.validate_action(missing_profile) is None
+    assert adapter._plan_store.validate_action({
+        **event.metadata["slack_plan_action"], "profile": "default",
+    }) is None
+
+    authorization.secondary_pairing_store.is_approved.return_value = False
+    adapter.send = AsyncMock()
+    runner = _runner(adapter)
+
+    original_validate = adapter.validate_plan_action_metadata
+    with patch.object(
+        adapter, "validate_plan_action_metadata", wraps=original_validate
+    ) as validate:
+        assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+
+    validate.assert_called_once_with(event.metadata["slack_plan_action"])
+    assert len(authorization.sources) == 2
+    assert authorization.sources[-1].profile == "secondary"
+    assert authorization.sources[-1].thread_id == "10.0"
+    adapter.send.assert_awaited_once()
+
+    authorization.pairing_stores = {}
+    adapter.send.reset_mock()
+    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+    assert len(authorization.sources) == 2
+    authorization.pairing_store.is_approved.assert_not_called()
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_claim_time_rejects_current_ineligible_task_status(tmp_path) -> None:
+    adapter = _real_adapter(tmp_path)
+    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
+    event = await _ingress_plan_event(adapter)
+    current = adapter.record_desired_plan_snapshot(
+        session_key="sk",
+        session_id="sid",
+        team_id="T1",
+        channel_id="C1",
+        thread_ts="10.0",
+        route_user_id="U1",
+        chat_type="group",
+        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
+    )
+    assert adapter._plan_store.mark_applied(
+        "sk", revision=current["desired_revision"],
+        snapshot_hash=current["desired_hash"], message_ts="20.0",
+    )
+    metadata = {
+        **event.metadata["slack_plan_action"],
+        "revision": current["desired_revision"],
+        "snapshot_hash": current["desired_hash"],
+        "task_ids": ["user:a"],
+        "complete_task_ids": ["user:a"],
+        "reopen_task_ids": [],
+    }
+    event.metadata["slack_plan_action"] = metadata
+
+    adapter.send = AsyncMock()
+    runner = _runner(adapter)
+    original_validate = adapter.validate_plan_action_metadata
+    with patch.object(
+        adapter, "validate_plan_action_metadata", wraps=original_validate
+    ) as validate:
+        assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+
+    assert metadata["revision"] == adapter._plan_store.get_session("sk")["desired_revision"]
+    assert metadata["snapshot_hash"] == adapter._plan_store.get_session("sk")["desired_hash"]
+    assert runner.session_store._entries["sk"].session_id == "sid"
+    validate.assert_called_once_with(event.metadata["slack_plan_action"])
+    adapter.send.assert_awaited_once()
+    assert "stale" in adapter.send.call_args.args[1].lower()
 
 
 def test_final_revalidation_is_between_session_claim_and_agent_turn() -> None:

--- a/tests/gateway/test_slack_plan_card_gateway.py
+++ b/tests/gateway/test_slack_plan_card_gateway.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType, SessionSource
+from gateway.run import GatewayRunner
+
+
+def _source(platform=Platform.SLACK) -> SessionSource:
+    return SessionSource(
+        platform=platform,
+        chat_id="C1",
+        chat_type="group",
+        user_id="U1",
+        thread_id="10.0",
+        scope_id="T1",
+    )
+
+
+def _runner(adapter) -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {Platform.SLACK: adapter}
+    runner.config = MagicMock()
+    runner.session_store = MagicMock()
+    runner.session_store._entries = {"sk": SimpleNamespace(session_id="sid")}
+    return runner
+
+
+def test_todo_completion_persists_before_threadsafe_wake_without_coroutine() -> None:
+    order = []
+    adapter = MagicMock()
+    adapter.record_desired_plan_snapshot.side_effect = lambda **kwargs: (
+        order.append(("persist", kwargs)),
+        {"desired_revision": 4},
+    )[1]
+    runner = _runner(adapter)
+    result = '{"todos":[{"id":"a","content":"A","status":"pending"}]}'
+
+    loop = MagicMock()
+    loop.is_closed.return_value = False
+    loop.call_soon_threadsafe.side_effect = lambda callback: (
+        order.append(("wake", callback)),
+        callback(),
+    )
+    state = runner._record_slack_plan_tool_completion(
+        event_type="tool.completed",
+        tool_name="todo",
+        is_error=False,
+        result=result,
+        source=_source(),
+        session_key="sk",
+        session_id="sid",
+        loop=loop,
+    )
+
+    assert state["desired_revision"] == 4
+    assert [item[0] for item in order] == ["persist", "wake"]
+    loop.call_soon_threadsafe.assert_called_once_with(adapter.request_plan_reconcile)
+    adapter.request_plan_reconcile.assert_called_once_with()
+    persisted = order[0][1]
+    assert persisted["team_id"] == "T1"
+    assert persisted["thread_ts"] == "10.0"
+    assert persisted["route_user_id"] == "U1"
+    assert persisted["chat_type"] == "group"
+    assert persisted["todos"][0]["id"] == "a"
+
+
+@pytest.mark.parametrize(
+    ("event_type", "tool_name", "is_error", "platform"),
+    [
+        ("tool.started", "todo", False, Platform.SLACK),
+        ("tool.completed", "terminal", False, Platform.SLACK),
+        ("tool.completed", "todo", True, Platform.SLACK),
+        ("tool.completed", "todo", False, Platform.DISCORD),
+    ],
+)
+def test_bridge_ignores_non_success_non_todo_non_slack(event_type, tool_name, is_error, platform) -> None:
+    adapter = MagicMock()
+    runner = _runner(adapter)
+    assert runner._record_slack_plan_tool_completion(
+        event_type=event_type,
+        tool_name=tool_name,
+        is_error=is_error,
+        result='{"todos":[]}',
+        source=_source(platform),
+        session_key="sk",
+        session_id="sid",
+        loop=MagicMock(),
+    ) is None
+    adapter.record_desired_plan_snapshot.assert_not_called()
+
+
+def test_bridge_isolates_projection_failure_from_agent_progress() -> None:
+    adapter = MagicMock()
+    adapter.record_desired_plan_snapshot.side_effect = OSError("disk unavailable")
+    runner = _runner(adapter)
+    loop = MagicMock()
+    assert runner._record_slack_plan_tool_completion(
+        event_type="tool.completed", tool_name="todo", is_error=False,
+        result='{"todos":[]}', source=_source(), session_key="sk",
+        session_id="sid", loop=loop,
+    ) is None
+    loop.call_soon_threadsafe.assert_not_called()
+
+
+def test_gateway_plan_bridge_has_no_detached_coroutine_scheduling() -> None:
+    source = inspect.getsource(GatewayRunner._record_slack_plan_tool_completion)
+    for forbidden in (
+        "run_coroutine_threadsafe",
+        "safe_schedule_threadsafe",
+        "create_task",
+        "reconcile_plan_card",
+    ):
+        assert forbidden not in source
+    assert "call_soon_threadsafe" in source
+
+
+@pytest.mark.asyncio
+async def test_runner_revalidates_stale_action_and_sends_notice() -> None:
+    adapter = MagicMock()
+    adapter.validate_plan_action_metadata.return_value = False
+    adapter.send = AsyncMock()
+    runner = _runner(adapter)
+    event = MessageEvent(
+        text="trusted action",
+        message_type=MessageType.TEXT,
+        source=_source(),
+        internal=True,
+        metadata={"slack_plan_action": {
+            "session_key": "sk", "session_id": "sid", "revision": 1,
+        }},
+    )
+
+    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+    adapter.send.assert_awaited_once()
+    assert "stale" in adapter.send.call_args.args[1].lower()
+
+    adapter.validate_plan_action_metadata.return_value = True
+    adapter.send.reset_mock()
+    assert await runner._validate_slack_plan_action_after_claim(event, "sk")
+    adapter.send.assert_not_awaited()
+
+    assert not await runner._validate_slack_plan_action_after_claim(event, "other")
+    adapter.send.assert_awaited_once()
+
+    runner.session_store._entries["sk"] = SimpleNamespace(session_id="new-session")
+    adapter.send.reset_mock()
+    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
+    adapter.send.assert_awaited_once()
+
+
+def test_final_revalidation_is_between_session_claim_and_agent_turn() -> None:
+    source = inspect.getsource(GatewayRunner._handle_message)
+    claim = source.index("_claim_active_session_slot")
+    validate = source.index("_validate_slack_plan_action_after_claim")
+    start_turn = source.index("_handle_message_with_agent", validate)
+    assert claim < validate < start_turn

--- a/tests/gateway/test_slack_plan_card_gateway.py
+++ b/tests/gateway/test_slack_plan_card_gateway.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import asyncio
 import inspect
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform
 from gateway.platforms.base import MessageEvent, MessageType, SessionSource
 from gateway.run import GatewayRunner
-from plugins.platforms.slack.adapter import SlackAdapter
 
 
 def _source(platform=Platform.SLACK) -> SessionSource:
@@ -35,82 +34,6 @@ def _runner(adapter) -> GatewayRunner:
         {profile: {Platform.SLACK: adapter}} if profile else {}
     )
     return runner
-
-
-def _real_adapter(tmp_path, *, home=None) -> SlackAdapter:
-    config = PlatformConfig(
-        enabled=True,
-        token="xoxb-test",
-        extra={"native_plan_cards": True},
-    )
-    with patch("hermes_constants.get_hermes_home", return_value=home or tmp_path):
-        adapter = SlackAdapter(config)
-    adapter._plan_signing_secret_override = "signing-secret"
-    return adapter
-
-
-async def _ingress_plan_event(
-    adapter: SlackAdapter,
-    *,
-    handler=None,
-    expect_event: bool = True,
-) -> MessageEvent | None:
-    state = adapter.record_desired_plan_snapshot(
-        session_key="sk",
-        session_id="sid",
-        team_id="T1",
-        channel_id="C1",
-        thread_ts="10.0",
-        route_user_id="U1",
-        chat_type="group",
-        todos=[{"id": "user:a", "content": "A", "status": "in_progress"}],
-    )
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    if handler is None:
-        events = []
-
-        async def handle(event):
-            events.append(event)
-
-        adapter.set_message_handler(handle)
-    else:
-        adapter.set_message_handler(handler)
-        events = handler.__self__.events
-    body = {
-        "team": {"id": "T1"}, "channel": {"id": "C1"},
-        "message": {"ts": "20.0", "thread_ts": "10.0"},
-        "user": {"id": "U1"}, "actions": [{"action_ts": "ingress"}],
-    }
-    await adapter._handle_plan_action(AsyncMock(), body, {
-        "action_id": "hermes_plan_complete",
-        "block_id": "hermes-plan-controls-r1-" + state["desired_hash"][:10],
-        "selected_options": [{"value": "user:a"}],
-    })
-    await asyncio.sleep(0)
-    assert len(events) == (1 if expect_event else 0)
-    return events[0] if events else None
-
-
-class _ProfileAuthorizationRunner:
-    def __init__(self) -> None:
-        self.events = []
-        self.sources = []
-        self.pairing_store = MagicMock()
-        self.pairing_store.is_approved.return_value = True
-        self.secondary_pairing_store = MagicMock()
-        self.secondary_pairing_store.is_approved.return_value = True
-        self.pairing_stores = {"secondary": self.secondary_pairing_store}
-
-    def _is_user_authorized(self, source) -> bool:
-        self.sources.append(source)
-        store = self.pairing_stores.get(source.profile, self.pairing_store)
-        return bool(store.is_approved(source.platform.value, source.user_id))
-
-    async def handle(self, event) -> None:
-        self.events.append(event)
 
 
 def test_todo_completion_persists_before_threadsafe_wake_without_coroutine() -> None:
@@ -203,7 +126,7 @@ def test_gateway_plan_bridge_has_no_detached_coroutine_scheduling() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runner_revalidates_stale_action_and_sends_notice() -> None:
+async def test_runner_rejects_queued_legacy_plan_action_and_sends_notice() -> None:
     adapter = MagicMock()
     adapter.validate_plan_action_metadata.return_value = False
     adapter.send = AsyncMock()
@@ -222,11 +145,7 @@ async def test_runner_revalidates_stale_action_and_sends_notice() -> None:
     adapter.send.assert_awaited_once()
     assert "stale" in adapter.send.call_args.args[1].lower()
 
-    adapter.validate_plan_action_metadata.return_value = True
     adapter.send.reset_mock()
-    assert await runner._validate_slack_plan_action_after_claim(event, "sk")
-    adapter.send.assert_not_awaited()
-
     assert not await runner._validate_slack_plan_action_after_claim(event, "other")
     adapter.send.assert_awaited_once()
 
@@ -236,130 +155,6 @@ async def test_runner_revalidates_stale_action_and_sends_notice() -> None:
     adapter.send.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_claim_time_rechecks_current_actor_authorization(tmp_path) -> None:
-    default_adapter = _real_adapter(tmp_path / "default")
-    assert default_adapter._plan_profile is None
-
-    missing_adapter = _real_adapter(
-        tmp_path,
-        home=tmp_path / "missing-root" / "profiles" / "secondary",
-    )
-    missing_authorization = _ProfileAuthorizationRunner()
-    missing_authorization.pairing_stores = {}
-    await _ingress_plan_event(
-        missing_adapter,
-        handler=missing_authorization.handle,
-        expect_event=False,
-    )
-    assert missing_authorization.events == []
-    assert missing_authorization.sources == []
-    missing_authorization.pairing_store.is_approved.assert_not_called()
-
-    adapter = _real_adapter(
-        tmp_path,
-        home=tmp_path / "hermes-root" / "profiles" / "secondary",
-    )
-    authorization = _ProfileAuthorizationRunner()
-    event = await _ingress_plan_event(adapter, handler=authorization.handle)
-    assert authorization.sources[-1].profile == "secondary"
-    assert authorization.sources[-1].thread_id == "10.0"
-    assert event.metadata["slack_plan_action"]["profile"] == "secondary"
-    assert adapter._plan_store.get_session("sk")["profile"] == "secondary"
-    missing_profile = dict(event.metadata["slack_plan_action"])
-    missing_profile.pop("profile")
-    assert adapter._plan_store.validate_action(missing_profile) is None
-    assert adapter._plan_store.validate_action({
-        **event.metadata["slack_plan_action"], "profile": "default",
-    }) is None
-
-    authorization.secondary_pairing_store.is_approved.return_value = False
-    adapter.send = AsyncMock()
-    runner = _runner(adapter)
-
-    original_validate = adapter.validate_plan_action_metadata
-    with patch.object(
-        adapter, "validate_plan_action_metadata", wraps=original_validate
-    ) as validate:
-        assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
-
-    validate.assert_called_once_with(event.metadata["slack_plan_action"])
-    assert len(authorization.sources) == 2
-    assert authorization.sources[-1].profile == "secondary"
-    assert authorization.sources[-1].thread_id == "10.0"
-    adapter.send.assert_awaited_once()
-
-    authorization.pairing_stores = {}
-    adapter.send.reset_mock()
-    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
-    assert len(authorization.sources) == 2
-    authorization.pairing_store.is_approved.assert_not_called()
-    adapter.send.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_claim_time_rejects_forged_metadata_from_unrelated_user(tmp_path) -> None:
-    adapter = _real_adapter(tmp_path)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    event = await _ingress_plan_event(adapter)
-    forged = {
-        **event.metadata["slack_plan_action"],
-        "action_user_id": "U-unrelated",
-    }
-
-    assert adapter._plan_store.validate_action(forged) is None
-    assert not adapter.validate_plan_action_metadata(forged)
-
-    event.metadata["slack_plan_action"] = forged
-    adapter.send = AsyncMock()
-    runner = _runner(adapter)
-    assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
-    adapter.send.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_claim_time_rejects_current_ineligible_task_status(tmp_path) -> None:
-    adapter = _real_adapter(tmp_path)
-    adapter._is_interactive_user_authorized = MagicMock(return_value=True)
-    event = await _ingress_plan_event(adapter)
-    current = adapter.record_desired_plan_snapshot(
-        session_key="sk",
-        session_id="sid",
-        team_id="T1",
-        channel_id="C1",
-        thread_ts="10.0",
-        route_user_id="U1",
-        chat_type="group",
-        todos=[{"id": "user:a", "content": "A", "status": "pending"}],
-    )
-    assert adapter._plan_store.mark_applied(
-        "sk", revision=current["desired_revision"],
-        snapshot_hash=current["desired_hash"], message_ts="20.0",
-    )
-    metadata = {
-        **event.metadata["slack_plan_action"],
-        "revision": current["desired_revision"],
-        "snapshot_hash": current["desired_hash"],
-        "task_ids": ["user:a"],
-        "complete_task_ids": ["user:a"],
-        "reopen_task_ids": [],
-    }
-    event.metadata["slack_plan_action"] = metadata
-
-    adapter.send = AsyncMock()
-    runner = _runner(adapter)
-    original_validate = adapter.validate_plan_action_metadata
-    with patch.object(
-        adapter, "validate_plan_action_metadata", wraps=original_validate
-    ) as validate:
-        assert not await runner._validate_slack_plan_action_after_claim(event, "sk")
-
-    assert metadata["revision"] == adapter._plan_store.get_session("sk")["desired_revision"]
-    assert metadata["snapshot_hash"] == adapter._plan_store.get_session("sk")["desired_hash"]
-    assert runner.session_store._entries["sk"].session_id == "sid"
-    validate.assert_called_once_with(event.metadata["slack_plan_action"])
-    adapter.send.assert_awaited_once()
-    assert "stale" in adapter.send.call_args.args[1].lower()
 
 
 def test_final_revalidation_is_between_session_claim_and_agent_turn() -> None:

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -21,6 +21,7 @@ from plugins.platforms.slack.plan_cards import (
     sign_private_metadata,
     verify_private_metadata,
 )
+from tools.todo_tool import MAX_TODO_ITEMS, TodoStore
 
 
 def _snapshot(count: int = 4) -> list[dict[str, str]]:
@@ -88,13 +89,67 @@ def _action_elements(rendered, *, fallback: bool = False):
     ]
 
 
-def test_user_task_id_namespace_is_strict_and_raw() -> None:
+def test_user_task_id_namespace_is_strict_over_canonical_ids() -> None:
     assert is_user_task_id("user:work")
     assert not is_user_task_id("user:")
     assert not is_user_task_id("task-1")
     assert not is_user_task_id("User:work")
-    assert not is_user_task_id(" user:work")
     assert not is_user_task_id("սser:work")
+
+
+def test_todo_store_canonical_ids_drive_plan_classification_and_controls(tmp_path) -> None:
+    todo_store = TodoStore()
+    todo_store.write([
+        {
+            "id": "  user:approve  ",
+            "content": "Approve release",
+            "status": "in_progress",
+        },
+        {
+            "id": "  User:review  ",
+            "content": "Wrong ASCII case",
+            "status": "in_progress",
+        },
+        {
+            "id": "  սser:lookalike  ",
+            "content": "Unicode lookalike",
+            "status": "in_progress",
+        },
+    ])
+    canonical_snapshot = todo_store.read()
+    assert [task["id"] for task in canonical_snapshot] == [
+        "user:approve", "User:review", "սser:lookalike",
+    ]
+
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    state = store.record_desired_snapshot(route, canonical_snapshot)
+    rendered = build_plan_blocks(
+        state["last_desired_snapshot"],
+        revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"],
+        signing_secret=b"secret",
+    )
+
+    assert [
+        task["task_id"] for task in rendered.native_blocks[0]["tasks"]
+    ] == ["user:approve", "User:review", "սser:lookalike"]
+    checkbox = next(
+        element for element in _action_elements(rendered)
+        if element["action_id"] == "hermes_plan_complete"
+    )
+    cancel = next(
+        element for element in _action_elements(rendered)
+        if element["action_id"] == "hermes_plan_cancel"
+    )
+    assert [option["value"] for option in checkbox["options"]] == ["user:approve"]
+    assert [option["value"] for option in cancel["options"]] == ["user:approve"]
+    assert is_user_task_id(state["last_desired_snapshot"][0]["id"])
+    assert not is_user_task_id(state["last_desired_snapshot"][1]["id"])
+    assert not is_user_task_id(state["last_desired_snapshot"][2]["id"])
 
 
 def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> None:
@@ -105,7 +160,6 @@ def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> N
         {"id": "user:active", "content": "Human active", "status": "in_progress"},
         {"id": "user:cancelled", "content": "Human cancelled", "status": "cancelled"},
         {"id": "User:case", "content": "Wrong case", "status": "pending"},
-        {"id": " user:space", "content": "Leading space", "status": "pending"},
         {"id": "սser:lookalike", "content": "Lookalike", "status": "pending"},
     ]
     rendered = build_plan_blocks(
@@ -235,6 +289,45 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         "hermes_plan_add",
         "hermes_plan_refresh",
     ]
+
+
+@pytest.mark.parametrize(
+    ("count", "expect_add"),
+    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
+)
+def test_renderer_add_control_follows_authoritative_todo_capacity(
+    count: int, expect_add: bool,
+) -> None:
+    todos = [
+        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
+        for index in range(count - 2)
+    ] + [
+        {"id": "user:active", "content": "Active", "status": "in_progress"},
+        {"id": "user:done", "content": "Done", "status": "completed"},
+    ]
+    rendered = build_plan_blocks(
+        todos, revision=1, snapshot_hash="capacity", signing_secret=b"secret",
+    )
+    action_ids = [item["action_id"] for item in _action_elements(rendered)]
+    assert ("hermes_plan_add" in action_ids) is expect_add
+    assert "hermes_plan_complete" in action_ids
+    assert "hermes_plan_cancel" in action_ids
+    assert "hermes_plan_refresh" in action_ids
+    checkbox = next(
+        item for item in _action_elements(rendered)
+        if item["action_id"] == "hermes_plan_complete"
+    )
+    cancel = next(
+        item for item in _action_elements(rendered)
+        if item["action_id"] == "hermes_plan_cancel"
+    )
+    assert [option["value"] for option in checkbox["options"]] == [
+        "user:active", "user:done",
+    ]
+    assert [option["value"] for option in checkbox["initial_options"]] == [
+        "user:done",
+    ]
+    assert [option["value"] for option in cancel["options"]] == ["user:active"]
 
 
 def test_future_and_cancelled_user_tasks_do_not_consume_mutation_capacity() -> None:
@@ -708,6 +801,39 @@ def test_validate_add_capacity_counts_only_in_progress_and_completed_user_tasks(
     }
     assert store.consume_action_id("at-capacity")
     assert store.validate_action(at_capacity_metadata) is None
+
+
+@pytest.mark.parametrize(
+    ("count", "accepted"),
+    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
+)
+def test_validate_add_rejects_authoritative_todo_capacity(
+    tmp_path, count: int, accepted: bool,
+) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    snapshot = [
+        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
+        for index in range(count)
+    ]
+    state = store.record_desired_snapshot(route, snapshot)
+    assert store.mark_applied(
+        "sk", revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"], message_ts="20.0",
+    )
+    dedupe_id = f"capacity-{count}"
+    assert store.consume_action_id(dedupe_id)
+    metadata = {
+        **route, "message_ts": "20.0", "revision": state["desired_revision"],
+        "snapshot_hash": state["desired_hash"], "task_ids": ["user:new"],
+        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
+        "add_task_content": "New", "add_task_status": "in_progress",
+        "action_user_id": "U1", "action_dedupe_id": dedupe_id,
+    }
+    assert (store.validate_action(metadata) is not None) is accepted
 
 
 def _converged_session_with_retired_anchor(store, route):

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -10,11 +10,13 @@ from unittest.mock import patch
 import pytest
 
 from plugins.platforms.slack.plan_cards import (
+    MAX_INTERACTIVE_TASKS,
     PlanCardStore,
     _RetryScheduleKind,
     build_plan_blocks,
     decode_action_value,
     encode_action_value,
+    is_user_task_id,
     parse_todo_result,
     sign_private_metadata,
     verify_private_metadata,
@@ -68,7 +70,7 @@ def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
     assert [task["status"] for task in plan["tasks"]] == [
         "pending", "in_progress", "complete", "error"
     ]
-    assert plan["tasks"][3]["title"].startswith("[cancelled]")
+    assert plan["tasks"][3]["title"].startswith("[cancelled] Task 3")
     assert first.text == "Hermes plan: 4 tasks"
     assert first.native_blocks[0]["block_id"] != second.native_blocks[0]["block_id"]
     assert first.native_blocks[0]["tasks"][0]["block_id"] != second.native_blocks[0]["tasks"][0]["block_id"]
@@ -77,26 +79,88 @@ def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
     ))
 
 
-def test_renderer_adds_controls_and_degrades_without_truncating_truth() -> None:
-    normal = build_plan_blocks(
-        _snapshot(10), revision=3, snapshot_hash="hash", signing_secret=b"secret"
+def _action_elements(rendered, *, fallback: bool = False):
+    return [
+        element
+        for block in (rendered.fallback_blocks if fallback else rendered.native_blocks)
+        if block["type"] == "actions"
+        for element in block["elements"]
+    ]
+
+
+def test_user_task_id_namespace_is_strict_and_raw() -> None:
+    assert is_user_task_id("user:work")
+    assert not is_user_task_id("user:")
+    assert not is_user_task_id("task-1")
+    assert not is_user_task_id("User:work")
+    assert not is_user_task_id(" user:work")
+    assert not is_user_task_id("սser:work")
+
+
+def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> None:
+    todos = [
+        {"id": "agent:research", "content": "Agent research", "status": "pending"},
+        {"id": "user:pending", "content": "Human pending", "status": "pending"},
+        {"id": "user:done", "content": "Human done", "status": "completed"},
+        {"id": "user:active", "content": "Human active", "status": "in_progress"},
+        {"id": "user:cancelled", "content": "Human cancelled", "status": "cancelled"},
+        {"id": "User:case", "content": "Wrong case", "status": "pending"},
+        {"id": " user:space", "content": "Leading space", "status": "pending"},
+        {"id": "սser:lookalike", "content": "Lookalike", "status": "pending"},
+    ]
+    rendered = build_plan_blocks(
+        todos, revision=3, snapshot_hash="hash", signing_secret=b"secret"
     )
-    actions = normal.native_blocks[-1]
-    assert actions["type"] == "actions"
-    action_ids = [element["action_id"] for element in actions["elements"]]
+    assert [task["task_id"] for task in rendered.native_blocks[0]["tasks"]] == [
+        task["id"] for task in todos
+    ]
+    elements = _action_elements(rendered)
+    checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
+    cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
+    assert [option["value"] for option in checkbox["options"]] == [
+        "user:pending", "user:done"
+    ]
+    assert [option["value"] for option in checkbox["initial_options"]] == ["user:done"]
+    assert [option["value"] for option in cancel["options"]] == ["user:pending"]
+    assert next(item for item in elements if item["action_id"] == "hermes_plan_add")["text"]["text"] == "Add user task"
+
+
+def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> None:
+    large_agent_plan = [
+        {"id": f"agent:{index}", "content": f"Agent {index}", "status": "pending"}
+        for index in range(40)
+    ] + [
+        {"id": "user:one", "content": "One", "status": "pending"},
+        {"id": "user:two", "content": "Two", "status": "completed"},
+    ]
+    normal = build_plan_blocks(
+        large_agent_plan, revision=3, snapshot_hash="hash", signing_secret=b"secret"
+    )
+    assert len(normal.native_blocks[0]["tasks"]) == 42
+    action_ids = [element["action_id"] for element in _action_elements(normal)]
     assert action_ids == [
         "hermes_plan_complete",
         "hermes_plan_cancel",
         "hermes_plan_add",
         "hermes_plan_refresh",
     ]
+    assert [element["action_id"] for element in _action_elements(normal, fallback=True)] == action_ids
+
+    at_capacity = build_plan_blocks(
+        [{"id": f"user:{index}", "content": str(index), "status": "pending"}
+         for index in range(MAX_INTERACTIVE_TASKS)],
+        revision=4, snapshot_hash="capacity", signing_secret=b"secret",
+    )
+    assert "hermes_plan_add" not in [item["action_id"] for item in _action_elements(at_capacity)]
 
     oversized = build_plan_blocks(
-        _snapshot(11), revision=4, snapshot_hash="hash", signing_secret=b"secret"
+        [{"id": f"user:{index}", "content": str(index), "status": "pending"}
+         for index in range(MAX_INTERACTIVE_TASKS + 1)],
+        revision=5, snapshot_hash="oversized", signing_secret=b"secret",
     )
-    assert len(oversized.native_blocks[0]["tasks"]) == 11
-    assert "11 tasks" in oversized.text
-    assert all(block.get("type") != "actions" for block in oversized.native_blocks)
+    assert [item["action_id"] for item in _action_elements(oversized)] == [
+        "hermes_plan_refresh"
+    ]
     assert "controls unavailable" in json.dumps(oversized.fallback_blocks).lower()
 
     extreme = build_plan_blocks(
@@ -104,18 +168,144 @@ def test_renderer_adds_controls_and_degrades_without_truncating_truth() -> None:
             {"id": f"long-{index}", "content": "x" * 3000, "status": "pending"}
             for index in range(80)
         ],
-        revision=5,
+        revision=6,
         snapshot_hash="extreme",
         signing_secret=b"secret",
     )
     fallback_text = json.dumps(extreme.fallback_blocks).lower()
+    assert len(extreme.native_blocks[0]["tasks"]) == 80
+    assert len(extreme.fallback_blocks) <= 50
     assert "display truncated" in fallback_text
     assert "no tasks were omitted" not in fallback_text
+    assert [item["action_id"] for item in _action_elements(extreme, fallback=True)] == [
+        "hermes_plan_add", "hermes_plan_refresh",
+    ]
+
+    extreme_with_users = build_plan_blocks(
+        [
+            {"id": f"agent:long-{index}", "content": "x" * 3000, "status": "pending"}
+            for index in range(80)
+        ] + [
+            {"id": "user:pending", "content": "Pending", "status": "pending"},
+            {"id": "user:done", "content": "Done", "status": "completed"},
+        ],
+        revision=7,
+        snapshot_hash="extreme-users",
+        signing_secret=b"secret",
+    )
+    assert len(extreme_with_users.native_blocks[0]["tasks"]) == 82
+    assert len(extreme_with_users.fallback_blocks) <= 50
+    assert "display truncated" in json.dumps(extreme_with_users.fallback_blocks).lower()
+    assert [
+        item["action_id"] for item in _action_elements(extreme_with_users, fallback=True)
+    ] == [
+        "hermes_plan_complete",
+        "hermes_plan_cancel",
+        "hermes_plan_add",
+        "hermes_plan_refresh",
+    ]
+
+
+def test_inactive_user_tasks_do_not_consume_mutation_capacity() -> None:
+    inactive = [
+        {
+            "id": f"user:inactive-{index}",
+            "content": f"Inactive {index}",
+            "status": "cancelled" if index % 2 else "in_progress",
+        }
+        for index in range(MAX_INTERACTIVE_TASKS + 5)
+    ]
+    rendered = build_plan_blocks(
+        inactive + [{"id": "user:pending", "content": "Pending", "status": "pending"}],
+        revision=7,
+        snapshot_hash="inactive-capacity",
+        signing_secret=b"secret",
+    )
+
+    assert len(rendered.native_blocks[0]["tasks"]) == MAX_INTERACTIVE_TASKS + 6
+    elements = _action_elements(rendered)
+    assert [item["action_id"] for item in elements] == [
+        "hermes_plan_complete",
+        "hermes_plan_cancel",
+        "hermes_plan_add",
+        "hermes_plan_refresh",
+    ]
+    checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
+    cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
+    assert [option["value"] for option in checkbox["options"]] == ["user:pending"]
+    assert [option["value"] for option in cancel["options"]] == ["user:pending"]
+    assert "controls unavailable" not in json.dumps(rendered.fallback_blocks).lower()
+    assert [item["action_id"] for item in _action_elements(rendered, fallback=True)] == [
+        item["action_id"] for item in elements
+    ]
+
+
+def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> None:
+    todos = [
+        {"id": "agent:long", "content": "a" * 3000, "status": "pending"},
+        {"id": "user:long", "content": "u" * 3000, "status": "pending"},
+    ]
+    rendered = build_plan_blocks(
+        todos,
+        revision=8,
+        snapshot_hash="long-lines",
+        signing_secret=b"secret",
+    )
+    section_text = "".join(
+        block["text"]["text"]
+        for block in rendered.fallback_blocks
+        if block["type"] == "section"
+    )
+    expected = "\n".join([
+        "*Hermes plan* (2 tasks)",
+        f"• *Pending* `agent:long` — {'a' * 3000}",
+        f"• *Pending* `user:long` — {'u' * 3000}",
+    ])
+
+    assert section_text == expected
+    assert all(
+        len(block["text"]["text"]) <= 3000
+        for block in rendered.fallback_blocks
+        if block["type"] == "section"
+    )
+    assert len(rendered.fallback_blocks) <= 50
+    assert "display truncated" not in json.dumps(rendered.fallback_blocks).lower()
+    assert [item["action_id"] for item in _action_elements(rendered, fallback=True)] == [
+        "hermes_plan_complete",
+        "hermes_plan_cancel",
+        "hermes_plan_add",
+        "hermes_plan_refresh",
+    ]
+
+
+@pytest.mark.parametrize("task_prefix", ["agent", "user"])
+def test_native_task_titles_disclose_content_truncation_at_boundary(task_prefix) -> None:
+    exact_content = "x" * 3000
+    over_content = "y" * 3001
+    rendered = build_plan_blocks(
+        [
+            {"id": f"{task_prefix}:exact", "content": exact_content, "status": "pending"},
+            {"id": f"{task_prefix}:over", "content": over_content, "status": "pending"},
+        ],
+        revision=9,
+        snapshot_hash=f"title-{task_prefix}",
+        signing_secret=b"secret",
+    )
+    exact_title, over_title = [
+        task["title"] for task in rendered.native_blocks[0]["tasks"]
+    ]
+
+    assert exact_title == exact_content
+    assert len(exact_title) == 3000
+    assert len(over_title) <= 3000
+    assert over_title.endswith("... [truncated]")
+    assert over_title != over_content[:3000]
 
 
 def test_add_task_is_disabled_without_signing_material() -> None:
     rendered = build_plan_blocks(
-        _snapshot(2), revision=1, snapshot_hash="hash", signing_secret=None
+        [{"id": "user:a", "content": "A", "status": "pending"}],
+        revision=1, snapshot_hash="hash", signing_secret=None
     )
     actions = rendered.native_blocks[-1]["elements"]
     assert "hermes_plan_add" not in [item["action_id"] for item in actions]
@@ -371,8 +561,12 @@ def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
     )
     metadata = {
         **route, "message_ts": "20.0", "revision": original["desired_revision"],
-        "snapshot_hash": original["desired_hash"], "task_ids": [],
+        "snapshot_hash": original["desired_hash"], "task_ids": ["user:new"],
+        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
+        "add_task_content": "New", "action_user_id": "U1",
+        "action_dedupe_id": "dedupe",
     }
+    assert store.consume_action_id("dedupe")
 
     validated = store.validate_action(metadata)
     store.record_desired_snapshot(
@@ -383,6 +577,98 @@ def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
     assert validated["session_id"] == "sid"
     assert validated["channel_id"] == "C1"
     assert validated["desired_revision"] == original["desired_revision"]
+
+
+def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    state = store.record_desired_snapshot(route, [
+        {"id": "agent:a", "content": "Agent", "status": "pending"},
+        {"id": "user:a", "content": "User", "status": "pending"},
+    ])
+    assert store.mark_applied(
+        "sk", revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
+        message_ts="20.0",
+    )
+    base = {
+        **route, "message_ts": "20.0", "revision": state["desired_revision"],
+        "snapshot_hash": state["desired_hash"], "action_user_id": "U1",
+        "action_dedupe_id": "dedupe",
+    }
+    assert store.consume_action_id("dedupe")
+    assert store.validate_action({
+        **base, "action_kind": "complete_reopen", "task_ids": ["agent:a", "user:a"],
+        "complete_task_ids": ["agent:a", "user:a"], "reopen_task_ids": [],
+    }) is None
+    assert store.validate_action({
+        **base, "action_kind": "cancel", "task_ids": ["agent:a"],
+        "cancel_task_ids": ["agent:a"],
+    }) is None
+    assert store.validate_action({
+        **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
+        "add_task_ids": ["user:replacement"], "add_task_content": "New",
+    }) is None
+
+    data = json.loads(store.state_path.read_text(encoding="utf-8"))
+    duplicate = dict(data["sessions"]["sk"]["last_desired_snapshot"][1])
+    data["sessions"]["sk"]["last_desired_snapshot"].append(duplicate)
+    store.state_path.write_text(json.dumps(data), encoding="utf-8")
+    assert store.validate_action({
+        **base, "action_kind": "cancel", "task_ids": ["user:a"],
+        "cancel_task_ids": ["user:a"],
+    }) is None
+
+
+def test_validate_add_capacity_counts_only_pending_and_completed_user_tasks(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    inactive = [
+        {
+            "id": f"user:inactive-{index}",
+            "content": str(index),
+            "status": "cancelled" if index % 2 else "in_progress",
+        }
+        for index in range(MAX_INTERACTIVE_TASKS + 3)
+    ]
+    below_capacity = store.record_desired_snapshot(route, inactive + [
+        {"id": "user:pending", "content": "Pending", "status": "pending"},
+    ])
+    assert store.mark_applied(
+        "sk", revision=below_capacity["desired_revision"],
+        snapshot_hash=below_capacity["desired_hash"], message_ts="20.0",
+    )
+    metadata = {
+        **route, "message_ts": "20.0", "revision": below_capacity["desired_revision"],
+        "snapshot_hash": below_capacity["desired_hash"], "task_ids": ["user:new"],
+        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
+        "add_task_content": "New", "action_user_id": "U1",
+        "action_dedupe_id": "below-capacity",
+    }
+    assert store.consume_action_id("below-capacity")
+    assert store.validate_action(metadata) is not None
+
+    at_capacity = store.record_desired_snapshot(route, inactive + [
+        {"id": f"user:mutable-{index}", "content": str(index), "status": "pending"}
+        for index in range(MAX_INTERACTIVE_TASKS)
+    ])
+    assert store.mark_applied(
+        "sk", revision=at_capacity["desired_revision"],
+        snapshot_hash=at_capacity["desired_hash"], message_ts="20.0",
+    )
+    at_capacity_metadata = {
+        **metadata,
+        "revision": at_capacity["desired_revision"],
+        "snapshot_hash": at_capacity["desired_hash"],
+        "action_dedupe_id": "at-capacity",
+    }
+    assert store.consume_action_id("at-capacity")
+    assert store.validate_action(at_capacity_metadata) is None
 
 
 def _converged_session_with_retired_anchor(store, route):

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -24,6 +24,9 @@ from plugins.platforms.slack.plan_cards import (
 from tools.todo_tool import MAX_TODO_ITEMS, TodoStore
 
 
+_OWNER_CONTEXT = {"route_user_id": "U1"}
+
+
 def _snapshot(count: int = 4) -> list[dict[str, str]]:
     statuses = ["pending", "in_progress", "completed", "cancelled"]
     return [
@@ -56,10 +59,12 @@ def test_parse_todo_result_accepts_trailing_hint_and_rejects_errors() -> None:
 
 def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
     first = build_plan_blocks(
-        _snapshot(), revision=1, snapshot_hash="hash-1", signing_secret=b"secret"
+        _snapshot(), revision=1, snapshot_hash="hash-1", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     second = build_plan_blocks(
-        _snapshot(), revision=2, snapshot_hash="hash-1", signing_secret=b"secret"
+        _snapshot(), revision=2, snapshot_hash="hash-1", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
 
     plan = first.native_blocks[0]
@@ -124,7 +129,7 @@ def test_todo_store_canonical_ids_drive_plan_classification_and_controls(tmp_pat
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
     }
     state = store.record_desired_snapshot(route, canonical_snapshot)
     rendered = build_plan_blocks(
@@ -132,6 +137,7 @@ def test_todo_store_canonical_ids_drive_plan_classification_and_controls(tmp_pat
         revision=state["desired_revision"],
         snapshot_hash=state["desired_hash"],
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
 
     assert [
@@ -163,7 +169,8 @@ def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> N
         {"id": "սser:lookalike", "content": "Lookalike", "status": "pending"},
     ]
     rendered = build_plan_blocks(
-        todos, revision=3, snapshot_hash="hash", signing_secret=b"secret"
+        todos, revision=3, snapshot_hash="hash", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert [task["task_id"] for task in rendered.native_blocks[0]["tasks"]] == [
         task["id"] for task in todos
@@ -180,12 +187,37 @@ def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> N
     assert next(item for item in elements if item["action_id"] == "hermes_plan_add")["text"]["text"] == "Add user task"
 
 
+@pytest.mark.parametrize(
+    "action_context",
+    [None, {"route_user_id": ""}, {"route_user_id": "B-bot"}],
+)
+def test_renderer_without_mutation_owner_keeps_plan_and_refresh_only(
+    action_context,
+) -> None:
+    rendered = build_plan_blocks(
+        [{"id": "user:active", "content": "Active", "status": "in_progress"}],
+        revision=1,
+        snapshot_hash="read-only",
+        signing_secret=b"secret",
+        action_context=action_context,
+    )
+
+    assert rendered.native_blocks[0]["type"] == "plan"
+    assert [item["action_id"] for item in _action_elements(rendered)] == [
+        "hermes_plan_refresh"
+    ]
+    assert [
+        item["action_id"] for item in _action_elements(rendered, fallback=True)
+    ] == ["hermes_plan_refresh"]
+
+
 def test_pending_user_task_becomes_actionable_with_same_id_when_in_progress() -> None:
     pending = build_plan_blocks(
         [{"id": "user:stable", "content": "Stable", "status": "pending"}],
         revision=1,
         snapshot_hash="pending",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert [item["action_id"] for item in _action_elements(pending)] == [
         "hermes_plan_add", "hermes_plan_refresh",
@@ -196,6 +228,7 @@ def test_pending_user_task_becomes_actionable_with_same_id_when_in_progress() ->
         revision=2,
         snapshot_hash="active",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     checkbox = next(
         item for item in _action_elements(active)
@@ -219,7 +252,8 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         {"id": "user:two", "content": "Two", "status": "completed"},
     ]
     normal = build_plan_blocks(
-        large_agent_plan, revision=3, snapshot_hash="hash", signing_secret=b"secret"
+        large_agent_plan, revision=3, snapshot_hash="hash", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert len(normal.native_blocks[0]["tasks"]) == 42
     action_ids = [element["action_id"] for element in _action_elements(normal)]
@@ -235,6 +269,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
          for index in range(MAX_INTERACTIVE_TASKS)],
         revision=4, snapshot_hash="capacity", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert "hermes_plan_add" not in [item["action_id"] for item in _action_elements(at_capacity)]
 
@@ -242,6 +277,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
          for index in range(MAX_INTERACTIVE_TASKS + 1)],
         revision=5, snapshot_hash="oversized", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert [item["action_id"] for item in _action_elements(oversized)] == [
         "hermes_plan_refresh"
@@ -256,6 +292,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         revision=6,
         snapshot_hash="extreme",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     fallback_text = json.dumps(extreme.fallback_blocks).lower()
     assert len(extreme.native_blocks[0]["tasks"]) == 80
@@ -277,6 +314,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         revision=7,
         snapshot_hash="extreme-users",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     assert len(extreme_with_users.native_blocks[0]["tasks"]) == 82
     assert len(extreme_with_users.fallback_blocks) <= 50
@@ -307,6 +345,7 @@ def test_renderer_add_control_follows_authoritative_todo_capacity(
     ]
     rendered = build_plan_blocks(
         todos, revision=1, snapshot_hash="capacity", signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     action_ids = [item["action_id"] for item in _action_elements(rendered)]
     assert ("hermes_plan_add" in action_ids) is expect_add
@@ -344,6 +383,7 @@ def test_future_and_cancelled_user_tasks_do_not_consume_mutation_capacity() -> N
         revision=7,
         snapshot_hash="inactive-capacity",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
 
     assert len(rendered.native_blocks[0]["tasks"]) == MAX_INTERACTIVE_TASKS + 6
@@ -374,6 +414,7 @@ def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> Non
         revision=8,
         snapshot_hash="long-lines",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     section_text = "".join(
         block["text"]["text"]
@@ -414,6 +455,7 @@ def test_native_task_titles_disclose_content_truncation_at_boundary(task_prefix)
         revision=9,
         snapshot_hash=f"title-{task_prefix}",
         signing_secret=b"secret",
+        action_context=_OWNER_CONTEXT,
     )
     exact_title, over_title = [
         task["title"] for task in rendered.native_blocks[0]["tasks"]
@@ -429,7 +471,8 @@ def test_native_task_titles_disclose_content_truncation_at_boundary(task_prefix)
 def test_add_task_is_disabled_without_signing_material() -> None:
     rendered = build_plan_blocks(
         [{"id": "user:a", "content": "A", "status": "pending"}],
-        revision=1, snapshot_hash="hash", signing_secret=None
+        revision=1, snapshot_hash="hash", signing_secret=None,
+        action_context=_OWNER_CONTEXT,
     )
     actions = rendered.native_blocks[-1]["elements"]
     assert "hermes_plan_add" not in [item["action_id"] for item in actions]
@@ -676,7 +719,7 @@ def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
     }
     original = store.record_desired_snapshot(route, _snapshot(1))
     assert store.mark_applied(
@@ -708,7 +751,7 @@ def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
     }
     state = store.record_desired_snapshot(route, [
         {"id": "agent:a", "content": "Agent", "status": "pending"},
@@ -749,11 +792,81 @@ def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_
     }) is None
 
 
+@pytest.mark.parametrize("route_user_id", ["U-owner", "", "B-bot"])
+@pytest.mark.parametrize(
+    ("action_kind", "changes"),
+    [
+        (
+            "complete_reopen",
+            {
+                "task_ids": ["user:active"],
+                "complete_task_ids": ["user:active"],
+                "complete_task_status": "completed",
+                "reopen_task_ids": [],
+                "reopen_task_status": "in_progress",
+            },
+        ),
+        (
+            "cancel",
+            {
+                "task_ids": ["user:active"],
+                "cancel_task_ids": ["user:active"],
+                "cancel_task_status": "cancelled",
+            },
+        ),
+        (
+            "add_user_task",
+            {
+                "task_ids": ["user:new"],
+                "add_task_ids": ["user:new"],
+                "add_task_content": "New",
+                "add_task_status": "in_progress",
+            },
+        ),
+    ],
+)
+def test_validate_action_requires_nonempty_exact_route_owner_for_every_mutation(
+    tmp_path, route_user_id, action_kind, changes,
+) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk",
+        "session_id": "sid",
+        "team_id": "T1",
+        "channel_id": "C1",
+        "thread_ts": "10.0",
+        "route_user_id": route_user_id,
+    }
+    state = store.record_desired_snapshot(route, [
+        {"id": "user:active", "content": "Active", "status": "in_progress"},
+    ])
+    assert store.mark_applied(
+        "sk",
+        revision=state["desired_revision"],
+        snapshot_hash=state["desired_hash"],
+        message_ts="20.0",
+    )
+    dedupe_id = f"{route_user_id or 'empty'}-{action_kind}"
+    assert store.consume_action_id(dedupe_id)
+    metadata = {
+        **route,
+        "message_ts": "20.0",
+        "revision": state["desired_revision"],
+        "snapshot_hash": state["desired_hash"],
+        "action_kind": action_kind,
+        "action_user_id": "U-other",
+        "action_dedupe_id": dedupe_id,
+        **changes,
+    }
+
+    assert store.validate_action(metadata) is None
+
+
 def test_validate_add_capacity_counts_only_in_progress_and_completed_user_tasks(tmp_path) -> None:
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
     }
     read_only = [
         {
@@ -813,7 +926,7 @@ def test_validate_add_rejects_authoritative_todo_capacity(
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
     }
     snapshot = [
         {"id": f"agent:{index}", "content": str(index), "status": "pending"}

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -114,15 +114,46 @@ def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> N
     assert [task["task_id"] for task in rendered.native_blocks[0]["tasks"]] == [
         task["id"] for task in todos
     ]
+    assert "`user:pending`" in json.dumps(rendered.fallback_blocks)
     elements = _action_elements(rendered)
     checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
     cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
     assert [option["value"] for option in checkbox["options"]] == [
-        "user:pending", "user:done"
+        "user:done", "user:active"
     ]
     assert [option["value"] for option in checkbox["initial_options"]] == ["user:done"]
-    assert [option["value"] for option in cancel["options"]] == ["user:pending"]
+    assert [option["value"] for option in cancel["options"]] == ["user:active"]
     assert next(item for item in elements if item["action_id"] == "hermes_plan_add")["text"]["text"] == "Add user task"
+
+
+def test_pending_user_task_becomes_actionable_with_same_id_when_in_progress() -> None:
+    pending = build_plan_blocks(
+        [{"id": "user:stable", "content": "Stable", "status": "pending"}],
+        revision=1,
+        snapshot_hash="pending",
+        signing_secret=b"secret",
+    )
+    assert [item["action_id"] for item in _action_elements(pending)] == [
+        "hermes_plan_add", "hermes_plan_refresh",
+    ]
+
+    active = build_plan_blocks(
+        [{"id": "user:stable", "content": "Stable", "status": "in_progress"}],
+        revision=2,
+        snapshot_hash="active",
+        signing_secret=b"secret",
+    )
+    checkbox = next(
+        item for item in _action_elements(active)
+        if item["action_id"] == "hermes_plan_complete"
+    )
+    cancel = next(
+        item for item in _action_elements(active)
+        if item["action_id"] == "hermes_plan_cancel"
+    )
+    assert [option["value"] for option in checkbox["options"]] == ["user:stable"]
+    assert "initial_options" not in checkbox
+    assert [option["value"] for option in cancel["options"]] == ["user:stable"]
 
 
 def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> None:
@@ -130,7 +161,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
         {"id": f"agent:{index}", "content": f"Agent {index}", "status": "pending"}
         for index in range(40)
     ] + [
-        {"id": "user:one", "content": "One", "status": "pending"},
+        {"id": "user:one", "content": "One", "status": "in_progress"},
         {"id": "user:two", "content": "Two", "status": "completed"},
     ]
     normal = build_plan_blocks(
@@ -147,14 +178,14 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
     assert [element["action_id"] for element in _action_elements(normal, fallback=True)] == action_ids
 
     at_capacity = build_plan_blocks(
-        [{"id": f"user:{index}", "content": str(index), "status": "pending"}
+        [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
          for index in range(MAX_INTERACTIVE_TASKS)],
         revision=4, snapshot_hash="capacity", signing_secret=b"secret",
     )
     assert "hermes_plan_add" not in [item["action_id"] for item in _action_elements(at_capacity)]
 
     oversized = build_plan_blocks(
-        [{"id": f"user:{index}", "content": str(index), "status": "pending"}
+        [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
          for index in range(MAX_INTERACTIVE_TASKS + 1)],
         revision=5, snapshot_hash="oversized", signing_secret=b"secret",
     )
@@ -186,7 +217,7 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
             {"id": f"agent:long-{index}", "content": "x" * 3000, "status": "pending"}
             for index in range(80)
         ] + [
-            {"id": "user:pending", "content": "Pending", "status": "pending"},
+            {"id": "user:active", "content": "Active", "status": "in_progress"},
             {"id": "user:done", "content": "Done", "status": "completed"},
         ],
         revision=7,
@@ -206,17 +237,17 @@ def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> No
     ]
 
 
-def test_inactive_user_tasks_do_not_consume_mutation_capacity() -> None:
-    inactive = [
+def test_future_and_cancelled_user_tasks_do_not_consume_mutation_capacity() -> None:
+    read_only = [
         {
-            "id": f"user:inactive-{index}",
-            "content": f"Inactive {index}",
-            "status": "cancelled" if index % 2 else "in_progress",
+            "id": f"user:read-only-{index}",
+            "content": f"Read only {index}",
+            "status": "cancelled" if index % 2 else "pending",
         }
         for index in range(MAX_INTERACTIVE_TASKS + 5)
     ]
     rendered = build_plan_blocks(
-        inactive + [{"id": "user:pending", "content": "Pending", "status": "pending"}],
+        read_only + [{"id": "user:active", "content": "Active", "status": "in_progress"}],
         revision=7,
         snapshot_hash="inactive-capacity",
         signing_secret=b"secret",
@@ -232,8 +263,8 @@ def test_inactive_user_tasks_do_not_consume_mutation_capacity() -> None:
     ]
     checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
     cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
-    assert [option["value"] for option in checkbox["options"]] == ["user:pending"]
-    assert [option["value"] for option in cancel["options"]] == ["user:pending"]
+    assert [option["value"] for option in checkbox["options"]] == ["user:active"]
+    assert [option["value"] for option in cancel["options"]] == ["user:active"]
     assert "controls unavailable" not in json.dumps(rendered.fallback_blocks).lower()
     assert [item["action_id"] for item in _action_elements(rendered, fallback=True)] == [
         item["action_id"] for item in elements
@@ -243,7 +274,7 @@ def test_inactive_user_tasks_do_not_consume_mutation_capacity() -> None:
 def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> None:
     todos = [
         {"id": "agent:long", "content": "a" * 3000, "status": "pending"},
-        {"id": "user:long", "content": "u" * 3000, "status": "pending"},
+        {"id": "user:long", "content": "u" * 3000, "status": "in_progress"},
     ]
     rendered = build_plan_blocks(
         todos,
@@ -259,7 +290,7 @@ def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> Non
     expected = "\n".join([
         "*Hermes plan* (2 tasks)",
         f"• *Pending* `agent:long` — {'a' * 3000}",
-        f"• *Pending* `user:long` — {'u' * 3000}",
+        f"• *In progress* `user:long` — {'u' * 3000}",
     ])
 
     assert section_text == expected
@@ -563,7 +594,8 @@ def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
         **route, "message_ts": "20.0", "revision": original["desired_revision"],
         "snapshot_hash": original["desired_hash"], "task_ids": ["user:new"],
         "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "add_task_content": "New", "action_user_id": "U1",
+        "add_task_content": "New", "add_task_status": "in_progress",
+        "action_user_id": "U1",
         "action_dedupe_id": "dedupe",
     }
     assert store.consume_action_id("dedupe")
@@ -587,7 +619,7 @@ def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_
     }
     state = store.record_desired_snapshot(route, [
         {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:a", "content": "User", "status": "pending"},
+        {"id": "user:a", "content": "User", "status": "in_progress"},
     ])
     assert store.mark_applied(
         "sk", revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
@@ -601,15 +633,17 @@ def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_
     assert store.consume_action_id("dedupe")
     assert store.validate_action({
         **base, "action_kind": "complete_reopen", "task_ids": ["agent:a", "user:a"],
-        "complete_task_ids": ["agent:a", "user:a"], "reopen_task_ids": [],
+        "complete_task_ids": ["agent:a", "user:a"], "complete_task_status": "completed",
+        "reopen_task_ids": [], "reopen_task_status": "in_progress",
     }) is None
     assert store.validate_action({
         **base, "action_kind": "cancel", "task_ids": ["agent:a"],
-        "cancel_task_ids": ["agent:a"],
+        "cancel_task_ids": ["agent:a"], "cancel_task_status": "cancelled",
     }) is None
     assert store.validate_action({
         **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
         "add_task_ids": ["user:replacement"], "add_task_content": "New",
+        "add_task_status": "in_progress",
     }) is None
 
     data = json.loads(store.state_path.read_text(encoding="utf-8"))
@@ -618,26 +652,26 @@ def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_
     store.state_path.write_text(json.dumps(data), encoding="utf-8")
     assert store.validate_action({
         **base, "action_kind": "cancel", "task_ids": ["user:a"],
-        "cancel_task_ids": ["user:a"],
+        "cancel_task_ids": ["user:a"], "cancel_task_status": "cancelled",
     }) is None
 
 
-def test_validate_add_capacity_counts_only_pending_and_completed_user_tasks(tmp_path) -> None:
+def test_validate_add_capacity_counts_only_in_progress_and_completed_user_tasks(tmp_path) -> None:
     store = PlanCardStore(tmp_path)
     route = {
         "session_key": "sk", "session_id": "sid", "team_id": "T1",
         "channel_id": "C1", "thread_ts": "10.0",
     }
-    inactive = [
+    read_only = [
         {
-            "id": f"user:inactive-{index}",
+            "id": f"user:read-only-{index}",
             "content": str(index),
-            "status": "cancelled" if index % 2 else "in_progress",
+            "status": "cancelled" if index % 2 else "pending",
         }
         for index in range(MAX_INTERACTIVE_TASKS + 3)
     ]
-    below_capacity = store.record_desired_snapshot(route, inactive + [
-        {"id": "user:pending", "content": "Pending", "status": "pending"},
+    below_capacity = store.record_desired_snapshot(route, read_only + [
+        {"id": "user:active", "content": "Active", "status": "in_progress"},
     ])
     assert store.mark_applied(
         "sk", revision=below_capacity["desired_revision"],
@@ -647,14 +681,19 @@ def test_validate_add_capacity_counts_only_pending_and_completed_user_tasks(tmp_
         **route, "message_ts": "20.0", "revision": below_capacity["desired_revision"],
         "snapshot_hash": below_capacity["desired_hash"], "task_ids": ["user:new"],
         "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "add_task_content": "New", "action_user_id": "U1",
+        "add_task_content": "New", "add_task_status": "in_progress",
+        "action_user_id": "U1",
         "action_dedupe_id": "below-capacity",
     }
     assert store.consume_action_id("below-capacity")
     assert store.validate_action(metadata) is not None
 
-    at_capacity = store.record_desired_snapshot(route, inactive + [
-        {"id": f"user:mutable-{index}", "content": str(index), "status": "pending"}
+    at_capacity = store.record_desired_snapshot(route, read_only + [
+        {
+            "id": f"user:mutable-{index}",
+            "content": str(index),
+            "status": "in_progress" if index % 2 else "completed",
+        }
         for index in range(MAX_INTERACTIVE_TASKS)
     ])
     assert store.mark_applied(

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -1,0 +1,526 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+import pytest
+
+from plugins.platforms.slack.plan_cards import (
+    PlanCardStore,
+    _RetryScheduleKind,
+    build_plan_blocks,
+    decode_action_value,
+    encode_action_value,
+    parse_todo_result,
+    sign_private_metadata,
+    verify_private_metadata,
+)
+
+
+def _snapshot(count: int = 4) -> list[dict[str, str]]:
+    statuses = ["pending", "in_progress", "completed", "cancelled"]
+    return [
+        {"id": f"task-{index}", "content": f"Task {index}", "status": statuses[index % 4]}
+        for index in range(count)
+    ]
+
+
+def _process_write(home: str, index: int, output) -> None:
+    route = {
+        "session_key": "sk",
+        "session_id": "sid",
+        "team_id": "T1",
+        "channel_id": "C1",
+        "thread_ts": "",
+    }
+    revision = PlanCardStore(home).record_desired_snapshot(
+        route, [{"id": str(index), "content": str(index), "status": "pending"}]
+    )["desired_revision"]
+    output.put(revision)
+
+
+def test_parse_todo_result_accepts_trailing_hint_and_rejects_errors() -> None:
+    result = json.dumps({"todos": _snapshot()}) + "\n\n[Hint: persisted]"
+    parsed = parse_todo_result(result)
+    assert parsed == _snapshot()
+    assert parse_todo_result('{"error":"bad"}') is None
+    assert parse_todo_result("not json") is None
+
+
+def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
+    first = build_plan_blocks(
+        _snapshot(), revision=1, snapshot_hash="hash-1", signing_secret=b"secret"
+    )
+    second = build_plan_blocks(
+        _snapshot(), revision=2, snapshot_hash="hash-1", signing_secret=b"secret"
+    )
+
+    plan = first.native_blocks[0]
+    assert plan["type"] == "plan"
+    assert [task["type"] for task in plan["tasks"]] == ["task_card"] * 4
+    assert [task["task_id"] for task in plan["tasks"]] == [
+        "task-0", "task-1", "task-2", "task-3"
+    ]
+    assert [task["status"] for task in plan["tasks"]] == [
+        "pending", "in_progress", "complete", "error"
+    ]
+    assert plan["tasks"][3]["title"].startswith("[cancelled]")
+    assert first.text == "Hermes plan: 4 tasks"
+    assert first.native_blocks[0]["block_id"] != second.native_blocks[0]["block_id"]
+    assert first.native_blocks[0]["tasks"][0]["block_id"] != second.native_blocks[0]["tasks"][0]["block_id"]
+    assert all(block["block_id"] != other["block_id"] for block, other in zip(
+        first.native_blocks, second.native_blocks
+    ))
+
+
+def test_renderer_adds_controls_and_degrades_without_truncating_truth() -> None:
+    normal = build_plan_blocks(
+        _snapshot(10), revision=3, snapshot_hash="hash", signing_secret=b"secret"
+    )
+    actions = normal.native_blocks[-1]
+    assert actions["type"] == "actions"
+    action_ids = [element["action_id"] for element in actions["elements"]]
+    assert action_ids == [
+        "hermes_plan_complete",
+        "hermes_plan_cancel",
+        "hermes_plan_add",
+        "hermes_plan_refresh",
+    ]
+
+    oversized = build_plan_blocks(
+        _snapshot(11), revision=4, snapshot_hash="hash", signing_secret=b"secret"
+    )
+    assert len(oversized.native_blocks[0]["tasks"]) == 11
+    assert "11 tasks" in oversized.text
+    assert all(block.get("type") != "actions" for block in oversized.native_blocks)
+    assert "controls unavailable" in json.dumps(oversized.fallback_blocks).lower()
+
+    extreme = build_plan_blocks(
+        [
+            {"id": f"long-{index}", "content": "x" * 3000, "status": "pending"}
+            for index in range(80)
+        ],
+        revision=5,
+        snapshot_hash="extreme",
+        signing_secret=b"secret",
+    )
+    fallback_text = json.dumps(extreme.fallback_blocks).lower()
+    assert "display truncated" in fallback_text
+    assert "no tasks were omitted" not in fallback_text
+
+
+def test_add_task_is_disabled_without_signing_material() -> None:
+    rendered = build_plan_blocks(
+        _snapshot(2), revision=1, snapshot_hash="hash", signing_secret=None
+    )
+    actions = rendered.native_blocks[-1]["elements"]
+    assert "hermes_plan_add" not in [item["action_id"] for item in actions]
+
+
+def test_action_values_and_modal_metadata_are_tamper_evident() -> None:
+    payload = {
+        "session_key": "agent:main:slack:group:C1:1.0",
+        "revision": 7,
+        "snapshot_hash": "abc",
+    }
+    value = encode_action_value(payload)
+    assert decode_action_value(value) == payload
+
+    signed = sign_private_metadata(payload, b"secret")
+    assert verify_private_metadata(signed, b"secret") == payload
+    raw = json.loads(signed)
+    raw["payload"]["revision"] = 8
+    assert verify_private_metadata(json.dumps(raw), b"secret") is None
+    assert sign_private_metadata(payload, None) is None
+
+
+def test_store_revision_reverse_index_and_restart_persistence(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk",
+        "session_id": "sid",
+        "team_id": "T1",
+        "channel_id": "C1",
+        "thread_ts": "10.0",
+    }
+    one = store.record_desired_snapshot(route, _snapshot(2))
+    two = store.record_desired_snapshot(route, _snapshot(3))
+    assert one["desired_revision"] == 1
+    assert two["desired_revision"] == 2
+    assert two["applied_revision"] == 0
+
+    store.mark_applied("sk", revision=2, snapshot_hash=two["desired_hash"], message_ts="20.0")
+    restarted = PlanCardStore(tmp_path)
+    state = restarted.get_session("sk")
+    assert state["desired_revision"] == state["applied_revision"] == 2
+    assert restarted.lookup_route("T1", "C1", "20.0")["session_key"] == "sk"
+    assert store.lock_path != store.state_path
+    assert store.lock_path.exists()
+    first_lock_inode = store.lock_path.stat().st_ino
+    store.record_desired_snapshot(route, _snapshot(1))
+    assert store.lock_path.stat().st_size >= 1
+    if first_lock_inode:
+        assert store.lock_path.stat().st_ino == first_lock_inode
+
+
+def test_stale_apply_cannot_advance_or_overwrite_newer_desired_state(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    first = store.record_desired_snapshot(route, _snapshot(1))
+    second = store.record_desired_snapshot(route, _snapshot(2))
+
+    assert not store.mark_applied(
+        "sk", revision=first["desired_revision"],
+        snapshot_hash=first["desired_hash"], message_ts="stale",
+    )
+    current = store.get_session("sk")
+    assert current["desired_revision"] == second["desired_revision"]
+    assert current["applied_revision"] == 0
+    assert current["message_ts"] == ""
+
+
+def test_create_identity_is_stable_uuid_until_route_generation_changes(tmp_path) -> None:
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
+        "chat_type": "group",
+    }
+    store = PlanCardStore(tmp_path)
+    state = store.record_desired_snapshot(route, _snapshot(1))
+    prepared = store.prepare_create("sk", expected_route=state)
+    first_id = prepared["client_msg_id"]
+    assert prepared["was_attempted"] is False
+    assert str(uuid.UUID(first_id)) == first_id
+
+    restarted = PlanCardStore(tmp_path)
+    prepared_again = restarted.prepare_create(
+        "sk", expected_route=restarted.get_session("sk")
+    )
+    assert prepared_again["was_attempted"] is True
+    assert prepared_again["client_msg_id"] == first_id
+
+    moved = restarted.record_desired_snapshot({
+        **route, "session_id": "sid-2", "channel_id": "C2", "thread_ts": "11.0",
+    }, _snapshot(2))
+    assert moved["client_msg_id"] == ""
+    assert moved["retired_anchors"][0]["client_msg_id"] == first_id
+    next_generation = restarted.prepare_create("sk", expected_route=moved)
+    assert str(uuid.UUID(next_generation["client_msg_id"])) == next_generation["client_msg_id"]
+    assert next_generation["client_msg_id"] != first_id
+
+
+def test_retired_anchor_retry_survives_restart_until_cleanup_succeeds(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    state = store.record_desired_snapshot(route, _snapshot(1))
+    prepared = store.prepare_create("sk", expected_route=state)
+    assert store.mark_applied(
+        "sk", revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
+        message_ts="20.0", rendered_revision=state["desired_revision"],
+        expected_message_ts="", expected_client_msg_id=prepared["client_msg_id"],
+    )
+    moved = store.record_desired_snapshot({
+        **route, "session_id": "sid-2", "channel_id": "C2", "thread_ts": "11.0",
+    }, _snapshot(2))
+    retired = moved["retired_anchors"][0]
+    store.mark_retired_retry("sk", retired["anchor_id"], base_seconds=0)
+
+    restarted = PlanCardStore(tmp_path)
+    pending = restarted.list_retired("sk", now=float("inf"))
+    assert pending[0]["message_ts"] == "20.0"
+    assert pending[0]["retry_count"] == 1
+    assert restarted.complete_retired_cleanup("sk", pending[0]["anchor_id"])
+    assert restarted.list_retired("sk", now=float("inf")) == []
+
+
+def test_conflict_orphan_retirement_is_deduped_by_remote_identity(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
+        "chat_type": "group",
+    }
+    state = store.record_desired_snapshot(route, _snapshot(1))
+    prepared = store.prepare_create("sk", expected_route=state)
+    orphan = {
+        **prepared,
+        "message_ts": "99.0",
+        "client_msg_id": prepared["client_msg_id"],
+    }
+
+    assert store.retire_orphan_anchor("sk", orphan) is True
+    assert store.retire_orphan_anchor("sk", orphan) is False
+    retired = store.list_retired("sk", now=float("inf"))
+    assert len(retired) == 1
+    assert retired[0]["message_ts"] == "99.0"
+    assert retired[0]["client_msg_id"] == prepared["client_msg_id"]
+
+
+def test_route_change_invalidates_old_reverse_index(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    first = store.record_desired_snapshot({
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }, _snapshot(1))
+    store.mark_applied("sk", revision=1, snapshot_hash=first["desired_hash"], message_ts="20.0")
+    store.record_desired_snapshot({
+        "session_key": "sk", "session_id": "sid-2", "team_id": "T1",
+        "channel_id": "C2", "thread_ts": "11.0",
+    }, _snapshot(1))
+    assert store.lookup_route("T1", "C1", "20.0") is None
+    assert store.get_session("sk")["message_ts"] == ""
+    assert store.get_session("sk")["retired_anchors"][0]["message_ts"] == "20.0"
+
+
+def test_explicit_empty_route_fields_clear_prior_values_and_omitted_fields_inherit(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
+        "chat_type": "group",
+    }
+    first = store.record_desired_snapshot(route, _snapshot(1))
+    prepared = store.prepare_create("sk", expected_route=first)
+    assert store.mark_applied(
+        "sk", revision=first["desired_revision"], snapshot_hash=first["desired_hash"],
+        message_ts="20.0", rendered_revision=first["desired_revision"],
+        expected_message_ts="", expected_client_msg_id=prepared["client_msg_id"],
+    )
+
+    moved = store.record_desired_snapshot({
+        "session_key": "sk", "thread_ts": "", "route_user_id": "",
+    }, _snapshot(2))
+    assert moved["thread_ts"] == ""
+    assert moved["route_user_id"] == ""
+    assert moved["session_id"] == "sid"
+    assert moved["team_id"] == "T1"
+    assert moved["channel_id"] == "C1"
+    assert moved["chat_type"] == "group"
+    assert moved["message_ts"] == ""
+    assert moved["client_msg_id"] == ""
+    assert moved["retired_anchors"][0]["thread_ts"] == "10.0"
+    next_generation = store.prepare_create("sk", expected_route=moved)
+    assert next_generation["client_msg_id"] != prepared["client_msg_id"]
+
+
+def test_store_concurrent_increments_do_not_get_lost(tmp_path) -> None:
+    route = {
+        "session_key": "sk",
+        "session_id": "sid",
+        "team_id": "T1",
+        "channel_id": "C1",
+        "thread_ts": "",
+    }
+
+    def write(index: int) -> int:
+        return PlanCardStore(tmp_path).record_desired_snapshot(
+            route, [{"id": str(index), "content": str(index), "status": "pending"}]
+        )["desired_revision"]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        revisions = sorted(pool.map(write, range(24)))
+    assert revisions == list(range(1, 25))
+
+
+def test_store_cross_process_increments_do_not_get_lost(tmp_path) -> None:
+    ctx = multiprocessing.get_context("spawn")
+    output = ctx.Queue()
+    processes = [ctx.Process(target=_process_write, args=(str(tmp_path), index, output)) for index in range(8)]
+    for process in processes:
+        process.start()
+    for process in processes:
+        process.join(timeout=15)
+        assert process.exitcode == 0
+    assert sorted(output.get(timeout=2) for _ in processes) == list(range(1, 9))
+
+
+def test_store_corruption_fails_closed_and_recovers_on_next_snapshot(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    store.state_path.parent.mkdir(parents=True, exist_ok=True)
+    store.state_path.write_text("{broken", encoding="utf-8")
+    assert store.get_session("sk") is None
+    state = store.record_desired_snapshot(
+        {"session_key": "sk", "session_id": "sid", "team_id": "T", "channel_id": "C"},
+        _snapshot(1),
+    )
+    assert state["desired_revision"] == 1
+    assert store.get_session("sk")["last_desired_snapshot"] == _snapshot(1)
+    assert list(store.state_path.parent.glob("slack_plan_cards.json.corrupt.*"))
+
+
+def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    original = store.record_desired_snapshot(route, _snapshot(1))
+    assert store.mark_applied(
+        "sk", revision=original["desired_revision"],
+        snapshot_hash=original["desired_hash"], message_ts="20.0",
+    )
+    metadata = {
+        **route, "message_ts": "20.0", "revision": original["desired_revision"],
+        "snapshot_hash": original["desired_hash"], "task_ids": [],
+    }
+
+    validated = store.validate_action(metadata)
+    store.record_desired_snapshot(
+        {**route, "session_id": "sid-new", "channel_id": "C2", "thread_ts": "11.0"},
+        _snapshot(2),
+    )
+
+    assert validated["session_id"] == "sid"
+    assert validated["channel_id"] == "C1"
+    assert validated["desired_revision"] == original["desired_revision"]
+
+
+def _converged_session_with_retired_anchor(store, route):
+    first = store.record_desired_snapshot(route, _snapshot(1))
+    first_create = store.prepare_create("sk", expected_route=first)
+    assert store.mark_applied(
+        "sk", revision=first["desired_revision"], snapshot_hash=first["desired_hash"],
+        message_ts="20.0", expected_message_ts="",
+        expected_client_msg_id=first_create["client_msg_id"],
+    )
+    moved = store.record_desired_snapshot(
+        {**route, "channel_id": "C2"}, _snapshot(2)
+    )
+    moved_create = store.prepare_create("sk", expected_route=moved)
+    assert store.mark_applied(
+        "sk", revision=moved["desired_revision"], snapshot_hash=moved["desired_hash"],
+        message_ts="30.0", expected_message_ts="",
+        expected_client_msg_id=moved_create["client_msg_id"],
+    )
+    return store.list_retired("sk")[0]
+
+
+def test_retry_schedule_distinguishes_no_work_from_due_now(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    assert store.retry_schedule(now=100).kind is _RetryScheduleKind.NO_WORK
+
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    store.record_desired_snapshot(route, _snapshot(1))
+    assert store.retry_schedule(now=100).kind is _RetryScheduleKind.DUE_NOW
+
+
+def test_retry_schedule_ignores_converged_current_retry_metadata(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    state = store.record_desired_snapshot(route, _snapshot(1))
+    assert store.mark_applied(
+        "sk", revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
+        message_ts="20.0",
+    )
+    with (
+        patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
+        patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
+    ):
+        store.mark_retry("sk", base_seconds=10, max_seconds=10)
+
+    assert store.retry_schedule(now=105).kind is _RetryScheduleKind.NO_WORK
+
+
+def test_retry_schedule_deadline_crossing_after_dirty_scan_is_due_now(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    store.record_desired_snapshot(route, _snapshot(1))
+    with (
+        patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
+        patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
+    ):
+        store.mark_retry("sk", base_seconds=10, max_seconds=10)
+
+    assert store.list_dirty(now=109) == []
+    assert store.retry_schedule(now=111).kind is _RetryScheduleKind.DUE_NOW
+
+
+def test_retry_schedule_current_future_is_due_at(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    store.record_desired_snapshot(route, _snapshot(1))
+    with (
+        patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
+        patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
+    ):
+        store.mark_retry("sk", base_seconds=20, max_seconds=20)
+
+    schedule = store.retry_schedule(now=105)
+    assert schedule.kind is _RetryScheduleKind.DUE_AT
+    assert schedule.deadline == 120
+
+
+def test_retry_schedule_retired_future_is_due_at(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    retired = _converged_session_with_retired_anchor(store, route)
+    with (
+        patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
+        patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
+    ):
+        store.mark_retired_retry(
+            "sk", retired["anchor_id"], base_seconds=5, max_seconds=5
+        )
+
+    schedule = store.retry_schedule(now=101)
+    assert schedule.kind is _RetryScheduleKind.DUE_AT
+    assert schedule.deadline == 105
+
+
+def test_retry_schedule_mixed_work_picks_global_earliest(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    retired = _converged_session_with_retired_anchor(store, route)
+    store.request_refresh("sk")
+    with (
+        patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
+        patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
+    ):
+        store.mark_retry("sk", base_seconds=20, max_seconds=20)
+        store.mark_retired_retry(
+            "sk", retired["anchor_id"], base_seconds=5, max_seconds=5
+        )
+
+    schedule = store.retry_schedule(now=101)
+    assert schedule.kind is _RetryScheduleKind.DUE_AT
+    assert schedule.deadline == 105
+
+
+def test_retry_schedule_multiple_due_current_and_retired_is_due_now(tmp_path) -> None:
+    store = PlanCardStore(tmp_path)
+    route = {
+        "session_key": "sk", "session_id": "sid", "team_id": "T1",
+        "channel_id": "C1", "thread_ts": "10.0",
+    }
+    _converged_session_with_retired_anchor(store, route)
+    store.request_refresh("sk")
+
+    assert store.retry_schedule(now=time.time()).kind is _RetryScheduleKind.DUE_NOW

--- a/tests/gateway/test_slack_plan_cards.py
+++ b/tests/gateway/test_slack_plan_cards.py
@@ -10,21 +10,11 @@ from unittest.mock import patch
 import pytest
 
 from plugins.platforms.slack.plan_cards import (
-    MAX_INTERACTIVE_TASKS,
     PlanCardStore,
     _RetryScheduleKind,
     build_plan_blocks,
-    decode_action_value,
-    encode_action_value,
-    is_user_task_id,
     parse_todo_result,
-    sign_private_metadata,
-    verify_private_metadata,
 )
-from tools.todo_tool import MAX_TODO_ITEMS, TodoStore
-
-
-_OWNER_CONTEXT = {"route_user_id": "U1"}
 
 
 def _snapshot(count: int = 4) -> list[dict[str, str]]:
@@ -59,12 +49,10 @@ def test_parse_todo_result_accepts_trailing_hint_and_rejects_errors() -> None:
 
 def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
     first = build_plan_blocks(
-        _snapshot(), revision=1, snapshot_hash="hash-1", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
+        _snapshot(), revision=1, snapshot_hash="hash-1",
     )
     second = build_plan_blocks(
-        _snapshot(), revision=2, snapshot_hash="hash-1", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
+        _snapshot(), revision=2, snapshot_hash="hash-1",
     )
 
     plan = first.native_blocks[0]
@@ -85,337 +73,60 @@ def test_native_renderer_preserves_status_and_rotates_block_ids() -> None:
     ))
 
 
-def _action_elements(rendered, *, fallback: bool = False):
-    return [
-        element
-        for block in (rendered.fallback_blocks if fallback else rendered.native_blocks)
-        if block["type"] == "actions"
-        for element in block["elements"]
-    ]
-
-
-def test_user_task_id_namespace_is_strict_over_canonical_ids() -> None:
-    assert is_user_task_id("user:work")
-    assert not is_user_task_id("user:")
-    assert not is_user_task_id("task-1")
-    assert not is_user_task_id("User:work")
-    assert not is_user_task_id("սser:work")
-
-
-def test_todo_store_canonical_ids_drive_plan_classification_and_controls(tmp_path) -> None:
-    todo_store = TodoStore()
-    todo_store.write([
-        {
-            "id": "  user:approve  ",
-            "content": "Approve release",
-            "status": "in_progress",
-        },
-        {
-            "id": "  User:review  ",
-            "content": "Wrong ASCII case",
-            "status": "in_progress",
-        },
-        {
-            "id": "  սser:lookalike  ",
-            "content": "Unicode lookalike",
-            "status": "in_progress",
-        },
-    ])
-    canonical_snapshot = todo_store.read()
-    assert [task["id"] for task in canonical_snapshot] == [
-        "user:approve", "User:review", "սser:lookalike",
-    ]
-
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
-    }
-    state = store.record_desired_snapshot(route, canonical_snapshot)
-    rendered = build_plan_blocks(
-        state["last_desired_snapshot"],
-        revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"],
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-
-    assert [
-        task["task_id"] for task in rendered.native_blocks[0]["tasks"]
-    ] == ["user:approve", "User:review", "սser:lookalike"]
-    checkbox = next(
-        element for element in _action_elements(rendered)
-        if element["action_id"] == "hermes_plan_complete"
-    )
-    cancel = next(
-        element for element in _action_elements(rendered)
-        if element["action_id"] == "hermes_plan_cancel"
-    )
-    assert [option["value"] for option in checkbox["options"]] == ["user:approve"]
-    assert [option["value"] for option in cancel["options"]] == ["user:approve"]
-    assert is_user_task_id(state["last_desired_snapshot"][0]["id"])
-    assert not is_user_task_id(state["last_desired_snapshot"][1]["id"])
-    assert not is_user_task_id(state["last_desired_snapshot"][2]["id"])
-
-
-def test_renderer_shows_full_plan_but_controls_only_actionable_user_tasks() -> None:
+@pytest.mark.parametrize("count", [0, 1, 10, 100])
+def test_renderer_is_read_only_for_all_status_and_capacity_combinations(count) -> None:
+    statuses = ["pending", "in_progress", "completed", "cancelled"]
     todos = [
-        {"id": "agent:research", "content": "Agent research", "status": "pending"},
-        {"id": "user:pending", "content": "Human pending", "status": "pending"},
-        {"id": "user:done", "content": "Human done", "status": "completed"},
-        {"id": "user:active", "content": "Human active", "status": "in_progress"},
-        {"id": "user:cancelled", "content": "Human cancelled", "status": "cancelled"},
-        {"id": "User:case", "content": "Wrong case", "status": "pending"},
-        {"id": "սser:lookalike", "content": "Lookalike", "status": "pending"},
+        {
+            "id": f"user:{index}" if index % 2 else f"agent:{index}",
+            "content": f"Task {index}",
+            "status": statuses[index % len(statuses)],
+        }
+        for index in range(count)
     ]
-    rendered = build_plan_blocks(
-        todos, revision=3, snapshot_hash="hash", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
+    rendered = build_plan_blocks(todos, revision=7, snapshot_hash="read-only")
+
+    assert len(rendered.native_blocks) == 1
     assert [task["task_id"] for task in rendered.native_blocks[0]["tasks"]] == [
         task["id"] for task in todos
     ]
-    assert "`user:pending`" in json.dumps(rendered.fallback_blocks)
-    elements = _action_elements(rendered)
-    checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
-    cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
-    assert [option["value"] for option in checkbox["options"]] == [
-        "user:done", "user:active"
-    ]
-    assert [option["value"] for option in checkbox["initial_options"]] == ["user:done"]
-    assert [option["value"] for option in cancel["options"]] == ["user:active"]
-    assert next(item for item in elements if item["action_id"] == "hermes_plan_add")["text"]["text"] == "Add user task"
+    assert all(block["type"] != "actions" for block in rendered.native_blocks)
+    assert all(block["type"] != "actions" for block in rendered.fallback_blocks)
+    payload = json.dumps(
+        [rendered.native_blocks, rendered.fallback_blocks], ensure_ascii=False
+    ).lower()
+    for forbidden in (
+        "checkboxes", "hermes_plan_complete", "hermes_plan_cancel",
+        "hermes_plan_add", "hermes_plan_refresh", "add user task",
+    ):
+        assert forbidden not in payload
 
 
-@pytest.mark.parametrize(
-    "action_context",
-    [None, {"route_user_id": ""}, {"route_user_id": "B-bot"}],
-)
-def test_renderer_without_mutation_owner_keeps_plan_and_refresh_only(
-    action_context,
-) -> None:
-    rendered = build_plan_blocks(
-        [{"id": "user:active", "content": "Active", "status": "in_progress"}],
-        revision=1,
-        snapshot_hash="read-only",
-        signing_secret=b"secret",
-        action_context=action_context,
-    )
-
-    assert rendered.native_blocks[0]["type"] == "plan"
-    assert [item["action_id"] for item in _action_elements(rendered)] == [
-        "hermes_plan_refresh"
-    ]
-    assert [
-        item["action_id"] for item in _action_elements(rendered, fallback=True)
-    ] == ["hermes_plan_refresh"]
-
-
-def test_pending_user_task_becomes_actionable_with_same_id_when_in_progress() -> None:
-    pending = build_plan_blocks(
-        [{"id": "user:stable", "content": "Stable", "status": "pending"}],
-        revision=1,
-        snapshot_hash="pending",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    assert [item["action_id"] for item in _action_elements(pending)] == [
-        "hermes_plan_add", "hermes_plan_refresh",
-    ]
-
-    active = build_plan_blocks(
-        [{"id": "user:stable", "content": "Stable", "status": "in_progress"}],
-        revision=2,
-        snapshot_hash="active",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    checkbox = next(
-        item for item in _action_elements(active)
-        if item["action_id"] == "hermes_plan_complete"
-    )
-    cancel = next(
-        item for item in _action_elements(active)
-        if item["action_id"] == "hermes_plan_cancel"
-    )
-    assert [option["value"] for option in checkbox["options"]] == ["user:stable"]
-    assert "initial_options" not in checkbox
-    assert [option["value"] for option in cancel["options"]] == ["user:stable"]
-
-
-def test_renderer_limits_total_user_set_not_total_plan_and_keeps_refresh() -> None:
-    large_agent_plan = [
-        {"id": f"agent:{index}", "content": f"Agent {index}", "status": "pending"}
-        for index in range(40)
-    ] + [
-        {"id": "user:one", "content": "One", "status": "in_progress"},
-        {"id": "user:two", "content": "Two", "status": "completed"},
-    ]
-    normal = build_plan_blocks(
-        large_agent_plan, revision=3, snapshot_hash="hash", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    assert len(normal.native_blocks[0]["tasks"]) == 42
-    action_ids = [element["action_id"] for element in _action_elements(normal)]
-    assert action_ids == [
-        "hermes_plan_complete",
-        "hermes_plan_cancel",
-        "hermes_plan_add",
-        "hermes_plan_refresh",
-    ]
-    assert [element["action_id"] for element in _action_elements(normal, fallback=True)] == action_ids
-
-    at_capacity = build_plan_blocks(
-        [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
-         for index in range(MAX_INTERACTIVE_TASKS)],
-        revision=4, snapshot_hash="capacity", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    assert "hermes_plan_add" not in [item["action_id"] for item in _action_elements(at_capacity)]
-
-    oversized = build_plan_blocks(
-        [{"id": f"user:{index}", "content": str(index), "status": "in_progress"}
-         for index in range(MAX_INTERACTIVE_TASKS + 1)],
-        revision=5, snapshot_hash="oversized", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    assert [item["action_id"] for item in _action_elements(oversized)] == [
-        "hermes_plan_refresh"
-    ]
-    assert "controls unavailable" in json.dumps(oversized.fallback_blocks).lower()
-
-    extreme = build_plan_blocks(
-        [
-            {"id": f"long-{index}", "content": "x" * 3000, "status": "pending"}
-            for index in range(80)
-        ],
-        revision=6,
-        snapshot_hash="extreme",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    fallback_text = json.dumps(extreme.fallback_blocks).lower()
-    assert len(extreme.native_blocks[0]["tasks"]) == 80
-    assert len(extreme.fallback_blocks) <= 50
-    assert "display truncated" in fallback_text
-    assert "no tasks were omitted" not in fallback_text
-    assert [item["action_id"] for item in _action_elements(extreme, fallback=True)] == [
-        "hermes_plan_add", "hermes_plan_refresh",
-    ]
-
-    extreme_with_users = build_plan_blocks(
-        [
-            {"id": f"agent:long-{index}", "content": "x" * 3000, "status": "pending"}
-            for index in range(80)
-        ] + [
-            {"id": "user:active", "content": "Active", "status": "in_progress"},
-            {"id": "user:done", "content": "Done", "status": "completed"},
-        ],
-        revision=7,
-        snapshot_hash="extreme-users",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    assert len(extreme_with_users.native_blocks[0]["tasks"]) == 82
-    assert len(extreme_with_users.fallback_blocks) <= 50
-    assert "display truncated" in json.dumps(extreme_with_users.fallback_blocks).lower()
-    assert [
-        item["action_id"] for item in _action_elements(extreme_with_users, fallback=True)
-    ] == [
-        "hermes_plan_complete",
-        "hermes_plan_cancel",
-        "hermes_plan_add",
-        "hermes_plan_refresh",
-    ]
-
-
-@pytest.mark.parametrize(
-    ("count", "expect_add"),
-    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
-)
-def test_renderer_add_control_follows_authoritative_todo_capacity(
-    count: int, expect_add: bool,
-) -> None:
+def test_fallback_preserves_representable_progress_and_discloses_truncation() -> None:
     todos = [
-        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
-        for index in range(count - 2)
-    ] + [
-        {"id": "user:active", "content": "Active", "status": "in_progress"},
-        {"id": "user:done", "content": "Done", "status": "completed"},
-    ]
-    rendered = build_plan_blocks(
-        todos, revision=1, snapshot_hash="capacity", signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
-    action_ids = [item["action_id"] for item in _action_elements(rendered)]
-    assert ("hermes_plan_add" in action_ids) is expect_add
-    assert "hermes_plan_complete" in action_ids
-    assert "hermes_plan_cancel" in action_ids
-    assert "hermes_plan_refresh" in action_ids
-    checkbox = next(
-        item for item in _action_elements(rendered)
-        if item["action_id"] == "hermes_plan_complete"
-    )
-    cancel = next(
-        item for item in _action_elements(rendered)
-        if item["action_id"] == "hermes_plan_cancel"
-    )
-    assert [option["value"] for option in checkbox["options"]] == [
-        "user:active", "user:done",
-    ]
-    assert [option["value"] for option in checkbox["initial_options"]] == [
-        "user:done",
-    ]
-    assert [option["value"] for option in cancel["options"]] == ["user:active"]
-
-
-def test_future_and_cancelled_user_tasks_do_not_consume_mutation_capacity() -> None:
-    read_only = [
         {
-            "id": f"user:read-only-{index}",
-            "content": f"Read only {index}",
-            "status": "cancelled" if index % 2 else "pending",
+            "id": f"task-{index}",
+            "content": "x" * 3000,
+            "status": ("pending", "in_progress", "completed", "cancelled")[index % 4],
         }
-        for index in range(MAX_INTERACTIVE_TASKS + 5)
+        for index in range(80)
     ]
-    rendered = build_plan_blocks(
-        read_only + [{"id": "user:active", "content": "Active", "status": "in_progress"}],
-        revision=7,
-        snapshot_hash="inactive-capacity",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
+    rendered = build_plan_blocks(todos, revision=8, snapshot_hash="fallback")
+    fallback_text = json.dumps(rendered.fallback_blocks, ensure_ascii=False)
 
-    assert len(rendered.native_blocks[0]["tasks"]) == MAX_INTERACTIVE_TASKS + 6
-    elements = _action_elements(rendered)
-    assert [item["action_id"] for item in elements] == [
-        "hermes_plan_complete",
-        "hermes_plan_cancel",
-        "hermes_plan_add",
-        "hermes_plan_refresh",
-    ]
-    checkbox = next(item for item in elements if item["action_id"] == "hermes_plan_complete")
-    cancel = next(item for item in elements if item["action_id"] == "hermes_plan_cancel")
-    assert [option["value"] for option in checkbox["options"]] == ["user:active"]
-    assert [option["value"] for option in cancel["options"]] == ["user:active"]
-    assert "controls unavailable" not in json.dumps(rendered.fallback_blocks).lower()
-    assert [item["action_id"] for item in _action_elements(rendered, fallback=True)] == [
-        item["action_id"] for item in elements
-    ]
+    assert len(rendered.native_blocks[0]["tasks"]) == len(todos)
+    assert len(rendered.fallback_blocks) <= 50
+    assert "Slack display truncated this plan" in fallback_text
+    assert "*Pending* `task-0`" in fallback_text
+    assert all(block["type"] != "actions" for block in rendered.fallback_blocks)
 
 
-def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> None:
+def test_fallback_splits_overlong_lines_without_undisclosed_loss() -> None:
     todos = [
         {"id": "agent:long", "content": "a" * 3000, "status": "pending"},
         {"id": "user:long", "content": "u" * 3000, "status": "in_progress"},
     ]
-    rendered = build_plan_blocks(
-        todos,
-        revision=8,
-        snapshot_hash="long-lines",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
-    )
+    rendered = build_plan_blocks(todos, revision=9, snapshot_hash="long-lines")
     section_text = "".join(
         block["text"]["text"]
         for block in rendered.fallback_blocks
@@ -433,14 +144,7 @@ def test_fallback_splits_single_overlong_lines_without_undisclosed_loss() -> Non
         for block in rendered.fallback_blocks
         if block["type"] == "section"
     )
-    assert len(rendered.fallback_blocks) <= 50
     assert "display truncated" not in json.dumps(rendered.fallback_blocks).lower()
-    assert [item["action_id"] for item in _action_elements(rendered, fallback=True)] == [
-        "hermes_plan_complete",
-        "hermes_plan_cancel",
-        "hermes_plan_add",
-        "hermes_plan_refresh",
-    ]
 
 
 @pytest.mark.parametrize("task_prefix", ["agent", "user"])
@@ -452,47 +156,16 @@ def test_native_task_titles_disclose_content_truncation_at_boundary(task_prefix)
             {"id": f"{task_prefix}:exact", "content": exact_content, "status": "pending"},
             {"id": f"{task_prefix}:over", "content": over_content, "status": "pending"},
         ],
-        revision=9,
+        revision=10,
         snapshot_hash=f"title-{task_prefix}",
-        signing_secret=b"secret",
-        action_context=_OWNER_CONTEXT,
     )
     exact_title, over_title = [
         task["title"] for task in rendered.native_blocks[0]["tasks"]
     ]
 
     assert exact_title == exact_content
-    assert len(exact_title) == 3000
     assert len(over_title) <= 3000
     assert over_title.endswith("... [truncated]")
-    assert over_title != over_content[:3000]
-
-
-def test_add_task_is_disabled_without_signing_material() -> None:
-    rendered = build_plan_blocks(
-        [{"id": "user:a", "content": "A", "status": "pending"}],
-        revision=1, snapshot_hash="hash", signing_secret=None,
-        action_context=_OWNER_CONTEXT,
-    )
-    actions = rendered.native_blocks[-1]["elements"]
-    assert "hermes_plan_add" not in [item["action_id"] for item in actions]
-
-
-def test_action_values_and_modal_metadata_are_tamper_evident() -> None:
-    payload = {
-        "session_key": "agent:main:slack:group:C1:1.0",
-        "revision": 7,
-        "snapshot_hash": "abc",
-    }
-    value = encode_action_value(payload)
-    assert decode_action_value(value) == payload
-
-    signed = sign_private_metadata(payload, b"secret")
-    assert verify_private_metadata(signed, b"secret") == payload
-    raw = json.loads(signed)
-    raw["payload"]["revision"] = 8
-    assert verify_private_metadata(json.dumps(raw), b"secret") is None
-    assert sign_private_metadata(payload, None) is None
 
 
 def test_store_revision_reverse_index_and_restart_persistence(tmp_path) -> None:
@@ -715,238 +388,6 @@ def test_store_corruption_fails_closed_and_recovers_on_next_snapshot(tmp_path) -
     assert list(store.state_path.parent.glob("slack_plan_cards.json.corrupt.*"))
 
 
-def test_validate_action_returns_exact_matching_snapshot(tmp_path) -> None:
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
-    }
-    original = store.record_desired_snapshot(route, _snapshot(1))
-    assert store.mark_applied(
-        "sk", revision=original["desired_revision"],
-        snapshot_hash=original["desired_hash"], message_ts="20.0",
-    )
-    metadata = {
-        **route, "message_ts": "20.0", "revision": original["desired_revision"],
-        "snapshot_hash": original["desired_hash"], "task_ids": ["user:new"],
-        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "add_task_content": "New", "add_task_status": "in_progress",
-        "action_user_id": "U1",
-        "action_dedupe_id": "dedupe",
-    }
-    assert store.consume_action_id("dedupe")
-
-    validated = store.validate_action(metadata)
-    store.record_desired_snapshot(
-        {**route, "session_id": "sid-new", "channel_id": "C2", "thread_ts": "11.0"},
-        _snapshot(2),
-    )
-
-    assert validated["session_id"] == "sid"
-    assert validated["channel_id"] == "C1"
-    assert validated["desired_revision"] == original["desired_revision"]
-
-
-def test_validate_action_rejects_duplicate_snapshot_ids_and_forged_metadata(tmp_path) -> None:
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
-    }
-    state = store.record_desired_snapshot(route, [
-        {"id": "agent:a", "content": "Agent", "status": "pending"},
-        {"id": "user:a", "content": "User", "status": "in_progress"},
-    ])
-    assert store.mark_applied(
-        "sk", revision=state["desired_revision"], snapshot_hash=state["desired_hash"],
-        message_ts="20.0",
-    )
-    base = {
-        **route, "message_ts": "20.0", "revision": state["desired_revision"],
-        "snapshot_hash": state["desired_hash"], "action_user_id": "U1",
-        "action_dedupe_id": "dedupe",
-    }
-    assert store.consume_action_id("dedupe")
-    assert store.validate_action({
-        **base, "action_kind": "complete_reopen", "task_ids": ["agent:a", "user:a"],
-        "complete_task_ids": ["agent:a", "user:a"], "complete_task_status": "completed",
-        "reopen_task_ids": [], "reopen_task_status": "in_progress",
-    }) is None
-    assert store.validate_action({
-        **base, "action_kind": "cancel", "task_ids": ["agent:a"],
-        "cancel_task_ids": ["agent:a"], "cancel_task_status": "cancelled",
-    }) is None
-    assert store.validate_action({
-        **base, "action_kind": "add_user_task", "task_ids": ["user:new"],
-        "add_task_ids": ["user:replacement"], "add_task_content": "New",
-        "add_task_status": "in_progress",
-    }) is None
-
-    data = json.loads(store.state_path.read_text(encoding="utf-8"))
-    duplicate = dict(data["sessions"]["sk"]["last_desired_snapshot"][1])
-    data["sessions"]["sk"]["last_desired_snapshot"].append(duplicate)
-    store.state_path.write_text(json.dumps(data), encoding="utf-8")
-    assert store.validate_action({
-        **base, "action_kind": "cancel", "task_ids": ["user:a"],
-        "cancel_task_ids": ["user:a"], "cancel_task_status": "cancelled",
-    }) is None
-
-
-@pytest.mark.parametrize("route_user_id", ["U-owner", "", "B-bot"])
-@pytest.mark.parametrize(
-    ("action_kind", "changes"),
-    [
-        (
-            "complete_reopen",
-            {
-                "task_ids": ["user:active"],
-                "complete_task_ids": ["user:active"],
-                "complete_task_status": "completed",
-                "reopen_task_ids": [],
-                "reopen_task_status": "in_progress",
-            },
-        ),
-        (
-            "cancel",
-            {
-                "task_ids": ["user:active"],
-                "cancel_task_ids": ["user:active"],
-                "cancel_task_status": "cancelled",
-            },
-        ),
-        (
-            "add_user_task",
-            {
-                "task_ids": ["user:new"],
-                "add_task_ids": ["user:new"],
-                "add_task_content": "New",
-                "add_task_status": "in_progress",
-            },
-        ),
-    ],
-)
-def test_validate_action_requires_nonempty_exact_route_owner_for_every_mutation(
-    tmp_path, route_user_id, action_kind, changes,
-) -> None:
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk",
-        "session_id": "sid",
-        "team_id": "T1",
-        "channel_id": "C1",
-        "thread_ts": "10.0",
-        "route_user_id": route_user_id,
-    }
-    state = store.record_desired_snapshot(route, [
-        {"id": "user:active", "content": "Active", "status": "in_progress"},
-    ])
-    assert store.mark_applied(
-        "sk",
-        revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"],
-        message_ts="20.0",
-    )
-    dedupe_id = f"{route_user_id or 'empty'}-{action_kind}"
-    assert store.consume_action_id(dedupe_id)
-    metadata = {
-        **route,
-        "message_ts": "20.0",
-        "revision": state["desired_revision"],
-        "snapshot_hash": state["desired_hash"],
-        "action_kind": action_kind,
-        "action_user_id": "U-other",
-        "action_dedupe_id": dedupe_id,
-        **changes,
-    }
-
-    assert store.validate_action(metadata) is None
-
-
-def test_validate_add_capacity_counts_only_in_progress_and_completed_user_tasks(tmp_path) -> None:
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
-    }
-    read_only = [
-        {
-            "id": f"user:read-only-{index}",
-            "content": str(index),
-            "status": "cancelled" if index % 2 else "pending",
-        }
-        for index in range(MAX_INTERACTIVE_TASKS + 3)
-    ]
-    below_capacity = store.record_desired_snapshot(route, read_only + [
-        {"id": "user:active", "content": "Active", "status": "in_progress"},
-    ])
-    assert store.mark_applied(
-        "sk", revision=below_capacity["desired_revision"],
-        snapshot_hash=below_capacity["desired_hash"], message_ts="20.0",
-    )
-    metadata = {
-        **route, "message_ts": "20.0", "revision": below_capacity["desired_revision"],
-        "snapshot_hash": below_capacity["desired_hash"], "task_ids": ["user:new"],
-        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "add_task_content": "New", "add_task_status": "in_progress",
-        "action_user_id": "U1",
-        "action_dedupe_id": "below-capacity",
-    }
-    assert store.consume_action_id("below-capacity")
-    assert store.validate_action(metadata) is not None
-
-    at_capacity = store.record_desired_snapshot(route, read_only + [
-        {
-            "id": f"user:mutable-{index}",
-            "content": str(index),
-            "status": "in_progress" if index % 2 else "completed",
-        }
-        for index in range(MAX_INTERACTIVE_TASKS)
-    ])
-    assert store.mark_applied(
-        "sk", revision=at_capacity["desired_revision"],
-        snapshot_hash=at_capacity["desired_hash"], message_ts="20.0",
-    )
-    at_capacity_metadata = {
-        **metadata,
-        "revision": at_capacity["desired_revision"],
-        "snapshot_hash": at_capacity["desired_hash"],
-        "action_dedupe_id": "at-capacity",
-    }
-    assert store.consume_action_id("at-capacity")
-    assert store.validate_action(at_capacity_metadata) is None
-
-
-@pytest.mark.parametrize(
-    ("count", "accepted"),
-    [(MAX_TODO_ITEMS - 1, True), (MAX_TODO_ITEMS, False)],
-)
-def test_validate_add_rejects_authoritative_todo_capacity(
-    tmp_path, count: int, accepted: bool,
-) -> None:
-    store = PlanCardStore(tmp_path)
-    route = {
-        "session_key": "sk", "session_id": "sid", "team_id": "T1",
-        "channel_id": "C1", "thread_ts": "10.0", "route_user_id": "U1",
-    }
-    snapshot = [
-        {"id": f"agent:{index}", "content": str(index), "status": "pending"}
-        for index in range(count)
-    ]
-    state = store.record_desired_snapshot(route, snapshot)
-    assert store.mark_applied(
-        "sk", revision=state["desired_revision"],
-        snapshot_hash=state["desired_hash"], message_ts="20.0",
-    )
-    dedupe_id = f"capacity-{count}"
-    assert store.consume_action_id(dedupe_id)
-    metadata = {
-        **route, "message_ts": "20.0", "revision": state["desired_revision"],
-        "snapshot_hash": state["desired_hash"], "task_ids": ["user:new"],
-        "action_kind": "add_user_task", "add_task_ids": ["user:new"],
-        "add_task_content": "New", "add_task_status": "in_progress",
-        "action_user_id": "U1", "action_dedupe_id": dedupe_id,
-    }
-    assert (store.validate_action(metadata) is not None) is accepted
 
 
 def _converged_session_with_retired_anchor(store, route):
@@ -1063,7 +504,8 @@ def test_retry_schedule_mixed_work_picks_global_earliest(tmp_path) -> None:
         "channel_id": "C1", "thread_ts": "10.0",
     }
     retired = _converged_session_with_retired_anchor(store, route)
-    store.request_refresh("sk")
+    current = store.get_session("sk")
+    store.record_desired_snapshot(current, current["last_desired_snapshot"])
     with (
         patch("plugins.platforms.slack.plan_cards.time.time", return_value=100),
         patch("plugins.platforms.slack.plan_cards.random.uniform", return_value=0),
@@ -1085,6 +527,7 @@ def test_retry_schedule_multiple_due_current_and_retired_is_due_now(tmp_path) ->
         "channel_id": "C1", "thread_ts": "10.0",
     }
     _converged_session_with_retired_anchor(store, route)
-    store.request_refresh("sk")
+    current = store.get_session("sk")
+    store.record_desired_snapshot(current, current["last_desired_snapshot"])
 
     assert store.retry_schedule(now=time.time()).kind is _RetryScheduleKind.DUE_NOW

--- a/tests/gateway/test_slack_plugin_action_handlers.py
+++ b/tests/gateway/test_slack_plugin_action_handlers.py
@@ -228,6 +228,7 @@ def _connect_with_recording_app(
     mock_app.event = mock_event
     mock_app.command = mock_command
     mock_app.action = mock_action
+    mock_app.view = mock_action
     mock_app.client = AsyncMock()
 
     mock_web_client = AsyncMock()
@@ -289,6 +290,29 @@ class TestSlackAdapterPluginActionWiring:
         # Built-ins still wired
         action_ids = [aid for aid, _cb in registered]
         assert "hermes_approve_once" in action_ids
+
+    def test_disabled_plan_cards_still_register_ack_handlers(self):
+        config = PlatformConfig(
+            enabled=True,
+            token="xoxb-fake",
+            extra={"native_plan_cards": False},
+        )
+        adapter = SlackAdapter(config)
+
+        result, registered = _connect_with_recording_app(
+            adapter, plugin_handlers=[],
+        )
+
+        assert result is True
+        action_ids = [action_id for action_id, _callback in registered]
+        assert {
+            "hermes_plan_complete",
+            "hermes_plan_cancel",
+            "hermes_plan_add",
+            "hermes_plan_refresh",
+            "hermes_plan_add_task",
+        }.issubset(action_ids)
+        assert adapter._plan_reconcile_task is None
 
     def test_plugin_exception_does_not_propagate_to_slack(self):
         """A misbehaving plugin handler must NOT crash slack_bolt's dispatch.

--- a/website/docs/user-guide/messaging/slack.md
+++ b/website/docs/user-guide/messaging/slack.md
@@ -48,7 +48,8 @@ Mode — all at once.
 3. Pick your workspace, paste the JSON contents, review, click **Next**
    → **Create**
 4. Skip ahead to **Step 6: Install App to Workspace**. The manifest
-   handled scopes, events, and slash commands for you.
+   handled scopes, events, slash commands, and enabled Interactivity &
+   Shortcuts for you.
 
 ### Option B: From scratch (manual)
 
@@ -117,6 +118,11 @@ You can always find or regenerate app-level tokens under **Settings → Basic In
 ---
 
 ## Step 4: Subscribe to Events
+
+Before subscribing to events for a manually configured app, open **Features →
+Interactivity & Shortcuts** and switch **Interactivity** on. Hermes receives
+interactive actions through Socket Mode, so no public Request URL is required.
+The generated manifest already sets `settings.interactivity.is_enabled: true`.
 
 This step is critical — it controls what messages the bot can see.
 
@@ -347,6 +353,49 @@ In channels, always @mention the bot to start a conversation. Once the bot is ac
 
 Beyond the required environment variables from Step 8, you can customize Slack bot behavior through `~/.hermes/config.yaml`.
 
+### Native Plan Cards
+
+Native Plan Cards are disabled by default. Enable them and configure the
+metadata signing key through the top-level Slack settings:
+
+```yaml
+slack:
+  native_plan_cards: true
+  native_plan_cards_signing_secret: "<owner-generated secret>"
+```
+
+Use a strong secret generated and retained by the owner; do not copy the
+placeholder above. `SLACK_SIGNING_SECRET` remains supported when resolved
+through the current profile's scoped environment or secret store and takes
+precedence over `native_plan_cards_signing_secret`. In a multiplexed background
+context with no profile scope, Hermes fails closed instead of reading another
+profile's process-global environment; the adapter-local YAML value remains the
+safe fallback. Without either signing value, Hermes still renders and refreshes
+plan cards but omits **Add task** rather than accepting unverifiable modal
+metadata.
+
+Restart the Gateway after changing either value. The legacy nested forms
+`platforms.slack.extra.native_plan_cards` and
+`platforms.slack.extra.native_plan_cards_signing_secret` remain compatible,
+but the top-level `slack:` form above is the recommended user-facing path.
+
+Plan-card recovery is restart-safe on a best-effort basis, not a global
+exactly-once guarantee. Hermes persists Slack's UUID `client_msg_id` before a
+create and reuses it after restart; it also attempts a bounded history read to
+recover the resulting message timestamp. A single active anchor therefore
+depends on Slack retaining/deduplicating that identity or allowing the bot to
+read the relevant thread/channel history. Retention gaps or missing history
+permissions can limit recovery, although Hermes still retries with the same
+`client_msg_id` rather than inventing a new one.
+
+:::caution Disabling or downgrading plan cards
+Turning `native_plan_cards` off stops new cards and mutations, while the current
+candidate still acknowledges controls on cards that were already posted. Before
+downgrading to an older Hermes binary that has no plan-card handlers, delete or
+neutralize those existing Slack card messages while this candidate is still
+running. Otherwise their stale controls will no longer be acknowledged.
+:::
+
 ### Thread & Reply Behavior
 
 ```yaml
@@ -406,6 +455,8 @@ platforms:
 | `platforms.slack.extra.reply_broadcast` | `false` | When `true`, thread replies are also posted to the main channel. Only the first chunk is broadcast. |
 | `platforms.slack.extra.rich_blocks` | `false` | When `true`, agent messages are rendered as [Block Kit](https://docs.slack.dev/block-kit/) blocks (headers, dividers, true nested lists, and native tables). A plain-text fallback is always sent. Tables over Slack's limits fall back to aligned monospace. No app reinstall required — it's a send-side change only. |
 | `platforms.slack.extra.feedback_buttons` | `false` | When `true` with `rich_blocks`, appends Slack-native feedback controls to final replies. |
+| `slack.native_plan_cards` | `false` | Projects successful Hermes todo snapshots into native Slack plan cards. Todo remains authoritative. Interactive controls are limited to 10 tasks; extreme Slack display limits may truncate the visible fallback while Hermes retains the complete todo list. Restart the Gateway after changing it. |
+| `slack.native_plan_cards_signing_secret` | unset | Signs **Add task** modal metadata. A `SLACK_SIGNING_SECRET` resolved through the current profile's scoped environment or secret store takes precedence. In multiplexed no-scope contexts, Hermes fails closed and uses this adapter-local YAML value instead of process-global environment. Restart the Gateway after changing it. |
 | `platforms.slack.extra.suggested_prompts` | `[]` | Up to four `{title, message}` prompts for Agent/Assistant DM entry points; accepts either a list or `{title, prompts}`. |
 | `platforms.slack.extra.assistant_thread_titles` | `true` | When `true`, names Agent/Assistant DM threads from the first user message. |
 | `platforms.slack.extra.cron_continuable_surface` | `"thread"` | Delivery surface for [continuable cron jobs](../features/cron.md#flat-in-channel-continuation-slack). `"thread"` opens a dedicated thread per delivery (default); `"in_channel"` delivers flat into the channel timeline. Pair `in_channel` with `reply_in_thread: false` (and `require_mention: false`) so a plain channel reply continues the job. |


### PR DESCRIPTION
## Summary

- preserve native Slack `plan` / `task_card` as a complete read-only projection of Hermes Todo
- stop emitting checkbox, Complete, Cancel, Reopen, Add, and Refresh controls in native and fallback Plan Card rendering
- keep compatibility handlers for historical cards, but only ACK and return a read-only migration notice
- prevent historical Plan Card interactions from enqueueing events or mutating Todo state
- leave Slack Clarify unchanged as the user input surface

No Hermes Core or TodoStore schema change is included.

## Verification

- `uv run --with pytest --with pytest-asyncio python -m pytest tests/gateway/test_slack_plan_cards.py tests/gateway/test_slack_plan_card_adapter.py tests/gateway/test_slack_plan_card_gateway.py tests/gateway/test_slack_plugin_action_handlers.py -q`
- 125 passed
- `uv run python -m py_compile plugins/platforms/slack/plan_cards.py plugins/platforms/slack/adapter.py`
- `git diff --check`
