### PR TITLE
fix(cli): restore @ context and path completion after skill slash commands

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -2075,7 +2075,23 @@ class SlashCommandCompleter(Completer):
             # unbroken (see split_stacked_skill_commands in
             # agent/skill_commands.py).
             if self._is_skill_command(base_cmd):
-                yield from self._stacked_skill_completions(text)
+                skill_comps = list(self._stacked_skill_completions(text))
+                if skill_comps:
+                    yield from skill_comps
+                    return
+                # Stacked skill completions yielded nothing — the user has
+                # moved past the skill chain into instruction text. Fall
+                # through to @ context and path completion on the sub_text,
+                # mirroring the non-slash branch above. Without this, typing
+                # `/skill-name @file:...` or `/skill-name ./path` produced no
+                # completion menu at all.
+                ctx_word = self._extract_context_word(sub_text)
+                if ctx_word is not None:
+                    yield from self._context_completions(ctx_word)
+                    return
+                path_word = self._extract_path_word(sub_text)
+                if path_word is not None:
+                    yield from self._path_completions(path_word)
                 return
 
             # Dynamic completions for commands with runtime lists

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -367,6 +367,35 @@ class TestStackedSkillCompletion:
         assert _completions(_stacked_completer(), "/skill-a do the") == []
         assert _completions(_stacked_completer(), "/skill-a ") == []
 
+    def test_at_context_completion_after_skill_command(self):
+        """``@`` context completions must fire after a skill slash command.
+
+        Regression: ``SlashCommandCompleter.get_completions`` early-returned
+        on the skill-command branch, so typing ``/skill-a @`` or
+        ``/skill-a @file:path`` produced no completion menu. The ``@``
+        reference itself still worked at submit time — only the Tab/menu
+        completion was broken.
+        """
+        completer = _stacked_completer()
+        comps = _completions(completer, "/skill-a @")
+        texts = [c.text for c in comps]
+        # Static context references should appear
+        assert "@diff" in texts
+        assert "@staged" in texts
+        assert "@file:" in texts
+        assert "@folder:" in texts
+        assert "@url:" in texts
+
+    def test_path_completion_after_skill_command(self):
+        """Path completions must fire after a skill slash command.
+
+        Same regression class as ``@`` context: the early ``return`` skipped
+        the path fallback so ``/skill-a ./src/`` produced nothing.
+        """
+        completer = _stacked_completer()
+        comps = _completions(completer, "/skill-a ./")
+        assert len(comps) > 0  # cwd should always have entries
+
 
     def test_cap_stops_completions(self):
         skills = {f"/stk-{i}": {"description": f"S{i}"} for i in range(8)}


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `@` context completions (`@diff`, `@file:path`, `@url:...`, etc.) and file-path completions (`./`, `~/`, relative paths) **silently failed after a skill slash command**. Typing `/skill-name @file:...` or `/skill-name ./path` produced no completion menu at all — the `@` reference itself still worked at submit time, so the failure was easy to miss.

## Root Cause

`SlashCommandCompleter.get_completions` (`hermes_cli/commands.py`) has a branch for stacked slash-skill invocations:

```python
if self._is_skill_command(base_cmd):
    yield from self._stacked_skill_completions(text)
    return   # ← unconditional return
```

`_stacked_skill_completions` returns empty as soon as the current word no longer starts with `/` — i.e. the moment the user moves past the skill chain into instruction text. The unconditional `return` then skips the `@` context and file-path fallback branches that only run when `text.startswith("/")` is `False`.

Net effect: after `/skill-name `, **all** `@` and path completion in the instruction text was dead.

## Fix

When `_stacked_skill_completions` yields nothing, fall back to `_extract_context_word` / `_extract_path_word` on the `sub_text` (the instruction portion after the skill name), mirroring the non-slash branch above:

```python
if self._is_skill_command(base_cmd):
    skill_comps = list(self._stacked_skill_completions(text))
    if skill_comps:
        yield from skill_comps
        return
    ctx_word = self._extract_context_word(sub_text)
    if ctx_word is not None:
        yield from self._context_completions(ctx_word)
        return
    path_word = self._extract_path_word(sub_text)
    if path_word is not None:
        yield from self._path_completions(path_word)
    return
```

## Related Issue

No existing issue or PR covers this — searched `gh search issues/prs` for "skill @", "completion after skill", "stacked skill context" before opening.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/commands.py` — `SlashCommandCompleter.get_completions`: fall back to `@` context / path completion on `sub_text` when `_stacked_skill_completions` yields nothing, instead of unconditional `return`.
- `tests/hermes_cli/test_commands.py` — added two regression tests in `TestStackedSkillCompletion`:
  - `test_at_context_completion_after_skill_command` — verifies `/skill-a @` yields `@diff`, `@staged`, `@file:`, `@folder:`, `@url:`
  - `test_path_completion_after_skill_command` — verifies `/skill-a ./` yields cwd entries

## How to Test

```bash
cd ~/.hermes/hermes-agent
venv/bin/python -m pytest tests/hermes_cli/test_commands.py::TestStackedSkillCompletion -v
```

Manual repro (before fix → `[]`; after fix → completion list):

```python
from prompt_toolkit.document import Document
from hermes_cli.commands import SlashCommandCompleter
c = SlashCommandCompleter(skill_commands_provider=lambda: {"/hermes-agent": {"description": "test"}})
doc = Document("/hermes-agent @", 15)
print([(comp.text, comp.display_meta) for comp in c.get_completions(doc, None)])
```

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli):`)
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix (2 files: `commands.py` + test)
- [x] I have run `pytest tests/hermes_cli/ tests/agent/test_skill_commands.py` — 90 passed, 0 failed
- [x] I have added tests for my changes (bug-fix regression tests)
- [x] I have tested on my platform: macOS 15.7.3

### Documentation & Housekeeping

- [x] N/A — no config keys, no architecture changes, no tool behavior changes