### PR TITLE
fix(weixin): pass context_token to getuploadurl for media uploads

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -558,21 +558,25 @@ async def _get_upload_url(
     rawfilemd5: str,
     filesize: int,
     aeskey_hex: str,
+    context_token: Optional[str] = None,
 ) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "filekey": filekey,
+        "media_type": media_type,
+        "to_user_id": to_user_id,
+        "rawsize": rawsize,
+        "rawfilemd5": rawfilemd5,
+        "filesize": filesize,
+        "no_need_thumb": True,
+        "aeskey": aeskey_hex,
+    }
+    if context_token:
+        payload["context_token"] = context_token
     return await _api_post(
         session,
         base_url=base_url,
         endpoint=EP_GET_UPLOAD_URL,
-        payload={
-            "filekey": filekey,
-            "media_type": media_type,
-            "to_user_id": to_user_id,
-            "rawsize": rawsize,
-            "rawfilemd5": rawfilemd5,
-            "filesize": filesize,
-            "no_need_thumb": True,
-            "aeskey": aeskey_hex,
-        },
+        payload=payload,
         token=token,
         timeout_ms=API_TIMEOUT_MS,
     )
@@ -2155,6 +2159,7 @@ class WeixinAdapter(BasePlatformAdapter):
         aes_key = secrets.token_bytes(16)
         rawsize = len(plaintext)
         rawfilemd5 = hashlib.md5(plaintext).hexdigest()
+        context_token = self._token_store.get(self._account_id, chat_id)
         upload_response = await _get_upload_url(
             self._send_session,
             base_url=self._base_url,
@@ -2166,6 +2171,7 @@ class WeixinAdapter(BasePlatformAdapter):
             rawfilemd5=rawfilemd5,
             filesize=_aes_padded_size(rawsize),
             aeskey_hex=aes_key.hex(),
+            context_token=context_token,
         )
         upload_param = str(upload_response.get("upload_param") or "")
         upload_full_url = str(upload_response.get("upload_full_url") or "")
@@ -2186,7 +2192,6 @@ class WeixinAdapter(BasePlatformAdapter):
             ciphertext=ciphertext,
             upload_url=upload_url,
         )
-        context_token = self._token_store.get(self._account_id, chat_id)
         # The iLink API expects aes_key as base64(hex_string), not base64(raw_bytes).
         # Sending base64(raw_bytes) causes images to show as grey boxes on the
         # receiver side because the decryption key doesn't match.


### PR DESCRIPTION
## Bug Description

The Weixin (WeChat) platform adapter can send text messages but **fails to send all images/files** with `CDN upload HTTP 500` (or `getuploadurl` returning `errcode: -14 "session timeout"`).

Text messaging works fine — only media upload is broken.

## Root Cause

In `gateway/platforms/weixin.py`, `_send_file()` calls `_get_upload_url()` **without passing `context_token`**. The WeChat iLink API requires the per-user `context_token` (cached in `~/.hermes/weixin/accounts/<acct>.context-tokens.json`, refreshed on every inbound message) to obtain an upload URL. Without it, `getuploadurl` returns `errcode: -14 "session timeout"` — which is misleading: the bot session is perfectly valid (text send + getconfig both succeed).

Meanwhile `_send_message()` (text) **does** pass `context_token`.

## Reproduction

1. Configure Weixin platform (iLink bot)
2. Send any image to a user
3. Observe: `[Weixin] send_document failed ... CDN upload HTTP 500` in gateway logs

Direct API evidence with the same token:

| Request | Result |
|---------|--------|
| `sendmessage` (text) | ✅ success |
| `getconfig` | ✅ success |
| `getuploadurl` without `context_token` | ❌ `errcode: -14 "session timeout"` |
| `getuploadurl` with `context_token` | ✅ returns `upload_full_url` |

## Fix

- `_get_upload_url()` accepts an optional `context_token` and includes it in the `getUploadUrl` request payload when present
- `_send_file()` fetches the peer's `context_token` before requesting the upload URL and passes it through

## Verification

Verified end-to-end against a live Weixin account: `getuploadurl` → AES-128-ECB encrypt → CDN POST → `sendmessage` returns `message_id` and the image is delivered to the recipient's WeChat.

## Environment

- Hermes Agent v0.19.0 (2026.7.20)
- Docker image, Weixin platform (iLink)
