### PR TITLE
whatsapp-cloud :tolerate malformed webhook_port on adapter init

### DIFF
--- a/gateway/platforms/whatsapp_cloud.py
+++ b/gateway/platforms/whatsapp_cloud.py
@@ -105,6 +105,15 @@ WAMID_DEDUP_CACHE_SIZE = 5000
 # cache. Generous for any realistic number of in-flight prompts / chats.
 INTERACTIVE_STATE_CACHE_SIZE = 1000
 
+
+def _coerce_int(value: object, *, default: int) -> int:
+    """Parse config ints; malformed values must not crash adapter init."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
 # Per-type size caps documented by Meta for the Cloud API /media endpoint.
 # These are the hard limits; we refuse uploads above them with a clean
 # error instead of round-tripping to Graph just to be rejected.
@@ -234,7 +243,10 @@ class WhatsAppCloudAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
         self._webhook_host: Optional[str] = (
             str(_raw_webhook_host) if _raw_webhook_host else None
         )
-        self._webhook_port: int = int(extra.get("webhook_port", DEFAULT_WEBHOOK_PORT))
+        self._webhook_port: int = _coerce_int(
+            extra.get("webhook_port", DEFAULT_WEBHOOK_PORT),
+            default=DEFAULT_WEBHOOK_PORT,
+        )
         self._webhook_path: str = self._normalize_path(
             extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
         )

--- a/tests/gateway/test_whatsapp_cloud.py
+++ b/tests/gateway/test_whatsapp_cloud.py
@@ -18,7 +18,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 
 
 @pytest.fixture(autouse=True)
@@ -108,6 +108,26 @@ def _make_adapter(**overrides):
     for key, value in overrides.items():
         setattr(adapter, key, value)
     return adapter
+
+
+def test_invalid_webhook_port_falls_back_to_default():
+    from gateway.platforms.whatsapp_cloud import (
+        DEFAULT_WEBHOOK_PORT,
+        WhatsAppCloudAdapter,
+    )
+
+    adapter = WhatsAppCloudAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "phone_number_id": "1234567890",
+                "access_token": "test-token",
+                "webhook_port": "bad-port",
+            },
+        )
+    )
+
+    assert adapter._webhook_port == DEFAULT_WEBHOOK_PORT
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- `WhatsAppCloudAdapter` used unguarded `int()` for `webhook_port`.
- A malformed config value raised during construction and took the Cloud webhook adapter down instead of falling back to the documented default port.
- Add a small int coercion helper and regression coverage for the invalid-port case.
