### PR TITLE
fix(tui): preserve archived compaction history on prompt.submit truncation

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -4383,7 +4383,7 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
             self._target()
 
     class _FakeDB:
-        def replace_messages(self, key, messages):
+        def replace_messages(self, key, messages, active_only=False):
             replaced.append((key, list(messages)))
 
     history = [
@@ -9223,7 +9223,7 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages):
+        def replace_messages(self, session_id, messages, active_only=False):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()
@@ -9279,7 +9279,7 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
     server._sessions["trunc-fail-sid"] = sess
 
     class _FailDb:
-        def replace_messages(self, session_id, messages):
+        def replace_messages(self, session_id, messages, active_only=False):
             raise OSError("disk full")
 
     monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
@@ -9311,6 +9311,104 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
         assert sess.get("running") is not True
     finally:
         server._sessions.pop("trunc-fail-sid", None)
+
+
+def test_prompt_submit_truncation_preserves_archived_compaction_rows(
+    monkeypatch, tmp_path
+):
+    """Edit/regenerate truncation must not DELETE soft-archived compaction rows.
+
+    With compression.in_place (the default, #38763) archive_and_compact()
+    keeps the pre-compaction transcript on disk as active=0/compacted=1 rows
+    under the same session id the live transcript uses. session["history"]
+    only holds the live set, so a bare replace_messages() (default
+    active_only=False) DELETEs every row for the session and reinserts only
+    the truncated live tail: a routine desktop/TUI edit after a compaction
+    permanently wipes the archived history. The handler must probe
+    has_archived_messages() and pass active_only=True so only the live rows
+    are replaced, the same contract ACP _persist and gateway /compress
+    already honor (#61145). Runs against a real SessionDB so the archived
+    rows are physically verified, not mocked.
+    """
+    from hermes_state import SessionDB
+
+    compacted_live = [
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "first reply"},
+        {"role": "user", "content": "second"},
+        {"role": "assistant", "content": "second reply"},
+    ]
+    db = SessionDB(tmp_path / "state.db")
+    try:
+        db.create_session("session-key", source="tui")
+        db.append_message("session-key", "user", "old question")
+        db.append_message("session-key", "assistant", "old answer")
+        # In-place compaction: the two rows above are soft-archived and the
+        # compacted transcript becomes the live set under the same id.
+        db.archive_and_compact("session-key", compacted_live)
+        assert db.has_archived_messages("session-key") is True
+
+        class _Agent:
+            def run_conversation(
+                self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+            ):
+                return {
+                    "final_response": "edited reply",
+                    "messages": [
+                        *(conversation_history or []),
+                        {"role": "user", "content": prompt},
+                        {"role": "assistant", "content": "edited reply"},
+                    ],
+                }
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        server._sessions["sid"] = _session(agent=_Agent(), history=list(compacted_live))
+        try:
+            monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+            monkeypatch.setattr(server, "_get_usage", lambda _a: {})
+            monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
+            monkeypatch.setattr(server, "_emit", lambda *a: None)
+            monkeypatch.setattr(server, "_get_db", lambda: db)
+
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "prompt.submit",
+                    "params": {
+                        "session_id": "sid",
+                        "text": "edited second",
+                        "truncate_before_user_ordinal": 1,
+                    },
+                }
+            )
+            assert resp.get("result"), f"got error: {resp.get('error')}"
+        finally:
+            server._sessions.pop("sid", None)
+
+        # The archived pre-compaction rows survive the rewrite untouched.
+        archived = [
+            m for m in db.get_messages("session-key", include_inactive=True)
+            if not m["active"]
+        ]
+        assert [(m["role"], m["content"]) for m in archived] == [
+            ("user", "old question"),
+            ("assistant", "old answer"),
+        ]
+        assert all(m["compacted"] == 1 for m in archived)
+        # The live set is exactly the truncated transcript.
+        live = db.get_messages("session-key")
+        assert [(m["role"], m["content"]) for m in live] == [
+            ("user", "first"),
+            ("assistant", "first reply"),
+        ]
+    finally:
+        db.close()
 
 
 # ---------------------------------------------------------------------------
@@ -9370,7 +9468,7 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
         def __init__(self):
             self.replaced = []
 
-        def replace_messages(self, session_id, messages):
+        def replace_messages(self, session_id, messages, active_only=False):
             self.replaced.append((session_id, list(messages)))
 
     stub_db = _StubDb()

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -219,8 +219,24 @@ def _(rid, params: dict) -> dict:
             # zombie history on resume, and the edit/regenerate never sticks.
             # Fail closed: refuse the turn and leave memory/DB unchanged.
             if (db := _get_db()) is not None:
+                # In-place compaction (compression.in_place, #38763) keeps the
+                # pre-compaction transcript on disk as soft-archived
+                # active=0/compacted=1 rows under this same session id, while
+                # session["history"] only holds the live set. A default
+                # replace_messages(active_only=False) would DELETE those
+                # archived rows and reinsert only the truncated live tail, so
+                # any edit/regenerate/rewind after a compaction permanently
+                # wipes the archived history (same class as #61145). Mirror
+                # the ACP adapter: replace only the live rows when archives
+                # exist on disk.
                 try:
-                    db.replace_messages(session["session_key"], truncated)
+                    has_archived = db.has_archived_messages(session["session_key"])
+                except Exception:
+                    has_archived = False
+                try:
+                    db.replace_messages(
+                        session["session_key"], truncated, active_only=has_archived
+                    )
                 except Exception as exc:
                     logger.error(
                         "prompt.submit: replace_messages failed for session %s "


### PR DESCRIPTION
## What does this PR do?

After a successful in-place compaction (compression.in_place, the default since #38763), the pre-compaction transcript stays on disk as soft-archived active=0/compacted=1 rows under the same session id, and SessionDB keeps them searchable. The prompt.submit truncation path in tui_gateway (desktop/TUI edit, regenerate, rewind via truncate_before_user_ordinal) called replace_messages() with the default active_only=False, which DELETEs every row for the session and reinserts only the truncated live tail. Any edit after a compaction permanently destroyed the archived history: hard ID gaps, empty archive queries, missing in_place_committed history.

This mirrors the ACP adapter's _persist: probe has_archived_messages() and pass active_only so only the live rows are replaced when archives exist on disk. Same durability contract the gateway /compress path documents in gateway/slash_commands.py (#61145, #44794, #39704) and that replace_messages states in its own docstring.

Likely a partial explanation for #79391, not the whole story. The explicit_interrupt branch in agent/conversation_compression.py restores the in-memory transcript and aborts before archive_and_compact runs, so an interrupt alone does not DELETE rows. A later edit/regenerate wiping the archives matches the reported "earlier successful in_place_committed archives are missing". Refs rather than fixes.

## Related Issue

Refs #79391

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/methods_prompt.py`: prompt.submit truncation probes has_archived_messages() and calls replace_messages(..., active_only=has_archived), mirroring acp_adapter/session.py _persist. A probe failure falls back to False, preserving the current behavior for sessions without archived rows.
- `tests/test_tui_gateway_server.py`: new regression test drives prompt.submit truncation against a real SessionDB seeded with soft-archived compaction rows and asserts the archived rows survive (active=0/compacted=1) and the live set matches the truncated transcript. Existing fake DBs accept the new active_only kwarg.

Searched for competing PRs on this call site and found none open. #72694 covers the ACP /compress path only. gateway/session.py rewrite_transcript has the same bare call but different semantics (/undo vs archived rewind rows), left out of scope on purpose.

## How to Test

1. `scripts/run_tests.sh tests/test_tui_gateway_server.py -k truncat -q`
   - 8 passed, 0 failed (includes the new archived-rows regression test)
2. `scripts/run_tests.sh tests/test_tui_gateway_server.py -q`
   - 517 passed, 1 failed. The failure is test_write_json_serializes_concurrent_writes, a thread-timing assertion on stdout chunking far from this change. It passes on an isolated rerun and does not touch the truncation path.
3. Manual reasoning check: seed a session with archive_and_compact(), then truncate via prompt.submit. Before the fix the archived rows are DELETEed; after it they survive with active=0/compacted=1. The new test does exactly this against a real SessionDB.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the suites above. The one full-file failure is a flaky thread-timing test that passes in isolation and is unrelated to this change
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, the fix brings the caller in line with the existing replace_messages docstring contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - SQLite query path only, no platform surface. Developed and tested on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

```shell
$ scripts/run_tests.sh tests/test_tui_gateway_server.py -k truncat -q
=== Summary: 1 files, 8 tests passed, 0 failed (100% complete) in 8.7s (32 workers) ===
```
