### PR TITLE
fix(tts): localize spoken symbol normalization

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1162,6 +1162,7 @@ platform_toolsets:
 #
 # tts:
 #   provider: "gemini"
+#   language: ""            # optional BCP-47 override; blank infers from provider/voice
 #   speed: 1.0              # global speed multiplier (provider-specific overrides this)
 #   gemini:
 #     model: "gemini-3.1-flash-tts-preview"

--- a/cli.py
+++ b/cli.py
@@ -12541,15 +12541,17 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return
         self._voice_tts_done.clear()
         try:
-            from tools.tts_tool import text_to_speech_tool
+            from tools.tts_tool import (
+                _prepare_spoken_text_for_tts,
+                text_to_speech_tool,
+            )
             from tools.voice_mode import play_audio_file
 
             # Strip markdown and non-speech content for cleaner TTS via the
             # shared cleaner (tools/tts_text_normalize): markdown, emoji,
             # <think> blocks, verifier footer, units, newline flattening.
             try:
-                from tools.tts_text_normalize import prepare_spoken_text
-                tts_text = prepare_spoken_text(text, max_chars=4000)
+                tts_text = _prepare_spoken_text_for_tts(text, max_chars=4000)
             except Exception:
                 # Legacy fallback pipeline — keep voice replies best-effort.
                 tts_text = text[:4000] if len(text) > 4000 else text

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4095,11 +4095,12 @@ class BasePlatformAdapter(ABC):
         blocks, or compact symbols to the speech provider.  It should receive
         a transcript-like script: reasoning blocks removed, headings and
         bullets flattened into sentence pauses, and units like ``°C``
-        expanded to words such as ``degrees Celsius``.
+        expanded according to the configured TTS language.
         """
         try:
-            from tools.tts_text_normalize import prepare_spoken_text
-            return prepare_spoken_text(text, max_chars=4000)
+            from tools.tts_tool import _prepare_spoken_text_for_tts
+
+            return _prepare_spoken_text_for_tts(text, max_chars=4000)
         except Exception:
             # Keep auto-TTS best-effort if the normalizer ever fails.
             text = re.sub(r'<think[\s>].*?</think>', ' ', text, flags=re.DOTALL)

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -76,6 +76,10 @@ class StreamingTTSConsumer:
         # Resolve the streaming provider once. If unavailable, the consumer is
         # inactive and the gateway falls back to whole-file TTS.
         self._streamer = resolve_streaming_provider(tts_config)
+        self._spoken_provider = (
+            getattr(self._streamer, "provider_name", "")
+            or str(tts_config.get("provider") or "edge").lower().strip()
+        )
         self._chunker = SentenceChunker()
 
         if self._streamer is not None:
@@ -360,7 +364,11 @@ class StreamingTTSConsumer:
         if self._strip_markdown is None:
             try:
                 from tools.tts_tool import _strip_markdown_for_tts as _strip
-                self._strip_markdown = _strip
+                self._strip_markdown = lambda value: _strip(
+                    value,
+                    tts_config=getattr(self, "_tts_config", None),
+                    provider=getattr(self, "_spoken_provider", None),
+                )
             except ImportError:
                 self._strip_markdown = lambda t: t  # noqa: E731
         return self._strip_markdown(text).strip()

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1426,6 +1426,9 @@ DEFAULT_CONFIG = {
         # Set explicitly to pin a backend:
         # "edge" (free) | "elevenlabs" (premium) | "openai" | "xai" | "minimax" | "mistral" | "gemini" | "deepinfra" | "neutts" (local) | "kittentts" (local) | "piper" (local)
         "provider": "edge",
+        # Optional spoken-text language override. Blank infers from provider
+        # language settings or Edge/Piper-style voice identifiers.
+        "language": "",
         "edge": {
             "voice": "en-US-AriaNeural",
             # Popular: AriaNeural, JennyNeural, AndrewNeural, BrianNeural, SoniaNeural

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -977,8 +977,9 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
         # Shared cleaner (tools/tts_text_normalize): markdown, emoji,
         # <think> blocks, verifier footer, units, newline flattening.
         try:
-            from tools.tts_text_normalize import prepare_spoken_text
-            tts_text = prepare_spoken_text(text, max_chars=4000)
+            from tools.tts_tool import _prepare_spoken_text_for_tts
+
+            tts_text = _prepare_spoken_text_for_tts(text, max_chars=4000)
         except Exception:
             # Legacy fallback pipeline — keep speak_text best-effort.
             tts_text = text[:4000] if len(text) > 4000 else text

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4655,14 +4655,20 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
         with _config_profile_scope(profile):
             cfg = _load_tts_config()
             streamer = resolve_streaming_provider(cfg)
-            cap = _resolve_max_text_length(_get_provider(cfg), cfg) if streamer else 0
-        return streamer, cap
+            configured_provider = _get_provider(cfg)
+            spoken_provider = (
+                getattr(streamer, "provider_name", "") or configured_provider
+            )
+            cap = _resolve_max_text_length(configured_provider, cfg) if streamer else 0
+        return streamer, cap, cfg, spoken_provider
 
     try:
-        streamer, cap = await loop.run_in_executor(None, _resolve)
+        streamer, cap, tts_config, spoken_provider = await loop.run_in_executor(
+            None, _resolve
+        )
     except Exception:
         _log.exception("speak-stream provider resolution failed")
-        streamer, cap = None, 0
+        streamer, cap, tts_config, spoken_provider = None, 0, {}, None
     if streamer is None:
         with contextlib.suppress(Exception):
             await ws.send_json({"type": "fallback"})
@@ -4715,7 +4721,11 @@ async def speak_stream_ws(ws: "WebSocket") -> None:
 
         try:
             for sentence in _sentences():
-                cleaned = _strip_markdown_for_tts(sentence)
+                cleaned = _strip_markdown_for_tts(
+                    sentence,
+                    tts_config=tts_config,
+                    provider=spoken_provider,
+                )
                 if not cleaned:
                     continue
                 for piece in _split_text_for_speak_stream(cleaned, cap):

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -351,6 +351,31 @@ class TestStreamerFormatAndLooping:
             tts_streaming.resolve_streaming_provider = original_resolve
             loop.close()
 
+    def test_consumer_normalizes_with_streaming_provider_locale(self, monkeypatch):
+        streamer = FakeStreamer(chunks_per_clause=1)
+        streamer.provider_name = "edge"
+        monkeypatch.setattr(
+            "tools.tts_streaming.resolve_streaming_provider",
+            lambda *_args, **_kwargs: streamer,
+        )
+        loop = asyncio.new_event_loop()
+        try:
+            consumer = StreamingTTSConsumer(
+                FakeVoiceAdapter(),
+                "chat1",
+                {
+                    "provider": "edge",
+                    "edge": {"voice": "fr-FR-HenriNeural"},
+                },
+                loop,
+            )
+
+            assert consumer._strip_markdown_for_tts("44 % à 28 °C") == (
+                "44 pour cent à 28 degrés Celsius"
+            )
+        finally:
+            loop.close()
+
 
 class TestGatewayIntegrationSeam:
     """The actual adapter seam is per-turn, not chat-only."""

--- a/tests/hermes_cli/test_web_server_speak_stream.py
+++ b/tests/hermes_cli/test_web_server_speak_stream.py
@@ -49,9 +49,10 @@ class _FakeStreamer:
         yield from self.chunks
 
 
-def _patch_provider(monkeypatch, streamer, cap=4000):
+def _patch_provider(monkeypatch, streamer, cap=4000, config=None):
+    config = config or {}
     monkeypatch.setattr("tools.tts_streaming.resolve_streaming_provider", lambda cfg: streamer)
-    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: {})
+    monkeypatch.setattr("tools.tts_tool._load_tts_config", lambda: config)
     monkeypatch.setattr("tools.tts_tool._get_provider", lambda cfg: "fake")
     monkeypatch.setattr("tools.tts_tool._resolve_max_text_length", lambda provider, cfg: cap)
 
@@ -74,6 +75,27 @@ def test_streams_pcm_frames_then_end(stream_client, monkeypatch):
         assert conn.receive_json() == {"type": "end"}
 
     assert streamer.requests == ["Hello there."]
+
+
+def test_stream_uses_configured_voice_locale(stream_client, monkeypatch):
+    streamer = _FakeStreamer([b"\x00\x00"])
+    streamer.provider_name = "edge"
+    _patch_provider(
+        monkeypatch,
+        streamer,
+        config={
+            "provider": "edge",
+            "edge": {"voice": "fr-FR-HenriNeural"},
+        },
+    )
+
+    with stream_client.websocket_connect(_url()) as conn:
+        assert conn.receive_json()["type"] == "start"
+        conn.send_text(json.dumps({"text": "44 % à 28 °C", "done": True}))
+        assert conn.receive_bytes() == b"\x00\x00"
+        assert conn.receive_json() == {"type": "end"}
+
+    assert streamer.requests == ["44 pour cent à 28 degrés Celsius"]
 
 
 
@@ -119,5 +141,4 @@ def test_split_text_respects_cap_and_preserves_content():
     joined = " ".join(pieces)
     for word in text.replace(".", "").split():
         assert word in joined
-
 

--- a/tests/tools/test_tts_locale_normalization.py
+++ b/tests/tools/test_tts_locale_normalization.py
@@ -1,0 +1,143 @@
+"""Locale-aware spoken-text normalization regressions for issue #80136."""
+
+from pathlib import Path
+
+import pytest
+
+from tools.tts_text_normalize import prepare_spoken_text
+from tools.tts_tool import (
+    _load_tts_config,
+    _prepare_spoken_text_for_tts,
+    _resolve_tts_locale,
+    _strip_markdown_for_tts,
+)
+
+
+class TestLocalizedSymbolExpansion:
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [
+            ("Il fait 44 % d'humidité.", "Il fait 44 pour cent d'humidité."),
+            ("Il fait 28,2 °C.", "Il fait 28,2 degrés Celsius."),
+            ("Vent à 12 km/h.", "Vent à 12 kilomètres par heure."),
+            ("Entre 11,5-17,2 °C.", "Entre 11,5 à 17,2 degrés Celsius."),
+        ],
+    )
+    def test_french_expansions(self, source, expected):
+        assert prepare_spoken_text(source, max_chars=None, locale="fr-FR") == expected
+
+    def test_default_remains_english_for_backward_compatibility(self):
+        assert prepare_spoken_text("44 % at 28 °C", max_chars=None) == (
+            "44 percent at 28 degrees Celsius"
+        )
+
+    def test_unbundled_non_english_locale_never_injects_english(self):
+        spoken = prepare_spoken_text(
+            "44 % a 28 °C y 12 km/h", max_chars=None, locale="es-ES"
+        )
+
+        assert "percent" not in spoken
+        assert "degrees" not in spoken
+        assert "kilometres per hour" not in spoken
+        assert "44 %" in spoken
+        assert "28 °C" in spoken
+        assert "12 km/h" in spoken
+
+
+class TestTtsLocaleResolution:
+    def test_provider_language_wins(self):
+        config = {
+            "provider": "openai",
+            "language": "de-DE",
+            "openai": {"language": " fr_fr "},
+        }
+
+        assert _resolve_tts_locale("openai", config) == "fr-FR"
+
+    def test_global_language_precedes_voice_inference(self):
+        config = {
+            "provider": "edge",
+            "language": "de-DE",
+            "edge": {"voice": "fr-FR-HenriNeural"},
+        }
+
+        assert _resolve_tts_locale("edge", config) == "de-DE"
+
+    @pytest.mark.parametrize(
+        ("provider", "voice", "expected"),
+        [
+            ("edge", "fr-FR-HenriNeural", "fr-FR"),
+            ("piper", "fr_FR-siwis-medium", "fr-FR"),
+            ("piper", "/voices/de_DE-thorsten-medium.onnx", "de-DE"),
+        ],
+    )
+    def test_locale_is_inferred_from_structured_voice_names(
+        self, provider, voice, expected
+    ):
+        config = {"provider": provider, provider: {"voice": voice}}
+
+        assert _resolve_tts_locale(provider, config) == expected
+
+    def test_opaque_voice_keeps_english_compatibility_fallback(self):
+        config = {"provider": "openai", "openai": {"voice": "alloy"}}
+
+        assert _resolve_tts_locale("openai", config) == "en"
+
+    def test_explicit_auto_leaves_symbols_to_provider(self):
+        config = {
+            "provider": "edge",
+            "edge": {"language": "auto", "voice": "fr-FR-HenriNeural"},
+        }
+
+        assert _resolve_tts_locale("edge", config) == "und"
+
+
+class TestLocalePropagation:
+    def test_config_aware_streaming_cleaner_uses_voice_locale(self):
+        config = {
+            "provider": "edge",
+            "edge": {"voice": "fr-FR-HenriNeural"},
+        }
+
+        assert _strip_markdown_for_tts("**44 %**", tts_config=config) == (
+            "44 pour cent"
+        )
+
+    def test_real_config_load_reaches_provider_dispatch(self, tmp_path, monkeypatch):
+        from hermes_constants import get_config_path
+        from tools import tts_tool
+
+        config_path = Path(get_config_path())
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(
+            "tts:\n"
+            "  provider: edge\n"
+            "  edge:\n"
+            "    voice: fr-FR-HenriNeural\n",
+            encoding="utf-8",
+        )
+
+        config = _load_tts_config()
+        assert _prepare_spoken_text_for_tts(
+            "44 % à 28 °C",
+            max_chars=None,
+            tts_config=config,
+        ) == "44 pour cent à 28 degrés Celsius"
+
+        captured = {}
+
+        async def fake_edge(text, output_path, _tts_config):
+            captured["text"] = text
+            Path(output_path).write_bytes(b"ID3fake-audio")
+            return output_path
+
+        monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+        monkeypatch.setattr(tts_tool, "_generate_edge_tts", fake_edge)
+
+        result = tts_tool.text_to_speech_tool(
+            "44 % à 28 °C",
+            output_path=str(tmp_path / "speech.mp3"),
+        )
+
+        assert '"success": true' in result
+        assert captured["text"] == "44 pour cent à 28 degrés Celsius"

--- a/tools/tts_streaming.py
+++ b/tools/tts_streaming.py
@@ -131,6 +131,7 @@ class SentenceChunker:
 class StreamingTTSProvider(ABC):
     """Yields raw int16, little-endian, mono PCM chunks at ``sample_rate``."""
 
+    provider_name: str = ""
     sample_rate: int = 24000
     channels: int = 1
     sample_width: int = 2  # bytes/sample (int16)
@@ -154,6 +155,7 @@ _REGISTRY: Dict[str, type[StreamingTTSProvider]] = {}
 
 def register(name: str) -> Callable[[type[StreamingTTSProvider]], type[StreamingTTSProvider]]:
     def _wrap(cls: type[StreamingTTSProvider]) -> type[StreamingTTSProvider]:
+        cls.provider_name = name
         _REGISTRY[name] = cls
         return cls
 

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -84,24 +84,94 @@ def strip_markdown_for_tts(text: str) -> str:
     return text
 
 
-def _normalize_temperature_ranges(text: str) -> str:
-    # 11-17 degrees C -> "11 to 17 degrees Celsius" (en/em dash or hyphen).
+_NUMBER_RE = r"[-+\u2212]?\d+(?:[.,]\d+)?"
+
+_EN_SYMBOL_FORMS = {
+    "range_to": "to",
+    "degrees_celsius": "degrees Celsius",
+    "degrees_fahrenheit": "degrees Fahrenheit",
+    "degrees": "degrees",
+    "km_per_hour": "kilometres per hour",
+    "millimetres": "millimetres",
+    "centimetres": "centimetres",
+    "metres": "metres",
+    "per": "per",
+    "nzd": "New Zealand dollars",
+    "aud": "Australian dollars",
+    "usd": "US dollars",
+    "eur": "euros",
+    "gbp": "pounds",
+    "dollars": "dollars",
+    "percent": "percent",
+    "and": "and",
+    "to": "to",
+    "about": "about",
+}
+
+_FR_SYMBOL_FORMS = {
+    "range_to": "à",
+    "degrees_celsius": "degrés Celsius",
+    "degrees_fahrenheit": "degrés Fahrenheit",
+    "degrees": "degrés",
+    "km_per_hour": "kilomètres par heure",
+    "millimetres": "millimètres",
+    "centimetres": "centimètres",
+    "metres": "mètres",
+    "per": "par",
+    "nzd": "dollars néo-zélandais",
+    "aud": "dollars australiens",
+    "usd": "dollars américains",
+    "eur": "euros",
+    "gbp": "livres sterling",
+    "dollars": "dollars",
+    "percent": "pour cent",
+    "and": "et",
+    "to": "à",
+    "about": "environ",
+}
+
+
+def _symbol_forms_for_locale(locale: str | None) -> dict[str, str] | None:
+    """Return spoken forms for *locale*.
+
+    ``None`` preserves the historical English behavior. For a known
+    non-English locale without a bundled table, leave semantic symbols intact
+    so the selected voice can pronounce them instead of injecting English.
+    """
+    if locale is None:
+        return _EN_SYMBOL_FORMS
+    language = str(locale).strip().lower().replace("_", "-").split("-", 1)[0]
+    if not language or language == "en":
+        return _EN_SYMBOL_FORMS
+    if language == "fr":
+        return _FR_SYMBOL_FORMS
+    return None
+
+
+def _normalize_temperature_ranges(text: str, forms: dict[str, str]) -> str:
+    # 11-17 degrees C -> a locale-appropriate spoken range.
     text = re.sub(
-        r"(?<!\w)([-+\u2212]?\d+(?:\.\d+)?)\s*[\u2013\u2014-]\s*([-+\u2212]?\d+(?:\.\d+)?)\s*°\s*C\b",
-        lambda m: f"{m.group(1).replace(chr(0x2212), '-')} to {m.group(2).replace(chr(0x2212), '-')} degrees Celsius",
+        rf"(?<!\w)({_NUMBER_RE})\s*[\u2013\u2014-]\s*({_NUMBER_RE})\s*°\s*C\b",
+        lambda m: (
+            f"{m.group(1).replace(chr(0x2212), '-')} {forms['range_to']} "
+            f"{m.group(2).replace(chr(0x2212), '-')} {forms['degrees_celsius']}"
+        ),
         text,
         flags=re.IGNORECASE,
     )
     text = re.sub(
-        r"(?<!\w)([-+\u2212]?\d+(?:\.\d+)?)\s*[\u2013\u2014-]\s*([-+\u2212]?\d+(?:\.\d+)?)\s*°\s*F\b",
-        lambda m: f"{m.group(1).replace(chr(0x2212), '-')} to {m.group(2).replace(chr(0x2212), '-')} degrees Fahrenheit",
+        rf"(?<!\w)({_NUMBER_RE})\s*[\u2013\u2014-]\s*({_NUMBER_RE})\s*°\s*F\b",
+        lambda m: (
+            f"{m.group(1).replace(chr(0x2212), '-')} {forms['range_to']} "
+            f"{m.group(2).replace(chr(0x2212), '-')} {forms['degrees_fahrenheit']}"
+        ),
         text,
         flags=re.IGNORECASE,
     )
     return text
 
 
-def normalize_symbols_for_tts(text: str) -> str:
+def normalize_symbols_for_tts(text: str, locale: str | None = None) -> str:
     """Expand common symbols/shorthand into words a TTS engine reads well."""
     if not text:
         return ""
@@ -110,46 +180,70 @@ def normalize_symbols_for_tts(text: str) -> str:
     text = re.sub("[   ]", " ", text)  # non-breaking / thin spaces
     text = text.replace("\u2212", "-")  # minus sign
     text = text.replace("…", "...")  # ellipsis
-    text = _normalize_temperature_ranges(text)
+    forms = _symbol_forms_for_locale(locale)
+
+    # Do not inject English into known non-English languages for which Hermes
+    # has no table. Their TTS provider gets the original semantic symbols.
+    if forms is None:
+        text = re.sub("[•◦▪▫]", " ", text)
+        text = _VARIATION_SELECTOR_RE.sub("", text)
+        return _EMOJI_RE.sub("", text)
+
+    text = _normalize_temperature_ranges(text, forms)
 
     # Temperatures with a number.  Do this before generic degree handling.
-    text = re.sub(r"(?<!\w)([-+]?\d+(?:\.\d+)?)\s*°\s*C\b", r"\1 degrees Celsius", text, flags=re.IGNORECASE)
-    text = re.sub(r"(?<!\w)([-+]?\d+(?:\.\d+)?)\s*°\s*F\b", r"\1 degrees Fahrenheit", text, flags=re.IGNORECASE)
+    text = re.sub(
+        rf"(?<!\w)({_NUMBER_RE})\s*°\s*C\b",
+        lambda m: f"{m.group(1)} {forms['degrees_celsius']}",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(
+        rf"(?<!\w)({_NUMBER_RE})\s*°\s*F\b",
+        lambda m: f"{m.group(1)} {forms['degrees_fahrenheit']}",
+        text,
+        flags=re.IGNORECASE,
+    )
     # Bare units with no leading number ("measured in degrees C").
-    text = re.sub(r"°\s*C\b", "degrees Celsius", text, flags=re.IGNORECASE)
-    text = re.sub(r"°\s*F\b", "degrees Fahrenheit", text, flags=re.IGNORECASE)
+    text = re.sub(r"°\s*C\b", forms["degrees_celsius"], text, flags=re.IGNORECASE)
+    text = re.sub(r"°\s*F\b", forms["degrees_fahrenheit"], text, flags=re.IGNORECASE)
     # Any remaining degree symbol (angles, stray cases).
-    text = re.sub(r"(?<!\w)([-+]?\d+(?:\.\d+)?)\s*°", r"\1 degrees", text)
-    text = text.replace("°", " degrees")
+    text = re.sub(
+        rf"(?<!\w)({_NUMBER_RE})\s*°",
+        lambda m: f"{m.group(1)} {forms['degrees']}",
+        text,
+    )
+    text = text.replace("°", f" {forms['degrees']}")
 
     # Common weather/travel units.
-    text = re.sub(r"(?<=\d)\s*km\s*/\s*h\b", " kilometres per hour", text, flags=re.IGNORECASE)
-    text = re.sub(r"(?<=\d)\s*km/h\b", " kilometres per hour", text, flags=re.IGNORECASE)
-    text = re.sub(r"(?<=\d)\s*mm\b", " millimetres", text, flags=re.IGNORECASE)
-    text = re.sub(r"(?<=\d)\s*cm\b", " centimetres", text, flags=re.IGNORECASE)
-    text = re.sub(r"(?<=\d)\s*m\b", " metres", text, flags=re.IGNORECASE)
+    text = re.sub(r"(?<=\d)\s*km\s*/\s*h\b", f" {forms['km_per_hour']}", text, flags=re.IGNORECASE)
+    text = re.sub(r"(?<=\d)\s*km/h\b", f" {forms['km_per_hour']}", text, flags=re.IGNORECASE)
+    text = re.sub(r"(?<=\d)\s*mm\b", f" {forms['millimetres']}", text, flags=re.IGNORECASE)
+    text = re.sub(r"(?<=\d)\s*cm\b", f" {forms['centimetres']}", text, flags=re.IGNORECASE)
+    text = re.sub(r"(?<=\d)\s*m\b", f" {forms['metres']}", text, flags=re.IGNORECASE)
 
     # Numeric rates only ("5/month" -> "5 per month").  Requiring digit-then-letter
     # keeps "and/or", "N/A", "TCP/IP" and dates like "2026/06" intact.
-    text = re.sub(r"(?<=\d)\s*/\s*(?=[A-Za-z])", " per ", text)
+    text = re.sub(r"(?<=\d)\s*/\s*(?=[A-Za-zÀ-ÖØ-öø-ÿ])", f" {forms['per']} ", text)
 
     # Money and percentages.  The integer part must END in a digit so a trailing
     # comma ("A$50, ...") is not swallowed into the spoken amount.
-    text = re.sub(r"NZ\$\s*([\d,]*\d(?:\.\d+)?)", r"\1 New Zealand dollars", text, flags=re.IGNORECASE)
-    text = re.sub(r"A\$\s*([\d,]*\d(?:\.\d+)?)", r"\1 Australian dollars", text, flags=re.IGNORECASE)
-    text = re.sub(r"US\$\s*([\d,]*\d(?:\.\d+)?)", r"\1 US dollars", text, flags=re.IGNORECASE)
-    text = re.sub(r"€\s*([\d,]*\d(?:\.\d+)?)", r"\1 euros", text)
-    text = re.sub(r"£\s*([\d,]*\d(?:\.\d+)?)", r"\1 pounds", text)
-    text = re.sub(r"\$\s*([\d,]*\d(?:\.\d+)?)", r"\1 dollars", text)
-    text = re.sub(r"(?<=\d)\s*%", " percent", text)
+    amount = r"([\d,]*\d(?:\.\d+)?)"
+    text = re.sub(rf"NZ\$\s*{amount}", lambda m: f"{m.group(1)} {forms['nzd']}", text, flags=re.IGNORECASE)
+    text = re.sub(rf"A\$\s*{amount}", lambda m: f"{m.group(1)} {forms['aud']}", text, flags=re.IGNORECASE)
+    text = re.sub(rf"US\$\s*{amount}", lambda m: f"{m.group(1)} {forms['usd']}", text, flags=re.IGNORECASE)
+    text = re.sub(rf"€\s*{amount}", lambda m: f"{m.group(1)} {forms['eur']}", text)
+    text = re.sub(rf"£\s*{amount}", lambda m: f"{m.group(1)} {forms['gbp']}", text)
+    text = re.sub(rf"\$\s*{amount}", lambda m: f"{m.group(1)} {forms['dollars']}", text)
+    text = re.sub(r"(?<=\d)\s*%", f" {forms['percent']}", text)
 
     # Operators and separators that commonly leak from formatted answers.
-    text = text.replace("&", " and ")
+    text = text.replace("&", f" {forms['and']} ")
     text = re.sub("[•◦▪▫]", " ", text)  # bullet glyphs
-    text = text.replace("→", " to ")  # ->
-    text = text.replace("⇒", " to ")  # =>
-    text = text.replace("≈", " about ")  # almost equal
-    text = text.replace("~", " about ")
+    text = text.replace("→", f" {forms['to']} ")  # ->
+    text = text.replace("⇒", f" {forms['to']} ")  # =>
+    text = text.replace("≈", f" {forms['about']} ")  # almost equal
+    text = text.replace("~", f" {forms['about']} ")
 
     text = _VARIATION_SELECTOR_RE.sub("", text)
     text = _EMOJI_RE.sub("", text)
@@ -258,7 +352,11 @@ def flatten_newlines_for_payload(text: str) -> str:
     return text.strip()
 
 
-def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
+def prepare_spoken_text(
+    text: str,
+    max_chars: int | None = 4000,
+    locale: str | None = None,
+) -> str:
     """Return a TTS-friendly script from assistant text.
 
     Deterministic cleanup, not a semantic rewrite: it removes ``<think>``
@@ -270,7 +368,7 @@ def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
     """
     spoken = strip_nonspoken_blocks(text)
     spoken = strip_markdown_for_tts(spoken)
-    spoken = normalize_symbols_for_tts(spoken)
+    spoken = normalize_symbols_for_tts(spoken, locale=locale)
     spoken = smooth_whitespace_for_tts(spoken)
     spoken = flatten_newlines_for_payload(spoken)
     if max_chars is not None and max_chars > 0 and len(spoken) > max_chars:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -706,6 +706,91 @@ def _resolve_command_provider_config(
     return None
 
 
+_TTS_LOCALE_RE = re.compile(
+    r"^[A-Za-z]{2,3}(?:[-_][A-Za-z0-9]{2,8})*$"
+)
+_VOICE_LOCALE_RE = re.compile(
+    r"(?:^|[/\\])([A-Za-z]{2,3})[-_]([A-Za-z]{2})(?=[-_])"
+)
+
+
+def _canonicalize_tts_locale(value: object) -> Optional[str]:
+    """Return a conservative BCP-47-like locale, or ``None`` if absent."""
+    if not isinstance(value, str):
+        return None
+    locale = value.strip()
+    if not locale:
+        return None
+    if locale.lower() in {"auto", "und"}:
+        return "und"
+    if not _TTS_LOCALE_RE.fullmatch(locale):
+        return None
+    parts = locale.replace("_", "-").split("-")
+    normalized = [parts[0].lower()]
+    for part in parts[1:]:
+        normalized.append(part.upper() if len(part) == 2 else part)
+    return "-".join(normalized)
+
+
+def _infer_tts_locale_from_voice(provider_config: Dict[str, Any]) -> Optional[str]:
+    """Infer locales embedded in Edge/Piper-style voice identifiers."""
+    for key in ("voice", "voice_id"):
+        value = provider_config.get(key)
+        if not isinstance(value, str):
+            continue
+        match = _VOICE_LOCALE_RE.search(value.strip())
+        if match:
+            return _canonicalize_tts_locale(
+                f"{match.group(1)}-{match.group(2)}"
+            )
+    return None
+
+
+def _resolve_tts_locale(
+    provider: Optional[str],
+    tts_config: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Resolve the language used by Hermes' spoken-text normalizer.
+
+    Resolution order is provider-specific ``language``/``locale``, global
+    ``tts.language``, then a locale embedded in Edge/Piper-style voice names.
+    English remains the compatibility fallback. An explicit ``auto``/``und``
+    returns ``und`` so the normalizer leaves semantic symbols to the provider.
+    """
+    config = tts_config if isinstance(tts_config, dict) else _load_tts_config()
+    provider_key = (provider or _get_provider(config)).lower().strip()
+    if provider_key in BUILTIN_TTS_PROVIDERS:
+        provider_config = _get_provider_section(config, provider_key)
+    else:
+        provider_config = _get_named_provider_config(config, provider_key)
+
+    for candidate in (
+        provider_config.get("language"),
+        provider_config.get("locale"),
+        config.get("language"),
+    ):
+        locale = _canonicalize_tts_locale(candidate)
+        if locale is not None:
+            return locale
+
+    return _infer_tts_locale_from_voice(provider_config) or "en"
+
+
+def _prepare_spoken_text_for_tts(
+    text: str,
+    *,
+    max_chars: Optional[int] = None,
+    tts_config: Optional[Dict[str, Any]] = None,
+    provider: Optional[str] = None,
+) -> str:
+    """Apply shared cleanup using the configured provider's language."""
+    config = tts_config if isinstance(tts_config, dict) else _load_tts_config()
+    locale = _resolve_tts_locale(provider, config)
+    from tools.tts_text_normalize import prepare_spoken_text
+
+    return prepare_spoken_text(text, max_chars=max_chars, locale=locale)
+
+
 def _dispatch_to_plugin_provider(
     text: str,
     output_path: str,
@@ -2819,15 +2904,26 @@ def text_to_speech_tool(
     if not text or not text.strip():
         return tool_error("Text is required", success=False)
 
+    tts_config = _load_tts_config()
+
+    # Resolve the provider before cleanup so symbol/unit expansion follows the
+    # configured voice language instead of always injecting English.
+    if provider:
+        provider = provider.lower().strip()
+    else:
+        provider = _get_provider(tts_config)
+
     try:
-        from tools.tts_text_normalize import prepare_spoken_text
-        text = prepare_spoken_text(text, max_chars=None)
+        text = _prepare_spoken_text_for_tts(
+            text,
+            max_chars=None,
+            tts_config=tts_config,
+            provider=provider,
+        )
     except Exception:
         text = text.strip()
     if not text:
         return tool_error("Text is empty after TTS cleanup", success=False)
-
-    tts_config = _load_tts_config()
 
     # When the model supplies a speed parameter, inject it into the config
     # so all downstream provider functions pick it up uniformly.
@@ -2835,12 +2931,6 @@ def text_to_speech_tool(
         clamped = max(0.25, min(4.0, float(speed)))
         tts_config = dict(tts_config)  # shallow copy to avoid mutating the cache
         tts_config["speed"] = clamped
-
-    # Allow per-call provider override; fall back to the configured default.
-    if provider:
-        provider = provider.lower().strip()
-    else:
-        provider = _get_provider(tts_config)
 
     # User-declared command provider (type: command under tts.providers.<name>)
     # resolves BEFORE the built-in dispatch. Built-in names short-circuit here
@@ -3319,19 +3409,29 @@ _EMOJI = re.compile(
 _THINK_BLOCK = re.compile(r'<think[\s>].*?</think>', flags=re.DOTALL)
 
 
-def _strip_markdown_for_tts(text: str) -> str:
+def _strip_markdown_for_tts(
+    text: str,
+    *,
+    tts_config: Optional[Dict[str, Any]] = None,
+    provider: Optional[str] = None,
+) -> str:
     """Prepare text for speech via the shared cleaner in tts_text_normalize.
 
     One cleaner for every TTS path (tool, gateway auto-TTS, voice-mode
     streaming, web dashboard): strips <think> reasoning blocks, the
     file-mutation verifier footer, markdown, and emoji; expands units and
     symbols; and flattens newlines to sentence breaks so newline-sensitive
-    providers (Kokoro) speak the whole script.  Falls back to the legacy
-    regex pipeline if the normalizer ever fails.
+    providers (Kokoro) speak the whole script. Symbol and unit expansions use
+    the resolved provider language. Falls back to the legacy regex pipeline if
+    the normalizer ever fails.
     """
     try:
-        from tools.tts_text_normalize import prepare_spoken_text
-        return prepare_spoken_text(text, max_chars=None)
+        return _prepare_spoken_text_for_tts(
+            text,
+            max_chars=None,
+            tts_config=tts_config,
+            provider=provider,
+        )
     except Exception:
         pass
     text = _THINK_BLOCK.sub(' ', text)
@@ -3479,6 +3579,11 @@ def stream_tts_to_speaker(
         # per-sentence sync synthesis (universal — edge + every non-streamer).
         from tools.tts_streaming import SentenceChunker, resolve_streaming_provider
         streamer = resolve_streaming_provider(tts_config, preferred=provider)
+        spoken_provider = (
+            getattr(streamer, "provider_name", "")
+            or provider
+            or _get_provider(tts_config)
+        )
 
         # No chunked streamer: per-sentence sync synthesis, pipelined so the
         # next sentence synthesizes while the current one plays (closed in the
@@ -3727,7 +3832,11 @@ def stream_tts_to_speaker(
             """Display sentence and route to the appropriate audio path."""
             if stop_event.is_set():
                 return
-            cleaned = _strip_markdown_for_tts(sentence).strip()
+            cleaned = _strip_markdown_for_tts(
+                sentence,
+                tts_config=tts_config,
+                provider=spoken_provider,
+            ).strip()
             if not cleaned:
                 return
             # Skip duplicate/near-duplicate sentences (LLM repetition)

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -45,6 +45,7 @@ Convert text to speech with eleven providers:
 # In ~/.hermes/config.yaml
 tts:
   provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "deepinfra" | "neutts" | "kittentts" | "piper"
+  language: ""                  # Optional BCP-47 override; blank infers from provider/voice
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -104,6 +105,15 @@ tts:
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
 ```
+
+Hermes uses the resolved TTS language when expanding symbols and units before
+synthesis. Provider-specific `language` or `locale` settings take priority,
+then `tts.language`; when both are blank, locale-bearing Edge and Piper voice
+names such as `fr-FR-HenriNeural` and `fr_FR-siwis-medium` are detected
+automatically. English remains the compatibility fallback. For other
+explicitly configured languages without a bundled expansion table, Hermes
+leaves semantic symbols for the selected voice to pronounce instead of
+inserting English words.
 
 MiniMax TTS selects its region, endpoint, and credential together:
 


### PR DESCRIPTION
## What does this PR do?

The shared TTS normalizer expanded symbols and units with hard-coded English words before the configured provider or voice language was available. A French Edge voice such as `fr-FR-HenriNeural` therefore received mixed-language input such as `44 percent`, `28,2 degrees Celsius`, and `12 kilometres per hour`.

This makes spoken-text normalization locale-aware across synchronous TTS, CLI voice mode, gateway auto-TTS, gateway streaming, and the dashboard speak-stream WebSocket. Provider `language`/`locale` settings win, followed by the optional global `tts.language`; Edge/Piper-style locale-bearing voice names are inferred when neither is set. English remains the compatibility fallback.

French gets localized expansions for the existing symbol/unit surface. For explicitly configured non-English locales without a bundled table, Hermes leaves semantic symbols such as `%`, `°C`, and `km/h` intact for the selected TTS provider instead of injecting English.

## Related Issue

Fixes #80136

Related: #73966 adds user-configurable literal pronunciation substitutions. That is a complementary manual override; it does not resolve a locale from the configured provider/voice or automatically localize the built-in symbol expansions.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Why this is the right fix

The failure is in the shared source path, not provider behavior: `prepare_spoken_text()` called the English-only symbol normalizer before `text_to_speech_tool()` loaded TTS config. Several callers also pre-cleaned text without any language context, so fixing only the explicit tool path would leave CLI, gateway, and streaming behavior inconsistent.

The patch keeps locale resolution in the TTS dispatch layer and keeps `tts_text_normalize.py` deterministic: the normalizer receives a locale but does not read config itself. Streaming providers expose their registered provider name so profile-scoped config is resolved against the provider that actually receives the text.

No localization dependency is added for this initial English/French surface. Babel is the closest future fit because its CLDR data can render localized units and currencies, but Hermes would still need its own mixed-text token recognition and handling for `%`, arrows, and operators. Once the built-in surface reaches roughly 3-5 languages, the more maintainable direction is to migrate unit/currency rendering to Babel/CLDR and retain only a small table for forms CLDR does not cover.

## Changes Made

- `tools/tts_text_normalize.py`: add locale-selected English/French spoken forms, decimal-comma range handling, and a non-English pass-through for locales without a bundled table.
- `tools/tts_tool.py`: resolve the TTS locale from provider config, global config, or structured voice names before shared cleanup.
- CLI, gateway, and streaming entry points: propagate the resolved provider/config through every spoken-text cleanup path.
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example`, and TTS docs: document the optional `tts.language` override and inference order.
- Regression tests: cover French output, English compatibility, unsupported-language pass-through, Edge/Piper inference, real config-to-provider dispatch, gateway streaming, and dashboard WebSocket streaming.

## How to Test

1. On clean `upstream/main@8f2712725`, run `prepare_spoken_text()` on French weather text. It produces:

   ```text
   Il fait 44 percent d'humidité.
   Il fait 28,2 degrees Celsius.
   Vent à 12 kilometres per hour.
   ```

2. Configure `tts.edge.voice: fr-FR-HenriNeural` and run the same inputs with this branch. The provider-bound text is:

   ```text
   Il fait 44 pour cent d'humidité.
   Il fait 28,2 degrés Celsius.
   Vent à 12 kilomètres par heure.
   ```

3. Run the focused suites:

   ```bash
   .venv/bin/pytest -q tests/tools/test_tts*.py tests/tools/test_voice_cli_integration.py tests/gateway/test_*tts*.py tests/gateway/test_auto_voice_reply_format.py tests/hermes_cli/test_*tts*.py tests/hermes_cli/test_voice_wrapper.py tests/hermes_cli/test_web_server_speak_stream.py
   # 344 passed, 2 skipped

   rg --files tests/hermes_cli tests/cli | rg '/test_config.*\.py$' | xargs .venv/bin/pytest -q
   # 98 passed
   ```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit follows Conventional Commits
- [x] I searched for existing PRs and compared the adjacent #73966 path
- [x] The PR contains only changes related to locale-aware TTS normalization
- [x] The focused TTS and config suites pass
- [x] Regression tests cover the changed behavior
- [x] Tested on macOS 26.5.2 arm64 with Python 3.11.15

### Documentation & Housekeeping

- [x] Updated the TTS documentation and `cli-config.yaml.example`
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are not required
- [x] Cross-platform impact checked; no platform-specific runtime APIs added
- [x] Tool schema changes are not required

## Validation Logs

```text
TTS-related suites: 344 passed, 2 skipped
Config suites: 98 passed
Ruff: passed on all touched Python files
py_compile: passed on all touched runtime Python files
Windows footgun scan: passed on 11 touched Python files
git diff --check: passed
```

## Remaining Risks

- French is the only newly bundled non-English expansion table in this PR. Other explicit non-English locales avoid the original mixed-language bug by preserving semantic symbols for provider-native pronunciation.
- No live cloud TTS request was made; tests verify the exact text delivered to fake provider boundaries across synchronous and streaming paths.
