### PR TITLE
test(kanban): preserve failed Telegram topic notifications

### DIFF
--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -284,11 +284,61 @@ class ReportedFailureAdapter:
 
     def __init__(self):
         self.attempts = 0
+        self.chat_ids = []
+        self.metadata = []
 
     async def send(self, chat_id, text, metadata=None):
         self.attempts += 1
+        self.chat_ids.append(chat_id)
+        self.metadata.append(metadata or {})
         from gateway.platforms.base import SendResult
         return SendResult(success=False, error="Not connected")
+
+
+def test_notifier_rewinds_failed_telegram_topic_delivery(tmp_path, monkeypatch):
+    """A reported send failure keeps the completion and subscription retryable."""
+    db_path = tmp_path / "failed-topic-delivery.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="topic completion", assignee="worker")
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="-100123",
+            thread_id="2",
+        )
+        kb.complete_task(conn, tid, summary="finished")
+    finally:
+        conn.close()
+
+    adapter = ReportedFailureAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.attempts == 1
+    assert adapter.chat_ids == ["-100123"]
+    assert adapter.metadata == [{"thread_id": "2"}]
+    conn = kb.connect()
+    try:
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="-100123",
+            thread_id="2",
+            kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
+        )
+        assert [event.kind for event in events] == ["completed"]
+        subscriptions = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+
+    assert len(subscriptions) == 1
+    assert subscriptions[0]["thread_id"] == "2"
 
 
 def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add a DB-to-gateway regression for Telegram Kanban completion delivery in topic `2`
- verify `SendResult(success=False)` keeps the completion event unseen and the subscription intact for retry
- verify the original chat and `thread_id` are passed to the adapter

The production guard is already present on current `main` in `gateway/kanban_watchers.py`: failed `SendResult` values enter the existing rewind/retry path. This PR restores explicit regression coverage for the reported failure mode.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_kanban_notifier.py -q` (9 passed)
- `uvx --from ruff==0.15.10 ruff check tests/gateway/test_kanban_notifier.py`

## Context
Kanban task `t_95d31432`; reported Telegram group topic was thread `2`.