### PR TITLE
fix(weixin): 区分 ret=-2 的 'prepare failed' 参数错误，不再误报为限流

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -115,6 +115,9 @@ RATE_LIMIT_ERRCODE = -2  # iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
 
 
+CONTEXT_TOKEN_ERROR_ERRMSG = "prepare failed"
+
+
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
@@ -124,6 +127,24 @@ def _is_stale_session_ret(
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
     return (errmsg or "").lower() == "unknown error"
+
+
+def _is_context_token_error_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when iLink returns ret=-2 / errcode=-2 with 'prepare failed',
+    which is a parameter error — missing/invalid context_token — rather
+    than a genuine rate limit.
+
+    The iLink protocol returns ``ret=-2`` for *any* bad-request condition
+    and disambiguates via ``errmsg``: "prepare failed" means the outbound
+    sendmessage did not carry a valid context_token (typically a fresh
+    account with no inbound message yet), "unknown error" means a stale
+    session (handled by :func:`_is_stale_session_ret`), and only the
+    remaining cases are genuine frequency limits."""
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").strip().lower() == CONTEXT_TOKEN_ERROR_ERRMSG
 
 
 MEDIA_IMAGE = 1
@@ -1826,6 +1847,22 @@ class WeixinAdapter(BasePlatformAdapter):
                                 self.name, _safe_id(chat_id),
                             )
                             continue
+                        # Missing/invalid context_token (ret=-2 with
+                        # errmsg="prepare failed") is a parameter error —
+                        # NOT a rate limit. Surface a descriptive error and
+                        # do NOT open the rate-limit circuit breaker, so the
+                        # real cause (fresh account with no inbound message
+                        # yet) isn't hidden behind a misleading "rate limited"
+                        # cooldown. Fail fast — retrying a deterministic
+                        # parameter error is pointless.
+                        if _is_context_token_error_ret(ret, errcode, resp.get("errmsg")):
+                            token_dir = self._token_store._root
+                            last_error = RuntimeError(
+                                "iLink sendmessage parameter error: prepare failed "
+                                "(missing/invalid context_token? — user must send an "
+                                f"inbound message first, or re-pair; check {token_dir}/*.context-tokens.json)"
+                            )
+                            break
                         # Rate limit (-2) — backoff and retry
                         is_rate_limited = (
                             ret == RATE_LIMIT_ERRCODE

--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -72,6 +72,27 @@ LONG_POLL_TIMEOUT_MS, API_TIMEOUT_MS, CONFIG_TIMEOUT_MS, QR_TIMEOUT_MS = 35_000,
 MAX_CONSECUTIVE_FAILURES, RETRY_DELAY_SECONDS, BACKOFF_DELAY_SECONDS = 3, 2, 30
 SESSION_EXPIRED_ERRCODE, RATE_LIMIT_ERRCODE = -14, -2  # -2: iLink frequency limit — backoff and retry
 MESSAGE_DEDUP_TTL_SECONDS = 300
+CONTEXT_TOKEN_ERROR_ERRMSG = "prepare failed"
+
+
+def _is_context_token_error_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when iLink returns ret=-2 / errcode=-2 with 'prepare failed',
+    which is a parameter error — missing/invalid context_token — rather
+    than a genuine rate limit.
+
+    The iLink protocol returns ``ret=-2`` for *any* bad-request condition
+    and disambiguates via ``errmsg``: "prepare failed" means the outbound
+    sendmessage did not carry a valid context_token (typically a fresh
+    account with no inbound message yet), "unknown error" means a stale
+    session (handled by :func:`_is_stale_session_ret`), and only the
+    remaining cases are genuine frequency limits."""
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").strip().lower() == CONTEXT_TOKEN_ERROR_ERRMSG
+
+
 MEDIA_IMAGE, MEDIA_VIDEO, MEDIA_FILE, MEDIA_VOICE = 1, 2, 3, 4  # getuploadurl media_type
 ITEM_TEXT, ITEM_IMAGE, ITEM_VOICE, ITEM_FILE, ITEM_VIDEO = 1, 2, 3, 4, 5  # item_list entry types
 MSG_TYPE_BOT, MSG_STATE_FINISH = 2, 2
@@ -1039,6 +1060,22 @@ class WeixinAdapter(BasePlatformAdapter):
                             self._token_store._cache.pop(self._token_store._key(self._account_id, chat_id), None)
                             logger.warning("[%s] session expired for %s; retrying without context_token", self.name, _safe_id(chat_id))
                             continue
+                        # Missing/invalid context_token (ret=-2 with
+                        # errmsg="prepare failed") is a parameter error —
+                        # NOT a rate limit. Surface a descriptive error and
+                        # do NOT open the rate-limit circuit breaker, so the
+                        # real cause (fresh account with no inbound message
+                        # yet) isn't hidden behind a misleading "rate limited"
+                        # cooldown. Fail fast — retrying a deterministic
+                        # parameter error is pointless.
+                        if _is_context_token_error_ret(ret, errcode, resp.get("errmsg")):
+                            token_dir = self._token_store._root
+                            last_error = RuntimeError(
+                                "iLink sendmessage parameter error: prepare failed "
+                                "(missing/invalid context_token? — user must send an "
+                                f"inbound message first, or re-pair; check {token_dir}/*.context-tokens.json)"
+                            )
+                            break
                         errmsg = resp.get("errmsg") or resp.get("msg")
                         if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
                             raise RuntimeError(f"iLink sendmessage error: ret={ret} errcode={errcode} errmsg={errmsg or 'unknown error'}")

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -270,6 +270,51 @@ class TestWeixinChunkDelivery:
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
 
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_prepare_failed_raises_descriptive_error_without_opening_breaker(
+        self, send_message_mock, sleep_mock
+    ):
+        # Regression for #80125: ret=-2 with errmsg "prepare failed" is a
+        # parameter error (missing/invalid context_token), NOT a rate limit.
+        # It must surface a descriptive error and must NOT open the 30s
+        # rate-limit circuit breaker, which would hide the real cause.
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_window_seconds = 60
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "prepare failed",
+        }
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert result.error is not None
+        assert "parameter error" in result.error
+        assert "prepare failed" in result.error
+        assert "context_token" in result.error
+        # The message must NOT look like a frequency-limit self-recovery.
+        assert "rate limited" not in result.error
+        assert "cooldown" not in result.error
+        # Fail fast: exactly one API call, no retry, no backoff sleep.
+        assert send_message_mock.await_count == 1
+        assert sleep_mock.await_count == 0
+        # The circuit breaker must NOT have opened.
+        assert adapter._rate_limit_events == []
+        assert adapter._rate_limit_circuit_until == 0.0
+
+        # A subsequent send with a healthy response must succeed immediately,
+        # proving the breaker was never tripped by the parameter error.
+        send_message_mock.return_value = {"ret": 0}
+        ok = asyncio.run(adapter.send("wxid_test123", "hello again"))
+        assert ok.success is True
+
 
 class TestWeixinOutboundMedia:
 
@@ -509,6 +554,41 @@ class TestIsStaleSessionRet:
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the
         # helper only disambiguates -2 from a genuine rate limit.
         assert weixin._is_stale_session_ret(-14, None, "session expired") is False
+
+
+class TestIsContextTokenErrorRet:
+    """Regression test for #80125: ret=-2 with errmsg 'prepare failed' is a
+    parameter error (missing/invalid context_token), not a rate limit."""
+
+
+    def test_ret_minus_2_with_prepare_failed_is_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-2, None, "prepare failed") is True
+
+
+    def test_errcode_minus_2_with_prepare_failed_is_context_token_error(self):
+        assert weixin._is_context_token_error_ret(None, -2, "prepare failed") is True
+
+
+    def test_prepare_failed_matches_case_insensitively(self):
+        assert weixin._is_context_token_error_ret(-2, -2, "Prepare Failed") is True
+
+
+    def test_freq_limit_is_not_context_token_error(self):
+        # Genuine rate limit — must NOT be treated as a parameter error.
+        assert weixin._is_context_token_error_ret(-2, None, "freq limit") is False
+
+
+    def test_unknown_error_is_not_context_token_error(self):
+        # Stale-session signal — handled by _is_stale_session_ret instead.
+        assert weixin._is_context_token_error_ret(-2, None, "unknown error") is False
+
+
+    def test_missing_errmsg_is_not_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-2, None, None) is False
+
+
+    def test_non_minus_2_ret_is_not_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-14, None, "prepare failed") is False
 
 
 class TestWeixinContentDedup:

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -322,6 +322,51 @@ class TestWeixinChunkDelivery:
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
 
+    @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_prepare_failed_raises_descriptive_error_without_opening_breaker(
+        self, send_message_mock, sleep_mock
+    ):
+        # Regression for #80125: ret=-2 with errmsg "prepare failed" is a
+        # parameter error (missing/invalid context_token), NOT a rate limit.
+        # It must surface a descriptive error and must NOT open the 30s
+        # rate-limit circuit breaker, which would hide the real cause.
+        adapter = self._connected_adapter()
+        adapter._send_chunk_retries = 3
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_window_seconds = 60
+        adapter._rate_limit_circuit_open_seconds = 60
+
+        send_message_mock.return_value = {
+            "ret": weixin.RATE_LIMIT_ERRCODE,
+            "errcode": weixin.RATE_LIMIT_ERRCODE,
+            "errmsg": "prepare failed",
+        }
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert result.error is not None
+        assert "parameter error" in result.error
+        assert "prepare failed" in result.error
+        assert "context_token" in result.error
+        # The message must NOT look like a frequency-limit self-recovery.
+        assert "rate limited" not in result.error
+        assert "cooldown" not in result.error
+        # Fail fast: exactly one API call, no retry, no backoff sleep.
+        assert send_message_mock.await_count == 1
+        assert sleep_mock.await_count == 0
+        # The circuit breaker must NOT have opened.
+        assert adapter._rate_limit_events == []
+        assert adapter._rate_limit_circuit_until == 0.0
+
+        # A subsequent send with a healthy response must succeed immediately,
+        # proving the breaker was never tripped by the parameter error.
+        send_message_mock.return_value = {"ret": 0}
+        ok = asyncio.run(adapter.send("wxid_test123", "hello again"))
+        assert ok.success is True
+
 
 class TestWeixinOutboundMedia:
 
@@ -561,6 +606,41 @@ class TestIsStaleSessionRet:
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the
         # helper only disambiguates -2 from a genuine rate limit.
         assert weixin._is_stale_session_ret(-14, None, "session expired") is False
+
+
+class TestIsContextTokenErrorRet:
+    """Regression test for #80125: ret=-2 with errmsg 'prepare failed' is a
+    parameter error (missing/invalid context_token), not a rate limit."""
+
+
+    def test_ret_minus_2_with_prepare_failed_is_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-2, None, "prepare failed") is True
+
+
+    def test_errcode_minus_2_with_prepare_failed_is_context_token_error(self):
+        assert weixin._is_context_token_error_ret(None, -2, "prepare failed") is True
+
+
+    def test_prepare_failed_matches_case_insensitively(self):
+        assert weixin._is_context_token_error_ret(-2, -2, "Prepare Failed") is True
+
+
+    def test_freq_limit_is_not_context_token_error(self):
+        # Genuine rate limit — must NOT be treated as a parameter error.
+        assert weixin._is_context_token_error_ret(-2, None, "freq limit") is False
+
+
+    def test_unknown_error_is_not_context_token_error(self):
+        # Stale-session signal — handled by _is_stale_session_ret instead.
+        assert weixin._is_context_token_error_ret(-2, None, "unknown error") is False
+
+
+    def test_missing_errmsg_is_not_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-2, None, None) is False
+
+
+    def test_non_minus_2_ret_is_not_context_token_error(self):
+        assert weixin._is_context_token_error_ret(-14, None, "prepare failed") is False
 
 
 class TestWeixinContentDedup:


### PR DESCRIPTION
## 背景

修复 #80125: weixin adapter 中 iLink sendmessage 返回 `ret=-2` 被无条件当作限流处理，打开 30s 熔断器并记录 `rate limited; cooldown active for 30.0s` 的误导性日志，掩盖了真实原因（新配对账号尚无入站消息、没有 context_token），导致 2026-08-04→08-06 的推送故障数天无法定位。

## 根因分析

在 `gateway/platforms/weixin.py` 的 `_send_text_chunk_locked` 中，`ret=-2`（或 `errcode=-2`）被无条件判定为 `RATE_LIMIT_ERRCODE` 进入限流分支。但按 iLink 协议（https://www.wechatbot.dev/zh/protocol#errors），`ret=-2` 实际表示**参数错误**，服务器通过 `errmsg` 区分具体原因：

- `errmsg: "prepare failed"` → context_token 缺失/失效（参数错误）
- `errmsg: "unknown error"` → 会话过期（已有 `_is_stale_session_ret` 专门处理）
- 其余 → 真实限流

## 修复方式

1. 新增 `_is_context_token_error_ret` 辅助函数：`ret=-2`/`errcode=-2` 且 `errmsg == "prepare failed"` 时判定为 context_token 参数错误。
2. 在 `_send_text_chunk_locked` 中，将 `prepare failed` 检查置于限流分支之前：命中时抛出描述性错误（提示先发一条入站消息或重新配对，并指向 `*.context-tokens.json` 检查点），**不触发**限流熔断器、不重试，快速失败。
3. `unknown error` 仍走既有 stale-session 路径；其余 `errmsg` 仍按限流处理，行为不变。

## Who should enable this

任何使用 **WeChat / Weixin 平台适配器**的 Hermes 用户：

- 新配对账号（尚无入站消息、`context_token` 尚未生成）首次发消息被误报 "rate limited"、被 30s 熔断卡住的场景
- 排查推送故障时被误导性日志带偏（真实原因是 context_token 缺失，不是限流）的场景

**无需任何配置变更**——修复随代码生效，行为对现有部署透明。

## Platform compatibility

| 平台 | 兼容性 |
|---|---|
| macOS | ✅ 完全兼容（适配器层修复，与平台无关） |
| Linux | ✅ 完全兼容 |
| Windows | ✅ 完全兼容 |
| 架构 | ✅ 无关（纯 Python 逻辑） |

## Quick-start guide

1. `hermes update`（或拉取本 PR 分支）升级到包含本修复的版本
2. 无需修改 `config.yaml` 或 `.env`
3. 新账号首次发送时，若返回 `prepare failed` 错误，提示包含具体修复指引：
   ```
   iLink sendmessage parameter error: prepare failed (missing/invalid context_token? — user must send an inbound message first, or re-pair; check ~/.hermes/.../*.context-tokens.json)
   ```
4. 按提示操作：让用户先发一条入站消息，或重新配对生成有效 context_token

## Troubleshooting

| 症状 | 原因 | 修复 |
|---|---|---|
| 日志出现 "rate limited; cooldown active for 30.0s" 但实际不是限流 | 旧版本 bug：`prepare failed` 被误判为限流 | 升级到本修复；确认日志不再出现误导性 cooldown |
| 报错 "prepare failed (missing/invalid context_token?)" | context_token 缺失/失效（新账号无入站消息） | 用户先发一条入站消息，或重新配对；检查 `*.context-tokens.json` |
| 报错 "session expired" | 会话过期 | 既有 stale-session 路径自动处理（未改变） |
| 报错 "rate limited" | 真实限流 | 既有熔断逻辑正常工作（未改变） |

## 验证

- [x] 新增 7 个 `_is_context_token_error_ret` 单元回归测试 + 1 个集成回归测试（验证 `prepare failed` 不打开熔断器、错误信息描述性、后续发送立即恢复）
- [x] `tests/gateway/test_weixin.py` 38 项全部通过
- [x] ruff 检查通过
- [x] 遵循项目 AGENTS.md 贡献规范
- [x] 无破坏性变更（真实限流行为保持不变）

Closes #80125
