### PR TITLE
fix(security): anchor p?kill to word boundary in lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -74,8 +74,13 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both
     # token orders because real reproductions show both.
-    r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
-    r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
+    # Leading \b is critical: without it, `KILL` inside `SKILL.md` (or any
+    # word ending in -kill) matches p?kill and a later `hermes ... gateway`
+    # anywhere on the same line turns a harmless file path into a false
+    # positive (#77131-class). `\b` after the optional `p` anchors both
+    # `kill` and `pkill` to a word boundary.
+    r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
+    r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
 )
 
 

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -93,6 +93,14 @@ class TestGatewayLifecyclePattern:
         "launchctl submit -l com.example.backup -- /bin/sh backup.sh",
         "systemctl restart hermes-meta.service",
         "systemctl restart hermes-cron-helper",
+        # #77131-class: `KILL` inside `SKILL.md` (or any word ending in
+        # -kill) must not match Branch D's p?kill — a leading \b anchors
+        # the verb to a word boundary. Without it, a harmless file path
+        # followed by `hermes ... gateway` on the same line is a false
+        # positive.
+        "SKILL.md hermes gateway",
+        "path/to/backfill.py hermes gateway",
+        "killall hermes gateway",
         # Regression (#30728 follow-up): legit prompts that merely mention an
         # unrelated gateway + a restart must NOT be blocked. The cron prompt is
         # fed to an LLM, not a shell, so substring detection on English text is
@@ -275,6 +283,11 @@ class TestTerminalToolGatewayLifecycleGuard:
         "launchctl submit -l com.foo -- /path/gateway",
         "launchctl bootstrap gui/501 ~/Library/LaunchAgents/ai.hermes.gateway.restart-once.plist",
         "pkill -f hermes.*gateway",
+        # Branch D direct kill shapes — both token orders, with and
+        # without sudo (real reproductions show both).
+        "kill hermes-gateway",
+        "kill -9 gateway hermes",
+        "sudo pkill hermes gateway --signal TERM",
     ])
     def test_blocks_lifecycle_commands_inside_gateway(self, monkeypatch, cmd):
         import tools.terminal_tool as tt


### PR DESCRIPTION
## Problem

`_GATEWAY_LIFECYCLE_PATTERN` Branch D matches `p?kill` **without a leading word boundary**:

```
r"|(?:p?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
r"|(?:p?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
```

`KILL` inside `SKILL.md` (or any word ending in `-kill`) matches the
un-anchored `p?kill`, and `[^\n]*` then bridges to a `hermes...gateway` file
name anywhere on the same line. A harmless path like
`devops/hermes-messaging-gateway/SKILL.md` in a `grep`/`for` loop therefore
turns into a false positive that blocks an innocent terminal command as a
gateway-lifecycle attempt.

## Fix

Add `\b` before the optional `p` in both token orders:

```
r"|(?:\bp?kill\b[^\n]*\bhermes\b[^\n]*\bgateway)"
r"|(?:\bp?kill\b[^\n]*\bgateway\b[^\n]*\bhermes)"
```

`\b` after the optional `p` anchors both `kill` and `pkill` to a word
boundary: real invocations still match, `SKILL.md`-style false positives do not.

## Verification (9-case check on `contains_gateway_lifecycle_command`)

Blocked (must match):
- `pkill -f hermes gateway`
- `kill hermes-gateway`
- `kill -9 gateway hermes`
- `sudo pkill hermes gateway --signal TERM`

Allowed (must NOT match):
- `SKILL.md hermes gateway`  ← the reported false positive class
- `path/to/backfill.py hermes gateway`
- `killall hermes gateway`
- `kill hermes` (no gateway token)
- `hermes gateway start` (intentionally allowed)

## Notes

Same family as the #76762 / #77131 lifecycle-guard crash/false-positive
fixes. Comment added in-code explaining why the `\b` is critical.
