### PR TITLE
fix(guard): skip NUL-binary text in recursion and bound remote script reads

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -332,6 +332,15 @@ def _contains_unsafe_gateway_action(
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
             script_text = read_remote_script(str(script_path))
+        if script_text and "\x00" in script_text:
+            # Any read_remote_script callback (terminal_tool's env-based
+            # fallback, SSH/Modal/Daytona backends) may return binary
+            # content. A NUL byte in the text marks machine code, not a
+            # shell script: feeding it to the recursion re-tokenizes it
+            # into NUL-bearing paths that crash os.open with
+            # `ValueError: embedded null byte` (#77703, #77780). Treat it
+            # as "nothing to scan", mirroring _read_referenced_script.
+            continue
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2565,6 +2565,11 @@ def terminal_tool(
                             # Binary content from a remote `cat`: skip for the
                             # same reason as the local branch above (#77703).
                             return None
+                        if len(output) > 1024 * 1024:
+                            # Same size bound as the local branch: never feed
+                            # oversized content (e.g. a large remote binary)
+                            # into the scanner recursion (#77780).
+                            return None
                         return output
                 except Exception:
                     pass


### PR DESCRIPTION
## What does this PR do?

Closes the two remaining fringe cases in the lifecycle-guard scanner that
survived #79454 (merged as `49d8a155c4`):

1. **NUL-binary text in the recursion** (`cron/lifecycle_guard.py`):
   `_contains_unsafe_gateway_action` feeds `script_text` returned by a
   `read_remote_script` callback into the recursive scan without checking
   for NUL bytes. Remote backends (terminal_tool's env-based `cat`
   fallback, SSH/Modal/Daytona) can return binary content; re-tokenizing
   machine code produces NUL-bearing paths that crash `os.open` with
   `ValueError: embedded null byte` (#77703, #77780). This mirrors the
   existing NUL skip in `_read_referenced_script` and treats such text as
   "nothing to scan".

2. **Unbounded remote `cat`** (`tools/terminal_tool.py`):
   the env-based `cat` fallback in `_read_script_in_env` had no size
   bound. A large remote binary (>1 MiB) was fully scanned, hitting the
   same oversized-content path that triggers false-positive blocks
   ("cannot restart or stop the gateway"). Applies the same 1-MiB bound
   as the local read branch.

## Verification

`guard-fringe-tests.py` against this branch (imports `lifecycle_guard.py`
via importlib and statically inspects `terminal_tool.py`):

- T3 (recursion guard: NUL-binary text from callback) — **PASS**
- T4 (remote cat size bound) — **PASS**

For comparison, main + #79454 (`49d8a155c4`) fails 0/4 of these fringe
tests. T1/T2 (expanduser NUL in `_resolve_terminal_script_path` /
`_resolve_script_path`) are a separate, intentionally out-of-scope fix.

## Related

- #77703 (Windows report, affects Linux too)
- #77780 (macOS + Linux evidence)
- #79454 (previously merged partial fix)
