### PR TITLE
yuanbao-proto : guard malformed ForwardMsgData numeric fields

### DIFF
--- a/gateway/platforms/yuanbao_proto.py
+++ b/gateway/platforms/yuanbao_proto.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 import threading
-from typing import Optional
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -833,6 +833,18 @@ def _decode_forward_msg(data: bytes) -> dict:
     }
 
 
+def _coerce_int_or_none(value: Any) -> int | None:
+    """Best-effort int conversion for protobuf numeric fields.
+
+    These encode helpers may be fed malformed dicts when used for mock/test
+    data. Avoid raising during encoding by skipping fields we can't coerce.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def decode_forward_msg_data(data: bytes) -> Optional[dict]:
     """Parse ForwardMsgData protobuf bytes (the base64-decoded ext_map value).
 
@@ -867,13 +879,15 @@ def _encode_forward_multimedia(media: dict) -> bytes:
             buf += _encode_field(fn, WT_LEN, _encode_string(str(v)))
     for fn, key in [(5, "file_size"), (6, "width"), (7, "height")]:
         v = media.get(key, 0)
-        if v:
-            buf += _encode_field(fn, WT_VARINT, _encode_varint(int(v)))
+        coerced = _coerce_int_or_none(v)
+        if coerced:
+            buf += _encode_field(fn, WT_VARINT, _encode_varint(coerced))
     return buf
 
 
 def _encode_forward_msg_content(content: dict) -> bytes:
-    buf = _encode_field(1, WT_VARINT, _encode_varint(int(content.get("type", 0))))
+    coerced_type = _coerce_int_or_none(content.get("type", 0)) or 0
+    buf = _encode_field(1, WT_VARINT, _encode_varint(coerced_type))
     text = content.get("text", "")
     if text:
         buf += _encode_field(2, WT_LEN, _encode_string(str(text)))
@@ -888,8 +902,9 @@ def _encode_forward_msg(msg: dict) -> bytes:
     if sender:
         buf += _encode_field(1, WT_LEN, _encode_string(str(sender)))
     time_val = msg.get("time", 0)
-    if time_val:
-        buf += _encode_field(2, WT_VARINT, _encode_varint(int(time_val)))
+    coerced_time = _coerce_int_or_none(time_val)
+    if coerced_time:
+        buf += _encode_field(2, WT_VARINT, _encode_varint(coerced_time))
     plain = msg.get("plainText", "")
     if plain:
         buf += _encode_field(3, WT_LEN, _encode_string(str(plain)))
@@ -903,11 +918,13 @@ def encode_forward_msg_data(data: dict) -> bytes:
 
     Mainly used to build mock / test data; production code never needs to encode this.
     """
-    buf = _encode_field(1, WT_VARINT, _encode_varint(int(data.get("sub_type", 0))))
+    coerced_sub_type = _coerce_int_or_none(data.get("sub_type", 0)) or 0
+    buf = _encode_field(1, WT_VARINT, _encode_varint(coerced_sub_type))
     for fn, key in [(2, "begin_time"), (3, "end_time")]:
         v = data.get(key, 0)
-        if v:
-            buf += _encode_field(fn, WT_VARINT, _encode_varint(int(v)))
+        coerced = _coerce_int_or_none(v)
+        if coerced:
+            buf += _encode_field(fn, WT_VARINT, _encode_varint(coerced))
     nick = data.get("nick_name", "")
     if nick:
         buf += _encode_field(4, WT_LEN, _encode_string(str(nick)))

--- a/tests/test_yuanbao_proto.py
+++ b/tests/test_yuanbao_proto.py
@@ -42,6 +42,9 @@ from gateway.platforms.yuanbao_proto import (
     encode_auth_bind,
     encode_ping,
     encode_push_ack,
+    # ForwardMsgData helpers (mock/test encoding)
+    encode_forward_msg_data,
+    decode_forward_msg_data,
     # 常量
     PB_MSG_TYPES,
     BIZ_SERVICES,
@@ -466,6 +469,40 @@ class TestEndToEnd:
         assert el_dec["msg_type"] == "TIMTextElem"
         assert el_dec["msg_content"]["text"] == "端到端测试"
 
+
+class TestEncodeForwardMsgDataGuards:
+    def test_malformed_numeric_fields_fall_back_to_zero(self):
+        # These helpers are used to build mock ForwardMsgData protobuf bytes.
+        # Malformed numeric fields should not crash encoding.
+        encoded = encode_forward_msg_data(
+            {
+                "sub_type": "not-an-int",
+                "begin_time": "also-bad",
+                "end_time": 0,
+                "nick_name": "nick",
+                "msg": [
+                    {
+                        "sender": "sender",
+                        "time": "bad-time",
+                        "plainText": "",
+                        "msgContent": [
+                            {"type": "bad-content-type", "text": "hello"}
+                        ],
+                    }
+                ],
+            }
+        )
+        decoded = decode_forward_msg_data(encoded)
+        assert decoded is not None
+        assert decoded["sub_type"] == 0
+        assert decoded["begin_time"] == 0
+        assert decoded["end_time"] == 0
+        assert decoded["nick_name"] == "nick"
+        assert len(decoded["msg"]) == 1
+        assert decoded["msg"][0]["sender"] == "sender"
+        assert decoded["msg"][0]["time"] == 0
+        assert decoded["msg"][0]["msgContent"][0]["type"] == 0
+        assert decoded["msg"][0]["msgContent"][0]["text"] == "hello"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a small _coerce_int_or_none() helper in gateway/platforms/yuanbao_proto.py
Uses it to defensively coerce/skip uncoercible numeric fields during ForwardMsgData encoding
Ensures malformed inputs don’t crash encoding and that decoded output falls back to safe defaults