### PR TITLE
fix(cli): scope plugin-removal config cleanup to the plugin actually being removed

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -694,8 +694,105 @@ def cmd_remove(name: str) -> None:
         console.print(f"[red]Error:[/red] {e}")
         sys.exit(1)
 
+    # Strip config state BEFORE the tree goes away: every identity check in
+    # _plugin_removal_identities needs the plugin still on disk, and if the
+    # config write fails we would rather leave the plugin installed than leave
+    # a deleted plugin listed in plugins.enabled.
+    _remove_plugin_config_state(_plugin_removal_identities(target))
+
     shutil.rmtree(target)
     _display_removed(name, plugins_dir)
+
+
+def _plugin_removal_identities(target: Path) -> set:
+    """Return the ``plugins.*`` config keys demonstrably owned by *target*.
+
+    ``hermes plugins uninstall`` has to strip the removed plugin out of
+    ``plugins.enabled`` / ``plugins.disabled`` / ``plugins.entries``, and
+    ``plugins.entries.<key>`` can hold the privileged ``allow_tool_override``
+    grant that :meth:`PluginContext._tool_override_allowed` reads by canonical
+    key — so a record left behind here is re-applied to whatever is installed
+    at that key next.
+
+    Ownership is established by the directory being deleted, not by the name
+    the user typed: the discovered entry whose directory *is* *target* supplies
+    the canonical key and the manifest name. A bare directory leaf is NOT an
+    identity on its own, because user plugins may be nested and path-derived
+    keys mean a namespaced ``image_gen/openai`` shares its leaf with a wholly
+    separate flat ``openai``. A leaf or manifest alias is therefore only
+    collected when :func:`_resolve_plugin_key` — the single normalization point
+    ``enable`` / ``disable`` already write through — maps it back to this same
+    plugin, and it is not some other installed plugin's canonical key. That
+    keeps legacy bare-name cleanup working in every case where the alias
+    provably identifies one plugin, and declines only when it belongs to
+    somebody else.
+
+    MUST be called before the tree is deleted; discovery scans the plugins
+    directory. Returns an empty set when discovery is unavailable, which leaves
+    config untouched exactly as it is today.
+    """
+    try:
+        target_dir = target.resolve()
+        entries = _discover_all_plugins()
+        # entry = (name, version, description, source, dir_path, key)
+        owned = [e for e in entries if Path(e[4]).resolve() == target_dir]
+        if len(owned) != 1:
+            return set()
+        manifest_name, canonical = owned[0][0], owned[0][5]
+        identities = {canonical}
+        foreign_keys = {e[5] for e in entries if e[5] != canonical}
+        for alias in (manifest_name, target.name):
+            if not alias or alias in identities or alias in foreign_keys:
+                continue
+            if _resolve_plugin_key(alias) == canonical:
+                identities.add(alias)
+        return identities
+    except Exception:
+        # Discovery walks the filesystem; a removal the operator explicitly
+        # asked for must not be blocked by it. Degrade to main's behaviour
+        # (delete the tree, leave config alone) rather than failing the command.
+        logger.debug("Plugin discovery failed; leaving config untouched", exc_info=True)
+        return set()
+
+
+def _remove_plugin_config_state(identities: set) -> None:
+    """Drop *identities* from ``plugins.enabled`` / ``disabled`` / ``entries``.
+
+    One load/save pair so a removal cannot half-apply. The managed-config
+    decision is left to ``save_config``, which prints the canonical managed
+    error and returns without writing — matching every other config writer in
+    ``hermes_cli`` instead of raising a second, inconsistent refusal here.
+    """
+    if not identities:
+        return
+    from hermes_cli.config import load_config, save_config
+
+    config = load_config()
+    plugins_cfg = config.get("plugins")
+    if not isinstance(plugins_cfg, dict):
+        return
+
+    changed = False
+    for list_key in ("enabled", "disabled"):
+        current = plugins_cfg.get(list_key)
+        if not isinstance(current, list):
+            continue
+        kept = [item for item in current if item not in identities]
+        if len(kept) != len(current):
+            plugins_cfg[list_key] = kept
+            changed = True
+
+    entries = plugins_cfg.get("entries")
+    if isinstance(entries, dict):
+        for identity in identities:
+            if identity in entries:
+                del entries[identity]
+                changed = True
+
+    # Only write when something actually changed, so an uninstall of a plugin
+    # that was never enabled stays a no-op on config.yaml.
+    if changed:
+        save_config(config)
 
 
 def _get_disabled_set() -> set:
@@ -2023,7 +2120,7 @@ def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
 
 
 def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
-    """Delete a plugin tree under ``~/.hermes/plugins/`` only."""
+    """Delete a plugin tree under ``~/.hermes/plugins/`` and its config state."""
     plugins_dir = _plugins_dir()
     for n, _ver, _d, src, _path, _key in _discover_all_plugins():
         if n == name and src == "bundled":
@@ -2035,6 +2132,10 @@ def dashboard_remove_user_plugin(name: str) -> dict[str, Any]:
             "ok": False,
             "error": f"Plugin '{name}' was not found under {plugins_dir}.",
         }
+
+    # Same ordering as the CLI path (see cmd_remove): resolve identities and
+    # clean config while the plugin is still on disk.
+    _remove_plugin_config_state(_plugin_removal_identities(target))
 
     shutil.rmtree(target)
     return {"ok": True, "name": name}

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -734,8 +734,16 @@ def _plugin_removal_identities(target: Path) -> set:
     try:
         target_dir = target.resolve()
         entries = _discover_all_plugins()
-        # entry = (name, version, description, source, dir_path, key)
-        owned = [e for e in entries if Path(e[4]).resolve() == target_dir]
+        # entry = (name, version, description, source, dir_path, key).
+        # Entry-point plugins are installed as Python packages and carry the
+        # entry-point value ("pkg.mod:register") in the dir_path slot instead of
+        # a directory, so restrict the match to real Path entries: that string
+        # is invalid path syntax on Windows, and letting one raise escape here
+        # would abandon the whole identity set and silently skip cleanup.
+        owned = [
+            e for e in entries
+            if isinstance(e[4], Path) and e[4].resolve() == target_dir
+        ]
         if len(owned) != 1:
             return set()
         manifest_name, canonical = owned[0][0], owned[0][5]

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -259,6 +259,45 @@ class TestDashboardRemoval:
         assert flat.is_dir()
 
 
+class TestEntryPointPlugins:
+    """An entry-point plugin must not take part in directory matching.
+
+    ``_discover_all_plugins`` stores the entry-point value ("pkg.mod:register")
+    where directory-backed plugins store a ``Path``. Feeding that to
+    ``Path.resolve()`` is meaningless everywhere and invalid path syntax on
+    Windows, and a raise there would abandon the whole identity set and skip
+    cleanup silently — reintroducing the bug this file guards.
+    """
+
+    @pytest.mark.parametrize(
+        "ep_value",
+        [
+            "pkg.mod:register",
+            # Stands in for any value Path() rejects outright; Windows reaches
+            # the same branch with the ordinary colon-bearing value above.
+            "pkg.mod:register\x00bad",
+        ],
+    )
+    def test_entry_point_plugin_does_not_block_cleanup(
+        self, plugin_env, monkeypatch, ep_value
+    ):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins_cmd._discover_entrypoint_plugins",
+            lambda: [("ep_plugin", "1.0.0", "", ep_value)],
+        )
+
+        cmd_remove("solo")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+
+
 class TestManagedMode:
     """Managed mode keeps main's behaviour: the tree goes, config is not written."""
 

--- a/tests/hermes_cli/test_plugins_cmd_remove.py
+++ b/tests/hermes_cli/test_plugins_cmd_remove.py
@@ -1,0 +1,284 @@
+"""Regression tests for plugin-removal config cleanup (``hermes plugins uninstall``).
+
+``cmd_remove`` / ``dashboard_remove_user_plugin`` delete the plugin tree, so they
+must also drop the plugin out of ``plugins.enabled`` / ``plugins.disabled`` /
+``plugins.entries`` — a stale ``plugins.entries.<key>`` record keeps a privileged
+``allow_tool_override`` grant alive for whatever is installed at that key next.
+
+The cleanup has to be scoped to identities the removed plugin demonstrably owns.
+User plugins may be nested and their keys are path-derived, so a namespaced
+``image_gen/openai`` shares its directory leaf with a wholly separate flat
+``openai`` plugin. These tests drive real ``config.yaml`` I/O under a temporary
+``HERMES_HOME`` rather than patching the helpers under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugins_cmd import cmd_remove, dashboard_remove_user_plugin
+
+
+@pytest.fixture
+def plugin_env(tmp_path, monkeypatch):
+    """Isolate HERMES_HOME, the bundled plugin tree, and entry-point plugins."""
+    home = tmp_path / "home"
+    (home / "plugins").mkdir(parents=True)
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Managed mode short-circuits save_config; keep it off unless a test asks.
+    monkeypatch.delenv("HERMES_MANAGED", raising=False)
+    # Discovery is deliberately real, but it must not see the repo's own
+    # bundled plugins: Hermes ships plugins/image_gen/openai, whose key would
+    # collide with the namespaced fixture below and make these tests depend on
+    # what upstream happens to bundle. Entry-point plugins likewise depend on
+    # what is pip-installed in the test environment.
+    monkeypatch.setattr("hermes_cli.plugins.get_bundled_plugins_dir", lambda: bundled)
+    monkeypatch.setattr(
+        "hermes_cli.plugins_cmd._discover_entrypoint_plugins", lambda: []
+    )
+    return home
+
+
+def _install(home: Path, rel_path: str, manifest_name: str) -> Path:
+    """Create a user plugin at ``plugins/<rel_path>`` with *manifest_name*."""
+    plugin_dir = home / "plugins" / rel_path
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        yaml.safe_dump({"name": manifest_name, "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    return plugin_dir
+
+
+def _write_plugins_config(home: Path, plugins_block: dict) -> None:
+    (home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": plugins_block}), encoding="utf-8"
+    )
+
+
+def _read_plugins_config(home: Path) -> dict:
+    raw = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8")) or {}
+    return raw.get("plugins") or {}
+
+
+def _grant(*keys: str) -> dict:
+    return {key: {"allow_tool_override": True} for key in keys}
+
+
+class TestLeafCollision:
+    """A namespaced removal must not strip a same-leaf flat plugin's state."""
+
+    def test_removing_namespaced_plugin_spares_flat_plugin_sharing_the_leaf(
+        self, plugin_env
+    ):
+        home = plugin_env
+        # image_gen/openai (key "image_gen/openai") and a separate flat plugin
+        # whose manifest name is also "openai" (key "openai").
+        namespaced = _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        cmd_remove("image_gen/openai")
+
+        plugins_cfg = _read_plugins_config(home)
+        # The bystander keeps its enabled state AND its override grant.
+        assert "openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["openai"]["allow_tool_override"] is True
+        assert flat.is_dir()
+        # The removed plugin loses both.
+        assert "image_gen/openai" not in plugins_cfg["enabled"]
+        assert "image_gen/openai" not in plugins_cfg["entries"]
+        assert not namespaced.exists()
+
+    def test_removing_flat_plugin_spares_namespaced_plugin_sharing_the_leaf(
+        self, plugin_env
+    ):
+        home = plugin_env
+        namespaced = _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        cmd_remove("openai")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert "image_gen/openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["image_gen/openai"]["allow_tool_override"] is True
+        assert namespaced.is_dir()
+        assert "openai" not in plugins_cfg["enabled"]
+        assert "openai" not in plugins_cfg["entries"]
+        assert not flat.exists()
+
+
+class TestOwnedStateIsCleaned:
+    """The removed plugin's own identities are stripped from all three keys."""
+
+    def test_flat_plugin_cleared_from_enabled_disabled_and_entries(self, plugin_env):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["solo", "bystander"],
+                "disabled": ["solo"],
+                "entries": _grant("solo", "bystander"),
+            },
+        )
+
+        cmd_remove("solo")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == ["bystander"]
+        assert plugins_cfg["disabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+        # An unrelated key we cannot prove anything about is left alone.
+        assert plugins_cfg["entries"]["bystander"]["allow_tool_override"] is True
+
+    def test_distinct_manifest_name_and_leaf_are_cleaned(self, plugin_env):
+        home = plugin_env
+        # Key is path-derived ("tools/relay_dir") while the manifest name is
+        # "nemo_relay"; both forms, plus the bare leaf, can be in config.
+        _install(home, "tools/relay_dir", "nemo_relay")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["tools/relay_dir", "nemo_relay"],
+                "disabled": ["relay_dir"],
+                "entries": _grant("tools/relay_dir", "nemo_relay", "relay_dir"),
+            },
+        )
+
+        cmd_remove("tools/relay_dir")
+
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert plugins_cfg["disabled"] == []
+        assert plugins_cfg["entries"] == {}
+
+    def test_uninstalling_a_never_enabled_plugin_leaves_config_untouched(
+        self, plugin_env
+    ):
+        home = plugin_env
+        _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["bystander"], "disabled": [], "entries": _grant("bystander")}
+        )
+        before = (home / "config.yaml").read_text(encoding="utf-8")
+
+        cmd_remove("solo")
+
+        assert (home / "config.yaml").read_text(encoding="utf-8") == before
+
+
+class TestRemovalOrdering:
+    """Config state is cleaned before the tree is deleted."""
+
+    def test_config_write_failure_leaves_the_plugin_installed(
+        self, plugin_env, monkeypatch
+    ):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+
+        def _boom(*_args, **_kwargs):
+            raise OSError("config volume is read-only")
+
+        monkeypatch.setattr("hermes_cli.config.save_config", _boom)
+
+        with pytest.raises(OSError):
+            cmd_remove("solo")
+
+        # The tree survives, so the operator can retry rather than being left
+        # with a deleted plugin still listed in plugins.enabled.
+        assert plugin_dir.is_dir()
+
+
+class TestDashboardRemoval:
+    """The dashboard entry point cleans the same state as the CLI."""
+
+    def test_dashboard_removal_clears_config_state(self, plugin_env):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["solo"],
+                "disabled": [],
+                "entries": _grant("solo"),
+            },
+        )
+
+        result = dashboard_remove_user_plugin("solo")
+
+        assert result["ok"] is True
+        plugins_cfg = _read_plugins_config(home)
+        assert plugins_cfg["enabled"] == []
+        assert "solo" not in plugins_cfg["entries"]
+        assert not plugin_dir.exists()
+
+    def test_dashboard_removal_spares_flat_plugin_sharing_the_leaf(self, plugin_env):
+        home = plugin_env
+        _install(home, "image_gen/openai", "openai")
+        flat = _install(home, "openai", "openai")
+        _write_plugins_config(
+            home,
+            {
+                "enabled": ["image_gen/openai", "openai"],
+                "disabled": [],
+                "entries": _grant("image_gen/openai", "openai"),
+            },
+        )
+
+        result = dashboard_remove_user_plugin("image_gen/openai")
+
+        assert result["ok"] is True
+        plugins_cfg = _read_plugins_config(home)
+        assert "openai" in plugins_cfg["enabled"]
+        assert plugins_cfg["entries"]["openai"]["allow_tool_override"] is True
+        assert flat.is_dir()
+
+
+class TestManagedMode:
+    """Managed mode keeps main's behaviour: the tree goes, config is not written."""
+
+    def test_managed_install_still_removes_the_tree(self, plugin_env):
+        home = plugin_env
+        plugin_dir = _install(home, "solo", "solo")
+        _write_plugins_config(
+            home, {"enabled": ["solo"], "disabled": [], "entries": _grant("solo")}
+        )
+        before = (home / "config.yaml").read_text(encoding="utf-8")
+        # A managed install is laid out by the activation script, which creates
+        # these before anything reads config; ensure_hermes_home() verifies them
+        # rather than creating them under managed mode.
+        for subdir in ("cron", "sessions", "logs", "memories"):
+            (home / subdir).mkdir()
+        (home / ".managed").write_text("", encoding="utf-8")
+
+        cmd_remove("solo")
+
+        # save_config prints the canonical managed error and returns without
+        # writing, so the removal proceeds exactly as it does on main today.
+        assert not plugin_dir.exists()
+        assert (home / "config.yaml").read_text(encoding="utf-8") == before


### PR DESCRIPTION
## What does this PR do?

`hermes plugins uninstall <name>` deletes the plugin tree and leaves **every** trace of the plugin in `config.yaml`. `cmd_remove` ends at `shutil.rmtree(target)` + `_display_removed(...)` with no config mutation at all, and `dashboard_remove_user_plugin` is the same. Two consequences:

1. `plugins.enabled` / `plugins.disabled` still list the plugin, so `hermes plugins list` reports a plugin that is gone from disk as `enabled` — the literal repro in #54336.
2. `plugins.entries.<key>` survives, **including `allow_tool_override: true`**. `PluginContext._tool_override_allowed` (`hermes_cli/plugins.py`) trusts bundled plugins and for every other source requires that grant under `plugins.entries.<plugin_id>`, read by canonical key. So: uninstall a third-party plugin that had been granted built-in-tool override, later install anything at the same canonical key, and it **silently re-acquires the privilege with no new consent prompt**. That grant is written by `_set_plugin_entry_flag`, keyed on the canonical key (`plugin_id = key` in `_resolve_tool_override_grant`) — the same key nothing was cleaning up.

### The invariant already exists in this file — it just isn't applied to the destructive path

`_resolve_plugin_key` is, in its own words, *"the single normalization point so `hermes plugins enable` / `disable` write the same key that `PluginManager` matches against"*. It matches the canonical key or manifest name first, and only then falls back to a bare leaf match — **guarded**:

```python
leaf_matches = [entry[5] for entry in entries if name == entry[5].split("/")[-1]]
if len(leaf_matches) == 1:
    return leaf_matches[0]
return None
```

with the comment *"but only when it resolves to exactly one plugin so we never silently pick the wrong same-named nested plugin."*

Main already refuses to treat a directory leaf as an identity when it is ambiguous. This PR applies that same existing rule on the one path that **deletes** state. No new policy is proposed.

The collision is reachable because keys really are path-derived — `_read_manifest_info` ends with `key = f"{prefix}/{d.name}" if prefix else name`. A namespaced plugin keys on `<prefix>/<dirname>`; a flat plugin keys on its manifest `name`. So `image_gen/openai` and a separate flat plugin whose `plugin.yaml` says `name: openai` coexist with distinct canonical keys and a colliding leaf.

### How ownership is decided

Cleanup is scoped to identities the removed plugin **demonstrably owns**, and ownership comes from the directory being deleted rather than the string the user typed:

- the discovered entry whose directory **is** the removal target supplies the canonical key and the manifest name (this also fixes a case pure name-resolution misses: a flat plugin whose manifest `name` differs from its directory name has a canonical key that `_resolve_plugin_key(<dirname>)` cannot find at all);
- a manifest-name or directory-leaf alias is collected **only** when `_resolve_plugin_key(alias)` maps back to this same plugin **and** the alias is not another installed plugin's canonical key.

This keeps legacy bare-name cleanup working in every case where the alias provably identifies one plugin, and declines only in the case where it belongs to somebody else. Verified against the collision fixture: `leaf_matches` for `openai` is `["openai", "image_gen/openai"]`, so the guard fires and the bystander is spared.

**Managed mode is delegated, not re-implemented.** `save_config` already owns that decision inside `_CONFIG_LOCK` (`if is_managed(): managed_error("save configuration"); return`) — it prints the repo's canonical managed error and returns **without raising**. This PR adds no `is_managed()` branch of its own, and only calls `save_config` when something actually changed. Under managed mode the removal therefore degrades exactly the way every other config write in `hermes_cli` degrades, which preserves today's behaviour: on main a managed uninstall already deletes the tree and touches no config. This is explicitly **not** a managed-mode regression, and no new refusal blocks a removal main allows. There is a test for it.

### Sibling-site coverage (the superset, not a subset)

`grep -rn "rmtree"` over production code returns five plugin-related sites. Both removal paths are covered here; the other three provably do not share the root cause:

| Site | Covered | Why |
| --- | --- | --- |
| `cmd_remove` (`plugins_cmd.py`) | ✅ | CLI `hermes plugins uninstall` / `rm` / `remove` |
| `dashboard_remove_user_plugin` (`plugins_cmd.py`) | ✅ | dashboard removal route (`web_server.py`) |
| `_install_plugin_core` force-reinstall | ➖ | replace-in-place; the plugin stays installed at the same canonical key, so its config state must survive |
| `_clear_plugin_bytecode` | ➖ | deletes `__pycache__` only, not the plugin |
| `plugins/disk-cleanup/` | ➖ | a bundled plugin's own cache cleanup, not plugin removal |

## Related Issue

Fixes #54336

## Supersedes #67811 and #54382 — what each got right

Both prior PRs found the same defect and both hit the same wall. Credit where due:

**#67811** (@ritsuKai2000) had the right *scope* — a shared helper covering `enabled` + `disabled` + `entries` from both entry points, cleaning **before** the tree delete. That ordering point is correct and is **kept here**. Its alias set was `{name.strip("/"), target.name}`, adding the directory leaf unconditionally, which is what the review on `hermes_cli/plugins_cmd.py:702` flagged. It also added its own `is_managed()` check that raised a bare `RuntimeError` out of `cmd_remove` (surfacing as a traceback) and re-implemented a policy `save_config` already enforces; this PR delegates instead.

**#54382** (@liuhao1024) fixed the same bug in narrower scope — `enabled`/`disabled` for the canonical key plus an unconditional bare leaf (`bare = key.split("/")[-1]`), with three further gaps: it never touches `plugins.entries`, so the privilege grant is left behind entirely; it cleans config **after** `shutil.rmtree`, so a failing config write leaves the tree deleted and the config stale; and its tests monkeypatch every helper under test (`_resolve_plugin_key`, `_get_enabled_set`, `_get_disabled_set`, `_save_enabled_set`, `_save_disabled_set`), so they exercise no real config I/O. The tests here drive real `config.yaml` I/O under a temporary `HERMES_HOME` instead.

### Review checklist from #67811

- [x] Keep `plugins.entries` cleanup scoped to the removed plugin's canonical key (and only demonstrably owned legacy keys); do not use an unconditional directory leaf alias.
- [x] Add a namespaced/flat leaf-collision regression that proves the unrelated plugin's enabled state and override grant survive.

## Changes Made

- `hermes_cli/plugins_cmd.py`
  - new `_plugin_removal_identities(target)` — resolves the set of `plugins.*` keys demonstrably owned by the plugin at `target`, using the entry whose directory is the target, plus alias checks through `_resolve_plugin_key`. Returns an empty set if discovery is unavailable, so a removal is never blocked by a filesystem walk (degrading to main's behaviour).
  - new `_remove_plugin_config_state(identities)` — drops those identities from `plugins.enabled`, `plugins.disabled` and `plugins.entries` in a **single** `load_config` / `save_config` pair, and only writes when something actually changed.
  - `cmd_remove` and `dashboard_remove_user_plugin` both call the pair **before** `shutil.rmtree(target)`; the `rmtree` calls themselves are unchanged.
  - `dashboard_remove_user_plugin` docstring corrected — it no longer deletes the tree "only".
- `tests/hermes_cli/test_plugins_cmd_remove.py` (new file) — 9 tests over real `config.yaml` I/O under a temporary `HERMES_HOME`.

## How to Test

```bash
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_plugins_cmd_remove.py -v          # 9 passed
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_plugins_cmd.py -q                 # 39 passed (unchanged)
uv run --with pytest --with pytest-asyncio python3 -m pytest \
  tests/hermes_cli/test_plugin_runtime_disable_gate.py \
  tests/hermes_cli/test_plugins_cmd_enable_disable_nested.py -q   # 14 passed
```

Manual repro of #54336:

1. Install and enable a user plugin, granting the override: `hermes plugins enable <name> --allow-tool-override`.
2. `grep -A6 '^plugins:' ~/.hermes/config.yaml` → the plugin is in `enabled` and has `entries.<key>.allow_tool_override: true`.
3. `hermes plugins uninstall <name>`.
4. Before this PR: both survive, and `hermes plugins list` still shows the plugin as `enabled`. After: both are gone, and a later install at the same key prompts for consent again.

**Every test was verified to fail without the corresponding production behaviour**, in its final file location:

| Production code replaced by | Tests that go red |
| --- | --- |
| unmodified `main` (no cleanup at all) | 6 of 9 |
| the unconditional directory-leaf alias used by both prior PRs | the 2 leaf-collision regressions |
| an own `is_managed()` refusal that raises | the managed-mode test |
| dropping the "only write when changed" guard | the never-enabled no-op test |

The union is all 9, so no test in this file passes vacuously. Against unmodified `main` the collision regressions pass trivially (main cleans nothing, so nothing can be over-cleaned) — which is exactly why the second experiment is reported: it is the one that proves those two tests detect the defect the review named.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — I ran the focused suites listed under "How to Test" (9 + 39 + 14 passed) rather than the full tree, and `ruff check` is clean on both touched files.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.4), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — corrected the `dashboard_remove_user_plugin` docstring; both new helpers are documented
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys (this only removes stale ones)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure `pathlib` / YAML with no platform branches; path comparison is done on `Path.resolve()` on both sides so it is case- and symlink-consistent per platform
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

Searched for other open PRs on this defect by symbol, since PR search matches title/body text only and does not index changed paths: `_remove_plugin_config_state`, `dashboard_remove_user_plugin`, `cmd_remove`, `_read_manifest_info`, `plugins.entries`, `_resolve_plugin_key`, `plugins_cmd.py`, and `54336`. The only PRs on this bug are #67811 and #54382, both superseded here. The other open PRs touching `hermes_cli/plugins_cmd.py` are different concerns in different functions (install subdirectories, symlink handling, install hardening, `cmd_list` load errors, `cmd_toggle` / enable-disable key normalization) and are not duplicated by this change.

One overlap worth flagging for whoever lands second: #54215 wraps `shutil.rmtree` in `dashboard_remove_user_plugin` in a `try/except OSError`. It is an unrelated fix and compatible in intent, but because this PR inserts the config cleanup immediately above that same call, the two do not auto-merge — the resolution is simply to keep both (cleanup, then the guarded `rmtree`). This PR is `MERGEABLE` against `main`; the `rmtree` calls here are left byte-identical to make that resolution as small as possible.
