### PR TITLE
fix(agent): take the compression lock before proactive prune's DB sync

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3156,7 +3156,40 @@ class ContextCompressor(ContextEngine):
         next_rearm_tokens = after + runway
         if session_db and session_id:
             # The capability gate above guarantees archive_and_compact exists.
+            # archive_and_compact soft-archives the active=1 rows and inserts a
+            # replacement set; a batch compression running concurrently on the
+            # same session_id (background_review forks share session_id with
+            # their parent; a gateway restart can race an old worker still
+            # finishing a rotation) does the exact same thing. Whichever
+            # commits second silently discards the other's already-committed
+            # write — the "split session lineage" corruption
+            # try_acquire_compression_lock's docstring says a caller MUST NOT
+            # risk. Take the same durable lock the batch path holds for its
+            # own archive_and_compact call before this one.
+            from agent.conversation_compression import _compression_lock_holder
+
+            holder = _compression_lock_holder(self)
+            lock_acquired = False
             try:
+                try_acquire = getattr(session_db, "try_acquire_compression_lock", None)
+                if callable(try_acquire):
+                    lock_acquired = try_acquire(session_id, holder, ttl_seconds=30.0)
+                else:
+                    # Legacy SessionDB instance predating the lock API
+                    # (hot-reload version skew) — nothing to coordinate
+                    # against, so proceed the same as before this fix existed.
+                    lock_acquired = True
+
+                if not lock_acquired:
+                    logger.info(
+                        "Proactive tool-result prune DB commit skipped for "
+                        "session=%s — a batch compression currently holds the "
+                        "compression lock; this cycle's reclaim is dropped "
+                        "and pruning re-evaluates on the next eligible turn",
+                        session_id,
+                    )
+                    return messages, 0
+
                 session_db.archive_and_compact(
                     session_id,
                     pruned_msgs,
@@ -3171,6 +3204,16 @@ class ContextCompressor(ContextEngine):
                     exc,
                 )
                 return messages, 0
+            finally:
+                if lock_acquired:
+                    try:
+                        release = getattr(session_db, "release_compression_lock", None)
+                        if callable(release):
+                            release(session_id, holder)
+                    except Exception:
+                        logger.debug(
+                            "proactive prune lock release failed", exc_info=True
+                        )
             for msg in pruned_msgs:
                 if isinstance(msg, dict):
                     msg[_DB_PERSISTED_MARKER] = True

--- a/tests/agent/test_proactive_prune_restart_safety.py
+++ b/tests/agent/test_proactive_prune_restart_safety.py
@@ -271,3 +271,59 @@ def test_incapable_store_short_circuits_before_prune_scan(tmp_path: Path) -> Non
 
     assert result is messages
     assert count == 0
+
+
+def test_proactive_prune_does_not_commit_while_a_batch_compression_holds_the_lock(
+    tmp_path: Path,
+) -> None:
+    """prune_tool_results_only must not race a concurrent batch compression.
+
+    archive_and_compact soft-archives the active=1 rows and inserts a
+    replacement set. Batch compression always holds SessionDB's durable
+    compression_locks row before its own archive_and_compact call —
+    try_acquire_compression_lock's docstring says a caller MUST NOT proceed
+    without it, since a racing rotation would split the session lineage.
+    Proactive pruning calls the exact same archive_and_compact on the exact
+    same session_id and, before this fix, took no lock at all: two writers
+    committing concurrently would have the second one silently discard the
+    first's already-committed write.
+    """
+    db = SessionDB(db_path=tmp_path / "state.db")
+    session_id = "PRUNE_LOCK_CONTENTION"
+    db.create_session(session_id, source="telegram")
+    db.append_messages_batch(session_id, _history())
+    agent = _build_agent(db, session_id)
+    _configure_pruning(agent)
+    compressor = agent.context_compressor
+    messages = db.get_messages_as_conversation(session_id)
+    original_contents = [message["content"] for message in messages]
+
+    # Simulate a concurrent batch compression already holding the lock. Uses
+    # this test process's own pid so _compression_lock_holder_process_is_dead
+    # doesn't treat it as an abandoned lease and reclaim it out from under us.
+    other_holder = f"pid={os.getpid()}:tid=1:agent=other:nonce=deadbeef"
+    assert db.try_acquire_compression_lock(session_id, other_holder, ttl_seconds=300.0)
+
+    result, count = compressor.prune_tool_results_only(messages, current_tokens=120_000)
+
+    # No-op contract: input object handed back unchanged, nothing committed.
+    assert result is messages
+    assert count == 0
+    assert [
+        message["content"] for message in db.get_messages_as_conversation(session_id)
+    ] == original_contents
+    # The other holder's lock must still be intact — a busy prune must not
+    # clobber (or accidentally release) a lock it never acquired.
+    assert db.get_compression_lock_holder(session_id) == other_holder
+
+    # Control: once the lock is free, the identical call commits normally —
+    # proves the no-op above was caused by lock contention, not some other
+    # gate silently rejecting the prune.
+    db.release_compression_lock(session_id, other_holder)
+    result2, count2 = compressor.prune_tool_results_only(messages, current_tokens=120_000)
+
+    assert count2 > 0, "prune must actually commit once the lock is free"
+    assert result2 is not messages
+    assert db.get_compression_lock_holder(session_id) is None, (
+        "the prune's own lock acquisition must be released after it commits"
+    )


### PR DESCRIPTION
## Summary

- `prune_tool_results_only()` calls `session_db.archive_and_compact()` directly, with no lock. The batch compression path always acquires `SessionDB`'s durable `compression_locks` row (`try_acquire_compression_lock`) before doing any rotation/in-place compaction, including its own `archive_and_compact` call — the lock's docstring states the invariant in absolute terms: a caller MUST NOT proceed without it, since a racing rotation would split the session lineage.
- Proactive tool-result pruning calls the exact same `archive_and_compact()` on the exact same table/`session_id` with zero lock coordination. Two writers sharing a `session_id` concurrently (a `background_review` fork sharing `session_id` with its parent, a gateway restart racing an old worker still finishing a batch compression, or two multiplex/cron processes touching the same session) can both soft-archive the active rows and insert their own replacement set — whichever commits second silently discards the other's already-committed write.
- This is the third sibling of the same `archive_and_compact` call site. The second sibling, `_sync_micro_compact_to_db()`, has the identical gap and is already covered by a separate, still-open PR (#77861) scoped to that one function. Today's proactive-prune durability commit (salvage of #79286, merged as #79640) reintroduced the identical anti-pattern in a third function in the same file.
- Wraps the `archive_and_compact` call with the same `try_acquire_compression_lock`/`release_compression_lock` pair the batch path and micro-compaction use. If the lock is held elsewhere, the prune skips this cycle — its existing no-op contract already covers this (return the input list unchanged, no rearm-token commit), so this degrades exactly like an `archive_and_compact` failure already does rather than racing the holder.

## Test plan

- [x] New regression test: holds the lock with a live-pid holder, confirms the prune no-ops without touching the transcript or the other holder's lock, then releases it and confirms the identical call commits normally — proving the no-op is caused by lock contention specifically, not some other gate.
- [x] Mutation-verified: the new test fails on pre-fix code (`git stash` the fix, test fails; restore, test passes).
- [x] Full neighboring suite green: `tests/agent/test_proactive_tool_result_pruning.py`, `tests/agent/test_proactive_prune_restart_safety.py`, `tests/run_agent/test_proactive_prune_loop_wiring.py`, `tests/agent/test_micro_compaction.py`, `tests/agent/test_compression_concurrent_fork.py` — 99 passed.
- [x] `ruff check` clean on changed files.