### PR TITLE
fix(projects): scope Projects RPC handlers to the active profile

### DIFF
--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -17,31 +17,33 @@ _profile_scoped = _registry.profile_scoped
 
 
 @method("projects.discover_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Repos for the desktop overview: scanned-from-disk (cached) ∪ session-derived."""
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"repos": []})
-        from hermes_cli import projects_db as pdb
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"repos": []})
+            from hermes_cli import projects_db as pdb
 
-        policy = _repo_discovery_policy()
-        policy_key = _repo_discovery_policy_key(policy)
-        with pdb.connect_closing() as conn:
-            pdb.reconcile_discovered_repos_policy(
-                conn,
-                policy_key,
-                preserve_unversioned=_repo_discovery_policy_is_default(policy),
-            )
-            repos = _discover_repos_payload(
-                db, conn=conn, include_cached=policy["enabled"]
-            )
-        return _ok(rid, {"repos": repos, "discovery_policy": policy})
+            policy = _repo_discovery_policy()
+            policy_key = _repo_discovery_policy_key(policy)
+            with pdb.connect_closing() as conn:
+                pdb.reconcile_discovered_repos_policy(
+                    conn,
+                    policy_key,
+                    preserve_unversioned=_repo_discovery_policy_is_default(policy),
+                )
+                repos = _discover_repos_payload(
+                    db, conn=conn, include_cached=policy["enabled"]
+                )
+            return _ok(rid, {"repos": repos, "discovery_policy": policy})
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.record_repos")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Persist git repo roots found by the client's filesystem scan, then return
     the merged repo list. The native crawl runs on the desktop (local fs); this
@@ -88,24 +90,25 @@ def _(rid, params: dict) -> dict:
             elif not policy["enabled"]:
                 pdb.clear_discovered_repos(conn, policy_key=policy_key)
 
-        db = _get_db()
-        return _ok(
-            rid,
-            {
-                "repos": _discover_repos_payload(
-                    db, include_cached=policy["enabled"]
-                )
-                if db is not None
-                else [],
-                "accepted": accepted,
-                "discovery_policy": policy,
-            },
-        )
+        with _profile_db(params) as db:
+            return _ok(
+                rid,
+                {
+                    "repos": _discover_repos_payload(
+                        db, include_cached=policy["enabled"]
+                    )
+                    if db is not None
+                    else [],
+                    "accepted": accepted,
+                    "discovery_policy": policy,
+                },
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.tree")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Authoritative project overview: project -> repo -> lane structure with
     counts + a few preview sessions per project, plus the flat set of session
@@ -113,26 +116,27 @@ def _(rid, params: dict) -> dict:
     Lanes carry no session rows here; drill-in uses ``projects.project_sessions``.
     """
     try:
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"projects": [], "active_id": None, "scoped_session_ids": []})
 
-        tree, active_id = _build_project_tree(
-            db,
-            preview_limit=int(params.get("preview_limit") or 3),
-            hydrate=False,
-            session_limit=int(params.get("session_limit") or 2000),
-            include_discovered=True,
-        )
-        return _ok(
-            rid,
-            {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
-        )
+            tree, active_id = _build_project_tree(
+                db,
+                preview_limit=int(params.get("preview_limit") or 3),
+                hydrate=False,
+                session_limit=int(params.get("session_limit") or 2000),
+                include_discovered=True,
+            )
+            return _ok(
+                rid,
+                {"projects": tree["projects"], "active_id": active_id, "scoped_session_ids": tree["scoped_session_ids"]},
+            )
     except Exception as e:
         return _err(rid, 5061, str(e))
 
 
 @method("projects.project_sessions")
+@_profile_scoped
 def _(rid, params: dict) -> dict:
     """Fully hydrated lanes (repo -> lane -> session rows) for one project,
     built from the same authoritative grouping as ``projects.tree`` so ids and
@@ -142,18 +146,18 @@ def _(rid, params: dict) -> dict:
         if not project_id:
             return _err(rid, 5063, "project_id required")
 
-        db = _get_db()
-        if db is None:
-            return _ok(rid, {"project": None})
+        with _profile_db(params) as db:
+            if db is None:
+                return _ok(rid, {"project": None})
 
-        # Drill-in only needs the entered project (which has sessions), so skip
-        # the zero-session discovery tier entirely.
-        tree, _active = _build_project_tree(
-            db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
-            include_discovered=False,
-        )
-        proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
-        return _ok(rid, {"project": proj})
+            # Drill-in only needs the entered project (which has sessions), so skip
+            # the zero-session discovery tier entirely.
+            tree, _active = _build_project_tree(
+                db, preview_limit=0, hydrate=True, session_limit=int(params.get("session_limit") or 5000),
+                include_discovered=False,
+            )
+            proj = next((p for p in tree["projects"] if p["id"] == project_id), None)
+            return _ok(rid, {"project": proj})
     except Exception as e:
         return _err(rid, 5061, str(e))
 


### PR DESCRIPTION
# fix(projects): scope Projects RPC handlers to the active profile

## Summary

In **app-global remote mode** (one `hermes serve` process serving multiple
profiles via the `profile` param), the desktop's **Projects** sidebar
(`projects.*` JSON-RPC methods) currently ignores the active profile and reads
the **launch** profile's data.  This is a cross-profile data leak.

The four `projects.*` handlers in `tui_gateway/methods_config.py`
(`projects.tree`, `projects.project_sessions`, `projects.discover_repos`,
`projects.record_repos`) call the shared `_get_db()` session store and
`projects_db` (both resolved against the launch profile's HERMES_HOME), instead
of honoring `params['profile']` the way every `session.*` handler does.

## Why this is a general bug (not just our deployment)

The desktop's "app-global remote mode" was designed so a single backend can
serve every profile (see the `_profile_home` / `_profile_scoped` /
`_profile_db` machinery in `tui_gateway/server.py`).  That machinery exists
precisely to isolate per-profile state in a multi-profile backend.  The
Projects surface was left out of it:

- **`_profile_scoped`** — binds HERMES_HOME to `params['profile']` so
  config/skills/projects.db resolve to the focused profile.  Used by pet RPCs.
- **`_profile_db(params)`** — yields the profile-scoped SessionDB (or the
  launch one when `profile` is omitted/own).  Used by `session.*` RPCs.

But the `projects.*` handlers use neither: they call `_get_db()` (shared
launch-profile handle) and `projects_db.connect_closing()` (resolved via the
launch HERMES_HOME).  So in any multi-profile deployment:

- A user's **Projects sidebar shows another profile's projects and sessions**
  (and "Home" mixes every profile's sessions).
- `projects.record_repos` / `projects.discover_repos` **write repo metadata
  into the wrong profile's `projects.db`**, corrupting the intended isolation.

## The fix

Apply the same profile-scoping the rest of the surface already uses:

```python
@method("projects.tree")
@_profile_scoped
def _(rid, params):
    with _profile_db(params) as db:
        ...
        tree, active_id = _build_project_tree(db, ...)
        ...
```

Done for all four `projects.*` handlers.  `@_profile_scoped` makes the
`projects.db` path (and repo-discovery policy) follow `params['profile']`; the
`_profile_db(params)` context manager makes the session store follow it too.

For a single-profile / local gateway (the common case), `profile` is omitted or
equal to the launch profile, so `_profile_home()` returns `None` and both helpers
no-op back to the launch profile — **zero behavior change** for the default
single-profile setup.

## Our use case

Website Toolbox runs a shared builderbot where ~28 staff profiles are served by
one `hermes serve` process behind a profile-manager proxy (which injects the
authenticated user's `profile` into every WS RPC).  A staff member reported
seeing other people's chats in their Projects sidebar.  Root cause: the Projects
RPC read the launch (default) profile's `state.db` + `projects.db` and ignored
`params['profile']`.  The HTTP sessions sidebar was already isolated; only this
JSON-RPC Projects surface leaked.

## Scope / risk

- Touches only the four `projects.*` JSON-RPC handlers.
- Reuses the exact, already-tested `_profile_scoped` / `_profile_db` helpers.
- No-op for single-profile backends.
- `projects.record_repos` also becomes profile-correct (writes to the right
  profile's `projects.db`), fixing a latent cross-profile write bug.