### PR TITLE
fix(desktop): fix a TOCTOU race in wake-word client-capture start/stop

### DIFF
--- a/apps/desktop/src/store/wake-word.test.ts
+++ b/apps/desktop/src/store/wake-word.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ClientWakeCaptureHandle } from '@/lib/wake-client-capture'
+
+vi.mock('@/lib/wake-client-capture', () => ({
+  startClientWakeCapture: vi.fn()
+}))
+
+import { startClientWakeCapture } from '@/lib/wake-client-capture'
+
 import {
   $wakeWord,
   applyWakeStartResult,
@@ -8,9 +16,12 @@ import {
   armWakeWord,
   resetWakeWordState,
   resumeWakeAfterVoice,
+  stopClientCapture,
   toggleWakeWord,
   type WakeRequester
 } from './wake-word'
+
+const mockStartClientWakeCapture = vi.mocked(startClientWakeCapture)
 
 const requester = (impl: (method: string, params?: Record<string, unknown>) => unknown) =>
   vi.fn(async (method: string, params: Record<string, unknown> = {}) =>
@@ -18,6 +29,7 @@ const requester = (impl: (method: string, params?: Record<string, unknown>) => u
   ) as unknown as WakeRequester
 
 beforeEach(() => {
+  mockStartClientWakeCapture.mockReset()
   resetWakeWordState()
 })
 
@@ -369,5 +381,73 @@ describe('resumeWakeAfterVoice (post-voice reconcile)', () => {
     await resumeWakeAfterVoice(request)
 
     expect($wakeWord.get()).toMatchObject({ available: false, listening: false })
+  })
+})
+
+/**
+ * applyWakeStartResult fires maybeStartClientCapture without awaiting it (the
+ * store update must be synchronous). A macrotask boundary (unlike a fixed
+ * count of microtask ticks) drains the entire microtask queue no matter how
+ * many `await`s are chained inside it, so it reliably waits out
+ * maybeStartClientCapture's post-resolve continuation regardless of exactly
+ * how the promises above it happen to interleave.
+ */
+const flushMicrotasks = (): Promise<void> => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('maybeStartClientCapture race safety', () => {
+  it('discards a getUserMedia() that resolves after stopClientCapture() ran', async () => {
+    // startClientWakeCapture() (getUserMedia) can block indefinitely on a
+    // first-run OS mic-permission prompt. Model that with a promise this
+    // test controls the resolution timing of.
+    let resolveCapture!: (handle: ClientWakeCaptureHandle) => void
+    mockStartClientWakeCapture.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveCapture = resolve
+      })
+    )
+
+    applyWakeStartResult({ capture: 'client', frame_length: 1280, started: true })
+    await flushMicrotasks()
+    expect(mockStartClientWakeCapture).toHaveBeenCalledTimes(1)
+
+    // The permission dialog is still up when the user toggles wake word back
+    // off — applyWakeStopResult's stopClientCapture() runs to completion
+    // synchronously while startClientWakeCapture() is still pending.
+    applyWakeStopResult({ stopped: true })
+    expect($wakeWord.get().listening).toBe(false)
+
+    // The user grants the permission after already seeing wake word as off.
+    const handle: ClientWakeCaptureHandle = { active: true, stop: vi.fn() }
+    resolveCapture(handle)
+    await flushMicrotasks()
+
+    expect(handle.stop).toHaveBeenCalledTimes(1)
+    // A bare stopClientCapture() call afterward must not double-stop a
+    // handle this path never adopted.
+    stopClientCapture()
+    expect(handle.stop).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps a capture that resolves while still current', async () => {
+    let resolveCapture!: (handle: ClientWakeCaptureHandle) => void
+    mockStartClientWakeCapture.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveCapture = resolve
+      })
+    )
+
+    applyWakeStartResult({ capture: 'client', frame_length: 1280, started: true })
+    await flushMicrotasks()
+
+    const handle: ClientWakeCaptureHandle = { active: true, stop: vi.fn() }
+    resolveCapture(handle)
+    await flushMicrotasks()
+
+    expect(handle.stop).not.toHaveBeenCalled()
+
+    // The next stop must close THIS handle — proves it was actually adopted,
+    // not silently dropped alongside the discard path above.
+    stopClientCapture()
+    expect(handle.stop).toHaveBeenCalledTimes(1)
   })
 })

--- a/apps/desktop/src/store/wake-word.ts
+++ b/apps/desktop/src/store/wake-word.ts
@@ -37,14 +37,33 @@ export const $wakeWord = atom<WakeWordState>(INITIAL_WAKE_WORD_STATE)
 /** Active client mic stream for remote wake (capture: client). */
 let clientCapture: ClientWakeCaptureHandle | null = null
 
+/**
+ * Bumped by every stop/(re)start so a `startClientWakeCapture()` call that is
+ * still awaiting `getUserMedia()` (unbounded — a first-run OS mic-permission
+ * prompt blocks on the user's click) can tell, once it resolves, whether it
+ * is still the current attempt. Without this, a stop/start race during that
+ * wait clobbers whatever the other call just did — including resurrecting a
+ * mic stream after the caller believes capture is off (see the discard check
+ * in `maybeStartClientCapture` below).
+ */
+let captureGeneration = 0
+
 /** Stop client-side PCM capture (also called on wake.detected before voice). */
 export function stopClientCapture(): void {
+  captureGeneration++
   clientCapture?.stop()
   clientCapture = null
 }
 
 async function maybeStartClientCapture(result: WakeStartResponse | null | undefined): Promise<void> {
-  stopClientCapture()
+  // Claim the current epoch before the synchronous stop below, so this call —
+  // not a still-pending earlier one — owns it. An earlier call whose
+  // getUserMedia() is still in flight will see a mismatch when it resolves
+  // (see the two discard checks below) and never assign/act on a stream this
+  // call, or a bare stopClientCapture(), already superseded.
+  const generation = ++captureGeneration
+  clientCapture?.stop()
+  clientCapture = null
 
   if (!result?.started) {
     return
@@ -57,11 +76,27 @@ async function maybeStartClientCapture(result: WakeStartResponse | null | undefi
   }
 
   try {
-    clientCapture = await startClientWakeCapture({
+    const handle = await startClientWakeCapture({
       frameLength: result.frame_length,
       request: gatewayRequester
     })
+
+    if (generation !== captureGeneration) {
+      // Superseded while getUserMedia() was pending — the winner already
+      // owns `clientCapture` (or nothing should be listening at all). Close
+      // this orphaned stream instead of assigning it, or it keeps
+      // recording/transmitting audio with zero UI indication it's active.
+      handle.stop()
+
+      return
+    }
+
+    clientCapture = handle
   } catch (error) {
+    if (generation !== captureGeneration) {
+      return
+    }
+
     const current = $wakeWord.get()
     $wakeWord.set({
       ...current,


### PR DESCRIPTION
## Summary

- `maybeStartClientCapture()` (`apps/desktop/src/store/wake-word.ts`) calls `stopClientCapture()` synchronously, then awaits `startClientWakeCapture()` (`getUserMedia` — unbounded duration: a first-run OS mic-permission prompt blocks on the user's click) and assigns the result straight to the module-level `clientCapture` variable with no generation/cancellation token.
- If a second stop or start happens while that await is still pending, the earlier call's assignment lands later and silently clobbers whatever the second call did — including resurrecting a mic stream after the user already believes wake word is off.
- Concrete failure: first-ever use pops the OS permission dialog while `getUserMedia()` blocks. The user toggles wake word off while the dialog is up (`stopClientCapture()` runs, a no-op since `clientCapture` is still `null`, and the UI shows off). The user then clicks Allow — `startClientWakeCapture()` resolves and assigns the handle, opening the mic and continuously streaming PCM via `wake.feed` with zero UI indication, even though the server-side lease was already released. Nothing calls `stopClientCapture()` for it again short of an app reload.
- Fix: a module-level generation counter. `stopClientCapture()` bumps it. `maybeStartClientCapture()` claims the current epoch (bumping it once, which also invalidates any still-pending earlier call) before its own synchronous stop, then checks the epoch again after the `getUserMedia()` await resolves — on success or failure. If superseded, the just-opened handle is stopped and discarded instead of assigned — the same "skip, don't race" degrade this codebase already uses for compression lock contention elsewhere.

## Test plan

- [x] New regression test: drives a controlled, pending `startClientWakeCapture()` promise through a stop-while-pending race and asserts the eventually-resolved handle gets its own `stop()` called (discarded) rather than adopted.
- [x] Control test: same setup with no race, proving a normal resolution is still adopted.
- [x] Mutation-verified: the discard test fails on pre-fix code (`vi.fn()` called 0 times instead of 1) — the orphaned handle is never stopped.
- [x] `npx vitest run` on the changed file plus neighboring suites (`controls.test.tsx`, `use-prompt-actions/index.test.tsx`) — 133 passed.
- [x] `npx tsc --noEmit` clean.