### PR TITLE
qqbot : ignore non-string outbound content

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -2487,7 +2487,7 @@ class QQAdapter(BasePlatformAdapter):
             if not await self._wait_for_reconnection():
                 return SendResult(success=False, error="Not connected", retryable=True)
 
-        if not content or not content.strip():
+        if not isinstance(content, str) or not content.strip():
             return SendResult(success=True)
 
         formatted = self.format_message(content)

--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -341,6 +341,7 @@ class QQAdapter(BasePlatformAdapter):
             # faster behind proxies like Cloudflare Warp (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
             from tools.url_safety import create_ssrf_safe_async_client
+
             self._http_client = create_ssrf_safe_async_client(
                 timeout=30.0,
                 follow_redirects=True,
@@ -577,15 +578,15 @@ class QQAdapter(BasePlatformAdapter):
 
                 # Stop reconnecting for fatal codes (unrecoverable errors)
                 if code in {
-                        4001,  # Invalid opcode
-                        4002,  # Invalid payload
-                        4010,  # Invalid shard
-                        4011,  # Sharding required
-                        4012,  # Invalid API version
-                        4013,  # Invalid intent
-                        4014,  # Intent not authorized
-                        4914,  # Offline/sandbox-only
-                        4915,  # Banned
+                    4001,  # Invalid opcode
+                    4002,  # Invalid payload
+                    4010,  # Invalid shard
+                    4011,  # Sharding required
+                    4012,  # Invalid API version
+                    4013,  # Invalid intent
+                    4014,  # Intent not authorized
+                    4914,  # Offline/sandbox-only
+                    4915,  # Banned
                 }:
                     fatal_descriptions = {
                         4001: "invalid opcode",
@@ -638,22 +639,22 @@ class QQAdapter(BasePlatformAdapter):
                 # Note: 4009 (connection timeout) is NOT included here — it is
                 # resumable per the QQ protocol and should preserve session state.
                 if code in {
-                        4006,
-                        4007,
-                        4900,
-                        4901,
-                        4902,
-                        4903,
-                        4904,
-                        4905,
-                        4906,
-                        4907,
-                        4908,
-                        4909,
-                        4910,
-                        4911,
-                        4912,
-                        4913,
+                    4006,
+                    4007,
+                    4900,
+                    4901,
+                    4902,
+                    4903,
+                    4904,
+                    4905,
+                    4906,
+                    4907,
+                    4908,
+                    4909,
+                    4910,
+                    4911,
+                    4912,
+                    4913,
                 }:
                     logger.info(
                         "[%s] Session error (%d), clearing session for re-identify",
@@ -669,7 +670,10 @@ class QQAdapter(BasePlatformAdapter):
                 else:
                     backoff_idx += 1
                     if backoff_idx >= MAX_RECONNECT_ATTEMPTS:
-                        logger.error("[%s] Max reconnect attempts reached (QQCloseError)", self._log_tag)
+                        logger.error(
+                            "[%s] Max reconnect attempts reached (QQCloseError)",
+                            self._log_tag,
+                        )
                         self._mark_disconnected()
                         return
 
@@ -731,7 +735,9 @@ class QQAdapter(BasePlatformAdapter):
                 payload = self._parse_json(msg.data)
                 if payload:
                     self._dispatch_payload(payload)
-            elif msg.type in {aiohttp.WSMsgType.PING,}:
+            elif msg.type in {
+                aiohttp.WSMsgType.PING,
+            }:
                 # aiohttp auto-replies with PONG
                 pass
             elif msg.type == aiohttp.WSMsgType.CLOSE:
@@ -773,9 +779,11 @@ class QQAdapter(BasePlatformAdapter):
             "d": {
                 "token": f"QQBot {token}",
                 "intents": (1 << 25)
-                           | (1 << 30)
-                           | (1 << 12)
-                           | (1 << 26),  # C2C_GROUP_AT_MESSAGES + PUBLIC_GUILD_MESSAGES + DIRECT_MESSAGE + INTERACTION
+                | (1 << 30)
+                | (1 << 12)
+                | (
+                    1 << 26
+                ),  # C2C_GROUP_AT_MESSAGES + PUBLIC_GUILD_MESSAGES + DIRECT_MESSAGE + INTERACTION
                 "shard": [0, 1],
                 "properties": {
                     "$os": "macOS",
@@ -877,11 +885,11 @@ class QQAdapter(BasePlatformAdapter):
             elif t == "RESUMED":
                 logger.info("[%s] Session resumed", self._log_tag)
             elif t in {
-                    "C2C_MESSAGE_CREATE",
-                    "GROUP_AT_MESSAGE_CREATE",
-                    "DIRECT_MESSAGE_CREATE",
-                    "GUILD_MESSAGE_CREATE",
-                    "GUILD_AT_MESSAGE_CREATE",
+                "C2C_MESSAGE_CREATE",
+                "GROUP_AT_MESSAGE_CREATE",
+                "DIRECT_MESSAGE_CREATE",
+                "GUILD_MESSAGE_CREATE",
+                "GUILD_AT_MESSAGE_CREATE",
             }:
                 asyncio.create_task(self._on_message(t, d))
             elif t == "INTERACTION_CREATE":
@@ -978,7 +986,9 @@ class QQAdapter(BasePlatformAdapter):
         # Route by event type
         if event_type == "C2C_MESSAGE_CREATE":
             await self._handle_c2c_message(d, msg_id, content, author, timestamp)
-        elif event_type in {"GROUP_AT_MESSAGE_CREATE",}:
+        elif event_type in {
+            "GROUP_AT_MESSAGE_CREATE",
+        }:
             await self._handle_group_message(d, msg_id, content, author, timestamp)
         elif event_type in {"GUILD_MESSAGE_CREATE", "GUILD_AT_MESSAGE_CREATE"}:
             await self._handle_guild_message(d, msg_id, content, author, timestamp)
@@ -1035,20 +1045,25 @@ class QQAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning(
                 "[%s] Failed to ACK interaction %s: %s",
-                self._log_tag, event.id, exc,
+                self._log_tag,
+                event.id,
+                exc,
             )
 
         logger.info(
             "[%s] Interaction: scene=%s button_data=%r operator=%s",
-            self._log_tag, event.scene, event.button_data, event.operator_openid,
+            self._log_tag,
+            event.scene,
+            event.button_data,
+            event.operator_openid,
         )
 
         callback = self._interaction_callback
         if callback is None:
             logger.debug(
-                "[%s] No interaction callback registered; dropping button "
-                "click %r",
-                self._log_tag, event.button_data,
+                "[%s] No interaction callback registered; dropping button click %r",
+                self._log_tag,
+                event.button_data,
             )
             return
         try:
@@ -1056,13 +1071,15 @@ class QQAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.error(
                 "[%s] Interaction callback raised: %s",
-                self._log_tag, exc, exc_info=True,
+                self._log_tag,
+                exc,
+                exc_info=True,
             )
 
     async def _acknowledge_interaction(
-            self,
-            interaction_id: str,
-            code: int = 0,
+        self,
+        interaction_id: str,
+        code: int = 0,
     ) -> None:
         """ACK a button interaction via ``PUT /interactions/{id}``.
 
@@ -1086,8 +1103,7 @@ class QQAdapter(BasePlatformAdapter):
         )
         if resp.status_code >= 400:
             raise RuntimeError(
-                f"Interaction ACK failed [{resp.status_code}]: "
-                f"{resp.text[:200]}"
+                f"Interaction ACK failed [{resp.status_code}]: {resp.text[:200]}"
             )
 
     # Mapping from QQ keyboard button decisions → the ``choice`` vocabulary
@@ -1117,9 +1133,9 @@ class QQAdapter(BasePlatformAdapter):
         return parsed
 
     def _is_authorized_interaction_for_session(
-            self,
-            event: InteractionEvent,
-            session_key: str,
+        self,
+        event: InteractionEvent,
+        session_key: str,
     ) -> bool:
         """Authorize approval/update interactions against session + operator."""
         parsed = self._parse_gateway_session_key(session_key)
@@ -1142,8 +1158,8 @@ class QQAdapter(BasePlatformAdapter):
         return False
 
     async def _default_interaction_dispatch(
-            self,
-            event: InteractionEvent,
+        self,
+        event: InteractionEvent,
     ) -> None:
         """Route ``INTERACTION_CREATE`` button clicks to the right subsystem.
 
@@ -1171,41 +1187,54 @@ class QQAdapter(BasePlatformAdapter):
             if choice is None:
                 logger.warning(
                     "[%s] Unknown approval decision %r (session=%s)",
-                    self._log_tag, decision, session_key,
+                    self._log_tag,
+                    decision,
+                    session_key,
                 )
                 return
             if not self._is_authorized_interaction_for_session(event, session_key):
                 logger.warning(
                     "[%s] Rejected unauthorized approval click for session %s "
                     "(operator=%s)",
-                    self._log_tag, session_key, event.operator_openid,
+                    self._log_tag,
+                    session_key,
+                    event.operator_openid,
                 )
                 return
             try:
                 # Import lazily to keep the adapter importable in tests that
                 # don't exercise the approval subsystem.
                 from tools.approval import resolve_gateway_approval
+
                 count = resolve_gateway_approval(session_key, choice)
                 logger.info(
                     "[%s] Button resolved %d approval(s) for session %s "
                     "(choice=%s, operator=%s)",
-                    self._log_tag, count, session_key, choice,
+                    self._log_tag,
+                    count,
+                    session_key,
+                    choice,
                     event.operator_openid,
                 )
             except Exception as exc:
                 logger.error(
                     "[%s] resolve_gateway_approval failed for session %s: %s",
-                    self._log_tag, session_key, exc,
+                    self._log_tag,
+                    session_key,
+                    exc,
                 )
             return
 
         update_answer = parse_update_prompt_button_data(button_data)
         if update_answer is not None:
             update_session_key = f"agent:main:qqbot:{event.scene}:{event.group_openid or event.guild_id or event.user_openid}"
-            if not self._is_authorized_interaction_for_session(event, update_session_key):
+            if not self._is_authorized_interaction_for_session(
+                event, update_session_key
+            ):
                 logger.warning(
                     "[%s] Rejected unauthorized update prompt click (operator=%s)",
-                    self._log_tag, event.operator_openid,
+                    self._log_tag,
+                    event.operator_openid,
                 )
                 return
             self._write_update_response(update_answer, event.operator_openid)
@@ -1213,7 +1242,9 @@ class QQAdapter(BasePlatformAdapter):
 
         logger.debug(
             "[%s] Unrecognised button_data %r from interaction %s",
-            self._log_tag, button_data, event.id,
+            self._log_tag,
+            button_data,
+            event.id,
         )
 
     @staticmethod
@@ -1227,6 +1258,7 @@ class QQAdapter(BasePlatformAdapter):
         """
         try:
             from hermes_constants import get_hermes_home
+
             home = get_hermes_home()
             response_path = home / ".update_response"
             tmp = response_path.with_suffix(".tmp")
@@ -1234,18 +1266,19 @@ class QQAdapter(BasePlatformAdapter):
             tmp.replace(response_path)
             logger.info(
                 "QQ update prompt answered %r by %s",
-                answer, operator or "(unknown)",
+                answer,
+                operator or "(unknown)",
             )
         except Exception as exc:
             logger.error("Failed to write update response: %s", exc)
 
     async def _handle_c2c_message(
-            self,
-            d: Dict[str, Any],
-            msg_id: str,
-            content: str,
-            author: Dict[str, Any],
-            timestamp: str,
+        self,
+        d: Dict[str, Any],
+        msg_id: str,
+        content: str,
+        author: Dict[str, Any],
+        timestamp: str,
     ) -> None:
         """Handle a C2C (private) message event."""
         user_openid = str(author.get("user_openid", ""))
@@ -1335,19 +1368,19 @@ class QQAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     async def _handle_group_message(
-            self,
-            d: Dict[str, Any],
-            msg_id: str,
-            content: str,
-            author: Dict[str, Any],
-            timestamp: str,
+        self,
+        d: Dict[str, Any],
+        msg_id: str,
+        content: str,
+        author: Dict[str, Any],
+        timestamp: str,
     ) -> None:
         """Handle a group @-message event."""
         group_openid = str(d.get("group_openid", ""))
         if not group_openid:
             return
         if not self._is_group_allowed(
-                group_openid, str(author.get("member_openid", ""))
+            group_openid, str(author.get("member_openid", ""))
         ):
             return
 
@@ -1400,12 +1433,12 @@ class QQAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     async def _handle_guild_message(
-            self,
-            d: Dict[str, Any],
-            msg_id: str,
-            content: str,
-            author: Dict[str, Any],
-            timestamp: str,
+        self,
+        d: Dict[str, Any],
+        msg_id: str,
+        content: str,
+        author: Dict[str, Any],
+        timestamp: str,
     ) -> None:
         """Handle a guild/channel message event."""
         channel_id = str(d.get("channel_id", ""))
@@ -1420,7 +1453,9 @@ class QQAdapter(BasePlatformAdapter):
         if not self._is_group_allowed(guild_id or channel_id, author_id):
             logger.debug(
                 "[%s] Guild message blocked by ACL: channel=%s user=%s",
-                self._log_tag, channel_id, author_id,
+                self._log_tag,
+                channel_id,
+                author_id,
             )
             return
 
@@ -1475,12 +1510,12 @@ class QQAdapter(BasePlatformAdapter):
         await self.handle_message(event)
 
     async def _handle_dm_message(
-            self,
-            d: Dict[str, Any],
-            msg_id: str,
-            content: str,
-            author: Dict[str, Any],
-            timestamp: str,
+        self,
+        d: Dict[str, Any],
+        msg_id: str,
+        content: str,
+        author: Dict[str, Any],
+        timestamp: str,
     ) -> None:
         """Handle a guild DM message event."""
         guild_id = str(d.get("guild_id", ""))
@@ -1494,7 +1529,9 @@ class QQAdapter(BasePlatformAdapter):
         if not self._is_dm_intake_allowed(author_id):
             logger.debug(
                 "[%s] Guild DM blocked by ACL: guild=%s user=%s",
-                self._log_tag, guild_id, author_id,
+                self._log_tag,
+                guild_id,
+                author_id,
             )
             return
 
@@ -1549,8 +1586,8 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _process_quoted_context(
-            self,
-            d: Dict[str, Any],
+        self,
+        d: Dict[str, Any],
     ) -> Dict[str, Any]:
         """Process the quoted message a user is replying to.
 
@@ -1676,8 +1713,8 @@ class QQAdapter(BasePlatformAdapter):
         return MessageType.TEXT
 
     async def _process_attachments(
-            self,
-            attachments: Any,
+        self,
+        attachments: Any,
     ) -> Dict[str, Any]:
         """Process inbound attachments (all message types).
 
@@ -1750,7 +1787,9 @@ class QQAdapter(BasePlatformAdapter):
                     voice_transcripts.append(f"[Voice] {transcript}")
                     logger.debug("[%s] Voice transcript: %s", self._log_tag, transcript)
                 else:
-                    logger.warning("[%s] Voice STT failed for %s", self._log_tag, url[:60])
+                    logger.warning(
+                        "[%s] Voice STT failed for %s", self._log_tag, url[:60]
+                    )
                     voice_transcripts.append("[Voice] [语音识别失败]")
             elif ct.startswith("image/"):
                 # Image: download and cache locally.
@@ -1778,7 +1817,9 @@ class QQAdapter(BasePlatformAdapter):
                         else:
                             other_attachments.append(f"[file: {name} ({cached_path})]")
                 except Exception as exc:
-                    logger.debug("[%s] Failed to cache attachment: %s", self._log_tag, exc)
+                    logger.debug(
+                        "[%s] Failed to cache attachment: %s", self._log_tag, exc
+                    )
 
         attachment_info = "\n".join(other_attachments) if other_attachments else ""
         return {
@@ -1789,7 +1830,10 @@ class QQAdapter(BasePlatformAdapter):
         }
 
     async def _download_and_cache(
-            self, url: str, content_type: str, original_name: str = "",
+        self,
+        url: str,
+        content_type: str,
+        original_name: str = "",
     ) -> Optional[str]:
         """Download a URL and cache it locally.
 
@@ -1821,23 +1865,22 @@ class QQAdapter(BasePlatformAdapter):
         if content_type.startswith("image/"):
             # preserves historical qqbot mapping: trust mimetypes'
             # guess (never the shared table) and fall back to .jpg.
-            ext = ext_for_mime(
-                content_type,
-                use_defaults=False,
-                use_mimetypes=True,
-                fallback=".jpg",
-            ) or ".jpg"
+            ext = (
+                ext_for_mime(
+                    content_type,
+                    use_defaults=False,
+                    use_mimetypes=True,
+                    fallback=".jpg",
+                )
+                or ".jpg"
+            )
             return cache_image_from_bytes(data, ext)
         elif content_type == "voice" or content_type.startswith("audio/"):
             # QQ voice messages are typically .amr or .silk format.
             # Convert to .wav using ffmpeg so STT engines can process it.
             return await self._convert_audio_to_wav(data, url)
         else:
-            filename = (
-                original_name
-                or Path(urlparse(url).path).name
-                or "qq_attachment"
-            )
+            filename = original_name or Path(urlparse(url).path).name or "qq_attachment"
             return cache_document_from_bytes(data, filename)
 
     @staticmethod
@@ -1853,8 +1896,15 @@ class QQAdapter(BasePlatformAdapter):
         if ct == "file":
             return False
         _VOICE_EXTENSIONS = (
-            ".silk", ".amr", ".mp3", ".wav", ".ogg",
-            ".m4a", ".aac", ".speex", ".flac",
+            ".silk",
+            ".amr",
+            ".mp3",
+            ".wav",
+            ".ogg",
+            ".m4a",
+            ".aac",
+            ".speex",
+            ".flac",
         )
         if any(fn.endswith(ext) for ext in _VOICE_EXTENSIONS):
             return True
@@ -1872,13 +1922,13 @@ class QQAdapter(BasePlatformAdapter):
         return {}
 
     async def _stt_voice_attachment(
-            self,
-            url: str,
-            content_type: str,
-            filename: str,
-            *,
-            asr_refer_text: Optional[str] = None,
-            voice_wav_url: Optional[str] = None,
+        self,
+        url: str,
+        content_type: str,
+        filename: str,
+        *,
+        asr_refer_text: Optional[str] = None,
+        voice_wav_url: Optional[str] = None,
     ) -> Optional[str]:
         """Download a voice attachment, convert to wav, and transcribe.
 
@@ -1892,7 +1942,9 @@ class QQAdapter(BasePlatformAdapter):
         # 1. Use QQ's built-in ASR text if available
         if asr_refer_text:
             logger.debug(
-                "[%s] STT: using QQ asr_refer_text: %r", self._log_tag, asr_refer_text[:100]
+                "[%s] STT: using QQ asr_refer_text: %r",
+                self._log_tag,
+                asr_refer_text[:100],
             )
             return asr_refer_text
 
@@ -1904,9 +1956,12 @@ class QQAdapter(BasePlatformAdapter):
                 voice_wav_url = f"https:{voice_wav_url}"
             download_url = voice_wav_url
             is_pre_wav = True
-            logger.debug("[%s] STT: using voice_wav_url (pre-converted WAV)", self._log_tag)
+            logger.debug(
+                "[%s] STT: using voice_wav_url (pre-converted WAV)", self._log_tag
+            )
 
         from tools.url_safety import is_safe_url
+
         if not is_safe_url(download_url):
             logger.warning("[QQ] STT blocked unsafe URL: %s", download_url[:80])
             return None
@@ -1996,7 +2051,7 @@ class QQAdapter(BasePlatformAdapter):
             return None
 
     async def _convert_audio_to_wav_file(
-            self, audio_data: bytes, filename: str
+        self, audio_data: bytes, filename: str
     ) -> Optional[str]:
         """Convert audio bytes to a temp .wav file using pilk (SILK) or ffmpeg.
 
@@ -2124,7 +2179,9 @@ class QQAdapter(BasePlatformAdapter):
 
         return None
 
-    async def _convert_raw_to_wav(self, audio_data: bytes, wav_path: str) -> Optional[str]:
+    async def _convert_raw_to_wav(
+        self, audio_data: bytes, wav_path: str
+    ) -> Optional[str]:
         """Last resort: try writing audio data as raw PCM 16-bit mono 16kHz WAV.
 
         This will produce garbage if the data isn't raw PCM, but at least
@@ -2143,7 +2200,9 @@ class QQAdapter(BasePlatformAdapter):
             logger.debug("[%s] raw PCM fallback failed: %s", self._log_tag, exc)
             return None
 
-    async def _convert_ffmpeg_to_wav(self, src_path: str, wav_path: str) -> Optional[str]:
+    async def _convert_ffmpeg_to_wav(
+        self, src_path: str, wav_path: str
+    ) -> Optional[str]:
         """Convert audio file to WAV using ffmpeg."""
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -2225,7 +2284,7 @@ class QQAdapter(BasePlatformAdapter):
                         "base_url": base_url,
                         "api_key": api_key,
                         "model": model
-                                 or ("glm-asr" if provider in {"zai", "glm"} else "whisper-1"),
+                        or ("glm-asr" if provider in {"zai", "glm"} else "whisper-1"),
                     }
 
         # 2. QQ-specific env vars (set by `hermes setup gateway` / `hermes gateway`)
@@ -2296,7 +2355,7 @@ class QQAdapter(BasePlatformAdapter):
             return None
 
     async def _convert_audio_to_wav(
-            self, audio_data: bytes, source_url: str
+        self, audio_data: bytes, source_url: str
     ) -> Optional[str]:
         """Convert audio bytes to .wav using pilk (SILK) or ffmpeg, caching the result."""
         import tempfile
@@ -2308,14 +2367,14 @@ class QQAdapter(BasePlatformAdapter):
             else ""
         )
         if not ext or ext not in {
-                ".silk",
-                ".amr",
-                ".mp3",
-                ".wav",
-                ".ogg",
-                ".m4a",
-                ".aac",
-                ".flac",
+            ".silk",
+            ".amr",
+            ".mp3",
+            ".wav",
+            ".ogg",
+            ".m4a",
+            ".aac",
+            ".flac",
         }:
             ext = self._guess_ext_from_data(audio_data)
 
@@ -2361,11 +2420,11 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def _api_request(
-            self,
-            method: str,
-            path: str,
-            body: Optional[Dict[str, Any]] = None,
-            timeout: float = DEFAULT_API_TIMEOUT,
+        self,
+        method: str,
+        path: str,
+        body: Optional[Dict[str, Any]] = None,
+        timeout: float = DEFAULT_API_TIMEOUT,
     ) -> Dict[str, Any]:
         """Make an authenticated REST API request to QQ Bot API."""
         if not self._http_client:
@@ -2397,14 +2456,14 @@ class QQAdapter(BasePlatformAdapter):
             raise RuntimeError(f"QQ Bot API timeout [{path}]: {exc}") from exc
 
     async def _upload_media(
-            self,
-            target_type: str,
-            target_id: str,
-            file_type: int,
-            url: Optional[str] = None,
-            file_data: Optional[str] = None,
-            srv_send_msg: bool = False,
-            file_name: Optional[str] = None,
+        self,
+        target_type: str,
+        target_id: str,
+        file_type: int,
+        url: Optional[str] = None,
+        file_data: Optional[str] = None,
+        srv_send_msg: bool = False,
+        file_name: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Upload media and return file_info."""
         path = (
@@ -2433,8 +2492,8 @@ class QQAdapter(BasePlatformAdapter):
             except RuntimeError as exc:
                 err_msg = str(exc)
                 if any(
-                        kw in err_msg
-                        for kw in ("400", "401", "Invalid", "timeout", "Timeout")
+                    kw in err_msg
+                    for kw in ("400", "401", "Invalid", "timeout", "Timeout")
                 ):
                     raise
                 if attempt < 2:
@@ -2457,8 +2516,11 @@ class QQAdapter(BasePlatformAdapter):
 
         Returns True if reconnected, False if still disconnected.
         """
-        logger.info("[%s] Not connected — waiting for reconnection (up to %.0fs)",
-                    self._log_tag, self._RECONNECT_WAIT_SECONDS)
+        logger.info(
+            "[%s] Not connected — waiting for reconnection (up to %.0fs)",
+            self._log_tag,
+            self._RECONNECT_WAIT_SECONDS,
+        )
         waited = 0.0
         while waited < self._RECONNECT_WAIT_SECONDS:
             await asyncio.sleep(self._RECONNECT_POLL_INTERVAL)
@@ -2466,15 +2528,19 @@ class QQAdapter(BasePlatformAdapter):
             if self.is_connected:
                 logger.info("[%s] Reconnected after %.1fs", self._log_tag, waited)
                 return True
-        logger.warning("[%s] Still not connected after %.0fs", self._log_tag, self._RECONNECT_WAIT_SECONDS)
+        logger.warning(
+            "[%s] Still not connected after %.0fs",
+            self._log_tag,
+            self._RECONNECT_WAIT_SECONDS,
+        )
         return False
 
     async def send(
-            self,
-            chat_id: str,
-            content: str,
-            reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a text or markdown message to a QQ user or group.
 
@@ -2503,10 +2569,10 @@ class QQAdapter(BasePlatformAdapter):
         return last_result
 
     async def _send_chunk(
-            self,
-            chat_id: str,
-            content: str,
-            reply_to: Optional[str] = None,
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a single chunk with retry + exponential backoff."""
         last_exc: Optional[Exception] = None
@@ -2529,13 +2595,13 @@ class QQAdapter(BasePlatformAdapter):
                 err = str(exc).lower()
                 # Permanent errors — don't retry
                 if any(
-                        k in err
-                        for k in ("invalid", "forbidden", "not found", "bad request")
+                    k in err
+                    for k in ("invalid", "forbidden", "not found", "bad request")
                 ):
                     break
                 # Transient — back off and retry
                 if attempt < 2:
-                    delay = 1.0 * (2 ** attempt)
+                    delay = 1.0 * (2**attempt)
                     logger.warning(
                         "[%s] send retry %d/3 after %.1fs: %s",
                         self._log_tag,
@@ -2553,11 +2619,11 @@ class QQAdapter(BasePlatformAdapter):
         return SendResult(success=False, error=error_msg, retryable=retryable)
 
     async def _send_c2c_text(
-            self,
-            openid: str,
-            content: str,
-            reply_to: Optional[str] = None,
-            keyboard: Optional[InlineKeyboard] = None,
+        self,
+        openid: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        keyboard: Optional[InlineKeyboard] = None,
     ) -> SendResult:
         """Send text to a C2C user via REST API.
 
@@ -2575,11 +2641,11 @@ class QQAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
     async def _send_group_text(
-            self,
-            group_openid: str,
-            content: str,
-            reply_to: Optional[str] = None,
-            keyboard: Optional[InlineKeyboard] = None,
+        self,
+        group_openid: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        keyboard: Optional[InlineKeyboard] = None,
     ) -> SendResult:
         """Send text to a group via REST API.
 
@@ -2599,7 +2665,7 @@ class QQAdapter(BasePlatformAdapter):
         return SendResult(success=True, message_id=msg_id, raw_response=data)
 
     async def _send_guild_text(
-            self, channel_id: str, content: str, reply_to: Optional[str] = None
+        self, channel_id: str, content: str, reply_to: Optional[str] = None
     ) -> SendResult:
         """Send text to a guild channel via REST API."""
         body: Dict[str, Any] = {"content": content[: self.MAX_MESSAGE_LENGTH]}
@@ -2615,11 +2681,11 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_with_keyboard(
-            self,
-            chat_id: str,
-            content: str,
-            keyboard: InlineKeyboard,
-            reply_to: Optional[str] = None,
+        self,
+        chat_id: str,
+        content: str,
+        keyboard: InlineKeyboard,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a single text message with an inline keyboard attached.
 
@@ -2633,9 +2699,7 @@ class QQAdapter(BasePlatformAdapter):
         """
         if not self.is_connected:
             if not await self._wait_for_reconnection():
-                return SendResult(
-                    success=False, error="Not connected", retryable=True
-                )
+                return SendResult(success=False, error="Not connected", retryable=True)
 
         chat_type = self._guess_chat_type(chat_id)
         formatted = self.format_message(content)
@@ -2643,31 +2707,32 @@ class QQAdapter(BasePlatformAdapter):
         try:
             if chat_type == "c2c":
                 return await self._send_c2c_text(
-                    chat_id, truncated, reply_to, keyboard=keyboard,
+                    chat_id,
+                    truncated,
+                    reply_to,
+                    keyboard=keyboard,
                 )
             if chat_type == "group":
                 return await self._send_group_text(
-                    chat_id, truncated, reply_to, keyboard=keyboard,
+                    chat_id,
+                    truncated,
+                    reply_to,
+                    keyboard=keyboard,
                 )
             return SendResult(
                 success=False,
-                error=(
-                    f"Inline keyboards not supported for chat_type "
-                    f"{chat_type!r}"
-                ),
+                error=(f"Inline keyboards not supported for chat_type {chat_type!r}"),
                 retryable=False,
             )
         except Exception as exc:
-            logger.error(
-                "[%s] send_with_keyboard failed: %s", self._log_tag, exc
-            )
+            logger.error("[%s] send_with_keyboard failed: %s", self._log_tag, exc)
             return SendResult(success=False, error=str(exc))
 
     async def send_approval_request(
-            self,
-            chat_id: str,
-            req: ApprovalRequest,
-            reply_to: Optional[str] = None,
+        self,
+        chat_id: str,
+        req: ApprovalRequest,
+        reply_to: Optional[str] = None,
     ) -> SendResult:
         """Send a 3-button approval request (``allow-once / allow-always / deny``).
 
@@ -2679,6 +2744,7 @@ class QQAdapter(BasePlatformAdapter):
         ``button_data`` via :func:`parse_approval_button_data`.
         """
         from gateway.platforms.qqbot.keyboards import build_approval_text
+
         return await self.send_with_keyboard(
             chat_id,
             build_approval_text(req),
@@ -2699,12 +2765,12 @@ class QQAdapter(BasePlatformAdapter):
     # Matrix, and Feishu already implement the same contract.
 
     async def send_exec_approval(
-            self,
-            chat_id: str,
-            command: str,
-            session_key: str,
-            description: str = "dangerous command",
-            metadata: Optional[Dict[str, Any]] = None,
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[Dict[str, Any]] = None,
         allow_permanent: bool = True,
         allow_session: bool = True,
         smart_denied: bool = False,
@@ -2717,7 +2783,9 @@ class QQAdapter(BasePlatformAdapter):
         adapter's interaction callback (:meth:`_default_interaction_dispatch`).
         """
         del metadata  # QQ doesn't have thread_id / DM targeting overrides.
-        del allow_session  # QQ's 3-button keyboard has no session tier (once/always/deny).
+        del (
+            allow_session
+        )  # QQ's 3-button keyboard has no session tier (once/always/deny).
         if smart_denied:
             description += " Owner override applies to this one operation only."
 
@@ -2735,18 +2803,20 @@ class QQAdapter(BasePlatformAdapter):
             allow_permanent=allow_permanent and not smart_denied,
         )
         return await self.send_approval_request(
-            chat_id, req, reply_to=msg_id,
+            chat_id,
+            req,
+            reply_to=msg_id,
         )
 
     _APPROVAL_TIMEOUT_SECONDS = 300  # matches gateway's default gateway_timeout
 
     async def send_update_prompt(
-            self,
-            chat_id: str,
-            prompt: str,
-            default: str = "",
-            session_key: str = "",
-            metadata: Optional[Dict[str, Any]] = None,
+        self,
+        chat_id: str,
+        prompt: str,
+        default: str = "",
+        session_key: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Yes/No update-confirmation prompt with inline buttons.
 
@@ -2771,7 +2841,7 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     def _build_text_body(
-            self, content: str, reply_to: Optional[str] = None
+        self, content: str, reply_to: Optional[str] = None
     ) -> Dict[str, Any]:
         """Build the message body for C2C/group text sending."""
         msg_seq = self._next_msg_seq(reply_to or "default")
@@ -2801,12 +2871,12 @@ class QQAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def send_image(
-            self,
-            chat_id: str,
-            image_url: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            metadata: Optional[Dict[str, Any]] = None,
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an image natively via QQ Bot API upload."""
         del metadata
@@ -2827,12 +2897,12 @@ class QQAdapter(BasePlatformAdapter):
         return await self.send(chat_id=chat_id, content=fallback, reply_to=reply_to)
 
     async def send_image_file(
-            self,
-            chat_id: str,
-            image_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            **kwargs,
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a local image file natively."""
         del kwargs
@@ -2841,12 +2911,12 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     async def send_voice(
-            self,
-            chat_id: str,
-            audio_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            **kwargs,
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a voice message natively."""
         del kwargs
@@ -2855,12 +2925,12 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     async def send_video(
-            self,
-            chat_id: str,
-            video_path: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            **kwargs,
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a video natively."""
         del kwargs
@@ -2869,13 +2939,13 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     async def send_document(
-            self,
-            chat_id: str,
-            file_path: str,
-            caption: Optional[str] = None,
-            file_name: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            **kwargs,
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
     ) -> SendResult:
         """Send a file/document natively."""
         del kwargs
@@ -2890,14 +2960,14 @@ class QQAdapter(BasePlatformAdapter):
         )
 
     async def _send_media(
-            self,
-            chat_id: str,
-            media_source: str,
-            file_type: int,
-            kind: str,
-            caption: Optional[str] = None,
-            reply_to: Optional[str] = None,
-            file_name: Optional[str] = None,
+        self,
+        chat_id: str,
+        media_source: str,
+        file_type: int,
+        kind: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        file_name: Optional[str] = None,
     ) -> SendResult:
         """Upload media and send as a native message.
 
@@ -2926,9 +2996,7 @@ class QQAdapter(BasePlatformAdapter):
             if self._is_url(media_source):
                 # URL upload — let the platform fetch it directly.
                 resolved_name = (
-                    file_name
-                    or Path(urlparse(media_source).path).name
-                    or "media"
+                    file_name or Path(urlparse(media_source).path).name or "media"
                 )
                 upload = await self._upload_media(
                     chat_type,
@@ -2948,9 +3016,9 @@ class QQAdapter(BasePlatformAdapter):
                     file_name,
                 )
 
-            file_info = upload.get("file_info") or (
-                upload.get("data", {}) or {}
-            ).get("file_info")
+            file_info = upload.get("file_info") or (upload.get("data", {}) or {}).get(
+                "file_info"
+            )
             if not file_info:
                 return SendResult(
                     success=False,
@@ -2988,7 +3056,9 @@ class QQAdapter(BasePlatformAdapter):
             # so the model can compose a helpful reply.
             logger.warning(
                 "[%s] Daily upload limit exceeded for %s (%s)",
-                self._log_tag, exc.file_name, exc.file_size_human,
+                self._log_tag,
+                exc.file_name,
+                exc.file_size_human,
             )
             return SendResult(
                 success=False,
@@ -3001,7 +3071,10 @@ class QQAdapter(BasePlatformAdapter):
         except UploadFileTooLargeError as exc:
             logger.warning(
                 "[%s] File too large: %s (%s, platform limit %s)",
-                self._log_tag, exc.file_name, exc.file_size_human, exc.limit_human,
+                self._log_tag,
+                exc.file_name,
+                exc.file_size_human,
+                exc.limit_human,
             )
             return SendResult(
                 success=False,
@@ -3016,12 +3089,12 @@ class QQAdapter(BasePlatformAdapter):
             return SendResult(success=False, error=str(exc))
 
     async def _upload_local_file(
-            self,
-            chat_type: str,
-            chat_id: str,
-            media_source: str,
-            file_type: int,
-            file_name: Optional[str],
+        self,
+        chat_type: str,
+        chat_id: str,
+        media_source: str,
+        file_type: int,
+        file_name: Optional[str],
     ) -> Tuple[str, Dict[str, Any]]:
         """Chunked-upload a local file and return ``(resolved_name, complete_response)``.
 
@@ -3064,7 +3137,7 @@ class QQAdapter(BasePlatformAdapter):
         return resolved_name, complete
 
     async def _load_media(
-            self, source: str, file_name: Optional[str] = None
+        self, source: str, file_name: Optional[str] = None
     ) -> Tuple[str, str, str]:
         """Load media from URL or local path. Returns (base64_or_url, content_type, filename)."""
         source = str(source).strip()
@@ -3096,7 +3169,7 @@ class QQAdapter(BasePlatformAdapter):
         raw = local_path.read_bytes()
         resolved_name = file_name or local_path.name
         content_type = (
-                mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
+            mimetypes.guess_type(str(local_path))[0] or "application/octet-stream"
         )
         b64 = base64.b64encode(raw).decode("ascii")
         return b64, content_type, resolved_name
@@ -3197,7 +3270,11 @@ class QQAdapter(BasePlatformAdapter):
     def _open_dm_opted_in(self) -> bool:
         if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}:
             return True
-        return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {"true", "1", "yes"}
+        return _resolve_qq_secret("QQ_ALLOW_ALL_USERS", "").lower() in {
+            "true",
+            "1",
+            "yes",
+        }
 
     def _is_dm_allowed(self, user_id: str) -> bool:
         if self._dm_policy == "disabled":

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -15,6 +15,7 @@ from gateway.config import PlatformConfig
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_config(**extra):
     """Build a PlatformConfig(enabled=True, extra=extra) for testing."""
     return PlatformConfig(enabled=True, extra=extra)
@@ -24,9 +25,11 @@ def _make_config(**extra):
 # check_qq_requirements
 # ---------------------------------------------------------------------------
 
+
 class TestQQRequirements:
     def test_returns_bool(self):
         from gateway.platforms.qqbot import check_qq_requirements
+
         result = check_qq_requirements()
         assert isinstance(result, bool)
 
@@ -35,23 +38,26 @@ class TestQQRequirements:
 # QQAdapter.__init__
 # ---------------------------------------------------------------------------
 
+
 class TestQQAdapterInit:
     def _make(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
-
     def test_env_fallback(self):
-        with mock.patch.dict(os.environ, {"QQ_APP_ID": "env_id", "QQ_CLIENT_SECRET": "env_sec"}, clear=False):
+        with mock.patch.dict(
+            os.environ,
+            {"QQ_APP_ID": "env_id", "QQ_CLIENT_SECRET": "env_sec"},
+            clear=False,
+        ):
             adapter = self._make()
             assert adapter._app_id == "env_id"
             assert adapter._client_secret == "env_sec"
 
-
     def test_dm_policy_default(self):
         adapter = self._make(app_id="a", client_secret="b")
         assert adapter._dm_policy == "pairing"
-
 
     def test_group_policy_default(self):
         adapter = self._make(app_id="a", client_secret="b")
@@ -60,7 +66,6 @@ class TestQQAdapterInit:
     def test_allow_from_parsing_string(self):
         adapter = self._make(app_id="a", client_secret="b", allow_from="x, y , z")
         assert adapter._allow_from == ["x", "y", "z"]
-
 
     def test_markdown_support_default(self):
         adapter = self._make(app_id="a", client_secret="b")
@@ -71,9 +76,11 @@ class TestQQAdapterInit:
 # _coerce_list
 # ---------------------------------------------------------------------------
 
+
 class TestCoerceList:
     def _fn(self, value):
         from gateway.platforms.qqbot import _coerce_list
+
         return _coerce_list(value)
 
     def test_none(self):
@@ -87,16 +94,16 @@ class TestCoerceList:
 # _is_voice_content_type
 # ---------------------------------------------------------------------------
 
+
 class TestIsVoiceContentType:
     def _fn(self, content_type, filename):
         from gateway.platforms.qqbot import QQAdapter
-        return QQAdapter._is_voice_content_type(content_type, filename)
 
+        return QQAdapter._is_voice_content_type(content_type, filename)
 
     def test_voice_extension_fallback_when_content_type_empty(self):
         """content_type='' with audio extension → True (extension fallback)."""
         assert self._fn("", "file.silk") is True
-
 
     def test_audio_extension_amr_fallback_when_content_type_empty(self):
         """content_type='' with .amr extension → True (extension fallback)."""
@@ -107,19 +114,24 @@ class TestIsVoiceContentType:
 # Voice attachment SSRF protection
 # ---------------------------------------------------------------------------
 
+
 class TestVoiceAttachmentSSRFProtection:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
-        return QQAdapter(_make_config(**extra))
 
+        return QQAdapter(_make_config(**extra))
 
     def test_connect_uses_redirect_guard_hook(self):
         from gateway.platforms.qqbot import QQAdapter, _ssrf_redirect_guard
 
         client = mock.AsyncMock()
-        with mock.patch("gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client) as async_client_cls:
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.httpx.AsyncClient", return_value=client
+        ) as async_client_cls:
             adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
-            adapter._ensure_token = mock.AsyncMock(side_effect=RuntimeError("stop after client creation"))
+            adapter._ensure_token = mock.AsyncMock(
+                side_effect=RuntimeError("stop after client creation")
+            )
 
             connected = asyncio.run(adapter.connect())
 
@@ -134,9 +146,11 @@ class TestVoiceAttachmentSSRFProtection:
 # Voice attachment temp-file cleanup
 # ---------------------------------------------------------------------------
 
+
 class TestVoiceAttachmentTempCleanup:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def _setup_download_mocks(self, adapter, content=b"RIFFmock-wav-audio-data"):
@@ -177,6 +191,7 @@ class TestVoiceAttachmentTempCleanup:
 # WebSocket proxy handling
 # ---------------------------------------------------------------------------
 
+
 class TestQQWebSocketProxy:
     @pytest.mark.asyncio
     async def test_open_ws_honors_proxy_env(self, monkeypatch):
@@ -210,19 +225,25 @@ class TestQQWebSocketProxy:
                 seen_ws_kwargs.update(kwargs)
                 return mock.AsyncMock(closed=False)
 
-        with mock.patch("gateway.platforms.qqbot.adapter.aiohttp.ClientSession", side_effect=FakeSession):
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.aiohttp.ClientSession",
+            side_effect=FakeSession,
+        ):
             await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
 
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
 
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------
 
+
 class TestStripAtMention:
     def _fn(self, content):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._strip_at_mention(content)
 
     def test_removes_mention(self):
@@ -234,11 +255,12 @@ class TestStripAtMention:
 # _is_dm_allowed
 # ---------------------------------------------------------------------------
 
+
 class TestDmAllowed:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
-        return QQAdapter(_make_config(**extra))
 
+        return QQAdapter(_make_config(**extra))
 
     def test_open_policy_with_opt_in(self, monkeypatch):
         monkeypatch.setenv("GATEWAY_ALLOW_ALL_USERS", "true")
@@ -246,9 +268,13 @@ class TestDmAllowed:
         assert adapter._is_dm_allowed("any_user") is True
         assert adapter._is_dm_intake_allowed("any_user") is True
 
-
     def test_allowlist_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", dm_policy="allowlist", allow_from="user1,user2")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            dm_policy="allowlist",
+            allow_from="user1,user2",
+        )
         assert adapter._is_dm_allowed("user1") is True
 
 
@@ -256,16 +282,21 @@ class TestDmAllowed:
 # _is_group_allowed
 # ---------------------------------------------------------------------------
 
+
 class TestGroupAllowed:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
-
     def test_allowlist_match(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", group_policy="allowlist", group_allow_from="grp1")
+        adapter = self._make_adapter(
+            app_id="a",
+            client_secret="b",
+            group_policy="allowlist",
+            group_allow_from="grp1",
+        )
         assert adapter._is_group_allowed("grp1", "user1") is True
-
 
     def test_pairing_default_blocks_groups(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
@@ -277,9 +308,11 @@ class TestGroupAllowed:
 # _resolve_stt_config
 # ---------------------------------------------------------------------------
 
+
 class TestResolveSTTConfig:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_no_config(self):
@@ -292,13 +325,16 @@ class TestResolveSTTConfig:
 # _detect_message_type
 # ---------------------------------------------------------------------------
 
+
 class TestDetectMessageType:
     def _fn(self, media_urls, media_types):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._detect_message_type(media_urls, media_types)
 
     def test_no_media(self):
         from gateway.platforms.base import MessageType
+
         assert self._fn([], []) == MessageType.TEXT
 
 
@@ -306,9 +342,11 @@ class TestDetectMessageType:
 # QQCloseError
 # ---------------------------------------------------------------------------
 
+
 class TestQQCloseError:
     def test_attributes(self):
         from gateway.platforms.qqbot import QQCloseError
+
         err = QQCloseError(4004, "bad token")
         assert err.code == 4004
         assert err.reason == "bad token"
@@ -318,9 +356,11 @@ class TestQQCloseError:
 # _dispatch_payload
 # ---------------------------------------------------------------------------
 
+
 class TestDispatchPayload:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         adapter = QQAdapter(_make_config(**extra))
         return adapter
 
@@ -330,7 +370,6 @@ class TestDispatchPayload:
         adapter._dispatch_payload({"op": 99, "d": {}})
         # last_seq should remain None
         assert adapter._last_seq is None
-
 
     def test_seq_increments(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
@@ -343,15 +382,18 @@ class TestDispatchPayload:
 # READY / RESUMED handling
 # ---------------------------------------------------------------------------
 
+
 class TestReadyHandling:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_ready_stores_session(self):
         adapter = self._make_adapter(app_id="a", client_secret="b")
         adapter._dispatch_payload({
-            "op": 0, "t": "READY",
+            "op": 0,
+            "t": "READY",
             "s": 1,
             "d": {"session_id": "sess_abc123"},
         })
@@ -362,9 +404,11 @@ class TestReadyHandling:
 # _parse_json
 # ---------------------------------------------------------------------------
 
+
 class TestParseJson:
     def _fn(self, raw):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter._parse_json(raw)
 
     def test_valid_json(self):
@@ -380,19 +424,25 @@ class TestParseJson:
 # _build_text_body
 # ---------------------------------------------------------------------------
 
+
 class TestBuildTextBody:
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     def test_plain_text(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=False)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=False
+        )
         body = adapter._build_text_body("hello world")
         assert body["msg_type"] == 0  # MSG_TYPE_TEXT
         assert body["content"] == "hello world"
 
     def test_markdown_text(self):
-        adapter = self._make_adapter(app_id="a", client_secret="b", markdown_support=True)
+        adapter = self._make_adapter(
+            app_id="a", client_secret="b", markdown_support=True
+        )
         body = adapter._build_text_body("**bold** text")
         assert body["msg_type"] == 2  # MSG_TYPE_MARKDOWN
         assert body["markdown"]["content"] == "**bold** text"
@@ -402,11 +452,13 @@ class TestBuildTextBody:
 # _wait_for_reconnection / send reconnection wait
 # ---------------------------------------------------------------------------
 
+
 class TestWaitForReconnection:
     """Test that send() waits for reconnection instead of silently dropping."""
 
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(**extra))
 
     @pytest.mark.asyncio
@@ -443,16 +495,18 @@ class TestWaitForReconnection:
 # ChunkedUploader
 # ---------------------------------------------------------------------------
 
+
 class TestChunkedUploadFormatSize:
     def test_bytes(self):
         from gateway.platforms.qqbot.chunked_upload import format_size
+
         assert format_size(100) == "100.0 B"
 
 
 class TestChunkedUploadErrors:
-
     def test_too_large_includes_limit(self):
         from gateway.platforms.qqbot.chunked_upload import UploadFileTooLargeError
+
         exc = UploadFileTooLargeError("huge.bin", 200 * 1024 * 1024, 100 * 1024 * 1024)
         assert exc.file_name == "huge.bin"
         assert "MB" in exc.file_size_human
@@ -461,23 +515,27 @@ class TestChunkedUploadErrors:
 
 
 class TestChunkedUploadHelpers:
-
     def test_read_chunk_short_read_raises(self, tmp_path):
         from gateway.platforms.qqbot.chunked_upload import _read_file_chunk
+
         f = tmp_path / "x.bin"
         f.write_bytes(b"hi")
         with pytest.raises(IOError):
             _read_file_chunk(str(f), 0, 100)
 
-
     def test_parse_prepare_response_wrapped_in_data(self):
         from gateway.platforms.qqbot.chunked_upload import _parse_prepare_response
+
         raw = {
             "data": {
                 "upload_id": "uid-42",
                 "block_size": 4096,
                 "parts": [
-                    {"part_index": 1, "presigned_url": "https://cos/1", "block_size": 4096},
+                    {
+                        "part_index": 1,
+                        "presigned_url": "https://cos/1",
+                        "block_size": 4096,
+                    },
                     {"index": 2, "url": "https://cos/2"},
                 ],
                 "concurrency": 3,
@@ -612,15 +670,19 @@ class TestChunkedUploaderFlow:
 # Inline keyboards — approval + update-prompt flows
 # ---------------------------------------------------------------------------
 
+
 class TestApprovalButtonData:
     def test_parse_allow_once(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
-        result = parse_approval_button_data("approve:agent:main:qqbot:c2c:UID:allow-once")
-        assert result == ("agent:main:qqbot:c2c:UID", "allow-once")
 
+        result = parse_approval_button_data(
+            "approve:agent:main:qqbot:c2c:UID:allow-once"
+        )
+        assert result == ("agent:main:qqbot:c2c:UID", "allow-once")
 
     def test_parse_empty_returns_none(self):
         from gateway.platforms.qqbot.keyboards import parse_approval_button_data
+
         assert parse_approval_button_data("") is None
         assert parse_approval_button_data(None) is None  # type: ignore[arg-type]
 
@@ -628,18 +690,21 @@ class TestApprovalButtonData:
 class TestUpdatePromptButtonData:
     def test_parse_yes(self):
         from gateway.platforms.qqbot.keyboards import parse_update_prompt_button_data
+
         assert parse_update_prompt_button_data("update_prompt:y") == "y"
 
 
 class TestBuildApprovalKeyboard:
     def test_three_buttons_in_single_row(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+
         kb = build_approval_keyboard("session-1")
         assert len(kb.content.rows) == 1
         assert len(kb.content.rows[0].buttons) == 3
 
     def test_button_data_embeds_session_key(self):
         from gateway.platforms.qqbot.keyboards import build_approval_keyboard
+
         kb = build_approval_keyboard("agent:main:qqbot:c2c:UID")
         datas = [b.action.data for b in kb.content.rows[0].buttons]
         assert datas[0] == "approve:agent:main:qqbot:c2c:UID:allow-once"
@@ -650,35 +715,40 @@ class TestBuildApprovalKeyboard:
 class TestBuildUpdatePromptKeyboard:
     def test_two_buttons(self):
         from gateway.platforms.qqbot.keyboards import build_update_prompt_keyboard
+
         kb = build_update_prompt_keyboard()
         assert len(kb.content.rows[0].buttons) == 2
 
 
 class TestBuildApprovalText:
-
-
     def test_truncates_long_commands(self):
         from gateway.platforms.qqbot.keyboards import (
-            ApprovalRequest, build_approval_text,
+            ApprovalRequest,
+            build_approval_text,
         )
+
         long = "x" * 1000
         req = ApprovalRequest(
-            session_key="s", title="t", command_preview=long, cwd="/x",
+            session_key="s",
+            title="t",
+            command_preview=long,
+            cwd="/x",
         )
         text = build_approval_text(req)
         # Preview is truncated to 300 chars; 1000 "x"s would still push the
         # body past 300, but the inline preview specifically must be capped.
-        preview_line = [
-            line for line in text.split("\n") if line.startswith("```")
-        ]
+        preview_line = [line for line in text.split("\n") if line.startswith("```")]
         # 2 backtick fences; the content line in between is separate.
-        xs_in_preview = sum(line.count("x") for line in text.split("\n") if line and "```" not in line)
+        xs_in_preview = sum(
+            line.count("x") for line in text.split("\n") if line and "```" not in line
+        )
         assert xs_in_preview <= 301  # 300 xs + one-off tolerance
 
 
 class TestInteractionEventParsing:
     def test_parse_c2c_interaction(self):
         from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
         raw = {
             "id": "interaction-42",
             "chat_type": 2,
@@ -706,6 +776,7 @@ class TestAdapterInteractionDispatch:
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -732,7 +803,10 @@ class TestAdapterInteractionDispatch:
             "user_openid": "user-1",
             "data": {
                 "type": 11,
-                "resolved": {"button_data": "approve:agent:main:qqbot:c2c:u:deny", "button_id": "deny"},
+                "resolved": {
+                    "button_data": "approve:agent:main:qqbot:c2c:u:deny",
+                    "button_id": "deny",
+                },
             },
         })
 
@@ -747,11 +821,13 @@ class TestAdapterInteractionDispatch:
 # Quoted-message handling (message_type=103 → msg_elements)
 # ---------------------------------------------------------------------------
 
+
 class TestProcessQuotedContext:
     """Verify the quoted-message pipeline: text + voice STT + images + files."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -760,7 +836,6 @@ class TestProcessQuotedContext:
         d = {"message_type": 0, "content": "hi"}
         out = await adapter._process_quoted_context(d)
         assert out == {"quote_block": "", "image_urls": [], "image_media_types": []}
-
 
     @pytest.mark.asyncio
     async def test_quote_with_voice_attachment_runs_stt(self):
@@ -782,14 +857,18 @@ class TestProcessQuotedContext:
 
         d = {
             "message_type": 103,
-            "msg_elements": [{
-                "content": "",
-                "attachments": [
-                    {"content_type": "audio/silk",
-                     "url": "https://qq-cdn/x.silk",
-                     "filename": "rec.silk"}
-                ],
-            }],
+            "msg_elements": [
+                {
+                    "content": "",
+                    "attachments": [
+                        {
+                            "content_type": "audio/silk",
+                            "url": "https://qq-cdn/x.silk",
+                            "filename": "rec.silk",
+                        }
+                    ],
+                }
+            ],
         }
         out = await adapter._process_quoted_context(d)
 
@@ -799,7 +878,6 @@ class TestProcessQuotedContext:
         assert "[Quoted message]:" in out["quote_block"]
         assert "hello from the quoted audio" in out["quote_block"]
 
-
     @pytest.mark.asyncio
     async def test_multiple_elements_concatenated(self):
         adapter = self._make_adapter()
@@ -807,8 +885,10 @@ class TestProcessQuotedContext:
         async def fake_process(atts):
             assert len(atts) == 2
             return {
-                "image_urls": [], "image_media_types": [],
-                "voice_transcripts": [], "attachment_info": "",
+                "image_urls": [],
+                "image_media_types": [],
+                "voice_transcripts": [],
+                "attachment_info": "",
             }
 
         adapter._process_attachments = fake_process  # type: ignore[assignment]
@@ -816,8 +896,14 @@ class TestProcessQuotedContext:
         d = {
             "message_type": 103,
             "msg_elements": [
-                {"content": "first", "attachments": [{"content_type": "image/png", "url": "a"}]},
-                {"content": "second", "attachments": [{"content_type": "image/png", "url": "b"}]},
+                {
+                    "content": "first",
+                    "attachments": [{"content_type": "image/png", "url": "a"}],
+                },
+                {
+                    "content": "second",
+                    "attachments": [{"content_type": "image/png", "url": "b"}],
+                },
             ],
         }
         out = await adapter._process_quoted_context(d)
@@ -828,6 +914,7 @@ class TestProcessQuotedContext:
 class TestMergeQuoteInto:
     def test_empty_quote_returns_original(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         assert QQAdapter._merge_quote_into("hello", "") == "hello"
 
 
@@ -835,11 +922,13 @@ class TestMergeQuoteInto:
 # Gateway-contract approval UX — send_exec_approval + default dispatcher
 # ---------------------------------------------------------------------------
 
+
 class TestDefaultInteractionDispatch:
     """Verify the adapter's default INTERACTION_CREATE router."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     def test_default_callback_installed_on_init(self):
@@ -847,7 +936,6 @@ class TestDefaultInteractionDispatch:
         adapter = self._make_adapter()
         assert adapter._interaction_callback is not None
         assert adapter._interaction_callback == adapter._default_interaction_dispatch
-
 
     @pytest.mark.asyncio
     async def test_approval_click_once_maps_to_once(self):
@@ -863,22 +951,27 @@ class TestDefaultInteractionDispatch:
         # Patch the *module-level* function that _default_interaction_dispatch
         # imports lazily.
         import tools.approval
+
         orig = tools.approval.resolve_gateway_approval
         tools.approval.resolve_gateway_approval = fake_resolve
         try:
             from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
             event = parse_interaction_event({
                 "id": "i",
                 "chat_type": 2,
                 "user_openid": "u-42",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"}},
+                "data": {
+                    "resolved": {
+                        "button_data": "approve:agent:main:qqbot:c2c:u-42:allow-once"
+                    }
+                },
             })
             await adapter._default_interaction_dispatch(event)
         finally:
             tools.approval.resolve_gateway_approval = orig
 
         assert resolve_calls == [("agent:main:qqbot:c2c:u-42", "once", False)]
-
 
     @pytest.mark.asyncio
     async def test_approval_click_rejects_unauthorized_operator(self):
@@ -890,15 +983,22 @@ class TestDefaultInteractionDispatch:
             return 1
 
         import tools.approval
+
         orig = tools.approval.resolve_gateway_approval
         tools.approval.resolve_gateway_approval = fake_resolve
         try:
             from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
             event = parse_interaction_event({
-                "id": "i", "chat_type": 1,
+                "id": "i",
+                "chat_type": 1,
                 "group_openid": "g-1",
                 "group_member_openid": "attacker",
-                "data": {"resolved": {"button_data": "approve:agent:main:qqbot:group:g-1:owner:allow-once"}},
+                "data": {
+                    "resolved": {
+                        "button_data": "approve:agent:main:qqbot:group:g-1:owner:allow-once"
+                    }
+                },
             })
             await adapter._default_interaction_dispatch(event)
         finally:
@@ -907,7 +1007,9 @@ class TestDefaultInteractionDispatch:
         assert resolve_calls == []
 
     @pytest.mark.asyncio
-    async def test_update_prompt_click_writes_response_file(self, tmp_path, monkeypatch):
+    async def test_update_prompt_click_writes_response_file(
+        self, tmp_path, monkeypatch
+    ):
         """update_prompt:y click writes 'y' to ~/.hermes/.update_response."""
         adapter = self._make_adapter()
         hermes_home = tmp_path / "hermes_home"
@@ -918,8 +1020,11 @@ class TestDefaultInteractionDispatch:
         )
 
         from gateway.platforms.qqbot.keyboards import parse_interaction_event
+
         event = parse_interaction_event({
-            "id": "i", "chat_type": 2, "user_openid": "u-1",
+            "id": "i",
+            "chat_type": 2,
+            "user_openid": "u-1",
             "data": {"resolved": {"button_data": "update_prompt:y"}},
         })
         await adapter._default_interaction_dispatch(event)
@@ -934,6 +1039,7 @@ class TestSendExecApproval:
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -944,6 +1050,7 @@ class TestSendExecApproval:
 
         async def fake_send_approval(chat_id, req, reply_to=None):
             from gateway.platforms.base import SendResult
+
             calls.append({"chat_id": chat_id, "req": req, "reply_to": reply_to})
             return SendResult(success=True, message_id="m-1")
 
@@ -971,6 +1078,7 @@ class TestSendUpdatePrompt:
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -981,6 +1089,7 @@ class TestSendUpdatePrompt:
 
         async def fake_swk(chat_id, content, keyboard, reply_to=None):
             from gateway.platforms.base import SendResult
+
             captured["chat_id"] = chat_id
             captured["content"] = content
             captured["keyboard"] = keyboard
@@ -991,8 +1100,11 @@ class TestSendUpdatePrompt:
         adapter._last_msg_id["u1"] = "prev-msg"
 
         result = await adapter.send_update_prompt(
-            chat_id="u1", prompt="Continue with update?",
-            default="y", session_key="ignored", metadata={"x": 1},
+            chat_id="u1",
+            prompt="Continue with update?",
+            default="y",
+            session_key="ignored",
+            metadata={"x": 1},
         )
         assert result.success
         assert "Continue with update?" in captured["content"]
@@ -1007,6 +1119,7 @@ class TestSendUpdatePrompt:
 class TestSendContentGuards:
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -1033,11 +1146,13 @@ class TestSendContentGuards:
 # _send_identify includes INTERACTION intent
 # ---------------------------------------------------------------------------
 
+
 class TestIdentifyIntents:
     """Verify the WebSocket identify payload includes the INTERACTION intent bit."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -1073,11 +1188,13 @@ class TestIdentifyIntents:
 # _process_attachments: video/file path exposure
 # ---------------------------------------------------------------------------
 
+
 class TestProcessAttachmentsPathExposure:
     """Verify that video and file attachments include the cached local path."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
@@ -1106,7 +1223,6 @@ class TestProcessAttachmentsPathExposure:
         assert "my_video.mp4" in info
         assert "/tmp/cache/video_abc123.mp4" in info
 
-
     @pytest.mark.asyncio
     async def test_quoted_video_includes_path_in_quote_block(self):
         """Quoted video attachments should surface the cached path in the quote block."""
@@ -1125,14 +1241,18 @@ class TestProcessAttachmentsPathExposure:
 
         d = {
             "message_type": 103,
-            "msg_elements": [{
-                "content": "看看这个视频",
-                "attachments": [
-                    {"content_type": "video/mp4",
-                     "url": "https://qq-cdn/clip.mp4",
-                     "filename": "clip.mp4"}
-                ],
-            }],
+            "msg_elements": [
+                {
+                    "content": "看看这个视频",
+                    "attachments": [
+                        {
+                            "content_type": "video/mp4",
+                            "url": "https://qq-cdn/clip.mp4",
+                            "filename": "clip.mp4",
+                        }
+                    ],
+                }
+            ],
         }
         out = await adapter._process_quoted_context(d)
         assert "[Quoted message]:" in out["quote_block"]
@@ -1143,11 +1263,13 @@ class TestProcessAttachmentsPathExposure:
 # WebSocket op 7 (Server Reconnect) and op 9 (Invalid Session)
 # ---------------------------------------------------------------------------
 
+
 class TestOp7ServerReconnect:
     """Verify op 7 triggers WS close (which triggers reconnect in outer loop)."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     def test_op7_closes_websocket(self):
@@ -1179,8 +1301,8 @@ class TestOp9InvalidSession:
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
-        return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     @pytest.mark.asyncio
     async def test_op9_non_resumable_triggers_ws_close(self):
@@ -1207,11 +1329,13 @@ class TestOp9InvalidSession:
 # Close code classification
 # ---------------------------------------------------------------------------
 
+
 class TestCloseCodeClassification:
     """Verify fatal close codes stop reconnecting and 4009 preserves session."""
 
     def _make_adapter(self):
         from gateway.platforms.qqbot.adapter import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b"))
 
     def test_4009_preserves_session(self):
@@ -1224,9 +1348,22 @@ class TestCloseCodeClassification:
         # We verify the logic directly: dispatch a close-code event that
         # exercises the session-clearing path (4006), then verify 4009 does not.
         session_clear_codes = {
-            4006, 4007, 4900, 4901, 4902, 4903,
-            4904, 4905, 4906, 4907, 4908, 4909,
-            4910, 4911, 4912, 4913,
+            4006,
+            4007,
+            4900,
+            4901,
+            4902,
+            4903,
+            4904,
+            4905,
+            4906,
+            4907,
+            4908,
+            4909,
+            4910,
+            4911,
+            4912,
+            4913,
         }
         assert 4009 not in session_clear_codes
 
@@ -1238,6 +1375,7 @@ class TestReadEventsClosedWsGuard:
 
     def _make_adapter(self, **extra):
         from gateway.platforms.qqbot import QQAdapter
+
         return QQAdapter(_make_config(app_id="a", client_secret="b", **extra))
 
     def test_read_events_raises_when_ws_closed_on_entry(self):
@@ -1246,4 +1384,3 @@ class TestReadEventsClosedWsGuard:
         adapter._ws = SimpleNamespace(closed=True)
         with pytest.raises(RuntimeError):
             asyncio.run(adapter._read_events())
-

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -1004,6 +1004,31 @@ class TestSendUpdatePrompt:
         assert datas == ["update_prompt:y", "update_prompt:n"]
 
 
+class TestSendContentGuards:
+    def _make_adapter(self):
+        from gateway.platforms.qqbot.adapter import QQAdapter
+        return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("content", [None, 0, [], {}])
+    async def test_nonstrings_return_success_without_sending(self, content):
+        adapter = self._make_adapter()
+        adapter.is_connected = True
+
+        called = False
+
+        async def fake_send_chunk(chat_id, chunk, reply_to=None):
+            nonlocal called
+            called = True
+            raise AssertionError("_send_chunk should not be called for invalid content")
+
+        adapter._send_chunk = fake_send_chunk  # type: ignore[assignment]
+
+        result = await adapter.send("user-1", content)  # type: ignore[arg-type]
+        assert result.success is True
+        assert called is False
+
+
 # ---------------------------------------------------------------------------
 # _send_identify includes INTERACTION intent
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Guard QQAdapter.send() against non-string outbound content
Treat malformed payloads like empty messages instead of raising
Add regression coverage for None, numeric, list, and dict content