### PR TITLE
 guard malformed interaction numeric fields

### DIFF
--- a/gateway/platforms/qqbot/keyboards.py
+++ b/gateway/platforms/qqbot/keyboards.py
@@ -439,15 +439,23 @@ class InteractionEvent:
         )
 
 
+def _coerce_int(value: Any, default: int = 0) -> int:
+    """Best-effort int coercion for webhook payload fields."""
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def parse_interaction_event(raw: Dict[str, Any]) -> InteractionEvent:
     """Parse a raw ``INTERACTION_CREATE`` dispatch payload (``d``)."""
     data_raw = raw.get("data") or {}
     resolved = data_raw.get("resolved") or {}
-    scene_code = int(raw.get("chat_type", 0) or 0)
+    scene_code = _coerce_int(raw.get("chat_type", 0) or 0, 0)
     scene = {0: "guild", 1: "group", 2: "c2c"}.get(scene_code, "")
     return InteractionEvent(
         id=str(raw.get("id", "")),
-        type=int(data_raw.get("type", 0) or 0),
+        type=_coerce_int(data_raw.get("type", 0) or 0, 0),
         chat_type=scene_code,
         scene=scene,
         group_openid=str(raw.get("group_openid", "")),

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -700,6 +700,23 @@ class TestInteractionEventParsing:
         assert ev.button_id == "allow"
         assert ev.operator_openid == "user-1"
 
+    def test_malformed_numeric_fields_fall_back_to_defaults(self):
+        from gateway.platforms.qqbot.keyboards import parse_interaction_event
+        raw = {
+            "id": "interaction-bad",
+            "chat_type": {"bad": "type"},
+            "user_openid": "user-2",
+            "data": {
+                "type": ["not-int"],
+                "resolved": {"button_data": "approve:sess:allow-once"},
+            },
+        }
+        ev = parse_interaction_event(raw)
+        assert ev.id == "interaction-bad"
+        assert ev.chat_type == 0
+        assert ev.type == 0
+        assert ev.scene == "guild"
+
 
 class TestAdapterInteractionDispatch:
     """End-to-end verification of _on_interaction including ACK + callback."""


### PR DESCRIPTION
QQ webhook payloads may contain malformed/non-numeric values for chat_type and data.type. Previously, parse_interaction_event() used direct int(...) conversion for these fields, which could raise exceptions during interaction dispatch.