### PR TITLE
fix(agent): restore the Actual Computer Responses-API routing branch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1586,6 +1586,11 @@ class AIAgent:
     ) -> bool:
         """Return True when this provider/model pair should use Responses API."""
         normalized_provider = (provider or "").strip().lower()
+        # Actual Computer is Responses-only: its profile declares
+        # api_mode="codex_responses" and it serves no chat-completions
+        # endpoint, so the answer never depends on the model id.
+        if normalized_provider == "actual":
+            return True
         # Nous serves GPT-5.x models via its OpenAI-compatible chat
         # completions endpoint; its /v1/responses endpoint returns 404.
         if normalized_provider == "nous":

--- a/tests/hermes_cli/test_actual_provider.py
+++ b/tests/hermes_cli/test_actual_provider.py
@@ -250,3 +250,26 @@ def test_actual_runtime_config_local_base_url_without_key(monkeypatch):
 
     assert resolved["api_key"] == ACTUAL_LOCAL_NOAUTH_PLACEHOLDER
     assert resolved["api_mode"] == "codex_responses"
+
+
+def test_actual_agent_side_routing_requires_responses_api_for_any_model():
+    """The agent-side routing must also know Actual is Responses-only.
+
+    ``determine_api_mode`` covers the provider profile, but two agent paths
+    decide api_mode without consulting it: the init upgrade in
+    ``agent/agent_init.py`` and, more consequentially, fallback activation in
+    ``agent/chat_completion_helpers.py``, which rebuilds api_mode from
+    provider/base-url/model alone starting at ``chat_completions``.
+
+    Actual serves no chat-completions endpoint and its models are not
+    GPT-5.x, so the generic model heuristic never rescues them — the provider
+    branch is what keeps a fallback to Actual off ``/v1/chat/completions``.
+    """
+    from run_agent import AIAgent
+
+    requires = AIAgent._provider_model_requires_responses_api
+    for model in ("glm-5.2-nvfp4", "some-model", "kimi-k2"):
+        assert requires(model, provider="actual") is True, model
+
+    # The profile path and the agent path must agree about this provider.
+    assert determine_api_mode("actual", DEFAULT_ACTUAL_BASE_URL) == "codex_responses"


### PR DESCRIPTION
## What

a9acb400b (2026-05-15, "feat(providers): add Actual Computer inference provider") added a provider branch to `_provider_model_requires_responses_api`:

```python
if normalized_provider == "actual":
    return True
```

8f2712725 (2026-08-05, "feat: /refine — run the memory/skill self-improvement review on demand") deleted it. That commit's message covers `/refine` and nothing else, and the deletion sits in `run_agent.py` alongside the `focus` parameter it was actually adding — an accidental revert picked up in a rebase, not a decision.

Actual Computer serves no chat-completions endpoint. Its plugin declares `api_mode="codex_responses"`, and `determine_api_mode("actual", …)` returns `codex_responses`. But two agent paths decide `api_mode` without asking the profile:

- the init upgrade in `agent/agent_init.py`, gated on `agent.api_mode == "chat_completions"`
- fallback activation in `agent/chat_completion_helpers.py`, which rebuilds the mode from provider/base-url/model alone and starts at `fb_api_mode = "chat_completions"`

The fallback chain tests `openai-codex`, nous, anthropic, azure, direct-OpenAI URL, then `_provider_model_requires_responses_api(fb_model, provider=fb_provider)`, then bedrock. Actual matches none of the others — its base URL is `https://api.actual.inc/v1`, so `_is_direct_openai_url` is False — and its models are not GPT-5.x, so the generic model heuristic never rescues them:

```
determine_api_mode('actual', ...)                                = codex_responses
requires_responses_api('glm-5.2-nvfp4', provider='actual')       = False
requires_responses_api('kimi-k2'      , provider='actual')       = False
_is_direct_openai_url('https://api.actual.inc/v1')               = False
```

So a fallback to Actual now activates with `api_mode = "chat_completions"` and posts to an endpoint the provider does not serve. This branch was the only thing keeping it on the Responses wire.

## The fix

Restore the branch, with a comment recording why it is unconditional — the provider is Responses-only, so the answer never depends on the model id. That is also why the check belongs above the model heuristics rather than folded into them.

## Tests and results

`test_actual_agent_side_routing_requires_responses_api_for_any_model` asserts the agent-side predicate returns True for Actual across three of its non-GPT-5 model ids, and pins the two paths to the same answer by also asserting `determine_api_mode` still reports `codex_responses`. It fails on `main` with `assert False is True` and passes with the fix.

The existing Actual suite stayed green through the regression, which is the interesting part: all nine of its `api_mode` assertions go through `determine_api_mode` — the provider-profile path, which was never touched. Nothing covered the predicate the two agent paths actually call. `tests/hermes_cli/test_actual_provider.py` is now 13 passed.

For regressions I ran all of `tests/run_agent/`: 27 failed / 1368 passed on `main`, and re-running those same 27 node ids against the fixed tree reproduces all 27 identically, so the failure set is unchanged and pre-existing. I also grepped the test tree for any expectation that Actual routes to `chat_completions` — there is none; every `api_mode` assertion for this provider asserts `codex_responses`.