### PR TITLE
fix(agent): gate finalization on active todos

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1786,6 +1786,14 @@ def init_agent(
     # conversation loop's intent-ack block.
     agent._intent_ack_continuation = _agent_section.get("intent_ack_continuation", "auto")
 
+    # Keep a foreground turn alive while Hermes-owned TodoStore state still
+    # contains pending/in-progress work.  This is provider- and api-mode
+    # independent; background notifications and explicit user-input requests
+    # are handled as intentional pauses by the conversation-loop gate.
+    agent._todo_completion_continuation = _agent_section.get(
+        "todo_completion_continuation", True
+    )
+
     # Universal task-completion guidance toggle.  Default True.  Surfaced
     # as a separate flag from tool_use_enforcement because the guidance
     # applies to ALL models, not just the model families enforcement

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3461,6 +3461,134 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 
 
+def _turn_has_pending_background_work(messages: List[Dict[str, Any]]) -> bool:
+    """Return whether this turn intentionally handed work to an async rail."""
+    for msg in messages or []:
+        if not isinstance(msg, dict) or msg.get("role") != "tool":
+            continue
+        payload = msg.get("content")
+        if isinstance(payload, str):
+            try:
+                payload = json.loads(payload)
+            except (TypeError, ValueError):
+                continue
+        if not isinstance(payload, dict):
+            continue
+        if (
+            payload.get("output") == "Background process started"
+            and payload.get("notify_on_complete") is True
+        ):
+            return True
+        if payload.get("status") == "dispatched" and payload.get("mode") == "background":
+            return True
+    return False
+
+
+def _messages_in_current_turn(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return the current user turn, never historical tool rows."""
+    turn_messages = list(messages or [])
+    for index in range(len(turn_messages) - 1, -1, -1):
+        if isinstance(turn_messages[index], dict) and turn_messages[index].get("role") == "user":
+            return turn_messages[index:]
+    return turn_messages
+
+
+def todo_completion_continuation_enabled(agent) -> bool:
+    """Whether an active TodoStore may keep a foreground turn alive."""
+    mode = getattr(agent, "_todo_completion_continuation", True)
+    if mode is False:
+        return False
+    if isinstance(mode, str) and mode.strip().lower() in {"false", "never", "no", "off"}:
+        return False
+    return True
+
+
+def _active_todo_items(agent) -> List[Dict[str, Any]]:
+    """Read pending/in-progress todos defensively from the session store."""
+    store = getattr(agent, "_todo_store", None)
+    read = getattr(store, "read", None)
+    if not callable(read):
+        return []
+    try:
+        items = read()
+    except Exception:
+        _ra().logger.debug("Could not read TodoStore for stop guard", exc_info=True)
+        return []
+    if not isinstance(items, list):
+        return []
+    return [
+        item for item in items
+        if isinstance(item, dict) and item.get("status") in {"pending", "in_progress"}
+    ]
+
+
+def _response_explicitly_waits_for_user(assistant_content: str) -> bool:
+    """Return True for a concrete user decision/permission request."""
+    text = (assistant_content or "").strip().lower()
+    if not text:
+        return False
+    return bool(
+        re.search(
+            r"\b(?:need|require|await|waiting for)\s+(?:your|the user'?s)\s+"
+            r"(?:approval|permission|input|confirmation|choice|decision|credentials?)\b",
+            text,
+        )
+        or re.search(r"\bplease\s+(?:provide|confirm|choose|approve)\b", text)
+        or re.search(
+            r"(?:需要|等待|请)(?:你|您|用户)(?:的)?"
+            r"(?:批准|授权|许可|确认|输入|选择|决定|凭证)",
+            text,
+        )
+        or re.search(r"请(?:提供|确认|选择|批准|授权)", text)
+    )
+
+
+def should_continue_for_active_todos(
+    agent,
+    assistant_content: str,
+    messages: List[Dict[str, Any]],
+) -> bool:
+    """Keep an unfinished foreground todo plan from silently ending."""
+    if not todo_completion_continuation_enabled(agent):
+        return False
+    if _turn_has_pending_background_work(_messages_in_current_turn(messages)):
+        return False
+    if _response_explicitly_waits_for_user(assistant_content):
+        return False
+    return bool(_active_todo_items(agent))
+
+
+def build_todo_completion_nudge(agent) -> str:
+    """Build the internal continuation instruction for active todos."""
+    active = _active_todo_items(agent)
+    labels = ", ".join(str(item.get("id", "?")) for item in active[:6])
+    if len(active) > 6:
+        labels += ", …"
+    return (
+        "[System: Your active task list is not complete"
+        + (f" ({labels})" if labels else "")
+        + ". Continue now: execute the next required tool call and update the "
+          "todo status when work is done. Do not stop after merely stating a "
+          "plan. If you truly need the user's approval, input, credentials, or "
+          "a decision, ask that concrete question instead.]"
+    )
+
+
+def build_todo_completion_exhausted_message(agent) -> str:
+    """Explain a bounded continuation failure without claiming task success."""
+    active = _active_todo_items(agent)
+    labels = ", ".join(str(item.get("id", "?")) for item in active[:6])
+    if len(active) > 6:
+        labels += ", …"
+    return (
+        "⚠️ Task remains incomplete"
+        + (f" ({labels})" if labels else "")
+        + ". Hermes reached its automatic continuation limit without resolving "
+          "the active todo items. Please continue the task or provide the "
+          "missing approval/input."
+    )
+
+
 def looks_like_codex_intermediate_ack(
     agent,
     user_message: Any,
@@ -4058,6 +4186,10 @@ __all__ = [
     "repair_tool_call",
     "sanitize_api_messages",
     "looks_like_codex_intermediate_ack",
+    "todo_completion_continuation_enabled",
+    "should_continue_for_active_todos",
+    "build_todo_completion_nudge",
+    "build_todo_completion_exhausted_message",
     "copy_reasoning_content_for_api",
     "cleanup_dead_connections",
     "extract_api_error_context",

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1909,6 +1909,7 @@ _SYNTHETIC_USER_FLAGS = (
     "_empty_recovery_synthetic",
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_todo_completion_synthetic",
     "_dropped_toolcall_nudge",
 )
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1354,6 +1354,7 @@ def run_conversation(
     interrupted = False
     failed = False
     codex_ack_continuations = 0
+    todo_completion_continuations = 0
     length_continue_retries = 0
     truncated_tool_call_retries = 0
     truncated_response_parts: List[str] = []
@@ -6956,8 +6957,58 @@ def run_conversation(
                     length_continue_retries = 0
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
-                
+
+                # Hermes-owned todo state is a stronger completion signal than
+                # model wording.  Keep the turn alive while any pending or
+                # in-progress item remains, with explicit exceptions for
+                # notified background work and concrete user-input requests.
+                from agent.agent_runtime_helpers import (
+                    build_todo_completion_exhausted_message,
+                    build_todo_completion_nudge,
+                    should_continue_for_active_todos,
+                )
+
+                _todo_stop_exhausted = False
+                _todo_should_continue = (
+                    bool(agent.valid_tool_names)
+                    and should_continue_for_active_todos(agent, final_response, messages)
+                )
+                if _todo_should_continue and todo_completion_continuations < 3:
+                    todo_completion_continuations += 1
+                    interim_msg = agent._build_assistant_message(
+                        assistant_message, "todo_completion_required"
+                    )
+                    messages.append(interim_msg)
+                    agent._emit_interim_assistant_message(interim_msg)
+                    messages.append({
+                        "role": "user",
+                        "content": build_todo_completion_nudge(agent),
+                        "_todo_completion_synthetic": True,
+                    })
+                    agent._session_messages = messages
+                    logger.info(
+                        "active todo stop guard issued (attempt %d/3)",
+                        todo_completion_continuations,
+                    )
+                    agent._emit_status(
+                        "↻ Active task list is incomplete — continuing work "
+                        f"({todo_completion_continuations}/3)"
+                    )
+                    final_response = None
+                    continue
+                if _todo_should_continue:
+                    _todo_stop_exhausted = True
+                    final_response = build_todo_completion_exhausted_message(agent)
+                    _turn_exit_reason = "todo_completion_exhausted"
+                    agent._emit_status(
+                        "⚠️ Active task list is still incomplete after 3 "
+                        "automatic continuation attempts"
+                    )
+
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
+                if _todo_stop_exhausted:
+                    final_msg["content"] = final_response
+                    final_msg["finish_reason"] = "todo_completion_exhausted"
 
                 # ── Dropped tool-call recovery (copilot/Claude) ────────
                 # Some providers (observed: claude-opus-4.8 / claude-sonnet-4.5
@@ -7207,7 +7258,8 @@ def run_conversation(
 
                 messages.append(final_msg)
                 
-                _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
+                if _turn_exit_reason != "todo_completion_exhausted":
+                    _turn_exit_reason = f"text_response(finish_reason={finish_reason})"
                 if not agent.quiet_mode:
                     agent._safe_print(f"🎉 Conversation completed after {api_call_count} OpenAI-compatible API call(s)")
                 break

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -50,6 +50,7 @@ def _is_pure_tool_call_tail(msg: dict) -> bool:
 _VERIFICATION_CONTINUATION_FLAGS = (
     "_verification_stop_synthetic",
     "_pre_verify_synthetic",
+    "_todo_completion_synthetic",
 )
 
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -821,6 +821,11 @@ agent:
   # Recommended: 20-30 for focused tasks, 50-100 for open exploration
   max_turns: 500
 
+  # Do not silently finalize a foreground turn while Hermes' TodoStore still
+  # has pending or in-progress work. Background notifications and direct
+  # user-approval/input requests remain valid pauses. Default: true.
+  # todo_completion_continuation: true
+
   # Inactivity timeout for gateway agent runs (seconds, 0 = unlimited).
   # The agent can run indefinitely when actively calling tools or receiving
   # API responses.  Only fires after the agent has been idle for this duration.

--- a/tests/agent/test_todo_completion_continuation.py
+++ b/tests/agent/test_todo_completion_continuation.py
@@ -1,0 +1,120 @@
+"""Regression coverage for the active TodoStore stop gate.
+
+The guard protects Hermes-owned execution state, rather than relying on a
+model's wording or provider-specific finish reason.  This is the case that
+the intent-ack detector alone cannot cover: ``Need commit.`` after a test
+passes, while the commit/CI todo remains in progress.
+"""
+
+import json
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import (
+    build_todo_completion_exhausted_message,
+    build_todo_completion_nudge,
+    should_continue_for_active_todos,
+    todo_completion_continuation_enabled,
+)
+from tools.todo_tool import TodoStore
+
+
+def _agent(*, enabled=True, todos=None):
+    store = TodoStore()
+    if todos is not None:
+        store.write(todos)
+    return SimpleNamespace(
+        _todo_completion_continuation=enabled,
+        _todo_store=store,
+    )
+
+
+ACTIVE = [
+    {"id": "s4-ci", "content": "Commit, push, and verify CI", "status": "in_progress"},
+]
+
+
+def test_active_todo_turn_catches_short_need_commit_stop():
+    agent = _agent(todos=ACTIVE)
+    messages = [{"role": "user", "content": "finish the release"}]
+
+    assert should_continue_for_active_todos(agent, "Need commit.", messages)
+    assert "s4-ci" in build_todo_completion_nudge(agent)
+
+
+def test_pending_todo_also_blocks_a_premature_stop():
+    agent = _agent(todos=[
+        {"id": "release", "content": "publish the release", "status": "pending"},
+    ])
+    messages = [{"role": "user", "content": "finish the release"}]
+
+    assert should_continue_for_active_todos(agent, "Ready for the next step.", messages)
+
+
+def test_active_todo_turn_catches_ci_queued_wait_stop():
+    agent = _agent(todos=ACTIVE)
+    messages = [{"role": "user", "content": "finish the release"}]
+
+    assert should_continue_for_active_todos(agent, "CI queued, wait.", messages)
+
+
+def test_notified_background_work_is_an_intentional_pause():
+    agent = _agent(todos=ACTIVE)
+    messages = [
+        {"role": "user", "content": "wait for CI"},
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {"output": "Background process started", "notify_on_complete": True}
+            ),
+        },
+    ]
+
+    assert not should_continue_for_active_todos(agent, "CI is running.", messages)
+
+
+def test_historical_background_work_does_not_disable_later_todo_guard():
+    agent = _agent(todos=ACTIVE)
+    messages = [
+        {
+            "role": "tool",
+            "content": json.dumps(
+                {"output": "Background process started", "notify_on_complete": True}
+            ),
+        },
+        {"role": "user", "content": "continue the release"},
+    ]
+
+    assert should_continue_for_active_todos(agent, "Need commit.", messages)
+
+
+def test_direct_user_approval_or_input_request_is_a_valid_stop():
+    agent = _agent(todos=ACTIVE)
+    messages = [{"role": "user", "content": "finish the release"}]
+
+    assert not should_continue_for_active_todos(
+        agent, "I need your approval before pushing the release branch.", messages
+    )
+    assert not should_continue_for_active_todos(
+        agent, "需要你的确认才能推送到生产分支。", messages
+    )
+
+
+def test_only_active_todos_trigger_and_config_can_opt_out():
+    completed = [
+        {"id": "done", "content": "already verified", "status": "completed"},
+        {"id": "cancel", "content": "not needed", "status": "cancelled"},
+    ]
+    messages = [{"role": "user", "content": "finish the release"}]
+
+    assert not should_continue_for_active_todos(_agent(todos=completed), "Need commit.", messages)
+    assert not should_continue_for_active_todos(_agent(enabled=False, todos=ACTIVE), "Need commit.", messages)
+    assert todo_completion_continuation_enabled(SimpleNamespace())
+
+
+def test_exhaustion_message_reports_unresolved_todo_ids():
+    agent = _agent(todos=ACTIVE)
+
+    message = build_todo_completion_exhausted_message(agent)
+
+    assert "incomplete" in message.lower()
+    assert "s4-ci" in message

--- a/tests/run_agent/test_todo_completion_continuation.py
+++ b/tests/run_agent/test_todo_completion_continuation.py
@@ -1,0 +1,113 @@
+"""End-to-end regression for active TodoStore continuation in the real loop."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _response(content):
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        model="test/model",
+        usage=None,
+    )
+
+
+@pytest.fixture
+def agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        instance = AIAgent(
+            session_id="todo-completion-test",
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            provider="openai-compat",
+            model="test/model",
+            max_iterations=2,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    instance._cached_system_prompt = "stable test prompt"
+    instance._session_db = None
+    instance._session_json_enabled = False
+    instance.save_trajectories = False
+    instance.compression_enabled = False
+    instance._cleanup_task_resources = lambda *_a, **_k: None
+    instance._save_trajectory = lambda *_a, **_k: None
+    instance.valid_tool_names = ["terminal"]
+    instance._todo_completion_continuation = True
+    return instance
+
+
+def test_active_todo_stop_is_reprompted_through_real_conversation_loop(agent, monkeypatch):
+    """A narration-only stop is not final while Hermes marks work in progress."""
+    agent._todo_store.write(
+        [{"id": "s4-ci", "content": "commit and verify CI", "status": "in_progress"}]
+    )
+    calls = 0
+
+    def model_call(_api_kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _response("Need commit.")
+        # This models the required todo update after the actual commit/CI work.
+        agent._todo_store.write(
+            [{"id": "s4-ci", "content": "commit and verify CI", "status": "completed"}]
+        )
+        return _response("Committed and CI passed.")
+
+    agent._interruptible_api_call = model_call
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        result = agent.run_conversation("finish the release")
+
+    assert calls == 2
+    assert result["final_response"] == "Committed and CI passed."
+    assert result["turn_exit_reason"] == "text_response(finish_reason=stop)"
+    assert result["completed"] is True
+    assert not any(
+        message.get("_todo_completion_synthetic")
+        for message in result["messages"]
+        if isinstance(message, dict)
+    )
+
+
+def test_active_todo_continuation_exhaustion_is_visible_not_silent(agent, monkeypatch):
+    """A model that ignores three nudges must not be reported as successful."""
+    agent.max_iterations = 4
+    agent.iteration_budget.max_total = 4
+    agent._todo_store.write(
+        [{"id": "s4-ci", "content": "commit and verify CI", "status": "in_progress"}]
+    )
+    calls = 0
+
+    def model_call(_api_kwargs):
+        nonlocal calls
+        calls += 1
+        return _response("Need commit.")
+
+    agent._interruptible_api_call = model_call
+    monkeypatch.setenv("HERMES_VERIFY_ON_STOP", "0")
+
+    with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+        result = agent.run_conversation("finish the release")
+
+    assert calls == 4
+    assert "Task remains incomplete" in result["final_response"]
+    assert result["turn_exit_reason"] == "todo_completion_exhausted"
+    assert result["completed"] is False


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes from silently finalizing a foreground turn while its own
TodoStore still contains `pending` or `in_progress` work.

The existing intermediate-ack protections classify assistant wording such as
"I'll do the next step" or "working...". They can miss short status messages
such as `Need commit.` or `CI queued, wait.`. This change uses the durable
execution state Hermes already maintains as the completion gate.

When active todos remain, the loop issues a bounded continuation nudge to
execute the next tool call and update todo state. It does not nudge when a
notified background task is running or when the assistant explicitly requests
user approval, input, credentials, or a decision. After three ignored nudges,
Hermes returns an explicit incomplete-task response with `completed=False`
instead of silently reporting success.

The synthetic continuation message is removed from finalization and context
compression paths so it cannot poison resumed sessions.

## Related reports

Related to #74604 and #42503. Complementary to #69779: those reports/PRs focus
on wording-based intermediate-ack detection; this PR covers the independent
state mismatch where Hermes knows work is active but accepts `finish_reason=stop`.

## Verification

- 13 targeted unit tests pass, covering pending/in-progress, completed/cancelled,
  background notifications, user approval/input, historical tool rows, config
  opt-out, and exhaustion messaging.
- Real Python 3.11 `run_conversation()` regression passes for active-todo
  recovery and bounded exhaustion.
- A real DeepSeek v4 Flash / HeyRoute run reproduced `Need commit.` with one
  in-progress and one pending todo; Hermes injected the continuation, completed
  both tasks, and only then ended the turn.
- The branch is based on current `origin/main` and applies without conflicts.

The full test suite was not run in this environment because the available
pytest executable is Python 3.12 while the Hermes release environment is
Python 3.11; the real loop was verified directly with the project Python 3.11
environment.
