### PR TITLE
feat(kanban): expose the per-task reasoning effort on the CLI

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -56,6 +56,20 @@ def _fmt_task_line(t: kb.Task) -> str:
     return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
 
 
+def _effort_choices(*extra: str) -> tuple[str, ...]:
+    """Valid ``--effort`` values for argparse ``choices``.
+
+    Derived from the same ``VALID_REASONING_EFFORTS`` constant that
+    ``kanban_db.normalize_reasoning_effort`` validates against, so the CLI
+    enum can never drift from the storage layer. ``"none"`` is a real level
+    (thinking off), not a clear. ``extra`` appends command-specific
+    sentinels (e.g. ``"clear"`` on ``set-model``).
+    """
+    from hermes_constants import VALID_REASONING_EFFORTS
+
+    return ("none", *VALID_REASONING_EFFORTS, *extra)
+
+
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     return {
         "id": t.id,
@@ -78,6 +92,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "reasoning_effort": t.reasoning_effort,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -380,6 +395,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Provider the --model belongs to (passed as "
                                "--provider <name> to the worker). Requires "
                                "--model.")
+    p_create.add_argument("--effort", default=None, dest="reasoning_effort",
+                          type=str.lower, choices=_effort_choices(),
+                          help="Pin the worker's reasoning effort for this "
+                               "task (passed as --reasoning <level>). "
+                               "'none' disables thinking. Independent of "
+                               "--model; omit to inherit the assignee "
+                               "profile's own agent.reasoning_effort.")
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -478,10 +500,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_assign.add_argument("task_id")
     p_assign.add_argument("profile", help="Profile name (or 'none' to unassign)")
 
-    # --- set-model (per-task model/provider override) ---
+    # --- set-model (per-task model/provider/effort override) ---
     p_set_model = sub.add_parser(
         "set-model",
-        help="Set or clear a task's model/provider override "
+        help="Set or clear a task's model/provider/effort override "
              "(takes effect on the next dispatch)",
     )
     p_set_model.add_argument("task_id")
@@ -493,6 +515,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--provider", default=None,
         help="Provider the model belongs to (worker is spawned with "
              "--provider <name>). Cleared together with the model.",
+    )
+    p_set_model.add_argument(
+        "--effort", default=None, dest="reasoning_effort",
+        type=str.lower, choices=_effort_choices("clear"),
+        help="Per-task reasoning effort (worker is spawned with "
+             "--reasoning <level>). 'none' is a real level — thinking "
+             "off; 'clear' resets to the assignee profile's own "
+             "agent.reasoning_effort. Independent of the model: with "
+             "--effort alone the model override is left untouched, and "
+             "clearing the model never resets the effort.",
     )
 
     # --- reclaim / reassign (recovery) ---
@@ -1583,6 +1615,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
+            reasoning_effort=getattr(args, "reasoning_effort", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
@@ -1762,6 +1795,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
     if task.model_override:
         _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
         print(f"  model:     {task.model_override}{_prov}")
+    if task.reasoning_effort:
+        print(f"  effort:    {task.reasoning_effort}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see
@@ -1874,22 +1909,50 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
     if model is not None and model.lower() in {"none", "-", "null", ""}:
         model = None
     provider = getattr(args, "provider", None)
+    effort = getattr(args, "reasoning_effort", None)
+    # The two knobs are independent: with --effort and no positional model
+    # the model override is left untouched (absent means "unchanged" here,
+    # not "clear"). Without --effort the historical contract holds — a
+    # missing or 'none' positional clears the model/provider override.
+    touch_model = args.model is not None or effort is None
+    if provider and not touch_model:
+        print("kanban: --provider requires a model", file=sys.stderr)
+        return 2
     try:
         with kb.connect_closing() as conn:
-            ok = kb.set_model_override(conn, args.task_id, model, provider=provider)
+            if touch_model:
+                ok = kb.set_model_override(
+                    conn, args.task_id, model, provider=provider,
+                )
+                if not ok:
+                    print(f"no such task: {args.task_id}", file=sys.stderr)
+                    return 1
+            if effort is not None:
+                ok = kb.set_reasoning_effort(
+                    conn, args.task_id,
+                    None if effort == "clear" else effort,
+                )
+                if not ok:
+                    print(f"no such task: {args.task_id}", file=sys.stderr)
+                    return 1
     except (ValueError, RuntimeError) as exc:
         print(f"kanban: {exc}", file=sys.stderr)
         return 2
-    if not ok:
-        print(f"no such task: {args.task_id}", file=sys.stderr)
-        return 1
-    if model:
-        label = f"{provider}:{model}" if provider else model
-        print(f"Set model override on {args.task_id}: {label} "
-              "(applies on next dispatch)")
-    else:
-        print(f"Cleared model override on {args.task_id} "
-              "(worker uses its profile default)")
+    if touch_model:
+        if model:
+            label = f"{provider}:{model}" if provider else model
+            print(f"Set model override on {args.task_id}: {label} "
+                  "(applies on next dispatch)")
+        else:
+            print(f"Cleared model override on {args.task_id} "
+                  "(worker uses its profile default)")
+    if effort is not None:
+        if effort == "clear":
+            print(f"Cleared reasoning effort on {args.task_id} "
+                  "(worker uses its profile's agent.reasoning_effort)")
+        else:
+            print(f"Set reasoning effort on {args.task_id}: {effort} "
+                  "(applies on next dispatch)")
     return 0
 
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -56,6 +56,20 @@ def _fmt_task_line(t: kb.Task) -> str:
     return f"{icon} {t.id}  {t.status:8s}  {assignee:20s}{tenant}  {t.title}"
 
 
+def _effort_choices(*extra: str) -> tuple[str, ...]:
+    """Valid ``--effort`` values for argparse ``choices``.
+
+    Derived from the same ``VALID_REASONING_EFFORTS`` constant that
+    ``kanban_db.normalize_reasoning_effort`` validates against, so the CLI
+    enum can never drift from the storage layer. ``"none"`` is a real level
+    (thinking off), not a clear. ``extra`` appends command-specific
+    sentinels (e.g. ``"clear"`` on ``set-model``).
+    """
+    from hermes_constants import VALID_REASONING_EFFORTS
+
+    return ("none", *VALID_REASONING_EFFORTS, *extra)
+
+
 def _task_to_dict(t: kb.Task) -> dict[str, Any]:
     return {
         "id": t.id,
@@ -78,6 +92,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "reasoning_effort": t.reasoning_effort,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,
@@ -380,6 +395,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Provider the --model belongs to (passed as "
                                "--provider <name> to the worker). Requires "
                                "--model.")
+    p_create.add_argument("--effort", default=None, dest="reasoning_effort",
+                          type=str.lower, choices=_effort_choices(),
+                          help="Pin the worker's reasoning effort for this "
+                               "task (passed as --reasoning <level>). "
+                               "'none' disables thinking. Independent of "
+                               "--model; omit to inherit the assignee "
+                               "profile's own agent.reasoning_effort.")
     p_create.add_argument("--goal", action="store_true", dest="goal_mode",
                           help="Run the worker in a goal loop: after each "
                                "turn a judge checks the response against the "
@@ -478,10 +500,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_assign.add_argument("task_id")
     p_assign.add_argument("profile", help="Profile name (or 'none' to unassign)")
 
-    # --- set-model (per-task model/provider override) ---
+    # --- set-model (per-task model/provider/effort override) ---
     p_set_model = sub.add_parser(
         "set-model",
-        help="Set or clear a task's model/provider override "
+        help="Set or clear a task's model/provider/effort override "
              "(takes effect on the next dispatch)",
     )
     p_set_model.add_argument("task_id")
@@ -493,6 +515,16 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--provider", default=None,
         help="Provider the model belongs to (worker is spawned with "
              "--provider <name>). Cleared together with the model.",
+    )
+    p_set_model.add_argument(
+        "--effort", default=None, dest="reasoning_effort",
+        type=str.lower, choices=_effort_choices("clear"),
+        help="Per-task reasoning effort (worker is spawned with "
+             "--reasoning <level>). 'none' is a real level — thinking "
+             "off; 'clear' resets to the assignee profile's own "
+             "agent.reasoning_effort. Independent of the model: with "
+             "--effort alone the model override is left untouched, and "
+             "clearing the model never resets the effort.",
     )
 
     # --- reclaim / reassign (recovery) ---
@@ -1516,6 +1548,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_retries=max_retries,
             model_override=getattr(args, "model_override", None),
             provider_override=getattr(args, "provider_override", None),
+            reasoning_effort=getattr(args, "reasoning_effort", None),
             goal_mode=bool(getattr(args, "goal_mode", False)),
             goal_max_turns=getattr(args, "goal_max_turns", None),
             initial_status=getattr(args, "initial_status", "running"),
@@ -1692,6 +1725,8 @@ def _cmd_show(args: argparse.Namespace) -> int:
     if task.model_override:
         _prov = f" (provider: {task.provider_override})" if task.provider_override else ""
         print(f"  model:     {task.model_override}{_prov}")
+    if task.reasoning_effort:
+        print(f"  effort:    {task.reasoning_effort}")
     # Effective retry threshold. Show the per-task override if set,
     # otherwise the dispatcher's resolved value from config (or the
     # default if config doesn't set it either). Helps operators see
@@ -1804,22 +1839,50 @@ def _cmd_set_model(args: argparse.Namespace) -> int:
     if model is not None and model.lower() in {"none", "-", "null", ""}:
         model = None
     provider = getattr(args, "provider", None)
+    effort = getattr(args, "reasoning_effort", None)
+    # The two knobs are independent: with --effort and no positional model
+    # the model override is left untouched (absent means "unchanged" here,
+    # not "clear"). Without --effort the historical contract holds — a
+    # missing or 'none' positional clears the model/provider override.
+    touch_model = args.model is not None or effort is None
+    if provider and not touch_model:
+        print("kanban: --provider requires a model", file=sys.stderr)
+        return 2
     try:
         with kb.connect_closing() as conn:
-            ok = kb.set_model_override(conn, args.task_id, model, provider=provider)
+            if touch_model:
+                ok = kb.set_model_override(
+                    conn, args.task_id, model, provider=provider,
+                )
+                if not ok:
+                    print(f"no such task: {args.task_id}", file=sys.stderr)
+                    return 1
+            if effort is not None:
+                ok = kb.set_reasoning_effort(
+                    conn, args.task_id,
+                    None if effort == "clear" else effort,
+                )
+                if not ok:
+                    print(f"no such task: {args.task_id}", file=sys.stderr)
+                    return 1
     except (ValueError, RuntimeError) as exc:
         print(f"kanban: {exc}", file=sys.stderr)
         return 2
-    if not ok:
-        print(f"no such task: {args.task_id}", file=sys.stderr)
-        return 1
-    if model:
-        label = f"{provider}:{model}" if provider else model
-        print(f"Set model override on {args.task_id}: {label} "
-              "(applies on next dispatch)")
-    else:
-        print(f"Cleared model override on {args.task_id} "
-              "(worker uses its profile default)")
+    if touch_model:
+        if model:
+            label = f"{provider}:{model}" if provider else model
+            print(f"Set model override on {args.task_id}: {label} "
+                  "(applies on next dispatch)")
+        else:
+            print(f"Cleared model override on {args.task_id} "
+                  "(worker uses its profile default)")
+    if effort is not None:
+        if effort == "clear":
+            print(f"Cleared reasoning effort on {args.task_id} "
+                  "(worker uses its profile's agent.reasoning_effort)")
+        else:
+            print(f"Set reasoning effort on {args.task_id}: {effort} "
+                  "(applies on next dispatch)")
     return 0
 
 

--- a/tests/hermes_cli/test_kanban_effort_cli.py
+++ b/tests/hermes_cli/test_kanban_effort_cli.py
@@ -1,0 +1,253 @@
+"""CLI surface for the per-task reasoning effort (``--effort``).
+
+The DB layer (``tasks.reasoning_effort``, ``set_reasoning_effort``), the
+dispatcher passthrough (``--reasoning <level>``), and the dashboard REST
+surface are covered by ``tests/plugins/test_kanban_model_override.py``.
+This file covers the operator-facing CLI that drives them:
+
+  * ``create --effort <level>`` persists (and rejects unknown levels).
+  * ``set-model <id> --effort <level>`` sets the depth WITHOUT touching an
+    existing model override (the independence contract).
+  * ``set-model <id> --effort none`` pins thinking OFF (a value, not a clear).
+  * ``set-model <id> --effort clear`` resets to the profile default.
+  * ``set-model <id> none`` (model clear) leaves the effort intact.
+  * ``show`` renders the effort line only when set; ``--json`` carries the
+    field; ``list --json`` carries it too.
+  * end-to-end: a CLI-set effort lands in the dispatcher's spawn argv.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _created_id(out: str) -> str:
+    import re
+
+    m = re.search(r"(t_[a-f0-9]+)", out)
+    assert m, f"no task id in output: {out!r}"
+    return m.group(1)
+
+
+# ---------------------------------------------------------------------------
+# create --effort
+# ---------------------------------------------------------------------------
+
+
+def test_create_with_effort_persists(kanban_home):
+    out = kc.run_slash("create 'deep task' --assignee coder --effort xhigh")
+    tid = _created_id(out)
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).reasoning_effort == "xhigh"
+
+
+def test_create_effort_uppercase_normalized(kanban_home):
+    """argparse lowercases via type=str.lower before the choices check."""
+    out = kc.run_slash("create 'deep task' --assignee coder --effort XHIGH")
+    tid = _created_id(out)
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).reasoning_effort == "xhigh"
+
+
+def test_create_rejects_unknown_effort(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder --effort turbo")
+    assert "usage error" in out or "invalid choice" in out
+    # Nothing was created.
+    with kb.connect() as conn:
+        assert kb.list_tasks(conn) == []
+
+
+def test_create_without_effort_is_null(kanban_home):
+    out = kc.run_slash("create 'plain' --assignee coder")
+    tid = _created_id(out)
+    with kb.connect() as conn:
+        raw = conn.execute(
+            "SELECT reasoning_effort FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+    assert raw["reasoning_effort"] is None
+
+
+# ---------------------------------------------------------------------------
+# set-model --effort — set / none / clear / independence
+# ---------------------------------------------------------------------------
+
+
+def test_set_effort_alone_leaves_model_untouched(kanban_home):
+    out = kc.run_slash(
+        "create 'opus task' --assignee coder "
+        "--model claude-opus-4.6 --provider anthropic"
+    )
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} --effort xhigh")
+    assert "Set reasoning effort" in res
+    assert "model override" not in res  # the model knob was not touched
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.reasoning_effort == "xhigh"
+    assert t.model_override == "claude-opus-4.6"
+    assert t.provider_override == "anthropic"
+
+
+def test_set_effort_none_is_a_value(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} --effort none")
+    assert "Set reasoning effort" in res
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).reasoning_effort == "none"
+
+
+def test_set_effort_clear_resets_to_profile(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder --effort high")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} --effort clear")
+    assert "Cleared reasoning effort" in res
+    with kb.connect() as conn:
+        raw = conn.execute(
+            "SELECT reasoning_effort FROM tasks WHERE id = ?", (tid,)
+        ).fetchone()
+    assert raw["reasoning_effort"] is None  # genuine NULL, not "clear"/"none"
+
+
+def test_clearing_model_keeps_effort(kanban_home):
+    out = kc.run_slash(
+        "create 'x' --assignee coder --model glm-5 --effort max"
+    )
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} none")
+    assert "Cleared model override" in res
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.model_override is None
+    assert t.reasoning_effort == "max"
+
+
+def test_set_model_and_effort_together(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} claude-opus-4.6 --effort high")
+    assert "Set model override" in res
+    assert "Set reasoning effort" in res
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.model_override == "claude-opus-4.6"
+    assert t.reasoning_effort == "high"
+
+
+def test_set_model_without_effort_still_clears(kanban_home):
+    """The historical contract: bare ``set-model <id>`` clears the model."""
+    out = kc.run_slash("create 'x' --assignee coder --model glm-5")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid}")
+    assert "Cleared model override" in res
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).model_override is None
+
+
+def test_set_effort_rejects_unknown_level(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder --effort high")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} --effort turbo")
+    assert "usage error" in res or "invalid choice" in res
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).reasoning_effort == "high"  # unchanged
+
+
+def test_set_effort_nonexistent_task(kanban_home):
+    res = kc.run_slash("set-model t_nope --effort high")
+    assert "no such task" in res
+
+
+def test_provider_with_effort_but_no_model_rejected(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder")
+    tid = _created_id(out)
+    res = kc.run_slash(f"set-model {tid} --provider anthropic --effort high")
+    assert "--provider requires a model" in res
+    with kb.connect() as conn:
+        t = kb.get_task(conn, tid)
+    assert t.provider_override is None
+    assert t.reasoning_effort is None  # rejected before any write
+
+
+# ---------------------------------------------------------------------------
+# show / json output
+# ---------------------------------------------------------------------------
+
+
+def test_show_renders_effort_line(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder --effort xhigh")
+    tid = _created_id(out)
+    show = kc.run_slash(f"show {tid}")
+    assert "effort:" in show
+    assert "xhigh" in show
+
+
+def test_show_omits_effort_line_when_unset(kanban_home):
+    out = kc.run_slash("create 'plain' --assignee coder")
+    tid = _created_id(out)
+    show = kc.run_slash(f"show {tid}")
+    assert "effort:" not in show
+
+
+def test_show_json_carries_reasoning_effort(kanban_home):
+    out = kc.run_slash("create 'x' --assignee coder --effort minimal")
+    tid = _created_id(out)
+    payload = json.loads(kc.run_slash(f"show {tid} --json"))
+    assert payload["task"]["reasoning_effort"] == "minimal"
+
+
+def test_list_json_carries_reasoning_effort(kanban_home):
+    kc.run_slash("create 'x' --assignee coder --effort low")
+    rows = json.loads(kc.run_slash("list --json"))
+    assert any(row.get("reasoning_effort") == "low" for row in rows)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: CLI write → store → reload → dispatcher spawn argv
+# ---------------------------------------------------------------------------
+
+
+def test_cli_set_effort_reaches_spawn_argv(kanban_home, monkeypatch):
+    import subprocess
+
+    out = kc.run_slash("create 'x' --assignee coder")
+    tid = _created_id(out)
+    kc.run_slash(f"set-model {tid} --effort xhigh")
+
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.reasoning_effort == "xhigh"
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4247
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = kanban_home / "ws"
+    workspace.mkdir(exist_ok=True)
+    kb._default_spawn(task, str(workspace))
+    cmd = captured["cmd"]
+    i = cmd.index("--reasoning")
+    assert cmd[i + 1] == "xhigh"

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -499,6 +499,22 @@ model:
 
 For the occasional quality-sensitive card, pin just that task back to a stronger model with the [per-task model override](#per-task-model-override) (`--model`/`--provider` at create time, `hermes kanban set-model` later, or the dashboard's model dropdown) — no profile edits needed.
 
+### Per-task reasoning effort
+
+Pin how hard a task's worker thinks, independent of both the model override and the assignee profile's `agent.reasoning_effort`:
+
+```bash
+# At creation
+hermes kanban create "hard refactor" --assignee coder --effort xhigh
+
+# Or later — takes effect on the next dispatch
+hermes kanban set-model t_abcd --effort xhigh
+hermes kanban set-model t_abcd --effort none     # thinking OFF (a real level, not a clear)
+hermes kanban set-model t_abcd --effort clear    # back to the profile's own setting
+```
+
+Levels: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. The dispatcher spawns the worker with `--reasoning <level>`, which overrides the profile's `agent.reasoning_effort` for that run only — the runtime maps the abstract level onto whatever the model's wire format expects. The two knobs are deliberately independent: `set-model <id> --effort xhigh` leaves an existing model override untouched, and clearing the model (`set-model <id> none`) never resets the effort.
+
 ### Lifecycle plugin hooks
 
 Board transitions fire [plugin hooks](/user-guide/features/hooks#plugin-hooks): `kanban_task_claimed`, `kanban_task_completed`, and `kanban_task_blocked`, each carrying `task_id` and `profile_name`. Hooks fire **after** the board DB change commits, so callbacks always see durable state. Note the process split: `kanban_task_claimed` fires in the **dispatcher** process, while `kanban_task_completed`/`kanban_task_blocked` fire in the **worker** process — register the hook in the dispatcher profile to observe every transition centrally.

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -473,6 +473,22 @@ hermes kanban set-model t_abcd none    # clear the override
 
 The dispatcher spawns the worker with the pinned model (`--provider <name>` is passed when set; `--provider` requires a model). The dashboard's per-task model dropdown drives the same `model_override` field. With no override, the worker uses its profile's configured model.
 
+### Per-task reasoning effort
+
+Pin how hard a task's worker thinks, independent of both the model override and the assignee profile's `agent.reasoning_effort`:
+
+```bash
+# At creation
+hermes kanban create "hard refactor" --assignee coder --effort xhigh
+
+# Or later — takes effect on the next dispatch
+hermes kanban set-model t_abcd --effort xhigh
+hermes kanban set-model t_abcd --effort none     # thinking OFF (a real level, not a clear)
+hermes kanban set-model t_abcd --effort clear    # back to the profile's own setting
+```
+
+Levels: `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. The dispatcher spawns the worker with `--reasoning <level>`, which overrides the profile's `agent.reasoning_effort` for that run only — the runtime maps the abstract level onto whatever the model's wire format expects. The two knobs are deliberately independent: `set-model <id> --effort xhigh` leaves an existing model override untouched, and clearing the model (`set-model <id> none`) never resets the effort.
+
 ### Lifecycle plugin hooks
 
 Board transitions fire [plugin hooks](/user-guide/features/hooks#plugin-hooks): `kanban_task_claimed`, `kanban_task_completed`, and `kanban_task_blocked`, each carrying `task_id` and `profile_name`. Hooks fire **after** the board DB change commits, so callbacks always see durable state. Note the process split: `kanban_task_claimed` fires in the **dispatcher** process, while `kanban_task_completed`/`kanban_task_blocked` fire in the **worker** process — register the hook in the dispatcher profile to observe every transition centrally.


### PR DESCRIPTION
## What

Operator CLI for the per-task reasoning effort that 0b69a6ac0 (`feat(kanban): let a task pin its own thinking depth`) added at the DB/spawn layer and f0ed0aebb exposed over REST. Until now the depth was only settable from the dashboard — `hermes kanban` had no flag for it.

- `create --effort <level>` — pin the depth at creation. Choices are derived from `hermes_constants.VALID_REASONING_EFFORTS` plus `none`, the same constant `kanban_db.normalize_reasoning_effort` validates against, so the CLI enum can't drift from the storage layer.
- `set-model <id> --effort <level>` — set the depth later (takes effect on the next dispatch, same as the model override). An extra `clear` sentinel resets to the profile's own `agent.reasoning_effort`.
- `show` renders an `effort:` line when set; `show --json` / `list --json` carry `reasoning_effort` (the dashboard task dict already did).
- Docs: a "Per-task reasoning effort" section next to the model-override section in `website/docs/user-guide/features/kanban.md`.

## Clear semantics (matches the DB layer's documented contract)

The two knobs are independent, exactly as `set_reasoning_effort`'s docstring specifies:

- `set-model <id> --effort xhigh` (no positional model) leaves an existing model override **untouched**. The positional model is only interpreted as "clear the model" when `--effort` is absent — so the historical bare `set-model <id>` / `set-model <id> none` behavior is byte-identical.
- `set-model <id> none` (model clear) never resets the effort.
- `--effort none` is a real level (thinking OFF); `--effort clear` is the reset.
- `--provider` together with `--effort` but no model is rejected before any write (partial-write safety).

## Verification

18 new tests in `tests/hermes_cli/test_kanban_effort_cli.py` via `run_slash` (the same entry the CLI and gateway share): create/set/none/clear, independence both directions, unknown-level rejection, nonexistent-task, show/json surfaces, and an end-to-end CLI-write → SQLite → reload → `--reasoning xhigh` spawn-argv round-trip.

RED-proof: with the `hermes_cli/kanban.py` change stashed, 14 of the 18 fail (the 4 that pass assert pre-existing DB-layer behavior reachable without the new flags).

Neighbor suites green: `test_kanban_cli`, `test_kanban_cli_dispatch_passthrough`, `test_kanban_model_override` (the file that covers 0b69a6ac0/f0ed0aebb), `test_kanban_core_functionality`, `test_kanban_db`, `test_kanban_db_init` — 97 passed, 1 skipped.
