### PR TITLE
fix: stop misclassifying multibyte UTF-8 text files as binary in read_file

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,29 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_from_byte_cut_not_flagged(self, tmp_path):
+        """A U+FFFD at the END of a 1000-byte sample is a `head -c 1000`
+        truncation artifact (multibyte UTF-8 char split at the byte boundary),
+        not evidence the file is binary. Japanese UTF-8 files must not be
+        misclassified as binary."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # Japanese text whose 1000-byte sample ends mid-character: the last
+        # byte pair (\xe5\xbe = "自" cut in half) decodes to a trailing U+FFFD.
+        sample = "# サトシ（受付・ワークコーディネーター）運用メモ\n\nこのファイルは、SOUL.md から分離した作業手順の正本。SOULの指示に従い、該当する作業の前に読むこと。" + "テキスト" * 100 + "\uFFFD"
+        assert ops._is_likely_binary("notes.txt", sample) is False
+
+    def test_replacement_in_middle_still_flagged(self, tmp_path):
+        """Genuine mojibake shows U+FFFD throughout the sample (not just at
+        the tail) — such files must still be flagged binary (read-only)."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        # U+FFFD in the middle, not just at the end.
+        lossy = "caf\ufffd r\ufffdsum\ufffd\nmore text\n"
+        assert ops._is_likely_binary("notes.txt", lossy) is True
+
+    def test_long_trailing_replacement_run_still_flagged(self, tmp_path):
+        """A trailing U+FFFD run of 4+ is beyond any UTF-8 cut artifact
+        (max 3 dangling bytes) and must stay binary (safe direction)."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        assert ops._is_likely_binary("notes.txt", "plain\n" + "\ufffd" * 5) is True
+        assert ops._is_likely_binary("notes.txt", "plain\n" + "\ufffd" * 3) is False

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,11 +903,25 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            sample = content_sample[:1000]
+            # Sampling artifact carve-out: read_file samples with
+            # `head -c 1000`, which cuts at a BYTE boundary. A multibyte
+            # UTF-8 char split across that cut decodes to 1-3 U+FFFD at the
+            # END of the sample (4-byte char → ≤3 dangling bytes), so a
+            # trailing run of ≤3 is not evidence of binary content — Japanese
+            # and other non-ASCII UTF-8 files would otherwise be
+            # misclassified as binary. Genuine mojibake shows U+FFFD
+            # throughout the sample, not just at the tail, so only the
+            # trailing run is stripped before judging. A longer trailing run
+            # (≥4) is kept as binary (safe direction).
+            stripped = sample.rstrip("\ufffd")
+            if len(sample) - len(stripped) <= 3:
+                sample = stripped
+            if "\ufffd" in sample:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in sample
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
+            return non_printable / min(len(sample), 1000) > 0.30
         
         return False
     


### PR DESCRIPTION
## Summary
`read_file` (and `read_file_raw`) classify **valid UTF-8 text files** as binary when the 1000-byte sampling boundary (`head -c 1000`) cuts through a multibyte character. Japanese, Chinese, Korean, and emoji-heavy text files are affected frequently (3-byte UTF-8 chars make a mid-character cut highly likely).

## Reproduction
Any UTF-8 text file whose byte 1000 lands inside a multibyte char, e.g. a Japanese markdown file > 1000 bytes. `read_file` returns:
```
Binary file - cannot display as text. Use appropriate tools to handle this file type.
```
Verified against a real 10 KB Japanese file: `head -c 1000` cut `"自"` (`\xe5\xbe\xaa`) after its 2nd byte, the incremental decoder (`errors="replace"`) produced one trailing U+FFFD at sample position 386, and `_is_likely_binary` returned True.

## Root cause
1. `read_file` samples the first **1000 bytes** (`head -c 1000`) for binary detection.
2. The terminal backend decodes child output with `codecs.getincrementaldecoder("utf-8")(errors="replace")` (`tools/environments/base.py`), so the dangling bytes of a cut multibyte char arrive as U+FFFD **at the end of the sample**.
3. `_is_likely_binary` treats **any** U+FFFD in the sample as evidence of mojibake → binary. That guard exists to prevent read→edit→write corruption of genuinely non-UTF-8 files, but it does not distinguish a truncation artifact (1–3 trailing U+FFFD) from genuine mojibake (U+FFFD throughout).

## Fix
In `_is_likely_binary`, strip a trailing run of ≤3 U+FFFD from the sample before judging. A 4-byte UTF-8 char split across the cut yields at most 3 dangling bytes, so a longer trailing run (≥4) still counts as binary (safe direction). Genuine mojibake (U+FFFD in the middle of the sample) is still flagged binary, preserving the corruption guard.

```python
sample = content_sample[:1000]
stripped = sample.rstrip("\ufffd")
if len(sample) - len(stripped) <= 3:
    sample = stripped
if "\ufffd" in sample:
    return True
non_printable = sum(1 for c in sample if ord(c) < 32 and c not in '\n\r\t')
return non_printable / min(len(sample), 1000) > 0.30
```

## Tests
Added 3 regression tests to `tests/tools/test_file_operations.py` (`TestReadNonUtf8IsBinary`):
- trailing U+FFFD (cut artifact) → text (not binary)
- mid-sample U+FFFD (genuine mojibake) → binary (guard preserved)
- trailing run of 5 → binary / trailing run of 3 → text (safe direction)

Full file: **49 passed**.