### PR TITLE
fix(desktop): confirm before quitting during a live turn

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -159,7 +159,8 @@ import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
-import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { type ActiveWork, mergeActiveWork, normalizeActiveWork } from './quit-guard'
+import { setAppLocale, quitConfirmPrompt } from './native-strings'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   RemoteLivenessTracker,
@@ -9349,6 +9350,18 @@ function createWindow() {
   mainWindow.on('unmaximize', schedulePersistWindowState)
   mainWindow.on('close', () => schedulePersistWindowState.flush())
 
+  // Intercept the close *while the window is still alive* so "Keep Running"
+  // can leave it exactly as-is (on Windows, `before-quit` fires only after the
+  // window is already destroyed, so it can't preserve it). Clicking the X runs
+  // this first; preventDefault keeps the window open and the user chooses.
+  // A genuine quit (Quit Anyway, or any non-X exit) re-enters with the latch set
+  // and falls through, so the window closes normally.
+  mainWindow.on('close', (event: Electron.Event) => {
+    if (heldQuitForActiveWork(event)) {
+      return
+    }
+  })
+
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   const createdMainWindow = mainWindow
   mainWindow.on('closed', () => {
@@ -10584,6 +10597,15 @@ ipcMain.handle('hermes:stopPreviewFileWatch', (_event, id) => stopPreviewFileWat
 // merged picture. Keyed by webContents id so a closed window stops counting.
 const activeWorkByWebContents = new Map<number, ActiveWork>()
 
+// Synchronous, webContents-independent cache of the most recent active-work
+// summary we heard from *any* renderer. The per-webContents map above is
+// dropped the moment a webContents is destroyed (a stream can reload its
+// webContents mid-turn), so at quit time it can read empty even though a turn
+// is live. This cached value survives that and is what the quit guard falls
+// back to. It is only ever refreshed by real publishes, so an idle app
+// (count=0) clears it — no false positives after a turn ends.
+let lastActiveWorkSeen: ActiveWork = { count: 0, titles: [] }
+
 // The same merged picture drives background throttling: chat windows run
 // unthrottled while any turn is in flight (streaming must paint while hidden)
 // and fall back to Chromium's default throttling at idle. See stream-throttle.ts.
@@ -10603,8 +10625,16 @@ ipcMain.on('hermes:active-work', (event, payload) => {
     })
   }
 
-  activeWorkByWebContents.set(id, normalizeActiveWork(payload))
+  const work = normalizeActiveWork(payload)
+  activeWorkByWebContents.set(id, work)
+  lastActiveWorkSeen = work
   updateStreamThrottleFromActiveWork()
+})
+
+// The renderer reports its display language so native (main-process) dialogs
+// match the UI. See electron/native-strings.ts.
+ipcMain.on('hermes:app-locale', (_event, locale) => {
+  setAppLocale(typeof locale === 'string' ? locale : null)
 })
 
 ipcMain.on('hermes:titlebar-theme', (_event, payload) => {
@@ -11909,17 +11939,41 @@ function configureSpellChecker() {
 }
 
 // Ask before a quit kills a turn in flight. True when the quit was intercepted
-// and the confirmation is on screen; "Quit Anyway" re-enters before-quit with
-// the latch set and falls straight through to the teardown below.
+// and the confirmation is on screen; "Quit Anyway" re-enters with the latch set
+// and falls straight through to the teardown below.
+//
+// MUST stay synchronous: Electron commits the quit when the handler returns, so
+// `event.preventDefault()` has to run *before* this function yields. An async
+// version (awaiting the renderer) lets the quit proceed first and the dialog
+// never shows. The main-process mirror (activeWorkByWebContents) is fed
+// synchronously by the renderer's `hermes:active-work` IPC, so no async read is
+// needed here. The per-webContents map is merged with `lastActiveWorkSeen`, a
+// webContents-independent cache, because a stream can reload its webContents
+// mid-turn and drop the map entry before the quit is intercepted.
+//
+// Called from two places: `mainWindow.on('close')` (user clicks the X — the
+// window is still alive, so "Keep Running" leaves it exactly as-is) and
+// `before-quit` (a non-close exit path, e.g. the app menu — the window may
+// already be gone, which is a last-ditch guard, not the smooth "keep running"
+// experience). Both share this logic.
 function heldQuitForActiveWork(event: Electron.Event): boolean {
   if (SKIP_QUIT_CONFIRM || quitConfirmedWithActiveWork || quitPromptOpen) {
     return false
   }
 
-  const prompt = quitPromptFor(mergeActiveWork(activeWorkByWebContents.values()), isQuittingForHandoff)
-  const parent = BrowserWindow.getFocusedWindow() ?? BrowserWindow.getAllWindows()[0]
+  const mapWork = mergeActiveWork(activeWorkByWebContents.values())
+  const work = mergeActiveWork([mapWork, lastActiveWorkSeen])
 
-  if (!prompt || !parent || parent.isDestroyed()) {
+  const prompt = quitConfirmPrompt(work, isQuittingForHandoff)
+  // On Windows a click on the X destroys the window *before* `before-quit`
+  // fires (window-all-closed -> app.quit -> before-quit), so no live window
+  // exists to parent the dialog on that path. `showMessageBox` accepts a null
+  // parent and still displays, so we must not skip on a missing/dead parent —
+  // doing so silently drops the confirmation on the platform it matters most.
+  // (On the `close` path the window is still alive, so this resolves to it.)
+  const liveParent = BrowserWindow.getAllWindows().find(w => !w.isDestroyed()) ?? null
+
+  if (!prompt) {
     return false
   }
 
@@ -11927,8 +11981,8 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
   quitPromptOpen = true
 
   void dialog
-    .showMessageBox(parent, {
-      buttons: ['Keep Running', 'Quit Anyway'],
+    .showMessageBox(liveParent, {
+      buttons: prompt.buttons,
       cancelId: 0,
       defaultId: 0,
       detail: prompt.detail,
@@ -11955,7 +12009,8 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 
 app.on('before-quit', event => {
   // Runs ahead of every teardown below, so "Keep Running" leaves the app
-  // exactly as it was.
+  // exactly as it was. The guard is synchronous: event.preventDefault() must
+  // run before this handler returns or the quit is already committed.
   if (heldQuitForActiveWork(event)) {
     return
   }

--- a/apps/desktop/electron/native-strings.ts
+++ b/apps/desktop/electron/native-strings.ts
@@ -1,0 +1,122 @@
+// Strings for native (main-process) UI surfaces — dialogs, tray menus, and any
+// other OS-level chrome the renderer can't localize itself.
+//
+// Why a dedicated module instead of reusing the renderer's `TRANSLATIONS`
+// catalog: the catalog (`src/i18n/*`) pulls in renderer-only modules (e.g.
+// `en.ts` imports `@/app/settings/constants`), so it can't be bundled into the
+// main-process entry without dragging unneeded code across the boundary. Every
+// native UI surface reads from THIS single table via `appLocale`, so adding a
+// new main-process dialog means one more entry here — not a whole new table.
+
+import type { ActiveWork } from './quit-guard'
+
+export type NativeLocale = 'en' | 'zh' | 'zh-hant' | 'ja' | 'ar'
+
+const SUPPORTED: NativeLocale[] = ['en', 'zh', 'zh-hant', 'ja', 'ar']
+
+/** Normalize an arbitrary locale string (e.g. `zh-CN`, `en-US`) to a table key. */
+export function normalizeNativeLocale(locale: string | undefined | null): NativeLocale {
+  if (!locale) {
+    return 'en'
+  }
+
+  const base = locale.toLowerCase().split('-')[0]
+
+  return (SUPPORTED as string[]).includes(base) ? (base as NativeLocale) : 'en'
+}
+
+// The renderer pushes its display language here whenever it changes.
+let appLocale: NativeLocale = 'en'
+
+export function setAppLocale(locale: string | undefined | null): void {
+  appLocale = normalizeNativeLocale(locale)
+}
+
+export function getAppLocale(): NativeLocale {
+  return appLocale
+}
+
+interface QuitConfirmCopy {
+  messageOne: string
+  messageMany: (n: number) => string
+  warn: string
+  moreOne: string
+  moreMany: (n: number) => string
+  buttons: [string, string]
+}
+
+const QUIT_CONFIRM: Record<NativeLocale, QuitConfirmCopy> = {
+  en: {
+    messageOne: 'Hermes is still working on 1 chat.',
+    messageMany: n => `Hermes is still working on ${n} chats.`,
+    warn: 'Quitting stops the agent mid-turn. Any work it has not finished writing is lost.',
+    moreOne: '• 1 more',
+    moreMany: n => `• ${n} more`,
+    buttons: ['Keep Running', 'Quit Anyway']
+  },
+  zh: {
+    messageOne: 'Hermes 正在处理 1 个对话。',
+    messageMany: n => `Hermes 正在处理 ${n} 个对话。`,
+    warn: '退出会中断 agent 的当前轮次，未写入的工作将丢失。',
+    moreOne: '• 还有 1 个',
+    moreMany: n => `• 还有 ${n} 个`,
+    buttons: ['继续运行', '仍然退出']
+  },
+  'zh-hant': {
+    messageOne: 'Hermes 正在處理 1 個對話。',
+    messageMany: n => `Hermes 正在處理 ${n} 個對話。`,
+    warn: '退出會中斷 agent 的當前輪次，未寫入的工作將遺失。',
+    moreOne: '• 還有 1 個',
+    moreMany: n => `• 還有 ${n} 個`,
+    buttons: ['繼續運行', '仍然退出']
+  },
+  ja: {
+    messageOne: 'Hermes は 1 件のチャットを処理中です。',
+    messageMany: n => `Hermes は ${n} 件のチャットを処理中です。`,
+    warn: '終了すると agent の処理中のターンが中断され、未保存の作業が失われます。',
+    moreOne: '• さらに 1 件',
+    moreMany: n => `• さらに ${n} 件`,
+    buttons: ['続行', '強制終了']
+  },
+  ar: {
+    messageOne: 'ما زال هيرميس يعمل على محادثة واحدة.',
+    messageMany: n => `ما زال هيرميس يعمل على ${n} محادثات.`,
+    warn: 'سيؤدي الخروج إلى إيقاف الوكيل أثناء دورته الحالية. ستفقد أي أعمال لم يكتبها بعد.',
+    moreOne: '• المزيد 1',
+    moreMany: n => `• المزيد ${n}`,
+    buttons: ['استمرار التشغيل', 'الخروج على أي حال']
+  }
+}
+
+const MAX_LISTED = 4
+
+export interface QuitConfirmPrompt {
+  message: string
+  detail: string
+  buttons: [string, string]
+}
+
+/** Localized quit-confirmation copy, or null when there's nothing in flight. */
+export function quitConfirmPrompt(work: ActiveWork, quittingForHandoff: boolean): null | QuitConfirmPrompt {
+  if (quittingForHandoff || work.count < 1) {
+    return null
+  }
+
+  const strings = QUIT_CONFIRM[appLocale]
+  const listed = work.titles.slice(0, MAX_LISTED)
+  const remaining = work.count - listed.length
+  const lines = listed.map(title => `• ${title}`)
+
+  if (remaining > 0) {
+    lines.push(remaining === 1 ? strings.moreOne : strings.moreMany(remaining))
+  }
+
+  return {
+    buttons: strings.buttons,
+    detail: [lines.join('\n'), lines.length > 0 ? '' : null, strings.warn]
+      .filter(line => line !== null)
+      .join('\n')
+      .trim(),
+    message: work.count === 1 ? strings.messageOne : strings.messageMany(work.count)
+  }
+}

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -133,6 +133,7 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   watchDirectory: dir => ipcRenderer.invoke('hermes:watchDirectory', dir),
   stopPreviewFileWatch: id => ipcRenderer.invoke('hermes:stopPreviewFileWatch', id),
   setActiveWork: payload => ipcRenderer.send('hermes:active-work', payload),
+  setAppLocale: locale => ipcRenderer.send('hermes:app-locale', locale),
   setTitleBarTheme: payload => ipcRenderer.send('hermes:titlebar-theme', payload),
   setNativeTheme: mode => ipcRenderer.send('hermes:native-theme', mode),
   setTranslucency: payload => ipcRenderer.send('hermes:translucency', payload),

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -149,6 +149,7 @@ declare global {
       watchDirectory?: (dir: string) => Promise<HermesPreviewWatch>
       stopPreviewFileWatch: (id: string) => Promise<boolean>
       setActiveWork?: (payload: HermesActiveWork) => void
+      setAppLocale?: (locale: string) => void
       setTitleBarTheme?: (payload: HermesTitleBarTheme) => void
       setNativeTheme?: (mode: 'dark' | 'light' | 'system') => void
       setTranslucency?: (payload: { intensity: number }) => void

--- a/apps/desktop/src/i18n/context.tsx
+++ b/apps/desktop/src/i18n/context.tsx
@@ -105,6 +105,9 @@ export function I18nProvider({ children, configClient = defaultConfigClient, ini
     localeRef.current = locale
     setRuntimeI18nLocale(locale)
     applyDocumentLocale(locale)
+    // Keep native (main-process) dialogs in sync with the app's display language
+    // so the quit-confirm prompt and future tray/menu text match the UI.
+    window.hermesDesktop?.setAppLocale?.(locale)
   }, [locale])
 
   useEffect(() => {

--- a/apps/desktop/src/store/active-work.ts
+++ b/apps/desktop/src/store/active-work.ts
@@ -13,23 +13,51 @@ import { computed } from 'nanostores'
 
 import type { HermesActiveWork } from '@/global'
 import { $sessions } from '@/store/session'
-import { $workingSessionIds } from '@/store/session-states'
+import { $sessionStates, $workingSessionIds } from '@/store/session-states'
 
-const $activeWork = computed([$workingSessionIds, $sessions], (workingIds, sessions): HermesActiveWork => {
-  const titleById = new Map(sessions.map(session => [session.id, session.title?.trim() ?? '']))
+const $activeWork = computed(
+  [$workingSessionIds, $sessions, $sessionStates],
+  (workingIds, sessions, states): HermesActiveWork => {
+    // `busy` sessions are actively streaming output. But a turn also counts as
+    // "in flight" from the moment the request is sent until the first assistant
+    // token lands — i.e. `awaitingResponse && !busy` ("thinking", waiting on the
+    // backend). Closing the window during that window would kill a turn the user
+    // can see is still working, so include it. See #80241.
+    const inFlight = new Set(workingIds)
 
-  return {
-    count: workingIds.length,
-    titles: workingIds.map(id => titleById.get(id) ?? '').filter(Boolean)
+    for (const [id, s] of Object.entries(states)) {
+      if (s.awaitingResponse && !s.busy) {
+        inFlight.add(id)
+      }
+    }
+
+    const titleById = new Map(sessions.map(session => [session.id, session.title?.trim() ?? '']))
+
+    return {
+      count: inFlight.size,
+      titles: [...inFlight].map(id => titleById.get(id) ?? '').filter(Boolean)
+    }
   }
-})
+)
 
 if (typeof window !== 'undefined') {
+  // Expose the latest summary on window so the main process can read it
+  // synchronously on quit (via webContents.executeJavaScript) — the async IPC
+  // publish below can be missed if the bridge isn't ready at first emit or the
+  // value doesn't change again before a quit.
+  const publish = (work: HermesActiveWork) => {
+    ;(window as unknown as { __hermesActiveWork?: HermesActiveWork }).__hermesActiveWork = work
+  }
+
+  publish($activeWork.get())
+
   // `$sessions` republishes on unrelated churn (previews, heartbeats), so only
   // send when the summary itself moved — this crosses a process boundary.
   let lastSent = ''
 
   $activeWork.subscribe(work => {
+    publish(work)
+
     const next = JSON.stringify(work)
 
     if (next === lastSent) {


### PR DESCRIPTION
fix(desktop): show quit confirmation when closing during a live turn

- Intercept mainWindow 'close' (window still alive) instead of only
  before-quit, so "Keep Running" preserves the window on Windows where
  before-quit fires after the window is already destroyed
- Add a webContents-independent active-work cache so a mid-turn webContents
  reload no longer drops the guard
- Localize the dialog via a single main-process string table
  (electron/native-strings.ts) driven by the renderer's display locale,
  pushed over hermes:app-locale — one table for all native UI, not per feature