### PR TITLE
feat(gateway): multi-platform delivery simulator

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6863,6 +6863,11 @@ def _block_until_terminated() -> None:
 def _gateway_command_inner(args):
     subcmd = getattr(args, "gateway_command", None)
 
+    if subcmd == "simulate-delivery":
+        from hermes_cli.gateway_delivery_simulator import cmd_simulate_delivery
+
+        return cmd_simulate_delivery(args)
+
     # Default to run if no subcommand
     if subcmd is None or subcmd == "run":
         if _maybe_redirect_run_to_s6_supervision(args):

--- a/hermes_cli/gateway_delivery_simulator.py
+++ b/hermes_cli/gateway_delivery_simulator.py
@@ -1,0 +1,210 @@
+"""Multi-platform delivery simulator — ``hermes gateway simulate-delivery``.
+
+Runs input text through the REAL per-adapter ``format_message()`` renderer
+and the shared ``BasePlatformAdapter.truncate_message()`` chunker — the
+exact code paths ``gateway/delivery.py`` drives before a live send — so
+rendering/chunking bugs (escaping, fence-splitting, oversized payloads)
+surface without opening a socket or touching credentials.
+
+Oracles are imported, never reimplemented — the render step reuses the
+same unbound-``format_message`` trick as the merged conformance-vector
+generator (``scripts/generate_conformance_vectors.py``): those methods are
+asserted self-free by ``tests/conformance/test_vector_generator.py``, so
+calling them with ``self=None`` (or a bare ``object.__new__`` instance for
+the WhatsApp mixin) is safe and avoids constructing a real adapter (which
+would need network config).
+
+Scope: this simulates RENDERING and STATIC CHUNKING, not draft/streaming
+diffs or wire-level SDK payloads — see the module docstring in the CLI
+parser (``hermes_cli/subcommands/gateway.py``) for the exact contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+__all__ = [
+    "SUPPORTED_PLATFORMS",
+    "DeliverySimulation",
+    "simulate",
+    "cmd_simulate_delivery",
+]
+
+
+@dataclass
+class DeliverySimulation:
+    """Result of rendering+chunking one message for one platform."""
+
+    platform: str
+    formatted: str
+    length: int
+    max_length: int
+    exceeds_limit: bool
+    splits_natively: bool
+    chunks: Optional[List[str]]  # None when the platform has no native chunker
+
+
+def _telegram_renderer() -> Dict[str, Any]:
+    from gateway.platforms.base import utf16_len
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    return {
+        "format": lambda text: TelegramAdapter.format_message(None, text),
+        "max_length": TelegramAdapter.MAX_MESSAGE_LENGTH,
+        "splits": TelegramAdapter.splits_long_messages,
+        "len_fn": utf16_len,
+        "truncate": TelegramAdapter.truncate_message,
+    }
+
+
+def _discord_renderer() -> Dict[str, Any]:
+    from plugins.platforms.discord.adapter import DiscordAdapter
+
+    return {
+        "format": lambda text: DiscordAdapter.format_message(None, text),
+        "max_length": DiscordAdapter.MAX_MESSAGE_LENGTH,
+        "splits": DiscordAdapter.splits_long_messages,
+        "len_fn": len,
+        "truncate": DiscordAdapter.truncate_message,
+    }
+
+
+def _slack_renderer() -> Dict[str, Any]:
+    from plugins.platforms.slack.adapter import SlackAdapter
+
+    return {
+        "format": lambda text: SlackAdapter.format_message(None, text),
+        "max_length": SlackAdapter.MAX_MESSAGE_LENGTH,
+        "splits": SlackAdapter.splits_long_messages,
+        "len_fn": len,
+        "truncate": SlackAdapter.truncate_message,
+    }
+
+
+def _whatsapp_renderer() -> Dict[str, Any]:
+    from gateway.platforms.base import BasePlatformAdapter
+    from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+
+    # format_message needs no __init__ state — same construction the
+    # conformance-vector generator uses (asserted by
+    # tests/conformance/test_vector_generator.py).
+    instance = object.__new__(WhatsAppBehaviorMixin)
+    return {
+        "format": instance.format_message,
+        # WhatsAppBehaviorMixin doesn't set MAX_MESSAGE_LENGTH — real
+        # adapters fall back to the literal 4096 documented in
+        # BasePlatformAdapter.max_message_length_for_chat().
+        "max_length": 4096,
+        "splits": BasePlatformAdapter.splits_long_messages,
+        "len_fn": len,
+        "truncate": BasePlatformAdapter.truncate_message,
+    }
+
+
+_RENDERERS: Dict[str, Callable[[], Dict[str, Any]]] = {
+    "telegram": _telegram_renderer,
+    "discord": _discord_renderer,
+    "slack": _slack_renderer,
+    "whatsapp": _whatsapp_renderer,
+}
+
+SUPPORTED_PLATFORMS = tuple(sorted(_RENDERERS))
+
+
+def simulate(platform: str, text: str) -> DeliverySimulation:
+    """Render+chunk ``text`` for ``platform`` through the real adapter code."""
+    if platform not in _RENDERERS:
+        raise ValueError(
+            f"unsupported platform {platform!r} — supported: "
+            f"{', '.join(SUPPORTED_PLATFORMS)}"
+        )
+    spec = _RENDERERS[platform]()
+    formatted = spec["format"](text)
+    len_fn = spec["len_fn"]
+    length = len_fn(formatted)
+    max_length = spec["max_length"]
+    exceeds = length > max_length
+    splits = bool(spec["splits"])
+
+    chunks: Optional[List[str]] = None
+    if splits:
+        chunks = spec["truncate"](formatted, max_length, len_fn=len_fn)
+
+    return DeliverySimulation(
+        platform=platform,
+        formatted=formatted,
+        length=length,
+        max_length=max_length,
+        exceeds_limit=exceeds,
+        splits_natively=splits,
+        chunks=chunks,
+    )
+
+
+def _format_human(sim: DeliverySimulation) -> str:
+    lines = [f"Delivery simulation: {sim.platform}", ""]
+    lines.append("--- formatted output ---")
+    lines.append(sim.formatted)
+    lines.append("--- end ---")
+    lines.append("")
+    lines.append(f"length: {sim.length} / {sim.max_length}")
+    lines.append(f"exceeds limit: {'yes' if sim.exceeds_limit else 'no'}")
+    lines.append(f"splits natively: {'yes' if sim.splits_natively else 'no'}")
+    if sim.chunks is not None:
+        lines.append(f"chunks: {len(sim.chunks)}")
+        for idx, chunk in enumerate(sim.chunks, start=1):
+            lines.append(f"  [{idx}/{len(sim.chunks)}] ({len(chunk)} chars)")
+    elif sim.exceeds_limit:
+        lines.append(
+            "  this platform has no native chunker — oversized-content "
+            "handling depends on the call path (e.g. cron truncates with "
+            "a footer; other paths are adapter-specific)."
+        )
+    return "\n".join(lines)
+
+
+def _format_json(sim: DeliverySimulation) -> str:
+    return json.dumps(
+        {
+            "platform": sim.platform,
+            "formatted": sim.formatted,
+            "length": sim.length,
+            "max_length": sim.max_length,
+            "exceeds_limit": sim.exceeds_limit,
+            "splits_natively": sim.splits_natively,
+            "chunks": sim.chunks,
+        },
+        indent=2,
+    )
+
+
+def cmd_simulate_delivery(args: argparse.Namespace) -> int:
+    platform = (getattr(args, "platform", "") or "").strip().lower()
+    input_path = getattr(args, "input", None)
+    text_arg = getattr(args, "text", None)
+
+    if input_path:
+        try:
+            with open(input_path, encoding="utf-8") as f:
+                text = f.read()
+        except OSError as exc:
+            print(f"error: cannot read {input_path}: {exc}", file=sys.stderr)
+            return 1
+    else:
+        text = text_arg or ""
+
+    try:
+        sim = simulate(platform, text)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if getattr(args, "json", False):
+        print(_format_json(sim))
+    else:
+        print(_format_human(sim))
+    return 0

--- a/hermes_cli/subcommands/gateway.py
+++ b/hermes_cli/subcommands/gateway.py
@@ -223,6 +223,30 @@ def build_gateway_parser(
     # gateway setup
     gateway_subparsers.add_parser("setup", help="Configure messaging platforms")
 
+    # gateway simulate-delivery
+    gateway_simulate = gateway_subparsers.add_parser(
+        "simulate-delivery",
+        help="Preview how content renders and chunks on a platform "
+        "(no network, no credentials)",
+        description=(
+            "Runs input text through the REAL adapter format_message() "
+            "renderer and truncate_message() chunker for the given "
+            "platform — the same code gateway/delivery.py calls before a "
+            "live send — without opening any socket."
+        ),
+    )
+    gateway_simulate.add_argument(
+        "--platform",
+        required=True,
+        help="Target platform (telegram, discord, slack, whatsapp)",
+    )
+    simulate_input = gateway_simulate.add_mutually_exclusive_group(required=True)
+    simulate_input.add_argument("--input", help="Path to a file with the message content")
+    simulate_input.add_argument("--text", help="Message content given directly")
+    gateway_simulate.add_argument(
+        "--json", action="store_true", help="Print machine-readable JSON"
+    )
+
     # gateway migrate-legacy
     gateway_migrate_legacy = gateway_subparsers.add_parser(
         "migrate-legacy",

--- a/tests/hermes_cli/test_gateway_delivery_simulator.py
+++ b/tests/hermes_cli/test_gateway_delivery_simulator.py
@@ -1,0 +1,112 @@
+"""Tests for ``hermes gateway simulate-delivery`` (real adapter oracles).
+
+Drives the REAL ``format_message``/``truncate_message`` adapter code —
+same construction as ``scripts/generate_conformance_vectors.py`` — so
+these tests double as a guard against silently swapping in a
+reimplementation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+
+import pytest
+
+from hermes_cli.gateway_delivery_simulator import (
+    SUPPORTED_PLATFORMS,
+    cmd_simulate_delivery,
+    simulate,
+)
+
+
+def test_supported_platforms_are_stable():
+    assert set(SUPPORTED_PLATFORMS) == {"telegram", "discord", "slack", "whatsapp"}
+
+
+def test_telegram_escapes_markdownv2_reserved_chars():
+    sim = simulate("telegram", "Price 3.50 (was 4.00) save ~12%!")
+    # Real MarkdownV2 escaping from TelegramAdapter.format_message — the
+    # exact bug class reported in #78524 (preview/final divergence).
+    assert "\\." in sim.formatted
+    assert "\\(" in sim.formatted
+    assert "\\~" in sim.formatted
+    assert "\\!" in sim.formatted
+
+
+def test_discord_passes_bold_through_unchanged():
+    sim = simulate("discord", "hello **world**")
+    assert sim.formatted == "hello **world**"
+
+
+def test_unsupported_platform_raises_value_error():
+    with pytest.raises(ValueError, match="unsupported platform"):
+        simulate("irc", "hi")
+
+
+def test_no_network_no_side_effects_just_pure_computation():
+    # Calling simulate() must never require credentials/config — both
+    # renderers below construct their adapter class without __init__.
+    sim = simulate("whatsapp", "plain text")
+    assert sim.platform == "whatsapp"
+    assert sim.splits_natively is False
+
+
+def test_chunking_splits_content_over_the_adapter_limit():
+    # Discord's real limit is 2000 chars; build content well past it.
+    long_text = "line\n" * 1000  # 5000 chars
+    sim = simulate("discord", long_text)
+    assert sim.exceeds_limit is True
+    assert sim.chunks is not None
+    assert len(sim.chunks) > 1
+    for chunk in sim.chunks:
+        assert len(chunk) <= sim.max_length
+
+
+def test_telegram_uses_utf16_length_for_the_limit_check():
+    # A short string under both code-point and UTF-16 length is fine;
+    # this just asserts the length reported matches utf16_len, not len().
+    from gateway.platforms.base import utf16_len
+
+    sim = simulate("telegram", "hello")
+    formatted_expected_len = utf16_len(sim.formatted)
+    assert sim.length == formatted_expected_len
+
+
+def test_cmd_simulate_delivery_json_output(capsys):
+    args = argparse.Namespace(
+        platform="slack", input=None, text="hi *there*", json=True
+    )
+    rc = cmd_simulate_delivery(args)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["platform"] == "slack"
+    assert out["chunks"] == [out["formatted"]]
+
+
+def test_cmd_simulate_delivery_reads_from_input_file(tmp_path, capsys):
+    input_file = tmp_path / "message.md"
+    input_file.write_text("hello from file", encoding="utf-8")
+    args = argparse.Namespace(
+        platform="discord", input=str(input_file), text=None, json=True
+    )
+    rc = cmd_simulate_delivery(args)
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["formatted"] == "hello from file"
+
+
+def test_cmd_simulate_delivery_unknown_platform_returns_error(capsys):
+    args = argparse.Namespace(platform="irc", input=None, text="hi", json=False)
+    rc = cmd_simulate_delivery(args)
+    assert rc == 1
+    assert "unsupported platform" in capsys.readouterr().err
+
+
+def test_cmd_simulate_delivery_missing_input_file_returns_error(capsys):
+    args = argparse.Namespace(
+        platform="telegram", input="/no/such/file.txt", text=None, json=False
+    )
+    rc = cmd_simulate_delivery(args)
+    assert rc == 1
+    assert "cannot read" in capsys.readouterr().err

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -247,6 +247,7 @@ Subcommands:
 | `install` | Install as a systemd (Linux) or launchd (macOS) background service. |
 | `uninstall` | Remove the installed service. |
 | `setup` | Interactive messaging-platform setup. |
+| `simulate-delivery` | Preview how content renders and chunks on a platform (`--platform`, `--input`/`--text`, `--json`) — runs the real adapter formatter/chunker with no network calls or credentials. |
 | `migrate-legacy` | Remove legacy `hermes.service` units left over from pre-rename installs. Profile units (`hermes-gateway-<profile>.service`) and unrelated services are never touched. Flags: `--dry-run`, `-y`/`--yes`. |
 | `enroll` | Experimental: enroll this gateway with a relay connector and save relay credentials for connector-backed platforms. See [Hermes Relay](/user-guide/messaging/relay). |
 


### PR DESCRIPTION
## Summary

Adds `hermes gateway simulate-delivery --platform <p> --text/--input [--json]` — a preview command that renders and chunks content through the REAL adapter code for Telegram, Discord, Slack, and WhatsApp, with zero network calls and no credentials required.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Raw Input Text] -->|Real format_message| B[Adapter Renderer]
    B -->|Telegram| C[MarkdownV2 Escaping]
    B -->|Discord| D[GFM Table to Bullets]
    B -->|Slack| E[mrkdwn]
    B -->|WhatsApp| F[Native Formatting]
    C --> G[truncate_message Chunker]
    D --> G
    E --> G
    F --> G
    G -->|No Network, No Credentials| H[Formatted Output + Chunk Report]
```
## Infographic : 
<img width="1024" height="1024" alt="gateway_simulator_infographic" src="https://github.com/user-attachments/assets/e0f315ba-b692-4948-a127-a85cffe8e96a" />


Closes #80174

## Why this doesn't duplicate existing work

- #71666 (merged) is the CI conformance-vector generator — a fixed corpus rendered through the same oracles for regression testing. This is the ad-hoc/interactive counterpart for arbitrary developer-supplied content, reusing the identical oracle functions rather than reimplementing them.
- #61694 (open) is media-capability *metadata*; this is text rendering/chunking — different surface.
- #74953 (open) is a static conformance test suite; this is an operational preview tool, not a test.

## Design notes

- **Oracles imported, never reimplemented.** `format_message()` is called unbound (`AdapterClass.format_message(None, text)`) for Telegram/Discord/Slack, and via a bare `object.__new__(WhatsAppBehaviorMixin)` instance for WhatsApp — the exact construction `scripts/generate_conformance_vectors.py` uses, asserted self-free by `tests/conformance/test_vector_generator.py`.
- **Chunking is the real `BasePlatformAdapter.truncate_message()` static method** (code-fence-boundary preservation included), called with each adapter's real `MAX_MESSAGE_LENGTH` and `len_fn` (Telegram measures UTF-16 code units via `utf16_len`, matching `gateway/delivery.py`'s real call site).
- **Scoped down from the original proposal.** The original report also asked for draft-vs-final streaming diffs and logical wire payloads. Those are genuinely adapter-specific (Telegram edit-streaming, Discord multi-message threading) and reimplementing them "byte-for-byte" within a correctness-first MVP risks shipping a tool that lies to the user — worse than not having it. This PR ships the rendering+chunking slice only, which is also the exact bug class #78524 reports. Draft/streaming simulation is a natural follow-up once this lands.
- New CLI wiring: `simulate-delivery` subparser added to the existing `gateway` parser (`hermes_cli/subcommands/gateway.py`), dispatched via one guard clause added at the top of `hermes_cli/gateway.py::_gateway_command_inner` — no existing `gateway` subcommand branch was touched.

## Test plan

- [x] `pytest tests/hermes_cli/test_gateway_delivery_simulator.py -q` — 11 passing: real MarkdownV2 escaping, Discord pass-through, UTF-16 length check, chunk-boundary correctness (`len(chunk) <= max_length` for every chunk), unsupported-platform error, file-input path, JSON output
- [x] `pytest tests/hermes_cli/test_gateway.py -q` — no regressions (10 passed, 5 pre-existing skips)
- [x] `ruff check` on new/changed files — clean
- [x] Manual run: `hermes gateway simulate-delivery --platform telegram --text "Price 3.50 (was 4.00) save ~12%!"` → correctly escaped MarkdownV2 output; `--platform whatsapp --json`; unsupported platform → clean error message