### PR TITLE
fix(goals): decode quality-gate output as UTF-8 instead of the process codepage

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -479,13 +479,15 @@ def workspace_fingerprint(cwd: Optional[str] = None) -> str:
     try:
         head = subprocess.run(
             ["git", "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10, cwd=workdir,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=10, cwd=workdir,
         )
         if head.returncode != 0:
             return ""
         status = subprocess.run(
             ["git", "status", "--porcelain"],
-            capture_output=True, text=True, timeout=30, cwd=workdir,
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=30, cwd=workdir,
         )
         if status.returncode != 0:
             return ""
@@ -509,6 +511,14 @@ def run_gate(gate: GoalGate, *, cwd: Optional[str] = None) -> Tuple[bool, int, s
             shell=True,
             capture_output=True,
             text=True,
+            # A gate runs whatever the operator configured, so its output is
+            # arbitrary bytes. The default text mode decodes with the process
+            # codepage under errors="strict": one byte the codepage can't map
+            # (emoji or CJK from a test runner on a non-UTF-8 Windows console,
+            # or stray binary) kills the reader thread, leaves stdout as None,
+            # and the tail the agent needs to fix the failure arrives empty.
+            encoding="utf-8",
+            errors="replace",
             timeout=max(1, int(gate.timeout_seconds)),
             cwd=cwd or None,
         )

--- a/tests/hermes_cli/test_goal_gates.py
+++ b/tests/hermes_cli/test_goal_gates.py
@@ -1,6 +1,7 @@
 """Tests for /goal quality gates (GoalGate, run_gate, GoalManager gate flow)."""
 
 import json
+import sys
 import time
 from unittest.mock import patch
 
@@ -75,6 +76,35 @@ def test_run_gate_timeout():
     assert passed is False
     assert code == -1
     assert "timed out" in out
+
+
+def test_run_gate_keeps_diagnostics_when_a_byte_will_not_decode(tmp_path):
+    """A gate's output tail must survive bytes the decoder rejects.
+
+    A gate runs whatever the operator configured, so its output is arbitrary
+    bytes — a test runner's checkmarks or CJK on a non-UTF-8 Windows console,
+    or stray binary. Decoding strictly means one bad byte kills subprocess's
+    reader thread, stdout comes back None, and the tail lands empty: the agent
+    is told the gate failed with nothing to act on, so it burns every retry and
+    the goal auto-pauses.
+    """
+    script = tmp_path / "gate.py"
+    script.write_text(
+        "import os, sys\n"
+        "os.write(1, b'FAILED: 3 tests broken \\x90\\x8d rerun me\\n')\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+
+    passed, code, out = run_gate(
+        GoalGate(command=f'"{sys.executable}" "{script}"'),
+    )
+
+    assert passed is False
+    assert code == 1
+    assert "FAILED: 3 tests broken" in out, (
+        f"gate diagnostics were lost to a decode failure (tail={out!r})"
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

A `/goal` quality gate runs whatever command the operator configured, so its output is arbitrary bytes. `run_gate` captured it in text mode with no encoding:

```python
proc = subprocess.run(
    gate.command, shell=True, capture_output=True, text=True,
    timeout=max(1, int(gate.timeout_seconds)), cwd=cwd or None,
)
```

That decodes with `locale.getpreferredencoding()` under the default `errors="strict"`. One byte the decoder rejects — a test runner's checkmarks or CJK on a non-UTF-8 Windows console, a stray binary byte anywhere in the stream — kills subprocess's reader thread. `proc.stdout` comes back as `None`, the `or ""` fallback right below turns that into an empty tail, and an unhandled traceback lands on stderr:

```
Exception in thread Thread-3 (_readerthread):
  ...
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 19: character maps to <undefined>
run_gate -> passed=True exit=0 tail=''
```

The verdict itself survives — it rides on the exit code. What is lost is the tail, and the tail is the whole point of the retry loop: `evaluate_gates` stores it as `last_output_tail` and feeds it back so the agent can fix what broke. Empty, the agent is told a gate failed and handed nothing to act on, so it burns `max_retries` and the goal auto-pauses with `quality gate exhausted N retries`.

`workspace_fingerprint` has the same two calls. There a non-ASCII path in `git status --porcelain` empties the fingerprint, which silently disables the unchanged-gate skip — the rule that exists so a stalled agent can't spin re-running an identical red suite.

## The fix

Decode as UTF-8 with `errors="replace"` at all three call sites. That is what git and modern toolchains actually emit, and it is already the house style: 262 of the repo's 299 text-mode subprocess calls pass an explicit encoding. `errors="replace"` also means genuinely undecodable bytes degrade to replacement characters instead of destroying the surrounding diagnostics.

Same class as the open `working_diff` and cron-script decode fixes; this is the `/goal` gate path, which none of them touch.

## Tests and results

`test_run_gate_keeps_diagnostics_when_a_byte_will_not_decode` runs a gate that prints a realistic failure line with one undecodable byte embedded and exits 1, then asserts the diagnostic text reaches the tail. It fails on `main` — `AssertionError: gate diagnostics were lost to a decode failure (tail='')` — and passes with the fix. The byte chosen is invalid under strict UTF-8 as well as the Windows ANSI codepages, so the test pins the behaviour on Linux CI, not only on the platform where I found it.

The three goals suites (`test_goal_gates.py`, `test_goals.py`, `test_kanban_goal_mode.py`) run to 57 passed with the fix versus 56 on `main` — the one added test — with the same single pre-existing failure both ways: `test_run_gate_fail_captures_output`, which shells out with POSIX syntax (`echo broken >&2; exit 3`) and does not run on a Windows shell. It is untouched by this change.