### PR TITLE
fix(slack): report attachment upload failures instead of success

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4031,7 +4031,10 @@ class SlackAdapter(BasePlatformAdapter):
             text = "⚠️ Couldn't deliver the image attachment."
             if caption:
                 text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            # Post the notice, but report the upload failure: the caller must
+            # not record this as a delivered attachment.
+            await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            return SendResult(success=False, error=str(e))
 
     async def send_image(
         self,
@@ -4192,7 +4195,10 @@ class SlackAdapter(BasePlatformAdapter):
             text = "⚠️ Couldn't deliver the video attachment."
             if caption:
                 text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            # Post the notice, but report the upload failure: the caller must
+            # not record this as a delivered attachment.
+            await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            return SendResult(success=False, error=str(e))
 
     async def send_document(
         self,
@@ -4260,7 +4266,10 @@ class SlackAdapter(BasePlatformAdapter):
             text = f"⚠️ Couldn't deliver the file attachment ({display_name})."
             if caption:
                 text = f"{caption}\n{text}"
-            return await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            # Post the notice, but report the upload failure: the caller must
+            # not record this as a delivered attachment.
+            await self.send(chat_id, text, reply_to=reply_to, metadata=metadata)
+            return SendResult(success=False, error=str(e))
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Get information about a Slack channel."""

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -1195,6 +1195,72 @@ class TestSendDocument:
         sleep_mock.assert_awaited_once()
 
 
+class TestUploadFailureReportsFailure:
+    """A failed attachment upload must not be reported to callers as success.
+
+    When the upload raises, the fallback posts a notice telling the user the
+    attachment did not arrive — but it returned that notice's own SendResult,
+    which is ``success=True``.  Callers therefore recorded the delivery as
+    complete, and agents went on to tell users to open an attachment that was
+    never uploaded.
+    """
+
+    @pytest.mark.asyncio
+    async def test_send_document_upload_failure_returns_failure(
+        self, adapter, tmp_path
+    ):
+        test_file = tmp_path / "report.pdf"
+        test_file.write_bytes(b"%PDF-1.4 fake content")
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            side_effect=RuntimeError("missing_scope")
+        )
+
+        result = await adapter.send_document(
+            chat_id="C123", file_path=str(test_file)
+        )
+
+        assert not result.success
+        assert result.error
+        # The user-facing notice is still delivered.
+        adapter._app.client.chat_postMessage.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_upload_failure_returns_failure(
+        self, adapter, tmp_path
+    ):
+        test_file = tmp_path / "shot.png"
+        test_file.write_bytes(b"png bytes")
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            side_effect=RuntimeError("missing_scope")
+        )
+
+        result = await adapter.send_image_file(
+            chat_id="C123", image_path=str(test_file)
+        )
+
+        assert not result.success
+        assert result.error
+        adapter._app.client.chat_postMessage.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_video_upload_failure_returns_failure(
+        self, adapter, tmp_path
+    ):
+        test_file = tmp_path / "clip.mp4"
+        test_file.write_bytes(b"mp4 bytes")
+        adapter._app.client.files_upload_v2 = AsyncMock(
+            side_effect=RuntimeError("missing_scope")
+        )
+
+        result = await adapter.send_video(
+            chat_id="C123", video_path=str(test_file)
+        )
+
+        assert not result.success
+        assert result.error
+        adapter._app.client.chat_postMessage.assert_called_once()
+
+
 class TestSendPrivateNotice:
     @pytest.mark.asyncio
     async def test_send_private_notice_uses_ephemeral_api(self, adapter):


### PR DESCRIPTION
## What does this PR do?

When a Slack attachment upload raises, `send_image_file` / `send_video` / `send_document` post a "Couldn't deliver …" notice and then **return that notice's own `SendResult` — which is `success=True`**. Callers therefore record the attachment as delivered.

This PR keeps posting the notice, but returns `SendResult(success=False, error=str(e))` so callers can tell a delivered attachment from a failed one.

### Why this matters

Observed in production. A bot whose token was missing `files:write` failed *every* upload with `missing_scope`. The adapter reported success, so the agent told the user the file was attached and to click it to download. The user could not find an attachment, and eventually asked whether a string in the message was the download URL. Several "here it is again" rounds followed — each one another silent failure.

The user-facing notice alone does not prevent this: the agent sees `success=True` and speaks accordingly. The delivery contract has to carry the failure.

## Related Issue

No existing issue. Related in spirit to #65863 (Mattermost: report missing attachments as failed) — the same "never report a non-delivery as success" contract, applied to the Slack adapter.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` — `send_image_file`, `send_video`, `send_document`: post the failure notice as before, then return `SendResult(success=False, error=str(e))` instead of the notice's own result.
- `tests/gateway/test_slack.py` — `TestUploadFailureReportsFailure`: three tests asserting a failed upload reports failure while still posting the notice.

The notice text is unchanged, and the host-local path is still never echoed into chat.

## How to Test

1. `pytest tests/gateway/test_slack.py -q` → 164 passed
2. To see the old behavior, restore the three `return await self.send(...)` lines: `TestUploadFailureReportsFailure` then fails with `assert not True` — the adapter reports `success=True` after the upload raised.
3. End-to-end: point a bot token *without* `files:write` at a channel and send a file. Before: the caller records a successful delivery. After: the delivery is reported as failed, and the channel still shows the same notice.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — no open PR touches the Slack upload failure path (#65863 covers Mattermost; #75001 was closed as a duplicate of it)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **see the note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6 (arm64), Python 3.11

> **Note on the test run.** `tests/gateway/test_slack.py` passes fully (164 passed). Across `tests/gateway/` + `tests/tools/` this machine shows 48 pre-existing failures (daytona, video/image generation, voice/transcription, systemd, computer-use — all environment-dependent). I verified they are unrelated rather than assuming it: running the same 23 files against unmodified `main` produces an identical failure list, so this PR introduces **0 new failures**.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no user-facing text or config changed)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure control flow, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The production failure, from the gateway log (path redacted):

```
ERROR gateway.platforms.slack: [Slack] Failed to send document …/audit.zip:
The request to the Slack API failed.
(url: https://slack.com/api/files.getUploadURLExternal, status: 200)
The server responded with: {'ok': False, 'error': 'missing_scope',
 'needed': 'files:write', 'provided': 'chat:write,chat:write.public,…'}
```

Each of these was followed by the agent telling the user the file had been attached and was ready to download.
