### PR TITLE
feat(gateway): add rolling activity messages

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1336,6 +1336,13 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # How gateway progress is grouped on platforms that support message editing.
+  #   accumulate: Edit one bubble, starting continuations at the message limit (default)
+  #   rolling:    Keep one bounded turn-activity bubble, then send the final separately
+  #   separate:   Send one message per tool (pre-v0.9 style; noisier)
+  # Per-platform override: display.platforms.<platform>.tool_progress_grouping
+  tool_progress_grouping: accumulate
+
   # Per-platform defaults can be quieter than the global setting. Telegram
   # tunes for mobile: tool_progress and busy_ack_detail default off (no
   # per-tool breadcrumb stream, no "iteration 21/60" debug detail in busy

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1543,6 +1543,13 @@ display:
   # Toggle at runtime with /verbose in the CLI
   tool_progress: all
 
+  # How gateway progress is grouped on platforms that support message editing.
+  #   accumulate: Edit one bubble, starting continuations at the message limit (default)
+  #   rolling:    Keep one bounded turn-activity bubble, then send the final separately
+  #   separate:   Send one message per tool (pre-v0.9 style; noisier)
+  # Per-platform override: display.platforms.<platform>.tool_progress_grouping
+  tool_progress_grouping: accumulate
+
   # Per-platform defaults can be quieter than the global setting. Telegram
   # tunes for mobile: tool_progress and busy_ack_detail default off (no
   # per-tool breadcrumb stream, no "iteration 21/60" debug detail in busy

--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -32,7 +32,7 @@ from typing import Any
 
 _GLOBAL_DEFAULTS: dict[str, Any] = {
     "tool_progress": "all",
-    "tool_progress_grouping": "accumulate",  # "accumulate" = edit one bubble; "separate" = one msg per tool
+    "tool_progress_grouping": "accumulate",  # accumulate | rolling | separate
     "show_reasoning": False,
     # How a reasoning/thinking summary is rendered when show_reasoning is on.
     #   "code"      -> 💭 **Reasoning:** + fenced code block (legacy default)
@@ -298,8 +298,8 @@ def _normalise(setting: str, value: Any) -> Any:
             return "off"
         return val if val in {"full", "verb", "off"} else "full"
     if setting == "tool_progress_grouping":
-        val = str(value).lower()
-        return val if val in ("accumulate", "separate") else "accumulate"
+        val = str(value).strip().lower()
+        return val if val in ("accumulate", "rolling", "separate") else "accumulate"
     if setting == "reasoning_style":
         val = str(value).lower()
         return val if val in ("code", "blockquote", "subtext") else "code"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -752,6 +752,29 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
+def _rolling_activity_terminal_header(
+    result: Optional[Dict[str, Any]],
+    *,
+    timed_out: bool = False,
+    cancelled: bool = False,
+) -> str:
+    """Choose the final state shown by a rolling activity message."""
+    result = result or {}
+    if timed_out:
+        return "⚠️ Needs attention"
+    if cancelled or result.get("interrupted"):
+        return "⏹️ Stopped"
+    if (
+        not result
+        or result.get("failed")
+        or result.get("partial")
+        or result.get("completed") is False
+        or bool(result.get("error"))
+    ):
+        return "⚠️ Needs attention"
+    return "✅ Completed"
+
+
 def render_notice_line(notice) -> str:
     """Render an AgentNotice to a single plaintext line for messaging platforms.
 
@@ -3968,9 +3991,12 @@ class TurnRunner:
                     break
             return
 
-        progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
+        progress_lines = []      # Complete tool entries in the CURRENT editable bubble
         progress_msg_id = None   # ID of the current progress message to edit
         can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+        rolling_omitted_count = 0
+        rolling_header = "⏳ Working…" if ctx.progress_grouping == "rolling" else None
+        rolling_state_changed = False
         _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
         _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
@@ -4030,7 +4056,28 @@ class TurnRunner:
             return await adapter.edit_message(**kwargs)
 
         def _progress_text(lines: list) -> str:
-            return "\n".join(str(line) for line in lines)
+            rendered = [str(line) for line in lines]
+            if rolling_header:
+                rendered.insert(0, rolling_header)
+            if rolling_header and rolling_omitted_count:
+                rendered.insert(
+                    1,
+                    f"… {rolling_omitted_count} earlier activities omitted",
+                )
+            return "\n".join(rendered)
+
+        def _fit_rolling_progress_tail() -> None:
+            """Drop whole oldest entries until the rolling bubble fits."""
+            nonlocal rolling_omitted_count
+            if ctx.progress_grouping != "rolling":
+                return
+            while (
+                progress_lines
+                and _progress_len_fn(_progress_text(progress_lines))
+                > _PROGRESS_TEXT_LIMIT
+            ):
+                progress_lines.pop(0)
+                rolling_omitted_count += 1
 
         def _split_progress_groups(lines: list) -> list[list]:
             """Partition progress lines into platform-sized editable bubbles."""
@@ -4075,6 +4122,9 @@ class TurnRunner:
                 """
             nonlocal progress_msg_id, progress_lines, can_edit
             if not progress_lines or not can_edit:
+                return False
+            if ctx.progress_grouping == "rolling":
+                _fit_rolling_progress_tail()
                 return False
             groups = _split_progress_groups(progress_lines)
             if len(groups) <= 1:
@@ -4140,10 +4190,15 @@ class TurnRunner:
                 # Handle dedup messages: update last line with repeat counter
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
-                    if progress_lines:
+                    if progress_lines and (
+                        progress_lines[-1] == base_msg
+                        or str(progress_lines[-1]).startswith(f"{base_msg} (×")
+                    ):
                         progress_lines[-1] = f"{base_msg} (×{count + 1})"
                     msg = progress_lines[-1] if progress_lines else base_msg
                 elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                    if ctx.progress_grouping == "rolling":
+                        continue
                     # Content bubble just landed on the platform — close off
                     # the current tool-progress bubble so the next tool
                     # starts a fresh bubble below the content. Without this,
@@ -4154,9 +4209,16 @@ class TurnRunner:
                     # linearization regression after PR #7885.)
                     progress_msg_id = None
                     progress_lines = []
+                    rolling_omitted_count = 0
                     ctx.last_progress_msg[0] = None
                     ctx.repeat_count[0] = 0
                     continue
+                elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__activity_start__":
+                    msg = rolling_header or "⏳ Working…"
+                elif isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__activity_state__":
+                    rolling_header = str(raw[1])
+                    rolling_state_changed = True
+                    msg = rolling_header
                 else:
                     msg = raw
                     progress_lines.append(msg)
@@ -4186,7 +4248,7 @@ class TurnRunner:
 
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
+                    full_text = _progress_text(progress_lines)
                     result = await _edit_progress_message(progress_msg_id, full_text)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
@@ -4226,7 +4288,7 @@ class TurnRunner:
                 else:
                     if can_edit:
                         # First tool: send all accumulated text as new message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _progress_text(progress_lines)
                         result = await adapter.send(
                             chat_id=ctx.source.chat_id,
                             content=full_text,
@@ -4262,10 +4324,15 @@ class TurnRunner:
                         raw = ctx.progress_queue.get_nowait()
                         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                             _, base_msg, count = raw
-                            if progress_lines:
+                            if progress_lines and (
+                                progress_lines[-1] == base_msg
+                                or str(progress_lines[-1]).startswith(f"{base_msg} (×")
+                            ):
                                 progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                 await _roll_progress_overflow_if_needed()
                         elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                            if ctx.progress_grouping == "rolling":
+                                continue
                             # Content-bubble marker during drain: close off
                             # the current progress bubble and start a fresh
                             # one for any tool lines that arrived after.
@@ -4278,17 +4345,30 @@ class TurnRunner:
                                     pass
                             progress_msg_id = None
                             progress_lines = []
+                            rolling_omitted_count = 0
                             ctx.last_progress_msg[0] = None
                             ctx.repeat_count[0] = 0
+                        elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__activity_start__":
+                            continue
+                        elif isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__activity_state__":
+                            rolling_header = str(raw[1])
+                            rolling_state_changed = True
                         else:
                             progress_lines.append(raw)
                             await _roll_progress_overflow_if_needed()
                     except Exception:
                         break
-                # Final edit with all remaining tools (only if editing works)
-                if can_edit and progress_lines and progress_msg_id:
+                # Final edit with all remaining tools (only if editing works).
+                # A rolling bubble can contain only its omission marker when a
+                # single oversized activity was dropped as one complete entry.
+                _has_final_progress = bool(
+                    progress_lines
+                    or rolling_state_changed
+                    or (rolling_header and rolling_omitted_count)
+                )
+                if can_edit and _has_final_progress and progress_msg_id:
                     await _roll_progress_overflow_if_needed()
-                if can_edit and progress_lines and progress_msg_id:
+                if can_edit and _has_final_progress and progress_msg_id:
                     full_text = _progress_text(progress_lines)
                     try:
                         await _edit_progress_message(progress_msg_id, full_text)
@@ -4545,6 +4625,15 @@ class TurnRunner:
             if not ctx._run_still_current():
                 return
             display_text = text
+            if (
+                ctx.progress_grouping == "rolling"
+                and ctx.tool_progress_enabled
+                and ctx.progress_queue is not None
+                and not already_streamed
+                and str(display_text or "").strip()
+            ):
+                ctx.progress_queue.put(f"💬 {display_text}")
+                return
             if _stream_consumer is not None:
                 if already_streamed:
                     _stream_consumer.on_segment_break()
@@ -24368,7 +24457,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
-        # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
+        # Tool progress grouping: accumulated history, bounded rolling tail, or
+        # one separate message per tool.
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
@@ -24841,6 +24931,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         progress_task = None
         if needs_progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
+            if progress_grouping == "rolling" and tool_progress_enabled:
+                progress_queue.put(("__activity_start__",))
 
         # Start the tool-call log writer when tool_progress == "log".
         log_task = None
@@ -25040,6 +25132,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
                 )
                 try:
+                    if (
+                        progress_grouping == "rolling"
+                        and tool_progress_enabled
+                        and progress_queue is not None
+                    ):
+                        progress_queue.put(_heartbeat_text)
+                        continue
                     _notify_res = None
                     if _heartbeat_msg_id:
                         try:
@@ -25105,6 +25204,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return False
             return False
 
+        _inactivity_timeout = False
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based
             # timeout instead of a wall-clock limit: the agent can run for
@@ -25190,7 +25290,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._run_in_executor_with_context(_run_sync_with_timeout_lifecycle)
             )
 
-            _inactivity_timeout = False
             _POLL_INTERVAL = 5.0
 
             if _agent_timeout is None:
@@ -25779,6 +25878,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
+                if progress_grouping == "rolling" and tool_progress_enabled:
+                    _activity_result = result_holder[0] or {}
+                    _current_task = asyncio.current_task()
+                    _activity_header = _rolling_activity_terminal_header(
+                        _activity_result,
+                        timed_out=_inactivity_timeout,
+                        cancelled=bool(
+                            _current_task and _current_task.cancelling()
+                        ),
+                    )
+                    progress_queue.put(("__activity_state__", _activity_header))
                 progress_task.cancel()
             if log_task:
                 log_task.cancel()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4828,7 +4828,7 @@ class TurnRunner:
             return
 
         progress_lines = []      # Complete tool entries in the CURRENT editable bubble
-        progress_msg_id = None   # ID of the current progress message to edit
+        progress_msg_id = ctx.initial_progress_msg_id  # May be seeded by preflight compression.
         can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
         rolling_omitted_count = 0
         rolling_header = "⏳ Working…" if ctx.progress_grouping == "rolling" else None
@@ -19522,6 +19522,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # Load conversation history from transcript
         history = await self.async_session_store.load_transcript(session_entry.session_id)
+        _hyg_progress_message_id = None
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
@@ -19778,6 +19779,48 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     )
 
                     _hyg_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+
+                    # Rolling activity owns one editable bubble for the whole
+                    # turn. Seed it before the potentially minutes-long hygiene
+                    # pass, then hand its ID to the normal progress sender.
+                    try:
+                        from gateway.display_config import resolve_display_setting
+
+                        _hyg_platform_key = _platform_config_key(source.platform)
+                        _hyg_progress_mode = resolve_display_setting(
+                            _hyg_data, _hyg_platform_key, "tool_progress", "all"
+                        )
+                        _hyg_progress_grouping = resolve_display_setting(
+                            _hyg_data,
+                            _hyg_platform_key,
+                            "tool_progress_grouping",
+                            "accumulate",
+                        )
+                        _hyg_adapter = self._adapter_for_source(source)
+                        _hyg_edit = (
+                            getattr(type(_hyg_adapter), "edit_message", None)
+                            if _hyg_adapter is not None
+                            else None
+                        )
+                        if (
+                            _hyg_progress_grouping == "rolling"
+                            and _hyg_progress_mode not in {"off", "log"}
+                            and not self._get_proxy_url()
+                            and _hyg_edit is not None
+                            and _hyg_edit is not BasePlatformAdapter.edit_message
+                        ):
+                            _hyg_send = await _hyg_adapter.send(
+                                source.chat_id,
+                                "⏳ Compressing conversation context…",
+                                metadata=_hyg_meta,
+                            )
+                            if _hyg_send.success and _hyg_send.message_id:
+                                _hyg_progress_message_id = str(_hyg_send.message_id)
+                    except Exception:
+                        logger.debug(
+                            "Session hygiene progress notice failed",
+                            exc_info=True,
+                        )
 
                     try:
                         from agent.conversation_compression import CompressionCommitFence
@@ -20297,6 +20340,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "Session hygiene auto-compress failed: %s", e
                         )
 
+                    if (
+                        _hyg_progress_message_id
+                        and self._is_session_run_current(_quick_key, run_generation)
+                    ):
+                        try:
+                            await _hyg_adapter.edit_message(
+                                source.chat_id,
+                                _hyg_progress_message_id,
+                                "⏳ Working…",
+                                metadata=_hyg_meta,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Session hygiene progress edit failed",
+                                exc_info=True,
+                            )
+
         # First-message onboarding -- only on the very first interaction ever.
         # Delivered on the current user message (sidecar), NOT the ephemeral
         # system prompt: present-on-turn-1/absent-on-turn-2 was a guaranteed
@@ -20512,6 +20572,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                progress_message_id=_hyg_progress_message_id,
                 message_type=event.message_type,
             )
             _turn_seconds = time.monotonic() - _turn_started_monotonic
@@ -28225,6 +28286,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
+        progress_message_id: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Profile-scoping wrapper around the agent run.
@@ -28245,6 +28307,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                progress_message_id=progress_message_id,
                 message_type=message_type,
             )
 
@@ -28258,6 +28321,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
                 persist_user_display_kind=persist_user_display_kind,
+                progress_message_id=progress_message_id,
                 message_type=message_type,
             )
 
@@ -28401,6 +28465,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         persist_user_message: Optional[Any] = None,
         persist_user_timestamp: Optional[float] = None,
         persist_user_display_kind: Optional[str] = None,
+        progress_message_id: Optional[str] = None,
         message_type: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
@@ -28663,6 +28728,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _cleanup_progress = False
             _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
+        if _cleanup_progress and progress_message_id:
+            _cleanup_msg_ids.append(progress_message_id)
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]
@@ -28687,6 +28754,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _LONG_TOOL_THRESHOLD_S=_LONG_TOOL_THRESHOLD_S,
             _cleanup_progress=_cleanup_progress,
             _cleanup_msg_ids=_cleanup_msg_ids,
+            initial_progress_msg_id=progress_message_id,
             message=message,
             AIAgent=AIAgent,
             resolve_display_setting=resolve_display_setting,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -891,6 +891,24 @@ def _rolling_activity_terminal_header(
     return "✅ Completed"
 
 
+def _resolve_tool_progress_mode(user_config: Any, platform_key: str) -> str:
+    """Resolve tool progress with the legacy env fallback precedence."""
+    from gateway.display_config import resolve_display_setting
+
+    resolved = resolve_display_setting(user_config, platform_key, "tool_progress")
+    env_mode = os.getenv("HERMES_TOOL_PROGRESS_MODE")
+    display = user_config.get("display", {}) if isinstance(user_config, dict) else {}
+    display = display if isinstance(display, dict) else {}
+    platform = (display.get("platforms") or {}).get(platform_key) or {}
+    legacy_overrides = display.get("tool_progress_overrides") or {}
+    configured = (
+        "tool_progress" in display
+        or (isinstance(platform, dict) and "tool_progress" in platform)
+        or (isinstance(legacy_overrides, dict) and platform_key in legacy_overrides)
+    )
+    return env_mode if env_mode and not configured else (resolved or env_mode or "all")
+
+
 def render_notice_line(notice) -> str:
     """Render an AgentNotice to a single plaintext line for messaging platforms.
 
@@ -19778,7 +19796,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         f"{_compress_token_threshold:,}",
                     )
 
-                    _hyg_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                    _hyg_reply_to = self._reply_anchor_for_event(event)
+                    _hyg_meta = self._thread_metadata_for_source(source, _hyg_reply_to)
+                    _hyg_progress_meta = _hyg_meta
+                    if (
+                        source.platform == Platform.DISCORD
+                        and getattr(source, "delivered_via_upstream_relay", False)
+                        and getattr(source, "prospective_thread_id", None)
+                        and not getattr(source, "thread_id", None)
+                        and _hyg_reply_to
+                    ):
+                        _hyg_progress_meta = dict(_hyg_progress_meta or {})
+                        _hyg_progress_meta["reply_to_message_id"] = str(
+                            _hyg_reply_to
+                        )
+                    _hyg_progress_meta = _non_conversational_metadata(
+                        _hyg_progress_meta,
+                        platform=source.platform,
+                    )
 
                     # Rolling activity owns one editable bubble for the whole
                     # turn. Seed it before the potentially minutes-long hygiene
@@ -19787,8 +19822,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         from gateway.display_config import resolve_display_setting
 
                         _hyg_platform_key = _platform_config_key(source.platform)
-                        _hyg_progress_mode = resolve_display_setting(
-                            _hyg_data, _hyg_platform_key, "tool_progress", "all"
+                        _hyg_progress_mode = _resolve_tool_progress_mode(
+                            _hyg_data, _hyg_platform_key
                         )
                         _hyg_progress_grouping = resolve_display_setting(
                             _hyg_data,
@@ -19812,7 +19847,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _hyg_send = await _hyg_adapter.send(
                                 source.chat_id,
                                 "⏳ Compressing conversation context…",
-                                metadata=_hyg_meta,
+                                reply_to=_hyg_reply_to,
+                                metadata=_hyg_progress_meta,
                             )
                             if _hyg_send.success and _hyg_send.message_id:
                                 _hyg_progress_message_id = str(_hyg_send.message_id)
@@ -20345,12 +20381,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         and self._is_session_run_current(_quick_key, run_generation)
                     ):
                         try:
-                            await _hyg_adapter.edit_message(
-                                source.chat_id,
-                                _hyg_progress_message_id,
-                                "⏳ Working…",
-                                metadata=_hyg_meta,
-                            )
+                            _hyg_edit_kwargs = {
+                                "chat_id": source.chat_id,
+                                "message_id": _hyg_progress_message_id,
+                                "content": "⏳ Working…",
+                            }
+                            try:
+                                _hyg_edit_params = inspect.signature(
+                                    _hyg_adapter.edit_message
+                                ).parameters
+                                if "metadata" in _hyg_edit_params or any(
+                                    param.kind is inspect.Parameter.VAR_KEYWORD
+                                    for param in _hyg_edit_params.values()
+                                ):
+                                    _hyg_edit_kwargs["metadata"] = _hyg_progress_meta
+                            except (TypeError, ValueError):
+                                pass
+                            await _hyg_adapter.edit_message(**_hyg_edit_kwargs)
                         except Exception:
                             logger.debug(
                                 "Session hygiene progress edit failed",
@@ -28538,28 +28585,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             pass
 
         # Tool progress mode — resolved per-platform with env var fallback
-        _resolved_tp = resolve_display_setting(user_config, platform_key, "tool_progress")
-        _env_tp = os.getenv("HERMES_TOOL_PROGRESS_MODE")
-        _display_cfg = display_config if isinstance(display_config, dict) else {}
-        _platforms_cfg = _display_cfg.get("platforms") or {}
-        _platform_cfg = _platforms_cfg.get(platform_key) or {}
-        _legacy_tp_overrides = _display_cfg.get("tool_progress_overrides") or {}
-        _tool_progress_configured = (
-            "tool_progress" in _display_cfg
-            or (
-                isinstance(_platform_cfg, dict)
-                and "tool_progress" in _platform_cfg
-            )
-            or (
-                isinstance(_legacy_tp_overrides, dict)
-                and platform_key in _legacy_tp_overrides
-            )
-        )
-        progress_mode = (
-            _env_tp
-            if _env_tp and not _tool_progress_configured
-            else (_resolved_tp or _env_tp or "all")
-        )
+        progress_mode = _resolve_tool_progress_mode(user_config, platform_key)
         # Tool progress grouping: accumulated history, bounded rolling tail, or
         # one separate message per tool.
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
@@ -30010,24 +30036,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                # Defer recursion until this turn's finally block has flushed
-                # its rolling terminal state and released its running slot.
-                # Awaiting the follow-up here leaves the first activity bubble
-                # at `⏳ Working…` while a second one is already active.
-                queued_parent_result = result
-                queued_followup_args = {
-                    "message": next_message,
-                    "context_prompt": context_prompt,
-                    "history": updated_history,
-                    "source": next_source,
-                    "session_id": session_id,
-                    "session_key": next_session_key,
-                    "run_generation": run_generation,
-                    "_interrupt_depth": _interrupt_depth + 1,
-                    "event_message_id": next_message_id,
-                    "channel_prompt": next_channel_prompt,
-                    "message_type": next_message_type,
-                }
+                if progress_grouping == "rolling" and tool_progress_enabled:
+                    # Defer recursion until this turn's finally block has
+                    # flushed its terminal state and released its running slot.
+                    queued_parent_result = result
+                    queued_followup_args = {
+                        "message": next_message,
+                        "context_prompt": context_prompt,
+                        "history": updated_history,
+                        "source": next_source,
+                        "session_id": session_id,
+                        "session_key": next_session_key,
+                        "run_generation": run_generation,
+                        "_interrupt_depth": _interrupt_depth + 1,
+                        "event_message_id": next_message_id,
+                        "channel_prompt": next_channel_prompt,
+                        "message_type": next_message_type,
+                    }
+                else:
+                    followup_result = await self._run_agent(
+                        message=next_message,
+                        context_prompt=context_prompt,
+                        history=updated_history,
+                        source=next_source,
+                        session_id=session_id,
+                        session_key=next_session_key,
+                        run_generation=run_generation,
+                        _interrupt_depth=_interrupt_depth + 1,
+                        event_message_id=next_message_id,
+                        channel_prompt=next_channel_prompt,
+                        message_type=next_message_type,
+                    )
+                    return _preserve_queued_followup_history_offset(
+                        result, followup_result
+                    )
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5006,6 +5006,12 @@ class TurnRunner:
                     return
 
                 raw = ctx.progress_queue.get_nowait()
+                _finish_after_flush = bool(
+                    isinstance(raw, tuple)
+                    and len(raw) >= 2
+                    and raw[0] == "__activity_finish__"
+                )
+                _finish_requested = bool(ctx.progress_finish_header[0])
 
                 # Drain silently when interrupted: events queued in the
                 # window between tool parse and interrupt processing
@@ -5014,8 +5020,10 @@ class TurnRunner:
                 # last progress-flavored bubble the user should see.
                 try:
                     _agent_for_interrupt = ctx.agent_holder[0] if ctx.agent_holder else None
-                    if _agent_for_interrupt is not None and getattr(
-                        _agent_for_interrupt, "is_interrupted", False
+                    if (
+                        not _finish_after_flush
+                        and _agent_for_interrupt is not None
+                        and getattr(_agent_for_interrupt, "is_interrupted", False)
                     ):
                         # Drop this event and continue draining.
                         await asyncio.sleep(0)
@@ -5055,6 +5063,10 @@ class TurnRunner:
                     rolling_header = str(raw[1])
                     rolling_state_changed = True
                     msg = rolling_header
+                elif _finish_after_flush:
+                    rolling_header = str(raw[1])
+                    rolling_state_changed = True
+                    msg = rolling_header
                 else:
                     msg = raw
                     progress_lines.append(msg)
@@ -5072,7 +5084,7 @@ class TurnRunner:
                 # instead of reacting to 429s.)
                 _now = time.monotonic()
                 _remaining = _PROGRESS_EDIT_INTERVAL - (_now - _last_edit_ts)
-                if _remaining > 0:
+                if _remaining > 0 and not _finish_requested:
                     # Wait out the throttle interval, then loop back to
                     # drain any additional queued messages before sending
                     # a single batched edit.
@@ -5146,6 +5158,9 @@ class TurnRunner:
 
                 _last_edit_ts = time.monotonic()
 
+                if _finish_after_flush:
+                    return
+
                 # Restore typing indicator
                 await asyncio.sleep(0.3)
                 if ctx._run_still_current():
@@ -5186,7 +5201,11 @@ class TurnRunner:
                             ctx.repeat_count[0] = 0
                         elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__activity_start__":
                             continue
-                        elif isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__activity_state__":
+                        elif (
+                            isinstance(raw, tuple)
+                            and len(raw) >= 2
+                            and raw[0] in {"__activity_state__", "__activity_finish__"}
+                        ):
                             rolling_header = str(raw[1])
                             rolling_state_changed = True
                         else:
@@ -28866,6 +28885,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         agent_holder = [None]  # Mutable container for the agent instance
         turn_ctx.agent_holder = agent_holder
         result_holder = [None]  # Mutable container for the result
+        queued_followup_args = None
+        queued_parent_result = None
         tools_holder = [None]   # Mutable container for the tool definitions
         stream_consumer_holder = [None]  # Mutable container for stream consumer
         # #60671 — streaming PCM audio consumer.  Created on the gateway
@@ -29921,20 +29942,24 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # what the follow-up's guard will consult.  Fail-safe in helper.
                 await self._refresh_agent_cache_message_count(session_key, session_id)
 
-                followup_result = await self._run_agent(
-                    message=next_message,
-                    context_prompt=context_prompt,
-                    history=updated_history,
-                    source=next_source,
-                    session_id=session_id,
-                    session_key=next_session_key,
-                    run_generation=run_generation,
-                    _interrupt_depth=_interrupt_depth + 1,
-                    event_message_id=next_message_id,
-                    channel_prompt=next_channel_prompt,
-                    message_type=next_message_type,
-                )
-                return _preserve_queued_followup_history_offset(result, followup_result)
+                # Defer recursion until this turn's finally block has flushed
+                # its rolling terminal state and released its running slot.
+                # Awaiting the follow-up here leaves the first activity bubble
+                # at `⏳ Working…` while a second one is already active.
+                queued_parent_result = result
+                queued_followup_args = {
+                    "message": next_message,
+                    "context_prompt": context_prompt,
+                    "history": updated_history,
+                    "source": next_source,
+                    "session_id": session_id,
+                    "session_key": next_session_key,
+                    "run_generation": run_generation,
+                    "_interrupt_depth": _interrupt_depth + 1,
+                    "event_message_id": next_message_id,
+                    "channel_prompt": next_channel_prompt,
+                    "message_type": next_message_type,
+                }
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
@@ -29948,8 +29973,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             _current_task and _current_task.cancelling()
                         ),
                     )
-                    progress_queue.put(("__activity_state__", _activity_header))
-                progress_task.cancel()
+                    # Graceful terminal flush: let the progress worker send or
+                    # edit the terminal header before it exits. Immediate tool
+                    # turns can otherwise cancel the worker between the initial
+                    # `⏳ Working…` send and the terminal edit, leaving a stale
+                    # activity message behind permanently.
+                    turn_ctx.progress_finish_header[0] = _activity_header
+                    progress_queue.put(("__activity_finish__", _activity_header))
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.shield(progress_task), timeout=5.0
+                        )
+                    except (asyncio.TimeoutError, asyncio.CancelledError):
+                        progress_task.cancel()
+                        try:
+                            await progress_task
+                        except asyncio.CancelledError:
+                            pass
+                    except Exception as _progress_finish_err:
+                        logger.warning(
+                            "Rolling activity terminal flush failed: %s",
+                            _progress_finish_err,
+                        )
+                else:
+                    progress_task.cancel()
             if log_task:
                 log_task.cancel()
             interrupt_monitor.cancel()
@@ -30025,6 +30072,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                             "background turn task failed during cleanup",
                             exc_info=True,
                         )
+
+        if queued_followup_args is not None:
+            followup_result = await self._run_agent(**queued_followup_args)
+            return _preserve_queued_followup_history_offset(
+                queued_parent_result or {}, followup_result
+            )
 
         # If streaming already delivered the response, mark it so the
         # caller's send() is skipped (avoiding duplicate messages).

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -868,6 +868,29 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
+def _rolling_activity_terminal_header(
+    result: Optional[Dict[str, Any]],
+    *,
+    timed_out: bool = False,
+    cancelled: bool = False,
+) -> str:
+    """Choose the final state shown by a rolling activity message."""
+    result = result or {}
+    if timed_out:
+        return "⚠️ Needs attention"
+    if cancelled or result.get("interrupted"):
+        return "⏹️ Stopped"
+    if (
+        not result
+        or result.get("failed")
+        or result.get("partial")
+        or result.get("completed") is False
+        or bool(result.get("error"))
+    ):
+        return "⚠️ Needs attention"
+    return "✅ Completed"
+
+
 def render_notice_line(notice) -> str:
     """Render an AgentNotice to a single plaintext line for messaging platforms.
 
@@ -4804,9 +4827,12 @@ class TurnRunner:
                     break
             return
 
-        progress_lines = []      # Accumulated tool lines for the CURRENT editable bubble
+        progress_lines = []      # Complete tool entries in the CURRENT editable bubble
         progress_msg_id = None   # ID of the current progress message to edit
         can_edit = ctx.progress_grouping != "separate"  # "separate" = one message per tool (pre-v0.9 behavior)
+        rolling_omitted_count = 0
+        rolling_header = "⏳ Working…" if ctx.progress_grouping == "rolling" else None
+        rolling_state_changed = False
         _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
         _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
 
@@ -4866,7 +4892,28 @@ class TurnRunner:
             return await adapter.edit_message(**kwargs)
 
         def _progress_text(lines: list) -> str:
-            return "\n".join(str(line) for line in lines)
+            rendered = [str(line) for line in lines]
+            if rolling_header:
+                rendered.insert(0, rolling_header)
+            if rolling_header and rolling_omitted_count:
+                rendered.insert(
+                    1,
+                    f"… {rolling_omitted_count} earlier activities omitted",
+                )
+            return "\n".join(rendered)
+
+        def _fit_rolling_progress_tail() -> None:
+            """Drop whole oldest entries until the rolling bubble fits."""
+            nonlocal rolling_omitted_count
+            if ctx.progress_grouping != "rolling":
+                return
+            while (
+                progress_lines
+                and _progress_len_fn(_progress_text(progress_lines))
+                > _PROGRESS_TEXT_LIMIT
+            ):
+                progress_lines.pop(0)
+                rolling_omitted_count += 1
 
         def _split_progress_groups(lines: list) -> list[list]:
             """Partition progress lines into platform-sized editable bubbles."""
@@ -4911,6 +4958,9 @@ class TurnRunner:
                 """
             nonlocal progress_msg_id, progress_lines, can_edit
             if not progress_lines or not can_edit:
+                return False
+            if ctx.progress_grouping == "rolling":
+                _fit_rolling_progress_tail()
                 return False
             groups = _split_progress_groups(progress_lines)
             if len(groups) <= 1:
@@ -4976,10 +5026,15 @@ class TurnRunner:
                 # Handle dedup messages: update last line with repeat counter
                 if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                     _, base_msg, count = raw
-                    if progress_lines:
+                    if progress_lines and (
+                        progress_lines[-1] == base_msg
+                        or str(progress_lines[-1]).startswith(f"{base_msg} (×")
+                    ):
                         progress_lines[-1] = f"{base_msg} (×{count + 1})"
                     msg = progress_lines[-1] if progress_lines else base_msg
                 elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                    if ctx.progress_grouping == "rolling":
+                        continue
                     # Content bubble just landed on the platform — close off
                     # the current tool-progress bubble so the next tool
                     # starts a fresh bubble below the content. Without this,
@@ -4990,9 +5045,16 @@ class TurnRunner:
                     # linearization regression after PR #7885.)
                     progress_msg_id = None
                     progress_lines = []
+                    rolling_omitted_count = 0
                     ctx.last_progress_msg[0] = None
                     ctx.repeat_count[0] = 0
                     continue
+                elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__activity_start__":
+                    msg = rolling_header or "⏳ Working…"
+                elif isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__activity_state__":
+                    rolling_header = str(raw[1])
+                    rolling_state_changed = True
+                    msg = rolling_header
                 else:
                     msg = raw
                     progress_lines.append(msg)
@@ -5022,7 +5084,7 @@ class TurnRunner:
 
                 if can_edit and progress_msg_id is not None:
                     # Try to edit the existing progress message
-                    full_text = "\n".join(progress_lines)
+                    full_text = _progress_text(progress_lines)
                     result = await _edit_progress_message(progress_msg_id, full_text)
                     if not result.success:
                         _err = (getattr(result, "error", "") or "").lower()
@@ -5062,7 +5124,7 @@ class TurnRunner:
                 else:
                     if can_edit:
                         # First tool: send all accumulated text as new message
-                        full_text = "\n".join(progress_lines)
+                        full_text = _progress_text(progress_lines)
                         result = await adapter.send(
                             chat_id=ctx.source.chat_id,
                             content=full_text,
@@ -5098,10 +5160,15 @@ class TurnRunner:
                         raw = ctx.progress_queue.get_nowait()
                         if isinstance(raw, tuple) and len(raw) == 3 and raw[0] == "__dedup__":
                             _, base_msg, count = raw
-                            if progress_lines:
+                            if progress_lines and (
+                                progress_lines[-1] == base_msg
+                                or str(progress_lines[-1]).startswith(f"{base_msg} (×")
+                            ):
                                 progress_lines[-1] = f"{base_msg} (×{count + 1})"
                                 await _roll_progress_overflow_if_needed()
                         elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__reset__":
+                            if ctx.progress_grouping == "rolling":
+                                continue
                             # Content-bubble marker during drain: close off
                             # the current progress bubble and start a fresh
                             # one for any tool lines that arrived after.
@@ -5114,17 +5181,30 @@ class TurnRunner:
                                     pass
                             progress_msg_id = None
                             progress_lines = []
+                            rolling_omitted_count = 0
                             ctx.last_progress_msg[0] = None
                             ctx.repeat_count[0] = 0
+                        elif isinstance(raw, tuple) and len(raw) >= 1 and raw[0] == "__activity_start__":
+                            continue
+                        elif isinstance(raw, tuple) and len(raw) >= 2 and raw[0] == "__activity_state__":
+                            rolling_header = str(raw[1])
+                            rolling_state_changed = True
                         else:
                             progress_lines.append(raw)
                             await _roll_progress_overflow_if_needed()
                     except Exception:
                         break
-                # Final edit with all remaining tools (only if editing works)
-                if can_edit and progress_lines and progress_msg_id:
+                # Final edit with all remaining tools (only if editing works).
+                # A rolling bubble can contain only its omission marker when a
+                # single oversized activity was dropped as one complete entry.
+                _has_final_progress = bool(
+                    progress_lines
+                    or rolling_state_changed
+                    or (rolling_header and rolling_omitted_count)
+                )
+                if can_edit and _has_final_progress and progress_msg_id:
                     await _roll_progress_overflow_if_needed()
-                if can_edit and progress_lines and progress_msg_id:
+                if can_edit and _has_final_progress and progress_msg_id:
                     full_text = _progress_text(progress_lines)
                     try:
                         await _edit_progress_message(progress_msg_id, full_text)
@@ -5500,6 +5580,15 @@ class TurnRunner:
             if not ctx._run_still_current():
                 return
             display_text = text
+            if (
+                ctx.progress_grouping == "rolling"
+                and ctx.tool_progress_enabled
+                and ctx.progress_queue is not None
+                and not already_streamed
+                and str(display_text or "").strip()
+            ):
+                ctx.progress_queue.put(f"💬 {display_text}")
+                return
             if _stream_consumer is not None:
                 if already_streamed:
                     _stream_consumer.on_segment_break()
@@ -28387,7 +28476,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _env_tp and not _tool_progress_configured
             else (_resolved_tp or _env_tp or "all")
         )
-        # Tool progress grouping: "accumulate" (edit one bubble) or "separate" (one msg per tool)
+        # Tool progress grouping: accumulated history, bounded rolling tail, or
+        # one separate message per tool.
         progress_grouping = resolve_display_setting(user_config, platform_key, "tool_progress_grouping") or "accumulate"
         from gateway.status_phrases import choose_status_phrase, resolve_status_phrase_catalog
         _generic_status_recent: List[str] = []
@@ -28895,6 +28985,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         progress_task = None
         if needs_progress_queue:
             progress_task = asyncio.create_task(send_progress_messages())
+            if progress_grouping == "rolling" and tool_progress_enabled:
+                progress_queue.put(("__activity_start__",))
 
         # Start the tool-call log writer when tool_progress == "log".
         log_task = None
@@ -29094,6 +29186,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     else f"⏳ Working — {_elapsed_mins} min{_status_detail}"
                 )
                 try:
+                    if (
+                        progress_grouping == "rolling"
+                        and tool_progress_enabled
+                        and progress_queue is not None
+                    ):
+                        progress_queue.put(_heartbeat_text)
+                        continue
                     _notify_res = None
                     if _heartbeat_msg_id:
                         try:
@@ -29159,6 +29258,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         return False
             return False
 
+        _inactivity_timeout = False
         try:
             # Run in thread pool to not block.  Use an *inactivity*-based
             # timeout instead of a wall-clock limit: the agent can run for
@@ -29244,7 +29344,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self._run_in_executor_with_context(_run_sync_with_timeout_lifecycle)
             )
 
-            _inactivity_timeout = False
             _POLL_INTERVAL = 5.0
 
             if _agent_timeout is None:
@@ -29839,6 +29938,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         finally:
             # Stop progress sender, interrupt monitor, and notification task
             if progress_task:
+                if progress_grouping == "rolling" and tool_progress_enabled:
+                    _activity_result = result_holder[0] or {}
+                    _current_task = asyncio.current_task()
+                    _activity_header = _rolling_activity_terminal_header(
+                        _activity_result,
+                        timed_out=_inactivity_timeout,
+                        cancelled=bool(
+                            _current_task and _current_task.cancelling()
+                        ),
+                    )
+                    progress_queue.put(("__activity_state__", _activity_header))
                 progress_task.cancel()
             if log_task:
                 log_task.cancel()

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -46,6 +46,10 @@ class TurnContext:
     # --- queues ----------------------------------------------------------
     progress_queue: Any = None
     log_queue: Any = None
+    # Set before enqueueing the rolling terminal sentinel. The progress
+    # sender uses this to bypass edit throttling while it drains every event
+    # that preceded the terminal state, then exits after the final edit.
+    progress_finish_header: list = field(default_factory=lambda: [None])
 
     # --- mutable single-element containers (shared with the outer body) --
     last_progress_msg: list = field(default_factory=lambda: [None])

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -68,6 +68,7 @@ class TurnContext:
     #     send_progress_messages is scheduled) ----------------------------
     _progress_metadata: Optional[dict] = None
     _progress_reply_to: Optional[Any] = None
+    initial_progress_msg_id: Optional[str] = None
 
     # ------------------------------------------------------------------
     # run_sync extraction (second wave of the seam): the closed-over locals

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1219,10 +1219,13 @@ DEFAULT_CONFIG = {
         # call in the turn reports usage.
         "spinner_token_flow": True,
         # How gateway tool-progress is grouped on platforms that support message
-        # editing: "accumulate" (default) edits one bubble in place; "separate"
-        # sends one message per tool (the pre-v0.9 behavior, noisier). Only
-        # applies where tool_progress is already enabled. Per-platform override
-        # via display.platforms.<platform>.tool_progress_grouping.
+        # editing: "accumulate" (default) edits one bubble in place and starts
+        # continuation bubbles at the platform limit; "rolling" keeps one
+        # bounded turn-activity bubble (tools, interim commentary, heartbeats)
+        # by omitting its oldest complete entries;
+        # "separate" sends one message per tool (the pre-v0.9 behavior, noisier).
+        # Only applies where tool_progress is already enabled. Per-platform
+        # override via display.platforms.<platform>.tool_progress_grouping.
         "tool_progress_grouping": "accumulate",
         # Optional custom phrases for generic long-running status messages.
         # Built-in defaults live in gateway/assets/status_phrases.yaml. Users

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1472,10 +1472,13 @@ DEFAULT_CONFIG = {
         # call in the turn reports usage.
         "spinner_token_flow": True,
         # How gateway tool-progress is grouped on platforms that support message
-        # editing: "accumulate" (default) edits one bubble in place; "separate"
-        # sends one message per tool (the pre-v0.9 behavior, noisier). Only
-        # applies where tool_progress is already enabled. Per-platform override
-        # via display.platforms.<platform>.tool_progress_grouping.
+        # editing: "accumulate" (default) edits one bubble in place and starts
+        # continuation bubbles at the platform limit; "rolling" keeps one
+        # bounded turn-activity bubble (tools, interim commentary, heartbeats)
+        # by omitting its oldest complete entries;
+        # "separate" sends one message per tool (the pre-v0.9 behavior, noisier).
+        # Only applies where tool_progress is already enabled. Per-platform
+        # override via display.platforms.<platform>.tool_progress_grouping.
         "tool_progress_grouping": "accumulate",
         # Optional custom phrases for generic long-running status messages.
         # Built-in defaults live in gateway/assets/status_phrases.yaml. Users

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -275,6 +275,22 @@ class TestToolProgressGrouping:
             == "separate"
         )
 
+    def test_platform_rolling(self):
+        from gateway.display_config import resolve_display_setting
+
+        config = {
+            "display": {
+                "tool_progress_grouping": "separate",
+                "platforms": {
+                    "discord": {"tool_progress_grouping": " RoLlInG "},
+                },
+            }
+        }
+        assert (
+            resolve_display_setting(config, "discord", "tool_progress_grouping")
+            == "rolling"
+        )
+
 
 class TestReasoningStyle:
     """Per-platform reasoning render style (code | blockquote | subtext)."""

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -131,6 +131,18 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
         return SendResult(success=True, message_id=message_id)
 
 
+class Utf16SmallLimitProgressAdapter(SmallLimitProgressAdapter):
+    """Small adapter whose platform limit is measured in UTF-16 units."""
+
+    @property
+    def message_len_fn(self):
+        return lambda text: len(text.encode("utf-16-le")) // 2
+
+
+class TinyLimitProgressAdapter(SmallLimitProgressAdapter):
+    MAX_MESSAGE_LENGTH = 48
+
+
 class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
     async def edit_message(
         self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
@@ -430,6 +442,30 @@ class ManyProgressLinesAgent:
         time.sleep(0.35)
         for idx in range(1, 8):
             cb("tool.started", "terminal", f"overflow-line-{idx}-" + "x" * 45, {})
+        time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RollingDedupAgent:
+    """Overflow the rolling tail, then repeat its newest complete entry."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        assert cb is not None
+        cb("tool.started", "terminal", "first-short", {})
+        time.sleep(0.35)
+        for idx in range(6):
+            cb("tool.started", "terminal", f"old-line-{idx}-" + "x" * 45, {})
+        for _ in range(3):
+            cb("tool.started", "web_search", "latest repeated query", {})
         time.sleep(0.1)
         return {
             "final_response": "done",
@@ -815,6 +851,23 @@ class CommentaryAgent:
         }
 
 
+class SlowToolAgent:
+    """Emit progress, then stay active long enough for a configured heartbeat."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "long command", {})
+        time.sleep(0.25)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -1160,6 +1213,186 @@ async def test_retryable_overflow_edit_keeps_editable_bubble_identity(monkeypatc
     assert any(call["message_id"] == "progress-1" for call in adapter.edits[1:])
     assert adapter.oversized_sends == []
     assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_keeps_one_bounded_editable_tail(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyProgressLinesAgent,
+        session_id="sess-progress-rolling-tail",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="C123",
+        chat_type="group",
+        thread_id="thread-1",
+        adapter_cls=Utf16SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"] is not None
+    assert adapter.edits
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
+    rendered = [adapter.sent[0]["content"], *(call["content"] for call in adapter.edits)]
+    effective_limit = adapter.MAX_MESSAGE_LENGTH - 64
+    assert all(adapter.message_len_fn(text) <= effective_limit for text in rendered)
+    final_progress = rendered[-1]
+    assert "earlier activities omitted" in final_progress
+    assert "overflow-line-7" in final_progress
+    assert "first-short" not in final_progress
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_omits_single_oversized_entry_without_splitting(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        VerboseAgent,
+        session_id="sess-progress-rolling-oversized-entry",
+        config_data={
+            "display": {
+                "tool_progress": "verbose",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=TinyLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == "⏳ Working…"
+    assert adapter.edits
+    progress_text = adapter.edits[-1]["content"]
+    assert progress_text == "✅ Completed\n… 1 earlier activities omitted"
+    assert VerboseAgent.LONG_CODE not in progress_text
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.parametrize(
+    ("result", "timed_out", "cancelled", "expected"),
+    [
+        ({}, True, False, "⚠️ Needs attention"),
+        ({"failed": True}, False, False, "⚠️ Needs attention"),
+        ({"completed": False}, False, False, "⚠️ Needs attention"),
+        ({"partial": True}, False, False, "⚠️ Needs attention"),
+        ({"error": "compression deferred"}, False, False, "⚠️ Needs attention"),
+        ({"interrupted": True}, False, False, "⏹️ Stopped"),
+        (None, False, True, "⏹️ Stopped"),
+        ({"failed": False}, False, False, "✅ Completed"),
+    ],
+)
+def test_rolling_activity_terminal_header_states(
+    result, timed_out, cancelled, expected
+):
+    gateway_run = importlib.import_module("gateway.run")
+
+    assert gateway_run._rolling_activity_terminal_header(
+        result,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    ) == expected
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_preserves_dedup_after_omitting_old_entries(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        RollingDedupAgent,
+        session_id="sess-progress-rolling-dedup",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    final_progress = adapter.edits[-1]["content"]
+    assert "earlier activities omitted" in final_progress
+    assert "latest repeated query" in final_progress
+    assert "(×3)" in final_progress
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_routes_interim_commentary_into_activity_bubble(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-progress-rolling-commentary",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    rendered = adapter.edits[-1]["content"]
+    assert "✅ Completed" in rendered
+    assert "I'll inspect the repo first." in rendered
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_routes_heartbeat_into_same_activity_bubble(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SlowToolAgent,
+        session_id="sess-progress-rolling-heartbeat",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+                "long_running_notifications": True,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    assert "Working — 0 min" in adapter.edits[-1]["content"]
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -112,6 +112,18 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
         return SendResult(success=True, message_id=message_id)
 
 
+class Utf16SmallLimitProgressAdapter(SmallLimitProgressAdapter):
+    """Small adapter whose platform limit is measured in UTF-16 units."""
+
+    @property
+    def message_len_fn(self):
+        return lambda text: len(text.encode("utf-16-le")) // 2
+
+
+class TinyLimitProgressAdapter(SmallLimitProgressAdapter):
+    MAX_MESSAGE_LENGTH = 48
+
+
 class MetadataEditProgressCaptureAdapter(ProgressCaptureAdapter):
     async def edit_message(
         self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
@@ -332,6 +344,30 @@ class ManyProgressLinesAgent:
         time.sleep(0.35)
         for idx in range(1, 8):
             cb("tool.started", "terminal", f"overflow-line-{idx}-" + "x" * 45, {})
+        time.sleep(0.1)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RollingDedupAgent:
+    """Overflow the rolling tail, then repeat its newest complete entry."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        assert cb is not None
+        cb("tool.started", "terminal", "first-short", {})
+        time.sleep(0.35)
+        for idx in range(6):
+            cb("tool.started", "terminal", f"old-line-{idx}-" + "x" * 45, {})
+        for _ in range(3):
+            cb("tool.started", "web_search", "latest repeated query", {})
         time.sleep(0.1)
         return {
             "final_response": "done",
@@ -717,6 +753,23 @@ class CommentaryAgent:
         }
 
 
+class SlowToolAgent:
+    """Emit progress, then stay active long enough for a configured heartbeat."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "long command", {})
+        time.sleep(0.25)
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -957,6 +1010,186 @@ async def test_retryable_overflow_edit_keeps_editable_bubble_identity(monkeypatc
     assert any(call["message_id"] == "progress-1" for call in adapter.edits[1:])
     assert adapter.oversized_sends == []
     assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_keeps_one_bounded_editable_tail(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyProgressLinesAgent,
+        session_id="sess-progress-rolling-tail",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="C123",
+        chat_type="group",
+        thread_id="thread-1",
+        adapter_cls=Utf16SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["metadata"] is not None
+    assert adapter.edits
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
+    rendered = [adapter.sent[0]["content"], *(call["content"] for call in adapter.edits)]
+    effective_limit = adapter.MAX_MESSAGE_LENGTH - 64
+    assert all(adapter.message_len_fn(text) <= effective_limit for text in rendered)
+    final_progress = rendered[-1]
+    assert "earlier activities omitted" in final_progress
+    assert "overflow-line-7" in final_progress
+    assert "first-short" not in final_progress
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_omits_single_oversized_entry_without_splitting(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        VerboseAgent,
+        session_id="sess-progress-rolling-oversized-entry",
+        config_data={
+            "display": {
+                "tool_progress": "verbose",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=TinyLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.sent[0]["content"] == "⏳ Working…"
+    assert adapter.edits
+    progress_text = adapter.edits[-1]["content"]
+    assert progress_text == "✅ Completed\n… 1 earlier activities omitted"
+    assert VerboseAgent.LONG_CODE not in progress_text
+    assert adapter.oversized_sends == []
+    assert adapter.oversized_edits == []
+
+
+@pytest.mark.parametrize(
+    ("result", "timed_out", "cancelled", "expected"),
+    [
+        ({}, True, False, "⚠️ Needs attention"),
+        ({"failed": True}, False, False, "⚠️ Needs attention"),
+        ({"completed": False}, False, False, "⚠️ Needs attention"),
+        ({"partial": True}, False, False, "⚠️ Needs attention"),
+        ({"error": "compression deferred"}, False, False, "⚠️ Needs attention"),
+        ({"interrupted": True}, False, False, "⏹️ Stopped"),
+        (None, False, True, "⏹️ Stopped"),
+        ({"failed": False}, False, False, "✅ Completed"),
+    ],
+)
+def test_rolling_activity_terminal_header_states(
+    result, timed_out, cancelled, expected
+):
+    gateway_run = importlib.import_module("gateway.run")
+
+    assert gateway_run._rolling_activity_terminal_header(
+        result,
+        timed_out=timed_out,
+        cancelled=cancelled,
+    ) == expected
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_preserves_dedup_after_omitting_old_entries(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        RollingDedupAgent,
+        session_id="sess-progress-rolling-dedup",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    final_progress = adapter.edits[-1]["content"]
+    assert "earlier activities omitted" in final_progress
+    assert "latest repeated query" in final_progress
+    assert "(×3)" in final_progress
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_routes_interim_commentary_into_activity_bubble(
+    monkeypatch, tmp_path
+):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        CommentaryAgent,
+        session_id="sess-progress-rolling-commentary",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": True,
+            },
+            "streaming": {"enabled": False},
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    rendered = adapter.edits[-1]["content"]
+    assert "✅ Completed" in rendered
+    assert "I'll inspect the repo first." in rendered
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_routes_heartbeat_into_same_activity_bubble(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_AGENT_NOTIFY_INTERVAL", "0.05")
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        SlowToolAgent,
+        session_id="sess-progress-rolling-heartbeat",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+                "long_running_notifications": True,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(adapter.sent) == 1
+    assert adapter.edits
+    assert "Working — 0 min" in adapter.edits[-1]["content"]
+    assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -131,6 +131,24 @@ class SmallLimitProgressAdapter(ProgressCaptureAdapter):
         return SendResult(success=True, message_id=message_id)
 
 
+class OrderedProgressAdapter(SmallLimitProgressAdapter):
+    """Capture send/edit chronology across queued logical turns."""
+
+    MAX_MESSAGE_LENGTH = 500
+
+    def __init__(self, platform=Platform.DISCORD):
+        super().__init__(platform=platform)
+        self.timeline = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.timeline.append(("send", content))
+        return await super().send(chat_id, content, reply_to, metadata)
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.timeline.append(("edit", content))
+        return await super().edit_message(chat_id, message_id, content)
+
+
 class Utf16SmallLimitProgressAdapter(SmallLimitProgressAdapter):
     """Small adapter whose platform limit is measured in UTF-16 units."""
 
@@ -868,6 +886,22 @@ class SlowToolAgent:
         }
 
 
+class InstantToolAgent:
+    """Finish immediately after emitting one tool event."""
+
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        self.tool_progress_callback("tool.started", "terminal", "instant command", {})
+        return {
+            "final_response": "done",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -1393,6 +1427,80 @@ async def test_rolling_progress_routes_heartbeat_into_same_activity_bubble(
     assert adapter.edits
     assert "Working — 0 min" in adapter.edits[-1]["content"]
     assert {call["message_id"] for call in adapter.edits} == {"progress-1"}
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_always_flushes_terminal_header_for_instant_turns(
+    monkeypatch, tmp_path
+):
+    for index in range(20):
+        adapter, result = await _run_with_agent(
+            monkeypatch,
+            tmp_path,
+            InstantToolAgent,
+            session_id=f"sess-progress-rolling-instant-{index}",
+            config_data={
+                "display": {
+                    "tool_progress": "all",
+                    "tool_progress_grouping": "rolling",
+                    "interim_assistant_messages": False,
+                }
+            },
+            platform=Platform.DISCORD,
+            chat_id="C123",
+            chat_type="group",
+            thread_id="thread-1",
+        )
+
+        assert result["final_response"] == "done"
+        assert len(adapter.sent) == 1
+        final_progress = (
+            adapter.edits[-1]["content"]
+            if adapter.edits
+            else adapter.sent[-1]["content"]
+        )
+        assert final_progress.startswith("✅ Completed")
+
+
+@pytest.mark.asyncio
+async def test_rolling_queued_followup_starts_after_parent_terminal_flush(
+    monkeypatch, tmp_path
+):
+    QueuedCommentaryAgent.calls = 0
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedCommentaryAgent,
+        session_id="sess-progress-rolling-queued-order",
+        pending_text="follow up",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": True,
+            }
+        },
+        platform=Platform.DISCORD,
+        chat_id="C123",
+        chat_type="group",
+        thread_id="thread-1",
+        adapter_cls=OrderedProgressAdapter,
+    )
+
+    assert result["final_response"] == "final response 2"
+    parent_terminal = next(
+        index
+        for index, (_, content) in enumerate(adapter.timeline)
+        if content.startswith("✅ Completed")
+    )
+    child_start = next(
+        index
+        for index, (_, content) in enumerate(
+            adapter.timeline[parent_terminal + 1 :], parent_terminal + 1
+        )
+        if content.startswith("⏳ Working…")
+    )
+    assert parent_terminal < child_start
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1093,6 +1093,7 @@ async def _run_with_agent(
     adapter_cls=ProgressCaptureAdapter,
     user_id=None,
     scope_id=None,
+    progress_message_id=None,
 ):
     if config_data:
         import yaml
@@ -1140,6 +1141,7 @@ async def _run_with_agent(
         source=source,
         session_id=session_id,
         session_key=session_key,
+        progress_message_id=progress_message_id,
     )
     return adapter, result
 
@@ -1284,6 +1286,31 @@ async def test_rolling_progress_keeps_one_bounded_editable_tail(monkeypatch, tmp
     assert "first-short" not in final_progress
     assert adapter.oversized_sends == []
     assert adapter.oversized_edits == []
+
+
+@pytest.mark.asyncio
+async def test_rolling_progress_reuses_preflight_compression_message(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        ManyProgressLinesAgent,
+        session_id="sess-progress-rolling-preflight",
+        progress_message_id="preflight-1",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": "rolling",
+                "interim_assistant_messages": False,
+            }
+        },
+        platform=Platform.DISCORD,
+        adapter_cls=Utf16SmallLimitProgressAdapter,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter.edits
+    assert {call["message_id"] for call in adapter.edits} == {"preflight-1"}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -1017,6 +1017,25 @@ class QueuedSilenceAgent:
         }
 
 
+class QueuedLifecycleAgent:
+    """Record queued-turn execution relative to parent cleanup."""
+
+    calls = 0
+    timeline = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        type(self).calls += 1
+        type(self).timeline.append(f"run-{type(self).calls}")
+        return {
+            "final_response": f"response {type(self).calls}",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class QueuedFailedEmptyAgent:
     """First turn fails empty; its normalized error must send before follow-up."""
 
@@ -1094,6 +1113,7 @@ async def _run_with_agent(
     user_id=None,
     scope_id=None,
     progress_message_id=None,
+    runner_setup=None,
 ):
     if config_data:
         import yaml
@@ -1110,6 +1130,8 @@ async def _run_with_agent(
 
     adapter = adapter_cls(platform=platform)
     runner = _make_runner(adapter)
+    if runner_setup:
+        runner_setup(runner)
     gateway_run = importlib.import_module("gateway.run")
     if config_data and "streaming" in config_data:
         runner.config.streaming = StreamingConfig.from_dict(config_data["streaming"])
@@ -1528,6 +1550,43 @@ async def test_rolling_queued_followup_starts_after_parent_terminal_flush(
         if content.startswith("⏳ Working…")
     )
     assert parent_terminal < child_start
+
+
+@pytest.mark.parametrize("grouping", ["accumulate", "separate"])
+@pytest.mark.asyncio
+async def test_nonrolling_queued_followup_preserves_nested_recursion(
+    monkeypatch, tmp_path, grouping
+):
+    QueuedLifecycleAgent.calls = 0
+    QueuedLifecycleAgent.timeline = []
+
+    def record_cleanup(runner):
+        original = runner._release_running_agent_state
+
+        def wrapped(*args, **kwargs):
+            QueuedLifecycleAgent.timeline.append("release")
+            return original(*args, **kwargs)
+
+        runner._release_running_agent_state = wrapped
+
+    _, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        QueuedLifecycleAgent,
+        session_id=f"sess-progress-{grouping}-queued-order",
+        pending_text="follow up",
+        config_data={
+            "display": {
+                "tool_progress": "all",
+                "tool_progress_grouping": grouping,
+                "interim_assistant_messages": False,
+            }
+        },
+        runner_setup=record_cleanup,
+    )
+
+    assert result["final_response"] == "response 2"
+    assert QueuedLifecycleAgent.timeline[:2] == ["run-1", "run-2"]
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -58,6 +58,7 @@ class HygieneCaptureAdapter(BasePlatformAdapter):
     def __init__(self):
         super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
         self.sent = []
+        self.edits = []
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         return True
@@ -75,6 +76,17 @@ class HygieneCaptureAdapter(BasePlatformAdapter):
             }
         )
         return SendResult(success=True, message_id="hygiene-1")
+
+    async def edit_message(self, chat_id, message_id, content, metadata=None) -> SendResult:
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
 
     async def get_chat_info(self, chat_id: str):
         return {"id": chat_id}
@@ -700,6 +712,16 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     fake_run_agent.AIAgent = FakeInPlaceCompressAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
+    (tmp_path / "config.yaml").write_text(
+        "compression:\n"
+        "  enabled: true\n"
+        "display:\n"
+        "  platforms:\n"
+        "    telegram:\n"
+        "      tool_progress: all\n"
+        "      tool_progress_grouping: rolling\n"
+    )
+
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
 
@@ -784,6 +806,9 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     # the just-archived rows (#61145). The hygiene handler must skip it.
     runner.session_store.rewrite_transcript.assert_not_called()
     runner._run_agent.assert_awaited_once()
+    assert adapter.sent[0]["content"] == "⏳ Compressing conversation context…"
+    assert adapter.edits[-1]["content"] == "⏳ Working…"
+    assert runner._run_agent.call_args.kwargs["progress_message_id"] == "hygiene-1"
     # A real in-place compaction IS a recovery, so the gate must have run and
     # cleared the streak. This is the positive half of the wiring contract.
     assert reset_calls, (

--- a/tests/gateway/test_session_hygiene.py
+++ b/tests/gateway/test_session_hygiene.py
@@ -55,8 +55,8 @@ def _make_large_history_tokens(target_tokens: int) -> list:
 
 
 class HygieneCaptureAdapter(BasePlatformAdapter):
-    def __init__(self):
-        super().__init__(PlatformConfig(enabled=True, token="fake-token"), Platform.TELEGRAM)
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="fake-token"), platform)
         self.sent = []
         self.edits = []
 
@@ -77,13 +77,12 @@ class HygieneCaptureAdapter(BasePlatformAdapter):
         )
         return SendResult(success=True, message_id="hygiene-1")
 
-    async def edit_message(self, chat_id, message_id, content, metadata=None) -> SendResult:
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
         self.edits.append(
             {
                 "chat_id": chat_id,
                 "message_id": message_id,
                 "content": content,
-                "metadata": metadata,
             }
         )
         return SendResult(success=True, message_id=message_id)
@@ -645,9 +644,10 @@ async def test_session_hygiene_timeout_continues_to_agent_and_sets_cooldown(monk
     SlowCompressAgent.last_instance.close.assert_called_once()
 
 
+@pytest.mark.parametrize("legacy_progress_mode", [None, "off", "log"])
 @pytest.mark.asyncio
 async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
-    monkeypatch, tmp_path
+    monkeypatch, tmp_path, legacy_progress_mode
 ):
     """Regression for #60947: gateway hygiene should not rely on
     helper-agent session rotation to shrink a live gateway transcript.
@@ -712,35 +712,37 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     fake_run_agent.AIAgent = FakeInPlaceCompressAgent
     monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
 
+    if legacy_progress_mode:
+        monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", legacy_progress_mode)
     (tmp_path / "config.yaml").write_text(
         "compression:\n"
         "  enabled: true\n"
         "display:\n"
         "  platforms:\n"
-        "    telegram:\n"
-        "      tool_progress: all\n"
+        "    discord:\n"
         "      tool_progress_grouping: rolling\n"
     )
 
     gateway_run = importlib.import_module("gateway.run")
     GatewayRunner = gateway_run.GatewayRunner
 
-    adapter = HygieneCaptureAdapter()
+    adapter = HygieneCaptureAdapter(Platform.DISCORD)
     runner = object.__new__(GatewayRunner)
     runner.config = GatewayConfig(
-        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake-token")}
+        platforms={Platform.DISCORD: PlatformConfig(enabled=True, token="fake-token")}
     )
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._adapter_for_source = lambda _source: adapter
     runner._voice_mode = {}
     runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
     runner.session_store = MagicMock()
     runner.session_store.get_or_create_session.return_value = SessionEntry(
-        session_key="agent:main:telegram:private:12345",
+        session_key="agent:main:discord:channel:12345",
         session_id="sess-1",
         created_at=datetime.now(),
         updated_at=datetime.now(),
-        platform=Platform.TELEGRAM,
-        chat_type="private",
+        platform=Platform.DISCORD,
+        chat_type="channel",
     )
     runner.session_store.load_transcript.return_value = _make_history(12, content_size=400)
     runner.session_store.has_any_sessions.return_value = True
@@ -774,10 +776,12 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     event = MessageEvent(
         text="hello",
         source=SessionSource(
-            platform=Platform.TELEGRAM,
+            platform=Platform.DISCORD,
             chat_id="12345",
-            chat_type="private",
+            chat_type="channel",
             user_id="12345",
+            delivered_via_upstream_relay=True,
+            prospective_thread_id="1",
         ),
         message_id="1",
     )
@@ -806,9 +810,17 @@ async def test_session_hygiene_forces_in_place_compaction_with_bound_session_db(
     # the just-archived rows (#61145). The hygiene handler must skip it.
     runner.session_store.rewrite_transcript.assert_not_called()
     runner._run_agent.assert_awaited_once()
-    assert adapter.sent[0]["content"] == "⏳ Compressing conversation context…"
-    assert adapter.edits[-1]["content"] == "⏳ Working…"
-    assert runner._run_agent.call_args.kwargs["progress_message_id"] == "hygiene-1"
+    if legacy_progress_mode:
+        assert adapter.sent == []
+        assert adapter.edits == []
+        assert runner._run_agent.call_args.kwargs["progress_message_id"] is None
+    else:
+        assert adapter.sent[0]["content"] == "⏳ Compressing conversation context…"
+        assert adapter.sent[0]["reply_to"] == "1"
+        assert adapter.sent[0]["metadata"]["reply_to_message_id"] == "1"
+        assert adapter.sent[0]["metadata"]["non_conversational"] is True
+        assert adapter.edits[-1]["content"] == "⏳ Working…"
+        assert runner._run_agent.call_args.kwargs["progress_message_id"] == "hygiene-1"
     # A real in-place compaction IS a recovery, so the gate must have run and
     # cleared the streak. This is the positive half of the wiring contract.
     assert reset_calls, (

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -438,10 +438,20 @@ display:
   tool_progress_command: false  # set to true to enable /verbose in messaging
   # How progress is grouped on platforms that support message editing:
   #   accumulate (default) — edit one bubble in place as tools run
+  #   rolling              — keep one bounded activity bubble for the turn
   #   separate             — send one message per tool (pre-v0.9 style; noisier)
   # Only applies where tool_progress is already enabled.
-  tool_progress_grouping: accumulate   # accumulate | separate
+  tool_progress_grouping: accumulate   # accumulate | rolling | separate
 ```
+
+`rolling` is useful for long-running turns in notification-heavy chats. Hermes
+sends one `⏳ Working…` activity bubble, edits it with tool progress, concise
+interim commentary, and long-running heartbeats, then marks it complete while
+the final answer is delivered separately. When the platform's message limit is
+reached, Hermes drops the oldest complete activity entries, adds an omission
+count, and keeps editing the same bubble. It never splits an individual entry.
+The default `accumulate` mode is unchanged and starts a continuation bubble
+when the current one fills.
 
 ### `log` mode — audit file instead of chat messages
 


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in `rolling` gateway activity mode for edit-capable messaging platforms and extends it through pre-turn session hygiene:

1. Hermes creates one `⏳ Working…` activity bubble.
2. Tool progress, concise interim assistant commentary, and long-running heartbeats update that same message.
3. At the platform message limit, the oldest complete entries are dropped and an omission count is shown.
4. The activity header becomes `✅ Completed`, `⏹️ Stopped`, or `⚠️ Needs attention`.
5. When pre-turn hygiene must compress a large transcript, Hermes creates the activity bubble before the potentially long compression wait as `⏳ Compressing conversation context…`, then edits it back to `⏳ Working…` and reuses the same message for normal progress.
6. The final answer remains a separate message.

The existing `accumulate` default and `separate` mode are unchanged. The implementation stays in the generic gateway progress path and uses adapter-specific message length units, so it is not Discord-specific.

No private chain-of-thought is exposed: this only coalesces the same user-visible progress/commentary surfaces Hermes already emits.

## Related Issue

Fixes #80234

Related but distinct: #69885 and #67338 cover plugin/task-card APIs rather than bounded turn progress.

## Type of Change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation update
- [x] ✅ Tests

## Implementation notes

- `gateway/display_config.py`: accepts `rolling` as a normalized `tool_progress_grouping` value.
- `gateway/run.py` and `gateway/turn_context.py`: maintain one bounded editable activity tail, finalize it deterministically, and seed/reuse it before session-hygiene compression.
- `hermes_cli/config_defaults.py` and `cli-config.yaml.example`: document the opt-in value without changing defaults.
- `website/docs/user-guide/messaging/index.md`: explains the notification/retention trade-off.
- Gateway tests cover normalization, UTF-16 limits, oversized entries, omission counts, deduplication, commentary, heartbeats, terminal state, metadata, cleanup, compression ordering, and preflight-message reuse.

The early compression activity is intentionally limited to rolling mode on edit-capable, non-proxy adapters. Other display modes remain byte-for-byte unchanged.

## Validation

```bash
python -m pytest \
  tests/gateway/test_session_hygiene.py \
  tests/gateway/test_display_config.py \
  tests/gateway/test_run_progress_topics.py \
  tests/gateway/test_discord_edit_message_overflow.py \
  tests/gateway/test_run_progress_interrupt.py \
  tests/gateway/test_run_cleanup_progress.py \
  tests/gateway/test_clarify_progress_leak.py \
  tests/gateway/test_telegram_progress_edit_transient.py \
  tests/gateway/test_telegram_polling_progress.py \
  tests/gateway/test_compression_progress_notices.py \
  tests/gateway/test_telegram_noise_filter.py \
  -o 'addopts=' -q
```

Result: **293 passed**.

Additional checks:

- `ruff check` passed for all changed Python files.
- `py_compile` passed for all changed Python files.
- `git diff --check` passed.
- Public-diff sensitive scan found zero environment-specific identifiers or credential-pattern hits.

## Checklist

- [x] Conventional commit messages
- [x] Focused changes only
- [x] Regression tests added
- [x] Relevant gateway regression suite passes
- [x] Documentation/config examples updated
- [x] No new dependency or model tool
- [x] Existing defaults remain unchanged
