### PR TITLE
fix(read_file): stop misjudging UTF-8 CJK files as binary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -304,7 +304,7 @@ class TestShellFileOpsHelpers:
             commands.append(command)
             if command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
-            if command.startswith("head -c"):
+            if command.startswith("python -c"):
                 return {"output": "hello", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
@@ -318,7 +318,11 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        # Binary sampling now goes through a Python snippet (character-safe
+        # UTF-8 head) instead of `head -c 1000` (byte-truncating, misjudged
+        # CJK files whose 1000-byte boundary split a 3-byte char).
+        assert commands[1].startswith("python -c ")
+        assert "C:/Users/alice/notes.txt" in commands[1]
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -881,7 +881,60 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
-    
+
+    def _sample_text_head(self, path: str) -> str:
+        """Sample the head of a file for binary detection without cutting a
+        multi-byte character in half.
+
+        The old ``head -c 1000`` sampled raw bytes; for UTF-8 files whose
+        byte-1000 boundary lands inside a 3-byte CJK char, the terminal env
+        decodes stdout with errors="replace", turning the dangling tail into
+        U+FFFD — and _is_likely_binary's U+FFFD guard then misclassified a
+        perfectly valid text file as binary. Reading via Python's text
+        decode backs off up to 3 bytes on a truncated sequence so the
+        sample always ends on a character boundary. Genuinely non-UTF-8
+        files (GBK etc.) still fail decode and yield U+FFFD, so the
+        existing binary protection holds. Mirrors _python_delete's
+        repr-embedded cross-shell snippet pattern.
+        """
+        if path.startswith("/") and len(path) > 2 and path[1].isalpha() \
+                and path[2] == "/":
+            # bash-style /c/Users/... → C:/Users/... for the native Windows
+            # interpreter; pathlib on Windows doesn't understand MSYS mounts.
+            path = path[1].upper() + ":/" + path[3:]
+        # Forward slashes only: _escape_shell_arg runs the snippet through
+        # _bash_safe_path, which rewrites backslashes (breaking repr'd
+        # paths AND the '\ufffd' escape). chr(0xFFFD) keeps the fallback
+        # marker backslash-free too.
+        snippet = (
+            "import pathlib, sys\n"
+            f"p = pathlib.Path({path.replace(chr(92), '/')!r})\n"
+            "try:\n"
+            "    data = p.read_bytes()[:1000]\n"
+            "except OSError:\n"
+            "    sys.exit(2)\n"
+            "s = None\n"
+            "for cut in range(4):\n"
+            "    try:\n"
+            "        s = data[:len(data) - cut].decode('utf-8')\n"
+            "        break\n"
+            "    except UnicodeDecodeError:\n"
+            "        continue\n"
+            "if s is None:\n"
+            "    s = chr(0xFFFD)\n"
+            # buffer.write bypasses any locale-dependent stdout encoding
+            "sys.stdout.buffer.write(s.encode('utf-8'))\n"
+        )
+        result = self._exec(f"python -c {self._escape_shell_arg(snippet)}")
+        if result.exit_code != 0:
+            result = self._exec(f"python3 -c {self._escape_shell_arg(snippet)}")
+        if result.exit_code != 0:
+            # Sampling failed entirely (missing interpreter, unreadable
+            # file…). Return U+FFFD so _is_likely_binary errs toward
+            # binary (safe) — never silently treat an unknown file as text.
+            return "\ufffd"
+        return _strip_terminal_fence_leaks(result.stdout)
+
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
         Check if a file is likely binary.
@@ -1189,9 +1242,7 @@ class ShellFileOperations(FileOperations):
             )
         
         # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
-        sample_result = self._exec(sample_cmd)
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+        sample_output = self._sample_text_head(path)
         
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
@@ -1307,8 +1358,7 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
-        sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
+        sample_output = self._sample_text_head(path)
         if self._is_likely_binary(path, sample_output):
             return ReadResult(
                 is_binary=True, file_size=file_size,


### PR DESCRIPTION
read_file/read_file_raw sampled the file head with 'head -c 1000', which truncates at an arbitrary byte boundary. For UTF-8 files whose byte-1000 boundary lands inside a multi-byte char (CJK text, emoji), the terminal env decodes stdout with errors="replace", turning the dangling tail into U+FFFD — and _is_likely_binary's U+FFFD guard then misclassified a perfectly valid text file as binary.

Replace the byte-truncating head sample with _sample_text_head(): a python -c snippet that reads the first 1000 bytes and decodes them as UTF-8, backing off up to 3 bytes on a truncated sequence so the sample always ends on a character boundary. Genuinely non-UTF-8 files (GBK etc.) still fail decode and yield U+FFFD, so the existing binary protection is preserved. Sampling failures err toward binary (safe).

Windows details: paths are normalized to forward slashes and the fallback marker uses chr(0xFFFD) because _escape_shell_arg runs the snippet through _bash_safe_path, which rewrites backslashes (breaking repr'd paths and the '\ufffd' escape).

Verification: character-boundary scan across 0..1001 byte prefixes, CJK/GBK/ASCII/empty/binary fixtures, read_file + read_file_raw.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

