### PR TITLE
fix(kanban): kanban_create now accepts and honours scheduled_at (#80119)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -993,6 +993,9 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Earliest dispatch time (Unix epoch seconds); NULL = dispatch as soon as
+    # ready. See the column comment in SCHEMA_SQL.
+    scheduled_at: Optional[int] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1086,6 +1089,9 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            scheduled_at=(
+                row["scheduled_at"] if "scheduled_at" in keys else None
             ),
         )
 
@@ -1274,7 +1280,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Earliest dispatch time (Unix epoch seconds). NULL = dispatch as soon as
+    -- ready. The dispatcher skips ready tasks whose scheduled_at is still in
+    -- the future and picks them up on the first tick after that timestamp.
+    -- Set via kanban_create(..., scheduled_at=...) or `hermes kanban schedule`.
+    scheduled_at         INTEGER
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2389,6 +2400,8 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         _add_column_if_missing(
             conn, "tasks", "max_runtime_seconds", "max_runtime_seconds INTEGER"
         )
+    if "scheduled_at" not in cols:
+        _add_column_if_missing(conn, "tasks", "scheduled_at", "scheduled_at INTEGER")
     if "last_heartbeat_at" not in cols:
         _add_column_if_missing(
             conn, "tasks", "last_heartbeat_at", "last_heartbeat_at INTEGER"
@@ -2906,6 +2919,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    scheduled_at: Optional[int] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3217,8 +3231,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, scheduled_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3244,6 +3258,7 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        int(scheduled_at) if scheduled_at is not None else None,
                     ),
                 )
                 for pid in parents:
@@ -8360,7 +8375,9 @@ def _dispatch_once_locked(
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
-        "ORDER BY priority DESC, created_at ASC"
+        "AND (scheduled_at IS NULL OR scheduled_at <= ?) "
+        "ORDER BY priority DESC, created_at ASC",
+        (int(time.time()),),
     ).fetchall()
     # Honour kanban.max_in_progress: if the board already has enough running
     # tasks, skip spawning this tick so slow workers (local LLMs,

--- a/tests/hermes_cli/test_kanban_scheduled_at.py
+++ b/tests/hermes_cli/test_kanban_scheduled_at.py
@@ -13,6 +13,7 @@ dispatcher gating (future = skip, past = dispatch), and legacy-DB migration.
 from __future__ import annotations
 
 import os
+import sqlite3
 import sys
 import tempfile
 import time
@@ -116,21 +117,41 @@ def test_scheduled_at_column_exists_in_schema(kanban_home):
 def test_scheduled_at_migrated_on_legacy_db(tmp_path, monkeypatch):
     """Opening a legacy DB (no scheduled_at) must add the column."""
     legacy = tmp_path / "legacy.db"
-    # Build a pre-#80119 schema by creating a fresh DB, then dropping the
-    # scheduled_at column via table rebuild.
+    # Build a genuinely pre-#80119 schema: same tasks table but WITHOUT the
+    # scheduled_at column. Copying via `CREATE TABLE x AS SELECT *` would
+    # keep the column, so construct the legacy DDL from the fresh schema's
+    # column list minus scheduled_at.
     conn = kb.connect(db_path=legacy)
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     assert "scheduled_at" in cols  # fresh schema has it
-    conn.execute("CREATE TABLE tasks_old AS SELECT * FROM tasks")
-    conn.execute("DROP TABLE tasks")
-    conn.execute("ALTER TABLE tasks_old RENAME TO tasks")
+    col_defs = [
+        (row["name"], row["type"], row["notnull"], row["dflt_value"])
+        for row in conn.execute("PRAGMA table_info(tasks)")
+        if row["name"] != "scheduled_at"
+    ]
+    conn.close()
+    legacy.unlink()
+
+    legacy_ddl = "CREATE TABLE tasks (\n" + ",\n".join(
+        f'"{name}" {typ}{" NOT NULL" if nn else ""}'
+        + (f' DEFAULT {dflt}' if dflt is not None else "")
+        for name, typ, nn, dflt in col_defs
+    ) + "\n)"
+    conn = sqlite3.connect(legacy)
+    conn.execute(legacy_ddl)
+    conn.execute("INSERT INTO tasks (id, title, status, created_at) VALUES ('t1', 'legacy', 'ready', 1)")
     conn.commit()
     conn.close()
 
     # Reopen via connect() -> init_db -> _migrate_add_optional_columns.
+    # _INITIALIZED_PATHS caches the fresh path; discard so the migration
+    # actually runs against the legacy schema (not skipped on the fast path).
+    kb._INITIALIZED_PATHS.discard(str(legacy.resolve()))
     conn = kb.connect(db_path=legacy)
     try:
         cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
         assert "scheduled_at" in cols
+        rows = conn.execute("SELECT id, title FROM tasks").fetchall()
+        assert [tuple(r) for r in rows] == [("t1", "legacy")]  # data preserved
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_scheduled_at.py
+++ b/tests/hermes_cli/test_kanban_scheduled_at.py
@@ -1,0 +1,136 @@
+"""Regression tests for #80119: kanban_create silently dropped scheduled_at.
+
+The tool schema lacked ``scheduled_at``, so an orchestrator agent calling
+``kanban_create(..., scheduled_at=\"2026-06-01T03:00:00Z\")`` had the value
+silently ignored — the task was created and dispatched immediately, with no
+error. The DB layer also had no ``scheduled_at`` column at all, so the
+documented delayed-dispatch feature was unreachable from the tool.
+
+These tests pin the full chain: schema column, create_task storage,
+dispatcher gating (future = skip, past = dispatch), and legacy-DB migration.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+
+import pytest
+
+import hermes_cli.kanban_db as kb
+
+
+@pytest.fixture()
+def isolated_kanban_home_with_profiles(monkeypatch):
+    """Spin up a fresh HERMES_HOME with kanban DB + alpha/beta profiles."""
+    test_home = tempfile.mkdtemp(prefix="kanban_scheduled_at_test_")
+    for prof in ("alpha", "beta", "default"):
+        os.makedirs(os.path.join(test_home, "profiles", prof), exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", test_home)
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("hermes_cli") or mod.startswith("hermes_state") or mod == "hermes_constants":
+            del sys.modules[mod]
+    from hermes_cli import kanban_db
+
+    yield kanban_db
+
+
+@pytest.fixture()
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from pathlib import Path
+
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_spawn(*args, **kwargs):
+    return 12345
+
+
+def test_create_task_stores_scheduled_at(isolated_kanban_home_with_profiles):
+    """scheduled_at must round-trip through create_task into the row."""
+    kbd = isolated_kanban_home_with_profiles
+    future = int(time.time()) + 3600
+    with kbd.connect_closing() as conn:
+        tid = kbd.create_task(
+            conn, title="delayed", assignee="alpha", scheduled_at=future
+        )
+        task = kbd.get_task(conn, tid)
+        assert task.scheduled_at == future
+        # No scheduled_at -> NULL (immediate dispatch preserved).
+        tid2 = kbd.create_task(conn, title="immediate", assignee="alpha")
+        assert kbd.get_task(conn, tid2).scheduled_at is None
+
+
+def test_dispatcher_skips_future_scheduled_at(isolated_kanban_home_with_profiles):
+    """A ready task whose scheduled_at is in the future must NOT spawn."""
+    kbd = isolated_kanban_home_with_profiles
+    with kbd.connect_closing() as conn:
+        kbd.create_board(slug="default", name="Test")
+        tid = kbd.create_task(
+            conn,
+            title="future job",
+            assignee="alpha",
+            scheduled_at=int(time.time()) + 3600,
+        )
+    with kbd.connect_closing() as conn:
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    spawned_ids = [s[0] for s in res.spawned]
+    assert tid not in spawned_ids, (
+        "future-scheduled task was dispatched before its scheduled_at"
+    )
+
+
+def test_dispatcher_dispatchs_past_scheduled_at(isolated_kanban_home_with_profiles):
+    """A ready task whose scheduled_at is in the past MUST spawn."""
+    kbd = isolated_kanban_home_with_profiles
+    with kbd.connect_closing() as conn:
+        kbd.create_board(slug="default", name="Test")
+        tid = kbd.create_task(
+            conn,
+            title="overdue job",
+            assignee="alpha",
+            scheduled_at=int(time.time()) - 60,
+        )
+    with kbd.connect_closing() as conn:
+        res = kbd.dispatch_once(conn, spawn_fn=_fake_spawn, dry_run=True)
+    spawned_ids = [s[0] for s in res.spawned]
+    assert tid in spawned_ids, (
+        "past-scheduled task was not dispatched when its time arrived"
+    )
+
+
+def test_scheduled_at_column_exists_in_schema(kanban_home):
+    """Fresh DBs must include the scheduled_at column."""
+    with kb.connect() as conn:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "scheduled_at" in cols
+
+
+def test_scheduled_at_migrated_on_legacy_db(tmp_path, monkeypatch):
+    """Opening a legacy DB (no scheduled_at) must add the column."""
+    legacy = tmp_path / "legacy.db"
+    # Build a pre-#80119 schema by creating a fresh DB, then dropping the
+    # scheduled_at column via table rebuild.
+    conn = kb.connect(db_path=legacy)
+    cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "scheduled_at" in cols  # fresh schema has it
+    conn.execute("CREATE TABLE tasks_old AS SELECT * FROM tasks")
+    conn.execute("DROP TABLE tasks")
+    conn.execute("ALTER TABLE tasks_old RENAME TO tasks")
+    conn.commit()
+    conn.close()
+
+    # Reopen via connect() -> init_db -> _migrate_add_optional_columns.
+    conn = kb.connect(db_path=legacy)
+    try:
+        cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
+        assert "scheduled_at" in cols
+    finally:
+        conn.close()

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -442,6 +442,39 @@ def _parse_bool_arg(args: dict, name: str, *, default: bool = False):
     return default, f"{name} must be a boolean or 'true'/'false'"
 
 
+def _parse_scheduled_at(value) -> Optional[int]:
+    """Parse an ISO-8601 timestamp (or Unix epoch int) into Unix epoch seconds.
+
+    Accepts the same shapes the CLI/docs use for ``--scheduled-at``:
+    ``2026-06-01T03:00:00Z``, ``2026-06-01 03:00:00+00:00``, or a bare epoch
+    integer. Returns None for unset. Raises ValueError on unparseable input so
+    the caller surfaces a clear tool error instead of silently dropping the
+    delay (the #80119 failure mode).
+    """
+    if value is None or value == "":
+        return None
+    if isinstance(value, (int, float)):
+        return int(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        # Bare epoch integer string.
+        return int(text)
+    except ValueError:
+        pass
+    try:
+        from datetime import datetime
+
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        return int(parsed.timestamp())
+    except ValueError:
+        raise ValueError(
+            f"scheduled_at must be ISO-8601 (e.g. '2026-06-01T03:00:00Z') "
+            f"or a Unix epoch integer, got {value!r}"
+        )
+
+
 def _require_orchestrator_tool(tool_name: str) -> Optional[str]:
     """Belt-and-suspenders runtime guard for orchestrator-only handlers.
 
@@ -1330,6 +1363,7 @@ def _handle_create(args: dict, **kw) -> str:
                 initial_status=str(initial_status),
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
                 session_id=session_id,
+                scheduled_at=_parse_scheduled_at(args.get("scheduled_at")),
             )
             new_task = kb.get_task(conn, new_tid)
             subscribed = _maybe_auto_subscribe(conn, new_tid)
@@ -2092,6 +2126,16 @@ KANBAN_CREATE_SCHEMA = {
                 ),
             },
             "board": _board_schema_prop(),
+            "scheduled_at": {
+                "type": "string",
+                "description": (
+                    "Optional ISO-8601 timestamp (e.g. '2026-06-01T03:00:00Z') "
+                    "or Unix epoch integer. When set, the dispatcher skips the "
+                    "task until the first tick after this time — use it to "
+                    "delay dispatch (nightly jobs, wait-for-a-time-window "
+                    "work). Omit for immediate dispatch."
+                ),
+            },
         },
         "required": ["title", "assignee"],
     },


### PR DESCRIPTION
## Summary

Fixes #80119: `kanban_create` silently dropped `scheduled_at`, so an orchestrator agent calling `kanban_create(..., scheduled_at="2026-06-01T03:00:00Z")` got a task created and **dispatched immediately** — no delay, no error.

**Root cause**: the tool schema had no `scheduled_at` param, and the DB layer had no `scheduled_at` column at all. The documented delayed-dispatch feature was unreachable from the tool (the docs reference `--scheduled-at` on `kanban create`, which never existed).

**Fix** — the full chain:
1. `tasks.scheduled_at INTEGER` (Unix epoch) column + legacy-DB migration (`_migrate_add_optional_columns`)
2. `create_task(scheduled_at=...)` stores it; `Task.from_row` maps it
3. Dispatcher ready-query gates: only dispatch tasks whose `scheduled_at` is NULL or already past — future-scheduled tasks wait for the first tick after their timestamp
4. `kanban_create` schema + handler accept ISO-8601 or epoch int, with a clear `ValueError` (not silent drop) on unparseable input

## Verification

- **RED**: all 5 new regression tests fail on pre-fix code (no column → schema/migration/round-trip/dispatch tests all fail)
- **GREEN**: 5/5 pass with the fix
- Broader kanban suite (test_kanban_db + per_profile_cap + dispatch_lock): 34/34 green
- No behavioral change for tasks without `scheduled_at` (NULL → immediate dispatch, unchanged)
