### PR TITLE
tolerate malformed SMS_WEBHOOK_PORT on adapter init

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -69,6 +69,14 @@ DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _TWILIO_WEBHOOK_MAX_BODY_BYTES = 65_536  # 64 KiB — Twilio payloads are small
 
 
+def _coerce_int(value: object, *, default: int) -> int:
+    """Parse config ints; malformed values must not crash adapter init."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
 def check_sms_requirements() -> bool:
     """Check if SMS adapter dependencies are available."""
     try:
@@ -93,8 +101,9 @@ class SmsAdapter(BasePlatformAdapter):
         self._account_sid: str = _get_scoped_secret("TWILIO_ACCOUNT_SID", "")
         self._auth_token: str = _get_scoped_secret("TWILIO_AUTH_TOKEN", "")
         self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
-        self._webhook_port: int = int(
-            os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
+        self._webhook_port: int = _coerce_int(
+            os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT)),
+            default=DEFAULT_WEBHOOK_PORT,
         )
         self._webhook_host: str = os.getenv("SMS_WEBHOOK_HOST", DEFAULT_WEBHOOK_HOST)
         self._webhook_url: str = os.getenv("SMS_WEBHOOK_URL", "").strip()

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -140,6 +140,20 @@ class TestWebhookHostConfig:
             adapter = SmsAdapter(pc)
             assert adapter._webhook_url == "https://example.com/webhooks/twilio"
 
+    def test_invalid_webhook_port_falls_back_to_default(self):
+        from plugins.platforms.sms.adapter import DEFAULT_WEBHOOK_PORT, SmsAdapter
+
+        env = {
+            "TWILIO_ACCOUNT_SID": "ACtest",
+            "TWILIO_AUTH_TOKEN": "tok",
+            "TWILIO_PHONE_NUMBER": "+15550001111",
+            "SMS_WEBHOOK_PORT": "not-a-port",
+        }
+        with patch.dict(os.environ, env):
+            pc = PlatformConfig(enabled=True, api_key="tok")
+            adapter = SmsAdapter(pc)
+            assert adapter._webhook_port == DEFAULT_WEBHOOK_PORT
+
 
 # ── Startup guard (fail-closed) ────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- `SmsAdapter` used unguarded `int()` for `SMS_WEBHOOK_PORT`.
- A malformed env value raised during construction and took the Twilio webhook adapter down instead of falling back to the documented default port.
- Add a small int coercion helper and regression coverage for the invalid-port case.
