### PR TITLE
feat(gateway): send a back-online notice to chats that saw the shutdown notice

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1752,6 +1752,11 @@ def _clear_planned_restart_notification() -> None:
     _planned_restart_notification_path().unlink(missing_ok=True)
 
 
+def _shutdown_notified_path() -> Path:
+    """Marker persisting which chats received the plain-shutdown notice."""
+    return _hermes_home / ".shutdown_notified.json"
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -9332,6 +9337,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     "Home-channel shutdown broadcast suppressed by drain marker "
                     "(suppress_notification=true)"
                 )
+                self._persist_shutdown_notified_targets(notified)
                 return
         except Exception as e:
             # Never let the suppression check block the shutdown broadcast —
@@ -9393,6 +9399,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     home.chat_id,
                     e,
                 )
+
+        self._persist_shutdown_notified_targets(notified)
+
+    def _persist_shutdown_notified_targets(
+        self, notified: set[tuple[str, str, Optional[str]]]
+    ) -> None:
+        """Persist plain-shutdown notification targets for a back-online ping.
+
+        Restart flows already announce their comeback (.restart_notify.json
+        for chat-originated /restart, .restart_pending.json for planned
+        service restarts), so only non-restart shutdowns are recorded here.
+        Startup reads the marker and pings the same chats once adapters are
+        connected again (_send_shutdown_recovery_notifications).
+        """
+        if self._restart_requested or not notified:
+            return
+        try:
+            atomic_json_write(
+                _shutdown_notified_path(),
+                {
+                    "written_at": time.time(),
+                    "targets": [
+                        {"platform": platform_str, "chat_id": chat_id, "thread_id": thread_id}
+                        for platform_str, chat_id, thread_id in notified
+                    ],
+                },
+                indent=None,
+            )
+        except Exception as e:
+            logger.debug("Failed to persist shutdown notification targets: %s", e)
 
     async def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
@@ -11364,7 +11400,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # of a restart cycle (see _is_stale_restart_redelivery).
         if chat_restart_notification_pending:
             self._booted_from_restart = True
-        await self._send_restart_notification()
+        startup_notified: set[tuple[str, str, Optional[str]]] = set()
+        restart_target = await self._send_restart_notification()
+        if restart_target is not None:
+            startup_notified.add(restart_target)
 
         # Broadcast a lightweight "gateway is back" message to configured home
         # channels only for non-chat planned restarts (terminal/SIGUSR1/service
@@ -11373,11 +11412,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # chat/topic instead of also leaking it to the configured home channel.
         if planned_restart_notification_pending:
             try:
-                await self._send_home_channel_startup_notifications(
+                startup_notified |= await self._send_home_channel_startup_notifications(
                     skip_targets=None,
                 )
             finally:
                 _clear_planned_restart_notification()
+
+        # Chats that saw the plain-shutdown "Gateway shutting down" notice get
+        # a matching back-online ping; their targets were persisted at shutdown
+        # by _notify_active_sessions_of_shutdown. Restart flows are excluded at
+        # write time, so this never double-pings the paths handled above.
+        await self._send_shutdown_recovery_notifications(skip_targets=startup_notified)
 
         # Automatically continue fresh sessions that were interrupted by the
         # previous gateway restart/shutdown.  The resume_pending flag is cleared
@@ -21270,6 +21315,108 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 )
 
         return delivered
+
+    async def _send_shutdown_recovery_notifications(
+        self,
+        *,
+        skip_targets: Optional[set[tuple[str, str, Optional[str]]]] = None,
+    ) -> None:
+        """Send a back-online ping to chats that saw the shutdown notice.
+
+        ``_notify_active_sessions_of_shutdown`` persists its delivery targets
+        for plain (non-restart) shutdowns; without this pass those chats see
+        "⚠️ Gateway shutting down" and then silence when the gateway returns
+        (service-managed restarts, machine reboots, manual starts). Restart
+        flows are excluded at write time — they already notify on comeback via
+        .restart_notify.json / .restart_pending.json. Best-effort: failures
+        are logged and never block startup.
+        """
+        marker = _shutdown_notified_path()
+        if not marker.exists():
+            return
+
+        targets: list = []
+        try:
+            data = json.loads(marker.read_text(encoding="utf-8"))
+            raw_targets = data.get("targets")
+            if isinstance(raw_targets, list):
+                targets = raw_targets
+        except Exception as e:
+            logger.debug("Failed to read shutdown-notified marker: %s", e)
+        finally:
+            marker.unlink(missing_ok=True)
+
+        skipped = skip_targets or set()
+        delivered: set[tuple[str, str, Optional[str]]] = set()
+        message = "♻️ Gateway online — Hermes is back and ready."
+
+        for entry in targets:
+            if not isinstance(entry, dict):
+                continue
+            platform_str = entry.get("platform")
+            chat_id = entry.get("chat_id")
+            thread_id = entry.get("thread_id")
+            if not platform_str or not chat_id:
+                continue
+            target = (str(platform_str), str(chat_id), str(thread_id) if thread_id else None)
+            if target in skipped or target in delivered:
+                continue
+
+            try:
+                platform = Platform(str(platform_str))
+            except ValueError:
+                continue
+
+            transport = resolve_delivery_transport(platform, self.config, self.adapters)
+            if transport is None:
+                continue
+
+            platform_cfg = self.config.platforms.get(platform)
+            if platform_cfg is not None and not platform_cfg.gateway_restart_notification:
+                logger.info(
+                    "Back-online notification suppressed: %s has gateway_restart_notification=false",
+                    platform.value,
+                )
+                continue
+
+            try:
+                metadata = self._thread_metadata_for_target(
+                    platform,
+                    target[1],
+                    target[2],
+                    adapter=transport.adapter,
+                )
+                send_metadata = _non_conversational_metadata(metadata, platform=platform)
+                if send_metadata is not None or transport.is_relay:
+                    result = await transport.send(
+                        platform,
+                        target[1],
+                        message,
+                        metadata=send_metadata,
+                    )
+                else:
+                    result = await transport.adapter.send(target[1], message)
+                if result is not None and getattr(result, "success", True) is False:
+                    logger.warning(
+                        "Back-online notification to %s:%s was not delivered: %s",
+                        platform.value,
+                        target[1],
+                        getattr(result, "error", "send returned success=False"),
+                    )
+                    continue
+                delivered.add(target)
+                logger.info(
+                    "Sent back-online notification to %s:%s",
+                    platform.value,
+                    target[1],
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Back-online notification failed for %s:%s: %s",
+                    platform.value,
+                    target[1],
+                    exc,
+                )
 
     def _set_session_env(self, context: SessionContext) -> list:
         """Set session context variables for the current async task.

--- a/tests/gateway/test_shutdown_online_notification.py
+++ b/tests/gateway/test_shutdown_online_notification.py
@@ -1,0 +1,194 @@
+"""Tests for the back-online notification after a plain gateway shutdown.
+
+A non-restart shutdown pings active chats and home channels with
+"⚠️ Gateway shutting down" but nothing announced the comeback: the
+home-channel startup broadcast only runs for planned restarts
+(.restart_pending.json) and .restart_notify.json only covers chat /restart.
+These tests cover the marker persisted at shutdown and the startup pass
+that pings the same chats once the gateway is back online.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import HomeChannel, Platform
+from gateway.platforms.base import SendResult
+from gateway.session import build_session_key
+from tests.gateway.restart_test_helpers import (
+    make_restart_runner,
+    make_restart_source,
+)
+
+ONLINE_MESSAGE = "♻️ Gateway online — Hermes is back and ready."
+
+
+def _write_marker(tmp_path, targets):
+    (tmp_path / ".shutdown_notified.json").write_text(
+        json.dumps({"written_at": 0, "targets": targets}), encoding="utf-8"
+    )
+
+
+# ── shutdown side: marker persistence ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_plain_shutdown_persists_notified_targets(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    source = make_restart_source(chat_id="active-42", chat_type="group", thread_id="topic-7")
+    session_key = build_session_key(source)
+    runner._running_agents[session_key] = object()
+    runner.session_store._entries[session_key] = MagicMock(origin=None)
+    runner._cache_session_source(session_key, source)
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    marker = tmp_path / ".shutdown_notified.json"
+    assert marker.exists()
+    data = json.loads(marker.read_text(encoding="utf-8"))
+    got = {(t["platform"], t["chat_id"], t["thread_id"]) for t in data["targets"]}
+    assert got == {
+        ("telegram", "active-42", "topic-7"),
+        ("telegram", "home-42", None),
+    }
+
+
+@pytest.mark.asyncio
+async def test_restart_shutdown_does_not_persist_marker(tmp_path, monkeypatch):
+    """Restart flows have their own comeback notifications — no marker."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner._restart_requested = True
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_awaited()  # "restarting" ping still goes out
+    assert not (tmp_path / ".shutdown_notified.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_muted_shutdown_persists_no_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    adapter.send.assert_not_awaited()
+    assert not (tmp_path / ".shutdown_notified.json").exists()
+
+
+# ── startup side: back-online delivery ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_startup_pings_persisted_targets_and_clears_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    _write_marker(
+        tmp_path,
+        [
+            {"platform": "telegram", "chat_id": "active-42", "thread_id": "topic-7"},
+            {"platform": "telegram", "chat_id": "home-42", "thread_id": None},
+        ],
+    )
+
+    await runner._send_shutdown_recovery_notifications()
+
+    assert not (tmp_path / ".shutdown_notified.json").exists()
+    assert [(chat_id, content) for chat_id, content, _meta in adapter.sent_calls] == [
+        ("active-42", ONLINE_MESSAGE),
+        ("home-42", ONLINE_MESSAGE),
+    ]
+    thread_metadata = adapter.sent_calls[0][2]
+    assert thread_metadata is not None and thread_metadata.get("thread_id") == "topic-7"
+    assert adapter.sent_calls[1][2] is None
+
+
+@pytest.mark.asyncio
+async def test_startup_skips_targets_already_notified(tmp_path, monkeypatch):
+    """A /restart or planned-restart notification wins over the marker ping."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="1"))
+    _write_marker(
+        tmp_path,
+        [{"platform": "telegram", "chat_id": "home-42", "thread_id": None}],
+    )
+
+    await runner._send_shutdown_recovery_notifications(
+        skip_targets={("telegram", "home-42", None)}
+    )
+
+    adapter.send.assert_not_awaited()
+    assert not (tmp_path / ".shutdown_notified.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_startup_respects_notification_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].gateway_restart_notification = False
+    adapter.send = AsyncMock()
+    _write_marker(
+        tmp_path,
+        [{"platform": "telegram", "chat_id": "home-42", "thread_id": None}],
+    )
+
+    await runner._send_shutdown_recovery_notifications()
+
+    adapter.send.assert_not_awaited()
+    assert not (tmp_path / ".shutdown_notified.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_startup_noop_without_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+
+    await runner._send_shutdown_recovery_notifications()
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_startup_survives_corrupt_marker(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    runner, adapter = make_restart_runner()
+    adapter.send = AsyncMock()
+    (tmp_path / ".shutdown_notified.json").write_text("not json", encoding="utf-8")
+
+    await runner._send_shutdown_recovery_notifications()
+
+    adapter.send.assert_not_awaited()
+    assert not (tmp_path / ".shutdown_notified.json").exists()


### PR DESCRIPTION
## What does this PR do?

When the gateway shuts down, active chats and home channels get "⚠️ Gateway shutting down — Your current task will be interrupted." — but when it comes back, nothing is announced unless the shutdown was a planned restart: the home-channel startup broadcast only fires when `.restart_pending.json` exists (terminal/SIGUSR1/service restarts) and `.restart_notify.json` only covers chat-originated `/restart`. Service-manager restarts that deliver SIGTERM, machine reboots, and `hermes gateway stop` → later `start` all end on the shutdown notice with no follow-up, leaving users to discover by trial message whether the gateway is alive again.

This PR closes the gap symmetrically — **whoever saw the shutdown notice gets the comeback notice**:

- `_notify_active_sessions_of_shutdown()` persists its actual delivery targets (active-session chats/threads + home channels) to `~/.hermes/.shutdown_notified.json` for plain (non-restart) shutdowns. Restart flows never write the marker — they already have their own comeback paths.
- On startup, the new `_send_shutdown_recovery_notifications()` sends the existing "♻️ Gateway online — Hermes is back and ready." message to those same targets (same chat, same thread) once adapters are connected, deduplicating against the `/restart` reply and the planned-restart home broadcast, then clears the marker.
- `gateway_restart_notification=false` suppresses the ping at both write time and send time. Delivery is best-effort and never blocks startup. A crash writes no marker (the shutdown notice never went out), so crash recovery stays silent — that lifecycle belongs to the crash-diagnostics work in #41763 / #42528 / #44275.

### Relation to the existing startup-notification cluster

#24271 (global opt-in flag), #30787 (per-platform opt-in + debounce), and #48360 (broadcast on every ordinary startup) all address this by broadcasting to **home channels on every startup**, and the open question there is noise: first boots and routine cold starts ping the home channel whether or not anyone noticed an outage. This PR takes a narrower cut that sidesteps that debate:

- only chats that actually received the shutdown notice are pinged — a first boot or a start nobody saw stays silent;
- active-session **threads** get the notice in place, not just the home channel;
- no new config key — the existing `gateway_restart_notification` gate covers both directions.

It composes with any of those PRs (targets already notified are deduplicated), so accepting one of them later would not conflict with this behavior.

## Related Issue

Related to #62512 and #27870 (not claiming "Fixes": those also ask for a first-boot notification, which this PR deliberately does not send — no shutdown notice was delivered, so there is nobody waiting on a comeback ping).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`
  - `_shutdown_notified_path()` module helper next to the existing restart-marker helpers.
  - `_persist_shutdown_notified_targets()` — called at both exits of `_notify_active_sessions_of_shutdown()` (including the drain-suppressed early return, which still pings active sessions); no-ops for restart flows and empty target sets.
  - `_send_shutdown_recovery_notifications()` — startup pass mirroring `_send_home_channel_startup_notifications()` delivery mechanics (`resolve_delivery_transport`, thread metadata, relay-aware send, per-target error isolation).
  - Startup wiring: collects the `/restart` reply target and the planned-restart broadcast deliveries into a skip set so no chat is pinged twice.
- `tests/gateway/test_shutdown_online_notification.py` (new, 8 tests): marker persistence on plain shutdown, no marker for restart flows or muted platforms, startup delivery with thread metadata, skip-target dedup, notification-flag suppression at send time, no-op without marker, corrupt-marker resilience.

## How to Test

1. `python -m pytest tests/gateway/test_shutdown_online_notification.py tests/gateway/test_restart_notification.py tests/gateway/test_gateway_shutdown.py tests/gateway/test_restart_resume_pending.py -q` — 58 passed on current main.
2. Manual: start the gateway with a home channel configured and a chat mid-conversation, then `kill -TERM <gateway pid>` (or stop/start the service). Both chats receive the shutting-down notice; on the next `hermes gateway start`, the same chats — including the thread — receive "♻️ Gateway online — Hermes is back and ready." exactly once.
3. Negative: `/restart` from a chat still produces only the targeted "Gateway restarted successfully" reply (no duplicate), and `.shutdown_notified.json` is never created for restart flows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the gateway test suites listed above; full `pytest tests/gateway -q` also run on the branch this was developed on (same failures as a clean checkout on macOS: platform-specific wecom/systemd tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (Apple Silicon), launchd-managed gateway — running in production on our self-hosted Mattermost workspace since 2026-08-06

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings only; no user-facing config changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — marker I/O uses the existing `atomic_json_write` / `Path.unlink(missing_ok=True)` helpers already used for the restart markers
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
