### PR TITLE
fix(acp): honor model in session/new and session/load, drop the extra set_session_model RTT (#80150)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -840,6 +840,27 @@ class HermesACPAgent(acp.Agent):
         return target_provider, new_model
 
     @staticmethod
+    def _resolve_session_model_kwarg(kwargs: dict) -> tuple[str | None, str | None]:
+        """Resolve an optional client-supplied ``model`` from ACP request kwargs.
+
+        The vendored ACP request schemas (``NewSessionRequest`` /
+        ``LoadSessionRequest``) do not declare a ``model`` field, so clients
+        convey it through the reserved ``_meta`` extension, which the router
+        merges into the handler's ``**kwargs``.  Both snake_case (``model``)
+        and camelCase (``modelId`` / ``model_id``) spellings are accepted.
+
+        Returns ``(requested_provider, resolved_model)``, or ``(None, None)``
+        when the client did not request a specific model.
+        """
+        raw = kwargs.get("model") or kwargs.get("modelId") or kwargs.get("model_id")
+        if not raw or not str(raw).strip():
+            return None, None
+        requested_provider, resolved_model = HermesACPAgent._resolve_model_selection(
+            str(raw).strip(), "openrouter"
+        )
+        return requested_provider, resolved_model
+
+    @staticmethod
     def _build_usage_update(state: SessionState) -> UsageUpdate | None:
         """Build ACP native context-usage data for clients like Zed.
 
@@ -1438,7 +1459,12 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        requested_provider, resolved_model = self._resolve_session_model_kwarg(kwargs)
+        state = self.session_manager.create_session(
+            cwd=cwd,
+            model=resolved_model,
+            requested_provider=requested_provider,
+        )
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1464,6 +1490,41 @@ class HermesACPAgent(acp.Agent):
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None
+        requested_provider, resolved_model = self._resolve_session_model_kwarg(kwargs)
+        if resolved_model:
+            # Client requested a specific model on load — apply it the same
+            # way ``set_session_model`` does (resolve → rebuild → persist) so
+            # no separate model-switch round-trip is required after load.
+            current_provider = getattr(state.agent, "provider", None)
+            provider_changed = bool(
+                current_provider and requested_provider != current_provider
+            )
+            current_base_url = (
+                None
+                if provider_changed
+                else getattr(state.agent, "base_url", None)
+            )
+            current_api_mode = (
+                None
+                if provider_changed
+                else getattr(state.agent, "api_mode", None)
+            )
+            state.model = resolved_model
+            state.agent = self.session_manager._make_agent(
+                session_id=session_id,
+                cwd=state.cwd,
+                model=resolved_model,
+                requested_provider=requested_provider,
+                base_url=current_base_url,
+                api_mode=current_api_mode,
+            )
+            self.session_manager.save_session(session_id)
+            logger.info(
+                "Session %s: model applied on load -> %s via provider %s",
+                session_id,
+                resolved_model,
+                requested_provider,
+            )
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("Loaded session %s", session_id)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -196,13 +196,29 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(
+        self,
+        cwd: str = ".",
+        model: str | None = None,
+        requested_provider: str | None = None,
+    ) -> SessionState:
+        """Create a new session with a unique ID and a fresh AIAgent.
+
+        ``model`` / ``requested_provider`` are optional: when supplied they are
+        forwarded to ``_make_agent`` so a client can request a specific model
+        at ``session/new`` time instead of forcing an extra
+        ``set_session_model`` round-trip.
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id,
+            cwd=cwd,
+            model=model,
+            requested_provider=requested_provider,
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -286,6 +286,68 @@ class TestSessionOps:
         resp = await agent.load_session(cwd="/tmp", session_id="bogus")
         assert resp is None
 
+    @pytest.mark.asyncio
+    async def test_new_session_forwards_model_kwarg_to_agent(self):
+        """session/new must honor an optional model kwarg (via _meta) instead of
+        forcing a separate set_session_model round-trip (#80150)."""
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="default-model",
+                provider="openrouter",
+                base_url=None,
+                api_mode=None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        manager._make_agent = MagicMock(wraps=manager._make_agent)
+
+        resp = await acp_agent.new_session(
+            cwd="/tmp", model="openai-codex:gpt-5.4"
+        )
+
+        assert resp.session_id
+        manager._make_agent.assert_called_once()
+        call_kwargs = manager._make_agent.call_args.kwargs
+        assert call_kwargs["session_id"] == resp.session_id
+        assert call_kwargs["model"] == "gpt-5.4"
+        assert call_kwargs["requested_provider"] == "openai-codex"
+
+    @pytest.mark.asyncio
+    async def test_load_session_applies_model_kwarg_to_rebuilt_agent(
+        self, agent, mock_manager
+    ):
+        """session/load must apply an optional model kwarg by rebuilding the
+        agent, matching set_session_model (#80150)."""
+        created = mock_manager.create_session(cwd="/tmp")
+        mock_manager._make_agent = MagicMock(wraps=mock_manager._make_agent)
+
+        resp = await agent.load_session(
+            cwd="/tmp", session_id=created.session_id, model="openai-codex:gpt-5.4"
+        )
+
+        assert isinstance(resp, LoadSessionResponse)
+        state = mock_manager.get_session(created.session_id)
+        assert state.model == "gpt-5.4"
+        mock_manager._make_agent.assert_called_once()
+        call_kwargs = mock_manager._make_agent.call_args.kwargs
+        assert call_kwargs["session_id"] == created.session_id
+        assert call_kwargs["model"] == "gpt-5.4"
+        assert call_kwargs["requested_provider"] == "openai-codex"
+
+    @pytest.mark.asyncio
+    async def test_load_session_without_model_kwarg_keeps_agent(self, agent, mock_manager):
+        """session/load with no model kwarg must not rebuild the agent."""
+        created = mock_manager.create_session(cwd="/tmp")
+        original_agent = created.agent
+        mock_manager._make_agent = MagicMock(wraps=mock_manager._make_agent)
+
+        resp = await agent.load_session(cwd="/tmp", session_id=created.session_id)
+
+        assert isinstance(resp, LoadSessionResponse)
+        state = mock_manager.get_session(created.session_id)
+        assert state.agent is original_agent
+        mock_manager._make_agent.assert_not_called()
+
 
 
 

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -37,6 +37,53 @@ class TestCreateSession:
         assert state.history == []
         assert state.agent is not None
 
+    def test_create_session_forwards_model_and_provider_to_agent(self, tmp_path, monkeypatch):
+        """create_session(model=..., requested_provider=...) must reach the
+        agent build so session/new can honor a client model request (#80150)."""
+        captured = {}
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            captured["requested_provider"] = requested
+            return {
+                "provider": "openrouter",
+                "api_mode": "chat_completions",
+                "base_url": "https://openrouter.example/v1",
+                "api_key": "test-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            captured["model"] = kwargs.get("model")
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider="openrouter",
+                base_url=None,
+                api_mode=None,
+            )
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"model": {"provider": "openrouter", "default": "test-model"}},
+        )
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        db = SessionDB(tmp_path / "state.db")
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            manager = SessionManager(db=db)
+            state = manager.create_session(
+                cwd="/work",
+                model="custom:ollama-remote1:qwen3.5:9b",
+                requested_provider="custom",
+            )
+
+        assert captured["model"] == "custom:ollama-remote1:qwen3.5:9b"
+        assert captured["requested_provider"] == "custom"
+        assert state.model == "custom:ollama-remote1:qwen3.5:9b"
+
 
 
     def test_register_task_cwd_translates_windows_drive_for_wsl_tools(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #80150 — `session/new` and `session/load` ignored the client-supplied `model` parameter, forcing every session initialization to issue a separate `set_session_model` call (an extra round-trip on every ACP session).

## Root cause

The vendored ACP request schemas (`NewSessionRequest` / `LoadSessionRequest`) declare no `model` field, so the value arrives via the reserved `_meta` extension, which the router merges into the handler's `**kwargs`. The handlers never read it:

- `new_session` called `session_manager.create_session(cwd=cwd)` — `_make_agent` then fell back to the config default.
- `load_session` only updated the cwd and left the restored agent's model untouched.

`set_session_model` already had the right pattern (resolve → rebuild agent → persist) but nothing shared it with session creation/loading.

## Fix

- `acp_adapter/session.py`: `SessionManager.create_session()` now accepts optional `model` / `requested_provider` and forwards them to `_make_agent`.
- `acp_adapter/server.py`:
  - New `_resolve_session_model_kwarg()` helper reads `model` / `modelId` / `model_id` from request kwargs (both spellings, since clients send `modelId` in `_meta`) and resolves provider+model the same way `set_session_model` does.
  - `new_session` passes the resolved model/provider into `create_session`.
  - `load_session` applies a requested model by rebuilding the agent through `_make_agent` (preserving `base_url`/`api_mode` unless the provider actually changes, mirroring `set_session_model`) and persists via `save_session`.
  - No model kwarg → behavior unchanged (existing sessions keep their stored model, no agent rebuild).

## Tests

Added 4 regression tests:

- `tests/acp/test_server.py::TestSessionOps::test_new_session_forwards_model_kwarg_to_agent` — asserts `_make_agent` receives the resolved `model` + `requested_provider` on `session/new`.
- `tests/acp/test_server.py::TestSessionOps::test_load_session_applies_model_kwarg_to_rebuilt_agent` — asserts `session/load` rebuilds the agent with the requested model.
- `tests/acp/test_server.py::TestSessionOps::test_load_session_without_model_kwarg_keeps_agent` — asserts no rebuild when no model is passed.
- `tests/acp/test_session.py::TestCreateSession::test_create_session_forwards_model_and_provider_to_agent` — verifies the SessionManager → `_make_agent` wiring end-to-end.

Verification: `venv/bin/python -m pytest tests/acp/ -q` → **130 passed** (new tests 4/4 pass; full ACP suite green).
