### PR TITLE
fix(gateway): isolate _auth_env under multiplex to prevent cross-profile allowlist leak (#80026)

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -29,12 +29,27 @@ from gateway.whatsapp_identity import (
 
 
 def _auth_env(name: str, default: str = "") -> str:
-    """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
+    """Read allowlist/auth env; prefer profile secret_scope under multiplex.
+
+    Under multiplex, when a profile scope is installed but does *not* contain
+    the requested key, return *default* instead of falling through to
+    ``os.environ``.  The process env may hold another profile's
+    first-writer-bridged value, so falling through would leak profile A's
+    allowlist into profile B (issue #80026).  Single-profile deployments
+    (no scope, or multiplex off) keep the legacy ``os.getenv`` fallback.
+    """
     if not name:
         return default
     try:
-        from agent.secret_scope import get_secret
+        from agent.secret_scope import current_secret_scope, get_secret, is_multiplex_active
 
+        scope = current_secret_scope()
+        if scope is not None and is_multiplex_active():
+            val = scope.get(name)
+            if val is None:
+                return default
+            return str(val).strip()
+        # Single-profile: prefer scope value, fall back to env.
         val = get_secret(name)
         if val is not None and str(val).strip():
             return str(val).strip()

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -97,16 +97,6 @@ class TestAuthzAllowAllScope:
         finally:
             ss.reset_secret_scope(tok)
 
-    @pytest.mark.xfail(
-        reason=(
-            "gateway/authz_mixin.py still reads the platform allow-all flag via "
-            "_auth_env, which falls through to os.environ on a scoped miss; the "
-            "scope-authoritative gate (_platform_gate_env semantics) for the "
-            "remaining authz_mixin reads lands in a separate PR. Flips green "
-            "when that PR converts the allow-all read."
-        ),
-        strict=True,
-    )
     def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
         # The PRIMARY profile opted in via os.environ; the secondary profile's
         # scope has no opt-in. The secondary must NOT inherit the primary's


### PR DESCRIPTION
## Fix: Isolate `_auth_env` under multiplex to prevent cross-profile allowlist leak

Fixes #80026

### Root Cause

`_auth_env()` in `gateway/authz_mixin.py` reads allowlist/auth environment variables used by the gateway's second authorization gate. When the profile's secret scope does not contain a requested key, it falls back to `os.getenv()` — the process-global environment.

Under multiplexed deployments, the process env holds **first-writer-bridged** values from whichever profile armed its YAML→env bridge first. This causes profile B's authorization gate to consume profile A's allowlist values (e.g. `DISCORD_ALLOWED_USERS`, `GATEWAY_ALLOWED_USERS`).

### Fix

Apply the same multiplex isolation guard already used by `_platform_gate_env()` (lines 46-73): when a profile scope is installed AND `is_multiplex_active()`, absent keys return `default` instead of falling through to `os.environ`.

Single-profile deployments (no scope installed, or multiplex off) retain the legacy `os.getenv()` fallback — behavior-neutral for the common case.

### Verification

- `python3 -m py_compile gateway/authz_mixin.py` — syntax OK
- Pattern matches existing `_platform_gate_env()` which has been in production since the #72348 fix
- 6 call sites in `_authorization_gate_check()` and `_is_user_authorized()` now use the isolated path under multiplex
