### PR TITLE
docs(integrations): add qwen-audio-agent voice frontend (EN + zh-Hans)

### DIFF
--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -78,6 +78,10 @@ Speech-to-text supports eight providers: local faster-whisper (free, runs on-dev
 
 - **[IDE Integration (ACP)](/user-guide/features/acp)** — Use Hermes Agent inside ACP-compatible editors such as VS Code, Zed, and JetBrains. Hermes runs as an ACP server, rendering chat messages, tool activity, file diffs, and terminal commands inside your editor.
 
+## Voice Frontends
+
+- **[qwen-audio-agent](/integrations/qwen-audio-agent)** — Open-source realtime full-duplex voice frontend. Drives `hermes acp` hands-free with barge-in, a fully local wake word, and background task results read back into the conversation. Ships a macOS desktop orb, terminal TUI, and web UI.
+
 ## Programmatic Access
 
 - **[API Server](/user-guide/features/api-server)** — Expose Hermes as an OpenAI-compatible HTTP endpoint. Any frontend that speaks the OpenAI format — Open WebUI, LobeChat, LibreChat, NextChat, ChatBox — can connect and use Hermes as a backend with its full toolset.

--- a/website/docs/integrations/qwen-audio-agent.md
+++ b/website/docs/integrations/qwen-audio-agent.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 5
+title: "qwen-audio-agent Integration"
+description: "Drive Hermes hands-free with realtime full-duplex voice over ACP — barge-in, a local wake word, and background task readback"
+---
+
+# qwen-audio-agent Integration
+
+[qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) is an open-source realtime full-duplex voice frontend for ACP agents. It spawns Hermes over stdio via `hermes acp` and turns a session into a hands-free voice conversation — in a macOS desktop orb, a terminal TUI, or a browser.
+
+## What it adds
+
+| Capability | Behavior |
+|---|---|
+| **Full-duplex voice with barge-in** | Talk while Hermes is speaking; the interruption stops generation immediately |
+| **Local wake word** | Wake-word detection runs fully on-device (sherpa-onnx); nothing leaves your machine for activation |
+| **Background task readback** | Long jobs run async; results return to the conversation when they finish |
+| **Voice permission confirmations** | Approve or deny Hermes' permission requests by voice |
+
+## Setup
+
+1. Install Hermes and complete authentication:
+
+   ```bash
+   hermes setup --portal
+   ```
+
+2. Install qwen-audio-agent and let it fill in any missing pieces:
+
+   ```bash
+   npm install -g qwen-audio-agent
+   qwenaudio install hermes
+   ```
+
+3. Verify, then start:
+
+   ```bash
+   qwenaudio setup --backend hermes
+   qwenaudio --backend hermes
+   ```
+
+Hermes is a natively supported backend in qwen-audio-agent, so your Hermes configuration — model, tools, MCP servers, skills — carries over unchanged.

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/index.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/index.md
@@ -69,6 +69,10 @@ Hermes 内置完整的浏览器自动化功能，提供多种后端选项，用�
 
 - **[IDE 集成（ACP）](/user-guide/features/acp)** — 在兼容 ACP 的编辑器（如 VS Code、Zed 和 JetBrains）中使用 Hermes Agent。Hermes 作为 ACP 服务器运行，在编辑器内渲染聊天消息、工具活动、文件差异和终端命令。
 
+## 语音前台
+
+- **[qwen-audio-agent](/integrations/qwen-audio-agent)** —— 开源实时全双工语音前台。通过 `hermes acp` 免提驱动 Hermes，支持插嘴打断、完全本地化的唤醒词，后台任务结果自动读回对话。提供 macOS 桌面悬浮球、终端 TUI 与 Web 三种形态。
+
 ## 程序化访问
 
 - **[API 服务器](/user-guide/features/api-server)** — 将 Hermes 暴露为兼容 OpenAI 的 HTTP 端点。任何支持 OpenAI 格式的前端——Open WebUI、LobeChat、LibreChat、NextChat、ChatBox——均可连接并将 Hermes 作为后端使用，享有其完整工具集。

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/qwen-audio-agent.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/integrations/qwen-audio-agent.md
@@ -1,0 +1,42 @@
+---
+sidebar_position: 5
+title: "qwen-audio-agent 集成"
+description: "通过 ACP 用实时全双工语音免提驱动 Hermes —— 插嘴打断、本地唤醒词、后台任务结果读回"
+---
+
+# qwen-audio-agent 集成
+
+[qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) 是面向 ACP Agent 的开源实时全双工语音前台。它通过 `hermes acp` 以 stdio 方式启动 Hermes，把会话变成免提语音对话 —— 提供 macOS 桌面悬浮球、终端 TUI 与浏览器三种形态。
+
+## 带来的能力
+
+| 能力 | 行为 |
+|---|---|
+| **全双工语音 + 插嘴打断** | Hermes 说话时随时开口，打断会立即停止生成 |
+| **本地唤醒词** | 唤醒词检测完全在本地运行（sherpa-onnx），激活不出本机 |
+| **后台任务结果读回** | 长任务异步执行，完成后结果自然回到当前对话 |
+| **语音权限确认** | 用语音批准或拒绝 Hermes 的权限请求 |
+
+## 配置步骤
+
+1. 安装 Hermes 并完成认证：
+
+   ```bash
+   hermes setup --portal
+   ```
+
+2. 安装 qwen-audio-agent，自动补齐缺失组件：
+
+   ```bash
+   npm install -g qwen-audio-agent
+   qwenaudio install hermes
+   ```
+
+3. 检查并启动：
+
+   ```bash
+   qwenaudio setup --backend hermes
+   qwenaudio --backend hermes
+   ```
+
+Hermes 是 qwen-audio-agent 的原生支持后台，你的 Hermes 配置 —— 模型、工具、MCP 服务器、技能 —— 原样复用。


### PR DESCRIPTION
## What does this PR do?

Docs-only change: adds a **qwen-audio-agent** integration page (EN + zh-Hans) under `website/docs/integrations/`, following the structure of the existing integration pages, and adds a new "Voice Frontends / 语音前台" section to the integrations index (EN + zh-Hans).

qwen-audio-agent is a realtime full-duplex voice frontend for ACP agents. It already integrates Hermes as a first-class backend: `hermes setup --portal` for auth, then `qwenaudio install hermes` / `qwenaudio setup --backend hermes` to run hands-free voice sessions against Hermes. This page documents that workflow for Hermes users.

Disclosure: I'm a maintainer of qwen-audio-agent.

## Related Issue

No issue — documentation addition only.

Fixes #N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no code changes)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `website/docs/integrations/qwen-audio-agent.md` — new EN integration page (capabilities table + 3-step setup)
- `website/i18n/zh-Hans/.../integrations/qwen-audio-agent.md` — zh-Hans mirror (follows the existing i18n layout)
- `website/docs/integrations/index.md` + zh-Hans `index.md` — new "Voice Frontends / 语音前台" section linking the page

## How to Test

1. `cd website && npm install && npm run start` (docusaurus)
2. Open the Integrations section; the new qwen-audio-agent page renders under "Voice Frontends"
3. Follow the 3 setup steps on a machine with Node.js; `qwenaudio --backend hermes` launches a voice session backed by Hermes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(integrations): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (N/A — docs only)
- [ ] I've added tests for my changes (N/A — docs only)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR is documentation
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — docs page notes macOS-first support
