### PR TITLE
feat(browser): add Remote Browser cloud provider plugin

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3664,6 +3664,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "REMOTE_BROWSER_API_KEY": {
+        "description": "Remote Browser API key for cloud browser (optional — local browser works without this)",
+        "prompt": "Remote Browser API key",
+        "url": "https://brapi.remote-browser.dev/",
+        "tools": ["browser_navigate", "browser_click"],
+        "password": True,
+        "category": "tool",
+    },
     "FIRECRAWL_BROWSER_TTL": {
         "description": "Firecrawl browser session TTL in seconds (optional, default 300)",
         "prompt": "Browser session TTL (seconds)",

--- a/plugins/browser/remote_browser/README.md
+++ b/plugins/browser/remote_browser/README.md
@@ -1,0 +1,78 @@
+# Remote Browser Hermes Plugin
+
+This plugin exposes Remote Browser as a Hermes cloud browser provider named
+`remote_browser`.
+
+It creates a Remote Browser session, waits until the CDP endpoint is ready,
+returns that endpoint to Hermes, and terminates the session during cleanup.
+
+## Enable
+
+```yaml
+browser:
+  cloud_provider: remote_browser
+```
+
+Store the API key in `~/.hermes/.env`:
+
+```bash
+REMOTE_BROWSER_API_KEY=rb_...
+```
+
+## Optional Config
+
+Non-secret settings belong in `~/.hermes/config.yaml`:
+
+```yaml
+browser:
+  cloud_provider: remote_browser
+  remote_browser:
+    base_url: https://brapi.remote-browser.dev
+    create_path: /dashboard/remote-browsers
+    status_path_template: /dashboard/remote-browsers/{session_id}/status
+    terminate_path_template: /dashboard/remote-browsers/{session_id}/terminate
+    timeout_minutes: 5
+    poll_timeout_seconds: 120
+    poll_interval_seconds: 2
+    ready_grace_seconds: 10
+    resolution: 2560x1440
+    region: auto
+    recording_enabled: true
+    recording_retention_days: 7
+    launch_arguments:
+      - --disable-dev-shm-usage
+    profile_id:
+    profile_name:
+    proxy_type:
+    proxy_url:
+```
+
+The provider still accepts the older `REMOTE_BROWSER_*` environment variables
+for compatibility with existing installs, but new configuration should use
+`browser.remote_browser`.
+
+## API Contract
+
+By default the plugin calls:
+
+```http
+POST /dashboard/remote-browsers
+Authorization: Bearer <REMOTE_BROWSER_API_KEY>
+X-API-Key: <REMOTE_BROWSER_API_KEY>
+Content-Type: application/json
+```
+
+Accepted response fields:
+
+```json
+{
+  "id": "rb_xxx",
+  "displayId": "rb_xxx",
+  "cdpUrl": "wss://brapi.remote-browser.dev/cdp/rb_xxx?token=...",
+  "connectUrl": "wss://..."
+}
+```
+
+The plugin stores `id` or `displayId` as Hermes' `bb_session_id`, returns
+`cdpUrl` or `connectUrl` as `cdp_url`, and injects the API key into the CDP URL
+as `/api-key/<key>` for the Remote Browser CDP gateway.

--- a/plugins/browser/remote_browser/__init__.py
+++ b/plugins/browser/remote_browser/__init__.py
@@ -1,0 +1,10 @@
+"""Remote Browser cloud browser plugin."""
+
+from __future__ import annotations
+
+from plugins.browser.remote_browser.provider import RemoteBrowserProvider
+
+
+def register(ctx) -> None:
+    """Register the Remote Browser provider with the plugin context."""
+    ctx.register_browser_provider(RemoteBrowserProvider())

--- a/plugins/browser/remote_browser/plugin.yaml
+++ b/plugins/browser/remote_browser/plugin.yaml
@@ -1,0 +1,7 @@
+name: remote_browser
+version: 0.1.0
+description: "Remote Browser cloud browser provider for Hermes. Creates Remote Browser sessions, returns CDP endpoints, and terminates sessions when Hermes is done."
+author: Remote Browser
+kind: backend
+provides_browser_providers:
+  - remote_browser

--- a/plugins/browser/remote_browser/provider.py
+++ b/plugins/browser/remote_browser/provider.py
@@ -1,0 +1,523 @@
+"""Remote Browser cloud browser provider.
+
+This provider follows the same lifecycle contract as the bundled cloud browser
+plugins: create a remote session, return its CDP URL to Hermes, and stop the
+session when Hermes is done.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+from urllib.parse import parse_qsl, quote, urlencode, urlsplit, urlunsplit
+
+import requests
+
+from agent.browser_provider import BrowserProvider
+from agent.secret_scope import get_secret
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://brapi.remote-browser.dev"
+_DEFAULT_CREATE_PATH = "/dashboard/remote-browsers"
+_DEFAULT_STATUS_PATH_TEMPLATE = "/dashboard/remote-browsers/{session_id}/status"
+_DEFAULT_TERMINATE_PATH_TEMPLATE = "/dashboard/remote-browsers/{session_id}/terminate"
+_DEFAULT_TIMEOUT_MINUTES = 5
+_DEFAULT_POLL_TIMEOUT_SECONDS = 120
+_DEFAULT_POLL_INTERVAL_SECONDS = 2
+_DEFAULT_READY_GRACE_SECONDS = 10
+_DEFAULT_RESOLUTION = "2560x1440"
+_DEFAULT_REGION = "auto"
+_DEFAULT_RECORDING_ENABLED = True
+_DEFAULT_RECORDING_RETENTION_DAYS = 7
+_READY_STATUSES = {"running"}
+_FAILED_STATUSES = {"failed", "stopped", "timed_out"}
+
+
+class RemoteBrowserProvider(BrowserProvider):
+    """Remote Browser cloud browser backend."""
+
+    @property
+    def name(self) -> str:
+        return "remote_browser"
+
+    @property
+    def display_name(self) -> str:
+        return "Remote Browser"
+
+    def is_available(self) -> bool:
+        return self._get_config_or_none() is not None
+
+    def _get_config_or_none(self) -> Optional[Dict[str, Any]]:
+        api_key = get_secret("REMOTE_BROWSER_API_KEY")
+        if not api_key:
+            return None
+
+        user_cfg = self._read_provider_config()
+        return {
+            "api_key": api_key,
+            "base_url": self._read_str(
+                user_cfg,
+                "base_url",
+                "REMOTE_BROWSER_BASE_URL",
+                _DEFAULT_BASE_URL,
+            ).rstrip("/"),
+            "create_path": self._read_str(
+                user_cfg,
+                "create_path",
+                "REMOTE_BROWSER_CREATE_PATH",
+                _DEFAULT_CREATE_PATH,
+            ),
+            "terminate_path_template": self._read_str(
+                user_cfg,
+                "terminate_path_template",
+                "REMOTE_BROWSER_TERMINATE_PATH_TEMPLATE",
+                _DEFAULT_TERMINATE_PATH_TEMPLATE,
+            ),
+            "status_path_template": self._read_str(
+                user_cfg,
+                "status_path_template",
+                "REMOTE_BROWSER_STATUS_PATH_TEMPLATE",
+                _DEFAULT_STATUS_PATH_TEMPLATE,
+            ),
+            "timeout_minutes": self._read_int(
+                user_cfg,
+                "timeout_minutes",
+                "REMOTE_BROWSER_TIMEOUT_MINUTES",
+                _DEFAULT_TIMEOUT_MINUTES,
+            ),
+            "poll_timeout_seconds": self._read_int(
+                user_cfg,
+                "poll_timeout_seconds",
+                "REMOTE_BROWSER_POLL_TIMEOUT_SECONDS",
+                _DEFAULT_POLL_TIMEOUT_SECONDS,
+            ),
+            "poll_interval_seconds": self._read_int(
+                user_cfg,
+                "poll_interval_seconds",
+                "REMOTE_BROWSER_POLL_INTERVAL_SECONDS",
+                _DEFAULT_POLL_INTERVAL_SECONDS,
+            ),
+            "ready_grace_seconds": self._read_int(
+                user_cfg,
+                "ready_grace_seconds",
+                "REMOTE_BROWSER_READY_GRACE_SECONDS",
+                _DEFAULT_READY_GRACE_SECONDS,
+            ),
+            "resolution": self._read_str(
+                user_cfg,
+                "resolution",
+                "REMOTE_BROWSER_RESOLUTION",
+                _DEFAULT_RESOLUTION,
+            ),
+            "region": self._read_str(
+                user_cfg,
+                "region",
+                "REMOTE_BROWSER_REGION",
+                _DEFAULT_REGION,
+            ),
+            "recording_enabled": self._read_bool(
+                user_cfg,
+                "recording_enabled",
+                "REMOTE_BROWSER_RECORDING",
+                _DEFAULT_RECORDING_ENABLED,
+            ),
+            "recording_retention_days": self._read_int(
+                user_cfg,
+                "recording_retention_days",
+                "REMOTE_BROWSER_RECORDING_RETENTION_DAYS",
+                _DEFAULT_RECORDING_RETENTION_DAYS,
+            ),
+            "launch_arguments": self._read_launch_arguments(
+                self._read_optional(user_cfg, "launch_arguments", "REMOTE_BROWSER_LAUNCH_ARGUMENTS")
+            ),
+            "profile_id": self._read_optional(user_cfg, "profile_id", "REMOTE_BROWSER_PROFILE_ID"),
+            "profile_name": self._read_optional(user_cfg, "profile_name", "REMOTE_BROWSER_PROFILE_NAME"),
+            "proxy_type": self._read_optional(user_cfg, "proxy_type", "REMOTE_BROWSER_PROXY_TYPE"),
+            "proxy_url": self._read_optional(user_cfg, "proxy_url", "REMOTE_BROWSER_PROXY_URL"),
+        }
+
+    def _get_config(self) -> Dict[str, Any]:
+        config = self._get_config_or_none()
+        if config is None:
+            raise ValueError("Remote Browser requires REMOTE_BROWSER_API_KEY.")
+        return config
+
+    def create_session(self, task_id: str) -> Dict[str, object]:
+        config = self._get_config()
+        payload = self._create_payload(config)
+        create_url = self._url(config, config["create_path"])
+
+        logger.info(
+            "Creating Remote Browser session: task_id=%s url=%s payload=%s",
+            task_id,
+            self._safe_url_for_log(create_url),
+            self._safe_payload_for_log(payload),
+        )
+
+        try:
+            response = requests.post(
+                create_url,
+                headers=self._headers(config),
+                json=payload,
+                timeout=30,
+            )
+        except requests.RequestException as exc:
+            raise RuntimeError(f"Remote Browser API connection failed: {exc}") from exc
+
+        if not response.ok:
+            raise RuntimeError(
+                f"Failed to create Remote Browser session: "
+                f"{response.status_code} {response.text}"
+            )
+
+        session_data = response.json()
+        session_id = self._read_session_id(session_data)
+        session_data = self._wait_for_session_ready(session_id, config, session_data)
+        cdp_url = self._read_cdp_url(session_data)
+        cdp_url = self._apply_api_key_to_cdp_url(cdp_url, config["api_key"])
+        session_name = f"remote_browser_{task_id}_{uuid.uuid4().hex[:8]}"
+
+        logger.info(
+            "Remote Browser session ready: task_id=%s session_id=%s status=%s cdp_url=%s",
+            task_id,
+            session_id,
+            session_data.get("status"),
+            self._safe_url_for_log(cdp_url),
+        )
+
+        return {
+            "session_name": session_name,
+            "bb_session_id": session_id,
+            "cdp_url": cdp_url,
+            "features": {
+                "remote_browser": True,
+                "viewer_url": session_data.get("viewerUrl") or session_data.get("viewer_url"),
+                "status": session_data.get("status"),
+            },
+        }
+
+    def close_session(self, session_id: str) -> bool:
+        config = self._get_config_or_none()
+        if config is None:
+            logger.warning(
+                "Cannot close Remote Browser session %s: missing credentials",
+                session_id,
+            )
+            return False
+
+        terminate_path = str(config["terminate_path_template"]).format(
+            session_id=session_id,
+        )
+        terminate_url = self._url(config, terminate_path)
+
+        try:
+            response = requests.post(
+                terminate_url,
+                headers=self._headers(config),
+                timeout=15,
+            )
+        except requests.RequestException as exc:
+            logger.warning("Remote Browser terminate failed for %s: %s", session_id, exc)
+            return False
+
+        if response.status_code in {200, 201, 204}:
+            logger.debug("Successfully closed Remote Browser session %s", session_id)
+            return True
+
+        logger.warning(
+            "Remote Browser terminate failed for %s: HTTP %s - %s",
+            session_id,
+            response.status_code,
+            response.text[:200],
+        )
+        return False
+
+    def emergency_cleanup(self, session_id: str) -> None:
+        self.close_session(session_id)
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Remote Browser",
+            "badge": "paid",
+            "tag": "Remote Chromium sessions with CDP and live viewing",
+            "env_vars": [
+                {
+                    "key": "REMOTE_BROWSER_API_KEY",
+                    "prompt": "Remote Browser API key",
+                    "url": "https://brapi.remote-browser.dev",
+                },
+            ],
+            "post_setup": "agent_browser",
+        }
+
+    def _headers(self, config: Dict[str, Any]) -> Dict[str, str]:
+        api_key = str(config["api_key"])
+        return {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_key}",
+            "X-API-Key": api_key,
+        }
+
+    def _create_payload(self, config: Dict[str, Any]) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "resolution": config["resolution"],
+            "idleTimeoutSeconds": max(60, int(config["timeout_minutes"]) * 60),
+            "region": config["region"],
+            "recordingEnabled": bool(config["recording_enabled"]),
+            "recordingRetentionDays": int(config["recording_retention_days"]),
+            "launchArguments": list(config["launch_arguments"]),
+        }
+
+        optional_config_to_payload = {
+            "profile_id": "profileId",
+            "profile_name": "profileName",
+            "proxy_type": "proxyType",
+            "proxy_url": "proxyUrl",
+        }
+        for config_name, payload_name in optional_config_to_payload.items():
+            value = config.get(config_name)
+            if value:
+                payload[payload_name] = value
+
+        return payload
+
+    def _wait_for_session_ready(
+        self,
+        session_id: str,
+        config: Dict[str, Any],
+        initial_session_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        deadline = time.monotonic() + int(config["poll_timeout_seconds"])
+        session_data = initial_session_data
+        poll_count = 0
+
+        while time.monotonic() < deadline:
+            status = str(session_data.get("status") or "").lower()
+            poll_count += 1
+
+            logger.debug(
+                "Remote Browser readiness poll: session_id=%s attempt=%s status=%s has_cdp_url=%s",
+                session_id,
+                poll_count,
+                status or "unknown",
+                self._has_cdp_url(session_data),
+            )
+
+            if status in _READY_STATUSES and self._has_cdp_url(session_data):
+                ready_grace_seconds = int(config["ready_grace_seconds"])
+                if ready_grace_seconds > 0:
+                    logger.debug(
+                        "Remote Browser running; waiting %s seconds for CDP readiness: session_id=%s",
+                        ready_grace_seconds,
+                        session_id,
+                    )
+                    time.sleep(ready_grace_seconds)
+                return session_data
+
+            if status in _FAILED_STATUSES:
+                raise RuntimeError(
+                    f"Remote Browser session {session_id} ended before CDP was ready: "
+                    f"{session_data.get('providerError') or status}"
+                )
+
+            time.sleep(int(config["poll_interval_seconds"]))
+            status_path = str(config["status_path_template"]).format(
+                session_id=session_id,
+            )
+            status_url = self._url(config, status_path)
+
+            try:
+                response = requests.get(
+                    status_url,
+                    headers=self._headers(config),
+                    timeout=15,
+                )
+            except requests.RequestException as exc:
+                raise RuntimeError(
+                    f"Remote Browser status check failed for {session_id}: {exc}"
+                ) from exc
+
+            if not response.ok:
+                raise RuntimeError(
+                    f"Remote Browser status check failed for {session_id}: "
+                    f"{response.status_code} {response.text}"
+                )
+
+            session_data = response.json()
+
+        raise RuntimeError(
+            f"Timed out waiting for Remote Browser session {session_id} to become running."
+        )
+
+    def _read_provider_config(self) -> Dict[str, Any]:
+        try:
+            from hermes_cli.config import read_raw_config
+
+            cfg = read_raw_config()
+        except Exception:
+            return {}
+
+        browser_cfg = cfg.get("browser", {})
+        if not isinstance(browser_cfg, dict):
+            return {}
+        provider_cfg = browser_cfg.get("remote_browser", {})
+        return provider_cfg if isinstance(provider_cfg, dict) else {}
+
+    def _read_session_id(self, session_data: Dict[str, Any]) -> str:
+        for key in ("displayId", "id", "sessionId", "browserId"):
+            value = session_data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        raise RuntimeError("Remote Browser response did not include a session id.")
+
+    def _read_cdp_url(self, session_data: Dict[str, Any]) -> str:
+        for key in ("cdpUrl", "cdp_url", "connectUrl", "connect_url"):
+            value = session_data.get(key)
+            if isinstance(value, str) and value:
+                return value
+        raise RuntimeError("Remote Browser response did not include a CDP URL.")
+
+    def _has_cdp_url(self, session_data: Dict[str, Any]) -> bool:
+        try:
+            self._read_cdp_url(session_data)
+            return True
+        except RuntimeError:
+            return False
+
+    def _apply_api_key_to_cdp_url(self, cdp_url: str, api_key: str) -> str:
+        parsed = urlsplit(cdp_url)
+        path = parsed.path.rstrip("/")
+        query = [
+            (key, value)
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if key not in {"apiKey", "token"}
+        ]
+
+        path = path.split("/api-key/", 1)[0]
+        path = f"{path}/api-key/{quote(api_key, safe='')}"
+
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                path,
+                urlencode(query),
+                parsed.fragment,
+            )
+        )
+
+    def _url(self, config: Dict[str, Any], path: str) -> str:
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        return f"{config['base_url']}/{path.lstrip('/')}"
+
+    def _safe_url_for_log(self, value: str) -> str:
+        parsed = urlsplit(value)
+        query = dict(parse_qsl(parsed.query, keep_blank_values=True))
+
+        for key in ("apiKey", "token"):
+            if key in query:
+                query[key] = self._mask_secret(query[key])
+
+        return urlunsplit(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path,
+                urlencode(query),
+                parsed.fragment,
+            )
+        )
+
+    def _safe_payload_for_log(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        redacted = dict(payload)
+        if "proxyUrl" in redacted:
+            redacted["proxyUrl"] = self._mask_secret(str(redacted["proxyUrl"]))
+        return redacted
+
+    def _mask_secret(self, value: str) -> str:
+        if len(value) <= 8:
+            return "***"
+        return f"{value[:4]}...{value[-4:]}"
+
+    def _read_optional(
+        self,
+        config: Dict[str, Any],
+        key: str,
+        env_name: str,
+    ) -> Optional[Any]:
+        if key in config:
+            value = config[key]
+        else:
+            value = os.environ.get(env_name)
+        if value in (None, ""):
+            return None
+        return value
+
+    def _read_str(
+        self,
+        config: Dict[str, Any],
+        key: str,
+        env_name: str,
+        fallback: str,
+    ) -> str:
+        value = self._read_optional(config, key, env_name)
+        if value is None:
+            return fallback
+        return str(value)
+
+    def _read_launch_arguments(self, value: Optional[Any]) -> List[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, list):
+            return [str(item) for item in value if str(item).strip()]
+
+        text = str(value)
+        if not text:
+            return []
+
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                return [str(item) for item in parsed if str(item).strip()]
+        except json.JSONDecodeError:
+            pass
+
+        return [item.strip() for item in text.split(",") if item.strip()]
+
+    def _read_bool(
+        self,
+        config: Dict[str, Any],
+        key: str,
+        env_name: str,
+        fallback: bool,
+    ) -> bool:
+        value = self._read_optional(config, key, env_name)
+        if value is None:
+            return fallback
+        if isinstance(value, bool):
+            return value
+        return str(value).lower() in {"1", "true", "yes", "on"}
+
+    def _read_int(
+        self,
+        config: Dict[str, Any],
+        key: str,
+        env_name: str,
+        fallback: int,
+    ) -> int:
+        value = self._read_optional(config, key, env_name)
+        if value is None:
+            return fallback
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return fallback
+        return parsed if parsed > 0 else fallback

--- a/tests/plugins/browser/test_browser_provider_plugins.py
+++ b/tests/plugins/browser/test_browser_provider_plugins.py
@@ -2,7 +2,7 @@
 
 Covers:
 
-- All three bundled plugins (browserbase, browser-use, firecrawl)
+- All bundled plugins (browserbase, browser-use, firecrawl, remote_browser)
   instantiate and self-report the expected ABC defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The browser_registry resolves an active provider in the documented
@@ -42,6 +42,24 @@ def _clear_browser_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "FIRECRAWL_API_KEY",
         "FIRECRAWL_API_URL",
         "FIRECRAWL_BROWSER_TTL",
+        "REMOTE_BROWSER_API_KEY",
+        "REMOTE_BROWSER_BASE_URL",
+        "REMOTE_BROWSER_CREATE_PATH",
+        "REMOTE_BROWSER_STATUS_PATH_TEMPLATE",
+        "REMOTE_BROWSER_TERMINATE_PATH_TEMPLATE",
+        "REMOTE_BROWSER_TIMEOUT_MINUTES",
+        "REMOTE_BROWSER_POLL_TIMEOUT_SECONDS",
+        "REMOTE_BROWSER_POLL_INTERVAL_SECONDS",
+        "REMOTE_BROWSER_READY_GRACE_SECONDS",
+        "REMOTE_BROWSER_RESOLUTION",
+        "REMOTE_BROWSER_REGION",
+        "REMOTE_BROWSER_PROFILE_ID",
+        "REMOTE_BROWSER_PROFILE_NAME",
+        "REMOTE_BROWSER_RECORDING",
+        "REMOTE_BROWSER_RECORDING_RETENTION_DAYS",
+        "REMOTE_BROWSER_PROXY_TYPE",
+        "REMOTE_BROWSER_PROXY_URL",
+        "REMOTE_BROWSER_LAUNCH_ARGUMENTS",
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
     ):
@@ -72,14 +90,14 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 class TestBundledPluginsRegister:
-    """All three bundled browser plugins discover and register correctly."""
+    """All bundled browser plugins discover and register correctly."""
 
-    def test_all_three_plugins_present_in_registry(self) -> None:
+    def test_all_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.browser_registry import list_providers
 
         names = sorted(p.name for p in list_providers())
-        assert names == ["browser-use", "browserbase", "firecrawl"]
+        assert names == ["browser-use", "browserbase", "firecrawl", "remote_browser"]
 
     @pytest.mark.parametrize(
         "plugin_name,expected_display",
@@ -87,6 +105,7 @@ class TestBundledPluginsRegister:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("remote_browser", "Remote Browser"),
         ],
     )
     def test_each_plugin_has_name_and_display_name(
@@ -150,6 +169,67 @@ class TestIsAvailable:
         monkeypatch.setenv("FIRECRAWL_API_KEY", "key")
         assert p.is_available() is True
 
+    def test_remote_browser_requires_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _ensure_plugins_loaded()
+        from agent.browser_registry import get_provider
+
+        p = get_provider("remote_browser")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("REMOTE_BROWSER_API_KEY", "key")
+        assert p.is_available() is True
+
+
+class TestRemoteBrowserProviderConfig:
+    """Remote Browser keeps secrets in env and behavioral settings in config."""
+
+    def test_reads_remote_browser_config_section(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from hermes_cli import config as hermes_config
+        from plugins.browser.remote_browser.provider import RemoteBrowserProvider
+
+        monkeypatch.setenv("REMOTE_BROWSER_API_KEY", "rb_secret")
+        monkeypatch.setattr(
+            hermes_config,
+            "read_raw_config",
+            lambda: {
+                "browser": {
+                    "remote_browser": {
+                        "base_url": "https://example.test/",
+                        "timeout_minutes": 9,
+                        "poll_interval_seconds": 3,
+                        "recording_enabled": False,
+                        "launch_arguments": ["--one", "--two"],
+                    }
+                }
+            },
+        )
+
+        config = RemoteBrowserProvider()._get_config()
+        assert config["api_key"] == "rb_secret"
+        assert config["base_url"] == "https://example.test"
+        assert config["timeout_minutes"] == 9
+        assert config["poll_interval_seconds"] == 3
+        assert config["recording_enabled"] is False
+        assert config["launch_arguments"] == ["--one", "--two"]
+
+    def test_cdp_url_uses_path_api_key_not_query_token(self) -> None:
+        from plugins.browser.remote_browser.provider import RemoteBrowserProvider
+
+        provider = RemoteBrowserProvider()
+        cdp_url = provider._apply_api_key_to_cdp_url(
+            "wss://brapi.example/cdp/rb_123?token=old&keep=yes",
+            "rb_secret/with space",
+        )
+
+        assert cdp_url == (
+            "wss://brapi.example/cdp/rb_123/api-key/"
+            "rb_secret%2Fwith%20space?keep=yes"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Registry resolution semantics
@@ -201,7 +281,7 @@ class TestLegacyAbcAliases:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["browserbase", "browser-use", "firecrawl"],
+        ["browserbase", "browser-use", "firecrawl", "remote_browser"],
     )
     def test_is_configured_delegates_to_is_available(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -217,6 +297,7 @@ class TestLegacyAbcAliases:
             ("browserbase", "Browserbase"),
             ("browser-use", "Browser Use"),
             ("firecrawl", "Firecrawl"),
+            ("remote_browser", "Remote Browser"),
         ],
     )
     def test_provider_name_returns_display_name(
@@ -236,7 +317,7 @@ class TestLegacyAbcAliases:
 
 
 class TestPickerIntegration:
-    """`_plugin_browser_providers()` exposes all three plugins as picker rows."""
+    """`_plugin_browser_providers()` exposes all plugins as picker rows."""
 
     def test_picker_rows_match_registered_plugins(self) -> None:
         _ensure_plugins_loaded()
@@ -244,6 +325,4 @@ class TestPickerIntegration:
 
         rows = _plugin_browser_providers()
         names = sorted(r.get("browser_provider") for r in rows)
-        assert names == ["browser-use", "browserbase", "firecrawl"]
-
-
+        assert names == ["browser-use", "browserbase", "firecrawl", "remote_browser"]


### PR DESCRIPTION
## What does this PR do?

Adds [Remote Browser](https://remote-browser.dev) as a bundled Hermes cloud browser provider.

This lets Hermes run browser automation against managed Remote Browser sessions via CDP, with live viewing and cloud-hosted Chromium available through the existing browser provider plugin architecture.

Users can enable it with:

```yaml
browser:
  cloud_provider: remote_browser
```
REMOTE_BROWSER_API_KEY remains the only required secret. Non-secret behavior settings, such as timeout, region, resolution, recording, profile, proxy, and endpoint paths, are read from browser.remote_browser in config.yaml, while existing REMOTE_BROWSER_* environment overrides remain supported for compatibility.
This approach keeps Hermes’ core narrow: Remote Browser is implemented as a provider plugin at the edge, using the existing BrowserProvider registry and picker flow instead of adding new model tools or core browser-specific branching.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added plugins/browser/remote_browser/plugin.yaml
- Added plugins/browser/remote_browser/__init__.py
- Added plugins/browser/remote_browser/provider.py
- Added plugins/browser/remote_browser/README.md
- Registered REMOTE_BROWSER_API_KEY in hermes_cli/config_defaults.py
- Updated tests/plugins/browser/test_browser_provider_plugins.py to include Remote Browser in provider registry and picker expectations
- Added Remote Browser provider tests for API-key availability, config loading, and CDP URL credential injection

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Add credentials and config:
```
REMOTE_BROWSER_API_KEY=rb_...
```
```
browser:
  cloud_provider: remote_browser
```
2. Run the targeted plugin tests:
```
pytest tests/plugins/browser/test_browser_provider_plugins.py -q
```
3. Run a browser automation task in Hermes and confirm a Remote Browser session is created, becomes ready, exposes a CDP URL, and is terminated during cleanup.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local validation performed:
```
python3 -m py_compile \
  plugins/browser/remote_browser/provider.py \
  plugins/browser/remote_browser/__init__.py \
  tests/plugins/browser/test_browser_provider_plugins.py \
  hermes_cli/config_defaults.py
```
Targeted pytest could not be run in this checkout because no local or shared Hermes virtualenv had pytest installed.
