### PR TITLE
fix(loop): don't double-append assistant turn on thinking-only prefill

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -599,11 +599,7 @@ def repair_message_sequence(agent, messages: List[Dict]) -> int:
     # Responses replay chain (the duplicate-detection logic at
     # conversation_loop.py already de-dups identical codex interims).
     def _is_codex_interim(m: Dict) -> bool:
-        return bool(
-            m.get("codex_reasoning_items")
-            or m.get("codex_message_items")
-            or m.get("finish_reason") == "incomplete"
-        )
+        return bool(m.get("codex_reasoning_items") or m.get("codex_message_items"))
 
     def _is_verification_candidate(m: Dict) -> bool:
         return m.get("finish_reason") in {

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6710,9 +6710,14 @@ def run_conversation(
                     # ── Thinking-only prefill continuation ──────────
                     # The model produced structured reasoning (via API
                     # fields) but no visible text content.  Rather than
-                    # giving up, append the assistant message as-is and
-                    # continue — the model will see its own reasoning
-                    # on the next turn and produce the text portion.
+                    # giving up, continue once with that reasoning in the
+                    # tail so the model can produce the text portion.
+                    # Some transports/logging paths have already appended
+                    # the raw thinking-only assistant turn by the time this
+                    # branch runs; in that case, do not append a duplicate
+                    # incomplete assistant message, because strict
+                    # OpenAI-compatible endpoints such as Ollama reject a
+                    # request ending in two assistant turns.
                     # Inspired by clawdbot's "incomplete-text" recovery.
                     # Also covers Qwen3/Ollama in-content <think> blocks
                     # (detected above as _has_inline_thinking).
@@ -6733,11 +6738,28 @@ def run_conversation(
                             f"↻ Thinking-only response — prefilling to continue "
                             f"({agent._thinking_prefill_retries}/2)"
                         )
-                        interim_msg = agent._build_assistant_message(
-                            assistant_message, "incomplete"
+                        previous_msg = messages[-1] if messages else None
+                        previous_is_thinking_tail = (
+                            isinstance(previous_msg, dict)
+                            and previous_msg.get("role") == "assistant"
+                            and not previous_msg.get("tool_calls")
+                            and not agent._has_content_after_think_block(
+                                previous_msg.get("content") or ""
+                            )
+                            and (
+                                agent._is_thinking_only_assistant(
+                                    previous_msg,
+                                    drop_codex_reasoning_items=False,
+                                )
+                                or previous_msg.get("finish_reason") == "incomplete"
+                            )
                         )
-                        interim_msg["_thinking_prefill"] = True
-                        messages.append(interim_msg)
+                        if not previous_is_thinking_tail:
+                            interim_msg = agent._build_assistant_message(
+                                assistant_message, "incomplete"
+                            )
+                            interim_msg["_thinking_prefill"] = True
+                            messages.append(interim_msg)
                         agent._session_messages = messages
                         continue
 

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -252,6 +252,97 @@ def test_flush_guard_clamps_overshooting_cursor():
 # ── Pass 0: merge consecutive assistant messages (issue #29148, #49147) ─────
 
 
+def test_repair_merges_chat_prefill_incomplete_assistant_tail_before_empty_heal():
+    """Thinking-only prefill scaffolding must not leave two assistant tail turns.
+
+    The raw thinking-only assistant is already in history. Older prefill
+    recovery appended a second assistant turn with ``finish_reason=incomplete``;
+    the pre-send empty-message healer then padded the raw non-final turn, so
+    the thinking-only drop pass could no longer remove it and Ollama rejected
+    the request with "Cannot have 2 or more assistant messages at the end".
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "", "reasoning": "hidden thought"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "hidden thought",
+            "finish_reason": "incomplete",
+            "_thinking_prefill": True,
+        },
+    ]
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+    api_messages = sanitize_api_messages([dict(m) for m in messages])
+    api_messages = AIAgent._drop_thinking_only_and_merge_users(api_messages)
+
+    assert repairs == 1
+    assert [m["role"] for m in api_messages] == ["user"]
+    assert len(messages) == 2
+
+
+def test_repair_merges_second_chat_prefill_attempt_tail():
+    """A second thinking-only prefill attempt must also be collapsed."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "continue"},
+        {"role": "assistant", "content": "", "reasoning": "first thought"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "first thought",
+            "finish_reason": "incomplete",
+            "_thinking_prefill": True,
+        },
+        {"role": "assistant", "content": "", "reasoning": "second thought"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "second thought",
+            "finish_reason": "incomplete",
+            "_thinking_prefill": True,
+        },
+    ]
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+    api_messages = sanitize_api_messages([dict(m) for m in messages])
+    api_messages = AIAgent._drop_thinking_only_and_merge_users(api_messages)
+
+    assert repairs == 3
+    assert [m["role"] for m in api_messages] == ["user"]
+    assert len(messages) == 2
+
+
+def test_repair_preserves_codex_incomplete_interims_with_continuation_items():
+    """Codex Responses interims carry replay state and must not be merged."""
+    agent = _bare_agent()
+    messages = [
+        {"role": "user", "content": "continue"},
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_reasoning_items": [{"id": "rs_1"}],
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "finish_reason": "incomplete",
+            "codex_message_items": [{"id": "msg_1"}],
+        },
+    ]
+
+    repairs = repair_message_sequence_with_cursor(agent, messages)
+
+    assert repairs == 0
+    assert len(messages) == 3
+
 
 
 
@@ -368,8 +459,6 @@ def test_sanitize_drops_empty_tool_calls_array():
 # "all messages must have non-empty content except for the optional final
 # assistant message" (INVALID_REQUEST_BODY). sanitize_api_messages now heals
 # such turns on the per-call copy so the session recovers itself in memory.
-
-
 
 
 


### PR DESCRIPTION
## Bug

HTTP 400 from Ollama's OpenAI-compatible endpoint (`/v1/chat/completions`):

```
Cannot have 2 or more assistant messages at the end of the list.
```

Reproduces with any reasoning model served via Ollama that emits **thinking-only** responses (reasoning but no visible text) — e.g. `oamazonasgabriel/lfm2.5-2.6b`, Qwen3-style inline `<think>` models.

## Root cause

1. `agent/conversation_loop.py` "Thinking-only prefill continuation" appends an interim assistant message (`finish_reason="incomplete"`, `_thinking_prefill=True`) and continues the loop.
2. The raw thinking-only assistant turn is **already** in `messages` at that point, so the next request's list ends with **two consecutive assistant messages**.
3. `repair_message_sequence` Pass 0 (merge consecutive assistants) skips the merge because `_is_codex_interim` exempts *any* message with `finish_reason == "incomplete"` — including ordinary chat-completions prefill interims. That exemption exists for the Codex Responses transport, where consecutive interims legitimately carry encrypted replay state.
4. `repair_empty_non_final_messages` then heals the empty non-final turn with `"[response interrupted]"`, making it non-empty so `_drop_thinking_only_and_merge_users` can no longer drop it. The pair reaches the wire; Ollama rejects.

## Fix

- **`agent/conversation_loop.py`**: the prefill branch no longer appends a duplicate assistant message when the history tail is already a thinking-only assistant turn (no visible content, no tool calls). The follow-up request ends with a single assistant message, which strict endpoints accept.
- **`agent/agent_runtime_helpers.py`**: `_is_codex_interim` now only exempts genuine Codex interims (messages carrying `codex_reasoning_items` / `codex_message_items`), not bare `finish_reason == "incomplete"`. This restores the consecutive-assistant merge for the chat-completions path while preserving Codex Responses replay.

## Tests

- `tests/run_agent/test_message_sequence_repair.py` — 3 new regression tests:
  - reported failure shape (raw thinking-only turn + prefill interim tail),
  - second-attempt (2/2) prefill shape,
  - Codex interims with continuation items remain unmerged.
- Verified on top of current `main`: `test_message_sequence_repair.py` + `test_partial_stream_finish_reason.py` = 32 passed. `test_streaming.py` 3 failures are pre-existing on `main` (confirmed via stash comparison).
- Also verified end-to-end: the exact failed request payload from a real session, replayed through the fixed pipeline, now produces a single trailing assistant message; a live request of the same shape to Ollama returns 200.
