### PR TITLE
fix(desktop): make user messages selectable for copying

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-message-text.tsx
@@ -122,7 +122,11 @@ export const UserMessageText: FC<UserMessageTextProps> = ({ className, text }) =
   const top = useMemo(() => splitFences(text), [text])
 
   return (
-    <span className={cn('block', className)} data-slot="aui_user-message-text">
+    <span
+      className={cn('block', className)}
+      data-selectable-text="true"
+      data-slot="aui_user-message-text"
+    >
       {top.map((segment, segmentIndex) => {
         if (segment.kind === 'fence') {
           return (


### PR DESCRIPTION
Retarget of #52466 onto the current component path per teknium1's review.

The component moved from `assistant-ui/user-message-text.tsx` to `assistant-ui/thread/user-message-text.tsx` in 7ff6908a. Added `data-selectable-text="true"` to the wrapper `<span>` at the new location, matching the existing CSS selector at `styles.css:1033-1034` that enables `user-select: text` on elements with this attribute.

Supersedes #52466
Closes #52457