### PR TITLE
fix: ignore missing user systemd unit in timeout check

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -367,12 +367,20 @@ def check_systemd_timing_alignment(drain_timeout: float) -> Optional[Dict[str, A
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl", *flag, "show", unit_name,
+                    "--property=LoadState", "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
+            continue
+        # A user manager can return its default TimeoutStopUSec even when the
+        # requested unit is absent.  Do not treat that default as this
+        # service's configured timeout; fall through to the system manager.
+        if any(line.strip() == "LoadState=not-found" for line in result.stdout.splitlines()):
             continue
         # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
         for line in result.stdout.splitlines():

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import signal
@@ -142,3 +143,39 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+    def test_skips_missing_user_unit_and_checks_system_service(self, monkeypatch):
+        monkeypatch.setenv("INVOCATION_ID", "abc")
+        monkeypatch.setattr(
+            "builtins.open",
+            lambda *args, **kwargs: io.StringIO("0::/system.slice/hermes-gateway.service\n"),
+        )
+
+        calls = []
+
+        class Result:
+            def __init__(self, stdout):
+                self.returncode = 0
+                self.stdout = stdout
+
+        def fake_run(command, **kwargs):
+            calls.append(command)
+            if "--user" in command:
+                # systemctl --user show returns manager defaults even when
+                # the requested unit does not exist.
+                return Result("TimeoutStopUSec=1min 30s\nLoadState=not-found\n")
+            return Result("TimeoutStopUSec=4min\nLoadState=loaded\n")
+
+        monkeypatch.setattr(sf.subprocess, "run", fake_run)
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result == {
+            "unit": "hermes-gateway.service",
+            "timeout_stop_sec": 240.0,
+            "drain_timeout": 180.0,
+            "expected_min": 210.0,
+            "mismatch": False,
+        }
+        assert any("--user" in command for command in calls)
+        assert any("--user" not in command for command in calls)


### PR DESCRIPTION
## Summary
- Ignore the user-manager default `TimeoutStopUSec` when the queried service has `LoadState=not-found`.
- Fall through to the system-level unit, avoiding a false stale-unit warning for system services.
- Add a regression test covering a missing user unit followed by a 240-second system unit.

## Test plan
- `scripts/run_tests.sh tests/gateway/test_shutdown_forensics.py -v --tb=short` (11 passed)