### PR TITLE
fix(cli): SIGINT during chat startup exits cleanly with code 130 (#80210)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2736,6 +2736,16 @@ def cmd_chat(args):
     except ValueError as e:
         print(f"Error: {e}")
         sys.exit(1)
+    except KeyboardInterrupt:
+        # SIGINT during startup/run must be a clean, standard exit — not an
+        # unhandled traceback with exit code null. The signal handler in
+        # cli.py (_signal_handler_q) raises KeyboardInterrupt to unwind the
+        # main thread; if the interrupt lands before cli_main's own
+        # run-loop try/except (e.g. during agent init or credential
+        # validation, both of which make network calls), it would otherwise
+        # escape cmd_chat entirely. Exit 130 (128+SIGINT) is the standard
+        # convention for an interrupt-cancelled process.
+        sys.exit(130)
 
 
 def cmd_gateway(args):

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3543,6 +3543,16 @@ def cmd_chat(args):
         if emit_partial_update_hint(e):
             sys.exit(1)
         raise
+    except KeyboardInterrupt:
+        # SIGINT during startup/run must be a clean, standard exit — not an
+        # unhandled traceback with exit code null. The signal handler in
+        # cli.py (_signal_handler_q) raises KeyboardInterrupt to unwind the
+        # main thread; if the interrupt lands before cli_main's own
+        # run-loop try/except (e.g. during agent init or credential
+        # validation, both of which make network calls), it would otherwise
+        # escape cmd_chat entirely. Exit 130 (128+SIGINT) is the standard
+        # convention for an interrupt-cancelled process.
+        sys.exit(130)
 
 
 def cmd_gateway(args):

--- a/tests/hermes_cli/test_cmd_chat_sigint.py
+++ b/tests/hermes_cli/test_cmd_chat_sigint.py
@@ -1,0 +1,95 @@
+"""Regression tests for #80210: SIGINT during `hermes chat` startup/run must
+exit cleanly with code 130, not crash with an unhandled traceback and a null
+exit code.
+
+The single-query signal handler in cli.py (_signal_handler_q) raises
+KeyboardInterrupt to unwind the main thread. cli_main() catches it around
+run_conversation (exit 130), but if the interrupt lands BEFORE the run loop —
+during agent init or credential validation, both of which make network calls —
+the exception escapes cmd_chat() entirely (cmd_chat only caught ValueError),
+producing a raw traceback and a signal-death exit. This test pins the
+cmd_chat-level catch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import pytest
+
+
+def _cmd_chat_args(**overrides) -> argparse.Namespace:
+    args = argparse.Namespace(
+        model=None,
+        provider=None,
+        reasoning=None,
+        toolsets=None,
+        skills=None,
+        verbose=False,
+        quiet=True,
+        query="hi",
+        image=None,
+        resume=None,
+        worktree=False,
+        checkpoints=False,
+        pass_session_id=False,
+        max_turns=None,
+        ignore_rules=False,
+        ignore_user_config=False,
+        compact=False,
+        yolo=False,
+        continue_last=None,
+        no_restore_cwd=True,
+        source=None,
+        tui=False,
+        tui_dev=False,
+        accept_hooks=False,
+        safe_mode=False,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def test_cmd_chat_swallows_keyboard_interrupt_during_startup(
+    monkeypatch,
+) -> None:
+    """SIGINT before the run loop must become a clean exit 130, not a crash.
+
+    The interrupt lands during agent init / credential validation (network
+    calls outside cli_main's own try/except). cmd_chat must catch it and
+    sys.exit(130) — the standard 128+SIGINT convention.
+    """
+
+    def boom(**kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr("cli.main", boom)
+
+    from hermes_cli.main import cmd_chat
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_chat(_cmd_chat_args())
+    assert excinfo.value.code == 130, (
+        "SIGINT during startup must exit 130, got "
+        f"{excinfo.value.code!r}"
+    )
+
+
+def test_cmd_chat_still_propagates_value_error(monkeypatch) -> None:
+    """The existing ValueError handling must be unaffected."""
+    captured: dict[str, object] = {}
+
+    def value_error(**kwargs):
+        captured["kwargs"] = kwargs
+        raise ValueError("bad config")
+
+    monkeypatch.setattr("cli.main", value_error)
+
+    from hermes_cli.main import cmd_chat
+
+    with pytest.raises(SystemExit) as excinfo:
+        cmd_chat(_cmd_chat_args())
+    assert excinfo.value.code == 1
+    assert captured["kwargs"]["query"] == "hi"

--- a/tests/hermes_cli/test_cmd_chat_sigint.py
+++ b/tests/hermes_cli/test_cmd_chat_sigint.py
@@ -66,6 +66,12 @@ def test_cmd_chat_swallows_keyboard_interrupt_during_startup(
         raise KeyboardInterrupt()
 
     monkeypatch.setattr("cli.main", boom)
+    # Hermetic: a clean CI has no provider configured, which makes cmd_chat
+    # exit at the first-run guard (code 1) before the interrupt can land.
+    # Force the configured path so the KeyboardInterrupt is genuinely reached.
+    monkeypatch.setattr(
+        "hermes_cli.main._has_any_provider_configured", lambda: True
+    )
 
     from hermes_cli.main import cmd_chat
 


### PR DESCRIPTION
## Summary

Fixes #80210: SIGINT during `hermes chat` startup/run could crash with an unhandled traceback and a null (SIGINT-killed, -2) exit code.

**Root cause**: the single-query signal handler (`cli.py:_signal_handler_q`) raises `KeyboardInterrupt` to unwind the main thread. `cli_main()` catches it around `run_conversation` (exit 130), but an interrupt landing **before** the run loop — during agent init or credential validation, both of which make network calls — escaped `cmd_chat()` entirely. `cmd_chat` only caught `ValueError`, so the `KeyboardInterrupt` propagated as an unhandled traceback and the process died with exit code null.

**Fix**: add `except KeyboardInterrupt: sys.exit(130)` to `cmd_chat`. 130 = 128+SIGINT, the standard convention for an interrupt-cancelled process.

## Verification

- **Repro before**: subprocess `hermes chat -q "say hi"`, SIGINT during startup → `returncode: -2` (signal death), full `KeyboardInterrupt` traceback on stderr.
- **After**: `returncode: 130`, empty stderr.
- **RED-GREEN**: new regression tests fail on pre-fix code (KeyboardInterrupt escapes, pytest aborts with "no tests ran"); pass with the fix (exit 130 + ValueError handling unchanged).
