### PR TITLE
fix(ssh): expose synced cache paths to agents

### DIFF
--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -422,6 +422,37 @@ class TestMapCachePathToContainer:
 
 
 class TestToAgentVisibleCachePath:
+    def test_local_backend_keeps_host_path(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / ".hermes"
+        doc_dir = hermes_home / "cache" / "documents"
+        doc_dir.mkdir(parents=True)
+        host_path = doc_dir / "report.pdf"
+        host_path.write_bytes(b"%PDF-1.7")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+
+        assert to_agent_visible_cache_path(str(host_path)) == str(host_path)
+
+    @pytest.mark.parametrize(
+        ("container_base", "expected"),
+        [
+            ("/root/.hermes", "/root/.hermes/cache/documents/report.pdf"),
+            ("/custom/.hermes", "/custom/.hermes/cache/documents/report.pdf"),
+        ],
+    )
+    def test_docker_backend_preserves_default_and_custom_bases(
+        self, tmp_path, monkeypatch, container_base, expected
+    ):
+        hermes_home = tmp_path / ".hermes"
+        doc_dir = hermes_home / "cache" / "documents"
+        doc_dir.mkdir(parents=True)
+        host_path = doc_dir / "report.pdf"
+        host_path.write_bytes(b"%PDF-1.7")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+        assert to_agent_visible_cache_path(str(host_path), container_base) == expected
+
     def test_ssh_maps_profile_cache_to_remote_hermes_home(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "profiles" / "workbot"
         doc_dir = hermes_home / "cache" / "documents"

--- a/tests/tools/test_credential_files.py
+++ b/tests/tools/test_credential_files.py
@@ -16,6 +16,7 @@ from tools.credential_files import (
     map_cache_path_to_container,
     register_credential_file,
     register_credential_files,
+    to_agent_visible_cache_path,
 )
 
 
@@ -418,6 +419,22 @@ class TestMapCachePathToContainer:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
 
         assert map_cache_path_to_container(str(hermes_home / "cache" / "images" / "x.png")) is None
+
+
+class TestToAgentVisibleCachePath:
+    def test_ssh_maps_profile_cache_to_remote_hermes_home(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "profiles" / "workbot"
+        doc_dir = hermes_home / "cache" / "documents"
+        doc_dir.mkdir(parents=True)
+        host_path = doc_dir / "report.pdf"
+        host_path.write_bytes(b"%PDF-1.7")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+        assert (
+            to_agent_visible_cache_path(str(host_path))
+            == "~/.hermes/cache/documents/report.pdf"
+        )
 
 
 class TestIterCacheFiles:

--- a/tests/tools/test_file_sync.py
+++ b/tests/tools/test_file_sync.py
@@ -11,7 +11,23 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tools.credential_files import to_agent_visible_cache_path
 from tools.environments.file_sync import FileSyncManager, _FORCE_SYNC_ENV, iter_sync_files
+
+
+def test_ssh_agent_path_matches_file_sync_destination(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "profiles" / "workbot"
+    doc_dir = hermes_home / "cache" / "documents"
+    doc_dir.mkdir(parents=True)
+    host_path = doc_dir / "report.pdf"
+    host_path.write_bytes(b"%PDF-1.7")
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+
+    sync_targets = dict(iter_sync_files("~/.hermes"))
+
+    assert str(host_path) in sync_targets
+    assert to_agent_visible_cache_path(str(host_path)) == sync_targets[str(host_path)]
 
 
 @pytest.fixture

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -479,20 +479,21 @@ def to_agent_visible_cache_path(
     host_path: str,
     container_base: str = "/root/.hermes",
 ) -> str:
-    """Translate a host cache path to its mounted path inside the sandbox.
+    """Translate a host cache path to the active backend's visible cache path.
 
-    Returns the input unchanged if it is not under any auto-mounted cache
-    directory, or if the active terminal backend does not require path
-    translation (only Docker for now).
+    Docker bind-mounts caches under ``container_base``. SSH mirrors the active
+    profile's cache files under the remote user's ``~/.hermes`` directory.
+    Unsupported/local backends keep the gateway-local path unchanged.
     """
-    # Only Docker backend requires translation at this time.  Other backends
-    # (Modal, Daytona, Vercel) use different mount semantics and will be
-    # addressed separately if needed.  Backend is identified by TERMINAL_ENV
-    # (same env var tools/terminal_tool.py reads in _get_environment_config).
-    if os.environ.get("TERMINAL_ENV", "local") != "docker":
+    backend = os.environ.get("TERMINAL_ENV", "local")
+    if backend == "docker":
+        target_base = container_base
+    elif backend == "ssh":
+        target_base = "~/.hermes"
+    else:
         return host_path
 
-    mapped = map_cache_path_to_container(host_path, container_base=container_base)
+    mapped = map_cache_path_to_container(host_path, container_base=target_base)
     return mapped if mapped is not None else host_path
 
 


### PR DESCRIPTION
## Summary
- map gateway-local Hermes cache paths to `~/.hermes/cache/...` when the active terminal backend is SSH
- keep local and unsupported backends unchanged and preserve the existing Docker mapping
- pin the path-identity invariant between `to_agent_visible_cache_path()` and `iter_sync_files("~/.hermes")`

## Root cause
Inbound Slack documents are downloaded into the gateway profile cache and mirrored by the SSH file-sync layer into the remote user's `~/.hermes/cache/...` tree. The prompt path translator only handled Docker, so SSH-backed agents were shown the private gateway path even though the bytes already existed on the worker. Terminal and file tools then failed against a path that was not visible in the SSH namespace.

The adapter path remains gateway-local for host-side vision, STT, and cache consumers. Translation happens only at the model-visible path boundary.

## Test plan
- TDD RED: both new SSH tests failed because the gateway-local path was returned
- TDD GREEN: both new SSH tests passed after the minimal backend mapping
- explicit local identity and Docker default/custom-base regression tests
- `tests/tools/test_credential_files.py tests/tools/test_file_sync.py`: **57 passed**
- Ruff: passed
- `py_compile`: passed
- `git diff --check`: passed
- independent read-only review: PASS, no security/correctness blockers, low regression risk

## Security
This does not relax gateway or worker home permissions and does not copy inbound files into the workspace. It exposes only cache-relative paths already selected by the existing cache allowlist and already mirrored by the SSH sync layer.