### PR TITLE
Update Google Chat and Telegram platform adapters

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -722,7 +722,8 @@ class GoogleChatAdapter(BasePlatformAdapter):
             from hermes_constants import get_hermes_home as _get_hermes_home
             _hermes_home = _get_hermes_home()
         except (ModuleNotFoundError, ImportError):
-            _hermes_home = _Path.home() / ".hermes"
+            from hermes_constants import get_hermes_home
+            _hermes_home = get_hermes_home()
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )
@@ -916,7 +917,7 @@ class GoogleChatAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
     def _bot_id_cache_path(self) -> _Path:
         """Location where the resolved bot user_id is cached across restarts."""
-        base = os.getenv("HERMES_HOME", str(_Path.home() / ".hermes"))
+        base = os.getenv("HERMES_HOME", str(get_hermes_home()))
         return _Path(base) / "google_chat_bot_id.json"
 
     def _load_cached_bot_id(self) -> Optional[str]:

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -45,7 +45,7 @@ import random
 import re
 import threading
 import time
-from pathlib import Path as _Path
+from pathlib import Path, Path as _Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # Heavy google-cloud + googleapiclient imports are deferred to first

--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -720,10 +720,9 @@ class GoogleChatAdapter(BasePlatformAdapter):
         # multi-restart sessions).
         try:
             from hermes_constants import get_hermes_home as _get_hermes_home
-            _hermes_home = _get_hermes_home()
+            _hermes_home = Path(_get_hermes_home())
         except (ModuleNotFoundError, ImportError):
-            from hermes_constants import get_hermes_home
-            _hermes_home = get_hermes_home()
+            _hermes_home = Path.home() / ".hermes"
         self._thread_count_store = _ThreadCountStore(
             _hermes_home / "google_chat_thread_counts.json"
         )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6743,7 +6743,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         from hermes_constants import get_hermes_home
 
-        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
+        script_path = Path(get_hermes_home()) / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6741,7 +6741,9 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         script_name, extra_args, success_label, is_state_verb = entry
 
-        script_path = _Path.home() / ".hermes" / "scripts" / "gmail-triage" / script_name
+        from hermes_constants import get_hermes_home
+
+        script_path = get_hermes_home() / "scripts" / "gmail-triage" / script_name
         if not script_path.exists():
             await query.answer(text=f"❌ {script_name} missing")
             logger.error("[%s] gmail-triage script missing: %s", self.name, script_path)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -18,6 +18,8 @@ import html as _html
 import re
 import threading
 import time
+
+from hermes_constants import get_hermes_home
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Any
@@ -274,7 +276,7 @@ except ImportError:
     ContextTypes = _MockContextTypes
 
 import sys
-from pathlib import Path as _Path
+from pathlib import Path, Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[3]))
 
 from gateway.authz_mixin import _coerce_allow_set
@@ -3398,7 +3400,6 @@ class TelegramAdapter(BasePlatformAdapter):
     ) -> None:
         """Save a newly created thread_id back into config.yaml so it persists across restarts."""
         try:
-            from hermes_constants import get_hermes_home
             config_path = get_hermes_home() / "config.yaml"
             if not config_path.exists():
                 logger.warning("[%s] Config file not found at %s, cannot persist thread_id", self.name, config_path)


### PR DESCRIPTION
## What does this PR do?

Updates the Google Chat and Telegram platform adapters to resolve cross-platform and compatibility issues on Windows environments.

## Related Issue

Fixes #80114

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 🌟 New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📜 Documentation update
- [ ] 🧪 Tests (adding or improving test coverage)
- [ ] 🧹 Refactor (no behavior change)
- [ ] 📦 New skill (bundled or hub)

## Changes Made

- Updated `plugins/platforms/google_chat/adapter.py`
- Updated `plugins/platforms/telegram/adapter.py`

## How to Test

1. Verify platform adapter imports and initialization on Windows/Linux environments.
2. Run relevant integration tests for Google Chat and Telegram messaging flows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A