### PR TITLE
fix(providers): restore Responses-API routing for Actual Computer

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1593,6 +1593,17 @@ class AIAgent:
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
+        # Actual Computer is Responses-only (its Hermes overlay is
+        # transport="codex_responses"), for every model it serves — not just
+        # gpt-5.x. The primary path gets this from the provider registry via
+        # determine_api_mode(), but the fallback-activation ladder in
+        # agent/chat_completion_helpers.py does not consult the registry: it
+        # decides fb_api_mode from an explicit provider list plus this
+        # predicate, and defaults to chat_completions. Without this branch an
+        # `actual` fallback entry is POSTed to /v1/chat/completions, which the
+        # endpoint does not serve.
+        if normalized_provider == "actual":
+            return True
         # Nous serves GPT-5.x models via its OpenAI-compatible chat
         # completions endpoint; its /v1/responses endpoint returns 404.
         if normalized_provider == "nous":

--- a/tests/hermes_cli/test_actual_provider.py
+++ b/tests/hermes_cli/test_actual_provider.py
@@ -250,3 +250,71 @@ def test_actual_runtime_config_local_base_url_without_key(monkeypatch):
 
     assert resolved["api_key"] == ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
     assert resolved["api_mode"] == "codex_responses"
+
+
+# ---------------------------------------------------------------------------
+# Responses-API routing on the agent-side predicate
+#
+# The tests above cover the registry/config route (determine_api_mode,
+# resolve_runtime_provider), which is what the PRIMARY path consults. The
+# fallback-activation ladder in agent/chat_completion_helpers.py does not
+# consult the registry — it derives fb_api_mode from an explicit provider list
+# plus AIAgent._provider_model_requires_responses_api, defaulting to
+# chat_completions. That predicate had no `actual` coverage, so when its
+# `actual` branch was dropped in 8f2712725 (an unrelated /refine commit) every
+# registry-route test above still passed and nothing failed.
+# ---------------------------------------------------------------------------
+
+
+def test_actual_predicate_requires_responses_api_for_non_gpt5_models():
+    """`actual` is Responses-only for every model it serves, not just gpt-5.x."""
+    from run_agent import AIAgent
+
+    for model in ("actual/local-model", "kimi-k2", "llama-3.3-70b", ""):
+        assert AIAgent._provider_model_requires_responses_api(
+            model, provider="actual"
+        ) is True, f"actual/{model!r} must route to the Responses API"
+
+
+def test_actual_predicate_is_case_and_whitespace_insensitive():
+    from run_agent import AIAgent
+
+    for spelling in ("ACTUAL", " actual ", "Actual"):
+        assert AIAgent._provider_model_requires_responses_api(
+            "some-model", provider=spelling
+        ) is True
+
+
+def test_actual_predicate_matches_its_registry_transport():
+    """The predicate must agree with the overlay that defines the wire format.
+
+    Ties the agent-side answer to the single source of truth, so a future edit
+    to either side that desynchronises them fails here.
+    """
+    from hermes_cli.providers import HERMES_OVERLAYS
+    from run_agent import AIAgent
+
+    assert HERMES_OVERLAYS["actual"].transport == "codex_responses"
+    assert AIAgent._provider_model_requires_responses_api(
+        "actual/local-model", provider="actual"
+    ) is True
+
+
+def test_other_providers_keep_their_existing_routing():
+    """Restoring the `actual` branch must not disturb its neighbours."""
+    from run_agent import AIAgent
+
+    # Nous and custom stay on chat completions even for gpt-5.x.
+    assert AIAgent._provider_model_requires_responses_api(
+        "gpt-5.4", provider="nous"
+    ) is False
+    assert AIAgent._provider_model_requires_responses_api(
+        "gpt-5.4", provider="custom"
+    ) is False
+    # An unrelated provider still falls through to the model-name rule.
+    assert AIAgent._provider_model_requires_responses_api(
+        "gpt-5.4", provider="openrouter"
+    ) is True
+    assert AIAgent._provider_model_requires_responses_api(
+        "llama-3.3-70b", provider="openrouter"
+    ) is False


### PR DESCRIPTION
## What does this PR do?

`8f2712725` ("feat: /refine — run the memory/skill self-improvement review on demand") also deleted two unrelated lines from `AIAgent._provider_model_requires_responses_api`:

```diff
-        if normalized_provider == "actual":
-            return True
```

Nothing in that commit's message or its stated scope touches provider routing — the feature threads a `focus` parameter through the background-review helpers. `git show 8f2712725 --stat -- run_agent.py` is `6 insertions(+), 2 deletions(-)`, and those two deletions are the whole of it. It reads as an accidental revert carried along in the same change.

Actual Computer is Responses-only for every model it serves: its Hermes overlay is `transport="codex_responses"` (added in `a9acb400b`, salvaged as #79644). With the branch gone the predicate falls through to the generic model-name rule, `model.startswith("gpt-5")`, which is False for the models Actual actually serves.

### Why the primary path hides it

The primary path resolves `api_mode` from the provider registry via `determine_api_mode()`, which still returns `codex_responses` for `actual` — so a normal `actual` session is unaffected, and every existing test stayed green.

The **fallback-activation** ladder does not consult the registry. `agent/chat_completion_helpers.py` derives `fb_api_mode` from an explicit provider list plus this predicate, starting from a `chat_completions` default:

```python
fb_api_mode = "chat_completions"
if fb_provider == "openai-codex":                                  ...
elif fb_provider in {"nous", "nous-portal", "nousresearch"}:       ...
elif <anthropic host>:                                             ...
elif _fb_is_azure:                                                 ...
elif agent._is_direct_openai_url(fb_base_url):                     ...
elif agent._provider_model_requires_responses_api(fb_model, provider=fb_provider):   # carried `actual`
elif fb_provider == "bedrock" or ...:                              ...
```

`actual` matches no other branch — `api.actual.inc` is not a direct OpenAI URL — so an `actual` fallback entry now keeps the `chat_completions` default and is POSTed to `/v1/chat/completions`, which the endpoint does not serve. The fallback fails at exactly the moment the chain exists to cover: when the primary provider is already down.

This is the same shape as the `#32243` / `#49247` bug the comment two branches above describes for custom Anthropic hosts — default to `chat_completions`, POST to an endpoint that answers 404.

### The fix

Restore the branch, with a comment recording why the registry answer is not sufficient at this call site.

Deliberately minimal: I did not touch the fallback ladder itself. Making it delegate to `determine_api_mode()` is the better structural fix and is already proposed in #59611 (open, touches `agent/chat_completion_helpers.py`); this change is a revert of an unintended deletion in `run_agent.py` and is orthogonal to it. If #59611 lands, this branch becomes redundant but stays correct.

## Related Issue

No existing issue. Searched open and merged PRs and issues first, per CONTRIBUTING's search-first section:

```
gh search prs --repo NousResearch/hermes-agent "actual in:title"                          --limit 40
gh search prs --repo NousResearch/hermes-agent "Actual Computer"                          --limit 40
gh search prs --repo NousResearch/hermes-agent "codex_responses"                          --limit 40
gh search prs --repo NousResearch/hermes-agent "_provider_model_requires_responses_api"   --limit 40
gh search prs --repo NousResearch/hermes-agent "responses api fallback in:title"          --limit 40
```

Nothing restores this branch. The nearest neighbour is #59611 (see above) — different file, no textual overlap, and it predates the deletion by a month so it is not a fix for this regression. #79644 is the merged provider integration this restores routing for.

## Type of Change

Bug fix (non-breaking). Regression, introduced 2026-08-05.

## Changes Made

- `run_agent.py` — restored the `actual` branch in `_provider_model_requires_responses_api`, with a comment explaining why the fallback ladder needs it even though the registry answers correctly on the primary path.
- `tests/hermes_cli/test_actual_provider.py` — 4 tests covering the predicate, which had no `actual` coverage at all.

## How to Test

```
pytest tests/hermes_cli/test_actual_provider.py -q
```

16 passed.

The coverage gap is the interesting part. The pre-existing tests in that file all exercise the **registry** route — `determine_api_mode("actual", ...)`, `resolve_runtime_provider`, provider profiles — which is why deleting this branch passed CI without a murmur. Nothing exercised `_provider_model_requires_responses_api` with `provider="actual"`.

Reverting only `run_agent.py` and rerunning:

```
FAILED test_actual_predicate_requires_responses_api_for_non_gpt5_models
FAILED test_actual_predicate_is_case_and_whitespace_insensitive
FAILED test_actual_predicate_matches_its_registry_transport
3 failed, 13 passed
```

with

```
E  AssertionError: actual/'actual/local-model' must route to the Responses API
E  assert False is True
```

The 13 that still pass are the pre-existing registry tests — that split *is* the coverage hole, reproduced.

The fourth new test (`test_other_providers_keep_their_existing_routing`) passes both before and after by design: it pins that restoring this branch does not disturb `nous`, `custom`, or the generic model-name fallthrough.

`test_actual_predicate_matches_its_registry_transport` asserts the predicate agrees with `HERMES_OVERLAYS["actual"].transport`, so a future edit to either side that desynchronises them fails here rather than silently in a fallback.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(providers): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (queries above)
- [x] My PR contains only changes related to this fix
- [x] I've run the affected suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.5), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — the restored branch carries a comment explaining the call-site asymmetry; no user-facing doc describes this internal routing
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A, string comparison only
- [x] Tool descriptions/schemas — N/A

## Notes for the reviewer

Worth a moment: five other providers carry `transport="codex_responses"` in `HERMES_OVERLAYS` — `openai-codex`, `openai-api`, `xai-oauth`, `copilot-acp`, `xai`. The fallback ladder handles `openai-codex` by name and `copilot-acp` is excluded upstream, but the others reach the same predicate. I have not audited whether each is covered by `_is_direct_openai_url` or falls through the way `actual` does, because that is the structural question #59611 is already about and I did not want to widen a revert into a routing change. Flagging it in case it is worth checking there.
