### PR TITLE
fix(tools): don't false-flag CJK files as binary in read_file

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,14 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_char_is_truncation_artifact(self, tmp_path):
+        """A U+FFFD only at the END of the sample is a `head -c 1000` cut
+        landing mid-way through a multi-byte UTF-8 char — a sampling artifact,
+        not evidence of binary content. CJK-heavy files hit this constantly."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Multi-byte content whose final char got truncated by the byte cut.
+        truncated = "单价" * 300 + "\ufffd"
+        assert ops._is_likely_binary("menu.md", truncated) is False
+        # Sanity: the same file's REAL corruption is still caught (mid-sample).
+        assert ops._is_likely_binary("menu.md", "正常\ufffd后半") is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,7 +903,13 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # One exception: the sample comes from `head -c 1000` (bytes), so
+            # when the 1000-byte cut lands mid-way through a multi-byte UTF-8
+            # char the partial char decodes to a trailing U+FFFD — a sampling
+            # artifact, not evidence of binary content (every CJK-heavy file
+            # would otherwise false-positive). Scan everything but the tail.
+            if content_sample and "\ufffd" in content_sample[:-1]:
                 return True
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')


### PR DESCRIPTION
## 问题

`read_file` 会把 CJK 密集的文本文件误判为二进制并拒绝读取（报 "Binary file - cannot display as text"）。

`_is_likely_binary` 用 `head -c 1000` 采样前 1000 字节。当截断点正好落在一个多字节 UTF-8 字符中间时，终端以 `errors="replace"` 解码，半个字符变成尾部 U+FFFD；而该函数把样本里出现的任何 U+FFFD 都当作"存在不可解码字节"的证据。中文文本的非 ASCII 字节占比高达 73%~98%，第 1000 字节落在字符中间的概率极高——实测这些文件几乎 100% 被误判。

## 修复

U+FFFD 出现在样本**末尾**是 `head -c 1000` 的截断伪影，不是二进制证据；真正的乱码（不可解码字节）会出现在样本**中部**。因此改为扫描 `content_sample[:-1]`（排除尾部截断伪影），其余判定逻辑不变：

- 样本中部的 U+FFFD → 仍判二进制（read→edit→write 破坏原始字节的保护不降级）
- 仅尾部的 U+FFFD（截断伪影）→ 按文本正常读取
- 控制字符比例判定、扩展名判定均不受影响

## 测试

- 新增回归测试 `test_trailing_replacement_char_is_truncation_artifact`：
  - 尾部 U+FFFD（截断伪影）→ 不判二进制
  - 中部 U+FFFD（真乱码）→ 仍判二进制
- 本地 `scripts/run_tests.sh tests/tools/test_file_operations.py` → **47 passed, 0 failed**
