### PR TITLE
fix(gateway): keep /heartbeat alive across a compression session rotation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18707,6 +18707,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if watch:
             watch.pop(quick_key, None)
 
+    async def _heartbeat_session_tip(self, session_id: str) -> str:
+        """Return the compression-continuation tip for *session_id*.
+
+        Returns the input unchanged when the session never rotated, when no
+        session DB is attached, or when the lookup fails, so callers can treat
+        the result as a plain rebind hint.
+        """
+        if not session_id or self._session_db is None:
+            return session_id
+        try:
+            tip = await self._session_db.get_compression_tip(session_id)
+        except Exception:
+            logger.debug(
+                "heartbeat compression-tip lookup failed for %s",
+                session_id, exc_info=True,
+            )
+            return session_id
+        return tip or session_id
+
     def _start_heartbeat_poller(self) -> None:
         """Start the single gateway-wide heartbeat poll task (idempotent)."""
         existing = getattr(self, "_heartbeat_poll_task", None)
@@ -18730,8 +18749,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                         mgr = HeartbeatManager(session_id=session_id)
                         if not mgr.has_heartbeat():
-                            watch.pop(quick_key, None)
-                            continue
+                            # Context compression re-homes the heartbeat onto
+                            # the continuation session and clears the parent
+                            # row, so the id captured at /heartbeat time reads
+                            # empty the first time the session rotates. Follow
+                            # the compression chain before concluding the user
+                            # cleared it — otherwise the poller unregisters a
+                            # live heartbeat and it silently never fires again.
+                            tip = await self._heartbeat_session_tip(session_id)
+                            if tip != session_id:
+                                rebound = HeartbeatManager(session_id=tip)
+                                if rebound.has_heartbeat():
+                                    watch[quick_key] = (source, tip)
+                                    mgr = rebound
+                            if not mgr.has_heartbeat():
+                                watch.pop(quick_key, None)
+                                continue
                         prompt = mgr.due_prompt()
                         if not prompt:
                             continue

--- a/tests/gateway/test_heartbeat_poller_rotation.py
+++ b/tests/gateway/test_heartbeat_poller_rotation.py
@@ -1,0 +1,144 @@
+"""The gateway heartbeat poller must survive a compression session rotation.
+
+``/heartbeat`` registers a watch keyed by the session id that was current when
+the command ran. Context compression re-homes the heartbeat onto the
+continuation session and clears the parent row, so that captured id reads
+empty the first time the session rotates — and the poller used to take that as
+"the user cleared it" and unregister the watch. The heartbeat then never fired
+again, silently, in exactly the long-running sessions it exists for.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+
+from gateway.run import GatewayRunner
+
+
+class _StubSessionDB:
+    """Minimal AsyncSessionDB stand-in exposing the compression chain."""
+
+    def __init__(self, tips: dict[str, str]):
+        self._tips = tips
+        self.lookups: list[str] = []
+
+    async def get_compression_tip(self, session_id: str) -> str:
+        self.lookups.append(session_id)
+        return self._tips.get(session_id, session_id)
+
+
+def _make_runner(watch: dict, tips: dict[str, str]):
+    runner = types.SimpleNamespace()
+    runner._heartbeat_watch = watch
+    runner._running_agents = {}
+    runner._session_db = _StubSessionDB(tips)
+    runner._background_tasks = set()
+    runner._heartbeat_poll_task = None
+    runner.enqueued: list = []
+    runner._adapter_for_source = lambda source: object()
+    runner._enqueue_fifo = lambda qk, ev, ad: runner.enqueued.append((qk, ev))
+
+    async def _tip(session_id: str) -> str:
+        return await runner._session_db.get_compression_tip(session_id)
+
+    runner._heartbeat_session_tip = _tip
+    runner._start_heartbeat_poller = types.MethodType(
+        GatewayRunner._start_heartbeat_poller, runner,
+    )
+    return runner
+
+
+async def _run_one_poll(runner) -> None:
+    runner._start_heartbeat_poller()
+    task = runner._heartbeat_poll_task
+    try:
+        await asyncio.sleep(0.15)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.fixture()
+def hb(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    from hermes_cli import heartbeat as module
+
+    monkeypatch.setattr(module, "POLL_SECONDS", 0.01)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_poller_follows_the_compression_rotation(hb):
+    """A rotated session rebinds the watch instead of dropping the heartbeat."""
+    hb.HeartbeatManager("sess-parent").set("Check the deployment", 600)
+    assert hb.migrate_heartbeat_to_session("sess-parent", "sess-child") is True
+
+    source = object()
+    watch = {"chat:1": (source, "sess-parent")}
+    runner = _make_runner(watch, {"sess-parent": "sess-child"})
+
+    await _run_one_poll(runner)
+
+    assert "chat:1" in watch, "live heartbeat was unregistered after rotation"
+    assert watch["chat:1"] == (source, "sess-child")
+
+
+@pytest.mark.asyncio
+async def test_poller_unregisters_a_genuinely_cleared_heartbeat(hb):
+    """/heartbeat clear on a session that never rotated still unregisters.
+
+    Pins the boundary: following the chain must not keep dead watches alive.
+    """
+    mgr = hb.HeartbeatManager("sess-solo")
+    mgr.set("Check the deployment", 600)
+    mgr.clear()
+
+    watch = {"chat:1": (object(), "sess-solo")}
+    runner = _make_runner(watch, {})
+
+    await _run_one_poll(runner)
+
+    assert watch == {}
+
+
+@pytest.mark.asyncio
+async def test_poller_unregisters_when_the_tip_has_no_heartbeat(hb):
+    """Rotation plus a real clear still unregisters — the tip is authoritative."""
+    hb.HeartbeatManager("sess-parent").set("Check the deployment", 600)
+    hb.migrate_heartbeat_to_session("sess-parent", "sess-child")
+    hb.HeartbeatManager("sess-child").clear()
+
+    watch = {"chat:1": (object(), "sess-parent")}
+    runner = _make_runner(watch, {"sess-parent": "sess-child"})
+
+    await _run_one_poll(runner)
+
+    assert watch == {}
+
+
+class _ExplodingSessionDB:
+    async def get_compression_tip(self, session_id: str) -> str:
+        raise RuntimeError("db down")
+
+
+@pytest.mark.asyncio
+async def test_session_tip_resolves_and_degrades_to_the_input():
+    """The tip helper follows the chain and never raises into the poll loop."""
+    runner = types.SimpleNamespace()
+    resolve = types.MethodType(GatewayRunner._heartbeat_session_tip, runner)
+
+    runner._session_db = _StubSessionDB({"sess-parent": "sess-child"})
+    assert await resolve("sess-parent") == "sess-child"
+    assert await resolve("sess-solo") == "sess-solo"
+
+    runner._session_db = None
+    assert await resolve("sess-parent") == "sess-parent"
+
+    runner._session_db = _ExplodingSessionDB()
+    assert await resolve("sess-parent") == "sess-parent"


### PR DESCRIPTION
## What

`/heartbeat` registers a gateway watch keyed by the session id that was current when the command ran:

```python
watch[quick_key] = (source, session_id)
```

Context compression then rotates the session. On rotation `agent/conversation_compression.py` calls `migrate_heartbeat_to_session(old_session_id, agent.session_id)`, which copies the state onto the continuation session and marks the parent row `status="cleared"` — and `load_heartbeat` returns `None` for a cleared row.

The poller still holds the id captured at `/heartbeat` time, so its liveness check reads False and it concludes the user cleared the heartbeat:

```python
mgr = HeartbeatManager(session_id=session_id)
if not mgr.has_heartbeat():
    watch.pop(quick_key, None)
    continue
```

The watch is dropped and the heartbeat never fires again. Nothing is logged above DEBUG and no message reaches the user — the recurring instruction they set just stops, in exactly the long-running sessions a heartbeat exists for. Driving the real functions:

```
before rotation: has_heartbeat(sess-parent) = True
compression rotation migrated: True
poller sees has_heartbeat(sess-parent) = False  -> unregisters watch
but the heartbeat is alive at sess-child = True
```

The CLI driver does not have this problem: `_get_heartbeat_manager` rebinds its manager whenever `session_id` changes, so it picks up the continuation session on the next poll. Only the gateway caches the id.

## The fix

Follow the compression chain before concluding the heartbeat is gone, then rebind the watch to the tip. `get_compression_tip` is the helper the delegation-binding and resume paths already use for this, and it returns the input unchanged when the session isn't a compression parent:

```
get_compression_tip('sess-parent') -> sess-child
heartbeat alive at tip: True
no-rotation case returns input: sess-child
```

The lookup runs only when the stored id comes back empty — a heartbeat that is simply not due never reaches it, so the steady-state poll is unchanged. `_heartbeat_session_tip` degrades to the input id when there is no rotation, no session DB is attached, or the query raises, so a DB hiccup can't turn into an exception inside the poll loop.

A genuinely cleared heartbeat still unregisters: the tip is authoritative, and if the heartbeat is cleared there the watch is dropped as before.

## Tests and results

New file `tests/gateway/test_heartbeat_poller_rotation.py`, driving the real poll loop with a stub runner supplying its collaborators:

- rotated session — the watch rebinds to the continuation id instead of being dropped
- `/heartbeat clear` with no rotation — still unregisters
- rotation followed by a real clear — still unregisters, the tip decides
- the tip helper itself — follows the chain, and returns the input id when the DB is absent or raises

On `main` the first test fails on its behavioural assertion (`live heartbeat was unregistered after rotation`) and the helper test fails because the method is new; the two boundary tests pass there, which is what a non-regression pin should do. All four pass with the fix.

`tests/gateway/` plus `tests/hermes_cli/test_heartbeat.py` run to 4798 passed. I ran that suite before and after the change and diffed the failure lists: 72 failures, byte-identical both ways, all pre-existing on `main` and unrelated (update command/streaming, and `test_teams.py`, which fails at collection on `main` and is excluded from the run for that reason).