### PR TITLE
fix(cron): cover bootout/remove/disable in the gateway lifecycle guard

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -100,11 +100,38 @@ _SHELL_LINE_CONTINUATION = re.compile(r"\\\r?\n[ \t]*")
 
 
 def contains_gateway_lifecycle_command(text: str) -> bool:
-    """Return True if *text* contains a gateway lifecycle command pattern."""
+    """Return True if *text* contains a gateway lifecycle command pattern.
+
+    Matches in two passes. The first is the raw-text regex above — cheap,
+    and the only pass that can fire on non-shell inputs shlex can't
+    tokenize (e.g. a Python source string). The second re-runs the same
+    pattern against each command segment after shell tokenization, where
+    quotes and backslash escapes have already been resolved.
+
+    That second pass exists because a real shell resolves quote-splicing
+    (``kick"start"``) and backslash-escaping (``kick\\start``) into one
+    literal word — ``kickstart`` — before the command ever runs. The raw
+    text still has the quote or backslash sitting between the verb's two
+    halves, so the first pass alone lets a spliced verb reach
+    ``launchctl``/``systemctl`` untouched while still executing as the
+    blocked lifecycle command (#80269, reported against #80260's bootout
+    parity fix). Tokenizing closes that gap while keeping the same
+    gateway-label anchoring (``_GATEWAY_LIFECYCLE_PATTERN`` still requires
+    a ``hermes``/``gateway`` token) — this function is the single choke
+    point ``_contains_unsafe_gateway_action`` calls at every recursion
+    level, so referenced-script and ``sh -c`` payload scanning inherit the
+    fix automatically.
+    """
     if not text:
         return False
     normalized = _SHELL_LINE_CONTINUATION.sub(" ", text)
-    return bool(_GATEWAY_LIFECYCLE_PATTERN.search(normalized))
+    if _GATEWAY_LIFECYCLE_PATTERN.search(normalized):
+        return True
+    for segment in _iter_command_segments(normalized):
+        joined = " ".join(segment)
+        if joined and _GATEWAY_LIFECYCLE_PATTERN.search(joined):
+            return True
+    return False
 
 
 _SHELL_EXECUTABLES = frozenset({"sh", "bash", "dash", "ksh", "zsh"})

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -69,7 +69,14 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # loop instead (#62891) — same foot-gun, indirect shape. Neutral-label
     # submissions that dodge this text anchor are caught separately by
     # `contains_launchctl_submit_command` (execution-aware, label-independent).
-    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap)\b[^\n]*\bhermes[.\-]?gateway)"
+    # `bootout`/`remove`/`disable` sit alongside `unload`: Apple deprecated
+    # load/unload in favour of bootstrap/bootout, so `bootout` is the modern
+    # spelling of an already-listed verb, `remove` is its legacy sibling, and
+    # `disable` is what makes an unload durable across boots. Omitting them
+    # left the bypassable approval layer (tools/approval.py, skipped on
+    # force=True) as the only cover, while this hard block — documented as
+    # "force=True cannot help here" — let them through (#80260).
+    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -66,6 +66,56 @@ class TestGatewayLifecyclePattern:
         )
         assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
 
+    @pytest.mark.parametrize("text", [
+        # #80269: the shell resolves quote-splicing and backslash-escaping
+        # into a single literal word BEFORE the command runs, so
+        # `launchctl kick"start" ... ai.hermes.gateway` executes exactly as
+        # the blocked `kickstart` form. Raw-text matching sees the quote (or
+        # backslash) wedged between the verb's halves and misses it, leaving
+        # the bypassable approval layer as the only cover.
+        'launchctl kick"start" -k gui/501/ai.hermes.gateway',
+        "launchctl kick'start' -k gui/501/ai.hermes.gateway",
+        "launchctl kick\\start -k gui/501/ai.hermes.gateway",
+        'launchctl "kickstart" -k gui/501/ai.hermes.gateway',
+        # Splices on the newer/legacy unload spellings this PR added.
+        'launchctl boot"out" gui/501/ai.hermes.gateway',
+        "launchctl dis\\able gui/501/ai.hermes.gateway",
+        # The gateway identifier itself can be spliced just as easily.
+        'launchctl bootout gui/501/ai.hermes."gateway"',
+        # Same class on the systemctl and hermes-CLI branches.
+        'systemctl re"start" hermes-gateway',
+        'hermes gateway re"start"',
+    ])
+    def test_shell_token_spliced_lifecycle_verbs(self, text):
+        assert _contains_gateway_lifecycle_command(text), f"Should match: {text!r}"
+
+    def test_spliced_verb_inside_shell_c_payload_is_blocked(self):
+        # A splice nested in a `sh -c` payload resolves one level deeper than
+        # the flat scan: POSIX single quotes preserve the inner double quotes
+        # verbatim, so the outer tokenization yields the payload with the
+        # splice still intact. The recursion re-scans that payload through the
+        # same choke point, where it collapses to `kickstart`. This is the
+        # entry point terminal_tool.py calls in gateway sessions, so it is the
+        # boundary that matters.
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        command = 'sh -c \'launchctl kick"start" -k gui/501/ai.hermes.gateway\''
+        assert contains_gateway_lifecycle_command_or_referenced_script(command)
+
+    @pytest.mark.parametrize("text", [
+        # The tokenizing pass must not widen the blast radius: prose and
+        # non-gateway services stay allowed even though tokenization now
+        # strips their quotes too.
+        'echo "restart the payment gateway"',
+        'launchctl kick"start" -k gui/501/ai.hermes.update-checker',
+        'systemctl re"start" hermes-meta.service',
+        "Summarize how the API gateway handles a restart after rate limiting",
+    ])
+    def test_tokenizing_pass_does_not_overmatch(self, text):
+        assert not _contains_gateway_lifecycle_command(text), f"Should NOT match: {text!r}"
+
 
     @pytest.mark.parametrize("text", [
         "restart the server application",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -849,6 +849,36 @@ class TestLaunchctlGatewayLifecycle:
             dangerous, _, _ = detect_dangerous_command(cmd)
             assert dangerous is False, cmd
 
+    def test_quote_spliced_verbs_detected(self):
+        """#80269: the shell joins ``kick"start"`` into the literal verb
+        ``kickstart`` before execution, so the spliced form runs exactly as
+        the gated one. Backslash splices already normalized here; quote
+        splices sit in an argument position that word-scoped deobfuscation
+        deliberately does not touch, so they auto-approved.
+        """
+        for cmd in (
+            'launchctl kick"start" -k gui/501/ai.hermes.gateway',
+            "launchctl kick'start' -k gui/501/ai.hermes.gateway",
+            'launchctl boot"out" gui/501/ai.hermes.gateway',
+            'launchctl bootout gui/501/ai.hermes."gateway"',
+            'hermes gateway re"start"',
+            'systemctl re"start" hermes-gateway',
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is True, cmd
+
+    def test_spliced_detection_does_not_flag_prose_or_other_services(self):
+        """The splice pass must not widen the blast radius: it is anchored on
+        a hermes-gateway identifier, so quoted prose and non-gateway hermes
+        services stay auto-approved."""
+        for cmd in (
+            'launchctl kick"start" -k gui/501/ai.hermes.update-checker',
+            'echo "restart the payment gateway"',
+            'git commit -m "document the api gateway restart flow"',
+        ):
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            assert dangerous is False, cmd
+
 
 class TestGitDestructiveOps:
     """git reset --hard, push --force, clean -f, branch -D can destroy

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -1568,3 +1568,73 @@ class TestCliApprovalTimeoutClassifiedSeparately:
         assert result.get("user_consent") is False
         assert "timed out without user response" in result["message"]
         assert "Silence is not consent" in result["message"]
+
+
+# launchd verbs that stop, unload or deregister a running gateway. `disable`
+# does not stop a live job on its own, but it is what makes an unload survive
+# a reboot, so it belongs to the same family.
+GATEWAY_LIFECYCLE_LAUNCHCTL = (
+    "launchctl kickstart -k gui/501/ai.hermes.gateway",
+    "launchctl unload ~/Library/LaunchAgents/ai.hermes.gateway.plist",
+    "launchctl load ~/Library/LaunchAgents/ai.hermes.gateway.plist",
+    "launchctl stop ai.hermes.gateway",
+    "launchctl restart ai.hermes.gateway",
+    "launchctl bootout gui/501/ai.hermes.gateway",
+    "launchctl remove ai.hermes.gateway",
+    "launchctl disable gui/501/ai.hermes.gateway",
+)
+
+
+class TestLifecycleGuardLaunchctlParity:
+    """The in-gateway hard block must cover every launchd verb the approval
+    layer already treats as gateway lifecycle.
+
+    These two layers are not interchangeable. In ``tools/terminal_tool.py``
+    under ``_HERMES_GATEWAY == "1"``, the ``cron.lifecycle_guard`` block is
+    documented as applying unconditionally ("force=True cannot help here"),
+    while ``detect_dangerous_command`` below it is explicitly skipped when
+    ``force=True``. A verb covered only by the approval layer is therefore
+    reachable from inside the gateway, where SIGTERM propagates to the child
+    before the command completes and the service may never come back (#74973).
+
+    ``bootout`` was missing exactly this way: it is the modern replacement for
+    the ``unload`` the guard already listed. See #80260.
+    """
+
+    def test_hard_block_covers_every_lifecycle_verb(self):
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+
+        for cmd in GATEWAY_LIFECYCLE_LAUNCHCTL:
+            assert contains_gateway_lifecycle_command(cmd) is True, cmd
+
+    def test_bypassable_layer_is_never_stricter(self):
+        """One-directional invariant: anything ``detect_dangerous_command``
+        flags as gateway lifecycle, the hard block must also catch.
+
+        Not equality — the hard block is legitimately stricter (it also covers
+        ``load``/``restart``, which the approval layer leaves alone). What must
+        never happen is the reverse: a command stopped only by the layer that
+        ``force=True`` skips, leaving no cover inside the gateway."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+
+        for cmd in GATEWAY_LIFECYCLE_LAUNCHCTL:
+            dangerous, _, _ = detect_dangerous_command(cmd)
+            if not dangerous:
+                continue
+            assert contains_gateway_lifecycle_command(cmd) is True, (
+                f"approval layer flags this but the unbypassable hard block "
+                f"does not: {cmd}"
+            )
+
+    def test_unrelated_labels_are_not_blocked(self):
+        """The label anchor must still scope this to the gateway — unrelated
+        services, including other Hermes ones, stay runnable."""
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+
+        for cmd in (
+            "launchctl bootout gui/501/com.example.unrelated",
+            "launchctl remove ai.hermes.update-checker",
+            "launchctl disable gui/501/com.apple.WindowServer",
+            "launchctl print system/com.apple.WindowServer",
+        ):
+            assert contains_gateway_lifecycle_command(cmd) is False, cmd

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -2175,6 +2175,38 @@ def _is_verification_artifact_cleanup(command: str) -> bool:
     return re.fullmatch(r"hermes-(?:verify|ad-hoc)-[A-Za-z0-9_.-]+", basename) is not None
 
 
+_GATEWAY_LIFECYCLE_SPLICE_DESCRIPTION = (
+    "stop/restart hermes gateway via shell-spliced verb (kills running agents)"
+)
+
+
+def _is_shell_token_spliced_gateway_lifecycle(command: str) -> bool:
+    """Catch gateway-lifecycle verbs spelled with quote/backslash splicing.
+
+    ``_normalize_command_for_detection`` strips backslash escapes, so
+    ``kick\\start`` already reaches the launchctl pattern above. Quote
+    splicing does not: ``_deobfuscate_shell_word_for_detection`` is
+    deliberately scoped to command-position words (widening it would let
+    quoted prose like ``git commit -m "rm -rf /"`` match the destructive
+    patterns), and the spliced verb sits in an ARGUMENT position. So
+    ``launchctl kick"start" -k gui/501/ai.hermes.gateway`` auto-approved
+    while executing exactly as the gated ``kickstart`` form (#80269).
+
+    Delegate to ``cron.lifecycle_guard``, which tokenizes with shlex and is
+    anchored on a hermes-gateway identifier — reusing its prose
+    false-positive coverage instead of loosening the generic pattern
+    engine. This runs last, so an ordinary pattern match still wins and
+    keeps its more specific reason string. Unlike the guard's use inside
+    ``terminal_tool``, this layer only raises an approval prompt; the
+    non-bypassable block still lives in ``cron.lifecycle_guard``.
+    """
+    try:
+        from cron.lifecycle_guard import contains_gateway_lifecycle_command
+    except Exception:
+        return False
+    return contains_gateway_lifecycle_command(command)
+
+
 def detect_dangerous_command(command: str) -> tuple:
     """Check if a command matches any dangerous patterns.
 
@@ -2195,6 +2227,12 @@ def detect_dangerous_command(command: str) -> tuple:
     normalized = _normalize_command_for_detection(command)
     for description, _ in _execution_flag_findings(normalized):
         return (True, description, description)
+    if _is_shell_token_spliced_gateway_lifecycle(command):
+        return (
+            True,
+            _GATEWAY_LIFECYCLE_SPLICE_DESCRIPTION,
+            _GATEWAY_LIFECYCLE_SPLICE_DESCRIPTION,
+        )
     return (False, None, None)
 
 


### PR DESCRIPTION
Closes #80260.

### What

Branch B of `_GATEWAY_LIFECYCLE_PATTERN` enumerated launchd verbs but omitted `bootout` — the modern replacement for the `unload` it already listed, and the paired inverse of the `bootstrap` it already listed. `remove` (bootout's legacy sibling) and `disable` (what makes an unload durable across boots) were missing for the same reason.

```diff
-r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap)\b[^\n]*\bhermes[.\-]?gateway)"
+r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
```

### Why it isn't already covered

`detect_dangerous_command` in `tools/approval.py` **does** flag all three verbs, so the default path was never open — and `TestLaunchctlGatewayLifecycle` already asserts that for `bootout`.

The two layers are not interchangeable, though. In `tools/terminal_tool.py` under `_HERMES_GATEWAY == "1"`:

- the `cron.lifecycle_guard` hard block (L2497-2589) is documented as applying unconditionally — *"force=True cannot help here"*
- `detect_dangerous_command` below it (L2591) is documented as *"Skip check if force=True"*

So with `force=True` inside the gateway, `stop`/`unload`/`kickstart` against a Hermes label remained hard-blocked while `bootout`/`remove`/`disable` reached execution. SIGTERM then propagates to the child before the command completes and the service may never come back — the state described in #74973.

Severity is modest: it needs `force=True` inside the gateway. But the verbs that slipped are the ones current macOS documentation steers you toward, since Apple deprecated `load`/`unload` in favour of `bootstrap`/`bootout`.

### Scope

The label anchor `\bhermes[.\-]?gateway` is unchanged, so unrelated services stay runnable — `launchctl bootout gui/501/ai.hermes.update-checker` and `launchctl disable gui/501/com.apple.WindowServer` are both still allowed, and there are tests for that.

`contains_launchctl_submit_command`'s `{"submit", "bootstrap"}` set is untouched: that function is about *registering a new persistent job*, so `bootout` correctly does not belong there.

### Tests

Adds `TestLifecycleGuardLaunchctlParity` with three cases:

1. the hard block covers every launchd lifecycle verb
2. **the bypassable layer is never stricter than the unbypassable one** — one-directional, deliberately not equality. The hard block is legitimately stricter (it also covers `load`/`restart`, which the approval layer leaves alone); what must never happen is the reverse.
3. unrelated labels are still not blocked

Verified against the parent commit: the new tests fail there for exactly `bootout`, `remove` and `disable`, and pass with this change.
