### PR TITLE
feat(credentials): read-only impact map for env-var credentials

### DIFF
--- a/hermes_cli/credential_impact.py
+++ b/hermes_cli/credential_impact.py
@@ -1,0 +1,302 @@
+"""Read-only credential dependency map.
+
+Answers "what breaks if I rotate or remove this env var?" by cross-
+referencing the provider registry, auxiliary-task config, MCP server
+config, and plugin/platform manifests (``requires_env`` / ``optional_env``)
+for a given env-var NAME.
+
+This is a diagnostic surface only — it never mutates any store. It
+deliberately duplicates a small amount of directory-walking logic from
+``hermes_cli.plugins`` instead of driving ``PluginManager.discover_and_load``,
+because that path imports and executes plugin modules; this module must
+stay side-effect-free so it is safe to run before deciding whether to
+rotate or remove a credential.
+
+Secrecy contract (same as ``credential_lifecycle.py``): no function here
+logs, prints, or returns a credential VALUE — only var NAMES and config
+PATHS.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+__all__ = ["CredentialImpact", "compute_impact", "credentials_command"]
+
+# Plugin categories with their own discovery system (see plugins.py
+# module docstring) — mirrors the skip-list PluginManager._scan_directory
+# call sites use for the top-level bundled scan.
+_OWN_DISCOVERY_CATEGORIES = frozenset(
+    {"memory", "context_engine", "platforms", "model-providers"}
+)
+
+
+@dataclass
+class CredentialImpact:
+    """Cross-referenced consumers of a single env-var NAME."""
+
+    var: str
+    declared_in_env: bool = False
+    providers: List[str] = field(default_factory=list)
+    auxiliary_tasks: List[str] = field(default_factory=list)
+    mcp_servers: List[str] = field(default_factory=list)
+    platforms: List[str] = field(default_factory=list)
+    plugins: List[str] = field(default_factory=list)
+
+    @property
+    def is_empty(self) -> bool:
+        return not (
+            self.declared_in_env
+            or self.providers
+            or self.auxiliary_tasks
+            or self.mcp_servers
+            or self.platforms
+            or self.plugins
+        )
+
+
+def _providers_for_var(var: str) -> List[str]:
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY
+    except Exception:
+        return []
+    hits: List[str] = []
+    for provider_id, cfg in PROVIDER_REGISTRY.items():
+        try:
+            if var in (cfg.api_key_env_vars or ()):
+                hits.append(provider_id)
+        except Exception:
+            continue
+    return sorted(hits)
+
+
+def _auxiliary_tasks_for_providers(
+    providers: List[str], config: Dict[str, Any]
+) -> List[str]:
+    """Auxiliary tasks whose resolved provider is in ``providers``.
+
+    A task without its own ``provider`` override falls back to the main
+    ``model.provider`` (mirrors ``agent.auxiliary_client`` resolution).
+    """
+    if not providers:
+        return []
+    aux = config.get("auxiliary")
+    if not isinstance(aux, dict):
+        return []
+    provider_set = set(providers)
+    main_provider = str((config.get("model") or {}).get("provider") or "").strip().lower()
+    hits: List[str] = []
+    for task, task_cfg in aux.items():
+        if not isinstance(task_cfg, dict):
+            continue
+        task_provider = str(task_cfg.get("provider") or main_provider).strip().lower()
+        if task_provider in provider_set:
+            hits.append(task)
+    return sorted(hits)
+
+
+def _mcp_servers_for_var(var: str, config: Dict[str, Any]) -> List[str]:
+    """MCP servers whose ``env:`` block declares this var NAME.
+
+    Only catches explicit ``env:`` bindings — a server that inherits the
+    var through the safe-env passthrough (see ``tools.mcp_tool._build_safe_env``)
+    without naming it is not detectable from config alone.
+    """
+    mcp_cfg = config.get("mcp")
+    servers = mcp_cfg.get("servers") if isinstance(mcp_cfg, dict) else None
+    if not isinstance(servers, dict):
+        return []
+    hits: List[str] = []
+    for name, server_cfg in servers.items():
+        if not isinstance(server_cfg, dict):
+            continue
+        env = server_cfg.get("env")
+        if isinstance(env, dict) and var in env:
+            hits.append(str(name))
+    return sorted(hits)
+
+
+def _manifest_env_names(data: Dict[str, Any]) -> List[str]:
+    names: List[str] = []
+    for section in ("requires_env", "optional_env"):
+        entries = data.get(section)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, str):
+                names.append(entry)
+            elif isinstance(entry, dict) and isinstance(entry.get("name"), str):
+                names.append(entry["name"])
+    return names
+
+
+def _scan_manifest_dir(
+    path: Path, *, skip_top_level: bool = False
+) -> List[Tuple[str, str, Dict[str, Any]]]:
+    """Walk ``plugin.yaml`` manifests under *path* (flat or one category deep).
+
+    Returns ``(key, kind, raw_manifest_dict)`` tuples so callers can
+    inspect ``requires_env``/``optional_env`` directly — mirrors the flat
+    vs. category layout ``PluginManager._scan_directory`` supports, without
+    depending on that private method or on ``PluginManifest`` (which drops
+    ``optional_env``).
+    """
+    from utils import fast_safe_load
+
+    results: List[Tuple[str, str, Dict[str, Any]]] = []
+    if not path.is_dir():
+        return results
+
+    def _read(manifest_file: Path) -> Dict[str, Any]:
+        try:
+            return fast_safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+        except Exception:
+            return {}
+
+    for child in sorted(path.iterdir()):
+        if not child.is_dir():
+            continue
+        if skip_top_level and child.name in _OWN_DISCOVERY_CATEGORIES:
+            continue
+        manifest_file = child / "plugin.yaml"
+        if not manifest_file.exists():
+            manifest_file = child / "plugin.yml"
+        if manifest_file.exists():
+            data = _read(manifest_file)
+            kind = str(data.get("kind", "standalone") or "standalone").strip().lower()
+            key = str(data.get("name", child.name))
+            results.append((key, kind, data))
+            continue
+        # No manifest at this level — treat as a category namespace and
+        # look one level deeper (mirrors PluginManager._scan_directory).
+        for grandchild in sorted(child.iterdir()):
+            if not grandchild.is_dir():
+                continue
+            gc_manifest = grandchild / "plugin.yaml"
+            if not gc_manifest.exists():
+                gc_manifest = grandchild / "plugin.yml"
+            if not gc_manifest.exists():
+                continue
+            data = _read(gc_manifest)
+            kind = str(data.get("kind", "standalone") or "standalone").strip().lower()
+            key = f"{child.name}/{grandchild.name}"
+            results.append((key, kind, data))
+    return results
+
+
+def _platforms_and_plugins_for_var(var: str) -> Tuple[List[str], List[str]]:
+    from hermes_cli.plugins import get_bundled_plugins_dir
+    from hermes_constants import get_hermes_home
+
+    platforms: set = set()
+    plugins: set = set()
+
+    repo_plugins = get_bundled_plugins_dir()
+    scans = [
+        _scan_manifest_dir(repo_plugins, skip_top_level=True),
+        _scan_manifest_dir(repo_plugins / "platforms"),
+        _scan_manifest_dir(get_hermes_home() / "plugins"),
+    ]
+    for manifests in scans:
+        for key, kind, data in manifests:
+            if var not in _manifest_env_names(data):
+                continue
+            if kind == "platform":
+                platforms.add(key)
+            else:
+                plugins.add(key)
+    return sorted(platforms), sorted(plugins)
+
+
+def compute_impact(var: str) -> CredentialImpact:
+    """Compute the read-only dependency map for env-var ``var``."""
+    from hermes_cli.config import load_config_readonly, load_env
+
+    var = var.strip()
+    config = load_config_readonly()
+    providers = _providers_for_var(var)
+    auxiliary_tasks = _auxiliary_tasks_for_providers(providers, config)
+    mcp_servers = _mcp_servers_for_var(var, config)
+    platforms, plugins = _platforms_and_plugins_for_var(var)
+    declared_in_env = var in load_env()
+
+    return CredentialImpact(
+        var=var,
+        declared_in_env=declared_in_env,
+        providers=providers,
+        auxiliary_tasks=auxiliary_tasks,
+        mcp_servers=mcp_servers,
+        platforms=platforms,
+        plugins=plugins,
+    )
+
+
+def _format_human(impact: CredentialImpact) -> str:
+    lines = [f"Credential impact map: {impact.var}"]
+    lines.append(f"  declared in .env: {'yes' if impact.declared_in_env else 'no'}")
+
+    def _section(title: str, items: List[str]) -> None:
+        lines.append(f"  {title} ({len(items)}):")
+        if items:
+            lines.extend(f"    - {item}" for item in items)
+        else:
+            lines.append("    (none)")
+
+    _section("providers", impact.providers)
+    _section("auxiliary tasks", impact.auxiliary_tasks)
+    _section("mcp servers", impact.mcp_servers)
+    _section("platforms", impact.platforms)
+    _section("plugins", impact.plugins)
+
+    if impact.is_empty:
+        lines.append("")
+        lines.append(
+            "  no declared consumer found for this name — could be unused, "
+            "a typo, or a dependency read dynamically from os.environ "
+            "(not covered by static manifest/config scanning)."
+        )
+    return "\n".join(lines)
+
+
+def _format_json(impact: CredentialImpact) -> str:
+    import json
+
+    return json.dumps(
+        {
+            "var": impact.var,
+            "declared_in_env": impact.declared_in_env,
+            "providers": impact.providers,
+            "auxiliary_tasks": impact.auxiliary_tasks,
+            "mcp_servers": impact.mcp_servers,
+            "platforms": impact.platforms,
+            "plugins": impact.plugins,
+        },
+        indent=2,
+    )
+
+
+def credentials_command(args: argparse.Namespace) -> int:
+    """``hermes credentials`` dispatcher."""
+    action = getattr(args, "credentials_action", None)
+    if action != "impact":
+        print(
+            "usage: hermes credentials impact <VAR_NAME> [--json]",
+            file=sys.stderr,
+        )
+        return 1
+
+    var = (getattr(args, "var", "") or "").strip()
+    if not var:
+        print("error: VAR_NAME is required", file=sys.stderr)
+        return 1
+
+    impact = compute_impact(var)
+    if getattr(args, "json", False):
+        print(_format_json(impact))
+    else:
+        print(_format_human(impact))
+    return 0

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -450,6 +450,7 @@ from hermes_cli.subcommands.slack import build_slack_parser
 from hermes_cli.subcommands.login import build_login_parser
 from hermes_cli.subcommands.logout import build_logout_parser
 from hermes_cli.subcommands.auth import build_auth_parser
+from hermes_cli.subcommands.credentials import build_credentials_parser
 from hermes_cli.subcommands.status import build_status_parser
 from hermes_cli.subcommands.webhook import build_webhook_parser
 from hermes_cli.subcommands.hooks import build_hooks_parser
@@ -4569,6 +4570,13 @@ def cmd_auth(args):
     from hermes_cli.auth_commands import auth_command
 
     auth_command(args)
+
+
+def cmd_credentials(args):
+    """Read-only credential dependency map."""
+    from hermes_cli.credential_impact import credentials_command
+
+    return credentials_command(args)
 
 
 def cmd_status(args):
@@ -11474,6 +11482,11 @@ def main():
     # auth command  (parser built in hermes_cli/subcommands/auth.py)
     # =========================================================================
     build_auth_parser(subparsers, cmd_auth=cmd_auth)
+
+    # =========================================================================
+    # credentials command  (parser built in hermes_cli/subcommands/credentials.py)
+    # =========================================================================
+    build_credentials_parser(subparsers, cmd_credentials=cmd_credentials)
 
     # =========================================================================
     # status command  (parser built in hermes_cli/subcommands/status.py)

--- a/hermes_cli/subcommands/credentials.py
+++ b/hermes_cli/subcommands/credentials.py
@@ -1,0 +1,34 @@
+"""``hermes credentials`` subcommand parser.
+
+Read-only credential dependency map — see ``hermes_cli.credential_impact``
+for the implementation. Handler is injected to avoid importing ``main``.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_credentials_parser(subparsers, *, cmd_credentials: Callable) -> None:
+    """Attach the ``credentials`` subcommand to ``subparsers``."""
+    credentials_parser = subparsers.add_parser(
+        "credentials",
+        help="Inspect which providers, tasks, MCP servers, and plugins "
+        "depend on a credential env var",
+    )
+    credentials_subparsers = credentials_parser.add_subparsers(
+        dest="credentials_action"
+    )
+
+    impact = credentials_subparsers.add_parser(
+        "impact",
+        help="Show every declared consumer of an env-var credential",
+    )
+    impact.add_argument(
+        "var", help="Env var name to inspect (for example: OPENAI_API_KEY)"
+    )
+    impact.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON"
+    )
+
+    credentials_parser.set_defaults(func=cmd_credentials)

--- a/tests/hermes_cli/test_credential_impact.py
+++ b/tests/hermes_cli/test_credential_impact.py
@@ -1,0 +1,220 @@
+"""Tests for the read-only credential dependency map (``hermes credentials impact``).
+
+Drives real config/plugin-manifest parsing against isolated fixtures — no
+mocking of the cross-reference logic itself, only of HERMES_HOME and the
+bundled-plugins root so results are deterministic and independent of the
+current repo's plugin roster.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli.credential_impact import compute_impact
+
+
+@pytest.fixture
+def hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / "cred_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+@pytest.fixture
+def bundled_plugins_dir(monkeypatch, tmp_path):
+    root = tmp_path / "bundled_plugins"
+    root.mkdir()
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(root))
+    return root
+
+
+def _write_yaml(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_config(home, text):
+    home.joinpath("config.yaml").write_text(text, encoding="utf-8")
+
+
+def test_provider_env_var_maps_to_provider_id(hermes_home, bundled_plugins_dir):
+    impact = compute_impact("OPENAI_API_KEY")
+    assert "openai-api" in impact.providers
+
+
+def test_unknown_var_is_empty(hermes_home, bundled_plugins_dir):
+    impact = compute_impact("TOTALLY_UNKNOWN_VAR_XYZ")
+    assert impact.is_empty
+
+
+def test_declared_in_env_reflects_dotenv_file(hermes_home, bundled_plugins_dir):
+    hermes_home.joinpath(".env").write_text("MY_TEST_VAR=placeholder\n", encoding="utf-8")
+    impact = compute_impact("MY_TEST_VAR")
+    assert impact.declared_in_env is True
+
+    impact_missing = compute_impact("NEVER_DECLARED_VAR")
+    assert impact_missing.declared_in_env is False
+
+
+def test_auxiliary_task_maps_through_resolved_provider(hermes_home, bundled_plugins_dir):
+    _write_config(
+        hermes_home,
+        """
+model:
+  provider: openai-api
+auxiliary:
+  summarizer:
+    provider: openai-api
+  fallback_only:
+    provider: some-other-provider
+""",
+    )
+    impact = compute_impact("OPENAI_API_KEY")
+    assert impact.auxiliary_tasks == ["summarizer"]
+
+
+def test_auxiliary_task_falls_back_to_main_model_provider(hermes_home, bundled_plugins_dir):
+    _write_config(
+        hermes_home,
+        """
+model:
+  provider: openai-api
+auxiliary:
+  summarizer: {}
+""",
+    )
+    impact = compute_impact("OPENAI_API_KEY")
+    assert impact.auxiliary_tasks == ["summarizer"]
+
+
+def test_mcp_server_env_block_is_detected(hermes_home, bundled_plugins_dir):
+    _write_config(
+        hermes_home,
+        """
+mcp:
+  servers:
+    github:
+      command: npx
+      env:
+        GITHUB_PERSONAL_ACCESS_TOKEN: placeholder
+    filesystem:
+      command: npx
+      env: {}
+""",
+    )
+    impact = compute_impact("GITHUB_PERSONAL_ACCESS_TOKEN")
+    assert impact.mcp_servers == ["github"]
+
+    impact_other = compute_impact("SOME_UNRELATED_VAR")
+    assert impact_other.mcp_servers == []
+
+
+def test_platform_plugin_manifest_requires_env_is_detected(hermes_home, bundled_plugins_dir):
+    _write_yaml(
+        bundled_plugins_dir / "platforms" / "acme" / "plugin.yaml",
+        """
+name: acme-platform
+kind: platform
+requires_env:
+  - name: ACME_BOT_TOKEN
+    description: token
+""",
+    )
+    impact = compute_impact("ACME_BOT_TOKEN")
+    assert impact.platforms == ["acme-platform"]
+    assert impact.plugins == []
+
+
+def test_standalone_plugin_optional_env_is_detected_as_plugin_not_platform(
+    hermes_home, bundled_plugins_dir
+):
+    _write_yaml(
+        bundled_plugins_dir / "disk-cleanup" / "plugin.yaml",
+        """
+name: disk-cleanup
+kind: standalone
+optional_env:
+  - name: DISK_CLEANUP_THRESHOLD
+""",
+    )
+    impact = compute_impact("DISK_CLEANUP_THRESHOLD")
+    assert impact.plugins == ["disk-cleanup"]
+    assert impact.platforms == []
+
+
+def test_category_plugin_env_var_is_detected(hermes_home, bundled_plugins_dir):
+    _write_yaml(
+        bundled_plugins_dir / "image_gen" / "acme" / "plugin.yaml",
+        """
+name: acme-image-gen
+kind: backend
+requires_env:
+  - name: ACME_IMAGE_API_KEY
+""",
+    )
+    impact = compute_impact("ACME_IMAGE_API_KEY")
+    assert impact.plugins == ["image_gen/acme"]
+
+
+def test_own_discovery_categories_are_skipped_at_top_level(hermes_home, bundled_plugins_dir):
+    # memory/ has its own discovery system — the top-level general scan
+    # must not descend into it (mirrors PluginManager's skip_names).
+    _write_yaml(
+        bundled_plugins_dir / "memory" / "acme" / "plugin.yaml",
+        """
+name: acme-memory
+kind: exclusive
+requires_env:
+  - name: ACME_MEMORY_TOKEN
+""",
+    )
+    impact = compute_impact("ACME_MEMORY_TOKEN")
+    assert impact.plugins == []
+    assert impact.platforms == []
+
+
+def test_impact_never_exposes_credential_values(hermes_home, bundled_plugins_dir):
+    hermes_home.joinpath(".env").write_text(
+        "SECRET_SHAPED_VAR=super-secret-value-should-never-appear\n", encoding="utf-8"
+    )
+    impact = compute_impact("SECRET_SHAPED_VAR")
+    dumped = json.dumps(impact.__dict__)
+    assert "super-secret-value-should-never-appear" not in dumped
+
+
+def test_credentials_command_cli_json_output(hermes_home, bundled_plugins_dir, capsys):
+    import argparse
+
+    from hermes_cli.credential_impact import credentials_command
+
+    args = argparse.Namespace(
+        credentials_action="impact", var="OPENAI_API_KEY", json=True
+    )
+    rc = credentials_command(args)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["var"] == "OPENAI_API_KEY"
+    assert "openai-api" in out["providers"]
+
+
+def test_credentials_command_requires_var(hermes_home, bundled_plugins_dir, capsys):
+    import argparse
+
+    from hermes_cli.credential_impact import credentials_command
+
+    args = argparse.Namespace(credentials_action="impact", var="", json=False)
+    rc = credentials_command(args)
+    assert rc == 1
+
+
+def test_credentials_command_unknown_action(hermes_home, bundled_plugins_dir, capsys):
+    import argparse
+
+    from hermes_cli.credential_impact import credentials_command
+
+    args = argparse.Namespace(credentials_action=None)
+    rc = credentials_command(args)
+    assert rc == 1

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -543,6 +543,15 @@ hermes auth spotify                                      # Authenticate Hermes w
 
 Subcommands: `add`, `list`, `remove`, `reset`, `status`, `logout`, `spotify`. When called with no subcommand, launches the interactive management wizard.
 
+## `hermes credentials`
+
+Read-only credential dependency map: shows every declared consumer (providers, auxiliary tasks, MCP servers, platforms, plugins) of an env-var credential, so you can check what a rotation or removal will affect before touching a key. Never prints credential values.
+
+```bash
+hermes credentials impact OPENAI_API_KEY          # Human-readable report
+hermes credentials impact OPENAI_API_KEY --json   # Machine-readable
+```
+
 ## `hermes status`
 
 ```bash


### PR DESCRIPTION
## Summary

Adds `hermes credentials impact <VAR_NAME> [--json]` — a read-only diagnostic that answers "what depends on this credential?" before you rotate or remove it, instead of finding out by trial and error.

It cross-references, for the given env-var **name only** (never the value):

- `hermes_cli.auth.PROVIDER_REGISTRY` → provider id(s) the var backs
- `auxiliary.<task>` config → auxiliary tasks resolved to one of those providers (falls back to `model.provider` when a task has no override)
- `mcp.servers.<name>.env` → MCP servers that declare the var directly
- bundled + user plugin `plugin.yaml` manifests (`requires_env` / `optional_env`) → platforms and other plugins that declare the var

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Credential Var Name] -->|Static Scan| B[Provider Registry]
    A -->|Static Scan| C[Auxiliary Task Config]
    A -->|Static Scan| D[MCP Server Env Blocks]
    A -->|Manifest Scan| E[Plugin & Platform Manifests]
    B -->|Resolves Task Provider| C
    B --> F[Impact Report]
    C --> F
    D --> F
    E --> F
    F -->|Human Text or JSON| G[Safe Abort: No Value Ever Printed]
```

Closes #80163

## Why this doesn't duplicate existing work

- #77188 covers transactional removal/rotation across `.env`/`auth.json`/`config.yaml` — it **mutates** state; this is read-only and answers impact, not atomicity.
- #64243 exposes redacted effective **provenance** (where a value currently resolves from) — this is a static **consumer graph**, a different question.
- The underlying data (`PluginManifest.requires_env`, provider registry, MCP server config) already exists; nothing today cross-references it for a single var.

## Design notes

- Manifest scanning re-implements a small amount of directory-walking instead of driving `PluginManager.discover_and_load()`, because that path imports and executes plugin modules — this command must stay side-effect-free.
- Secrecy contract matches `credential_lifecycle.py`: no function logs, prints, or returns a credential **value** — only var names and config paths.
- Static/declared consumers only. A dynamic `os.environ.get(...)` read that isn't declared in a manifest shows up as "no declared consumer" rather than a silent false negative.
- New CLI wiring follows the existing `hermes_cli/subcommands/<name>.py` + `build_<name>_parser` + `cmd_<name>` pattern (mirrors `auth.py`).

## Test plan

- [x] `pytest tests/hermes_cli/test_credential_impact.py -q` — 14 passing (provider match, auxiliary-task resolution incl. fallback-to-main-provider, MCP env-block match, platform vs. plugin manifest classification, category-plugin match, own-discovery-category skip, `.env` declaration, never-leaks-value, CLI JSON/error paths)
- [x] `pytest tests/hermes_cli/test_credential_lifecycle.py tests/hermes_cli/test_plugins.py -q` — no regressions (54 total passing)
- [x] `ruff check` on new files — clean
- [x] Manual run against the real repo: `hermes credentials impact TELEGRAM_BOT_TOKEN`, `hermes credentials impact OPENAI_API_KEY --json`, unknown var, missing arg — all correct