### PR TITLE
msgraph-webhook : tolerate malformed int config on adapter init

### DIFF
--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -44,6 +44,14 @@ DEFAULT_MAX_BODY_BYTES = 1_048_576
 NotificationScheduler = Callable[[Dict[str, Any], MessageEvent], Awaitable[None] | None]
 
 
+def _coerce_int(value: object, *, default: int) -> int:
+    """Parse config ints; malformed values must not crash adapter init."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
 def check_msgraph_webhook_requirements() -> bool:
     """Return whether required webhook dependencies are available."""
     return AIOHTTP_AVAILABLE
@@ -58,7 +66,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         # Falsy host (None/"") collapses to the dual-stack default.
         _raw_host = extra.get("host", DEFAULT_HOST) or DEFAULT_HOST
         self._host: Optional[str] = str(_raw_host) if _raw_host else None
-        self._port: int = int(extra.get("port", DEFAULT_PORT))
+        self._port: int = _coerce_int(extra.get("port", DEFAULT_PORT), default=DEFAULT_PORT)
         self._webhook_path: str = self._normalize_path(
             extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
         )
@@ -70,10 +78,18 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         ]
         self._client_state: Optional[str] = self._string_or_none(extra.get("client_state"))
         self._max_seen_receipts = max(
-            1, int(extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS))
+            1,
+            _coerce_int(
+                extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS),
+                default=DEFAULT_MAX_SEEN_RECEIPTS,
+            ),
         )
         self._max_body_bytes = max(
-            1, int(extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES))
+            1,
+            _coerce_int(
+                extra.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES),
+                default=DEFAULT_MAX_BODY_BYTES,
+            ),
         )
         self._allowed_source_networks: list[ipaddress._BaseNetwork] = (
             self._parse_allowed_source_cidrs(extra.get("allowed_source_cidrs"))

--- a/tests/gateway/test_msgraph_webhook_int_guard.py
+++ b/tests/gateway/test_msgraph_webhook_int_guard.py
@@ -1,0 +1,39 @@
+"""MS Graph webhook adapter must tolerate malformed int config fields."""
+
+from gateway.config import PlatformConfig
+from gateway.platforms.msgraph_webhook import (
+    DEFAULT_MAX_BODY_BYTES,
+    DEFAULT_MAX_SEEN_RECEIPTS,
+    DEFAULT_PORT,
+    MSGraphWebhookAdapter,
+)
+
+
+def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
+    extra = {
+        "host": "127.0.0.1",
+        "client_state": "expected-client-state",
+        "accepted_resources": ["communications/onlineMeetings"],
+    }
+    extra.update(extra_overrides)
+    return MSGraphWebhookAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def test_malformed_port_falls_back_to_default():
+    adapter = _make_adapter(port="bad-port")
+    assert adapter._port == DEFAULT_PORT
+
+
+def test_malformed_receipt_limit_falls_back_to_default():
+    adapter = _make_adapter(max_seen_receipts="bad-limit")
+    assert adapter._max_seen_receipts == DEFAULT_MAX_SEEN_RECEIPTS
+
+
+def test_malformed_body_limit_falls_back_to_default():
+    adapter = _make_adapter(max_body_bytes="bad-size")
+    assert adapter._max_body_bytes == DEFAULT_MAX_BODY_BYTES
+
+
+def test_valid_port_is_honored():
+    adapter = _make_adapter(port=9006)
+    assert adapter._port == 9006


### PR DESCRIPTION
## Summary
- `MSGraphWebhookAdapter` used unguarded `int()` for `port`, `max_seen_receipts`, and `max_body_bytes`.
- Malformed config values raised during construction and took the webhook platform down.
- Coerce these fields with safe defaults instead, matching the newer adapter-init guard pattern used elsewhere.
