### PR TITLE
fix(read): don't flag UTF-8 text as binary when byte 1000 cuts a multibyte char

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -304,7 +304,7 @@ class TestShellFileOpsHelpers:
             commands.append(command)
             if command.startswith("wc -c"):
                 return {"output": "5\n", "returncode": 0}
-            if command.startswith("head -c"):
+            if "import sys" in command:
                 return {"output": "hello", "returncode": 0}
             if command.startswith("sed -n"):
                 return {"output": "hello\n", "returncode": 0}
@@ -318,7 +318,8 @@ class TestShellFileOpsHelpers:
 
         assert result.error is None
         assert commands[0] == "wc -c < '/c/Users/alice/notes.txt' 2>/dev/null"
-        assert commands[1] == "head -c 1000 '/c/Users/alice/notes.txt' 2>/dev/null"
+        assert "import sys" in commands[1]
+        assert commands[1].endswith("'/c/Users/alice/notes.txt' 2>/dev/null")
         assert commands[2] == "sed -n '1,2000p' '/c/Users/alice/notes.txt'"
         assert commands[3] == "wc -l < '/c/Users/alice/notes.txt'"
 
@@ -673,3 +674,65 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+
+class TestReadUtf8BoundaryCut:
+    """UTF-8 text whose 1000th byte lands mid-character must read as text.
+
+    Regression: the sample was taken with ``head -c 1000``, a byte-aligned cut.
+    When byte 1000 landed inside a multi-byte UTF-8 char, the truncated tail
+    decoded (errors="replace") to U+FFFD, the binary detector saw mojibake and
+    flagged a legitimate UTF-8 file as binary. The fix samples via python and
+    extends the window to the next char boundary.
+    """
+
+    # A 3-byte char exactly straddling byte 1000: 998 ASCII + 中 (E4 B8 AD)
+    # puts the char's tail at index 999-1000, so `head -c 1000` would cut it.
+    def _write_straddling_file(self, tmp_path, name="notes.md"):
+        path = tmp_path / name
+        path.write_bytes(b"a" * 998 + "中".encode("utf-8") + b"b" * 50)
+        return path
+
+    @pytest.fixture()
+    def ops(self, tmp_path):
+        from tools.environments.local import LocalEnvironment
+
+        return ShellFileOperations(LocalEnvironment(cwd=str(tmp_path)))
+
+    def test_read_file_not_binary_when_boundary_cuts_char(self, tmp_path, ops):
+        path = self._write_straddling_file(tmp_path)
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is False, result.error
+        assert result.error is None
+        assert "中" in result.content
+
+    def test_read_file_raw_not_binary_when_boundary_cuts_char(self, tmp_path, ops):
+        path = self._write_straddling_file(tmp_path)
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.is_binary is False, result.error
+        assert "中" in result.content
+
+    def test_utf8_char_spanning_window_tail_kept_intact(self, tmp_path, ops):
+        """A 4-byte char (emoji) straddling the boundary must not lose bytes."""
+        # 996 ASCII + 1-byte char + 😀 (F0 9F 98 80) spans indices 997-1000.
+        path = tmp_path / "emoji.md"
+        path.write_bytes(b"a" * 996 + b"x" + "😀".encode("utf-8") + b"y" * 50)
+
+        result = ops.read_file_raw(str(path))
+
+        assert result.is_binary is False, result.error
+        assert "😀" in result.content
+
+    def test_real_binary_still_flagged_after_sample_change(self, tmp_path, ops):
+        """The python sampler must not let genuine binary content through."""
+        path = tmp_path / "blob.bin"
+        # 1200 bytes of high-bit garbage + NULs — genuinely binary.
+        path.write_bytes(b"\x00\xff\xfe" * 400)
+
+        result = ops.read_file(str(path))
+
+        assert result.is_binary is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -29,6 +29,7 @@ import os
 import re
 import difflib
 import hashlib
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any, ClassVar
@@ -1188,8 +1189,22 @@ class ShellFileOperations(FileOperations):
                 ),
             )
         
-        # Read a sample to check for binary content
-        sample_cmd = f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null"
+        # Read a sample to check for binary content. Use python instead of a
+        # raw `head -c 1000`: a byte-aligned cut can land mid-way through a
+        # multi-byte UTF-8 char, and the truncated tail decodes (utf-8,
+        # errors="replace") into U+FFFD — which the binary detector treats as
+        # mojibake and wrongly flags legitimate UTF-8 text as binary. Extend
+        # the window to the next char boundary so the sample is always whole
+        # chars; genuinely undecodable bytes still produce U+FFFD and are
+        # caught by _is_likely_binary as before.
+        sample_cmd = (
+            f"{self._escape_shell_arg(sys.executable)} -c \"import sys;"
+            f"d=open(sys.argv[1],'rb').read();"
+            f"n=min(1000,len(d));"
+            f"while n<len(d) and (d[n]&0xC0)==0x80: n+=1;"
+            f"sys.stdout.buffer.write(d[:n])\" "
+            f"{self._escape_shell_arg(path)} 2>/dev/null"
+        )
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         
@@ -1307,7 +1322,15 @@ class ShellFileOperations(FileOperations):
             file_size = 0
         if self._is_image(path):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
-        sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
+        sample_cmd = (
+            f"{self._escape_shell_arg(sys.executable)} -c \"import sys;"
+            f"d=open(sys.argv[1],'rb').read();"
+            f"n=min(1000,len(d));"
+            f"while n<len(d) and (d[n]&0xC0)==0x80: n+=1;"
+            f"sys.stdout.buffer.write(d[:n])\" "
+            f"{self._escape_shell_arg(path)} 2>/dev/null"
+        )
+        sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         if self._is_likely_binary(path, sample_output):
             return ReadResult(


### PR DESCRIPTION
## Summary

`read_file` / `read_file_raw` misclassify legitimate UTF-8 text files as binary
when the 1000-byte sampling window lands mid-way through a multi-byte character.

## Symptoms

A UTF-8 text file whose byte 1000 falls inside a multi-byte char (CJK, Cyrillic,
emoji — anything 2–4 bytes) gets flagged `is_binary: true` and refuses to read.
Concretely on a Chinese-language markdown file:

```
read_file → error: "Binary file - cannot display as text."
```

Same file reads fine on a retry because the byte position of the truncation
depends on the file's exact byte length — it is a ~50% lottery per file, not a
content property.

## Root cause

`tools/file_operations.py` samples the first 1000 **bytes** with
`head -c 1000`, then decodes that sample with `errors="replace"`. When byte
1000 cuts a multi-byte UTF-8 character in half, the truncated tail decodes to
U+FFFD (replacement char). `_is_likely_binary` sees U+FFFD and — correctly, for
genuine mojibake — treats the file as binary and blocks the read. The sample
boundary is byte-aligned, not character-aligned, so any UTF-8 text can trip it.

Verified: for the affected files, `head -c 1000` ends with a continuation byte
(`0x80–0xBF`); decoding that sample yields exactly one U+FFFD at the tail;
`_is_likely_binary` then returns True.

## Changes

`tools/file_operations.py` (both call sites — `read_file` and `read_file_raw`):

Replace the raw `head -c 1000` sample with a small python probe that reads the
first 1000 bytes **and extends the window to the next UTF-8 character
boundary** before writing the sample:

- `while n < len(d) and (d[n] & 0xC0) == 0x80: n += 1` — skip continuation
  bytes so the sample always ends on a complete character.
- Output is written via `sys.stdout.buffer.write` (raw bytes, no re-encoding),
  matching how the terminal env already decodes stdout as UTF-8.
- `sys.executable` is shell-escaped via the existing `_escape_shell_arg`.

Why this approach (not `errors="ignore"`): decoding the sample with
`errors="ignore"` would drop the U+FFFD signal entirely, so genuinely
undecodable content (latin-1 blobs, raw binary without a known extension) would
pass `_is_likely_binary` and get returned as lossy text — enabling a
read→edit→write round-trip to silently corrupt the original bytes. That
protection is the entire point of the U+FFFD branch (see its docstring). The
boundary-extension fix removes only the *artifact* of the byte-aligned cut;
real mojibake still produces U+FFFD mid-sample and is still caught.

## Testing

- New `TestReadUtf8BoundaryCut` class (4 tests, real subprocess via
  `LocalEnvironment`):
  - 3-byte CJK char straddling byte 1000 → `read_file` returns text, not binary
  - same for `read_file_raw`
  - 4-byte emoji spanning the window tail stays intact
  - genuine binary (NUL + high-bit garbage) still flagged binary
- Updated the existing `test_read_file_uses_bash_safe_windows_paths` command
  assertions to the new python sampler command shape.
- `tests/tools/test_file_operations.py` + `test_file_operations_edge_cases.py`:
  63 passed, 8 failed — all 8 failures are pre-existing on clean `main` on this
  Windows box (`TestSearchFilesFallbackHiddenPaths` ×2, atomic-write umask
  permissions ×4, symlink writes ×2 — local-environment limitations, unrelated
  to this change; verified by stashing the change and re-running).

## Related

- Mirrors the same root cause as #79641 (which proposed `errors="ignore"` and
  was rejected in review for weakening the mojibake guard; this PR fixes the
  same bug without that regression).

## Risks

- The sample command is now `python -c …` instead of `head -c 1000`. It runs
  once per read call, reads at most ~1003 bytes, and exits immediately — cost
  is negligible. `sys.executable` is escaped like every other shell arg in the
  file. Non-UTF-8 text files (e.g. latin-1) keep the existing behavior: sample
  decodes with replacement chars → flagged binary → read-only, preventing
  silent corruption. No config, schema, or env changes.
