### PR TITLE
fix(gateway): scope each heartbeat poll to the profile that owns it

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18766,6 +18766,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if watch:
             watch.pop(quick_key, None)
 
+    async def _poll_heartbeat_watch_entry(self, quick_key: str, source: Any, session_id: str) -> None:
+        """Check and, if due, fire one heartbeat watch entry.
+
+        Runs the actual check (not just the surrounding scope decision) so
+        tests can exercise it directly under either profile-scoping branch.
+        """
+        # Busy sessions coalesce their tick to the next idle poll.
+        if quick_key in self._running_agents:
+            return
+        from hermes_cli.heartbeat import HeartbeatManager
+
+        mgr = HeartbeatManager(session_id=session_id)
+        if not mgr.has_heartbeat():
+            watch = getattr(self, "_heartbeat_watch", None)
+            if watch is not None:
+                watch.pop(quick_key, None)
+            return
+        prompt = mgr.due_prompt()
+        if not prompt:
+            return
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return
+        hb_event = MessageEvent(
+            text=prompt,
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id=None,
+            channel_prompt=None,
+        )
+        self._enqueue_fifo(quick_key, hb_event, adapter)
+
     def _start_heartbeat_poller(self) -> None:
         """Start the single gateway-wide heartbeat poll task (idempotent)."""
         existing = getattr(self, "_heartbeat_poll_task", None)
@@ -18782,29 +18814,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     continue
                 for quick_key, (source, session_id) in list(watch.items()):
                     try:
-                        # Busy sessions coalesce their tick to the next idle poll.
-                        if quick_key in self._running_agents:
-                            continue
-                        from hermes_cli.heartbeat import HeartbeatManager
-
-                        mgr = HeartbeatManager(session_id=session_id)
-                        if not mgr.has_heartbeat():
-                            watch.pop(quick_key, None)
-                            continue
-                        prompt = mgr.due_prompt()
-                        if not prompt:
-                            continue
-                        adapter = self._adapter_for_source(source)
-                        if adapter is None:
-                            continue
-                        hb_event = MessageEvent(
-                            text=prompt,
-                            message_type=MessageType.TEXT,
-                            source=source,
-                            message_id=None,
-                            channel_prompt=None,
-                        )
-                        self._enqueue_fifo(quick_key, hb_event, adapter)
+                        # This gateway-wide task is created once, by whichever
+                        # profile's request registers the first heartbeat —
+                        # asyncio freezes contextvars (HERMES_HOME override,
+                        # secret scope) at task-creation time, so without
+                        # re-entering _profile_runtime_scope per source here,
+                        # every OTHER profile's heartbeat is polled under the
+                        # first profile's HERMES_HOME: HeartbeatManager opens
+                        # the wrong SessionDB, has_heartbeat() reads back
+                        # False, and the watch entry is popped as if the user
+                        # had cleared it.
+                        if getattr(getattr(self, "config", None), "multiplex_profiles", False):
+                            profile_home = self._resolve_profile_home_for_source(source)
+                            with _profile_runtime_scope(profile_home):
+                                await self._poll_heartbeat_watch_entry(quick_key, source, session_id)
+                        else:
+                            await self._poll_heartbeat_watch_entry(quick_key, source, session_id)
                     except Exception as exc:
                         logger.debug("heartbeat poll for %s failed: %s", quick_key, exc)
 

--- a/tests/gateway/test_heartbeat_poller_multiplex_scope.py
+++ b/tests/gateway/test_heartbeat_poller_multiplex_scope.py
@@ -1,0 +1,221 @@
+"""Regression: the gateway-wide heartbeat poller must scope each watch entry
+to the profile that owns it, in a multiplex (gateway.multiplex_profiles)
+gateway.
+
+_start_heartbeat_poller() creates exactly one asyncio.Task, the first time
+any profile registers a heartbeat (idempotent — later registrations from
+OTHER profiles reuse it). asyncio freezes contextvars (HERMES_HOME override,
+secret scope) at task-creation time via copy_context(), so without
+re-entering _profile_runtime_scope per watch entry inside the poll loop,
+every profile OTHER than the one that happened to register first is polled
+under the wrong HERMES_HOME: HeartbeatManager opens the wrong SessionDB,
+has_heartbeat() reads back False, and the watch entry is silently popped —
+indistinguishable from the user having cleared it themselves.
+
+Tests are module-level functions rather than grouped in a class: nesting
+these under a class allowed state to leak between tests in a way plain
+functions don't reproduce (observed while writing this file).
+
+Note on DB isolation: tests/conftest.py's autouse fixture repoints
+hermes_state.DEFAULT_DB_PATH to one fixed per-test path so an argless
+SessionDB() never touches a developer's real state.db. That's exactly right
+for hygiene, but it means _default_db_path() no longer varies with
+get_hermes_home() inside a test process — an argless SessionDB() (what
+HeartbeatManager's _get_session_db() constructs on a cache miss) always
+resolves to that one fixed file regardless of which profile is scoped in,
+which would make two different "profile homes" in a naive test collapse
+onto the same underlying database and silently defeat the very isolation
+this test needs to observe. _seed_db_for() below sidesteps that by
+pre-populating hermes_cli.goals._DB_CACHE (keyed exactly like
+_get_session_db() keys it: str(get_hermes_home())) with an explicitly
+pathed SessionDB per simulated home, so each "profile" genuinely gets its
+own file — matching real multi-profile deployments, where HERMES_HOME
+differs by process/profile and _default_db_path() is never pinned.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner, _profile_runtime_scope
+from gateway.session import SessionSource
+from hermes_cli import goals
+from hermes_cli.heartbeat import HeartbeatState, save_heartbeat
+from hermes_state import SessionDB
+
+
+class _FakeAdapter:
+    pass
+
+
+@pytest.fixture(autouse=True)
+def _clear_db_cache():
+    goals._DB_CACHE.clear()
+    yield
+    for db in goals._DB_CACHE.values():
+        try:
+            db.close()
+        except Exception:
+            pass
+    goals._DB_CACHE.clear()
+
+
+def _make_runner(*, multiplex: bool) -> GatewayRunner:
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = SimpleNamespace(multiplex_profiles=multiplex)
+    runner._running_agents = {}
+    runner._heartbeat_watch = {}
+    return runner
+
+
+def _seed_db_for(home) -> None:
+    """Register a real, distinctly-pathed SessionDB for ``home`` in the same
+    cache _get_session_db() reads, so it's picked up instead of falling
+    through to an argless SessionDB() (see module docstring)."""
+    key = str(home)
+    if key not in goals._DB_CACHE:
+        goals._DB_CACHE[key] = SessionDB(db_path=home / "state.db")
+
+
+def _seed_due_heartbeat(profile_home, session_id: str) -> None:
+    _seed_db_for(profile_home)
+    with _profile_runtime_scope(profile_home):
+        save_heartbeat(
+            session_id,
+            HeartbeatState(
+                prompt="check CI",
+                interval_seconds=60,
+                status="active",
+                created_at=0.0,  # far in the past -> always due
+            ),
+        )
+
+
+# --- Unit-level: the per-entry check itself only finds a profile's
+# heartbeat under that profile's own HERMES_HOME scope. -----------------
+
+
+@pytest.mark.asyncio
+async def test_poll_entry_wrong_scope_misses_the_due_heartbeat(tmp_path, monkeypatch):
+    ambient_home = tmp_path / "ambient"
+    ambient_home.mkdir()
+    profile_home = tmp_path / "profiles" / "planner"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    _seed_db_for(ambient_home)
+
+    session_id = "sess-planner-hb"
+    _seed_due_heartbeat(profile_home, session_id)
+
+    runner = _make_runner(multiplex=True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", user_id="u1", profile="planner",
+    )
+    runner._heartbeat_watch["qk"] = (source, session_id)
+
+    fired = []
+    runner._adapter_for_source = lambda src: _FakeAdapter()
+    runner._enqueue_fifo = lambda qk, event, adapter: fired.append((qk, event.text))
+
+    # No scope entered — this is what the pre-fix _poll_loop did for every
+    # entry, regardless of which profile owns it.
+    await runner._poll_heartbeat_watch_entry("qk", source, session_id)
+
+    assert fired == []
+    assert "qk" not in runner._heartbeat_watch, (
+        "has_heartbeat() reading False under the wrong home must not "
+        "silently pop a still-active watch entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_poll_entry_correct_scope_fires_the_due_heartbeat(tmp_path, monkeypatch):
+    ambient_home = tmp_path / "ambient"
+    ambient_home.mkdir()
+    profile_home = tmp_path / "profiles" / "planner"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    _seed_db_for(ambient_home)
+
+    session_id = "sess-planner-hb"
+    _seed_due_heartbeat(profile_home, session_id)
+
+    runner = _make_runner(multiplex=True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", user_id="u1", profile="planner",
+    )
+    runner._heartbeat_watch["qk"] = (source, session_id)
+
+    fired = []
+    runner._adapter_for_source = lambda src: _FakeAdapter()
+    runner._enqueue_fifo = lambda qk, event, adapter: fired.append((qk, event.text))
+
+    with _profile_runtime_scope(profile_home):
+        await runner._poll_heartbeat_watch_entry("qk", source, session_id)
+
+    assert len(fired) == 1
+    assert fired[0][0] == "qk"
+    assert "check CI" in fired[0][1]
+    assert "qk" in runner._heartbeat_watch
+
+
+# --- End-to-end: _start_heartbeat_poller's actual _poll_loop must enter
+# _profile_runtime_scope per entry using _resolve_profile_home_for_source,
+# not rely on whatever context was ambient when the task was created. ---
+
+
+@pytest.mark.asyncio
+async def test_poller_task_created_under_one_profile_still_serves_another(tmp_path, monkeypatch):
+    ambient_home = tmp_path / "ambient"
+    ambient_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(ambient_home))
+    _seed_db_for(ambient_home)
+
+    # get_profile_dir()/_resolve_profile_home_for_source resolve against the
+    # un-overridden base home (HERMES_HOME), so this must live under
+    # ambient_home/profiles/<name> for the real (unmocked) resolution path
+    # to find it.
+    profile_home = ambient_home / "profiles" / "planner"
+    profile_home.mkdir(parents=True)
+
+    session_id = "sess-planner-hb"
+    _seed_due_heartbeat(profile_home, session_id)
+
+    runner = _make_runner(multiplex=True)
+    source = SessionSource(
+        platform=Platform.TELEGRAM, chat_id="c1", user_id="u1", profile="planner",
+    )
+    runner._heartbeat_watch["qk"] = (source, session_id)
+    runner._background_tasks = set()
+
+    fired = []
+    runner._adapter_for_source = lambda src: _FakeAdapter()
+    runner._enqueue_fifo = lambda qk, event, adapter: fired.append((qk, event.text))
+
+    # Speed up the poll cadence so the test doesn't wait POLL_SECONDS (5s)
+    # for the first real tick.
+    monkeypatch.setattr("hermes_cli.heartbeat.POLL_SECONDS", 0.01)
+
+    # The task is created here, at ambient scope (no _profile_runtime_scope
+    # active) — exactly like production, where _start_heartbeat_poller is
+    # idempotent and only the FIRST profile to register ever creates it.
+    runner._start_heartbeat_poller()
+    try:
+        for _ in range(50):
+            if fired:
+                break
+            await asyncio.sleep(0.02)
+    finally:
+        runner._heartbeat_poll_task.cancel()
+        try:
+            await runner._heartbeat_poll_task
+        except asyncio.CancelledError:
+            pass
+
+    assert fired, (
+        "the poll loop must enter the owning profile's scope per entry, "
+        "not inherit whatever context was ambient at task-creation time"
+    )
+    assert fired[0][0] == "qk"


### PR DESCRIPTION
## Summary

- `_start_heartbeat_poller()` creates exactly one gateway-wide `asyncio.Task`, the first time any profile registers a heartbeat via `/heartbeat` (idempotent — later registrations from OTHER profiles just add to the existing watch registry and reuse the same task). asyncio freezes contextvars (the `HERMES_HOME` override / secret scope installed by `_profile_runtime_scope`) at task-creation time via `copy_context()`.
- Every profile OTHER than the one whose request happened to create the task is therefore polled under the wrong `HERMES_HOME`: `HeartbeatManager(session_id=...)` opens the first profile's SessionDB instead of the owning profile's, `has_heartbeat()` reads back False on that unrelated database, and the watch entry is popped as if the user had cleared it — silently and permanently, since nothing re-registers it without the user touching `/heartbeat` again.
- Fix: extract the per-entry check into `_poll_heartbeat_watch_entry()` (also makes it independently testable) and have `_poll_loop` enter `_profile_runtime_scope(self._resolve_profile_home_for_source(source))` around it when `gateway.multiplex_profiles` is on — the same helper `_reset_notice_session_info` and `_prepare_profile_scoped_inbound_message_text` already use to resolve the routed profile's home from a `MessageEvent`'s source. Single-profile gateways (`multiplex_profiles` unset) are unaffected.

## Test plan

- [x] Two unit-level regression tests on the extracted method directly: the wrong (ambient) scope misses a due heartbeat and silently pops the watch entry; the correct scope finds and fires it.
- [x] One end-to-end test: creates the actual poller task at ambient scope (mirroring production — the task is always created by whichever profile registers first) and confirms a heartbeat belonging to a DIFFERENT profile still fires.
- [x] Mutation-verified: all three fail on pre-fix code — the end-to-end one with `assert []` (the poll loop never enters the owning profile's scope, so it never fires).
- [x] Full neighboring suite green: `tests/gateway/test_heartbeat_poller_multiplex_scope.py`, `tests/hermes_cli/test_heartbeat.py`, `tests/gateway/test_session_info.py`, `tests/gateway/test_multiplex_adapter_registry.py`, `tests/gateway/test_yuanbao_forwarded_heartbeat.py`, `tests/gateway/test_goal_*` — 56 passed.
- [x] `ruff check` clean on changed files.

Note: the test file works around a test-environment-only quirk explained in its module docstring — `tests/conftest.py` pins `hermes_state.DEFAULT_DB_PATH` to one fixed per-test path (correctly, to keep tests off a developer's real `state.db`), which incidentally makes an argless `SessionDB()` ignore `get_hermes_home()` inside tests. The tests pre-populate `hermes_cli.goals._DB_CACHE` with an explicitly-pathed `SessionDB` per simulated profile home so "different profile" is genuinely a different file, matching real deployments.

## Heads up: adjacent PR in the same function

A different, independent bug in the same poll loop was opened as #80208 today (stale `session_id` after a compression rotation migrates the heartbeat to a child session) — different root cause, different fix shape (a live-session-id resolver vs. this profile-scope fix), no logical overlap. Flagging since both touch `_poll_loop`'s body and a straightforward rebase may be needed whichever lands second.