### PR TITLE
docs(compose): update entrypoint comment for entrypoint-dispatch.sh

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,11 +17,14 @@
 #     adds authentication — do NOT pass --insecure --host 0.0.0.0.
 #   - If you override entrypoint, keep `/init` as the first command in
 #     the chain (or let docker use the image's default ENTRYPOINT,
-#     which is `["/init", "/opt/hermes/docker/main-wrapper.sh"]`).
-#     `/init` is s6-overlay's PID 1 — it runs the cont-init.d scripts
-#     (chown, profile reconcile, dashboard toggle) and sets up the
-#     supervision tree before any service starts. Bypassing it skips
-#     all of that setup and the gateway will not work correctly.
+#     which is `["/opt/hermes/docker/entrypoint-dispatch.sh"]`).
+#     The dispatcher execs `/init` (s6-overlay's PID 1) + main-wrapper
+#     when the image owns PID 1, and falls back to a direct stage2
+#     bootstrap on wrapped runtimes (Fly Machines, `docker run --init`).
+#     `/init` runs the cont-init.d scripts (chown, profile reconcile,
+#     dashboard toggle) and sets up the supervision tree before any
+#     service starts. Bypassing it skips all of that setup and the
+#     gateway will not work correctly.
 #   - The gateway's API server is off unless you uncomment API_SERVER_KEY
 #     and API_SERVER_HOST. See docs/user-guide/api-server.md before doing
 #     this on an internet-facing host.


### PR DESCRIPTION
## What

The security note in `docker-compose.yml` still tells users the image ENTRYPOINT is `["/init", "/opt/hermes/docker/main-wrapper.sh"]`, but `f40f471e` replaced that with the `entrypoint-dispatch.sh` dispatcher. Following the stale comment to override the entrypoint would bypass the non-PID-1 fallback (Fly Machines, `docker run --init`) introduced in the same commit.

Updates the comment to reference the actual ENTRYPOINT and describe the dispatcher's two-path behaviour.

## Why

Fixes #78193. The "no such file or directory: /opt/hermes/docker/entrypoint-dispatch.sh" error reported there is a stale `/opt/hermes` volume/bind-mount from an older image overriding the new source tree. The repo's own compose file was one of the places still pointing at the pre-dispatcher entrypoint, which misleads users overriding the entrypoint (a common compose pattern) into skipping the dispatcher and landing exactly on the reported failure mode.

## Verification

- `docker run --rm nousresearch/hermes-agent:v2026.8.3 --version` → `Hermes Agent v0.20.0 (2026.8.3)` (PID-1 path works, entrypoint-dispatch.sh present in both amd64 and arm64 manifests)
- `docker run --rm --init nousresearch/hermes-agent --version` → non-PID-1 fallback path works
- Stale-volume failure mode confirmed: an old image's `/opt/hermes` tree lacks `entrypoint-dispatch.sh`; the fix documents the entrypoint change and the volume-recreate procedure