### PR TITLE
fix(matrix): filter phantom interrupt / redirect notices at intake

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -345,6 +345,41 @@ def _normalize_matrix_bang_command(text: str) -> str:
     return f"/{resolved}{match.group(2) or ''}"
 
 
+# Phantom interrupt / redirect / self-improvement-review messages emitted by
+# the gateway's own orchestrator (or leaked from upstream runtime scaffolding)
+# arrive at intake as if they were user messages. If we dispatch them they
+# trigger another phantom notice, forming a self-perpetuating loop until
+# the homeserver rate-limits the connection.
+#
+# Filter at intake. Full-prefix match only — a real user message that
+# happens to mention one of these tokens mid-sentence (e.g. "⚡ Interrupting
+# my workout to ask you…") must still pass through. See
+# ``test_matrix_phantom_intake_filter.py``.
+PHANTOM_INTAKE_PREFIXES = (
+    "[This response was interrupted by a user correction.]",
+    "↪ Redirected current run",
+    "⚡ Interrupting current task.",
+    "⚡ Interrupting current task:",  # occasional trailing-colon variant
+    "⚡ Stopped.",
+    "No active task to stop.",
+    "♻️ Recovered reply",
+    "💾 Self-improvement review:",
+    "💭 Reasoning:",
+)
+
+
+def _is_phantom_intake_message(body: str) -> bool:
+    """Return True if ``body`` matches a phantom notice shape that should
+    be dropped at intake instead of dispatched to the model."""
+    if not body:
+        return False
+    stripped = body.lstrip()
+    for prefix in PHANTOM_INTAKE_PREFIXES:
+        if stripped.startswith(prefix):
+            return True
+    return False
+
+
 class _MatrixHtmlSanitizer(HTMLParser):
     """Allowlist sanitizer for Matrix-compatible formatted HTML."""
 
@@ -3087,6 +3122,34 @@ class MatrixAdapter(BasePlatformAdapter):
             sender,
             room_id,
         )
+
+        # Phantom intake filter — drop orchestrator-emitted notices
+        # (interrupts, redirects, self-improvement reviews, recovered
+        # replies, reasoning bubbles) before any sender/room gating so
+        # they never reach the model. See _is_phantom_intake_message
+        # for the full shape list.
+        _content_for_phantom_check = getattr(event, "content", None)
+        if _content_for_phantom_check is not None:
+            if hasattr(_content_for_phantom_check, "body"):
+                _phantom_body = str(
+                    getattr(_content_for_phantom_check, "body", "") or ""
+                )
+            elif isinstance(_content_for_phantom_check, dict):
+                _phantom_body = str(
+                    _content_for_phantom_check.get("body", "") or ""
+                )
+            else:
+                _phantom_body = ""
+            if _is_phantom_intake_message(_phantom_body):
+                logger.debug(
+                    "Matrix: dropping phantom notice at intake (event=%s sender=%s "
+                    "room=%s head=%r)",
+                    getattr(event, "event_id", "?"),
+                    sender,
+                    room_id,
+                    _phantom_body[:40],
+                )
+                return
 
         # Ignore own messages (case-insensitive; also drops when our own
         # user_id hasn't been resolved yet — see _is_self_sender docstring

--- a/tests/gateway/test_matrix_phantom_intake_filter.py
+++ b/tests/gateway/test_matrix_phantom_intake_filter.py
@@ -1,0 +1,166 @@
+"""Tests for Matrix adapter phantom self-loop filtering.
+
+Phantom interrupt notices (text emitted by the gateway's own orchestrator
+or by upstream runtime scaffolding) leak into the chat surface as if they
+were user messages. When the bot's own gateway picks them back up via
+``_on_room_message`` they are dispatched as new user turns, triggering
+another interrupt notice, forming a self-perpetuating loop.
+
+Filter these at intake in ``_on_room_message`` so the loop is broken
+without relying on the model's own silence-token detection.
+
+Phantom shapes observed when a misconfigured bot fell into a self-loop
+emitting these messages in rapid succession until rate-limited:
+
+  - ``[This response was interrupted by a user correction.]``
+  - ``↪ Redirected current run (iteration N/500). I'll adjust using your correction.``
+  - ``⚡ Interrupting current task. I'll respond to your message shortly.``
+  - ``⚡ Stopped. You can continue this session.``
+  - ``No active task to stop.``
+  - ``♻️ Recovered reply ... the gateway restarted during delivery...``
+  - ``💾 Self-improvement review: ...``
+  - ``💭 Reasoning: ...``
+
+Some of these (``♻️ Recovered reply``, ``↪ Redirected``, ``⚡
+Interrupting``) are wrapped in OOB control messages that *should* be
+display_kind=hidden; their appearance in chat bodies is an upstream bug.
+For the matrix adapter we defend at the intake gate so the bot stops
+feeding its own phantom notices back into the model.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import time
+
+import pytest
+
+
+PHANTOM_BODIES = [
+    "[This response was interrupted by a user correction.]",
+    "↪ Redirected current run (iteration 3/500). I'll adjust using your correction.",
+    "⚡ Interrupting current task. I'll respond to your message shortly.",
+    "⚡ Stopped. You can continue this session.",
+    "No active task to stop.",
+    "♻️ Recovered reply — the gateway restarted during delivery, retrying.",
+    "💾 Self-improvement review: User profile updated (compressed).",
+    "💭 Reasoning: checking the sender field before responding",
+    # Edge case: phantom text appearing as a substring of a real message
+    # should NOT be filtered — the gate only matches full-prefix phantoms.
+    # Covered by the negative test below.
+]
+
+
+def _make_adapter():
+    """Same minimal adapter harness as test_matrix_message_event_metadata."""
+    import os
+
+    os.environ["MATRIX_REQUIRE_MENTION"] = "false"
+    os.environ["MATRIX_AUTO_THREAD"] = "false"
+
+    from plugins.platforms.matrix.adapter import MatrixAdapter
+
+    from gateway.config import PlatformConfig
+
+    config = PlatformConfig(
+        enabled=True,
+        token="syt_test_token",
+        extra={
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@hermes:example.org",
+        },
+    )
+    adapter = MatrixAdapter(config)
+    adapter._text_batch_delay_seconds = 0
+    adapter.handle_message = AsyncMock()
+    adapter._client = None
+    identity = SimpleNamespace(
+        display_name="Test Room",
+        room_topic=None,
+        server_name="example.org",
+        chat_type="dm",
+    )
+    adapter._resolve_room_identity = AsyncMock(return_value=identity)
+    return adapter
+
+
+def _make_event(body, sender="@alice:example.org", event_id="$evt1"):
+    return SimpleNamespace(
+        sender=sender,
+        event_id=event_id,
+        room_id="!room1:example.org",
+        timestamp=int(time.time() * 1000),
+        content={"body": body, "msgtype": "m.text"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Phantom intake filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_phantom_interrupt_text_is_dropped_at_intake():
+    """A phantom interrupt message must NOT be dispatched to handle_message."""
+    adapter = _make_adapter()
+    adapter._startup_ts = time.time() - 10
+
+    event = _make_event("[This response was interrupted by a user correction.]")
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phantom_body", PHANTOM_BODIES)
+async def test_all_phantom_shapes_are_dropped(phantom_body):
+    """Every documented phantom shape must be filtered.
+
+    Parametrized so a regression on any single shape fails loudly with the
+    specific body that leaked through.
+    """
+    adapter = _make_adapter()
+    adapter._startup_ts = time.time() - 10
+
+    event = _make_event(phantom_body)
+    await adapter._on_room_message(event)
+
+    assert adapter.handle_message.await_count == 0, (
+        f"phantom body leaked through: {phantom_body!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_real_message_with_phantom_substring_passes():
+    """Substring phantom text inside a real message must NOT be filtered.
+
+    Only full-prefix phantom shapes (or messages whose first non-whitespace
+    token is a phantom marker) are filtered. A user message like
+    '⚡ Interrupting my workout to ask you this...' must still reach the
+    model. This test pins that the filter is precise, not greedy.
+    """
+    adapter = _make_adapter()
+    adapter._startup_ts = time.time() - 10
+
+    event = _make_event(
+        "⚡ Interrupting my morning to ask — should I deploy the patch now?"
+    )
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text.startswith("⚡ Interrupting my morning")
+
+
+@pytest.mark.asyncio
+async def test_plain_user_message_still_dispatched():
+    """The filter must not regress normal user text."""
+    adapter = _make_adapter()
+    adapter._startup_ts = time.time() - 10
+
+    event = _make_event("hey hermes, what's the disk usage on the K3s nodes?")
+    await adapter._on_room_message(event)
+
+    adapter.handle_message.assert_awaited_once()
+    msg = adapter.handle_message.await_args.args[0]
+    assert msg.text == "hey hermes, what's the disk usage on the K3s nodes?"


### PR DESCRIPTION
## Summary

The matrix adapter's intake gate (`_on_room_message`) now drops messages
whose body matches an orchestrator-emitted phantom notice shape BEFORE any
sender / room / duplicate filtering.

Phantom shapes filtered (full-prefix match, real user messages with these
tokens mid-sentence still pass):

- `[This response was interrupted by a user correction.]`
- `↪ Redirected current run`
- `⚡ Interrupting current task.`
- `⚡ Stopped.`
- `No active task to stop.`
- `♻️ Recovered reply`
- `💾 Self-improvement review:`
- `💭 Reasoning:`

## Why

Hermes orchestrator notices (interrupt / redirect / self-improvement
review / recovered-reply) get delivered to the gateway as ordinary
inbound messages. Without a defensive filter the matrix adapter dispatches
them, the LLM treats them as a user turn, and the gateway emits another
phantom — a self-perpetuating loop until the homeserver rate-limits the
connection. Filtering at intake is the cheapest point to break the loop.

## Why this is a separate PR from #80206 (sender/reply metadata)

- #80206 fixes an affordance gap — `MessageEvent` now carries `user_id` /
  `user_name` / `reply_to_*` so the LLM CAN read sender info.
- This PR is a defensive intake filter — orchestrator noise NEVER reaches
  the LLM.

Different surface area, different risk profile, different rollback path.
AGENTS.md contribution rubric asks for focused PRs — these two fixes are
independently mergeable.

## Verification

**RED on origin/main** (stashed the source fix, kept the tests):
```
$ git stash push -- plugins/platforms/matrix/adapter.py
$ ./venv/bin/python -m pytest tests/gateway/test_matrix_phantom_intake_filter.py
9 failed, 2 passed in 0.98s
```

**GREEN after fix** (popped the stash):
```
$ git stash pop
$ ./venv/bin/python -m pytest tests/gateway/test_matrix_phantom_intake_filter.py
11 passed in 0.92s
```

**Sibling matrix tests** (`test_matrix*.py` plus the new file):
all green.

## Files changed

- `plugins/platforms/matrix/adapter.py:346` — new module-level
  `PHANTOM_INTAKE_PREFIXES` tuple + `_is_phantom_intake_message()` helper
  (full-prefix matching, rejects empty body).
- `plugins/platforms/matrix/adapter.py:3127` — `_on_room_message` now
  inspects `event.content.body` and returns early if the body matches a
  phantom prefix. Placed BEFORE the existing self-sender / allowed-room /
  duplicate-event gates so phantoms are dropped before any state writes.
- `tests/gateway/test_matrix_phantom_intake_filter.py` (new) — 11 tests:
  parametrized coverage of every prefix shape, plus a "real message that
  happens to mention the tokens mid-sentence still passes" guard test.

## Bot / duplicate check

- Open issues referencing this: none found
- Open PRs referencing this: none found
- No existing branch search needed (no PR competitor)
