### PR TITLE
fix(tui): ignore npm `deprecated` field in lockfile drift check

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1594,7 +1594,7 @@ def _print_tui_exit_summary(
     )
 
 
-_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer"})
+_NPM_LOCK_RUNTIME_KEYS = frozenset({"ideallyInert", "peer", "deprecated"})
 """Lockfile fields npm writes non-deterministically at install time.
 
 ``ideallyInert`` is npm's runtime annotation for packages it skipped installing


### PR DESCRIPTION
## Problem

`_tui_need_npm_install` compares the root `package-lock.json` against `node_modules/.package-lock.json` (npm's hidden lockfile) **by content**. npm strips the `deprecated` field from the hidden lockfile during install, so any deprecation-marked transitive dependency (e.g. `rimraf` v3, `inflight`, `glob` v7, `boolean`, `rcedit`) makes the comparison differ forever.

Result: `Installing TUI dependencies…` plus a full `npm install` on **every** TUI launch — the install rewrites the hidden lockfile without `deprecated`, so the next launch trips the same check. Observed on a standard git-checkout install with 5 deprecated transitives in the tree.

## Fix

Add `deprecated` to `_NPM_LOCK_RUNTIME_KEYS` (already contains `ideallyInert`, `peer` — npm-written runtime annotations that legitimately differ between the two lockfiles).

## Verification

- Reproduced: `_tui_need_npm_install(ui-tui)` returns `True` on a checkout where 5 packages differ only by the `deprecated` field; after fix it returns `False` and no `npm install` runs on launch.
- `scripts/run_tests.sh` on all TUI-related test files: **572 tests passed, 0 failed** (`test_tui_npm_install.py` 3✓, `test_tui_resume_flow.py` 6✓, `test_tui_bundled.py`/heap/mouse/dashboard-backcompat 8✓, `tests/test_tui_gateway_*.py` + mcp tests 555✓).