### PR TITLE
fix(config): fix(config): update uv exclude-newer absolute date and whitelist missing packages

### DIFF
--- a/contributors/emails/StanleyStetson@users.noreply.github.com
+++ b/contributors/emails/StanleyStetson@users.noreply.github.com
@@ -1,0 +1,1 @@
+StanleyStetson

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,8 +368,8 @@ override-dependencies = [
   # remove this when we update discord.py
   "pynacl>=1.6,<1.7",
 ]
-exclude-newer = "14 days"
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false }
+exclude-newer = "2026-07-22T00:00:00Z"
+exclude-newer-package = { vercel = false, nemo-relay = false, huggingface-hub = false, defusedxml = false, python-olm = false, unpaddedbase64 = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1683,7 +1683,7 @@ PY
         exit 1
     fi
 
-    if [ "$_tier_name" != "all (with RL/matrix extras)" ]; then
+    if [ "$_tier_name" != "all" ]; then
         log_warn "Note: installed via fallback tier ($_tier_name)."
         log_info "Some optional features may be missing. After resolving any"
         log_info "PyPI/network issue, re-run: $UV_CMD pip install -e '.[all]'"

--- a/uv.lock
+++ b/uv.lock
@@ -8,13 +8,15 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-20T16:38:42.729819205Z"
-exclude-newer-span = "P14D"
+exclude-newer = "2026-07-22T00:00:00Z"
 
 [options.exclude-newer-package]
-nemo-relay = false
+defusedxml = false
 vercel = false
+unpaddedbase64 = false
+nemo-relay = false
 huggingface-hub = false
+python-olm = false
 
 [manifest]
 overrides = [{ name = "pynacl", specifier = ">=1.6,<1.7" }]
@@ -3998,7 +4000,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4053,7 +4055,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4692,11 +4694,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [


### PR DESCRIPTION
## What changed & why
I fixed the daily failure of `uv sync --locked` caused by the relative `exclude-newer = "14 days"` cutoff in `pyproject.toml`. Because `uv` evaluates relative dates dynamically against the current date, it created a daily lock drift that broke the `--locked` command. I changed this value to an absolute RFC 3339 UTC date (`2026-07-22T00:00:00Z`) to stabilize the lockfile deterministically across all environments and timezones.

Additionally, I added three packages (`defusedxml`, `python-olm`, `unpaddedbase64`) to the `exclude-newer-package` list. These packages lack upload dates on PyPI and were blocking `uv` from resolving the `wecom` and `matrix` extras when the date cutoff was active.

Finally, I corrected an outdated tier check in `scripts/install.sh`. The check was looking for the legacy string `"all (with RL/matrix extras)"` instead of `"all"`, which caused the script to print a false-positive warning about falling back to a lower tier even on a fully successful installation.

## How to reproduce
1. On `main` before the fix, run `uv sync --extra all --locked`.
2. Notice the lockfile error (`The lockfile at uv.lock needs to be updated`) due to the daily timestamp drift.
3. Observe the warning `Note: installed via fallback tier...` when running `scripts/install.sh` despite a successful `[all]` installation.

## Verification
- I successfully generated the lockfile with the absolute UTC timestamp and whitelist using `uv lock`.
- I ran `uv sync --extra all --locked`, which executed cleanly with exit code 0.
- All code styles and lint checks passed via `npm run fix`.
- Verified pre-flight checks via `python scripts/verify_pr.py` and passed `local_sweeper` review.

Fixes #79434