### PR TITLE
fix(recovery): sqlite_sequence hint caps the high-edge probe when the tail leaf is corrupt (#80205)

### DIFF
--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -533,6 +533,14 @@ def _probe_populated_edge(
     domain at X; a probe that errors (its b-tree path crosses the damage) or
     finds a row keeps growing. At most ~64 probes per edge, so the cap costs
     a bounded, tiny slice of the salvage budget instead of all of it.
+
+    The ``sqlite_sequence`` hint (AUTOINCREMENT tables) caps in one query:
+    when the damaged leaf sits at the populated range's edge, every outward
+    gallop probe must cross it to confirm emptiness and raises instead —
+    the gallop then doubles into the synthetic tail and exhausts the budget,
+    the exact #80205 failure. The sequence value is a best-effort hint only
+    (never the sole source of truth); it is checked against ``anchor`` and
+    skipped on any read error.
     """
 
     ascending = edge == "high"
@@ -543,6 +551,25 @@ def _probe_populated_edge(
     )
     domain_limit = _MAX_SQLITE_ROWID if ascending else _MIN_SQLITE_ROWID
     result: dict[str, Any] = {"edge": edge, "probes": 0, "capped": False}
+
+    # AUTOINCREMENT hint (issue #80205 suggestion 2): sqlite_sequence records
+    # the highest rowid ever assigned. When the damaged leaf sits at the edge
+    # of the populated range, the gallop below can never confirm emptiness
+    # (every outward probe must cross the corrupt page and raises), so this
+    # hint caps in one query. Best-effort: only used when >= the readable
+    # anchor, skipped on read errors.
+    if ascending:
+        try:
+            row = source.execute(
+                "SELECT seq FROM sqlite_sequence WHERE name = ?", (table,)
+            ).fetchone()
+        except sqlite3.DatabaseError:
+            row = None
+        if row is not None and isinstance(row[0], int) and int(row[0]) >= anchor:
+            result["bound"] = int(row[0]) + 1
+            result["capped"] = True
+            result["hint"] = "sqlite_sequence"
+            return result
 
     position = anchor
     span = 1

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -541,6 +541,14 @@ def _probe_populated_edge(
     the exact #80205 failure. The sequence value is a best-effort hint only
     (never the sole source of truth); it is checked against ``anchor`` and
     skipped on any read error.
+
+    Scope: only AUTOINCREMENT tables (``messages`` and the other rowid
+    tables in state.db) get the hint. For tables without a sequence entry
+    (e.g. ``sessions``, TEXT primary key) the gallop still cannot confirm
+    emptiness past a corrupt tail leaf and falls back to the domain edge —
+    the residual #80205 budget-burn remains for those tables. Callers can
+    detect a hint-based cap via the ``hint`` key in the result and should
+    treat a hint-capped bound as approximate, not exact.
     """
 
     ascending = edge == "high"
@@ -565,7 +573,12 @@ def _probe_populated_edge(
             ).fetchone()
         except sqlite3.DatabaseError:
             row = None
-        if row is not None and isinstance(row[0], int) and int(row[0]) >= anchor:
+        if (
+            row is not None
+            and isinstance(row[0], int)
+            and int(row[0]) >= anchor
+            and int(row[0]) < domain_limit
+        ):
             result["bound"] = int(row[0]) + 1
             result["capped"] = True
             result["hint"] = "sqlite_sequence"
@@ -813,6 +826,19 @@ def _copy_table_salvage(
         result["error"] = (
             f"copied {result['copied_rows']} and excluded "
             f"{result['excluded_rows']} of {source_rows} source rows"
+        )
+    elif (
+        any(p.get("hint") for p in (bounds.get("edge_probes") or []))
+        and source_rows is None
+    ):
+        # The high bound came from the sqlite_sequence hint and the source
+        # row count is unverifiable (COUNT(*) crossed the damaged page), so a
+        # stale-low seq could silently drop tail rows. Never claim "complete"
+        # on a hint-capped bound without a count check.
+        result["status"] = "partial"
+        result["error"] = (
+            "hint-capped upper bound with unverifiable source row count "
+            "(COUNT(*) crossed the damaged page)"
         )
     else:
         result["status"] = "complete"

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -497,12 +497,66 @@ def _salvage_rowid_bounds(
         rows["low"] = _MIN_SQLITE_ROWID
         result["fallback_edges"].append("low")
     if rows["high"] is None:
-        rows["high"] = _MAX_SQLITE_ROWID
+        rows["high"] = _probe_upper_bound(source, table, rows["low"])
         result["fallback_edges"].append("high")
 
     result["low"] = rows["low"]
     result["high"] = rows["high"]
     return result
+
+
+def _probe_upper_bound(
+    source: sqlite3.Connection,
+    table: str,
+    low: Optional[int],
+) -> int:
+    """Find a practical upper rowid bound when the descending edge probe fails.
+
+    Instead of bounding the missing edge by ``_MAX_SQLITE_ROWID`` — which
+    forces bisection to spend its query budget exploring empty or unreadable
+    space orders of magnitude beyond the populated range — probe outward
+    from the surviving edge with bounded exponential steps. Each probe asks
+    for the highest rowid in ``[low, low + step)``; the first empty probe
+    caps the range just past the last populated region, and bisection then
+    spends its budget near the data instead of across the whole domain.
+    """
+
+    if low is None:
+        return _MAX_SQLITE_ROWID
+    # sqlite_sequence (AUTOINCREMENT) records the highest ever assigned
+    # rowid; a best-effort hint only, never trusted as the sole source of
+    # truth (the issue's suggestion 2).
+    try:
+        row = source.execute(
+            "SELECT seq FROM sqlite_sequence WHERE name = ?",
+            (table,),
+        ).fetchone()
+        if row is not None and isinstance(row[0], int):
+            seq = int(row[0])
+            if seq >= low:
+                return seq + 1
+    except sqlite3.DatabaseError:
+        pass
+
+    step = 1
+    probe_low = low
+    while step <= _MAX_SALVAGE_RANGE_QUERIES:
+        probe_high = low + step
+        try:
+            row = source.execute(
+                f'SELECT rowid FROM "{table}" '
+                "WHERE rowid BETWEEN ? AND ? ORDER BY rowid DESC LIMIT 1",
+                (probe_low, probe_high),
+            ).fetchone()
+        except sqlite3.DatabaseError:
+            # Damaged page inside the probe window — fall back to the domain
+            # max so bisection can isolate the readable sub-ranges.
+            return _MAX_SQLITE_ROWID
+        if row is None:
+            return probe_high
+        probe_low = int(row[0])
+        step *= 2
+    return _MAX_SQLITE_ROWID
 
 
 def _copy_table_salvage(

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -594,6 +594,100 @@ def test_cli_allow_partial_salvages_rows_across_a_corrupt_leaf(
     }
 
 
+def _corrupt_last_table_leaf(path: Path, root_page: int) -> int:
+    """Damage the rightmost data leaf so the descending rowid-edge probe fails.
+
+    The high-edge probe is ``ORDER BY rowid DESC LIMIT 1``; corrupting the
+    leaf holding the largest rowids makes that probe raise
+    ``database disk image is malformed`` while the low edge stays readable.
+    This reproduces #80205's exact shape: the populated range is small, the
+    high-edge probe fails, and the final recoverable row would previously be
+    skipped because bisection exhausted its budget on the domain-sized
+    fallback range.
+    """
+    page_size, leaf_pages = _btree_leaf_pages(path, root_page)
+    assert len(leaf_pages) >= 2
+    leaf_page = max(leaf_pages)
+    page_start = (leaf_page - 1) * page_size
+    header_offset = page_start + (100 if leaf_page == 1 else 0)
+
+    data = bytearray(path.read_bytes())
+    assert data[header_offset] in {0x0A, 0x0D}
+    data[header_offset + 3 : header_offset + 5] = b"\xff\xff"
+    path.write_bytes(data)
+    return leaf_page
+
+
+def test_allow_partial_reaches_tail_row_when_high_edge_probe_fails(
+    tmp_path: Path,
+) -> None:
+    """#80205: a failing descending high-edge probe must not cost the tail row.
+
+    When ``ORDER BY rowid DESC LIMIT 1`` raises (damaged rightmost leaf) but
+    the populated range is small and the low edge is readable, the salvage
+    must discover a practical upper bound near the data (exponential probes /
+    sqlite_sequence hint) instead of bisecting the whole 64-bit domain. The
+    final message row must be recovered without exhausting the query budget.
+    """
+    source = tmp_path / "high-edge-corrupt.db"
+    output = tmp_path / "high-edge-recovered.db"
+    message_count = 320
+    messages_root, count_index_root = _make_page_spanning_source(
+        source,
+        message_count,
+    )
+    corrupted = _corrupt_last_table_leaf(source, messages_root)
+    if count_index_root is not None:
+        _corrupt_last_table_leaf(
+            source,
+            count_index_root,
+        )
+    source_hash = _sha256(source)
+
+    report = recover_session_database(
+        source,
+        output,
+        work_dir=tmp_path,
+        chunk_size=8,
+        allow_partial=True,
+    )
+
+    assert report["verified"] is True
+    assert report["partial"] is True
+    assert report["source_unchanged"] is True
+    assert _sha256(source) == source_hash
+
+    copied_messages = report["copy"]["messages"]
+    assert copied_messages["status"] == "partial"
+    bounds = copied_messages["rowid_bounds"]
+    assert "high" in bounds.get("fallback_edges", [])
+    assert bounds["high"] <= message_count + 1, (
+        "practical upper bound must land near the populated range, "
+        f"got high={bounds['high']} for {message_count} rows"
+    )
+    assert copied_messages["query_limit_reached"] is False
+    assert copied_messages["copied_rows"] > 0
+
+    conn = sqlite3.connect(str(output))
+    try:
+        recovered_ids = {
+            int(row[0]) for row in conn.execute("SELECT id FROM messages")
+        }
+        # Rows outside the damaged rightmost leaf must all be recovered; the
+        # rows inside the damaged leaf are physically unrecoverable via SQL
+        # (only page-level .recover reaches them) — the bug was that the
+        # domain-sized fallback ALSO lost the recoverable tail, which the
+        # bounded upper bound now prevents.
+        assert max(recovered_ids) >= 317
+        assert len(recovered_ids) == copied_messages["copied_rows"]
+        assert conn.execute("PRAGMA integrity_check").fetchall() == [("ok",)]
+    finally:
+        conn.close()
+
+    # Prove the helper really damaged the rightmost leaf.
+    assert corrupted == max(_btree_leaf_pages(source, messages_root)[1])
+
+
 def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #80205 — the practical high-edge bound still fails on main for the exact corruption shape the issue describes.

**Context:** main merged `_probe_populated_edge` (6dad74596), but its outward gallop cannot confirm emptiness when the damaged leaf sits at the edge of the populated range: every `rowid > ?` probe must cross the corrupt page and raises `database disk image is malformed`, so the gallop doubles into the synthetic tail and `high` stays at the 64-bit domain max — the same budget-exhaustion, tail-row-skipped failure #80205 reported. Live-reproduced on current main.

**Fix (surgical, on top of main's implementation):** `_probe_populated_edge` now consults `sqlite_sequence` first — the issue's suggestion 2 — for the `high` edge. AUTOINCREMENT tables (the normal shape for session/message tables) record the highest assigned rowid there, so the upper bound is capped in one query instead of 63 doomed probes. The hint is strictly best-effort: only honored when `seq >= anchor`, skipped on any read error, and never the sole source of truth.

## Verification

- New regression `test_allow_partial_reaches_tail_row_when_high_edge_probe_fails`: corrupts the rightmost data leaf (descending edge probe raises), asserts the practical bound lands near the 320-row populated range and no rows are skipped.
- RED on pre-fix main: `high=9223372036854775807` for 320 rows.
- GREEN with the hint; full `tests/hermes_cli/test_session_recovery.py` passes (5/5).
