### PR TITLE
fix(whatsapp): run the bridge npm install off the event loop

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -590,7 +590,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                     # Read timeout from environment variable, default to 300 seconds (5 minutes)
                     # to accommodate slower systems like Unraid NAS
                     npm_install_timeout = env_int("WHATSAPP_NPM_INSTALL_TIMEOUT", 300)
-                    install_result = subprocess.run(
+                    # Off the event loop: a synchronous subprocess.run here
+                    # blocks every other adapter, every in-flight turn, the
+                    # watchdogs and the SIGTERM handler for the whole install
+                    # (up to WHATSAPP_NPM_INSTALL_TIMEOUT, default 300s). It
+                    # also defeats the per-platform connect timeout, which
+                    # relies on the loop being able to run its own deadline.
+                    install_result = await asyncio.to_thread(
+                        subprocess.run,
                         [_npm_bin, "install", "--silent"],
                         cwd=str(bridge_dir),
                         capture_output=True,

--- a/tests/gateway/test_whatsapp_npm_install_off_loop.py
+++ b/tests/gateway/test_whatsapp_npm_install_off_loop.py
@@ -1,0 +1,149 @@
+"""Regression test: the WhatsApp bridge npm install must not block the loop.
+
+``WhatsAppAdapter.connect()`` reinstalls the bridge's node_modules whenever
+``package.json`` changed since the last install — which is exactly what
+``hermes update`` does when it bumps the Baileys pin. That install ran through
+a synchronous ``subprocess.run`` inside the ``async def``, so it blocked the
+gateway's event loop for the whole install: every other platform adapter, every
+in-flight turn, the session watchdogs and the SIGTERM handler stopped for up to
+``WHATSAPP_NPM_INSTALL_TIMEOUT`` seconds (default 300).
+
+It also defeated ``_connect_adapter_with_timeout``, whose docstring promises to
+"connect an adapter without allowing one platform to block others" — that
+guarantee is an ``asyncio.wait(..., timeout=...)``, which cannot fire while the
+loop itself is blocked.
+
+The probe here is deliberately built on ``loop.call_later`` rather than
+``asyncio.sleep``: the shared connect harness patches ``asyncio.sleep``, and a
+patched sleep would make any coroutine-based probe look responsive whether or
+not the loop was actually free.
+"""
+import asyncio
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tests.gateway.test_whatsapp_connect import (
+    _connect_patches,
+    _make_adapter,
+    _mock_aiohttp,
+)
+
+
+# How long the faked npm install blocks its thread, and how often the probe
+# fires. A free loop gets ~30 ticks in that window; a blocked one gets ~0.
+_INSTALL_SECONDS = 0.3
+_TICK_SECONDS = 0.01
+_MIN_TICKS = 5
+
+
+class _LoopProbe:
+    """Counts how many times the event loop got to run a scheduled callback."""
+
+    def __init__(self):
+        self.ticks = 0
+        self._handle = None
+
+    def start(self):
+        self._schedule()
+        return self
+
+    def _schedule(self):
+        loop = asyncio.get_running_loop()
+        self._handle = loop.call_later(_TICK_SECONDS, self._fire)
+
+    def _fire(self):
+        self.ticks += 1
+        self._schedule()
+
+    def stop(self):
+        if self._handle is not None:
+            self._handle.cancel()
+            self._handle = None
+
+
+@pytest.mark.asyncio
+async def test_npm_install_does_not_block_the_event_loop():
+    """A slow bridge install must leave the loop free to run other work."""
+    adapter = _make_adapter()
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None
+    mock_fh = MagicMock()
+    mock_client_cls = _mock_aiohttp(status=200, json_data={"status": "connecting"})
+
+    install_calls = []
+
+    def _slow_npm_install(*args, **kwargs):
+        # Synchronous, like the real npm install.
+        install_calls.append(args[0] if args else None)
+        time.sleep(_INSTALL_SECONDS)
+        return MagicMock(returncode=0, stderr="")
+
+    patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+    probe = _LoopProbe().start()
+    try:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], \
+             patches[5], patches[6], patches[7], patches[8], \
+             patch.object(type(adapter), "_poll_messages", return_value=MagicMock()), \
+             patch("subprocess.run", side_effect=_slow_npm_install):
+            try:
+                await adapter.connect()
+            except Exception:
+                # connect() may still fail further down (no real bridge); the
+                # install is the only part under test.
+                pass
+    finally:
+        probe.stop()
+
+    assert install_calls, "the npm install path was never reached"
+    assert probe.ticks >= _MIN_TICKS, (
+        f"event loop was blocked during the bridge install "
+        f"({probe.ticks} ticks in {_INSTALL_SECONDS}s, expected >= {_MIN_TICKS})"
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_failure_still_aborts_connect():
+    """A non-zero install exit still fails the connect, as before."""
+    adapter = _make_adapter()
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None
+    mock_fh = MagicMock()
+    mock_client_cls = _mock_aiohttp(status=200, json_data={"status": "connecting"})
+
+    patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], \
+         patch.object(type(adapter), "_poll_messages", return_value=MagicMock()), \
+         patch("subprocess.run", return_value=MagicMock(returncode=1, stderr="boom")):
+        result = await adapter.connect()
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_install_timeout_still_aborts_connect():
+    """``subprocess.TimeoutExpired`` still propagates out of the worker thread."""
+    adapter = _make_adapter()
+
+    mock_proc = MagicMock()
+    mock_proc.poll.return_value = None
+    mock_fh = MagicMock()
+    mock_client_cls = _mock_aiohttp(status=200, json_data={"status": "connecting"})
+
+    import subprocess as _sp
+
+    patches = _connect_patches(mock_proc, mock_fh, mock_client_cls)
+
+    with patches[0], patches[1], patches[2], patches[3], patches[4], \
+         patches[5], patches[6], patches[7], patches[8], \
+         patch.object(type(adapter), "_poll_messages", return_value=MagicMock()), \
+         patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="npm", timeout=1)):
+        result = await adapter.connect()
+
+    assert result is False


### PR DESCRIPTION
## What does this PR do?

`WhatsAppAdapter.connect()` runs the bridge's `npm install` synchronously inside an `async def`, which blocks the gateway's event loop for the whole install — by default up to 300 seconds.

```python
install_result = subprocess.run(
    [_npm_bin, "install", "--silent"],
    cwd=str(bridge_dir),
    ...
    timeout=npm_install_timeout,     # env-tunable, default 300
)
```

Nothing else in the process runs during that window. Every other platform adapter (Telegram, Slack, Discord, …) stops serving, in-flight turns stall, the session watchdogs stop advancing, and SIGTERM cannot be serviced. #24721 made the timeout configurable for slow NAS hosts, which means the freeze can be configured longer, not shorter.

This is not a rare path. The code comment above it names the trigger: the install fires when `node_modules` is missing **or** `package.json` changed since the last install — *"e.g. after `hermes update` bumps the Baileys pin"*. So the first WhatsApp connect after an update that touches the bridge freezes the gateway.

### Why this is worse than a slow connect

The gateway already has a guard for exactly this hazard. `_connect_adapter_with_timeout` says so in its own docstring:

> Connect an adapter without allowing one platform to block others.

and enforces it with `asyncio.wait({task}, timeout=timeout)` — the detach-on-timeout pattern from #70344, chosen specifically so a wedged adapter cannot hold up recovery. But that deadline is scheduled *on the loop*. A synchronous call inside `connect()` blocks the loop, so the timeout cannot fire. The one mechanism designed to contain a slow platform is disabled by the very thing it exists to contain.

This is the same failure mode as #53175, whose regression test describes it: the bot goes silent, the runtime-status heartbeat stops advancing, and SIGTERM cannot be serviced.

### The fix

Route the install through `asyncio.to_thread` so the loop stays free. `subprocess.run` keeps its own `timeout`, and `TimeoutExpired` still propagates out of the worker thread into the existing handler — the failure paths are unchanged, only the blocking is gone.

## Related Issue

No existing issue. Searched open and merged PRs and issues first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "whatsapp npm install"        # only #24721 / #26795, see below
gh search prs --repo NousResearch/hermes-agent "whatsapp connect blocks"     # 0
gh search prs --repo NousResearch/hermes-agent "whatsapp event loop"         # 0
gh search prs --repo NousResearch/hermes-agent "blocking event loop subprocess"  # 0
gh search prs --repo NousResearch/hermes-agent "to_thread subprocess gateway"    # 0
```

The two nearby PRs are about the timeout's *value*, not the blocking: #24721 (merged) made it configurable, #26795 added coverage for it. #77853 (open) touches other npm install sites — `hermes_cli/main.py` and `hermes_cli/web_server.py` — not this one, so there is no overlap.

Precedent for the class: #73621 *"keep models.dev refreshes off the event loop"* and #74155 *"offload /model context-length resolution off the event loop"*, both P1.

## Type of Change

Bug fix (non-breaking).

## Changes Made

- `plugins/platforms/whatsapp/adapter.py` — the bridge `npm install` now runs via `asyncio.to_thread`; added a comment recording why it must stay off the loop.
- `tests/gateway/test_whatsapp_npm_install_off_loop.py` — new, 3 tests: loop liveness during a slow install, plus the two unchanged failure paths (non-zero exit and `TimeoutExpired` both still abort the connect).

## How to Test

```
pytest tests/gateway/test_whatsapp_npm_install_off_loop.py -q
```

3 passed.

The test drives the real `connect()` through the existing WhatsApp connect harness (`tests/gateway/test_whatsapp_connect.py`) with an install faked to block its thread for 0.3s, and measures loop liveness.

One detail worth flagging for review: the probe is built on `loop.call_later`, not `asyncio.sleep`. The shared harness patches `asyncio.sleep`, and since the adapter's `asyncio` is the module object itself, that patch is global — a coroutine-based probe would look responsive whether or not the loop was actually free. `call_later` is untouched by the harness and measures the thing we care about.

Reverting only `plugins/platforms/whatsapp/adapter.py` and rerunning:

```
E  AssertionError: event loop was blocked during the bridge install (0 ticks in 0.3s, expected >= 5)
1 failed, 2 passed
```

Zero ticks — the loop was completely blocked. The two that still pass without the fix are the failure-path tests, which is the point: they pin that this change alters nothing but the blocking.

Full gateway suite, this branch vs `main`, same environment, run serially:

```
main:   7 failed, 4847 passed, 30 skipped, 1 xfailed
branch: 7 failed, 4850 passed, 30 skipped, 1 xfailed
```

Failing sets are identical — zero added, zero removed. Those 7 are pre-existing in a non-hermetic single-process `pytest tests/gateway/` run; CI's per-file isolation via `run_tests_parallel.py` is the supported path.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(whatsapp): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — inline comment at the call site; no user-facing doc describes this internal behaviour
- [x] `cli-config.yaml.example` — N/A, no config keys (`WHATSAPP_NPM_INSTALL_TIMEOUT` is unchanged)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — considered: `asyncio.to_thread` is stdlib on every supported platform, and the Windows-specific `npm.cmd` resolution through `find_node_executable` is untouched
- [x] Tool descriptions/schemas — N/A

## Notes for the reviewer

`asyncio.to_thread` inherits the caller's context, so `with_hermes_node_path()` is still evaluated on the loop and its env dict is passed through unchanged — the portable-Node PATH resolution behaves exactly as before.

While scanning for this class I found one more synchronous `subprocess.run` on an async path: `gateway/platforms/webhook.py::_deliver_github_comment` shells out to `gh pr comment` with a 30s timeout, blocking the loop for the length of a GitHub round-trip on every `github_comment` delivery. Smaller window than this one and a different component, so I left it out rather than widen the PR — happy to send it separately if you want it.
