### PR TITLE
fix(weixin): distinguish ret=-2 'prepare failed' from genuine rate limit (#80125)

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -1826,6 +1826,20 @@ class WeixinAdapter(BasePlatformAdapter):
                                 self.name, _safe_id(chat_id),
                             )
                             continue
+                        # Parameter error (-2 + "prepare failed") — not a rate
+                        # limit.  iLink returns ret=-2 with errmsg "prepare
+                        # failed" when the context_token is missing or invalid
+                        # (e.g. fresh account with no inbound messages yet).
+                        # Treat this as a hard error so operators see the real
+                        # cause instead of a misleading 30s cooldown.
+                        if (
+                            ret == RATE_LIMIT_ERRCODE or errcode == RATE_LIMIT_ERRCODE
+                        ) and (resp.get("errmsg") or "").lower() == "prepare failed":
+                            raise RuntimeError(
+                                f"iLink sendmessage parameter error: prepare failed"
+                                f" (ret={ret}, likely missing context_token —"
+                                f" user must send an inbound message first or re-pair)"
+                            )
                         # Rate limit (-2) — backoff and retry
                         is_rate_limited = (
                             ret == RATE_LIMIT_ERRCODE


### PR DESCRIPTION
## Summary

iLink returns `ret=-2` for both rate limits AND parameter errors. When `errmsg` is `"prepare failed"`, the real cause is a missing/invalid `context_token` (e.g. fresh account with no inbound messages yet), not frequency limiting.

Previously this was unconditionally treated as a rate limit, opening a 30s circuit breaker and hiding the real cause behind "iLink sendmessage rate limited; cooldown active for 30.0s".

## Changes

In `_send_text_chunk_locked` (`gateway/platforms/weixin.py`), added a check **before** the generic rate-limit handler:

- `ret=-2` + `errmsg="prepare failed"` raises a descriptive `RuntimeError` immediately: *"iLink sendmessage parameter error: prepare failed (likely missing context_token -- user must send an inbound message first or re-pair)"*
- Does NOT trigger the rate-limit circuit breaker
- Genuine rate limits (`ret=-2` with other errmsg values) continue to work as before

## Impact

1. **Diagnostics**: operators see the real cause instead of a misleading "rate limited" message
2. **Recovery**: the error message guides users to send an inbound message or re-pair
3. **No regression**: stale session handling (`errmsg="unknown error"`) and genuine rate limits are unchanged

Fixes #80125