### PR TITLE
fix(web): surface explicit provider failures

### DIFF
--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -413,6 +413,40 @@ class FirecrawlWebSearchProvider(WebSearchProvider):
         client = _get_firecrawl_client()
         try:
             response = client.search(query=query, limit=limit)
+            response_plain = _to_plain_object(response)
+
+            if isinstance(response_plain, dict) and response_plain.get("success") is False:
+                detail = response_plain.get("error") or response_plain.get("message")
+                return {
+                    "success": False,
+                    "error": f"Firecrawl search failed: {detail or 'upstream returned failure'}",
+                }
+
+            valid_result_container = False
+            if isinstance(response_plain, dict):
+                data = response_plain.get("data")
+                valid_result_container = (
+                    isinstance(data, list)
+                    or (
+                        isinstance(data, dict)
+                        and (
+                            isinstance(data.get("web"), list)
+                            or isinstance(data.get("results"), list)
+                        )
+                    )
+                    or isinstance(response_plain.get("web"), list)
+                    or isinstance(response_plain.get("results"), list)
+                )
+            if not valid_result_container and hasattr(response, "web"):
+                valid_result_container = isinstance(getattr(response, "web", None), list)
+
+            if not valid_result_container:
+                logger.warning("Firecrawl search returned an unexpected response shape")
+                return {
+                    "success": False,
+                    "error": "Firecrawl search failed: unexpected response shape",
+                }
+
             web_results = _extract_web_search_results(response)
             logger.info("Firecrawl: found %d search results", len(web_results))
             return {"success": True, "data": {"web": web_results}}

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -87,6 +87,24 @@ class TestPerCapabilityBackendSelection:
         monkeypatch.setenv("TAVILY_API_KEY", "test-key")
         assert web_tools._get_search_backend() == "tavily"
 
+    def test_explicit_search_backend_remains_authoritative_when_unavailable(self, monkeypatch):
+        """Do not silently switch away from an explicitly selected backend.
+
+        The selected provider owns the actionable configuration error. Falling
+        through here can dispatch a different provider and report an empty
+        success without ever calling the backend the user configured (#79899).
+        """
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "backend": "firecrawl",
+            "search_backend": "exa",  # explicit, but no EXA_API_KEY
+        })
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.setenv("FIRECRAWL_API_KEY", "fc-key")
+
+        assert web_tools._get_search_backend() == "exa"
+
 
     def test_fully_backward_compatible_with_web_backend_only(self, monkeypatch):
         from tools import web_tools
@@ -388,6 +406,105 @@ class TestDispatchersTriggerPluginDiscovery:
             )
             assert "No web search provider configured" not in json.dumps(result)
             assert web_search_registry.get_provider("brave-free") is not None
+        finally:
+            restore()
+
+    def test_missing_explicit_search_provider_never_uses_alternate(self, monkeypatch):
+        """A missing configured backend must fail instead of returning empty success."""
+        from agent import web_search_registry
+        from agent.web_search_provider import WebSearchProvider
+        from tools import web_tools
+
+        restore = self._clear_registry()
+        alternate_calls = 0
+        try:
+            class EmptyAlternate(WebSearchProvider):
+                @property
+                def name(self):
+                    return "ddgs"
+
+                @property
+                def display_name(self):
+                    return "Empty Alternate"
+
+                def is_available(self):
+                    return True
+
+                def supports_search(self):
+                    return True
+
+                def search(self, query, limit=5):
+                    nonlocal alternate_calls
+                    alternate_calls += 1
+                    return {"success": True, "data": {"web": []}}
+
+            web_search_registry.register_provider(EmptyAlternate())
+            monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+            monkeypatch.setattr(
+                web_tools,
+                "_load_web_config",
+                lambda: {"search_backend": "firecrawl"},
+            )
+            monkeypatch.setenv("FIRECRAWL_API_KEY", "fake")
+
+            result = json.loads(web_tools.web_search_tool("python asyncio tutorial", limit=5))
+
+            assert result["success"] is False
+            assert "firecrawl" in result["error"]
+            assert alternate_calls == 0
+        finally:
+            restore()
+
+    def test_missing_explicit_extract_provider_never_uses_alternate(self, monkeypatch):
+        """The explicit-provider invariant applies to extraction too."""
+        import asyncio
+        from agent import web_search_registry
+        from agent.web_search_provider import WebSearchProvider
+        from tools import web_tools
+
+        restore = self._clear_registry()
+        alternate_calls = 0
+        try:
+            class EmptyAlternate(WebSearchProvider):
+                @property
+                def name(self):
+                    return "tavily"
+
+                @property
+                def display_name(self):
+                    return "Empty Alternate"
+
+                def is_available(self):
+                    return True
+
+                def supports_extract(self):
+                    return True
+
+                async def extract(self, urls, **kwargs):
+                    nonlocal alternate_calls
+                    alternate_calls += 1
+                    return []
+
+            async def _safe(_url):
+                return True
+
+            web_search_registry.register_provider(EmptyAlternate())
+            monkeypatch.setattr(web_tools, "_ensure_web_plugins_loaded", lambda: None)
+            monkeypatch.setattr(web_tools, "async_is_safe_url", _safe)
+            monkeypatch.setattr(
+                web_tools,
+                "_load_web_config",
+                lambda: {"extract_backend": "firecrawl"},
+            )
+            monkeypatch.setenv("FIRECRAWL_API_KEY", "fake")
+
+            result = json.loads(asyncio.run(web_tools.web_extract_tool([
+                "https://example.com/page",
+            ])))
+
+            assert result["success"] is False
+            assert "firecrawl" in result["error"]
+            assert alternate_calls == 0
         finally:
             restore()
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -380,6 +380,47 @@ class TestWebSearchErrorHandling:
         assert "traceback" not in result
 
 
+class TestFirecrawlSearchResponseHandling:
+    """Firecrawl must distinguish a valid empty result from backend failure."""
+
+    def test_explicit_upstream_failure_is_not_empty_success(self, monkeypatch):
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        client = MagicMock()
+        client.search.return_value = {"success": False, "error": "quota unavailable"}
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: client)
+
+        result = firecrawl_provider.FirecrawlWebSearchProvider().search("docs", 5)
+
+        assert result == {
+            "success": False,
+            "error": "Firecrawl search failed: quota unavailable",
+        }
+
+    def test_unexpected_response_shape_is_not_empty_success(self, monkeypatch):
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        client = MagicMock()
+        client.search.return_value = {"success": True, "data": {"status": "queued"}}
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: client)
+
+        result = firecrawl_provider.FirecrawlWebSearchProvider().search("docs", 5)
+
+        assert result["success"] is False
+        assert "unexpected response shape" in result["error"]
+
+    def test_legitimate_empty_web_results_remain_successful(self, monkeypatch):
+        from plugins.web.firecrawl import provider as firecrawl_provider
+
+        client = MagicMock()
+        client.search.return_value = {"success": True, "data": {"web": []}}
+        monkeypatch.setattr(firecrawl_provider, "_get_firecrawl_client", lambda: client)
+
+        result = firecrawl_provider.FirecrawlWebSearchProvider().search("no matches", 5)
+
+        assert result == {"success": True, "data": {"web": []}}
+
+
 class TestCheckWebApiKey:
     """Test suite for check_web_api_key() unified availability check."""
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -295,16 +295,30 @@ def _get_extract_backend() -> str:
     return _get_capability_backend("extract")
 
 
+def _configured_capability_backend(capability: str) -> str:
+    """Return the user-selected backend for *capability*, if any.
+
+    Per-capability configuration wins over the shared backend. The value is
+    returned without an availability probe: explicit selection is authoritative
+    so a provider-specific error is surfaced instead of silently dispatching a
+    different backend (#79899).
+    """
+    cfg = _load_web_config()
+    return (
+        (cfg.get(f"{capability}_backend") or "").lower().strip()
+        or (cfg.get("backend") or "").lower().strip()
+    )
+
+
 def _get_capability_backend(capability: str) -> str:
     """Shared helper for per-capability backend selection.
 
-    Reads ``web.{capability}_backend`` from config; if set and available,
-    uses it. Otherwise falls through to the shared ``_get_backend()``.
+    An explicitly configured capability/shared backend is authoritative. Only
+    when neither is set do we auto-detect an available backend.
     """
-    cfg = _load_web_config()
-    specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
-        return specific
+    configured = _configured_capability_backend(capability)
+    if configured:
+        return configured
     return _get_backend()
 
 
@@ -682,13 +696,18 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _disabled_web_plugin_for,
         )
 
+        configured_backend = _configured_capability_backend("search")
         backend = _get_search_backend()
         provider = _wsp_get_provider(backend) if backend else None
+
         if provider is None or not provider.supports_search():
-            # Fall back to availability-walked active provider when the
-            # configured backend isn't a registered search provider (typo,
-            # uninstalled plugin, or capability mismatch).
-            provider = get_active_search_provider()
+            if configured_backend:
+                # Explicit selection is authoritative. Do not silently run a
+                # different provider: that can turn a configuration/registry
+                # failure into a misleading successful empty result.
+                provider = None
+            else:
+                provider = get_active_search_provider()
 
         if provider is None:
             # A bundled web plugin the user explicitly disabled looks
@@ -704,6 +723,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
                         f"plugin ('{disabled_key}') is disabled in config. "
                         f"Re-enable it with `hermes plugins enable {disabled_key}` "
                         "(or remove it from plugins.disabled)."
+                    ),
+                }
+            elif configured_backend:
+                response_data = {
+                    "success": False,
+                    "error": (
+                        f"Configured web search provider '{configured_backend}' "
+                        "is not registered or does not support search. Check "
+                        "the provider plugin and credentials, or choose another "
+                        "provider with `hermes tools`."
                     ),
                 }
             else:
@@ -870,14 +899,14 @@ async def web_extract_tool(
                 _disabled_web_plugin_for,
             )
 
+            configured_backend = _configured_capability_backend("extract")
             provider = _wsp_get_provider(backend) if backend else None
+
             if provider is None or not provider.supports_extract():
                 # When the configured name IS registered but doesn't support
                 # extract (search-only providers like brave-free / ddgs /
                 # searxng), surface that as a typed "search-only" error
-                # rather than silently switching backends. When the name
-                # isn't registered at all (typo / uninstalled plugin), fall
-                # through to the active-provider walk.
+                # rather than silently switching backends.
                 if provider is not None and not provider.supports_extract():
                     return json.dumps(
                         {
@@ -891,7 +920,8 @@ async def web_extract_tool(
                         },
                         ensure_ascii=False,
                     )
-                provider = get_active_extract_provider()
+                if not configured_backend:
+                    provider = get_active_extract_provider()
                 if provider is None:
                     # If the configured backend is a bundled web plugin the
                     # user explicitly disabled, the backend is set correctly
@@ -910,6 +940,19 @@ async def web_extract_tool(
                                     "in config. Re-enable it with "
                                     f"`hermes plugins enable {disabled_key}` "
                                     "(or remove it from plugins.disabled)."
+                                ),
+                            },
+                            ensure_ascii=False,
+                        )
+                    if configured_backend:
+                        return json.dumps(
+                            {
+                                "success": False,
+                                "error": (
+                                    f"Configured web extract provider "
+                                    f"'{configured_backend}' is not registered. "
+                                    "Check the provider plugin and credentials, "
+                                    "or choose another provider with `hermes tools`."
                                 ),
                             },
                             ensure_ascii=False,


### PR DESCRIPTION
## What does this PR do?

Prevents an explicitly configured web provider from being silently replaced by another registered provider when the configured provider is unavailable or missing. That fallback could return a successful empty result even though the provider selected by the user was never called.

The change also makes Firecrawl distinguish three cases:

- an upstream `success: false` response becomes an actionable failure;
- an unexpected response shape becomes an actionable failure;
- a valid `{"success": true, "data": {"web": []}}` response remains a legitimate empty success.

## Related Issue

Fixes #79899

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/web_tools.py`: treat per-capability/shared explicit provider configuration as authoritative; preserve automatic provider walking only when no provider is explicitly configured.
- `plugins/web/firecrawl/provider.py`: propagate explicit Firecrawl failures and reject malformed response shapes without conflating them with valid empty results.
- `tests/tools/test_web_providers.py`: cover unavailable explicit selection and ensure search/extract never dispatch an alternate provider.
- `tests/tools/test_web_tools_config.py`: cover Firecrawl failure, malformed payload, and legitimate empty-result behavior.

## How to Test

1. Configure `web.search_backend: firecrawl` while leaving an alternate search provider registered and Firecrawl unavailable; `web_search` should return an actionable Firecrawl error and must not call the alternate provider.
2. Return `{"success": false, "error": "quota unavailable"}` or an unexpected payload from the Firecrawl client; the tool should return `success: false`.
3. Return `{"success": true, "data": {"web": []}}`; the tool should retain the valid empty success.

Canonical focused verification:

```text
scripts/run_tests.sh -j 4 \
  tests/tools/test_web_providers.py \
  tests/tools/test_web_tools_config.py \
  tests/tools/test_web_tools_truncate.py \
  tests/tools/test_web_extract_robustness.py \
  tests/tools/test_web_tools_dict_urls.py \
  tests/tools/test_web_providers_ddgs.py \
  tests/tools/test_web_providers_brave_free.py \
  tests/tools/test_web_providers_searxng.py \
  tests/tools/test_web_providers_xai.py \
  tests/tools/test_web_tools_tavily.py
# 10 files, 135 tests passed, 0 failed

ruff check tools/web_tools.py plugins/web/firecrawl/provider.py \
  tests/tools/test_web_providers.py tests/tools/test_web_tools_config.py
# All checks passed
```

A broader `tests/tools/` run was also attempted, but was not clean because this WSL environment lacks optional lazy dependencies (`daytona`, `fal-client`) and has unrelated platform/performance failures. The web-focused files above all pass under the canonical runner.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 22.04 under WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing config or command change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — provider routing is platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; schema is unchanged

## Screenshots / Logs

Not applicable; this is provider routing and response handling.
