### PR TITLE
fix(gateway): /reasoning status card reads per-platform show_reasoning override (#79885)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8278,14 +8278,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         cfg = _load_gateway_runtime_config()
         if platform_key:
-            from gateway.display_config import resolve_display_setting
-
-            value = resolve_display_setting(
-                cfg, platform_key, "show_reasoning", fallback=False
+            # Route through the canonical resolver so the picker and the
+            # recap-render path share ONE decision: per-platform override →
+            # global → default, plus the Mattermost platform-only opt-in
+            # guard (#79885). A hand-rolled read here would silently diverge
+            # from the render path's require_platform_override_for.
+            return _resolve_gateway_display_bool(
+                cfg,
+                platform_key,
+                "show_reasoning",
+                default=False,
+                require_platform_override_for={Platform.MATTERMOST},
             )
-            if isinstance(value, str):
-                return value.strip().lower() in {"true", "yes", "1", "on"}
-            return bool(value)
         return is_truthy_value(
             cfg_get(cfg, "display", "show_reasoning"),
             default=False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8266,9 +8266,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return None
 
     @staticmethod
-    def _load_show_reasoning() -> bool:
-        """Load show_reasoning toggle from config.yaml display section."""
+    def _load_show_reasoning(platform_key: Optional[str] = None) -> bool:
+        """Load show_reasoning toggle from config.yaml display section.
+
+        When ``platform_key`` is provided, resolves through the canonical
+        per-platform chain (``resolve_display_setting``: per-platform override
+        ``display.platforms.<platform>.show_reasoning`` → global
+        ``display.show_reasoning`` → default), matching what the recap-render
+        path actually uses. Without it, falls back to the legacy global-only
+        read so callers that lack platform context keep working.
+        """
         cfg = _load_gateway_runtime_config()
+        if platform_key:
+            from gateway.display_config import resolve_display_setting
+
+            value = resolve_display_setting(
+                cfg, platform_key, "show_reasoning", fallback=False
+            )
+            if isinstance(value, str):
+                return value.strip().lower() in {"true", "yes", "1", "on"}
+            return bool(value)
         return is_truthy_value(
             cfg_get(cfg, "display", "show_reasoning"),
             default=False,

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3501,7 +3501,15 @@ class GatewaySlashCommandsMixin:
         # reads — same fix as /model (#30479).
         _reasoning_source = await asyncio.to_thread(self._normalize_source_for_session_key, event.source)
         session_key = self._session_key_for_source(_reasoning_source)
-        self._show_reasoning = self._load_show_reasoning()
+        # Resolve the toggle through the same per-platform chain the recap
+        # render path uses (display.platforms.<platform>.show_reasoning →
+        # display.show_reasoning), so the status card can never disagree with
+        # what actually gets rendered (#79885). Before this, a /reasoning show
+        # written a per-platform override while the picker re-read only the
+        # global key at startup and reported "Display: off".
+        self._show_reasoning = self._load_show_reasoning(
+            _platform_config_key(event.source.platform)
+        )
         # Use the session's effective model (session /model override wins over
         # config default) so per-model reasoning_overrides display correctly.
         _session_model = str(

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -128,6 +128,32 @@ class TestReasoningCommand:
 
 
     @pytest.mark.asyncio
+    async def test_reasoning_picker_mattermost_requires_platform_override(self, tmp_path, monkeypatch):
+        """#79885: Mattermost is platform-only opt-in — a global
+        show_reasoning=true must NOT light up the picker without an explicit
+        display.platforms.mattermost.show_reasoning override, matching the
+        recap-render path's require_platform_override_for guard."""
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "display:\n"
+            "  show_reasoning: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        event = _make_event("/reasoning", platform=Platform.MATTERMOST)
+
+        result = await runner._handle_reasoning_command(event)
+
+        assert "**Display:** off" in result, (
+            "global show_reasoning=true must not enable reasoning display "
+            "on Mattermost without a per-platform override"
+        )
+        assert runner._show_reasoning is False
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("effort", ["max", "ultra"])
     async def test_handle_reasoning_command_accepts_extended_efforts(
         self, tmp_path, monkeypatch, effort

--- a/tests/gateway/test_reasoning_command.py
+++ b/tests/gateway/test_reasoning_command.py
@@ -93,6 +93,39 @@ class TestReasoningCommand:
         assert runner._reasoning_config == {"enabled": False}
         assert runner._show_reasoning is True
 
+    @pytest.mark.asyncio
+    async def test_reasoning_picker_reads_per_platform_override(self, tmp_path, monkeypatch):
+        """#79885: the status card must read the per-platform override.
+
+        Global display.show_reasoning=false + per-platform
+        display.platforms.matrix.show_reasoning=true: the recap render path
+        (resolve_display_setting) shows the reasoning box, so the picker must
+        report "Display: on" — not re-read only the global key and report
+        "Display: off".
+        """
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "display:\n"
+            "  show_reasoning: false\n"
+            "  platforms:\n"
+            "    matrix:\n"
+            "      show_reasoning: true\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        event = _make_event("/reasoning", platform=Platform.MATRIX)
+
+        result = await runner._handle_reasoning_command(event)
+
+        assert "**Display:** on ✓" in result, (
+            "picker must report on when the per-platform override enables "
+            "reasoning display"
+        )
+        assert runner._show_reasoning is True
+
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("effort", ["max", "ultra"])


### PR DESCRIPTION
## Summary

Fixes #79885: `/reasoning` picker status card always showed `Display: off` after `/reasoning show` on the messaging gateway.

**Root cause**: two coupled paths read the show-reasoning toggle from different sources:
- **Recap render** (`_resolve_gateway_display_bool`): resolves through the canonical chain (`display.platforms.<platform>.show_reasoning` → global `display.show_reasoning` → default) -- **correct**
- **Picker status card** (`_load_show_reasoning`): reads only global `display.show_reasoning` -- **stale**

When a user with global `show_reasoning: false` ran `/reasoning show` on Matrix, it wrote `display.platforms.matrix.show_reasoning: true` (per-platform). The render path found the per-platform override and displayed the reasoning box. The picker re-read only the global key and reported `Display: off`.

**Fix**: `_load_show_reasoning` now accepts an optional `platform_key` and resolves through `resolve_display_setting` (the same chain the render path uses) when provided, falling back to the legacy global-only read otherwise. `_handle_reasoning_command` passes the normalized platform key.

## Verification

- **RED**: new regression test (global false + per-platform matrix true → picker must report on) fails on pre-fix code with `picker must report on when the per-platform override enables reasoning display`
- **GREEN**: 9/9 tests pass with the fix
- Existing test (global show_reasoning: true → Display: on) unchanged and passing
