### PR TITLE
fix(credential-pool): don't count unleasable rows as something to rotate to

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -435,6 +435,21 @@ def _exhausted_until(entry: PooledCredential, *, sole_credential: bool = False) 
     return None
 
 
+def _can_rotate_in(entry: PooledCredential) -> bool:
+    """True when *entry* could ever be handed out by ``_available_entries``.
+
+    Sizing a sole-credential cooldown asks "is there another key to rotate
+    to?", so it must only count entries selection can actually return. Two
+    kinds never qualify: DEAD entries, which never re-enter rotation via TTL,
+    and api-key entries with no runtime token — metadata-only rows left by an
+    unhydrated borrowed credential, which ``_available_entries`` skips outright
+    so the pool never leases an empty key.
+    """
+    if entry.last_status == STATUS_DEAD:
+        return False
+    return not (entry.auth_type == AUTH_TYPE_API_KEY and not entry.runtime_api_key)
+
+
 def _normalize_custom_pool_name(name: str) -> str:
     """Normalize a custom provider name for use as a pool key suffix."""
     return name.strip().lower().replace(" ", "-")
@@ -697,9 +712,7 @@ class CredentialPool:
             # to rotate to, the sole entry's transient throttle cools down in
             # seconds — next_available_at must report that shorter window too,
             # or the fallback restore gate waits an hour for a 60s cooldown.
-            sole_credential = sum(
-                1 for e in self._entries if e.last_status != STATUS_DEAD
-            ) <= 1
+            sole_credential = sum(1 for e in self._entries if _can_rotate_in(e)) <= 1
             candidates: List[float] = []
             for entry in self._entries:
                 if entry.last_status != STATUS_EXHAUSTED:
@@ -1825,12 +1838,12 @@ class CredentialPool:
         # that can block for 20+ seconds.  We collect them under self._lock
         # and refresh outside the lock to avoid stalling all pool consumers.
         pending_refresh: List[tuple] = []  # (entry, sync_entry_fn)
-        # DEAD entries never re-enter rotation, so if at most one non-DEAD entry
-        # exists there is nothing to rotate to: an exhausted sole credential
-        # should cool down briefly rather than bench the only key for an hour.
-        sole_credential = sum(
-            1 for e in self._entries if e.last_status != STATUS_DEAD
-        ) <= 1
+        # Entries that can't be handed out are not something to rotate to, so
+        # if at most one of them remains an exhausted sole credential should
+        # cool down briefly rather than bench the only key for an hour. The
+        # count must match the skips below (DEAD, and empty api-key rows) or a
+        # pool holding one live key plus an unhydrated row reads as multi-key.
+        sole_credential = sum(1 for e in self._entries if _can_rotate_in(e)) <= 1
         for entry in self._entries:
             # Borrowed credentials persist as metadata-only references and are
             # hydrated from their live source on load.  A stale duplicate row

--- a/tests/agent/test_credential_pool_sole_cooldown.py
+++ b/tests/agent/test_credential_pool_sole_cooldown.py
@@ -148,6 +148,80 @@ def test_sole_credential_next_available_at_uses_short_cooldown(tmp_path, monkeyp
     )
 
 
+def _unhydrated_entry(cred_id: str = "cred-borrowed", priority: int = 1) -> dict:
+    """A metadata-only row: a borrowed credential that never got hydrated.
+
+    Borrowed credentials persist without their token and are refilled from the
+    live source on load; a stale duplicate can stay empty. Selection skips
+    these outright rather than leasing an empty key (#63620).
+    """
+    return {
+        "id": cred_id,
+        "label": cred_id,
+        "auth_type": "api_key",
+        "priority": priority,
+        "source": "manual",
+        "access_token": "",
+        "base_url": "https://openrouter.ai/api/v1",
+    }
+
+
+def test_unhydrated_row_does_not_defeat_sole_cooldown(tmp_path, monkeypatch):
+    """An empty api-key row is not something to rotate to.
+
+    Selection already skips these, so a pool holding one live key plus a stale
+    metadata-only row has exactly one usable credential. Counting the empty row
+    made it read as multi-key, and the only key that could serve a request was
+    benched for the full hour on a transient 429.
+    """
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        [_entry(429, age_seconds=90, cred_id="cred-1"), _unhydrated_entry()],
+    )
+    entry = pool.select()
+    assert entry is not None, "the only usable key stayed benched past its 60s cooldown"
+    assert entry.id == "cred-1"
+    assert entry.last_status == "ok"
+
+
+def test_unhydrated_row_does_not_stretch_next_available_at(tmp_path, monkeypatch):
+    """The same pool must report the short window, not an hour.
+
+    `next_available_at` gates the fallback restore, so an inflated wait keeps
+    the agent on a fallback provider long after the real key has recovered.
+    """
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        [_entry(429, age_seconds=10, cred_id="cred-1"), _unhydrated_entry()],
+    )
+    next_at = pool.next_available_at()
+    assert next_at is not None
+    remaining = next_at - time.time()
+    assert remaining < 300, (
+        f"next_available_at returned {remaining:.0f}s — should be seconds, not hours"
+    )
+
+
+def test_two_live_keys_plus_unhydrated_row_keeps_full_bench(tmp_path, monkeypatch):
+    """Only unusable rows are discounted — two real keys still mean rotation.
+
+    Pins the boundary: the count drops empty rows, not genuine alternatives.
+    """
+    pool = _load(
+        tmp_path,
+        monkeypatch,
+        [
+            _entry(429, age_seconds=90, cred_id="cred-1", priority=0),
+            _entry(429, age_seconds=90, cred_id="cred-2", priority=1),
+            _unhydrated_entry(priority=2),
+        ],
+    )
+    assert pool.has_available() is False
+    assert pool.select() is None
+
+
 def test_multi_key_429_keeps_full_bench(tmp_path, monkeypatch):
     """With more than one non-DEAD entry there IS something to rotate to, so the
     short cooldown must not kick in — both recently-throttled keys stay benched."""


### PR DESCRIPTION
## What

`_available_entries` sizes the sole-credential cooldown by asking whether the pool has another key to rotate to, and answers it by counting every non-DEAD entry:

```python
sole_credential = sum(1 for e in self._entries if e.last_status != STATUS_DEAD) <= 1
```

Selection, six lines below in the same loop, is stricter — it also skips api-key entries that carry no runtime token:

```python
if entry.auth_type == AUTH_TYPE_API_KEY and not entry.runtime_api_key:
    continue
```

Those are the metadata-only rows a borrowed credential leaves behind. Borrowed credentials persist without their token and are refilled from the live source on load; a stale duplicate can stay empty, which is why 5d524d042 (2025-11-13, "fix: reject empty credential pool leases (#63620)") made selection skip them outright rather than lease an empty key.

The count never learned about that exclusion. dcd750434 (2026-01-29, "fix(credential-pool): short cooldown for sole credential on transient throttle") added it directly above the skip, and d1eb08fcf copied the same expression verbatim into `next_available_at`, so a pool holding one live key plus one stale empty row reads as multi-key.

The consequence lands on the only credential that can serve a request. A transient 429/403/5xx benches it for `EXHAUSTED_TTL_429_SECONDS` — one hour — instead of the 60s `EXHAUSTED_TTL_SOLE_CREDENTIAL_SECONDS`, and `next_available_at` hands the inflated window to the fallback restore gate in `agent/agent_runtime_helpers.py`. For that hour the pool has nothing to return at all. Against a pool with one real key exhausted 90s ago and one unhydrated row:

```
select()             : None
has_available()      : False
next_available_at    : 3510s away        # 58 minutes
sole cooldown const  : 60s
```

## The fix

Count only the entries selection can actually hand out. Both call sites now go through one `_can_rotate_in` helper, which mirrors the skips in the loop — DEAD, and empty api-key rows. Sharing it matters beyond tidiness: the two sites already drifted once by copy-paste, and a single definition is what keeps the count and the skip from diverging the next time either grows a case.

Nothing else changes. The discount applies only to rows that could never be leased, so genuine alternatives still suppress the short cooldown.

## Tests and results

Three cases added to `tests/agent/test_credential_pool_sole_cooldown.py`, alongside the existing sole-cooldown coverage:

- one live key + one unhydrated row — `select()` returns the live key after its 60s cooldown
- the same pool — `next_available_at` reports seconds, not an hour
- two live keys + one unhydrated row — still the full bench, pinning the boundary so the discount can't over-broaden

The first two fail on `main` (`next_available_at returned 3590s — should be seconds, not hours`) and pass with the fix. The third passes both ways, as a non-regression pin should.

The credential-pool surface — 15 files, `test_credential_pool*.py` plus `test_custom_pool_mismatch_guard.py`, `test_restore_primary_pool_reselect.py`, `test_auxiliary_anthropic_pool_fallback_regression.py` — is 116 passed. `tests/run_agent/test_reset_aware_primary_restore.py`, which drives the restore gate that consumes `next_available_at`, is 16 passed.

For regressions I ran all of `tests/agent/` (3617 passed) before and after the change and diffed the failure lists: 126 failures, byte-identical both ways, all pre-existing on `main` and unrelated (codex transports, temperature retry, LSP npm install).