### PR TITLE
fix(environments): prevent delegated child marker snapshot leak

### DIFF
--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -10,9 +10,9 @@ stale value and its ``echo $HERMES_SESSION_ID`` reported a FOREIGN session's id
 — overriding the correct per-command Popen env injected by
 ``_inject_session_context_env``.
 
-The fix strips the per-session bridged vars (HERMES_SESSION_* / UI /
-CRON_AUTO_DELIVER_) from the snapshot at both dump sites in
-``tools/environments/base.py``; they are re-injected fresh on every command.
+The fix strips per-session bridged vars and the delegated-child process marker
+from the snapshot at both dump sites in ``tools/environments/base.py``; the
+current command's values are restored fresh after sourcing the snapshot.
 """
 
 import os
@@ -28,10 +28,10 @@ from tools.environments.base import (
 
 
 # ---------------------------------------------------------------------------
-# Unit: the exclusion regex matches exactly the bridged vars, nothing else.
+# Unit: the exclusion regex covers gateway-bridged and transient runtime vars.
 # ---------------------------------------------------------------------------
 
-def test_regex_matches_bridged_session_vars():
+def test_regex_matches_snapshot_transient_vars():
     rx = re.compile(_SNAPSHOT_EXCLUDED_ENV_REGEX)
     # Every var the gateway bridges must be excluded.
     from gateway.session_context import _VAR_MAP
@@ -39,6 +39,7 @@ def test_regex_matches_bridged_session_vars():
     for name in _VAR_MAP:
         line = f'declare -x {name}="whatever"'
         assert rx.search(line), f"{name} should be excluded from the snapshot"
+    assert rx.search('declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"')
 
 
 def test_export_snippet_shape():
@@ -50,6 +51,7 @@ def test_export_snippet_shape():
     assert "${!HERMES_SESSION_*}" in snippet
     assert "${!HERMES_CRON_AUTO_DELIVER_*}" in snippet
     assert "HERMES_UI_SESSION_ID" in snippet
+    assert "HERMES_DELEGATED_CHILD_CONTEXT" in snippet
     assert "grep -vE" not in snippet
     assert '"$__hermes_snap_tmp"' in snippet
     # The redirection must be attached to a brace group wrapping the dump,
@@ -104,5 +106,80 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
         if os.path.exists(snap):
             with open(snap) as f:
                 assert "HERMES_SESSION_ID" not in f.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_delegated_child_marker_does_not_leak_from_snapshot_to_parent(tmp_path, monkeypatch):
+    """A snapshot made by a delegated child must not taint later parent calls."""
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    with delegated_child_context():
+        env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        result = env.execute(
+            'printf "marker=<%s>\\n" "${HERMES_DELEGATED_CHILD_CONTEXT:-}"'
+        )
+
+        assert result["returncode"] == 0
+        assert "marker=<>" in result["output"]
+        with open(env._snapshot_path) as snap:
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in snap.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_delegated_child_marker_stays_local_to_the_child_command(tmp_path, monkeypatch):
+    """A child restores its live marker despite a stale snapshot."""
+    from agent.delegation_context import delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        with open(env._snapshot_path, "a") as snap:
+            snap.write('declare -x HERMES_DELEGATED_CHILD_CONTEXT="stale"\n')
+
+        with delegated_child_context():
+            child = env.execute(
+                'printf "marker=<%s>\\n" "${HERMES_DELEGATED_CHILD_CONTEXT:-}"'
+            )
+        parent = env.execute(
+            'printf "marker=<%s>\\n" "${HERMES_DELEGATED_CHILD_CONTEXT:-}"'
+        )
+
+        assert child["returncode"] == 0
+        assert "marker=<1>" in child["output"]
+        assert parent["returncode"] == 0
+        assert "marker=<>" in parent["output"]
+        with open(env._snapshot_path) as snap:
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in snap.read()
+    finally:
+        env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_parent_command_clears_marker_from_a_preexisting_snapshot(tmp_path, monkeypatch):
+    """The first parent command repairs a snapshot written by an older version."""
+    from tools.environments.local import LocalEnvironment
+
+    monkeypatch.delenv("HERMES_DELEGATED_CHILD_CONTEXT", raising=False)
+    env = LocalEnvironment(cwd=str(tmp_path), timeout=30)
+    try:
+        with open(env._snapshot_path, "a") as snap:
+            snap.write('declare -x HERMES_DELEGATED_CHILD_CONTEXT="1"\n')
+
+        result = env.execute(
+            'printf "marker=<%s>\\n" "${HERMES_DELEGATED_CHILD_CONTEXT:-}"'
+        )
+
+        assert result["returncode"] == 0
+        assert "marker=<>" in result["output"]
+        with open(env._snapshot_path) as snap:
+            assert "HERMES_DELEGATED_CHILD_CONTEXT" not in snap.read()
     finally:
         env.cleanup()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -463,13 +463,21 @@ def _cwd_marker(session_id: str) -> str:
 # should only carry the user's own shell state (PATH, functions, exports they
 # set), not Hermes' per-turn session identity.
 #
-# Kept in sync with gateway.session_context._VAR_MAP: every bridged name starts
-# with one of these prefixes (or is HERMES_UI_SESSION_ID). Used by unit tests
-# as the Python-side contract for the exclusion set; the dump path unsets by
+# Gateway-bridged names follow these prefixes (or are HERMES_UI_SESSION_ID);
+# this set also includes transient runtime markers. Used by unit tests as the
+# Python-side contract for snapshot exclusions; the dump path unsets by
 # name/prefix instead of grepping declare lines (see below / issue #71296).
 _SNAPSHOT_EXCLUDED_ENV_REGEX = (
-    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|HERMES_CRON_SESSION)"
+    "^declare -x (HERMES_SESSION_|HERMES_UI_SESSION_ID|HERMES_CRON_AUTO_DELIVER_|"
+    "HERMES_CRON_SESSION|HERMES_DELEGATED_CHILD_CONTEXT)"
 )
+# This marker is valid only for a process descended from ``delegate_task``.
+# A shared terminal snapshot outlives that process, so persisting the marker
+# would make a later parent command look like a delegated child and reject its
+# Kanban mutations.
+_SNAPSHOT_RUNTIME_EXCLUDED_ENV_NAMES = frozenset({
+    "HERMES_DELEGATED_CHILD_CONTEXT",
+})
 _SHELL_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
@@ -478,8 +486,9 @@ def _export_dump_excluding_session_vars(
     excluded_names: Iterable[str] = (),
 ) -> str:
     """Return a shell snippet that dumps ``export -p`` to *tmp_path* minus the
-    per-session bridged vars (see ``_SNAPSHOT_EXCLUDED_ENV_REGEX``) and any
-    additional names supplied by the caller.
+    per-session bridged vars, transient runtime vars (see
+    ``_SNAPSHOT_EXCLUDED_ENV_REGEX``), and any additional names supplied by
+    the caller.
 
     Unset the bridged vars in a subshell *before* ``export -p``. A line-based
     ``grep -vE`` filter is unsafe: bash 3.2 prints a value containing a newline
@@ -502,10 +511,11 @@ def _export_dump_excluding_session_vars(
     # because ``unset`` with only missing names is ignored under 2>/dev/null.
     # Quote caller-provided names so malformed configuration can never become
     # shell syntax. Valid environment names remain unquoted by shlex.quote().
-    safe_names = {
+    safe_names = set(_SNAPSHOT_RUNTIME_EXCLUDED_ENV_NAMES)
+    safe_names.update(
         name for name in excluded_names
         if isinstance(name, str) and name
-    }
+    )
     extra_unset = " ".join(shlex.quote(name) for name in sorted(safe_names))
     if extra_unset:
         extra_unset = f" {extra_unset}"
@@ -602,26 +612,27 @@ class BaseEnvironment(ABC):
         return ()
 
     def _snapshot_excluded_passthrough_names(self) -> tuple[str, ...]:
-        """Return profile-scoped names that must not persist in the snapshot.
+        """Return transient runtime and profile-scoped snapshot exclusions.
 
         The set is monotonic for the environment lifetime. A skill/config
         allowlist can be cleared after a value was captured; retaining the
         exclusion prevents that old value from becoming visible to a later
         profile through the shared snapshot.
         """
+        names = set(_SNAPSHOT_RUNTIME_EXCLUDED_ENV_NAMES)
         if not self._profile_scoped_passthrough:
-            return ()
+            return tuple(sorted(names))
         try:
             from agent.secret_scope import is_multiplex_active
             if is_multiplex_active():
                 from tools.env_passthrough import get_all_passthrough
-                names = (
+                profile_names = (
                     *get_all_passthrough(),
                     *self._additional_profile_scoped_passthrough_names(),
                 )
                 self._snapshot_passthrough_names.update(
                     name
-                    for name in names
+                    for name in profile_names
                     if isinstance(name, str) and _SHELL_ENV_NAME_RE.fullmatch(name)
                 )
         except Exception:
@@ -629,7 +640,8 @@ class BaseEnvironment(ABC):
                 "Could not refresh profile-scoped snapshot exclusions",
                 exc_info=True,
             )
-        return tuple(sorted(self._snapshot_passthrough_names))
+        names.update(self._snapshot_passthrough_names)
+        return tuple(sorted(names))
 
     def init_session(self):
         """Capture login shell environment into a snapshot file.


### PR DESCRIPTION
## Summary
- prevent `HERMES_DELEGATED_CHILD_CONTEXT` from being persisted in sourced environment snapshots
- preserve the marker for the delegated child command itself, then restore/unset it for later parent commands
- add regression coverage for stale/pre-existing markers and child-to-parent non-persistence

## Validation
- `env -u PYTHONPATH -u PYTHONHOME scripts/run_tests.sh tests/tools/test_snapshot_session_id_leak.py` — 6 passed
- `.venv/bin/ruff check tools/environments/base.py tests/tools/test_snapshot_session_id_leak.py` — passed
- `git diff --check 1be70d635..HEAD` — passed

## Review evidence
L2 review packet and independent Sol review completed. No source-code findings remain; full-suite, Windows/Git-Bash, and remote-CI coverage remain declared gaps.
