### PR TITLE
fix(desktop): use valid LC_CTYPE locale in terminal pane

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -10997,7 +10997,11 @@ function terminalShellEnv() {
   delete env.COLORFGBG
 
   env.COLORTERM = 'truecolor'
-  env.LC_CTYPE = env.LC_CTYPE || 'UTF-8'
+  // Fix: 'UTF-8' is not a valid locale name (setlocale fails, bash prints
+  // "setlocale: LC_CTYPE: 无法改变区域设置 (UTF-8)" on every shell start).
+  // Inherit the parent's LANG instead; only fall back to a locale name that
+  // actually exists on glibc systems.
+  env.LC_CTYPE = env.LC_CTYPE || env.LANG || 'C.UTF-8'
   env.TERM = 'xterm-256color'
   env.TERM_PROGRAM = 'Hermes'
   env.TERM_PROGRAM_VERSION = app.getVersion()


### PR DESCRIPTION
## Summary

- avoid assigning the invalid locale name `UTF-8` to the desktop terminal pane's `LC_CTYPE`
- inherit `LANG` when `LC_CTYPE` is unset, with `C.UTF-8` as the fallback
- prevent bash from printing `setlocale` warnings on every terminal start

## Verification

- reproduction confirmed: `LC_CTYPE=UTF-8` is rejected by the system locale implementation, while `C.UTF-8` resolves successfully
- `cd apps/desktop && npm run typecheck` passes
- no install or build run