### PR TITLE
fix(heartbeat): accept spaced interval forms in /heartbeat

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -2792,7 +2792,7 @@ class GatewaySlashCommandsMixin:
         gateway-wide poller injects due heartbeats through the adapter FIFO
         as ordinary user turns, so alternation and caching are untouched.
         """
-        from hermes_cli.heartbeat import parse_interval, format_interval, MIN_INTERVAL_SECONDS
+        from hermes_cli.heartbeat import split_interval_prefix, format_interval, MIN_INTERVAL_SECONDS
 
         args = (event.get_command_args() or "").strip()
         lower = args.lower()
@@ -2824,16 +2824,9 @@ class GatewaySlashCommandsMixin:
                 self._unregister_heartbeat_watch(quick_key)
             return "✓ Heartbeat cleared." if had else "No heartbeat set."
 
-        # Set: `/heartbeat every 10m <prompt>` (also accepts `10m <prompt>`).
-        tokens = args.split(None, 2)
-        interval = None
-        prompt = ""
-        if tokens and tokens[0].lower() == "every" and len(tokens) >= 2:
-            interval = parse_interval(f"every {tokens[1]}")
-            prompt = tokens[2] if len(tokens) > 2 else ""
-        elif tokens:
-            interval = parse_interval(tokens[0])
-            prompt = args[len(tokens[0]):].strip() if interval and interval > 0 else ""
+        # Set: `/heartbeat every 10m <prompt>` (also accepts `10m <prompt>` and
+        # the spaced forms `every 90 minutes <prompt>` / `every 2 hours <prompt>`).
+        interval, prompt = split_interval_prefix(args)
 
         if interval is None:
             return (

--- a/gateway/slash_commands_goals.py
+++ b/gateway/slash_commands_goals.py
@@ -215,7 +215,7 @@ class GatewayGoalCommandsMixin:
         """Handle /heartbeat (mirror of the CLI handler): the session's one recurring re-entry
         prompt. The gateway-wide poller injects due heartbeats through the adapter FIFO as
         ordinary user turns, so alternation and caching hold."""
-        from hermes_cli.heartbeat import parse_interval, format_interval, MIN_INTERVAL_SECONDS
+        from hermes_cli.heartbeat import split_interval_prefix, format_interval, MIN_INTERVAL_SECONDS
         args = (event.get_command_args() or "").strip()
         lower = args.lower()
         mgr, _session_entry = await self._get_heartbeat_manager_for_event(event)
@@ -245,14 +245,10 @@ class GatewayGoalCommandsMixin:
             return "✓ Heartbeat cleared." if had else "No heartbeat set."
 
         # Set: `/heartbeat every 10m <prompt>` (also accepts `10m <prompt>`).
-        tokens = args.split(None, 2)
-        interval, prompt = None, ""
-        if tokens[0].lower() == "every" and len(tokens) >= 2:
-            interval = parse_interval(f"every {tokens[1]}")
-            prompt = tokens[2] if len(tokens) > 2 else ""
-        else:
-            interval = parse_interval(tokens[0])
-            prompt = args[len(tokens[0]):].strip() if interval and interval > 0 else ""
+        # Also accepts the spaced forms `every 90 minutes <prompt>` /
+        # `every 2 hours <prompt>`: the value and the unit are two words there, so a
+        # token split strands the unit at the head of the prompt.
+        interval, prompt = split_interval_prefix(args)
         if interval is None:
             return (
                 "Usage: /heartbeat every <interval> <prompt>  (e.g. /heartbeat every 10m Check CI)\n"

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2397,7 +2397,7 @@ class CLICommandsMixin:
         cross-process schedules use `hermes cron`.
         """
         from cli import _DIM, _RST, _cprint
-        from hermes_cli.heartbeat import parse_interval, format_interval
+        from hermes_cli.heartbeat import split_interval_prefix, format_interval
 
         parts = (cmd or "").strip().split(None, 1)
         arg = parts[1].strip() if len(parts) > 1 else ""
@@ -2436,16 +2436,9 @@ class CLICommandsMixin:
                 _cprint(f"  {_DIM}No heartbeat set.{_RST}")
             return
 
-        # Set: `/heartbeat every 10m <prompt>` (also accepts `10m <prompt>`).
-        tokens = arg.split(None, 2)
-        interval = None
-        prompt = ""
-        if tokens and tokens[0].lower() == "every" and len(tokens) >= 2:
-            interval = parse_interval(f"every {tokens[1]}")
-            prompt = tokens[2] if len(tokens) > 2 else ""
-        elif tokens:
-            interval = parse_interval(tokens[0])
-            prompt = arg[len(tokens[0]):].strip() if interval and interval > 0 else ""
+        # Set: `/heartbeat every 10m <prompt>` (also accepts `10m <prompt>` and
+        # the spaced forms `every 90 minutes <prompt>` / `every 2 hours <prompt>`).
+        interval, prompt = split_interval_prefix(arg)
 
         if interval is None:
             _cprint("  Usage: /heartbeat every <interval> <prompt>   (e.g. /heartbeat every 10m Check CI)")

--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2113,16 +2113,11 @@ class CLICommandsMixin:
 
     def _heartbeat_set(self, mgr, arg: str) -> None:
         """Set: ``/heartbeat every 10m <prompt>`` (also accepts ``10m <prompt>``)."""
-        from hermes_cli.heartbeat import parse_interval, format_interval
-        tokens = arg.split(None, 2)
-        interval = None
-        prompt = ""
-        if tokens and tokens[0].lower() == "every" and len(tokens) >= 2:
-            interval = parse_interval(f"every {tokens[1]}")
-            prompt = tokens[2] if len(tokens) > 2 else ""
-        elif tokens:
-            interval = parse_interval(tokens[0])
-            prompt = arg[len(tokens[0]):].strip() if interval and interval > 0 else ""
+        from hermes_cli.heartbeat import split_interval_prefix, format_interval
+        # Also accepts the spaced forms `every 90 minutes <prompt>` /
+        # `every 2 hours <prompt>`: the value and the unit are two words there, so a
+        # token split strands the unit at the head of the prompt.
+        interval, prompt = split_interval_prefix(arg)
         if interval is None:
             return _cp(
                 "  Usage: /heartbeat every <interval> <prompt>   (e.g. /heartbeat every 10m Check CI)",

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -52,8 +52,13 @@ HEARTBEAT_PROMPT_TEMPLATE = (
     "invent work."
 )
 
-_INTERVAL_RE = re.compile(
-    r"^\s*(?:every\s+)?(\d+(?:\.\d+)?)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)\s*$",
+# Anchored at the start only, so the prompt following the interval can be
+# split off. ``\b`` (rather than ``$``) terminates the unit: on
+# `every 90 minutes Check CI` the alternation first tries `m`, finds no word
+# boundary before `inutes`, and backtracks until `minutes` matches whole.
+_INTERVAL_PREFIX_RE = re.compile(
+    r"^\s*(?:every\s+)?(\d+(?:\.\d+)?)\s*"
+    r"(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)\b\s*",
     re.IGNORECASE,
 )
 
@@ -68,21 +73,41 @@ _UNIT_SECONDS = {
 def parse_interval(text: str) -> Optional[int]:
     """Parse ``10m`` / ``every 2h`` / ``every 90 minutes`` into seconds.
 
-    Returns None when the text is not an interval. Values below
-    ``MIN_INTERVAL_SECONDS`` are rejected (returns -1 so callers can
-    distinguish "not an interval" from "too small").
+    Returns None when the text is not an interval (including when it is an
+    interval followed by anything else). Values below ``MIN_INTERVAL_SECONDS``
+    are rejected (returns -1 so callers can distinguish "not an interval" from
+    "too small").
+    """
+    seconds, remainder = split_interval_prefix(text)
+    if seconds is None or remainder:
+        return None
+    return seconds
+
+
+def split_interval_prefix(text: str) -> tuple[Optional[int], str]:
+    """Split a ``<interval> <prompt>`` string into its two halves.
+
+    ``every 90 minutes Check CI`` → ``(5400, "Check CI")``. Command handlers
+    need this rather than a whitespace split: the value and the unit are two
+    words in `every 2 hours`, so taking one token as the interval strands
+    `hours` at the head of the prompt and rejects the whole command.
+
+    The interval slot uses the same signalling as :func:`parse_interval`:
+    ``None`` when the text does not start with an interval at all, and ``-1``
+    when it does but the interval is below ``MIN_INTERVAL_SECONDS``. The prompt
+    half is returned in both cases so callers can report the more specific
+    error; its internal whitespace is preserved.
     """
     if not text:
-        return None
-    m = _INTERVAL_RE.match(text)
+        return None, ""
+    m = _INTERVAL_PREFIX_RE.match(text)
     if not m:
-        return None
-    value = float(m.group(1))
-    unit = m.group(2).lower()
-    seconds = int(value * _UNIT_SECONDS[unit])
+        return None, text.strip()
+    seconds = int(float(m.group(1)) * _UNIT_SECONDS[m.group(2).lower()])
+    prompt = text[m.end():].strip()
     if seconds < MIN_INTERVAL_SECONDS:
-        return -1
-    return seconds
+        return -1, prompt
+    return seconds, prompt
 
 
 def format_interval(seconds: int) -> str:
@@ -322,6 +347,7 @@ __all__ = [
     "HeartbeatState",
     "HeartbeatManager",
     "parse_interval",
+    "split_interval_prefix",
     "format_interval",
     "load_heartbeat",
     "save_heartbeat",

--- a/hermes_cli/heartbeat.py
+++ b/hermes_cli/heartbeat.py
@@ -25,8 +25,15 @@ HEARTBEAT_PROMPT_TEMPLATE = (
     "right now, reply briefly that nothing has changed and stop — do not invent work."
 )
 
-_INTERVAL_RE = re.compile(
-    r"^\s*(?:every\s+)?(\d+(?:\.\d+)?)\s*(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)\s*$", re.IGNORECASE)
+# Anchored at the start only, so the prompt following the interval can be
+# split off. ``\b`` (rather than ``$``) terminates the unit: on
+# `every 90 minutes Check CI` the alternation first tries `m`, finds no word
+# boundary before `inutes`, and backtracks until `minutes` matches whole.
+_INTERVAL_PREFIX_RE = re.compile(
+    r"^\s*(?:every\s+)?(\d+(?:\.\d+)?)\s*"
+    r"(s|sec|secs|seconds?|m|min|mins|minutes?|h|hr|hrs|hours?|d|days?)\b\s*",
+    re.IGNORECASE,
+)
 
 _UNIT_SECONDS = {
     **dict.fromkeys(("s", "sec", "secs", "second", "seconds"), 1),
@@ -45,13 +52,41 @@ _STATE_FIELDS = {
 def parse_interval(text: str) -> Optional[int]:
     """Parse ``10m`` / ``every 2h`` / ``every 90 minutes`` into seconds.
 
-    None when not an interval; below ``MIN_INTERVAL_SECONDS`` returns -1 so callers can tell "too small" apart.
+    Returns None when the text is not an interval (including when it is an
+    interval followed by anything else). Values below ``MIN_INTERVAL_SECONDS``
+    are rejected (returns -1 so callers can distinguish "not an interval" from
+    "too small").
     """
-    m = _INTERVAL_RE.match(text) if text else None
-    if not m:
+    seconds, remainder = split_interval_prefix(text)
+    if seconds is None or remainder:
         return None
+    return seconds
+
+
+def split_interval_prefix(text: str) -> tuple[Optional[int], str]:
+    """Split a ``<interval> <prompt>`` string into its two halves.
+
+    ``every 90 minutes Check CI`` → ``(5400, "Check CI")``. Command handlers
+    need this rather than a whitespace split: the value and the unit are two
+    words in `every 2 hours`, so taking one token as the interval strands
+    `hours` at the head of the prompt and rejects the whole command.
+
+    The interval slot uses the same signalling as :func:`parse_interval`:
+    ``None`` when the text does not start with an interval at all, and ``-1``
+    when it does but the interval is below ``MIN_INTERVAL_SECONDS``. The prompt
+    half is returned in both cases so callers can report the more specific
+    error; its internal whitespace is preserved.
+    """
+    if not text:
+        return None, ""
+    m = _INTERVAL_PREFIX_RE.match(text)
+    if not m:
+        return None, text.strip()
     seconds = int(float(m.group(1)) * _UNIT_SECONDS[m.group(2).lower()])
-    return -1 if seconds < MIN_INTERVAL_SECONDS else seconds
+    prompt = text[m.end():].strip()
+    if seconds < MIN_INTERVAL_SECONDS:
+        return -1, prompt
+    return seconds, prompt
 
 
 def format_interval(seconds: int) -> str:
@@ -251,8 +286,9 @@ def migrate_heartbeat_to_session(old_session_id: str, new_session_id: str) -> bo
 
 
 __all__ = [
-    "HeartbeatState", "HeartbeatManager", "parse_interval", "format_interval", "load_heartbeat", "save_heartbeat",
-    "migrate_heartbeat_to_session", "HEARTBEAT_PROMPT_TEMPLATE", "MIN_INTERVAL_SECONDS", "POLL_SECONDS",
+    "HeartbeatState", "HeartbeatManager", "parse_interval", "split_interval_prefix", "format_interval",
+    "load_heartbeat", "save_heartbeat", "migrate_heartbeat_to_session", "HEARTBEAT_PROMPT_TEMPLATE",
+    "MIN_INTERVAL_SECONDS", "POLL_SECONDS",
 ]
 
 

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -13,6 +13,7 @@ from hermes_cli.heartbeat import (
     migrate_heartbeat_to_session,
     parse_interval,
     save_heartbeat,
+    split_interval_prefix,
 )
 
 
@@ -47,6 +48,62 @@ def test_parse_interval_too_small_is_rejected():
     assert parse_interval("30s") == -1
     # Exactly the floor is allowed.
     assert parse_interval(f"{MIN_INTERVAL_SECONDS}s") == MIN_INTERVAL_SECONDS
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Compact unit — the form that already worked end-to-end.
+        ("every 10m Check CI", (600, "Check CI")),
+        ("10m Check CI", (600, "Check CI")),
+        # Spaced value/unit — parse_interval accepts these, so the command
+        # handlers must be able to peel them off too.
+        ("every 90 minutes Check CI", (5400, "Check CI")),
+        ("every 2 hours Check CI", (7200, "Check CI")),
+        ("every 30 min ping", (1800, "ping")),
+        ("90 minutes Check CI", (5400, "Check CI")),
+        ("every 1 day run the backup", (86400, "run the backup")),
+        # A unit that is a prefix of a longer unit must not match short:
+        # `m` would strand "inutes" at the head of the prompt.
+        ("every 5 minutes deploy", (300, "deploy")),
+        # Interval with no prompt.
+        ("every 10m", (600, "")),
+        # Prompt-internal whitespace is preserved.
+        ("every 10m  check   CI  ", (600, "check   CI")),
+    ],
+)
+def test_split_interval_prefix_valid(text, expected):
+    assert split_interval_prefix(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "banana check CI", "check CI", "every", "every soon", "m10 nope"],
+)
+def test_split_interval_prefix_not_an_interval(text):
+    interval, _prompt = split_interval_prefix(text)
+    assert interval is None
+
+
+def test_split_interval_prefix_too_small_keeps_the_prompt():
+    # -1 mirrors parse_interval's "below the floor" signal, and the prompt is
+    # still returned so callers can report the more specific error.
+    assert split_interval_prefix("every 30s Check CI") == (-1, "Check CI")
+    assert split_interval_prefix("every 30 seconds Check CI") == (-1, "Check CI")
+    assert split_interval_prefix(f"every {MIN_INTERVAL_SECONDS}s Check CI") == (
+        MIN_INTERVAL_SECONDS,
+        "Check CI",
+    )
+
+
+def test_split_interval_prefix_agrees_with_parse_interval():
+    # Every interval parse_interval accepts must survive being followed by a
+    # prompt — that equivalence is what the command handlers depend on.
+    for text in ("10m", "every 10m", "2h", "every 2 hours", "1d", "90 minutes"):
+        assert split_interval_prefix(f"{text} do the thing") == (
+            parse_interval(text),
+            "do the thing",
+        )
 
 
 def test_format_interval():

--- a/tests/hermes_cli/test_heartbeat.py
+++ b/tests/hermes_cli/test_heartbeat.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+import hermes_cli.heartbeat as _heartbeat_mod
 from hermes_cli.heartbeat import (
     HeartbeatManager,
     HeartbeatState,
@@ -14,6 +15,11 @@ from hermes_cli.heartbeat import (
     parse_interval,
     save_heartbeat,
 )
+
+
+def split_interval_prefix(text):
+    """Resolved at call time so a missing fix fails the assertions, not collection."""
+    return _heartbeat_mod.split_interval_prefix(text)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -47,6 +53,62 @@ def test_parse_interval_too_small_is_rejected():
     assert parse_interval("30s") == -1
     # Exactly the floor is allowed.
     assert parse_interval(f"{MIN_INTERVAL_SECONDS}s") == MIN_INTERVAL_SECONDS
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Compact unit — the form that already worked end-to-end.
+        ("every 10m Check CI", (600, "Check CI")),
+        ("10m Check CI", (600, "Check CI")),
+        # Spaced value/unit — parse_interval accepts these, so the command
+        # handlers must be able to peel them off too.
+        ("every 90 minutes Check CI", (5400, "Check CI")),
+        ("every 2 hours Check CI", (7200, "Check CI")),
+        ("every 30 min ping", (1800, "ping")),
+        ("90 minutes Check CI", (5400, "Check CI")),
+        ("every 1 day run the backup", (86400, "run the backup")),
+        # A unit that is a prefix of a longer unit must not match short:
+        # `m` would strand "inutes" at the head of the prompt.
+        ("every 5 minutes deploy", (300, "deploy")),
+        # Interval with no prompt.
+        ("every 10m", (600, "")),
+        # Prompt-internal whitespace is preserved.
+        ("every 10m  check   CI  ", (600, "check   CI")),
+    ],
+)
+def test_split_interval_prefix_valid(text, expected):
+    assert split_interval_prefix(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["", "banana check CI", "check CI", "every", "every soon", "m10 nope"],
+)
+def test_split_interval_prefix_not_an_interval(text):
+    interval, _prompt = split_interval_prefix(text)
+    assert interval is None
+
+
+def test_split_interval_prefix_too_small_keeps_the_prompt():
+    # -1 mirrors parse_interval's "below the floor" signal, and the prompt is
+    # still returned so callers can report the more specific error.
+    assert split_interval_prefix("every 30s Check CI") == (-1, "Check CI")
+    assert split_interval_prefix("every 30 seconds Check CI") == (-1, "Check CI")
+    assert split_interval_prefix(f"every {MIN_INTERVAL_SECONDS}s Check CI") == (
+        MIN_INTERVAL_SECONDS,
+        "Check CI",
+    )
+
+
+def test_split_interval_prefix_agrees_with_parse_interval():
+    # Every interval parse_interval accepts must survive being followed by a
+    # prompt — that equivalence is what the command handlers depend on.
+    for text in ("10m", "every 10m", "2h", "every 2 hours", "1d", "90 minutes"):
+        assert split_interval_prefix(f"{text} do the thing") == (
+            parse_interval(text),
+            "do the thing",
+        )
 
 
 def test_format_interval():
@@ -185,3 +247,68 @@ def test_migrate_heartbeat_to_session():
 def test_migrate_noop_without_source():
     assert migrate_heartbeat_to_session("hb-none-a", "hb-none-b") is False
     assert migrate_heartbeat_to_session("same", "same") is False
+
+
+# ──────────────────────────────────────────────────────────────────────
+# the command handler — what the user actually types
+# ──────────────────────────────────────────────────────────────────────
+
+
+def test_cli_heartbeat_accepts_a_spaced_interval(monkeypatch):
+    """`/heartbeat every 90 minutes Check CI` must set a heartbeat.
+
+    The old handler split the argument on whitespace and fed one token to
+    parse_interval, so `every 90` never parsed and the whole command was
+    rejected with the usage line — even though parse_interval has always
+    accepted `every 90 minutes`. This drives the real handler, so it fails on
+    the behaviour rather than on an import.
+    """
+    from types import SimpleNamespace
+
+    from hermes_cli import cli_commands_mixin as ccm
+
+    printed: list = []
+    monkeypatch.setattr(ccm, "_cp", lambda *lines: printed.extend(lines))
+
+    class _Mgr:
+        def __init__(self):
+            self.calls = []
+
+        def set(self, prompt, interval):
+            self.calls.append((prompt, interval))
+            return SimpleNamespace(interval_seconds=interval, prompt=prompt)
+
+    class _Shell(ccm.CLICommandsMixin):
+        def _start_heartbeat_watchdog(self):
+            pass
+
+    mgr = _Mgr()
+    _Shell()._heartbeat_set(mgr, "every 90 minutes Check CI")
+
+    assert mgr.calls == [("Check CI", 5400)], printed
+
+
+def test_cli_heartbeat_still_accepts_the_compact_form(monkeypatch):
+    """Guard: the form that already worked is unchanged."""
+    from types import SimpleNamespace
+
+    from hermes_cli import cli_commands_mixin as ccm
+
+    monkeypatch.setattr(ccm, "_cp", lambda *lines: None)
+
+    class _Mgr:
+        def __init__(self):
+            self.calls = []
+
+        def set(self, prompt, interval):
+            self.calls.append((prompt, interval))
+            return SimpleNamespace(interval_seconds=interval, prompt=prompt)
+
+    class _Shell(ccm.CLICommandsMixin):
+        def _start_heartbeat_watchdog(self):
+            pass
+
+    mgr = _Mgr()
+    _Shell()._heartbeat_set(mgr, "every 10m Check CI")
+
+    assert mgr.calls == [("Check CI", 600)]

--- a/website/docs/user-guide/features/heartbeat.md
+++ b/website/docs/user-guide/features/heartbeat.md
@@ -31,7 +31,7 @@ Rule of thumb: if the recurring prompt needs the conversation's context, use `/h
 
 | Command | What it does |
 |---|---|
-| `/heartbeat every <interval> <prompt>` | Set (or replace) the session's heartbeat. Intervals: `90s`, `10m`, `2h`, `1d` (minimum 60s). |
+| `/heartbeat every <interval> <prompt>` | Set (or replace) the session's heartbeat. Intervals: `90s`, `10m`, `2h`, `1d`, or spelled out — `90 minutes`, `2 hours` (minimum 60s). |
 | `/heartbeat` or `/heartbeat status` | Show the heartbeat, its interval, and time to next fire. |
 | `/heartbeat pause` | Stop firing without clearing. |
 | `/heartbeat resume` | Resume (re-anchors the timer — no instant stale fire). |


### PR DESCRIPTION
## What does this PR do?

`/heartbeat` rejects every interval that spells the unit as a separate word — `every 90 minutes`, `every 2 hours`, `every 30 min`, `every 1 day`. The user gets the usage banner instead of a heartbeat, on both the CLI and the gateway.

The parser is not the problem. `parse_interval` handles those forms and `tests/hermes_cli/test_heartbeat.py` already asserts it (`("every 2 hours", 7200)`, `("90 minutes", 5400)`). The two command handlers never give it the whole interval:

```python
tokens = arg.split(None, 2)                        # ["every", "90", "minutes Check CI"]
if tokens and tokens[0].lower() == "every" and len(tokens) >= 2:
    interval = parse_interval(f"every {tokens[1]}")   # parse_interval("every 90") -> None
    prompt = tokens[2] if len(tokens) > 2 else ""     # "minutes Check CI"
```

Splitting on whitespace assumes the interval is exactly one token. When it is two, the unit is stranded at the head of the prompt, `parse_interval` sees a bare number, and `interval` comes back `None`.

The fix splits the interval off using the interval grammar instead of using whitespace. `split_interval_prefix()` matches the same units anchored at the start of the string and returns `(seconds, prompt)`, so value and unit stay together however they were written.

One detail worth calling out: the unit is terminated with `\b` rather than `$`. On `every 90 minutes …` the alternation tries `m` first, finds no word boundary before `inutes`, and backtracks until `minutes` matches whole — so a short unit can never swallow a long one.

`parse_interval` now delegates to the new helper (whole string must be the interval, so a non-empty remainder is still `None`). That leaves one grammar in the module instead of two regexes that can drift apart, and keeps `parse_interval`'s existing signalling: `None` for "not an interval", `-1` for "below `MIN_INTERVAL_SECONDS`".

## Related Issue

No existing issue. Searched open and merged PRs and issues before starting, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "heartbeat interval"      # only connection-heartbeat PRs (WeCom/QQ/Discord)
gh search prs --repo NousResearch/hermes-agent "parse_interval"          # 0 results
gh search prs --repo NousResearch/hermes-agent "heartbeat every minutes" # 0 results
gh search issues --repo NousResearch/hermes-agent heartbeat in:title     # nothing on interval parsing
```

Regression from #79681, which shipped `/heartbeat` yesterday.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `hermes_cli/heartbeat.py` — added `split_interval_prefix(text) -> (Optional[int], str)`; replaced `_INTERVAL_RE` with the start-anchored `_INTERVAL_PREFIX_RE`; `parse_interval` now delegates to the helper; exported the helper in `__all__`.
- `hermes_cli/cli_commands_mixin.py` — `_handle_heartbeat_command` uses `split_interval_prefix(arg)` in place of the `split(None, 2)` block.
- `gateway/slash_commands.py` — same substitution in the gateway `_handle_heartbeat_command`.
- `tests/hermes_cli/test_heartbeat.py` — 4 new tests (30 cases) covering the spaced forms, the short-unit-prefix trap, the below-floor path, prompt whitespace preservation, and agreement between `split_interval_prefix` and `parse_interval`.
- `website/docs/user-guide/features/heartbeat.md` — the interval column now shows the spelled-out forms.

## How to Test

Before and after, on the same inputs:

| `/heartbeat …` | before | after |
|---|---|---|
| `every 10m Check CI` | `600s`, prompt `Check CI` | unchanged |
| `10m Check CI` | `600s`, prompt `Check CI` | unchanged |
| `every 90 minutes Check CI` | usage error | `5400s`, prompt `Check CI` |
| `every 2 hours Check CI` | usage error | `7200s`, prompt `Check CI` |
| `every 30 min ping` | usage error | `1800s`, prompt `ping` |
| `90 minutes Check CI` | usage error | `5400s`, prompt `Check CI` |
| `every 1 day run the backup` | usage error | `86400s`, prompt `run the backup` |
| `every 30s Check CI` | "interval too small" | unchanged |
| `banana check CI` | usage error | unchanged |

1. `pytest tests/hermes_cli/test_heartbeat.py -q` — 44 passed.
2. `pytest tests/hermes_cli/test_heartbeat.py tests/hermes_cli/test_commands.py tests/agent/test_refine_focus.py -q` — 99 passed.
3. Manually in the CLI: `/heartbeat every 2 hours Check the deploy` now prints `♥ Heartbeat set (every 2h): Check the deploy`; `/heartbeat status` confirms the interval and the next fire time.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(heartbeat): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — `heartbeat.md` interval column, plus docstrings on both functions
- [x] `cli-config.yaml.example` — N/A, no config keys touched
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact — N/A, pure string parsing, no paths or platform APIs
- [x] Tool descriptions/schemas — N/A, `/heartbeat` is a slash command, not a tool

## Notes for the reviewer

`parse_interval` stays exported and its contract is unchanged; only its implementation moved onto the shared grammar. `test_split_interval_prefix_agrees_with_parse_interval` pins that equivalence so the two entry points cannot diverge later.

Separately, while reading this feature I noticed the gateway heartbeat poller captures `session_id` at `_register_heartbeat_watch` time, so after a compression session rotation it polls the archived id, sees the migrated state as cleared, and drops the watch — the heartbeat stops silently. The CLI path rebinds its manager on `session_id` change and is unaffected. That is a separate defect with a separate fix, so it is deliberately not in this PR; happy to open a follow-up.
