### PR TITLE
fix(cron): make the lifecycle guard total — sanitize at ingestion, not per-syscall

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -410,7 +410,7 @@ def _contains_unsafe_gateway_action(
         # Relative references inside a script resolve against that script's
         # directory, not the original command's cwd.
         script_dir = _resolve_script_directory(str(resolved)) or cwd
-        if script_text and _contains_unsafe_gateway_action(
+        if _contains_unsafe_gateway_action(
             script_text,
             cwd=script_dir,
             depth=depth + 1,
@@ -488,7 +488,13 @@ def _resolve_script_path(script_path: str) -> Optional[Path]:
         return None
     if raw.is_absolute():
         return raw
-    return get_hermes_home() / "scripts" / raw
+    try:
+        return get_hermes_home() / "scripts" / raw
+    except (RuntimeError, OSError):
+        # get_hermes_home() falls back to Path.home(), which raises when
+        # neither HERMES_HOME nor HOME is resolvable (launchd/systemd
+        # environments) — same ingestion contract: nothing to scan.
+        return None
 
 
 def _read_script_for_scanning(script_path: str) -> str:

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -35,12 +35,15 @@ informative rejection instead of scheduling a job that will only fail
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shlex
 import stat
 from pathlib import Path
 from typing import Callable, Iterator, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class GatewayLifecycleBlocked(ValueError):
@@ -170,10 +173,41 @@ def contains_launchctl_submit_command(command: str) -> bool:
     return False
 
 
-def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Path:
-    path = Path(candidate).expanduser()
+def _expand_candidate_path(candidate: str) -> Optional[Path]:
+    """Sanitize a tokenized path candidate at the ingestion boundary.
+
+    Candidate tokens come from shlex-splitting arbitrary command text —
+    including text recursively decoded from binaries or remote reads — so
+    they can carry NUL bytes or other junk no real filesystem path can
+    contain. Every OS-facing ``Path`` operation downstream (``expanduser``,
+    ``os.open``, ``resolve``) raises a *different* exception for the same
+    junk (``ValueError: embedded null byte``, ``RuntimeError: Could not
+    determine home directory`` when HOME is unset under launchd, OSError
+    for over-long paths). Rejecting here — once, before any OS call — is
+    the whole-class fix; catching per-syscall was the whack-a-mole that
+    produced #76762, #77703, #77780, and #78256.
+
+    Returns ``None`` for candidates that cannot be a real path (nothing to
+    scan), otherwise the ``expanduser()``-expanded ``Path``.
+    """
+    if not candidate or "\x00" in candidate:
+        return None
+    try:
+        return Path(candidate).expanduser()
+    except (ValueError, RuntimeError, OSError):
+        return None
+
+
+def _resolve_terminal_script_path(candidate: str, cwd: Optional[str]) -> Optional[Path]:
+    path = _expand_candidate_path(candidate)
+    if path is None:
+        return None
     if not path.is_absolute():
-        path = Path(cwd or Path.cwd()) / path
+        try:
+            path = Path(cwd or Path.cwd()) / path
+        except OSError:
+            # Path.cwd() can raise when the process cwd was deleted.
+            return None
     return path
 
 
@@ -192,7 +226,9 @@ def _iter_referenced_shell_scripts(
 
         if executable_name in {".", "source"}:
             if len(segment) > index + 1:
-                yield _resolve_terminal_script_path(segment[index + 1], cwd)
+                resolved = _resolve_terminal_script_path(segment[index + 1], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         if executable_name in _SHELL_EXECUTABLES:
@@ -216,7 +252,9 @@ def _iter_referenced_shell_scripts(
                 "-c",
                 "--command",
             }:
-                yield _resolve_terminal_script_path(arguments[arg_index], cwd)
+                resolved = _resolve_terminal_script_path(arguments[arg_index], cwd)
+                if resolved is not None:
+                    yield resolved
             continue
 
         # A bare "/" token is pathlib's division operator in Python sources
@@ -226,7 +264,9 @@ def _iter_referenced_shell_scripts(
         # (#77131). Skip pure-separator tokens.
         if executable.strip("/"):
             if "/" in executable or executable.endswith((".sh", ".bash", ".zsh")):
-                yield _resolve_terminal_script_path(executable, cwd)
+                resolved = _resolve_terminal_script_path(executable, cwd)
+                if resolved is not None:
+                    yield resolved
 
 
 def _iter_shell_command_payloads(command: str) -> Iterator[str]:
@@ -246,7 +286,7 @@ def _resolve_script_directory(script_path: str) -> Optional[str]:
     """Return the directory *script_path* resolves to, handling relative names."""
     try:
         path = _resolve_script_path(script_path)
-        if path.is_absolute():
+        if path is not None and path.is_absolute():
             return str(path.parent)
     except Exception:
         pass
@@ -290,6 +330,31 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     return data.decode("utf-8", errors="replace"), False
 
 
+def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bool]:
+    """Apply the local-read contract to text from a ``read_remote_script`` callback.
+
+    The recursion boundary must not trust its callbacks: any backend (SSH,
+    Modal, Daytona, or a future one) can hand back raw binary bytes decoded
+    as text, or arbitrarily large output. Mirror
+    ``_read_referenced_script``'s semantics — NUL bytes mean binary
+    (nothing to scan, checked first, #77703), oversized text fails closed
+    like an oversized local file (#76762) — so remote and local reads can
+    never diverge again. The size bound here is in characters rather than
+    bytes: the downstream cost (shlex tokenization of the text) is
+    per-character, and decoded characters never exceed source bytes, so
+    the character bound is at least as strict for scan work. Enforced here
+    rather than inside each callback so the guarantee holds for every
+    callback, not just the ones we hardened.
+    """
+    if not text:
+        return None, False
+    if "\x00" in text:
+        return None, False
+    if len(text) > _MAX_REFERENCED_SCRIPT_BYTES:
+        return None, True
+    return text, False
+
+
 def _contains_unsafe_gateway_action(
     command: str,
     *,
@@ -331,7 +396,14 @@ def _contains_unsafe_gateway_action(
             return True
         if script_text is None and read_remote_script is not None:
             # Local path missing; try the remote backend if one is available.
-            script_text = read_remote_script(str(script_path))
+            # The callback's output crosses the same trust boundary as a
+            # local read — sanitize it identically before it enters the
+            # recursion (binary skip + size fail-closed).
+            script_text, unsafe = _sanitize_remote_script_text(
+                read_remote_script(str(script_path))
+            )
+            if unsafe:
+                return True
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's
@@ -354,19 +426,45 @@ def contains_gateway_lifecycle_command_or_referenced_script(
     cwd: Optional[str] = None,
     read_remote_script: Optional[_ReadRemoteScriptFn] = None,
 ) -> bool:
-    """Detect lifecycle/submit commands, including bounded nested scripts."""
-    return _contains_unsafe_gateway_action(
-        command,
-        cwd=cwd,
-        depth=0,
-        visited=set(),
-        read_remote_script=read_remote_script,
-    )
+    """Detect lifecycle/submit commands, including bounded nested scripts.
+
+    Total by construction: this function returns a verdict for *every*
+    input and never raises. The direct scans below are pure string
+    operations; the referenced-script walk touches the filesystem, remote
+    backends, and shlex on arbitrary decoded bytes, so it is best-effort
+    defense-in-depth — any unexpected failure inside it is logged and
+    treated as "walk found nothing" rather than crashing the caller.
+
+    This is the contract #76762 established ("a guarded path must never
+    crash the guard") enforced at the boundary instead of per-syscall: a
+    guard crash propagates out of ``tools/terminal_tool.py`` and breaks
+    every terminal command until the gateway restarts (#77780, #78256),
+    which is strictly worse than either verdict.
+    """
+    if contains_gateway_lifecycle_command(command) or contains_launchctl_submit_command(
+        command
+    ):
+        return True
+    try:
+        return _contains_unsafe_gateway_action(
+            command,
+            cwd=cwd,
+            depth=0,
+            visited=set(),
+            read_remote_script=read_remote_script,
+        )
+    except Exception:
+        logger.warning(
+            "lifecycle guard referenced-script walk failed; "
+            "falling back to direct-scan verdict",
+            exc_info=True,
+        )
+        return False
 
 
 
 
-def _resolve_script_path(script_path: str) -> Path:
+def _resolve_script_path(script_path: str) -> Optional[Path]:
     """Resolve a cron ``script`` value the same way the scheduler does.
 
     The scheduler (``cron.scheduler``) resolves a bare/relative script path
@@ -376,10 +474,17 @@ def _resolve_script_path(script_path: str) -> Path:
     (``~/.hermes/scripts/restart.sh``) but is passed as the bare name
     ``restart.sh`` would read as a nonexistent relative path and silently
     scan prompt-only content, letting the command through.
+
+    Returns ``None`` for values that cannot be a real path (NUL bytes,
+    unexpandable ``~``) — the same ingestion contract as
+    ``_expand_candidate_path``; such a value can never name a file the
+    scheduler would execute, so there is nothing to scan.
     """
     from hermes_constants import get_hermes_home
 
-    raw = Path(script_path).expanduser()
+    raw = _expand_candidate_path(script_path)
+    if raw is None:
+        return None
     if raw.is_absolute():
         return raw
     return get_hermes_home() / "scripts" / raw
@@ -389,10 +494,13 @@ def _read_script_for_scanning(script_path: str) -> str:
     """Read a cron script with the bounded terminal-script scanner.
 
     Non-regular or oversized inputs fail closed by returning a lifecycle-shaped
-    sentinel, while missing/unreadable paths remain empty so ordinary scheduler
-    path validation can report them.
+    sentinel, while missing/unreadable/unresolvable paths remain empty so
+    ordinary scheduler path validation can report them.
     """
-    script_text, unsafe = _read_referenced_script(_resolve_script_path(script_path))
+    resolved = _resolve_script_path(script_path)
+    if resolved is None:
+        return ""
+    script_text, unsafe = _read_referenced_script(resolved)
     if unsafe:
         return "hermes gateway restart"
     return script_text or ""
@@ -417,7 +525,8 @@ def check_gateway_lifecycle(
     combined = prompt or ""
     python_script = False
     if script:
-        python_script = _resolve_script_path(script).suffix == ".py"
+        resolved_script = _resolve_script_path(script)
+        python_script = resolved_script is not None and resolved_script.suffix == ".py"
         script_text = _read_script_for_scanning(script)
         if script_text:
             combined = f"{combined}\n{script_text}"

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -336,21 +336,22 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     The recursion boundary must not trust its callbacks: any backend (SSH,
     Modal, Daytona, or a future one) can hand back raw binary bytes decoded
     as text, or arbitrarily large output. Mirror
-    ``_read_referenced_script``'s semantics — NUL bytes mean binary
+    ``_read_referenced_script``'s semantics exactly — NUL bytes mean binary
     (nothing to scan, checked first, #77703), oversized text fails closed
     like an oversized local file (#76762) — so remote and local reads can
-    never diverge again. The size bound here is in characters rather than
-    bytes: the downstream cost (shlex tokenization of the text) is
-    per-character, and decoded characters never exceed source bytes, so
-    the character bound is at least as strict for scan work. Enforced here
-    rather than inside each callback so the guarantee holds for every
-    callback, not just the ones we hardened.
+    never diverge again. The size check re-encodes to compare *bytes*
+    (matching the local read and the ``head -c`` wire bound): a >1 MiB
+    multibyte file truncated at the byte cap decodes to fewer characters
+    than bytes, and a character-count check would scan the truncated text
+    instead of failing closed. Enforced here rather than inside each
+    callback so the guarantee holds for every callback, not just the ones
+    we hardened.
     """
     if not text:
         return None, False
     if "\x00" in text:
         return None, False
-    if len(text) > _MAX_REFERENCED_SCRIPT_BYTES:
+    if len(text.encode("utf-8", errors="replace")) > _MAX_REFERENCED_SCRIPT_BYTES:
         return None, True
     return text, False
 
@@ -441,11 +442,8 @@ def contains_gateway_lifecycle_command_or_referenced_script(
     every terminal command until the gateway restarts (#77780, #78256),
     which is strictly worse than either verdict.
     """
-    if contains_gateway_lifecycle_command(command) or contains_launchctl_submit_command(
-        command
-    ):
-        return True
     try:
+        # Includes the direct regex/submit scans at depth 0.
         return _contains_unsafe_gateway_action(
             command,
             cwd=cwd,
@@ -459,7 +457,10 @@ def contains_gateway_lifecycle_command_or_referenced_script(
             "falling back to direct-scan verdict",
             exc_info=True,
         )
-        return False
+        # Pure string scans of the top-level command — cannot raise.
+        return contains_gateway_lifecycle_command(
+            command
+        ) or contains_launchctl_submit_command(command)
 
 
 

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2251,7 +2251,16 @@ def _run_job_script(
     scripts_dir.mkdir(parents=True, exist_ok=True)
     scripts_dir_resolved = scripts_dir.resolve()
 
-    raw = Path(script_path).expanduser()
+    try:
+        raw = Path(script_path).expanduser()
+    except (ValueError, RuntimeError, OSError):
+        # Same ingestion contract as cron.lifecycle_guard: a NUL-bearing
+        # value (ValueError) or an unexpandable ``~`` (RuntimeError with no
+        # resolvable HOME) can never name a real script. The creation-time
+        # guard tolerates such values as "nothing to scan", so they can
+        # reach fire time — fail the run with a report instead of crashing
+        # the scheduler with an unhandled exception.
+        return False, f"Blocked: script path is not a valid filesystem path: {script_path!r}"
     if raw.is_absolute():
         path = raw.resolve()
     else:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -118,3 +118,16 @@ def test_run_job_script_path_traversal_still_blocked(hermes_env):
     ok, output = _run_job_script("/etc/passwd")
     assert ok is False
     assert "Blocked" in output or "outside" in output
+
+
+def test_run_job_script_nul_path_fails_cleanly(hermes_env):
+    """Sibling of the lifecycle-guard ingestion fix: a NUL-bearing script
+    value can survive to fire time (the creation-time guard treats it as
+    "nothing to scan"), and ``Path.expanduser()`` raises ValueError — not
+    OSError — on it. The scheduler must fail the run with a report, not
+    crash with an unhandled exception."""
+    from cron.scheduler import _run_job_script
+
+    ok, output = _run_job_script("~user\x00bad.sh")
+    assert ok is False
+    assert "Blocked" in output

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -867,6 +867,30 @@ class TestLifecycleGuardModule:
             "echo hello"
         ) is False
 
+    def test_cron_guard_total_when_home_unresolvable(self, monkeypatch):
+        """`get_hermes_home()` falls back to Path.home(), which raises
+        RuntimeError when neither HERMES_HOME nor HOME resolves
+        (arbitrary-UID containers, launchd). The cron entry point must
+        treat a relative script value as unresolvable — nothing to scan —
+        not crash."""
+        from pathlib import Path
+
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.setattr(
+            Path,
+            "home",
+            classmethod(
+                lambda cls: (_ for _ in ()).throw(
+                    RuntimeError("Could not determine home directory")
+                )
+            ),
+        )
+        # Must not raise; relative script cannot resolve without a home.
+        check_gateway_lifecycle("daily ops", "relative-script.sh")
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -761,6 +761,112 @@ class TestLifecycleGuardModule:
         with pytest.raises(GatewayLifecycleBlocked):
             check_gateway_lifecycle("daily ops", str(script))
 
+    # -- Whole-class regression tests (tilllt's T1-T4 on PR #79454) --------
+
+    def test_tilde_nul_candidate_does_not_crash_terminal_walk(self):
+        """T1: ``Path('~user\\x00...').expanduser()`` raises ValueError one
+        frame *before* ``os.open`` — the per-syscall guards never see it. The
+        ingestion-boundary sanitizer must reject the candidate instead."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "'~jenkins\x00broken/payload.sh' arg", cwd="/tmp"
+        )
+        assert result is False
+
+    def test_tilde_nul_candidate_does_not_crash_cron_script_resolution(self):
+        """T2: the same ``expanduser`` crash via the cron ``script`` path
+        (``_resolve_script_path`` / ``check_gateway_lifecycle``)."""
+        from cron.lifecycle_guard import check_gateway_lifecycle
+
+        # Must neither raise ValueError nor block: an unresolvable script
+        # value has nothing to scan, and scheduler path validation reports
+        # the bad path separately.
+        check_gateway_lifecycle("daily ops", "~jenkins\x00broken/payload.sh")
+
+    def test_binary_from_remote_callback_never_false_positives(self):
+        """T3: a ``read_remote_script`` callback returning NUL-bearing binary
+        text that *happens to contain* a lifecycle-looking fragment must be
+        skipped as binary at the recursion boundary — not matched and
+        blocked. Hardening one callback (#79454) left every other current or
+        future callback exposed; the boundary sanitizer covers them all."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        def _remote_read(_path: str):
+            return "MZ\x00\x00\x90\x00 hermes gateway restart \x00\x00junk"
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /nonexistent/dir/helper.sh",
+            cwd="/tmp",
+            read_remote_script=_remote_read,
+        )
+        assert result is False
+
+    def test_oversized_remote_callback_text_fails_closed(self):
+        """T4: >1 MiB of NUL-free text from a remote callback must follow the
+        local-read contract (oversized regular file → fail closed, #76762)
+        instead of being scanned unbounded — the 179 MiB case from #77729."""
+        from cron.lifecycle_guard import (
+            _MAX_REFERENCED_SCRIPT_BYTES,
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        big = "x" * (_MAX_REFERENCED_SCRIPT_BYTES + 1)
+
+        result = contains_gateway_lifecycle_command_or_referenced_script(
+            "bash /nonexistent/dir/big_helper.sh",
+            cwd="/tmp",
+            read_remote_script=lambda _path: big,
+        )
+        assert result is True
+
+    def test_guard_is_total_against_adversarial_inputs(self, monkeypatch):
+        """The public guard is a total function: no input may raise. Covers
+        the residual class beyond the four named sites — including
+        ``expanduser`` RuntimeError when HOME is unset under launchd."""
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        monkeypatch.delenv("HOME", raising=False)
+        adversarial = [
+            "'~\x00' run",
+            "bash '~user\x00/x.sh'",
+            "source /tmp/e\x00vil.sh",
+            "sh ~/scripts/anything.sh",  # HOME unset → RuntimeError pre-fix
+            ". '\x00\x00\x00'",
+            "bash " + "A" * 5000 + ".sh",  # over-long path → OSError
+        ]
+        for command in adversarial:
+            # Must return a bool, never raise.
+            verdict = contains_gateway_lifecycle_command_or_referenced_script(
+                command, cwd="/tmp"
+            )
+            assert verdict is False
+
+    def test_walk_crash_falls_back_to_direct_scan_verdict(self, monkeypatch):
+        """If the best-effort walk itself crashes, the guard logs and falls
+        back to the direct-scan verdict instead of propagating — a guard
+        crash breaks every terminal command until gateway restart (#77780),
+        strictly worse than either verdict."""
+        import cron.lifecycle_guard as lg
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("sibling site nobody found yet")
+
+        monkeypatch.setattr(lg, "_contains_unsafe_gateway_action", _boom)
+        # Direct scan still blocks a literal lifecycle command...
+        assert lg.contains_gateway_lifecycle_command_or_referenced_script(
+            "hermes gateway restart"
+        ) is True
+        # ...and a benign command fails open instead of crashing.
+        assert lg.contains_gateway_lifecycle_command_or_referenced_script(
+            "echo hello"
+        ) is False
+
 
 # ---------------------------------------------------------------------------
 # Defense 2 (chokepoint): cron.jobs.create_job blocks the AGENT model-tool path
@@ -856,7 +962,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
         import tools.terminal_tool as tt
 
         # Path only exists on the remote backend; locally it is absent, so the
-        # guard must fall back to env.execute('cat ...') to scan it.
+        # guard must fall back to a bounded env.execute('head -c ...') read.
         script = "/remote/workspace/remote.sh"
         calls = []
 
@@ -865,7 +971,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
             cwd = str(tmp_path)
             def execute(self, command, **kwargs):
                 calls.append(command)
-                if "cat" in command and "/remote/workspace/remote.sh" in command:
+                if "head -c" in command and "/remote/workspace/remote.sh" in command:
                     return {"output": "#!/bin/bash\\nhermes gateway restart\\n", "returncode": 0}
                 return {"output": "", "returncode": 0}
 
@@ -877,7 +983,7 @@ class TestTerminalToolGatewayLifecycleGuardRemote:
 
         assert result["exit_code"] == 1
         assert "referenced script" in result["error"]
-        assert any("cat" in c for c in calls)
+        assert any("head -c" in c for c in calls)
 
 
 class TestCronCreateLifecycleBlockExtra:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2533,7 +2533,7 @@ def terminal_tool(
 
                 For local backends the script path is on the host filesystem. For
                 SSH/Modal/Daytona the same path is remote; the local read misses, so we
-                fall back to ``env.execute('cat ...')``.
+                fall back to a bounded ``env.execute('head -c ... < path')`` read.
                 """
                 if env is None:
                     return None

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2503,6 +2503,7 @@ def terminal_tool(
         # but applies unconditionally (force=True cannot help here).
         if os.environ.get("_HERMES_GATEWAY") == "1":
             from cron.lifecycle_guard import (
+                _MAX_REFERENCED_SCRIPT_BYTES,
                 contains_gateway_lifecycle_command_or_referenced_script,
                 contains_launchctl_submit_command,
             )
@@ -2542,9 +2543,9 @@ def terminal_tool(
                         local_path = Path(guard_cwd) / local_path
                     if local_path.is_file():
                         metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
+                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= _MAX_REFERENCED_SCRIPT_BYTES:
                             data = local_path.read_bytes()
-                            if len(data) <= 1024 * 1024:
+                            if len(data) <= _MAX_REFERENCED_SCRIPT_BYTES:
                                 if b"\x00" in data:
                                     # Binary (ELF/Mach-O/PE), not a shell script:
                                     # feeding its decoded bytes back into the guard
@@ -2561,12 +2562,15 @@ def terminal_tool(
                 # file (e.g. a 166MB ELF invoked by absolute path) never
                 # crosses the wire — `cat` of such a binary previously pinned
                 # the gateway's tool thread on a superlinear shlex scan for
-                # 30+ minutes. One byte over the guard's 1 MiB budget is
-                # enough for lifecycle_guard's sanitizer to fail the
-                # oversized case closed, mirroring the local-read semantics.
+                # 30+ minutes. One byte over the guard's budget is enough for
+                # lifecycle_guard's sanitizer to fail the oversized case
+                # closed, mirroring the local-read semantics. The `< path`
+                # redirect keeps leading-dash paths out of argv (same form as
+                # tools/image_source.py).
                 try:
                     result = env.execute(
-                        f"head -c 1048577 {shlex.quote(script_path)}"
+                        f"head -c {_MAX_REFERENCED_SCRIPT_BYTES + 1} "
+                        f"< {shlex.quote(script_path)}"
                     )
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2557,12 +2557,21 @@ def terminal_tool(
                 except Exception:
                     pass
                 # Remote / sandboxed backend: read via the environment's shell.
+                # Bound the read at the source with `head -c` so an oversized
+                # file (e.g. a 166MB ELF invoked by absolute path) never
+                # crosses the wire — `cat` of such a binary previously pinned
+                # the gateway's tool thread on a superlinear shlex scan for
+                # 30+ minutes. One byte over the guard's 1 MiB budget is
+                # enough for lifecycle_guard's sanitizer to fail the
+                # oversized case closed, mirroring the local-read semantics.
                 try:
-                    result = env.execute(f"cat {shlex.quote(script_path)}")
+                    result = env.execute(
+                        f"head -c 1048577 {shlex.quote(script_path)}"
+                    )
                     if result.get("returncode", -1) == 0:
                         output = result.get("output", "")
                         if output and "\x00" in output:
-                            # Binary content from a remote `cat`: skip for the
+                            # Binary content from a remote read: skip for the
                             # same reason as the local branch above (#77703).
                             return None
                         return output


### PR DESCRIPTION
## Summary

The gateway lifecycle guard is now a total function — every input maps to a verdict, no input can crash it or stall it — by sanitizing untrusted bytes at three boundaries instead of catching exceptions at whichever syscall crashed that week.

Root cause of the class: the guard feeds untrusted byte streams (shlex-tokenized binaries, remote `cat` output) into OS-path and shell-text operations with no ingestion boundary. Each incident (#76762, #77703, #77780, #78256, #77729) got a per-callsite `except`; @tilllt's regression suite on #79454 ([comment](https://github.com/NousResearch/hermes-agent/pull/79454#issuecomment-5201504169)) showed 4 members of the class still open on merged main, and ~30 open community PRs each hot-fix another fragment.

## Changes

- `cron/lifecycle_guard.py` — `_expand_candidate_path()`: single ingestion chokepoint for path candidates. Rejects NUL/empty tokens before any `Path` OS call and tolerates `ValueError`/`RuntimeError`/`OSError` from `expanduser()` (T1/T2, plus the HOME-unset launchd crash from #78056). Both `_resolve_terminal_script_path` and `_resolve_script_path` route through it.
- `cron/lifecycle_guard.py` — `_sanitize_remote_script_text()`: applies the local-read contract (NUL = binary = nothing to scan; >1 MiB = fail closed) to whatever **any** `read_remote_script` callback returns, at the recursion boundary. The guard stops trusting its callbacks — #79454 hardened one callback; this covers every current and future one (T3/T4).
- `cron/lifecycle_guard.py` — `contains_gateway_lifecycle_command_or_referenced_script()` is total by construction: direct regex scans (pure string ops) run first; the best-effort filesystem walk is wrapped so an unexpected failure logs a warning and falls back to the direct-scan verdict instead of breaking every terminal command until gateway restart.
- `tools/terminal_tool.py` — remote fallback reads `head -c 1048577` instead of `cat`, so an oversized file never crosses the wire. One byte over budget is enough for the sanitizer to fail closed.
- `tests/hermes_cli/test_gateway_restart_loop.py` — tilllt's T1–T4 adopted as regression tests, plus an adversarial never-raises sweep (NUL paths, unset HOME, over-long paths) and a walk-crash fallback test.

## Validation

tilllt's T1–T4 harness against merged main (`49d8a155c`) vs this branch:

| Test | main @ 49d8a155c | this PR |
|---|---|---|
| T1 `~\x00` candidate via terminal walk | crash (`ValueError: embedded null byte`) | pass (False) |
| T2 `~\x00` candidate via cron script path | crash (`ValueError: embedded null byte`) | pass (no raise) |
| T3 NUL binary from remote callback | false-positive block | pass (False) |
| T4 >1 MiB remote text | scanned unbounded | fail-closed (True) |

Live probes (real imports, no guard mocks): all positive detections preserved — direct commands, launchctl kickstart/submit, nested wrapper scripts, remote-callback detection of a real lifecycle script; a 170 MB callback payload goes from a 30+ minute superlinear-shlex stall (#79838's field report) to a 0.02 s fail-closed verdict.

Tests: `test_gateway_restart_loop.py` 91 passed; `test_terminal_tool.py` + `tests/cron/` 422 passed.

## Credit

- @tilllt — the regression suite and boundary analysis on #79454 that mapped the residual class (T1–T4 adopted verbatim as tests).
- Field reports: #77703 (@zedi), #77780/#78256, #77729, #79838 (166 MB ELF stall), #78056 (HOME-unset launchd crash).
