### PR TITLE
fix(dashboard): heal named-profile session stores behind the schema contract (OOF-76)

### DIFF
--- a/gateway/readiness.py
+++ b/gateway/readiness.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import sqlite3
+import time
 from contextlib import closing
 from pathlib import Path
 from typing import Any
@@ -15,6 +17,22 @@ from hermes_constants import get_hermes_home
 
 _DISK_DEGRADED_PERCENT = 90.0
 
+# Bounded scan of named-profile stores (<home>/profiles/*/state.db). The
+# probe reports aggregate counts only — never profile names or paths.
+# Bounded two ways: store count AND elapsed wall time — each sqlite connect
+# carries a 1s busy timeout, so a count limit alone still risks a ~30s
+# worst case inside a health poll.
+_PROFILE_STORE_PROBE_LIMIT = 32
+_PROFILE_STORE_PROBE_BUDGET_SECONDS = 1.0
+
+# Rotating start offset for the capped profile scan. A fixed sorted()[:cap]
+# window would leave every profile past the cap permanently uninspected —
+# the same "silently unchecked store" blind spot OOF-76 fixed, just moved
+# past index 32. Advancing the window each poll gives eventual coverage of
+# the whole fleet. Plain int mutation under CPython's GIL; a lost race
+# costs at most one repeated window.
+_profile_probe_cursor = 0
+
 
 def _check(status: str, detail: str | None = None, **extra: Any) -> dict[str, Any]:
     result: dict[str, Any] = {"status": status}
@@ -24,25 +42,133 @@ def _check(status: str, detail: str | None = None, **extra: Any) -> dict[str, An
     return result
 
 
-def _probe_state_db(home: Path) -> dict[str, Any]:
-    path = home / "state.db"
-    if not path.exists():
-        return _check("ok", "not initialized")
+def _inspect_state_store(path: Path) -> tuple[str, int]:
+    """Read-only inspection of one session store.
+
+    Returns ``(status, mismatch_count)`` where status is ``ok`` (readable
+    and schema-converged), ``stale`` (readable but behind the SCHEMA_SQL
+    contract — OOF-76: dashboard session routes 500 on such stores while
+    naive readable-only probes stay green), or ``error`` (unreadable or
+    corrupt). Never takes a write reservation.
+    """
+    # A readiness probe must never compete with normal state writers. A
+    # read-only schema query still catches unreadable/corrupt databases
+    # without taking a write reservation on every health poll.
+    # ``closing(...)`` is required: sqlite3's connection context manager
+    # only commits/rolls back — it never closes, so a bare ``with
+    # sqlite3.connect(...)`` leaks one connection (and its fds) per
+    # health poll in the long-running gateway (#69678/#69567 bug class).
     try:
-        # A readiness probe must never compete with normal state writers. A
-        # read-only schema query still catches unreadable/corrupt databases
-        # without taking a write reservation on every health poll.
-        # ``closing(...)`` is required: sqlite3's connection context manager
-        # only commits/rolls back — it never closes, so a bare ``with
-        # sqlite3.connect(...)`` leaks one connection (and its fds) per
-        # health poll in the long-running gateway (#69678/#69567 bug class).
+        from hermes_state_common import state_schema_mismatches
+
         uri = f"file:{path.as_posix()}?mode=ro"
         with closing(sqlite3.connect(uri, uri=True, timeout=1.0)) as conn:
             conn.execute("PRAGMA query_only = ON")
             conn.execute("SELECT name FROM sqlite_master LIMIT 1").fetchone()
-        return _check("ok")
+            # Errors from the diff itself (locked, malformed mid-read)
+            # propagate to the outer handler and report "error" — a store
+            # whose schema cannot be read is not healthy. Only contract
+            # construction fails open (inside state_schema_mismatches).
+            mismatches = state_schema_mismatches(conn)
+        if mismatches:
+            return "stale", len(mismatches)
+        return "ok", 0
+    except Exception:
+        return "error", 0
+
+
+def _probe_state_db(home: Path) -> dict[str, Any]:
+    path = home / "state.db"
+    if not path.exists():
+        return _check("ok", "not initialized")
+    status, mismatch_count = _inspect_state_store(path)
+    if status == "error":
+        return _check("degraded", "unreadable")
+    if status == "stale":
+        return _check("degraded", "schema behind contract", mismatches=mismatch_count)
+    return _check("ok")
+
+
+def _probe_profile_state_dbs(home: Path) -> dict[str, Any]:
+    """Aggregate schema/readability status of named-profile session stores.
+
+    Named profiles whose gateway is not running never get a writable open,
+    so their stores drift behind the dashboard's read surface silently
+    (OOF-76) — the exact class of store this probe exists to surface.
+    Reports counts only: never profile names or paths. Bounded to
+    ``_PROFILE_STORE_PROBE_LIMIT`` stores per poll.
+    """
+    profiles_root = home / "profiles"
+    try:
+        # Name listing only — no per-entry stat yet. The count cap must bound
+        # the stat traffic too, not just the sqlite opens: this runs inside a
+        # health poll and a pathological profiles dir must not turn the
+        # listing itself into the cost.
+        names = sorted(os.listdir(profiles_root))
+    except FileNotFoundError:
+        return _check("ok", "no profiles")
     except Exception as exc:
         return _check("degraded", type(exc).__name__)
+    stores: list[Path] = []
+    # Strict entry bound: cap the entries EXAMINED, not the stores found —
+    # otherwise a profiles dir full of non-store entries still stats every
+    # one of them inside the health poll. Entries past the cap are
+    # unverified, so the scan is truncated regardless of what they hold.
+    truncated = len(names) > _PROFILE_STORE_PROBE_LIMIT
+    if truncated:
+        # Rotate the capped window across polls so entries past the cap are
+        # eventually inspected instead of staying invisible forever.
+        global _profile_probe_cursor
+        start = _profile_probe_cursor % len(names)
+        _profile_probe_cursor = start + _PROFILE_STORE_PROBE_LIMIT
+        window = (names[start:] + names[:start])[:_PROFILE_STORE_PROBE_LIMIT]
+    else:
+        window = names
+    for name in window:
+        candidate = profiles_root / name / "state.db"
+        try:
+            if candidate.is_file():
+                stores.append(candidate)
+        except OSError:
+            continue
+    if not stores:
+        if truncated:
+            return _check("ok", "profile store probe incomplete", truncated=True)
+        return _check("ok", "no profiles")
+    stale = 0
+    errors = 0
+    checked = 0
+    deadline = time.monotonic() + _PROFILE_STORE_PROBE_BUDGET_SECONDS
+    for store in stores:
+        if checked and time.monotonic() >= deadline:
+            truncated = True
+            break
+        status, _count = _inspect_state_store(store)
+        checked += 1
+        if status == "stale":
+            stale += 1
+        elif status == "error":
+            errors += 1
+    # A truncated scan (count cap or time budget) is incomplete evidence,
+    # not evidence of failure: even on this advisory check, a fleet with
+    # >_PROFILE_STORE_PROBE_LIMIT healthy profiles would otherwise sit
+    # permanently "degraded" on every poll, training operators to ignore
+    # the signal. Truncation is surfaced explicitly via detail/extra so the
+    # verdict stays honest about its coverage.
+    result_status = "degraded" if (stale or errors) else "ok"
+    extra: dict[str, Any] = {"checked": checked, "stale": stale, "errors": errors}
+    if truncated:
+        extra["truncated"] = True
+    detail = None
+    if stale and errors:
+        detail = "profile stores behind schema contract and unreadable"
+    elif stale:
+        detail = "profile stores behind schema contract"
+    elif errors:
+        detail = "profile stores unreadable"
+    elif truncated:
+        detail = "profile store probe incomplete"
+    return _check(result_status, detail, **extra)
 
 
 def _probe_config(home: Path) -> dict[str, Any]:
@@ -104,6 +230,7 @@ def collect_runtime_readiness(
     runtime = runtime_status if isinstance(runtime_status, dict) else {}
     checks = {
         "state_db": _probe_state_db(home),
+        "profile_state_dbs": _probe_profile_state_dbs(home),
         "config": _probe_config(home),
         "model": _check("ok" if str(configured_model or "").strip() else "degraded"),
         "disk": _probe_disk(home),
@@ -115,7 +242,22 @@ def collect_runtime_readiness(
             active_delegations=max(0, int(active_delegations)),
         ),
     }
-    overall = "ok" if all(item.get("status") == "ok" for item in checks.values()) else "degraded"
+    # profile_state_dbs is advisory: named-profile schema drift is real user
+    # impact (dashboard session routes 500) but restart-driven remediation
+    # cannot heal an idle profile store — only the dashboard's heal-capable
+    # read path can. Folding it into the restart-driving overall verdict
+    # would invite an unhealable-signal restart loop (OOF-39 class), so it
+    # is surfaced in checks but excluded from the rollup.
+    advisory_checks = {"profile_state_dbs"}
+    overall = (
+        "ok"
+        if all(
+            item.get("status") == "ok"
+            for name, item in checks.items()
+            if name not in advisory_checks
+        )
+        else "degraded"
+    )
     return {"status": overall, "checks": checks}
 
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -44,6 +44,7 @@ router = APIRouter()
 # Late-bound web_server helpers (resolved at call time; cycle-safe,
 # monkeypatch-transparent).
 _cron_profile_home = late("_cron_profile_home")
+_open_session_db_at_path = late("_open_session_db_at_path")
 _disable_unselected_skills = late("_disable_unselected_skills")
 _fallback_profile_dicts = late("_fallback_profile_dicts")
 _hub_action_name = late("_hub_action_name")
@@ -92,7 +93,6 @@ def get_profiles_sessions(
     if order not in ("created", "recent"):
         raise HTTPException(status_code=400, detail="order must be one of: created, recent")
 
-    from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
     targets: List[Tuple[str, Path]] = []
@@ -132,10 +132,14 @@ def get_profiles_sessions(
         if not db_path.exists():
             continue
         try:
-            # Read-only: this loop runs on every sidebar refresh, so it must
-            # never DDL/write-lock another profile's live DB (see SessionDB
-            # read_only docstring).
-            db = SessionDB(db_path=db_path, read_only=True)
+            # Read-only aggregation: this loop runs on every sidebar refresh,
+            # so the healthy path must never DDL/write-lock another profile's
+            # live DB (see SessionDB read_only docstring). The shared opener
+            # heals a stale/older schema through one idempotent writable open
+            # (OOF-76: idle named profiles never get a writable open, so their
+            # stores otherwise drift behind the dashboard's read surface and
+            # 500 here forever).
+            db = _open_session_db_at_path(db_path, read_only=True)
         except Exception as exc:
             errors.append({"profile": name, "error": str(exc)})
             continue
@@ -226,7 +230,6 @@ def get_profiles_sessions_sidebar(
     ``min_messages=1`` / ``archived=exclude`` / recency order, matching the
     desktop's per-slice calls.
     """
-    from hermes_state import SessionDB
     from hermes_cli import profiles as profiles_mod
 
     # cron + messaging are cross-profile; recents is scoped to recents_profile.
@@ -290,7 +293,8 @@ def get_profiles_sessions_sidebar(
         if not db_path.exists():
             continue
         try:
-            db = SessionDB(db_path=db_path, read_only=True)
+            # Same heal-capable opener as /api/profiles/sessions (OOF-76).
+            db = _open_session_db_at_path(db_path, read_only=True)
         except Exception as exc:
             errors.append({"profile": name, "error": str(exc)})
             continue

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3258,6 +3258,14 @@ async def get_status(profile: Optional[str] = None):
         try:
             from gateway.readiness import _probe_state_db
 
+            # Named-profile schema drift (OOF-76) is deliberately NOT folded
+            # into this public storage status: restart-driven remediation
+            # cannot heal an idle profile store (only the dashboard's
+            # heal-capable read path can), so surfacing it here could put
+            # supervisors into a restart loop against an unhealable-signal
+            # (OOF-39 class). Profile-store drift is reported on the
+            # authenticated detailed readiness endpoint instead
+            # (gateway.readiness.collect_runtime_readiness).
             storage_check = await asyncio.get_running_loop().run_in_executor(
                 None, functools.partial(_probe_state_db, get_hermes_home())
             )
@@ -11195,16 +11203,61 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
 # query raises "no such table: sessions".
 _session_db_bootstrap_lock = threading.Lock()
 
-# Stale-schema probe for read-only opens: compiled against the newest columns
-# the dashboard read paths query. Reads at most one row per table. Read-only
-# opens skip _reconcile_columns(), so an older store would otherwise 500 on
-# every poll until something opened it writable.
+# Store keys are (path, st_dev, st_ino): recovery/restore machinery can
+# atomically replace a state.db at the same path without restarting this
+# process, and the replacement must not inherit the original file's heal or
+# validation state (SQLite schema cookies are small integers that collide
+# trivially between databases born from the same DDL).
+def _session_store_key(db_path: Path) -> "tuple[str, int, int]":
+    try:
+        stat = db_path.stat()
+        return (str(db_path), stat.st_dev, stat.st_ino)
+    except OSError:
+        return (str(db_path), -1, -1)
+
+
+# (store key, stale schema cookie) pairs whose heal already ran in this
+# process. Keying by the cookie observed at stale-detection time (instead of
+# the store alone) means a SECOND drift later in the process lifetime — a
+# recovery rewriting the file in place, an external tool dropping a column —
+# gets its own heal attempt rather than 500ing forever. Still loop-bounded:
+# the writable reconcile is idempotent, so an unhealable store's cookie
+# stops changing after one repair pass and its stale state lands in this set
+# permanently (fail-visible, never a DDL loop). Inspected and mutated only
+# under _session_db_bootstrap_lock.
+_session_db_heal_attempted: "set[tuple[tuple[str, int, int], int]]" = set()
+
+# Contract-validation cache: store key -> SQLite schema cookie (PRAGMA
+# schema_version — the engine's monotonic DDL counter, NOT the application
+# schema_version table) at the last successful contract diff. A matching
+# cookie means no DDL has touched the store since it last converged, so the
+# per-poll cost stays one PRAGMA read; any DDL (including an external
+# gateway's own reconcile) bumps the cookie and forces revalidation.
+_session_db_contract_validated: "dict[tuple[str, int, int], int]" = {}
+
+# Fast-fail stale-schema probe for read-only opens: touches the newest
+# columns and tables the dashboard read paths query (at most one row per
+# table). Read-only opens skip _reconcile_columns(), so an older store
+# would otherwise 500 on every poll until something opened it writable.
+# OOF-76: named-profile stores whose gateway isn't running never get a
+# writable open, so a store missing the newer read surface (system_prompts,
+# sessions.last_activity_at/system_prompt_hash) 500ed on every dashboard
+# session route until redeploy. The durable guard is the SCHEMA_SQL
+# contract diff in _open_session_db_at_path() (state_schema_mismatches);
+# this probe stays as a cheap direct read against the known-hot surface.
 _SESSION_DB_READ_PROBE_SQL = (
     "SELECT (SELECT archived FROM sessions LIMIT 1), "
     "(SELECT pinned FROM sessions LIMIT 1), "
+    "(SELECT last_activity_at FROM sessions LIMIT 1), "
+    "(SELECT system_prompt_hash FROM sessions LIMIT 1), "
+    "(SELECT hash FROM system_prompts LIMIT 1), "
     "(SELECT active FROM messages LIMIT 1), "
     "(SELECT compacted FROM messages LIMIT 1)"
 )
+
+
+class _StaleSessionSchema(Exception):
+    """Read-only open found the store behind the SCHEMA_SQL contract."""
 
 
 def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
@@ -11212,21 +11265,38 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
 
     ``profile`` None/empty selects this process's own ``state.db``. A named
     profile opens that profile's on-disk store directly.
-
-    Writable opens keep the full init and repair path. Read-only opens
-    bootstrap a missing or zero-byte store once, and heal an older or
-    malformed schema through one writable open before reopening read-only.
-    The healthy read path never takes a write lock or requests a checkpoint.
     """
-    import sqlite3
-
-    from hermes_state import SessionDB, _default_db_path, is_malformed_db_error
+    from hermes_state import _default_db_path
 
     if profile:
         _name, home = _cron_profile_home(profile)
         db_path = Path(home) / "state.db"
     else:
         db_path = Path(_default_db_path())
+    return _open_session_db_at_path(db_path, read_only=read_only)
+
+
+def _open_session_db_at_path(db_path: Path, *, read_only: bool):
+    """Open a SessionDB at ``db_path`` with an explicit access mode.
+
+    Writable opens keep the full init and repair path. Read-only opens
+    bootstrap a missing or zero-byte store once, and heal an older or
+    malformed schema through one writable open before reopening read-only.
+    Staleness is detected two ways: the read probe (missing table/column on
+    the hot dashboard surface raises immediately) and a full diff of the
+    store's regular tables against the SCHEMA_SQL contract (catches stores
+    that predate ANY newer read path before a route 500s on it), cached on
+    SQLite's schema cookie so converged stores pay one PRAGMA read per open.
+    The application's recorded ``schema_version`` integer is deliberately
+    not consulted — it legitimately sits behind ``SCHEMA_VERSION`` on
+    FTS5-unavailable runtimes even when every regular table has converged.
+    The healthy read path never takes a write lock or requests a checkpoint.
+    """
+    import sqlite3
+
+    from hermes_state import SessionDB, is_malformed_db_error
+    from hermes_state_common import state_schema_mismatches
+
     if not read_only:
         return SessionDB(db_path=db_path, read_only=False)
 
@@ -11243,14 +11313,49 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
             if _needs_bootstrap():
                 SessionDB(db_path=db_path, read_only=False).close()
 
+    store_key = _session_store_key(db_path)
+
+    # Schema cookie observed by the most recent probe. Captured before the
+    # hot-surface probe so a "no such table" failure still records which
+    # schema state was stale — the heal marker is keyed on it. -1 = cookie
+    # unreadable (malformed store).
+    observed_cookie = -1
+
     def _open_probed():
+        nonlocal observed_cookie
         db = SessionDB(db_path=db_path, read_only=True)
         # Unit-test fakes may replace SessionDB without exposing a raw
         # connection. Probe only real connections.
         conn = getattr(db, "_conn", None)
         if conn is not None:
             try:
+                cookie_row = conn.execute("PRAGMA schema_version").fetchone()
+                cookie = int(cookie_row[0]) if cookie_row else -1
+                observed_cookie = cookie
                 conn.execute(_SESSION_DB_READ_PROBE_SQL).fetchone()
+                # Contract diff, cached on the engine's schema cookie: a
+                # store that converged and has seen no DDL since costs one
+                # PRAGMA read per open here.
+                if _session_db_contract_validated.get(store_key) != cookie:
+                    mismatches = state_schema_mismatches(conn)
+                    if mismatches:
+                        raise _StaleSessionSchema(
+                            f"{db_path.name} behind schema contract: "
+                            + "; ".join(mismatches[:4])
+                        )
+                    # Re-read the cookie after the diff: an external process
+                    # (another profile's gateway reconciling) may have run
+                    # DDL mid-diff, making the diff's view unreliable. Cache
+                    # only a fenced result; an unfenced pass still serves
+                    # this request and revalidates on the next open.
+                    cookie_after_row = conn.execute(
+                        "PRAGMA schema_version"
+                    ).fetchone()
+                    cookie_after = (
+                        int(cookie_after_row[0]) if cookie_after_row else -2
+                    )
+                    if cookie_after == cookie:
+                        _session_db_contract_validated[store_key] = cookie
             except BaseException:
                 db.close()
                 raise
@@ -11258,12 +11363,41 @@ def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):
 
     try:
         return _open_probed()
-    except sqlite3.DatabaseError as exc:
-        message = str(exc).lower()
-        stale_schema = "no such table" in message or "no such column" in message
-        if not stale_schema and not is_malformed_db_error(exc):
-            raise
-        SessionDB(db_path=db_path, read_only=False).close()
+    except (_StaleSessionSchema, sqlite3.DatabaseError) as exc:
+        if not isinstance(exc, _StaleSessionSchema):
+            message = str(exc).lower()
+            stale_schema = "no such table" in message or "no such column" in message
+            if not stale_schema and not is_malformed_db_error(exc):
+                raise
+        # Serialise the writable heal: concurrent stale reads must not run
+        # overlapping DDL against one store.
+        heal_key = (store_key, observed_cookie)
+        with _session_db_bootstrap_lock:
+            if heal_key not in _session_db_heal_attempted:
+                # First healer for this stale schema state in this process.
+                # A concurrent request may still have repaired it between
+                # our failed probe and taking the lock — the writable open
+                # is idempotent, so one redundant reconcile is cheaper than
+                # re-probing here.
+                #
+                # Mark BEFORE opening writable: a reconcile that raises
+                # deterministically (disk full, unfixable DDL) must not be
+                # retried by every subsequent poll. Only transient lock
+                # contention un-marks itself to stay retryable.
+                _session_db_heal_attempted.add(heal_key)
+                try:
+                    SessionDB(db_path=db_path, read_only=False).close()
+                except sqlite3.OperationalError as heal_exc:
+                    heal_message = str(heal_exc).lower()
+                    if "locked" in heal_message or "busy" in heal_message:
+                        _session_db_heal_attempted.discard(heal_key)
+                    raise
+        # The reopen keeps the full probe + contract diff: if the writable
+        # reconcile could not converge the store, the error propagates to
+        # the route (fail-visible) instead of silently serving a degraded
+        # read surface. The heal marker above still guarantees at most one
+        # writable heal per stale schema state — an unhealable store costs
+        # one error per request, never a DDL loop.
         return _open_probed()
 
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -612,3 +612,85 @@ AFTER UPDATE OF content, tool_name, tool_calls ON messages BEGIN
     );
 END;
 """
+
+
+# ---------------------------------------------------------------------------
+# Schema contract (derived from SCHEMA_SQL — single source of truth)
+# ---------------------------------------------------------------------------
+
+# Lazily-built {table: {column, ...}} contract parsed from SCHEMA_SQL via an
+# in-memory database (same Beets/sqlite-utils trick as
+# SessionSchemaMixin._parse_schema_columns). SCHEMA_SQL is static application
+# code: if it fails to parse, that is a programming fault and the error must
+# propagate — silently disabling drift detection for the whole process would
+# recreate the OOF-76 false-green. ``None`` = not built yet.
+_STATE_SCHEMA_CONTRACT_CACHE = None
+
+
+def _state_schema_contract():
+    """Return the expected {table: {columns}} map for a session store."""
+    global _STATE_SCHEMA_CONTRACT_CACHE
+    if _STATE_SCHEMA_CONTRACT_CACHE is not None:
+        return _STATE_SCHEMA_CONTRACT_CACHE
+    import sqlite3
+
+    contract = {}
+    ref = sqlite3.connect(":memory:")
+    try:
+        ref.executescript(SCHEMA_SQL)
+        for (tbl,) in ref.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall():
+            contract[tbl] = {
+                row[1] for row in ref.execute(f'PRAGMA table_info("{tbl}")')
+            }
+    finally:
+        ref.close()
+    _STATE_SCHEMA_CONTRACT_CACHE = contract
+    return contract
+
+
+def state_schema_mismatches(conn) -> "list[str]":
+    """Diff a live connection's regular tables against the SCHEMA_SQL contract.
+
+    Returns bounded human-readable mismatch descriptions (missing tables or
+    columns), or ``[]`` when the store converges. FTS virtual tables are
+    intentionally out of scope: their layout is capability-dependent
+    (``fts_storage_version`` in ``state_meta``) and managed separately, and
+    the recorded ``schema_version`` may legitimately sit behind
+    ``SCHEMA_VERSION`` on FTS5-unavailable runtimes even after every regular
+    table has converged — which is exactly why callers must diff the
+    contract, not the version integer (OOF-76).
+
+    A store with no tables at all is treated as uninitialised (``[]``) —
+    bootstrap owns creation, not this check. Once any table exists, every
+    contract table and column is required. Live-database errors (locked,
+    malformed) propagate to the caller.
+    """
+    contract = _state_schema_contract()
+    live_tables = {
+        row[0]
+        for row in conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+    }
+    if not live_tables:
+        # A database with no tables at all is uninitialised, not stale —
+        # bootstrap owns creation. Any non-empty database claiming to be a
+        # session store must satisfy the full contract; a store holding
+        # only foreign tables is exactly the failure this check surfaces.
+        return []
+    mismatches = []
+    for tbl in sorted(contract):
+        if tbl not in live_tables:
+            mismatches.append(f"missing table {tbl}")
+            continue
+        live_cols = {
+            row[1] for row in conn.execute(f'PRAGMA table_info("{tbl}")')
+        }
+        missing = sorted(contract[tbl] - live_cols)
+        if missing:
+            mismatches.append(f"table {tbl} missing columns: {', '.join(missing)}")
+    return mismatches

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -1,11 +1,42 @@
 from __future__ import annotations
 
 import json
-import os
 import sqlite3
 from pathlib import Path
 
-from gateway.readiness import collect_runtime_readiness
+from gateway.readiness import (
+    _probe_profile_state_dbs,
+    _probe_state_db,
+    collect_runtime_readiness,
+)
+
+
+def _seed_session_store(db_path: Path) -> None:
+    """Create a real schema-converged session store (not a bare fixture DB).
+
+    Readiness is schema-aware since OOF-76: a database holding only foreign
+    tables is exactly the drift the probe exists to catch, so healthy
+    fixtures must carry the real contract.
+    """
+    from hermes_state import SessionDB
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    SessionDB(db_path=db_path).close()
+
+
+def _drop_sessions_column(db_path: Path, column: str) -> None:
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(f"ALTER TABLE sessions DROP COLUMN {column}")
+
+
+def _force_disk_ok(monkeypatch) -> None:
+    """Pin the disk probe: it measures the developer's real volume, and a
+    host sitting above the 90% threshold must not fail unrelated tests."""
+    import gateway.readiness as readiness_mod
+
+    monkeypatch.setattr(
+        readiness_mod, "_probe_disk", lambda _home: {"status": "ok"}
+    )
 
 
 def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monkeypatch):
@@ -15,9 +46,9 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
         "model:\n  provider: openrouter\n  model: test/model\n",
         encoding="utf-8",
     )
-    with sqlite3.connect(home / "state.db") as conn:
-        conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+    _seed_session_store(home / "state.db")
     monkeypatch.setenv("HERMES_HOME", str(home))
+    _force_disk_ok(monkeypatch)
 
     result = collect_runtime_readiness(
         configured_model="test/model",
@@ -35,7 +66,7 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
     assert result["checks"]["model"]["status"] == "ok"
     assert result["checks"]["gateway"]["status"] == "ok"
     assert result["checks"]["background_queues"]["active_api_runs"] == 2
-    assert result["checks"]["disk"]["status"] in {"ok", "degraded"}
+    assert result["checks"]["profile_state_dbs"]["status"] == "ok"
 
 
 def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gateway(
@@ -59,3 +90,172 @@ def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gatewa
     assert (home / "config.yaml").read_text(encoding="utf-8") == "model: [unterminated"
 
 
+
+
+def test_probe_state_db_flags_schema_drift(tmp_path):
+    """A readable store missing contract columns must degrade, not stay green.
+
+    This is the OOF-76 false-green: readability-only probes reported "ok"
+    while every dashboard session route 500'd on the missing columns.
+    """
+    home = tmp_path / ".hermes"
+    _seed_session_store(home / "state.db")
+    assert _probe_state_db(home)["status"] == "ok"
+
+    _drop_sessions_column(home / "state.db", "archived")
+
+    check = _probe_state_db(home)
+    assert check["status"] == "degraded"
+    assert check["detail"] == "schema behind contract"
+    assert check["mismatches"] >= 1
+
+
+def test_probe_state_db_foreign_tables_are_stale_not_ok(tmp_path):
+    """A non-empty DB holding only unrelated tables is drift, not 'ok'."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+    assert _probe_state_db(home)["status"] == "degraded"
+
+
+def test_probe_state_db_missing_and_empty_stores_are_ok(tmp_path):
+    """Uninitialised stores belong to bootstrap, not the readiness probe."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    assert _probe_state_db(home) == {"status": "ok", "detail": "not initialized"}
+
+    # Zero-byte / no-tables store: created but never bootstrapped.
+    sqlite3.connect(home / "state.db").close()
+    assert _probe_state_db(home)["status"] == "ok"
+
+
+def test_probe_profile_state_dbs_reports_idle_profile_drift(tmp_path):
+    """Named-profile stores drift silently (no writable opens while idle) —
+    the aggregate probe must surface counts without leaking profile names."""
+    home = tmp_path / ".hermes"
+    _seed_session_store(home / "profiles" / "alpha" / "state.db")
+    _seed_session_store(home / "profiles" / "bravo" / "state.db")
+    assert _probe_profile_state_dbs(home)["status"] == "ok"
+
+    _drop_sessions_column(home / "profiles" / "bravo" / "state.db", "pinned")
+
+    check = _probe_profile_state_dbs(home)
+    assert check["status"] == "degraded"
+    assert check["checked"] == 2
+    assert check["stale"] == 1
+    assert check["errors"] == 0
+    # Aggregate counts only: never profile names or paths.
+    assert "alpha" not in json.dumps(check)
+    assert "bravo" not in json.dumps(check)
+
+
+def test_probe_profile_state_dbs_bounded_scan_flags_truncation(
+    tmp_path, monkeypatch
+):
+    """The probe must stay bounded inside a health poll: entries past the
+    cap are never opened, and the verdict admits its incomplete coverage
+    via the truncated flag instead of degrading a healthy fleet."""
+    import gateway.readiness as readiness_mod
+
+    home = tmp_path / ".hermes"
+    for name in ("alpha", "bravo", "charlie"):
+        _seed_session_store(home / "profiles" / name / "state.db")
+    monkeypatch.setattr(readiness_mod, "_PROFILE_STORE_PROBE_LIMIT", 2)
+    # The capped window rotates across polls via a module-global cursor —
+    # pin it so this test asserts against a known window regardless of
+    # execution order.
+    monkeypatch.setattr(readiness_mod, "_profile_probe_cursor", 0)
+
+    check = _probe_profile_state_dbs(home)
+
+    assert check["status"] == "ok"
+    assert check["checked"] == 2
+    assert check["truncated"] is True
+    assert check["detail"] == "profile store probe incomplete"
+
+    # A stale store INSIDE the scanned window still degrades the check even
+    # when the scan is truncated.
+    _drop_sessions_column(home / "profiles" / "alpha" / "state.db", "archived")
+    stale_check = _probe_profile_state_dbs(home)
+    assert stale_check["status"] == "degraded"
+    assert stale_check["stale"] == 1
+    assert stale_check["truncated"] is True
+
+
+def test_probe_profile_state_dbs_capped_window_rotates_across_polls(
+    tmp_path, monkeypatch
+):
+    """With more profiles than the cap, successive polls must rotate the
+    scanned window: a stale store past the first window is eventually
+    inspected instead of staying invisible forever (the OOF-76 blind spot
+    relocated past the cap)."""
+    import gateway.readiness as readiness_mod
+
+    home = tmp_path / ".hermes"
+    for name in ("alpha", "bravo", "charlie", "delta"):
+        _seed_session_store(home / "profiles" / name / "state.db")
+    # Stale store deliberately LAST in sort order, outside the first window.
+    _drop_sessions_column(home / "profiles" / "delta" / "state.db", "archived")
+    monkeypatch.setattr(readiness_mod, "_PROFILE_STORE_PROBE_LIMIT", 2)
+    monkeypatch.setattr(readiness_mod, "_profile_probe_cursor", 0)
+
+    first = _probe_profile_state_dbs(home)
+    assert first["status"] == "ok"
+    assert first["truncated"] is True
+
+    second = _probe_profile_state_dbs(home)
+    assert second["status"] == "degraded"
+    assert second["stale"] == 1
+    assert second["truncated"] is True
+
+
+def test_probe_profile_state_dbs_no_profiles_is_ok(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    assert _probe_profile_state_dbs(home) == {"status": "ok", "detail": "no profiles"}
+
+
+def test_probe_profile_state_dbs_unreadable_store_counts_as_error(tmp_path):
+    home = tmp_path / ".hermes"
+    store = home / "profiles" / "broken" / "state.db"
+    store.parent.mkdir(parents=True)
+    store.write_bytes(b"this is not a sqlite database at all" * 40)
+
+    check = _probe_profile_state_dbs(home)
+    assert check["status"] == "degraded"
+    assert check["errors"] == 1
+
+
+def test_collect_runtime_readiness_reports_stale_profile_store_as_advisory(
+    tmp_path, monkeypatch
+):
+    """Profile drift must be VISIBLE in checks but excluded from the
+    restart-driving overall verdict: restarting cannot heal an idle profile
+    store (only the dashboard's heal-capable read path can), so a degraded
+    rollup here would invite an unhealable-signal restart loop (OOF-39
+    class)."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text(
+        "model:\n  provider: openrouter\n  model: test/model\n",
+        encoding="utf-8",
+    )
+    _seed_session_store(home / "state.db")
+    _seed_session_store(home / "profiles" / "ops" / "state.db")
+    _drop_sessions_column(home / "profiles" / "ops" / "state.db", "archived")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _force_disk_ok(monkeypatch)
+
+    result = collect_runtime_readiness(
+        configured_model="test/model",
+        runtime_status={
+            "gateway_state": "running",
+            "platforms": {"telegram": {"state": "connected"}},
+            "updated_at": "2026-07-09T00:00:00Z",
+        },
+    )
+
+    assert result["status"] == "ok"
+    assert result["checks"]["state_db"]["status"] == "ok"
+    assert result["checks"]["profile_state_dbs"]["status"] == "degraded"

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1672,6 +1672,229 @@ class TestWebServerEndpoints:
         assert payload["limit"] == 3
         assert len(payload["sessions"]) == 3
 
+    @staticmethod
+    def _seed_named_profile_store(name: str):
+        """Create profiles/<name>/state.db with one real session and return
+        the store path. Named profiles are the OOF-76 population: their
+        gateways aren't running, so nothing ever opens these stores writable."""
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "profiles" / name / "state.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session(f"{name}-session", source="cli")
+            seed.append_message(
+                session_id=f"{name}-session", role="user", content="hello"
+            )
+        finally:
+            seed.close()
+        return db_path
+
+    @staticmethod
+    def _degrade_store(db_path, *, drop_column=None, drop_table=None):
+        import sqlite3
+
+        legacy = sqlite3.connect(str(db_path))
+        try:
+            if drop_column:
+                legacy.execute(
+                    f"ALTER TABLE sessions DROP COLUMN {drop_column}"
+                )
+            if drop_table:
+                legacy.execute(f"DROP TABLE {drop_table}")
+            legacy.commit()
+        finally:
+            legacy.close()
+
+    @pytest.mark.parametrize(
+        "degradation",
+        [{"drop_column": "archived"}, {"drop_table": "system_prompts"}],
+        ids=["missing-column", "missing-table"],
+    )
+    def test_profiles_sessions_heals_stale_named_profile_store(self, degradation):
+        """OOF-76 regression: a named profile whose store predates the current
+        read surface must be healed by the aggregate route, not 500 forever.
+        Idle named profiles never get a writable open, so before the shared
+        heal-capable opener this drift was permanent until redeploy."""
+        import sqlite3
+
+        db_path = self._seed_named_profile_store("opsbot")
+        self._degrade_store(db_path, **degradation)
+
+        resp = self.client.get("/api/profiles/sessions?profile=opsbot")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload.get("errors") in (None, [])
+        assert [row["id"] for row in payload["sessions"]] == ["opsbot-session"]
+        healed = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1] for row in healed.execute("PRAGMA table_info(sessions)")
+            }
+            tables = {
+                row[0]
+                for row in healed.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+        finally:
+            healed.close()
+        assert "archived" in columns
+        assert "system_prompts" in tables
+
+    def test_profiles_sessions_heals_repeated_drift_in_one_process(self):
+        """The heal marker is keyed on (store identity, stale schema cookie),
+        not the path alone: a SECOND drift later in the process lifetime
+        (restore rewriting the file, external DDL) must get its own heal
+        instead of 500ing until restart."""
+        import sqlite3
+
+        db_path = self._seed_named_profile_store("driftbot")
+        self._degrade_store(db_path, drop_column="archived")
+        first = self.client.get("/api/profiles/sessions?profile=driftbot")
+        assert first.status_code == 200
+
+        self._degrade_store(db_path, drop_column="pinned")
+        second = self.client.get("/api/profiles/sessions?profile=driftbot")
+
+        assert second.status_code == 200
+        assert [row["id"] for row in second.json()["sessions"]] == [
+            "driftbot-session"
+        ]
+        healed = sqlite3.connect(str(db_path))
+        try:
+            columns = {
+                row[1] for row in healed.execute("PRAGMA table_info(sessions)")
+            }
+        finally:
+            healed.close()
+        assert {"archived", "pinned"} <= columns
+
+    def test_profiles_sessions_concurrent_stale_reads_heal_once(self, monkeypatch):
+        """Concurrent requests against one stale store must serialise into a
+        single writable reconcile (DDL), with every request still succeeding."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        import hermes_state
+
+        db_path = self._seed_named_profile_store("racebot")
+        self._degrade_store(db_path, drop_column="archived")
+
+        real_session_db = hermes_state.SessionDB
+        writable_opens = []
+
+        class CountingSessionDB(real_session_db):
+            def __init__(self, *args, **kwargs):
+                if not kwargs.get("read_only", False):
+                    writable_opens.append(kwargs.get("db_path"))
+                super().__init__(*args, **kwargs)
+
+        # The opener resolves SessionDB at call time via `from hermes_state
+        # import SessionDB`, so patching the module attribute is sufficient.
+        monkeypatch.setattr(hermes_state, "SessionDB", CountingSessionDB)
+
+        with ThreadPoolExecutor(max_workers=6) as pool:
+            responses = list(
+                pool.map(
+                    self.client.get,
+                    ["/api/profiles/sessions?profile=racebot"] * 6,
+                )
+            )
+
+        assert [r.status_code for r in responses] == [200] * 6
+        stale_store_heals = [p for p in writable_opens if p == db_path]
+        assert len(stale_store_heals) == 1
+
+    def test_profiles_sessions_sidebar_heals_stale_named_profile_store(self):
+        """The batched sidebar aggregate uses the same heal-capable opener."""
+        db_path = self._seed_named_profile_store("sidebot")
+        self._degrade_store(db_path, drop_column="archived")
+
+        resp = self.client.get("/api/profiles/sessions/sidebar")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload.get("errors") in (None, [])
+        recents = payload["recents"]["sessions"]
+        assert any(row["id"] == "sidebot-session" for row in recents)
+
+    def test_stale_store_deterministic_heal_failure_is_not_retried(
+        self, monkeypatch
+    ):
+        """A writable reconcile that fails deterministically (disk full,
+        unfixable DDL) must be attempted exactly once per stale schema
+        state — never re-run as DDL on every subsequent poll."""
+        import sqlite3
+
+        import hermes_state
+
+        db_path = self._seed_named_profile_store("doomedbot")
+        self._degrade_store(db_path, drop_column="archived")
+
+        real_session_db = hermes_state.SessionDB
+        writable_opens = []
+
+        class FailingWritableSessionDB(real_session_db):
+            def __init__(self, *args, **kwargs):
+                if (
+                    not kwargs.get("read_only", False)
+                    and kwargs.get("db_path") == db_path
+                ):
+                    writable_opens.append(kwargs.get("db_path"))
+                    raise sqlite3.OperationalError("disk I/O error")
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(hermes_state, "SessionDB", FailingWritableSessionDB)
+
+        first = self.client.get("/api/profiles/sessions?profile=doomedbot")
+        second = self.client.get("/api/profiles/sessions?profile=doomedbot")
+
+        # The route degrades per-profile (errors list), never 500s the
+        # aggregate — and the failed heal is not re-attempted as DDL.
+        assert first.status_code == 200
+        assert second.status_code == 200
+        assert len(writable_opens) == 1
+
+    def test_stale_store_locked_heal_failure_stays_retryable(self, monkeypatch):
+        """Transient lock/busy contention during the writable reconcile must
+        NOT consume the store's single heal attempt: once the lock clears,
+        the next request heals and succeeds."""
+        import sqlite3
+
+        import hermes_state
+
+        db_path = self._seed_named_profile_store("lockedbot")
+        self._degrade_store(db_path, drop_column="archived")
+
+        real_session_db = hermes_state.SessionDB
+        writable_opens = []
+
+        class LockedOnceSessionDB(real_session_db):
+            def __init__(self, *args, **kwargs):
+                if (
+                    not kwargs.get("read_only", False)
+                    and kwargs.get("db_path") == db_path
+                ):
+                    writable_opens.append(kwargs.get("db_path"))
+                    if len(writable_opens) == 1:
+                        raise sqlite3.OperationalError("database is locked")
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(hermes_state, "SessionDB", LockedOnceSessionDB)
+
+        first = self.client.get("/api/profiles/sessions?profile=lockedbot")
+        second = self.client.get("/api/profiles/sessions?profile=lockedbot")
+
+        assert first.status_code == 200  # degraded per-profile, not healed yet
+        assert second.status_code == 200
+        assert [row["id"] for row in second.json()["sessions"]] == [
+            "lockedbot-session"
+        ]
+        assert len(writable_opens) == 2
+
     def test_get_session_messages_rejects_negative_limit(self):
         """limit=-1 previously bypassed the documented 500-row clamp because
         min(-1, 500) == -1, which SQLite treats as 'no limit'."""

--- a/tests/state/test_state_schema_contract.py
+++ b/tests/state/test_state_schema_contract.py
@@ -1,0 +1,122 @@
+"""Contract-diff primitives behind the OOF-76 stale-schema detection.
+
+``state_schema_mismatches`` is what lets read paths and readiness probes
+distinguish "this store is behind the dashboard's read surface" from "this
+store legitimately reports an older application ``schema_version``" — the
+two were conflated in the original incident (FTS5-unavailable runtimes pin
+the version integer below ``SCHEMA_VERSION`` by design even when every
+regular table has converged).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from contextlib import closing
+
+import pytest
+
+from hermes_state_common import (
+    SCHEMA_SQL,
+    _state_schema_contract,
+    state_schema_mismatches,
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    """A schema-converged store built straight from SCHEMA_SQL."""
+    path = tmp_path / "state.db"
+    with closing(sqlite3.connect(path)) as conn:
+        conn.executescript(SCHEMA_SQL)
+    return path
+
+
+def _connect(path):
+    return closing(sqlite3.connect(path))
+
+
+class TestStateSchemaContract:
+    def test_contract_contains_core_tables_and_columns(self):
+        contract = _state_schema_contract()
+        assert "sessions" in contract
+        assert "messages" in contract
+        assert "system_prompts" in contract
+        # The exact read-surface columns the OOF-76 incident 500'd on.
+        assert {"archived", "pinned", "last_activity_at", "system_prompt_hash"} <= (
+            contract["sessions"]
+        )
+        assert {"active", "compacted"} <= contract["messages"]
+
+    def test_contract_excludes_fts_virtual_tables(self):
+        # FTS layout is capability-dependent (fts_storage_version) and
+        # managed separately — requiring it here would flag every
+        # FTS5-unavailable runtime as permanently stale.
+        contract = _state_schema_contract()
+        assert not any("fts" in table for table in contract)
+
+    def test_contract_is_cached(self):
+        assert _state_schema_contract() is _state_schema_contract()
+
+
+class TestStateSchemaMismatches:
+    def test_converged_store_has_no_mismatches(self, store):
+        with _connect(store) as conn:
+            assert state_schema_mismatches(conn) == []
+
+    def test_lagging_schema_version_integer_is_not_drift(self, store):
+        # The application version integer sitting behind SCHEMA_VERSION is
+        # legitimate (FTS5-unavailable runtimes) — only the table contract
+        # matters. This is the exact false-positive OOF-76's fix must avoid.
+        with _connect(store) as conn:
+            conn.execute("DELETE FROM schema_version")
+            conn.execute("INSERT INTO schema_version (version) VALUES (1)")
+            conn.commit()
+            assert conn.execute("SELECT version FROM schema_version").fetchone() == (1,)
+            assert state_schema_mismatches(conn) == []
+
+    def test_missing_column_is_reported(self, store):
+        with _connect(store) as conn:
+            conn.execute("ALTER TABLE sessions DROP COLUMN archived")
+            conn.commit()
+            mismatches = state_schema_mismatches(conn)
+        assert mismatches == ["table sessions missing columns: archived"]
+
+    def test_missing_table_is_reported(self, store):
+        with _connect(store) as conn:
+            conn.execute("DROP TABLE system_prompts")
+            conn.commit()
+            mismatches = state_schema_mismatches(conn)
+        assert "missing table system_prompts" in mismatches
+
+    def test_extra_tables_and_columns_are_tolerated(self, store):
+        # Reconcile only ever ADDs; newer stores read by older code, or
+        # user-created side tables, must not be flagged.
+        with _connect(store) as conn:
+            conn.execute("CREATE TABLE user_side_table (id INTEGER)")
+            conn.execute("ALTER TABLE sessions ADD COLUMN future_col TEXT")
+            conn.commit()
+            assert state_schema_mismatches(conn) == []
+
+    def test_empty_database_is_uninitialised_not_stale(self, tmp_path):
+        path = tmp_path / "fresh.db"
+        with _connect(path) as conn:
+            assert state_schema_mismatches(conn) == []
+
+    def test_foreign_only_database_is_drift(self, tmp_path):
+        # Once ANY table exists the full contract is required: a database
+        # holding only unrelated tables is exactly the failure to surface.
+        path = tmp_path / "foreign.db"
+        with _connect(path) as conn:
+            conn.execute("CREATE TABLE probe (id INTEGER PRIMARY KEY)")
+            conn.commit()
+            mismatches = state_schema_mismatches(conn)
+        assert mismatches
+        assert any(m == "missing table sessions" for m in mismatches)
+
+    def test_multiple_missing_columns_sorted_and_grouped(self, store):
+        with _connect(store) as conn:
+            conn.execute("ALTER TABLE sessions DROP COLUMN pinned")
+            conn.execute("ALTER TABLE sessions DROP COLUMN archived")
+            conn.commit()
+            mismatches = state_schema_mismatches(conn)
+        assert mismatches == ["table sessions missing columns: archived, pinned"]


### PR DESCRIPTION
## Problem (OOF-76)

Named-profile session stores (`<home>/profiles/<name>/state.db`) drift behind the dashboard's read surface silently: idle profiles' gateways never open them writable, so `_reconcile_columns()` never runs. Once a store misses newer read-surface tables/columns (`system_prompts`, `sessions.last_activity_at`/`system_prompt_hash`, ...), every cross-profile dashboard session route 500s **forever** — until a redeploy happens to force a writable open somewhere. Two production instances were forensically confirmed serving permanent 500s this way (one store stuck at schema v23) while readiness stayed green.

The false-green had a second cause worth calling out: the application `schema_version` integer **legitimately lags** `SCHEMA_VERSION` on FTS5-unavailable runtimes even when every regular table has converged, so any drift check keyed on that integer is wrong by design. The fix diffs the actual table contract instead.

## Fix

**`hermes_state_common.py`** — new SCHEMA_SQL-derived contract:
- `_state_schema_contract()` builds a `{table: {columns}}` map by executing `SCHEMA_SQL` against an in-memory database (same technique as `SessionSchemaMixin._parse_schema_columns`), cached per process.
- `state_schema_mismatches(conn)` diffs a live store's regular tables against it. FTS virtual tables and the `schema_version` integer are deliberately out of scope. A store with zero tables is uninitialised (bootstrap's job), not stale; once any contract table exists, the full contract is required. Extra tables/columns are tolerated (reconcile only ever ADDs).

**`hermes_cli/web_server.py`** — shared heal-capable read-only opener `_open_session_db_at_path()`:
- Staleness detected two ways: a fast hot-surface read probe (extended to the newest dashboard columns) plus the full contract diff, cached on SQLite's schema cookie (`PRAGMA schema_version` — the engine's DDL counter) so converged stores pay one PRAGMA read per open.
- On staleness: **one** serialized, idempotent writable reconcile per `(store identity, stale cookie)` state. Concurrent stale reads produce exactly one DDL heal. Deterministic heal failures (disk full, unfixable DDL) are never re-run as DDL on every poll; transient lock/busy contention un-marks itself and stays retryable.
- Store identity is `(path, st_dev, st_ino)` so a restore/recovery replacing the file in place gets fresh heal + validation state; a second drift later in the process lifetime gets its own heal attempt (keyed on the observed cookie) instead of 500ing until restart.
- Reopen after heal keeps full probing: an unhealable store fails visible at the route, never silently serves a degraded read surface, and never loops DDL.

**`hermes_cli/web_routers/profiles.py`** — both cross-profile aggregation routes (`/api/profiles/sessions`, `/api/profiles/sessions/sidebar`) now go through the shared opener instead of raw read-only `SessionDB` opens (the primary 500 path in the incident).

**`gateway/readiness.py`** — schema-aware probes:
- `state_db` probe now degrades on a readable-but-drifted default store (was readability-only — the exact false-green).
- New `profile_state_dbs` probe: bounded scan of named-profile stores (count cap **and** 1s wall-clock budget — each sqlite connect carries a 1s busy timeout), aggregate counts only (never profile names/paths), capped window **rotates across polls** so fleets larger than the cap get eventual coverage, truncation reported explicitly.
- The profile check is **advisory**: visible in `checks` but excluded from the restart-driving overall verdict. Restarting cannot heal an idle profile store (only the dashboard's heal-capable read path can), so folding it into the rollup would invite an unhealable-signal restart loop (OOF-39 class). Public `/api/status` keeps its default-store-only storage probe for the same reason.

## Tests

- `tests/state/test_state_schema_contract.py` (new): contract contents, FTS exclusion, caching; converged/empty/foreign-only stores; **lagging `schema_version` integer is NOT drift** (the OOF-76 false-positive); missing table/column reporting; extra tables/columns tolerated.
- `tests/gateway/test_readiness.py`: drift degrades `state_db`; foreign-only store is drift; uninitialised stores stay ok; profile probe aggregate counts + no name leakage; bounded scan + truncation flag; window rotation reaches a stale store past the cap; advisory rollup (drifted profile store ⇒ overall still ok, check degraded); disk probe pinned (host sits above the 90% threshold — pre-existing environmental failure now mooted).
- `tests/hermes_cli/test_web_server.py`: idle named-profile heal for missing column AND missing table; sidebar route heal; repeated drift in one process heals again; 6 concurrent stale reads → exactly one writable reconcile, all 200; deterministic heal failure attempted once, transient lock failure retried and healed.

## Validation

- Targeted: 167 passed / 1 skipped across web-server + readiness + contract suites; ruff clean.
- Full `tests/gateway/`: branch 10 failed / 4857 passed vs baseline (`origin/main` @ ff3793fdf) 12 failed / 4849 passed — **zero branch-only failures**; the branch additionally fixes the environmental readiness failure.
- Broad web/state/hermes_state comparison: failure sets identical to baseline (pre-existing `test_dashboard_param_clamps` + `test_write_lock_patience` flakes on both sides).

Fixes OOF-76.
