### PR TITLE
fix(gateway): preserve /update completion across restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20772,6 +20772,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         chat_id = None
         session_key = None
         metadata = None
+        initiating_gateway_pid = None
         for path in (claimed_path, pending_path):
             if path.exists():
                 try:
@@ -20780,6 +20781,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     chat_id = pending.get("chat_id")
                     chat_type = pending.get("chat_type")
                     session_key = pending.get("session_key")
+                    initiating_gateway_pid = pending.get("initiating_gateway_pid")
                     thread_id = pending.get("thread_id")
                     message_id = pending.get("message_id")
                     if platform_str and chat_id:
@@ -20865,35 +20867,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         pass
                 await _flush_buffer()
 
-                # Send final status
+                # A successful gateway update writes its exit marker before it
+                # asks systemd to restart the gateway.  The initiating process
+                # must leave the durable target marker for the next process;
+                # otherwise a send racing with shutdown can fail and erase the
+                # only record of who should receive the completion message.
                 try:
                     exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
                     exit_code = int(exit_code_raw)
-                    if exit_code == 0:
+                except (OSError, ValueError):
+                    exit_code = 1
+
+                if (
+                    exit_code == 0
+                    and initiating_gateway_pid is not None
+                    and str(initiating_gateway_pid) == str(os.getpid())
+                ):
+                    try:
                         await adapter.send(
+                            chat_id,
+                            "✅ Hermes update installed.\n♻️ Restarting gateway…",
+                            metadata=_non_conversational_metadata(metadata, platform=platform),
+                        )
+                    except Exception as e:
+                        # The restart may already be stopping this process.
+                        # Keeping the markers is what guarantees that the new
+                        # gateway can still deliver the definitive result.
+                        logger.info("Pre-restart update notification was not delivered: %s", e)
+                    return
+
+                # Send final status for failed updates and legacy markers that
+                # predate initiating_gateway_pid.  Cleanup only after delivery.
+                delivered = False
+                try:
+                    if exit_code == 0:
+                        send_result = await adapter.send(
                             chat_id,
                             "✅ Hermes update finished.",
                             metadata=_non_conversational_metadata(metadata, platform=platform),
                         )
                     else:
-                        await adapter.send(
+                        send_result = await adapter.send(
                             chat_id,
                             "❌ Hermes update failed (exit code {}).".format(exit_code),
                             metadata=_non_conversational_metadata(metadata, platform=platform),
                         )
-                    logger.info("Update finished (exit=%s), notified %s", exit_code, session_key)
+                    if (
+                        send_result is not None
+                        and getattr(send_result, "success", True) is False
+                    ):
+                        logger.warning(
+                            "Update final notification was not delivered: %s",
+                            getattr(send_result, "error", "send returned success=False"),
+                        )
+                    else:
+                        delivered = True
+                        logger.info(
+                            "Update finished (exit=%s), notified %s",
+                            exit_code,
+                            session_key,
+                        )
                 except Exception as e:
                     logger.warning("Update final notification failed: %s", e)
 
-                # Cleanup
-                for p in (pending_path, claimed_path, output_path,
-                          exit_code_path, prompt_path):
-                    p.unlink(missing_ok=True)
-                (_hermes_home / ".update_response").unlink(missing_ok=True)
-                _up_done = self._peek_session_state(session_key)
-                if _up_done is not None:
-                    _up_done.persistent.update_prompt_pending = False
-                return
+                if delivered:
+                    for p in (pending_path, claimed_path, output_path,
+                              exit_code_path, prompt_path):
+                        p.unlink(missing_ok=True)
+                    (_hermes_home / ".update_response").unlink(missing_ok=True)
+                    _up_done = self._peek_session_state(session_key)
+                    if _up_done is not None:
+                        _up_done.persistent.update_prompt_pending = False
+                    return
+
+                await asyncio.sleep(poll_interval)
+                continue
 
             # Check for new output
             if output_path.exists():
@@ -21037,6 +21085,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             exit_code_raw = exit_code_path.read_text(encoding="utf-8").strip() or "1"
             exit_code = int(exit_code_raw)
 
+            initiating_gateway_pid = pending.get("initiating_gateway_pid")
+            if (
+                exit_code == 0
+                and initiating_gateway_pid is not None
+                and str(initiating_gateway_pid) == str(os.getpid())
+            ):
+                logger.info(
+                    "Update completion deferred until the gateway restarts "
+                    "(initiating pid=%s)",
+                    initiating_gateway_pid,
+                )
+                cleanup = False
+                active_pending_path = pending_path
+                claimed_path.replace(pending_path)
+                return False
+
             # Read the captured update output
             output = ""
             if output_path.exists():
@@ -21080,18 +21144,47 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if len(output) > 3500:
                         output = "…" + output[-3500:]
                     if exit_code == 0:
-                        msg = f"✅ Hermes update finished.\n\n```\n{output}\n```"
+                        msg = (
+                            "✅ Hermes update finished.\n"
+                            "♻️ Gateway restarted and is back online.\n\n"
+                            f"```\n{output}\n```"
+                        )
                     else:
                         msg = f"❌ Hermes update failed.\n\n```\n{output}\n```"
                 elif exit_code == 0:
-                    msg = "✅ Hermes update finished successfully."
+                    msg = (
+                        "✅ Hermes update finished successfully.\n"
+                        "♻️ Gateway restarted and is back online."
+                    )
                 else:
                     msg = "❌ Hermes update failed. Check the gateway logs or run `hermes update` manually for details."
-                await adapter.send(
-                    chat_id,
-                    msg,
-                    metadata=_non_conversational_metadata(metadata, platform=platform),
-                )
+                try:
+                    send_result = await adapter.send(
+                        chat_id,
+                        msg,
+                        metadata=_non_conversational_metadata(metadata, platform=platform),
+                    )
+                except Exception as send_error:
+                    # A transient platform reconnect or network failure must
+                    # not destroy the only durable completion target. Restore
+                    # the claim so the startup watcher can retry delivery.
+                    logger.warning("Post-update notification send failed: %s", send_error)
+                    cleanup = False
+                    active_pending_path = pending_path
+                    claimed_path.replace(pending_path)
+                    return False
+                if (
+                    send_result is not None
+                    and getattr(send_result, "success", True) is False
+                ):
+                    logger.warning(
+                        "Post-update notification was not delivered: %s",
+                        getattr(send_result, "error", "send returned success=False"),
+                    )
+                    cleanup = False
+                    active_pending_path = pending_path
+                    claimed_path.replace(pending_path)
+                    return False
                 logger.info(
                     "Sent post-update notification to %s:%s (exit=%s)",
                     platform_str,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -5590,6 +5590,11 @@ class GatewaySlashCommandsMixin:
             "user_id": event.source.user_id,
             "session_key": session_key,
             "timestamp": datetime.now().isoformat(),
+            # Lets the completion watcher distinguish the gateway that
+            # initiated the update from the freshly restarted process.  The
+            # old process must not consume the final notification marker just
+            # before systemd stops it.
+            "initiating_gateway_pid": os.getpid(),
         }
         if event.source.thread_id:
             pending["thread_id"] = event.source.thread_id

--- a/tests/gateway/test_update_command.py
+++ b/tests/gateway/test_update_command.py
@@ -5,13 +5,14 @@ the _send_update_notification startup hook (sends results after restart).
 """
 
 import json
+import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -132,6 +133,7 @@ class TestHandleUpdateCommand:
         assert data["chat_id"] == "99999"
         assert data["chat_type"] == "dm"
         assert data["message_id"] == "m-update"
+        assert data["initiating_gateway_pid"] == os.getpid()
         assert "timestamp" in data
         assert not (hermes_home / ".update_exit_code").exists()
 
@@ -347,8 +349,8 @@ class TestSendUpdateNotification:
 
 
     @pytest.mark.asyncio
-    async def test_cleans_up_on_error(self, tmp_path):
-        """Files are cleaned up even if notification fails."""
+    async def test_preserves_markers_when_notification_send_fails(self, tmp_path):
+        """A transient send failure remains retryable after restart."""
         runner = _make_runner()
         hermes_home = tmp_path / "hermes"
         hermes_home.mkdir()
@@ -368,12 +370,95 @@ class TestSendUpdateNotification:
         runner.adapters = {Platform.TELEGRAM: mock_adapter}
 
         with patch("gateway.run._hermes_home", hermes_home):
-            await runner._send_update_notification()
+            result = await runner._send_update_notification()
 
-        # Files should still be cleaned up (finally block)
+        assert result is False
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
+        assert not (hermes_home / ".update_pending.claimed.json").exists()
+
+
+    @pytest.mark.asyncio
+    async def test_preserves_markers_when_notification_returns_failure(self, tmp_path):
+        """SendResult(success=False) is a failed delivery, not a completed send."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        output_path = hermes_home / ".update_output.txt"
+        exit_code_path = hermes_home / ".update_exit_code"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram", "chat_id": "111", "user_id": "222",
+        }))
+        output_path.write_text("✓ Done")
+        exit_code_path.write_text("0")
+        mock_adapter = AsyncMock()
+        mock_adapter.send.return_value = SendResult(
+            success=False,
+            error="Telegram temporarily unavailable",
+        )
+        runner.adapters = {Platform.TELEGRAM: mock_adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            result = await runner._send_update_notification()
+
+        assert result is False
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_code_path.exists()
+        assert not (hermes_home / ".update_pending.claimed.json").exists()
+
+
+    @pytest.mark.asyncio
+    async def test_initiating_gateway_defers_success_until_restart(self, tmp_path):
+        """The old process cannot consume the new process's completion marker."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "initiating_gateway_pid": 101,
+        }))
+        (hermes_home / ".update_exit_code").write_text("0")
+        runner.adapters = {Platform.TELEGRAM: AsyncMock()}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.os.getpid", return_value=101):
+            result = await runner._send_update_notification()
+
+        assert result is False
+        assert pending_path.exists()
+        runner.adapters[Platform.TELEGRAM].send.assert_not_called()
+
+
+    @pytest.mark.asyncio
+    async def test_restarted_gateway_sends_final_online_notification(self, tmp_path):
+        """A new PID delivers the definitive completion and then cleans up."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "initiating_gateway_pid": 101,
+        }))
+        (hermes_home / ".update_exit_code").write_text("0")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.os.getpid", return_value=202):
+            result = await runner._send_update_notification()
+
+        assert result is True
+        message = adapter.send.await_args.args[1]
+        assert "Gateway restarted and is back online" in message
         assert not pending_path.exists()
-        assert not output_path.exists()
-        assert not exit_code_path.exists()
+        assert not (hermes_home / ".update_exit_code").exists()
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_update_streaming.py
+++ b/tests/gateway/test_update_streaming.py
@@ -16,7 +16,7 @@ from unittest.mock import patch, MagicMock, AsyncMock
 import pytest
 
 from gateway.config import Platform
-from gateway.platforms.base import MessageEvent
+from gateway.platforms.base import MessageEvent, SendResult
 from gateway.session import SessionSource
 
 
@@ -168,6 +168,72 @@ class TestUpdateCommandGatewayFlag:
 
 class TestWatchUpdateProgress:
     """Tests for _watch_update_progress() streaming output."""
+
+    @pytest.mark.asyncio
+    async def test_success_from_initiating_process_preserves_restart_marker(self, tmp_path):
+        """The watcher reports restart intent but leaves final delivery to the new PID."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "session_key": "agent:main:telegram:dm:111",
+            "initiating_gateway_pid": 101,
+        }))
+        output_path = hermes_home / ".update_output.txt"
+        output_path.write_text("✓ Code updated!\n")
+        exit_path = hermes_home / ".update_exit_code"
+        exit_path.write_text("0")
+        adapter = AsyncMock()
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home), \
+             patch("gateway.run.os.getpid", return_value=101):
+            await runner._watch_update_progress(
+                poll_interval=0.01,
+                stream_interval=0.01,
+                timeout=1.0,
+            )
+
+        sent = " ".join(str(call) for call in adapter.send.await_args_list)
+        assert "Restarting gateway" in sent
+        assert pending_path.exists()
+        assert output_path.exists()
+        assert exit_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_final_notification_retries_send_result_failure(self, tmp_path):
+        """A soft adapter failure must not consume legacy completion markers."""
+        runner = _make_runner()
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        pending_path = hermes_home / ".update_pending.json"
+        pending_path.write_text(json.dumps({
+            "platform": "telegram",
+            "chat_id": "111",
+            "session_key": "agent:main:telegram:dm:111",
+        }))
+        exit_path = hermes_home / ".update_exit_code"
+        exit_path.write_text("0")
+        adapter = AsyncMock()
+        adapter.send.side_effect = [
+            SendResult(success=False, error="temporary failure"),
+            SendResult(success=True),
+        ]
+        runner.adapters = {Platform.TELEGRAM: adapter}
+
+        with patch("gateway.run._hermes_home", hermes_home):
+            await runner._watch_update_progress(
+                poll_interval=0.01,
+                stream_interval=0.01,
+                timeout=1.0,
+            )
+
+        assert adapter.send.await_count == 2
+        assert not pending_path.exists()
+        assert not exit_path.exists()
 
     @pytest.mark.asyncio
     async def test_streams_output_to_adapter(self, tmp_path):
@@ -397,4 +463,3 @@ class TestCmdUpdateGatewayMode:
 
         assert len(calls) == 1
         assert "Restore" in calls[0]
-


### PR DESCRIPTION
## What does this PR do?

Makes `/update` completion notifications survive the gateway restart they report.

The updater writes `.update_exit_code` before asking systemd (or another platform supervisor) to restart the gateway. The old gateway watcher can therefore observe success while shutdown is already in progress. It currently attempts the final send and then unconditionally deletes `.update_pending.json`, `.update_output.txt`, and `.update_exit_code`, including when delivery fails. The new gateway starts with no durable target left and cannot notify the initiating chat.

This PR turns success notification into a two-phase lifecycle:

1. The initiating gateway records its PID in the pending marker and may announce that restart is beginning.
2. It preserves the completion markers instead of consuming them.
3. The freshly started gateway sends the definitive “update finished / gateway online” notification and cleans up only after confirmed delivery.

Both raised exceptions and `SendResult(success=False)` preserve and restore the marker for retry. Legacy markers without an initiating PID retain their existing behavior.

## Related Issue

N/A — no matching open or closed issue/PR was found after searching update, restart, completion-notification, and marker-related terms.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: persist the initiating gateway PID in the durable update target.
- `gateway/run.py`: defer success to the restarted gateway, preserve markers on exceptions and soft send failures, and explicitly report that the gateway is back online.
- `tests/gateway/test_update_command.py`: cover PID handoff, successful post-restart delivery, cleanup, exception retry, and `SendResult(success=False)` retry.
- `tests/gateway/test_update_streaming.py`: reproduce the old-watcher race and verify soft-failure retries.

## How to Test

1. Start a messaging gateway under a restart-capable supervisor and invoke `/update`.
2. Confirm the initiating process can send `Update installed / Restarting gateway` without deleting the durable markers.
3. Confirm the new gateway PID sends `Update finished / Gateway restarted and is back online`, then removes the markers.
4. Make `adapter.send()` raise or return `SendResult(success=False)` and confirm the pending marker remains retryable.
5. Run:

   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_update_command.py \
     tests/gateway/test_update_streaming.py \
     tests/gateway/test_startup_restart_race.py -q
   ```

   Result: 27 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux/systemd reproduction; macOS 26.5.1 targeted test suite

The full repository suite was not run locally. The three directly related test files pass via the canonical runner, and Ruff passes for every changed Python file.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing configuration or syntax changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; the existing marker/watcher architecture is retained
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `os.getpid()` and durable marker handoff are platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no model tool changed

## Screenshots / Logs

Before:

```text
.update_exit_code appears before supervisor restart
→ old gateway attempts adapter.send()
→ shutdown/network race fails delivery
→ completion markers are deleted anyway
→ new gateway has no notification target
```

Validation:

```text
Summary: 3 files, 27 tests passed, 0 failed
Ruff: All checks passed
```
