### PR TITLE
feat(tools): add named and dynamic execution targets

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -40,7 +40,7 @@ from agent.message_sanitization import (
     _repair_tool_call_arguments,
 )
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
-from tools.terminal_tool import is_persistent_env
+from tools.terminal_tool import is_persistent_env  # Backward-compatible test/patch seam.
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
@@ -2413,9 +2413,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 def cleanup_task_resources(agent, task_id: str) -> None:
     """Clean up VM and browser resources for a given task.
 
-    Skips ``cleanup_vm`` when the active terminal environment is marked
-    persistent (``persistent_filesystem=True``) so that long-lived sandbox
-    containers survive between turns. The idle reaper in
+    Removes each non-persistent target while keeping persistent named sibling
+    environments live so long-lived containers survive between turns. The
+    idle reaper in
     ``terminal_tool._cleanup_inactive_envs`` still tears them down once
     ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
     torn down per-turn as before to prevent resource leakage (the original
@@ -2427,14 +2427,26 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     idle sessions.
     """
     try:
-        if is_persistent_env(task_id):
-            if agent.verbose_logging:
-                logging.debug(
-                    f"Skipping per-turn cleanup_vm for persistent env {task_id}; "
-                    f"idle reaper will handle it."
-                )
-        else:
-            _ra().cleanup_vm(task_id)
+        from tools.terminal_tool import (
+            active_environment_turns,
+            defer_environment_turn_cleanup,
+            release_logical_environment_turn_for_cleanup,
+        )
+
+        # The current logical turn must stop counting itself before deciding
+        # whether it is the last user of the collapsed shared environment.
+        # The lease is idempotent, so duplicate finalization paths and the
+        # outer exception fallback cannot decrement another overlapping turn.
+        release_logical_environment_turn_for_cleanup(task_id)
+        remaining_turns = active_environment_turns(task_id)
+        include_collapsed = remaining_turns == 0
+        if not include_collapsed:
+            defer_environment_turn_cleanup(task_id)
+        _ra().cleanup_vm(
+            task_id,
+            preserve_persistent=True,
+            include_collapsed=include_collapsed,
+        )
     except Exception as e:
         if agent.verbose_logging:
             logger.warning("Failed to cleanup VM for task %s: %s", task_id, e)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -45,7 +45,7 @@ from agent.message_sanitization import (
 )
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
-from tools.terminal_tool import is_persistent_env
+from tools.terminal_tool import is_persistent_env  # Backward-compatible test/patch seam.
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
@@ -3191,9 +3191,9 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
 def cleanup_task_resources(agent, task_id: str) -> None:
     """Clean up VM and browser resources for a given task.
 
-    Skips ``cleanup_vm`` when the active terminal environment is marked
-    persistent (``persistent_filesystem=True``) so that long-lived sandbox
-    containers survive between turns. The idle reaper in
+    Removes each non-persistent target while keeping persistent named sibling
+    environments live so long-lived containers survive between turns. The
+    idle reaper in
     ``terminal_tool._cleanup_inactive_envs`` still tears them down once
     ``terminal.lifetime_seconds`` is exceeded. Non-persistent backends are
     torn down per-turn as before to prevent resource leakage (the original
@@ -3205,14 +3205,26 @@ def cleanup_task_resources(agent, task_id: str) -> None:
     idle sessions.
     """
     try:
-        if is_persistent_env(task_id):
-            if agent.verbose_logging:
-                logging.debug(
-                    f"Skipping per-turn cleanup_vm for persistent env {task_id}; "
-                    f"idle reaper will handle it."
-                )
-        else:
-            _ra().cleanup_vm(task_id)
+        from tools.terminal_tool import (
+            active_environment_turns,
+            defer_environment_turn_cleanup,
+            release_logical_environment_turn_for_cleanup,
+        )
+
+        # The current logical turn must stop counting itself before deciding
+        # whether it is the last user of the collapsed shared environment.
+        # The lease is idempotent, so duplicate finalization paths and the
+        # outer exception fallback cannot decrement another overlapping turn.
+        release_logical_environment_turn_for_cleanup(task_id)
+        remaining_turns = active_environment_turns(task_id)
+        include_collapsed = remaining_turns == 0
+        if not include_collapsed:
+            defer_environment_turn_cleanup(task_id)
+        _ra().cleanup_vm(
+            task_id,
+            preserve_persistent=True,
+            include_collapsed=include_collapsed,
+        )
     except Exception as e:
         if agent.verbose_logging:
             logger.warning("Failed to cleanup VM for task %s: %s", task_id, e)

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -49,6 +49,10 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
+            # Keyed execution-target fingerprint secret. Exposing or replacing
+            # it would let an untrusted tool forge persisted target identities.
+            str(hermes_home / ".execution-target-fingerprint-key"),
+            str(hermes_root / ".execution-target-fingerprint-key"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -276,6 +280,7 @@ def get_read_block_error(path: str) -> Optional[str]:
         "auth.lock",
         ".anthropic_oauth.json",
         ".env",
+        ".execution-target-fingerprint-key",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
         # Bitwarden Secrets Manager disk cache: stores plaintext secret values

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -59,6 +59,10 @@ def build_write_denied_paths(home: str) -> set[str]:
             # Bitwarden Secrets Manager encrypted disk cache.
             str(hermes_home / "cache" / "bws_cache.enc.json"),
             str(hermes_root / "cache" / "bws_cache.enc.json"),
+            # Keyed execution-target fingerprint secret. Exposing or replacing
+            # it would let an untrusted tool forge persisted target identities.
+            str(hermes_home / ".execution-target-fingerprint-key"),
+            str(hermes_root / ".execution-target-fingerprint-key"),
             os.path.join(home, ".netrc"),
             os.path.join(home, ".pgpass"),
             os.path.join(home, ".npmrc"),
@@ -329,6 +333,7 @@ def get_read_block_error(path: str) -> Optional[str]:
         "auth.lock",
         ".anthropic_oauth.json",
         ".env",
+        ".execution-target-fingerprint-key",
         "webhook_subscriptions.json",
         os.path.join("auth", "google_oauth.json"),
         # Bitwarden Secrets Manager disk cache: stores plaintext secret values

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -1005,7 +1006,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # a mid-process backend switch rebuilds the string. Kept in-module (not on
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 _WINDOWS_BASH_SHELL_HINT = (
@@ -1019,7 +1020,11 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
-def _probe_remote_backend(env_type: str) -> str | None:
+def _probe_remote_backend(
+    env_type: str,
+    terminal_config: dict | None = None,
+    target_name: str = "",
+) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
     Returns a pre-formatted multi-line string describing the backend's OS,
@@ -1027,8 +1032,14 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
+    if terminal_config is None:
+        config_identity = os.getenv("TERMINAL_CWD", "")
+    else:
+        serialized = json.dumps(
+            terminal_config, sort_keys=True, default=str, ensure_ascii=True,
+        )
+        config_identity = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    cache_key = (env_type, target_name, config_identity)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached or None
@@ -1043,7 +1054,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
         return None
 
     try:
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(terminal_config))
+            if terminal_config is not None
+            else _get_env_config()
+        )
         # Build the environment the same way tools/terminal_tool.py does for a
         # live command: select the backend image, then assemble ssh/container
         # config from the env-derived dict. (There is no `get_environment`
@@ -1095,7 +1110,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
             timeout=config.get("timeout", 180),
             ssh_config=ssh_config,
             container_config=container_config,
-            task_id="prompt-backend-probe",
+            task_id=(
+                "prompt-backend-probe-"
+                + hashlib.sha256(
+                    f"{env_type}:{target_name}:{config_identity}".encode("utf-8")
+                ).hexdigest()[:12]
+            ),
             host_cwd=config.get("host_cwd"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
@@ -1173,7 +1193,26 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    target_inventory = ()
+    default_target = None
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        resolved_targets = list_execution_targets()
+        if resolved_targets and resolved_targets[0].named:
+            target_inventory = resolved_targets
+            default_target = next(
+                (item for item in target_inventory if item.is_default),
+                target_inventory[0],
+            )
+    except Exception as e:
+        logger.debug("Could not resolve named execution targets for prompt: %s", e)
+
+    backend = (
+        default_target.backend
+        if default_target is not None
+        else (os.getenv("TERMINAL_ENV") or "local")
+    ).strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:
@@ -1191,8 +1230,15 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
-        except OSError:
+            if default_target is not None:
+                from tools.terminal_tool import _get_env_config
+
+                cwd_hint = _get_env_config(dict(default_target.config)).get("cwd")
+            else:
+                cwd_hint = resolve_agent_cwd()
+            if cwd_hint:
+                host_lines.append(f"Current working directory: {cwd_hint}")
+        except (OSError, TypeError, ValueError):
             pass
 
         if sys.platform == "win32" and not is_wsl():
@@ -1210,11 +1256,32 @@ def build_environment_hints() -> str:
             hints.append(_WINDOWS_BASH_SHELL_HINT)
     else:
         # --- Remote backend block (host info suppressed) ---
-        probe = _probe_remote_backend(backend)
+        probe = (
+            _probe_remote_backend(
+                backend,
+                terminal_config=dict(default_target.config),
+                target_name=(
+                    f"{default_target.profile_scope}:{default_target.target}"
+                    if default_target.profile_scope
+                    else default_target.target
+                ),
+            )
+            if default_target is not None
+            else _probe_remote_backend(backend)
+        )
+        tool_scope = (
+            "Calls to `terminal`, `read_file`, `write_file`, `patch`, "
+            "`search_files`, and `execute_code` that omit an execution-target "
+            "selector operate"
+            if default_target is not None
+            else (
+                "Your `terminal`, `read_file`, `write_file`, `patch`, "
+                "`search_files`, and `execute_code` tools all operate"
+            )
+        )
         if probe:
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside this {backend} environment — NOT on the machine "
                 f"where Hermes itself is running. The host OS, home, and cwd "
                 f"of the Hermes process are irrelevant; only the following "
@@ -1225,8 +1292,7 @@ def build_environment_hints() -> str:
                 backend, f"a {backend} environment (likely Linux)"
             )
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside {description} — NOT on the machine where Hermes "
                 f"itself runs. The backend probe didn't respond at "
                 f"prompt-build time, so the sandbox's current user, $HOME, "
@@ -1234,6 +1300,23 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+
+    if default_target is not None and default_target.named:
+        target_summary = ", ".join(
+            f"{json.dumps(item.target, ensure_ascii=True)} ({item.backend}"
+            f"{', default' if item.is_default else ''})"
+            for item in target_inventory
+        )
+        hints.append(
+            "Configured execution targets: " + target_summary + ". "
+            "`terminal`, `read_file`, `write_file`, `patch`, and `execute_code` "
+            "select one with `target`; `search_files` uses `execution_target` "
+            "because its existing `target` argument selects content/files mode. "
+            "Omitting the selector uses the default target. Environment facts "
+            "above describe only the default target "
+            f"{json.dumps(default_target.target, ensure_ascii=True)}; "
+            "tool results report the resolved target, backend, and cwd."
+        )
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -4,6 +4,7 @@ All functions are stateless. AIAgent._build_system_prompt() calls these to
 assemble pieces, then combines them with memory and ephemeral prompts.
 """
 
+import hashlib
 import json
 import logging
 import os
@@ -1128,7 +1129,7 @@ _BACKEND_FALLBACK_DESCRIPTIONS: dict[str, str] = {
 # a mid-process backend switch rebuilds the string. Kept in-module (not on
 # disk) because the probe captures live backend state that may change
 # across Hermes restarts.
-_BACKEND_PROBE_CACHE: dict[tuple[str, str], str] = {}
+_BACKEND_PROBE_CACHE: dict[tuple[str, str, str], str] = {}
 
 
 def _windows_marketing_version() -> str:
@@ -1175,7 +1176,11 @@ _WINDOWS_BASH_SHELL_HINT = (
 )
 
 
-def _probe_remote_backend(env_type: str) -> str | None:
+def _probe_remote_backend(
+    env_type: str,
+    terminal_config: dict | None = None,
+    target_name: str = "",
+) -> str | None:
     """Run a tiny introspection command inside the active terminal backend.
 
     Returns a pre-formatted multi-line string describing the backend's OS,
@@ -1183,8 +1188,14 @@ def _probe_remote_backend(env_type: str) -> str | None:
     per process. Used only for non-local backends where the agent's tools
     operate on a different machine than the host Hermes runs on.
     """
-    cwd_hint = os.getenv("TERMINAL_CWD", "")
-    cache_key = (env_type, cwd_hint)
+    if terminal_config is None:
+        config_identity = os.getenv("TERMINAL_CWD", "")
+    else:
+        serialized = json.dumps(
+            terminal_config, sort_keys=True, default=str, ensure_ascii=True,
+        )
+        config_identity = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    cache_key = (env_type, target_name, config_identity)
     cached = _BACKEND_PROBE_CACHE.get(cache_key)
     if cached is not None:
         return cached or None
@@ -1199,7 +1210,11 @@ def _probe_remote_backend(env_type: str) -> str | None:
         return None
 
     try:
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(terminal_config))
+            if terminal_config is not None
+            else _get_env_config()
+        )
         # Build the environment the same way tools/terminal_tool.py does for a
         # live command: select the backend image, then assemble ssh/container
         # config from the env-derived dict. (There is no `get_environment`
@@ -1251,7 +1266,12 @@ def _probe_remote_backend(env_type: str) -> str | None:
             timeout=config.get("timeout", 180),
             ssh_config=ssh_config,
             container_config=container_config,
-            task_id="prompt-backend-probe",
+            task_id=(
+                "prompt-backend-probe-"
+                + hashlib.sha256(
+                    f"{env_type}:{target_name}:{config_identity}".encode("utf-8")
+                ).hexdigest()[:12]
+            ),
             host_cwd=config.get("host_cwd"),
         )
         # Single-line POSIX probe — works on any Unixy backend. Wrapped in
@@ -1329,7 +1349,26 @@ def build_environment_hints() -> str:
 
     hints: list[str] = []
 
-    backend = (os.getenv("TERMINAL_ENV") or "local").strip().lower()
+    target_inventory = ()
+    default_target = None
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        resolved_targets = list_execution_targets()
+        if resolved_targets and resolved_targets[0].named:
+            target_inventory = resolved_targets
+            default_target = next(
+                (item for item in target_inventory if item.is_default),
+                target_inventory[0],
+            )
+    except Exception as e:
+        logger.debug("Could not resolve named execution targets for prompt: %s", e)
+
+    backend = (
+        default_target.backend
+        if default_target is not None
+        else (os.getenv("TERMINAL_ENV") or "local")
+    ).strip().lower()
     is_remote_backend = backend in _REMOTE_TERMINAL_BACKENDS
 
     if not is_remote_backend:
@@ -1347,8 +1386,15 @@ def build_environment_hints() -> str:
 
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
-            host_lines.append(f"Current working directory: {resolve_agent_cwd()}")
-        except OSError:
+            if default_target is not None:
+                from tools.terminal_tool import _get_env_config
+
+                cwd_hint = _get_env_config(dict(default_target.config)).get("cwd")
+            else:
+                cwd_hint = resolve_agent_cwd()
+            if cwd_hint:
+                host_lines.append(f"Current working directory: {cwd_hint}")
+        except (OSError, TypeError, ValueError):
             pass
 
         if sys.platform == "win32" and not is_wsl():
@@ -1366,11 +1412,32 @@ def build_environment_hints() -> str:
             hints.append(_WINDOWS_BASH_SHELL_HINT)
     else:
         # --- Remote backend block (host info suppressed) ---
-        probe = _probe_remote_backend(backend)
+        probe = (
+            _probe_remote_backend(
+                backend,
+                terminal_config=dict(default_target.config),
+                target_name=(
+                    f"{default_target.profile_scope}:{default_target.target}"
+                    if default_target.profile_scope
+                    else default_target.target
+                ),
+            )
+            if default_target is not None
+            else _probe_remote_backend(backend)
+        )
+        tool_scope = (
+            "Calls to `terminal`, `read_file`, `write_file`, `patch`, "
+            "`search_files`, and `execute_code` that omit an execution-target "
+            "selector operate"
+            if default_target is not None
+            else (
+                "Your `terminal`, `read_file`, `write_file`, `patch`, "
+                "`search_files`, and `execute_code` tools all operate"
+            )
+        )
         if probe:
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside this {backend} environment — NOT on the machine "
                 f"where Hermes itself is running. The host OS, home, and cwd "
                 f"of the Hermes process are irrelevant; only the following "
@@ -1381,8 +1448,7 @@ def build_environment_hints() -> str:
                 backend, f"a {backend} environment (likely Linux)"
             )
             hints.append(
-                f"Terminal backend: {backend}. Your `terminal`, `read_file`, "
-                f"`write_file`, `patch`, and `search_files` tools all operate "
+                f"Terminal backend: {backend}. {tool_scope} "
                 f"inside {description} — NOT on the machine where Hermes "
                 f"itself runs. The backend probe didn't respond at "
                 f"prompt-build time, so the sandbox's current user, $HOME, "
@@ -1390,6 +1456,23 @@ def build_environment_hints() -> str:
                 f"them, probe directly with a terminal call like "
                 f"`uname -a && whoami && pwd`."
             )
+
+    if default_target is not None and default_target.named:
+        target_summary = ", ".join(
+            f"{json.dumps(item.target, ensure_ascii=True)} ({item.backend}"
+            f"{', default' if item.is_default else ''})"
+            for item in target_inventory
+        )
+        hints.append(
+            "Configured execution targets: " + target_summary + ". "
+            "`terminal`, `read_file`, `write_file`, `patch`, `search_files`, and "
+            "`execute_code` select one with `execution_target`. "
+            "`search_files.target` remains its content/files search-mode selector. "
+            "Omitting the selector uses the default target. Environment facts "
+            "above describe only the default target "
+            f"{json.dumps(default_target.target, ensure_ascii=True)}; "
+            "tool results report the resolved target, backend, and cwd."
+        )
 
     if is_wsl():
         hints.append(WSL_ENVIRONMENT_HINT)

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -113,6 +113,18 @@ def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return False
 
 
+def _named_execution_targets_enabled() -> bool:
+    """Return whether omitted file selectors route through a named default."""
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        return any(target.named for target in list_execution_targets())
+    except Exception:
+        # The tools report malformed target config. The planner must still fail
+        # conservative rather than race path mutations before that happens.
+        return True
+
+
 def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = None) -> List[tuple]:
     """Split a tool-call batch into ordered ``(kind, calls)`` segments.
 
@@ -127,18 +139,10 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
 
     * ``_NEVER_PARALLEL_TOOLS`` (interactive tools) → barrier.
     * Unparseable / non-dict arguments → barrier.
-    * Path-scoped tools (``read_file``/``search_files``/``write_file``/
-      ``patch``) join a parallel run only when their target path(s) do not
-      CONFLICT with a path already reserved in the same run.  Reservations
-      carry a reader/writer role: reader↔reader overlap is harmless (two
-      reads of the same file commute) and stays parallel; any overlap
-      involving a writer closes the run so the conflicting call starts a
-      NEW run after the first completes.  ``search_files`` reserves its
-      search root (default ``.``) as a reader — a search batched after a
-      write into the searched subtree is ordered behind that write instead
-      of racing it.  For V4A ``patch(mode="patch")`` the reserved paths are
-      the file headers in the patch body, not a possibly-stale ``path=``
-      argument.
+    * Once named execution targets are enabled, stateful tools become
+      conservative barriers. Target-specific cwd/path identity is resolved
+      lazily by the tool layer and cannot be compared safely in this lexical
+      planner.
     * Anything not in ``_PARALLEL_SAFE_TOOLS`` and not an opted-in MCP
       tool → barrier.
 
@@ -150,6 +154,7 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
     current: list = []
     # (canonical_path, is_writer) reservations for the current parallel run.
     reserved_paths: list[tuple[Path, bool]] = []
+    named_default = _named_execution_targets_enabled()
 
     def _close_parallel() -> None:
         nonlocal current, reserved_paths
@@ -193,6 +198,14 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
             continue
 
         if tool_name in _PATH_SCOPED_TOOLS:
+            target_selected = (
+                function_args.get("execution_target") is not None
+                if tool_name == "search_files"
+                else function_args.get("target") is not None
+            )
+            if named_default or target_selected:
+                _add_sequential(tool_call)
+                continue
             scoped_paths = _extract_parallel_scope_paths(
                 tool_name, function_args, execution_cwd=execution_cwd
             )

--- a/agent/tool_dispatch_helpers.py
+++ b/agent/tool_dispatch_helpers.py
@@ -114,6 +114,18 @@ def _is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return False
 
 
+def _named_execution_targets_enabled() -> bool:
+    """Return whether omitted file selectors route through a named default."""
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        return any(target.named for target in list_execution_targets())
+    except Exception:
+        # The tools report malformed target config. The planner must still fail
+        # conservative rather than race path mutations before that happens.
+        return True
+
+
 def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = None) -> List[tuple]:
     """Split a tool-call batch into ordered ``(kind, calls)`` segments.
 
@@ -128,18 +140,10 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
 
     * ``_NEVER_PARALLEL_TOOLS`` (interactive tools) → barrier.
     * Unparseable / non-dict arguments → barrier.
-    * Path-scoped tools (``read_file``/``search_files``/``write_file``/
-      ``patch``) join a parallel run only when their target path(s) do not
-      CONFLICT with a path already reserved in the same run.  Reservations
-      carry a reader/writer role: reader↔reader overlap is harmless (two
-      reads of the same file commute) and stays parallel; any overlap
-      involving a writer closes the run so the conflicting call starts a
-      NEW run after the first completes.  ``search_files`` reserves its
-      search root (default ``.``) as a reader — a search batched after a
-      write into the searched subtree is ordered behind that write instead
-      of racing it.  For V4A ``patch(mode="patch")`` the reserved paths are
-      the file headers in the patch body, not a possibly-stale ``path=``
-      argument.
+    * Once named execution targets are enabled, stateful tools become
+      conservative barriers. Target-specific cwd/path identity is resolved
+      lazily by the tool layer and cannot be compared safely in this lexical
+      planner.
     * Anything not in ``_PARALLEL_SAFE_TOOLS`` and not an opted-in MCP
       tool → barrier.
 
@@ -151,6 +155,7 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
     current: list = []
     # (canonical_path, is_writer) reservations for the current parallel run.
     reserved_paths: list[tuple[Path, bool]] = []
+    named_default = _named_execution_targets_enabled()
 
     def _close_parallel() -> None:
         nonlocal current, reserved_paths
@@ -194,6 +199,10 @@ def _plan_tool_batch_segments(tool_calls, *, execution_cwd: Optional[Path] = Non
             continue
 
         if tool_name in _PATH_SCOPED_TOOLS:
+            target_selected = function_args.get("execution_target") is not None
+            if named_default or target_selected:
+                _add_sequential(tool_call)
+                continue
             scoped_paths = _extract_parallel_scope_paths(
                 tool_name, function_args, execution_cwd=execution_cwd
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -21,7 +21,7 @@ import random
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from agent.display import (
     KawaiiSpinner,
@@ -45,6 +45,7 @@ from tools.terminal_tool import (
 )
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
+    PERSISTED_OUTPUT_TAG,
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
@@ -64,13 +65,24 @@ def _ensure_file_checkpoint(
     if not file_path:
         return
 
+    # Checkpointing is a host-filesystem operation. Never interpret an SSH or
+    # container path with local path semantics merely because it resembles one.
+    target_cwd = _selected_local_target_cwd(
+        effective_task_id, function_name, function_args,
+    )
+    if not target_cwd:
+        return
+
     # File tools resolve relative paths against the task's live/session cwd,
     # which can differ from the Hermes process cwd (notably in Docker).  Resolve
     # through that same path pipeline before asking the checkpoint manager to
     # discover the project root.
     from tools.file_tools import _resolve_path_for_task
 
-    resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
+    target = function_args.get("target")
+    resolved_path = _resolve_path_for_task(
+        file_path, effective_task_id or "default", target,
+    )
     work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
 
@@ -89,6 +101,276 @@ def _budget_for_agent(agent) -> BudgetConfig:
         return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
         return DEFAULT_BUDGET
+
+
+def _handle_function_call_with_env_usage(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+    **kwargs,
+):
+    from tools.terminal_tool import (
+        environment_turn_usage,
+        execution_environment_turn_key,
+    )
+
+    with environment_turn_usage(
+        effective_task_id,
+        environment_key=execution_environment_turn_key(
+            function_name, function_args, task_id=effective_task_id,
+        ),
+    ):
+        return _ra().handle_function_call(
+            function_name, function_args, effective_task_id, **kwargs,
+        )
+
+
+_TARGET_RESULT_TOOLS = {
+    "terminal", "read_file", "write_file", "patch", "search_files",
+    "execute_code", "process",
+}
+
+
+def _resolved_tool_target(tool_name: str, args: dict, result: Any = None) -> str | None:
+    """Resolve the target identity carried by a tool call/result."""
+    if tool_name in _TARGET_RESULT_TOOLS and isinstance(result, str):
+        try:
+            payload = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("target"), str):
+            return payload["target"]
+    if tool_name == "search_files":
+        value = args.get("execution_target")
+    elif tool_name in _TARGET_RESULT_TOOLS:
+        value = args.get("target")
+    else:
+        value = None
+    return value if isinstance(value, str) and value else None
+
+
+def _result_runtime_scope(result: Any) -> str | None:
+    if not isinstance(result, str) or not result.lstrip().startswith("{"):
+        return None
+    try:
+        payload = json.loads(result)
+    except (TypeError, ValueError):
+        return None
+    scope = payload.get("runtime_scope") if isinstance(payload, dict) else None
+    return scope if isinstance(scope, str) and scope else None
+
+
+def _active_env_for_tool_result(
+    task_id: str, tool_name: str, args: dict, result: Any = None,
+):
+    if tool_name == "process":
+        session_id = args.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            try:
+                from tools.process_registry import process_registry
+
+                session = process_registry.get(session_id)
+                if session is not None and session.env_ref is not None:
+                    return session.env_ref
+            except Exception:
+                pass
+    if tool_name in _TARGET_RESULT_TOOLS and isinstance(result, str):
+        try:
+            payload = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if isinstance(payload, dict):
+            runtime_scope = payload.get("runtime_scope")
+            result_target = payload.get("target")
+            if (
+                isinstance(runtime_scope, str) and runtime_scope
+                and isinstance(result_target, str) and result_target
+            ):
+                try:
+                    from tools.terminal_tool import (
+                        get_environment_for_target_scope,
+                    )
+
+                    return get_environment_for_target_scope(
+                        task_id, result_target, runtime_scope,
+                    )
+                except Exception:
+                    return None
+    target = _resolved_tool_target(tool_name, args, result)
+    try:
+        return get_active_env(task_id, target=target)
+    except Exception:
+        # Persistence is best-effort. Preserve the handler's actionable
+        # configuration error instead of raising a second lookup failure.
+        return None
+
+
+def _append_persisted_target_hint(
+    content: str, target: str | None, runtime_scope: str | None = None,
+) -> str:
+    if (
+        target
+        and PERSISTED_OUTPUT_TAG in content
+        and "Execution target for this saved output:" not in content
+    ):
+        selector = f"target={json.dumps(target, ensure_ascii=True)}"
+        if runtime_scope:
+            selector += (
+                ", runtime_scope="
+                + json.dumps(runtime_scope, ensure_ascii=True)
+            )
+        return (
+            content
+            + "\nExecution target for this saved output: "
+            + json.dumps(target, ensure_ascii=True)
+            + f". Pass {selector} to `read_file`."
+        )
+    return content
+
+
+def _tool_target_map(agent) -> dict[str, Any]:
+    mapping = getattr(agent, "_execution_target_by_tool_call", None)
+    if not isinstance(mapping, dict):
+        mapping = {}
+        setattr(agent, "_execution_target_by_tool_call", mapping)
+    return mapping
+
+
+def _selected_local_target_cwd(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+) -> str | None:
+    """Return the selected target's host cwd, or None for remote targets."""
+    selector_name = (
+        "execution_target" if function_name == "search_files" else "target"
+    )
+    target = function_args.get(selector_name)
+    try:
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        selected = resolution.target if resolution.named else None
+        cwd = get_session_cwd(effective_task_id, target=selected)
+        if not cwd:
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named
+                else _get_env_config()
+            )
+            cwd = config.get("cwd")
+        if not isinstance(cwd, str) or not cwd:
+            return None
+        return os.path.abspath(os.path.expanduser(cwd))
+    except Exception:
+        return None
+
+
+def _target_subdirectory_hints(
+    agent,
+    task_id: str,
+    tool_name: str,
+    args: dict,
+    target: str | None,
+):
+    """Load local hints from the selected target; never scan host paths for remotes."""
+    try:
+        from agent.subdirectory_hints import SubdirectoryHintTracker
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        if not resolution.named:
+            return agent._subdirectory_hints.check_tool_call(tool_name, args)
+        selected_target = resolution.target
+        cwd = get_session_cwd(task_id, target=selected_target)
+        if not cwd:
+            cwd = _get_env_config(dict(resolution.config)).get("cwd")
+        if not isinstance(cwd, str) or not cwd.strip():
+            return None
+        cache_key = (resolution.profile_scope, selected_target, cwd)
+        trackers = getattr(agent, "_target_subdirectory_hints", None)
+        if not isinstance(trackers, dict):
+            trackers = {}
+            setattr(agent, "_target_subdirectory_hints", trackers)
+        tracker = trackers.get(cache_key)
+        if tracker is None:
+            tracker = SubdirectoryHintTracker(working_dir=cwd)
+            trackers[cache_key] = tracker
+        return tracker.check_tool_call(tool_name, args)
+    except Exception:
+        # Hints are optional context. Never replace a tool result with hint
+        # discovery/configuration failures.
+        return None
+
+
+def _enforce_target_aware_turn_budget(
+    tool_messages: list[dict], task_id: str, config: BudgetConfig,
+    target_by_tool_call: dict[str, Any] | None = None,
+) -> None:
+    """Persist each aggregate-spilled result in its producing target."""
+    if target_by_tool_call is None:
+        target_by_tool_call = {}
+
+    def _resolve_message_env(message: dict):
+        call_id = str(message.get("tool_call_id") or "")
+        if call_id not in target_by_tool_call:
+            return default_env
+        identity = target_by_tool_call.get(call_id)
+        if isinstance(identity, dict):
+            env = identity.get("env")
+            if env is not None:
+                return env
+            target = identity.get("target")
+            runtime_scope = identity.get("runtime_scope")
+            if isinstance(target, str) and isinstance(runtime_scope, str):
+                try:
+                    from tools.terminal_tool import get_environment_for_target_scope
+
+                    return get_environment_for_target_scope(
+                        task_id, target, runtime_scope,
+                    )
+                except Exception:
+                    return None
+        else:
+            target = identity
+        if not isinstance(target, str) or not target:
+            return None
+        try:
+            return get_active_env(task_id, target=target)
+        except Exception:
+            return None
+
+    try:
+        default_env = get_active_env(task_id)
+    except Exception:
+        default_env = None
+
+    enforce_turn_budget(
+        tool_messages,
+        env=default_env,
+        env_resolver=_resolve_message_env,
+        config=config,
+    )
+    for message in tool_messages:
+        tool_call_id = str(message.get("tool_call_id") or "")
+        identity = target_by_tool_call.get(tool_call_id)
+        target = identity.get("target") if isinstance(identity, dict) else identity
+        runtime_scope = (
+            identity.get("runtime_scope") if isinstance(identity, dict) else None
+        )
+        content = message.get("content", "")
+        if isinstance(content, str):
+            message["content"] = _append_persisted_target_hint(
+                content, target, runtime_scope,
+            )
+        if tool_call_id:
+            target_by_tool_call.pop(tool_call_id, None)
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -519,8 +801,31 @@ def _run_agent_tool_execution_middleware(
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        _advance_start_order(_begin)
-        return execute(final_args)
+        from contextlib import nullcontext
+
+        target_config_scope = nullcontext()
+        if function_name in _TARGET_RESULT_TOOLS:
+            from tools.execution_targets import frozen_execution_target_config
+
+            target_config_scope = frozen_execution_target_config()
+
+        # Checkpoint preflight and handler execution must observe exactly the
+        # same target generation. A live alias reload becomes visible only to
+        # the next tool dispatch, never between these two side effects.
+        with target_config_scope:
+            _advance_start_order(_begin)
+            from tools.terminal_tool import (
+                environment_turn_usage,
+                execution_environment_turn_key,
+            )
+
+            with environment_turn_usage(
+                effective_task_id,
+                environment_key=execution_environment_turn_key(
+                    function_name, final_args, task_id=effective_task_id,
+                ),
+            ):
+                return execute(final_args)
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(
@@ -657,12 +962,15 @@ def _begin_tool_execution(
         try:
             command = function_args.get("command", "")
             if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv(
-                    "TERMINAL_CWD", os.getcwd()
+                # Checkpointing reads the host filesystem. Never treat a
+                # Docker/SSH/cloud path as local merely because it is absolute.
+                cwd = _selected_local_target_cwd(
+                    effective_task_id, function_name, function_args,
                 )
-                agent._checkpoint_mgr.ensure_checkpoint(
-                    cwd, f"before terminal: {command[:60]}"
-                )
+                if cwd:
+                    agent._checkpoint_mgr.ensure_checkpoint(
+                        cwd, f"before terminal: {command[:60]}"
+                    )
         except Exception:
             pass
 
@@ -1240,20 +1548,35 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s){_status_suffix}")
 
         display_function_result = function_result
+        result_execution_target = _resolved_tool_target(
+            name, args, function_result,
+        )
+        result_runtime_scope = _result_runtime_scope(function_result)
+        producing_env = _active_env_for_tool_result(
+            effective_task_id, name, args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
             tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
+            env=producing_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target, result_runtime_scope,
+            )
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+        subdir_hints = _target_subdirectory_hints(
+            agent, effective_task_id, name, args, result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 # Append the hint to the text summary part so the model
                 # still sees it; don't touch the image blocks.
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -1272,6 +1595,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tc.id,
             effect_disposition=effect_disposition,
         )
+        if result_execution_target:
+            _tool_target_map(agent)[str(tc.id)] = {
+                "target": result_execution_target,
+                "runtime_scope": result_runtime_scope,
+                "env": producing_env,
+            }
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -1342,7 +1671,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            turn_tool_msgs, effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -1945,19 +2277,38 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logging.debug("Tool result (%d chars): %s", len(_log_result), _log_result)
 
         display_function_result = function_result
+        result_execution_target = _resolved_tool_target(
+            function_name, function_args, function_result,
+        )
+        result_runtime_scope = _result_runtime_scope(function_result)
+        producing_env = _active_env_for_tool_result(
+            effective_task_id, function_name, function_args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
             tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
+            env=producing_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target, result_runtime_scope,
+            )
 
         # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        subdir_hints = _target_subdirectory_hints(
+            agent,
+            effective_task_id,
+            function_name,
+            function_args,
+            result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -1965,6 +2316,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
         # (see parallel path for rationale). String results pass through.
         _tool_content = agent._tool_result_content_for_active_model(function_name, function_result)
         tool_message = make_tool_result_message(function_name, _tool_content, tool_call.id)
+        if result_execution_target:
+            _tool_target_map(agent)[str(tool_call.id)] = {
+                "target": result_execution_target,
+                "runtime_scope": result_runtime_scope,
+                "env": producing_env,
+            }
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -2052,7 +2409,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # be discarded when aggregate budget enforcement replaces a tool result.
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            messages[-num_tools_seq:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -2115,10 +2475,9 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
     total_tools = len(assistant_message.tool_calls)
     if total_tools > 0:
         _tool_budget = _budget_for_agent(agent)
-        enforce_turn_budget(
-            messages[-total_tools:],
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
+        _enforce_target_aware_turn_budget(
+            messages[-total_tools:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -21,7 +21,7 @@ import random
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from agent.display import (
     KawaiiSpinner,
@@ -46,6 +46,7 @@ from tools.terminal_tool import (
 )
 from tools.thread_context import propagate_context_to_thread
 from tools.tool_result_storage import (
+    PERSISTED_OUTPUT_TAG,
     maybe_persist_tool_result,
     enforce_turn_budget,
 )
@@ -65,13 +66,24 @@ def _ensure_file_checkpoint(
     if not file_path:
         return
 
+    # Checkpointing is a host-filesystem operation. Never interpret an SSH or
+    # container path with local path semantics merely because it resembles one.
+    target_cwd = _selected_local_target_cwd(
+        effective_task_id, function_name, function_args,
+    )
+    if not target_cwd:
+        return
+
     # File tools resolve relative paths against the task's live/session cwd,
     # which can differ from the Hermes process cwd (notably in Docker).  Resolve
     # through that same path pipeline before asking the checkpoint manager to
     # discover the project root.
     from tools.file_tools import _resolve_path_for_task
 
-    resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
+    target = function_args.get("execution_target")
+    resolved_path = _resolve_path_for_task(
+        file_path, effective_task_id or "default", target,
+    )
     work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
 
@@ -90,6 +102,271 @@ def _budget_for_agent(agent) -> BudgetConfig:
         return budget_for_context_window(int(ctx)) if ctx else DEFAULT_BUDGET
     except Exception:
         return DEFAULT_BUDGET
+
+
+def _handle_function_call_with_env_usage(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+    **kwargs,
+):
+    from tools.terminal_tool import (
+        environment_turn_usage,
+        execution_environment_turn_key,
+    )
+
+    with environment_turn_usage(
+        effective_task_id,
+        environment_key=execution_environment_turn_key(
+            function_name, function_args, task_id=effective_task_id,
+        ),
+    ):
+        return _ra().handle_function_call(
+            function_name, function_args, effective_task_id, **kwargs,
+        )
+
+
+_TARGET_RESULT_TOOLS = {
+    "terminal", "read_file", "write_file", "patch", "search_files",
+    "execute_code", "process",
+}
+
+
+def _resolved_tool_target(tool_name: str, args: dict, result: Any = None) -> str | None:
+    """Resolve the target identity carried by a tool call/result."""
+    if tool_name in _TARGET_RESULT_TOOLS and isinstance(result, str):
+        try:
+            payload = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if isinstance(payload, dict) and isinstance(payload.get("target"), str):
+            return payload["target"]
+    if tool_name in _TARGET_RESULT_TOOLS:
+        value = args.get("execution_target")
+    else:
+        value = None
+    return value if isinstance(value, str) and value else None
+
+
+def _result_runtime_scope(result: Any) -> str | None:
+    if not isinstance(result, str) or not result.lstrip().startswith("{"):
+        return None
+    try:
+        payload = json.loads(result)
+    except (TypeError, ValueError):
+        return None
+    scope = payload.get("runtime_scope") if isinstance(payload, dict) else None
+    return scope if isinstance(scope, str) and scope else None
+
+
+def _active_env_for_tool_result(
+    task_id: str, tool_name: str, args: dict, result: Any = None,
+):
+    if tool_name == "process":
+        session_id = args.get("session_id")
+        if isinstance(session_id, str) and session_id:
+            try:
+                from tools.process_registry import process_registry
+
+                session = process_registry.get(session_id)
+                if session is not None and session.env_ref is not None:
+                    return session.env_ref
+            except Exception:
+                pass
+    if tool_name in _TARGET_RESULT_TOOLS and isinstance(result, str):
+        try:
+            payload = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            payload = None
+        if isinstance(payload, dict):
+            runtime_scope = payload.get("runtime_scope")
+            result_target = payload.get("target")
+            if (
+                isinstance(runtime_scope, str) and runtime_scope
+                and isinstance(result_target, str) and result_target
+            ):
+                try:
+                    from tools.terminal_tool import (
+                        get_environment_for_target_scope,
+                    )
+
+                    return get_environment_for_target_scope(
+                        task_id, result_target, runtime_scope,
+                    )
+                except Exception:
+                    return None
+    target = _resolved_tool_target(tool_name, args, result)
+    try:
+        return get_active_env(task_id, target=target)
+    except Exception:
+        # Persistence is best-effort. Preserve the handler's actionable
+        # configuration error instead of raising a second lookup failure.
+        return None
+
+
+def _append_persisted_target_hint(
+    content: str, target: str | None, runtime_scope: str | None = None,
+) -> str:
+    if (
+        target
+        and PERSISTED_OUTPUT_TAG in content
+        and "Execution target for this saved output:" not in content
+    ):
+        selector = f"execution_target={json.dumps(target, ensure_ascii=True)}"
+        if runtime_scope:
+            selector += (
+                ", runtime_scope="
+                + json.dumps(runtime_scope, ensure_ascii=True)
+            )
+        return (
+            content
+            + "\nExecution target for this saved output: "
+            + json.dumps(target, ensure_ascii=True)
+            + f". Pass {selector} to `read_file`."
+        )
+    return content
+
+
+def _tool_target_map(agent) -> dict[str, Any]:
+    mapping = getattr(agent, "_execution_target_by_tool_call", None)
+    if not isinstance(mapping, dict):
+        mapping = {}
+        setattr(agent, "_execution_target_by_tool_call", mapping)
+    return mapping
+
+
+def _selected_local_target_cwd(
+    effective_task_id: str,
+    function_name: str,
+    function_args: dict,
+) -> str | None:
+    """Return the selected target's host cwd, or None for remote targets."""
+    try:
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        target = function_args.get("execution_target")
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        selected = resolution.target if resolution.named else None
+        cwd = get_session_cwd(effective_task_id, target=selected)
+        if not cwd:
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named
+                else _get_env_config()
+            )
+            cwd = config.get("cwd")
+        if not isinstance(cwd, str) or not cwd:
+            return None
+        return os.path.abspath(os.path.expanduser(cwd))
+    except Exception:
+        return None
+
+
+def _target_subdirectory_hints(
+    agent,
+    task_id: str,
+    tool_name: str,
+    args: dict,
+    target: str | None,
+):
+    """Load local hints from the selected target; never scan host paths for remotes."""
+    try:
+        from agent.subdirectory_hints import SubdirectoryHintTracker
+        from tools.execution_targets import resolve_execution_target
+        from tools.terminal_tool import _get_env_config, get_session_cwd
+
+        resolution = resolve_execution_target(target)
+        if resolution.backend != "local":
+            return None
+        if not resolution.named:
+            return agent._subdirectory_hints.check_tool_call(tool_name, args)
+        selected_target = resolution.target
+        cwd = get_session_cwd(task_id, target=selected_target)
+        if not cwd:
+            cwd = _get_env_config(dict(resolution.config)).get("cwd")
+        if not isinstance(cwd, str) or not cwd.strip():
+            return None
+        cache_key = (resolution.profile_scope, selected_target, cwd)
+        trackers = getattr(agent, "_target_subdirectory_hints", None)
+        if not isinstance(trackers, dict):
+            trackers = {}
+            setattr(agent, "_target_subdirectory_hints", trackers)
+        tracker = trackers.get(cache_key)
+        if tracker is None:
+            tracker = SubdirectoryHintTracker(working_dir=cwd)
+            trackers[cache_key] = tracker
+        return tracker.check_tool_call(tool_name, args)
+    except Exception:
+        # Hints are optional context. Never replace a tool result with hint
+        # discovery/configuration failures.
+        return None
+
+
+def _enforce_target_aware_turn_budget(
+    tool_messages: list[dict], task_id: str, config: BudgetConfig,
+    target_by_tool_call: dict[str, Any] | None = None,
+) -> None:
+    """Persist each aggregate-spilled result in its producing target."""
+    if target_by_tool_call is None:
+        target_by_tool_call = {}
+
+    def _resolve_message_env(message: dict):
+        call_id = str(message.get("tool_call_id") or "")
+        if call_id not in target_by_tool_call:
+            return default_env
+        identity = target_by_tool_call.get(call_id)
+        if isinstance(identity, dict):
+            env = identity.get("env")
+            if env is not None:
+                return env
+            target = identity.get("target")
+            runtime_scope = identity.get("runtime_scope")
+            if isinstance(target, str) and isinstance(runtime_scope, str):
+                try:
+                    from tools.terminal_tool import get_environment_for_target_scope
+
+                    return get_environment_for_target_scope(
+                        task_id, target, runtime_scope,
+                    )
+                except Exception:
+                    return None
+        else:
+            target = identity
+        if not isinstance(target, str) or not target:
+            return None
+        try:
+            return get_active_env(task_id, target=target)
+        except Exception:
+            return None
+
+    try:
+        default_env = get_active_env(task_id)
+    except Exception:
+        default_env = None
+
+    enforce_turn_budget(
+        tool_messages,
+        env=default_env,
+        env_resolver=_resolve_message_env,
+        config=config,
+    )
+    for message in tool_messages:
+        tool_call_id = str(message.get("tool_call_id") or "")
+        identity = target_by_tool_call.get(tool_call_id)
+        target = identity.get("target") if isinstance(identity, dict) else identity
+        runtime_scope = (
+            identity.get("runtime_scope") if isinstance(identity, dict) else None
+        )
+        content = message.get("content", "")
+        if isinstance(content, str):
+            message["content"] = _append_persisted_target_hint(
+                content, target, runtime_scope,
+            )
+        if tool_call_id:
+            target_by_tool_call.pop(tool_call_id, None)
 
 # Maximum number of concurrent worker threads for parallel tool execution.
 # Mirrors the constant in ``run_agent`` for tests/imports that look here.
@@ -574,8 +851,22 @@ def _run_agent_tool_execution_middleware(
                     "Hermes tool execution callback invoked more than once"
                 )
             state["dispatched"] = True
-            state["blocked"] = False
             state["args"] = final_args
+
+        # Execution middleware has now produced the final arguments. Enforce
+        # the canonical routing API before hooks, guardrails, progress, or approval.
+        try:
+            from tools.execution_targets import (
+                ExecutionTargetError,
+                validate_execution_target_args,
+            )
+
+            validate_execution_target_args(function_name, final_args)
+        except ExecutionTargetError as exc:
+            state["blocked"] = True
+            return json.dumps({"error": str(exc)}, ensure_ascii=False)
+        state["blocked"] = False
+        state["args"] = final_args
 
         def _begin() -> None:
             _begin_tool_execution(
@@ -669,28 +960,48 @@ def _run_agent_tool_execution_middleware(
         elif function_name == "skill_manage":
             agent._iters_since_skill = 0
 
-        _advance_start_order(_begin)
+        from contextlib import nullcontext
 
-        # Keep the gateway turn-inactivity watchdog from abandoning a turn
-        # whose tool call runs silently for longer than the inactivity
-        # timeout (#84491): stamp activity periodically while the tool is
-        # in flight, not just at start/completion. Both the sequential and
-        # the concurrent paths funnel through here, so a single heartbeat
-        # covers every tool.
-        _hb_stop = threading.Event()
-        _hb_thread = threading.Thread(
-            target=_run_tool_activity_heartbeat,
-            args=(agent, _hb_stop, f"tool running: {function_name}"),
-            kwargs={"interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S},
-            daemon=True,
-            name=f"tool-activity-hb-{function_name[:24]}",
-        )
-        _hb_thread.start()
-        try:
-            return execute(final_args)
-        finally:
-            _hb_stop.set()
-            _hb_thread.join(timeout=2.0)
+        target_config_scope = nullcontext()
+        if function_name in _TARGET_RESULT_TOOLS:
+            from tools.execution_targets import frozen_execution_target_config
+
+            target_config_scope = frozen_execution_target_config()
+
+        # Checkpoint preflight and handler execution must observe exactly the
+        # same target generation. A live alias reload becomes visible only to
+        # the next tool dispatch, never between these two side effects.
+        with target_config_scope:
+            _advance_start_order(_begin)
+            from tools.terminal_tool import (
+                environment_turn_usage,
+                execution_environment_turn_key,
+            )
+
+            with environment_turn_usage(
+                effective_task_id,
+                environment_key=execution_environment_turn_key(
+                    function_name, final_args, task_id=effective_task_id,
+                ),
+            ):
+                # Keep the gateway turn-inactivity watchdog from abandoning a
+                # turn whose tool call runs silently for longer than the
+                # inactivity timeout (#84491). Both sequential and concurrent
+                # dispatch funnel through here.
+                _hb_stop = threading.Event()
+                _hb_thread = threading.Thread(
+                    target=_run_tool_activity_heartbeat,
+                    args=(agent, _hb_stop, f"tool running: {function_name}"),
+                    kwargs={"interval": _TOOL_ACTIVITY_HEARTBEAT_INTERVAL_S},
+                    daemon=True,
+                    name=f"tool-activity-hb-{function_name[:24]}",
+                )
+                _hb_thread.start()
+                try:
+                    return execute(final_args)
+                finally:
+                    _hb_stop.set()
+                    _hb_thread.join(timeout=2.0)
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
         request_result = apply_tool_request_middleware(
@@ -1035,12 +1346,21 @@ def _begin_tool_execution(
         try:
             command = function_args.get("command", "")
             if _is_destructive_command(command):
-                cwd = function_args.get("workdir") or os.getenv(
-                    "TERMINAL_CWD", os.getcwd()
+                # Checkpointing reads the host filesystem. Never treat a
+                # Docker/SSH/cloud path as local merely because it is absolute.
+                target_cwd = _selected_local_target_cwd(
+                    effective_task_id, function_name, function_args,
                 )
-                agent._checkpoint_mgr.ensure_checkpoint(
-                    cwd, f"before terminal: {command[:60]}"
-                )
+                if target_cwd:
+                    explicit_workdir = function_args.get("workdir")
+                    cwd = (
+                        os.path.abspath(os.path.expanduser(explicit_workdir))
+                        if isinstance(explicit_workdir, str) and explicit_workdir
+                        else target_cwd
+                    )
+                    agent._checkpoint_mgr.ensure_checkpoint(
+                        cwd, f"before terminal: {command[:60]}"
+                    )
         except Exception:
             pass
 
@@ -1757,20 +2077,35 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         agent._touch_activity(f"tool completed: {name} ({tool_duration:.1f}s){_status_suffix}")
 
         display_function_result = function_result
+        result_execution_target = _resolved_tool_target(
+            name, args, function_result,
+        )
+        result_runtime_scope = _result_runtime_scope(function_result)
+        producing_env = _active_env_for_tool_result(
+            effective_task_id, name, args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=name,
             tool_use_id=tc.id,
-            env=get_active_env(effective_task_id),
+            env=producing_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target, result_runtime_scope,
+            )
 
-        subdir_hints = agent._subdirectory_hints.check_tool_call(name, args)
+        subdir_hints = _target_subdirectory_hints(
+            agent, effective_task_id, name, args, result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
                 # Append the hint to the text summary part so the model
                 # still sees it; don't touch the image blocks.
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -1789,6 +2124,12 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             tc.id,
             effect_disposition=effect_disposition,
         )
+        if result_execution_target:
+            _tool_target_map(agent)[str(tc.id)] = {
+                "target": result_execution_target,
+                "runtime_scope": result_runtime_scope,
+                "env": producing_env,
+            }
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -1859,7 +2200,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     num_tools = len(parsed_calls)
     if finalize and num_tools > 0:
         turn_tool_msgs = messages[-num_tools:]
-        enforce_turn_budget(turn_tool_msgs, env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            turn_tool_msgs, effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # Append any pending user steer text to the last tool result so the
@@ -2572,19 +2916,38 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logging.debug("Tool result (%d chars): %s", len(_log_result), _log_result)
 
         display_function_result = function_result
+        result_execution_target = _resolved_tool_target(
+            function_name, function_args, function_result,
+        )
+        result_runtime_scope = _result_runtime_scope(function_result)
+        producing_env = _active_env_for_tool_result(
+            effective_task_id, function_name, function_args, function_result,
+        )
         function_result = maybe_persist_tool_result(
             content=function_result,
             tool_name=function_name,
             tool_use_id=tool_call.id,
-            env=get_active_env(effective_task_id),
+            env=producing_env,
             config=_tool_budget,
         ) if not _is_multimodal_tool_result(function_result) else function_result
+        if isinstance(function_result, str):
+            function_result = _append_persisted_target_hint(
+                function_result, result_execution_target, result_runtime_scope,
+            )
 
         # Discover subdirectory context files from tool arguments
-        subdir_hints = agent._subdirectory_hints.check_tool_call(function_name, function_args)
+        subdir_hints = _target_subdirectory_hints(
+            agent,
+            effective_task_id,
+            function_name,
+            function_args,
+            result_execution_target,
+        )
         if subdir_hints:
             if _is_multimodal_tool_result(function_result):
-                _append_subdir_hint_to_multimodal(function_result, subdir_hints)
+                _append_subdir_hint_to_multimodal(
+                    cast(dict[str, Any], function_result), subdir_hints,
+                )
             else:
                 function_result += subdir_hints
 
@@ -2597,6 +2960,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             tool_call.id,
             effect_disposition="unknown" if _execution_timed_out else None,
         )
+        if result_execution_target:
+            _tool_target_map(agent)[str(tool_call.id)] = {
+                "target": result_execution_target,
+                "runtime_scope": result_runtime_scope,
+                "env": producing_env,
+            }
         messages.append(tool_message)
         risk_metadata = tool_message.get("_tool_output_risk")
         if not _flush_session_db_after_tool_progress(
@@ -2684,7 +3053,10 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     # be discarded when aggregate budget enforcement replaces a tool result.
     num_tools_seq = len(assistant_message.tool_calls)
     if finalize and num_tools_seq > 0:
-        enforce_turn_budget(messages[-num_tools_seq:], env=get_active_env(effective_task_id), config=_tool_budget)
+        _enforce_target_aware_turn_budget(
+            messages[-num_tools_seq:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
+        )
 
     # ── /steer injection ──────────────────────────────────────────────
     # See _execute_tool_calls_parallel for the rationale. Same hook,
@@ -2747,10 +3119,9 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
     total_tools = len(assistant_message.tool_calls)
     if total_tools > 0:
         _tool_budget = _budget_for_agent(agent)
-        enforce_turn_budget(
-            messages[-total_tools:],
-            env=get_active_env(effective_task_id),
-            config=_tool_budget,
+        _enforce_target_aware_turn_budget(
+            messages[-total_tools:], effective_task_id, _tool_budget,
+            _tool_target_map(agent),
         )
         agent._apply_pending_steer_to_tool_results(messages, total_tools)
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -336,6 +336,23 @@ terminal:
   # sudo_password: "hunter2"  # Optional: pipe a sudo password via sudo -S. SECURITY WARNING: plaintext.
   # sudo_password: ""         # Explicit empty password: try empty and never open the interactive sudo prompt.
 
+# Optional: route each tool call to one of several execution environments.
+# Top-level terminal settings (such as timeout and resource limits) are
+# inherited by every target; values inside a target override them. Keep
+# targets absent or empty to retain the single-backend configuration above.
+# terminal:
+#   timeout: 180
+#   default_target: "local"
+#   targets:
+#     local:
+#       backend: "local"
+#       cwd: "/workspace/local"
+#     devbox:
+#       backend: "ssh"
+#       ssh_host: "devbox.example.com"
+#       ssh_user: "bruno"
+#       cwd: "/home/bruno/project"
+
 # -----------------------------------------------------------------------------
 # OPTION 2: SSH remote execution
 # Commands run on a remote server - agent code stays local (sandboxed)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -243,6 +243,23 @@ terminal:
   # sudo_password: "hunter2"  # Optional: pipe a sudo password via sudo -S. SECURITY WARNING: plaintext.
   # sudo_password: ""         # Explicit empty password: try empty and never open the interactive sudo prompt.
 
+# Optional: route each tool call to one of several execution environments.
+# Top-level terminal settings (such as timeout and resource limits) are
+# inherited by every target; values inside a target override them. Keep
+# targets absent or empty to retain the single-backend configuration above.
+# terminal:
+#   timeout: 180
+#   default_target: "local"
+#   targets:
+#     local:
+#       backend: "local"
+#       cwd: "/workspace/local"
+#     devbox:
+#       backend: "ssh"
+#       ssh_host: "devbox.example.com"
+#       ssh_user: "bruno"
+#       cwd: "/home/bruno/project"
+
 # -----------------------------------------------------------------------------
 # OPTION 2: SSH remote execution
 # Commands run on a remote server - agent code stays local (sandboxed)

--- a/cli.py
+++ b/cli.py
@@ -614,7 +614,7 @@ def load_cli_config() -> Dict[str, Any]:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
+    from hermes_cli.config import _expand_env_vars, effective_terminal_config
     defaults = _expand_env_vars(defaults)
 
     # Managed scope: overlay administrator-pinned values LAST so they win over
@@ -629,8 +629,19 @@ def load_cli_config() -> Dict[str, Any]:
 
     defaults = managed_scope.apply_managed_overlay(defaults)
 
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        from tools.execution_targets import set_execution_target_config_source
+
+        set_execution_target_config_source(defaults)
+
     # Apply terminal config to environment variables (so terminal_tool picks them up)
-    terminal_config = defaults.get("terminal", {})
+    raw_terminal_config = defaults.get("terminal", {})
+    named_terminal_mode = (
+        isinstance(raw_terminal_config, dict)
+        and isinstance(raw_terminal_config.get("targets"), dict)
+        and bool(raw_terminal_config.get("targets"))
+    )
+    terminal_config = effective_terminal_config(raw_terminal_config)
     
     # Normalize config key: the new config system (hermes_cli/config.py) and all
     # documentation use "backend", the legacy cli-config.yaml uses "env_type".
@@ -646,9 +657,13 @@ def load_cli_config() -> Dict[str, Any]:
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
-    if effective_backend == "local":
+    if effective_backend == "local" and (
+        not named_terminal_mode
+        or terminal_config.get("cwd") in _CWD_PLACEHOLDERS
+    ):
         terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        if not named_terminal_mode:
+            defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
     

--- a/cli.py
+++ b/cli.py
@@ -618,7 +618,7 @@ def load_cli_config() -> Dict[str, Any]:
             logger.warning("Failed to load cli-config.yaml: %s", e)
 
     # Expand ${ENV_VAR} references in config values before bridging to env vars.
-    from hermes_cli.config import _expand_env_vars
+    from hermes_cli.config import _expand_env_vars, effective_terminal_config
     defaults = _expand_env_vars(defaults)
 
     # Managed scope: overlay administrator-pinned values LAST so they win over
@@ -633,8 +633,19 @@ def load_cli_config() -> Dict[str, Any]:
 
     defaults = managed_scope.apply_managed_overlay(defaults)
 
+    if os.environ.get("_HERMES_GATEWAY") != "1":
+        from tools.execution_targets import set_execution_target_config_source
+
+        set_execution_target_config_source(defaults)
+
     # Apply terminal config to environment variables (so terminal_tool picks them up)
-    terminal_config = defaults.get("terminal", {})
+    raw_terminal_config = defaults.get("terminal", {})
+    named_terminal_mode = (
+        isinstance(raw_terminal_config, dict)
+        and isinstance(raw_terminal_config.get("targets"), dict)
+        and bool(raw_terminal_config.get("targets"))
+    )
+    terminal_config = effective_terminal_config(raw_terminal_config)
     
     # Normalize config key: the new config system (hermes_cli/config.py) and all
     # documentation use "backend", the legacy cli-config.yaml uses "env_type".
@@ -650,9 +661,13 @@ def load_cli_config() -> Dict[str, Any]:
     _CWD_PLACEHOLDERS = (".", "auto", "cwd")
     effective_backend = terminal_config.get("env_type", "local")
 
-    if effective_backend == "local":
+    if effective_backend == "local" and (
+        not named_terminal_mode
+        or terminal_config.get("cwd") in _CWD_PLACEHOLDERS
+    ):
         terminal_config["cwd"] = os.getcwd()
-        defaults["terminal"]["cwd"] = terminal_config["cwd"]
+        if not named_terminal_mode:
+            defaults["terminal"]["cwd"] = terminal_config["cwd"]
     elif terminal_config.get("cwd") in _CWD_PLACEHOLDERS:
         terminal_config.pop("cwd", None)
     

--- a/contributors/emails/bruno@ribarich.me
+++ b/contributors/emails/bruno@ribarich.me
@@ -1,0 +1,1 @@
+ribaricplusplus

--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -174,7 +174,8 @@ _BINARY_SNIFF_BYTES = 4096
 
 
 
-_ReadRemoteScriptFn = Callable[[str], Optional[str]]
+_ReadRemoteScriptResult = Optional[str] | tuple[Optional[str], bool]
+_ReadRemoteScriptFn = Callable[[str], _ReadRemoteScriptResult]
 
 
 def _iter_command_segments(command: str) -> Iterator[list[str]]:
@@ -529,7 +530,9 @@ def _read_referenced_script(path: Path) -> tuple[Optional[str], bool]:
     return data.decode("utf-8", errors="replace"), False
 
 
-def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bool]:
+def _sanitize_remote_script_text(
+    result: _ReadRemoteScriptResult,
+) -> tuple[Optional[str], bool]:
     """Apply the local-read contract to text from a ``read_remote_script`` callback.
 
     The recursion boundary must not trust its callbacks: any backend (SSH,
@@ -546,8 +549,18 @@ def _sanitize_remote_script_text(text: Optional[str]) -> tuple[Optional[str], bo
     callback so the guarantee holds for every callback, not just the ones
     we hardened.
     """
+    if isinstance(result, tuple):
+        if len(result) != 2 or not isinstance(result[1], bool):
+            return None, True
+        text, unsafe = result
+        if unsafe:
+            return None, True
+    else:
+        text = result
     if not text:
         return None, False
+    if not isinstance(text, str):
+        return None, True
     if "\x00" in text:
         return None, False
     if len(text.encode("utf-8", errors="replace")) > _MAX_REFERENCED_SCRIPT_BYTES:
@@ -599,19 +612,20 @@ def _contains_unsafe_gateway_action(
         if resolved in visited:
             continue
         visited.add(resolved)
-        script_text, unsafe = _read_referenced_script(script_path)
-        if unsafe:
-            return True
-        if script_text is None and read_remote_script is not None:
-            # Local path missing; try the remote backend if one is available.
-            # The callback's output crosses the same trust boundary as a
-            # local read — sanitize it identically before it enters the
-            # recursion (binary skip + size fail-closed).
+        if read_remote_script is not None:
+            # A supplied reader represents the selected execution target and
+            # is authoritative. Consulting the Hermes host first would let a
+            # coincidentally matching local path shadow the remote script (or
+            # falsely block a safe remote script based on unsafe host bytes).
+            # Sanitize callback output at the same bounded, binary-safe trust
+            # boundary as local reads.
             script_text, unsafe = _sanitize_remote_script_text(
                 read_remote_script(str(script_path))
             )
-            if unsafe:
-                return True
+        else:
+            script_text, unsafe = _read_referenced_script(script_path)
+        if unsafe:
+            return True
         if not script_text:
             continue
         # Relative references inside a script resolve against that script's

--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -230,7 +230,11 @@ def annotate_tool_execution(**kwargs):
 ```
 
 Execution middleware may call `next_call(modified_args)` to pass a changed
-payload to later middleware and the base tool dispatcher.
+payload to later middleware and the base tool dispatcher. For target-aware tools,
+those modified arguments must preserve the exact `execution_target` that hooks
+and approvals evaluated. Use `tool_request` middleware when routing must change
+before authorization. The unrelated `search_files.target` field remains its
+`content`/`files` operation selector.
 
 Plugin-specific examples should live with the plugin that owns the behavior.
 For NeMo Relay adaptive execution middleware, see

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1943,6 +1943,12 @@ if _config_path.exists():
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
+            from hermes_cli.config import effective_terminal_config
+
+            # Legacy consumers below still read TERMINAL_* as the one backend
+            # used when a tool call omits target. In named mode that is the
+            # selected default target, not the top-level inheritance mapping.
+            _terminal_cfg = effective_terminal_config(_terminal_cfg)
             _terminal_backend = str(
                 _terminal_cfg.get("backend") or os.environ.get("TERMINAL_ENV") or ""
             ).strip().lower()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2200,6 +2200,12 @@ if _config_path.exists():
         # config.yaml overrides .env for these since it's the documented config path.
         _terminal_cfg = _cfg.get("terminal", {})
         if _terminal_cfg and isinstance(_terminal_cfg, dict):
+            from hermes_cli.config import effective_terminal_config
+
+            # Legacy consumers below still read TERMINAL_* as the one backend
+            # used when a tool call omits target. In named mode that is the
+            # selected default target, not the top-level inheritance mapping.
+            _terminal_cfg = effective_terminal_config(_terminal_cfg)
             _terminal_backend = str(
                 _terminal_cfg.get("backend") or os.environ.get("TERMINAL_ENV") or ""
             ).strip().lower()

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3185,6 +3185,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "modal_mode": "TERMINAL_MODAL_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "home_mode": "TERMINAL_HOME_MODE",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
@@ -3218,6 +3219,38 @@ def _terminal_env_value(value: Any) -> str:
     if isinstance(value, (list, dict)):
         return json.dumps(value)
     return str(value)
+
+
+def effective_terminal_config(terminal_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the flat settings represented by the configured default target.
+
+    Legacy/runtime-adjacent consumers still use ``TERMINAL_*`` variables to
+    describe the environment selected when a tool call omits ``target``. In
+    named-target mode those variables must mirror ``default_target`` rather
+    than the top-level inheritance defaults.
+
+    Invalid target configuration remains the strict resolver's responsibility;
+    this compatibility bridge stays fail-open so config loading retains its
+    historical behavior.
+    """
+    if not isinstance(terminal_cfg, dict):
+        return {}
+    targets = terminal_cfg.get("targets")
+    default_target = terminal_cfg.get("default_target")
+    flat = {
+        key: value for key, value in terminal_cfg.items()
+        if key not in {"targets", "default_target"}
+    }
+    if not isinstance(targets, dict) or not targets:
+        return dict(terminal_cfg)
+    if not isinstance(default_target, str):
+        return flat
+    selected = targets.get(default_target)
+    if not isinstance(selected, dict):
+        return flat
+    effective = dict(flat)
+    effective.update(selected)
+    return effective
 
 
 def terminal_config_env_var_for_key(key: str) -> Optional[str]:
@@ -3258,12 +3291,19 @@ def apply_terminal_config_to_env(
     terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
     if not isinstance(terminal_cfg, dict):
         return target
+    terminal_cfg = effective_terminal_config(terminal_cfg)
+    terminal_backend = str(
+        terminal_cfg.get("backend") or terminal_cfg.get("env_type") or "local"
+    ).strip().lower()
 
-    # A caller-supplied config is its own source of explicit keys.  For the
-    # normal merged-config path, only keys present in raw config.yaml may
-    # override existing env values; keys inherited from DEFAULT_CONFIG are
-    # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
+    # A caller-supplied config is its own source of explicit keys. For the
+    # normal merged-config path, include the selected raw target's keys so its
+    # backend/cwd overrides are as authoritative as legacy flat keys.
+    explicit_keys = (
+        terminal_cfg.keys()
+        if config is not None
+        else effective_terminal_config(raw_terminal_cfg).keys()
+    )
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():
         if cfg_key not in terminal_cfg:
@@ -3273,7 +3313,9 @@ def apply_terminal_config_to_env(
             raw_cwd = str(value or "").strip()
             if raw_cwd in {".", "auto", "cwd"}:
                 continue
-            if isinstance(value, str):
+            if isinstance(value, str) and not (
+                terminal_backend == "ssh" and value.strip().startswith("~")
+            ):
                 value = os.path.expanduser(value)
         if (should_override and cfg_key in explicit_keys) or env_var not in target:
             target[env_var] = _terminal_env_value(value)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3376,6 +3376,7 @@ TERMINAL_CONFIG_ENV_MAP = {
     "degraded_mode": "TERMINAL_DEGRADED_MODE",
     "cwd": "TERMINAL_CWD",
     "timeout": "TERMINAL_TIMEOUT",
+    "home_mode": "TERMINAL_HOME_MODE",
     "lifetime_seconds": "TERMINAL_LIFETIME_SECONDS",
     "docker_image": "TERMINAL_DOCKER_IMAGE",
     "docker_forward_env": "TERMINAL_DOCKER_FORWARD_ENV",
@@ -3409,6 +3410,38 @@ def _terminal_env_value(value: Any) -> str:
     if isinstance(value, (list, dict)):
         return json.dumps(value)
     return str(value)
+
+
+def effective_terminal_config(terminal_cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the flat settings represented by the configured default target.
+
+    Legacy/runtime-adjacent consumers still use ``TERMINAL_*`` variables to
+    describe the environment selected when a tool call omits
+    ``execution_target``. In named-target mode those variables must mirror
+    ``default_target`` rather than the top-level inheritance defaults.
+
+    Invalid target configuration remains the strict resolver's responsibility;
+    this compatibility bridge stays fail-open so config loading retains its
+    historical behavior.
+    """
+    if not isinstance(terminal_cfg, dict):
+        return {}
+    targets = terminal_cfg.get("targets")
+    default_target = terminal_cfg.get("default_target")
+    flat = {
+        key: value for key, value in terminal_cfg.items()
+        if key not in {"targets", "default_target"}
+    }
+    if not isinstance(targets, dict) or not targets:
+        return dict(terminal_cfg)
+    if not isinstance(default_target, str):
+        return flat
+    selected = targets.get(default_target)
+    if not isinstance(selected, dict):
+        return flat
+    effective = dict(flat)
+    effective.update(selected)
+    return effective
 
 
 def terminal_config_env_var_for_key(key: str) -> Optional[str]:
@@ -3461,20 +3494,33 @@ def apply_terminal_config_to_env(
     terminal_cfg = cfg.get("terminal", {}) if isinstance(cfg, dict) else {}
     if not isinstance(terminal_cfg, dict):
         return target
+    terminal_cfg = effective_terminal_config(terminal_cfg)
+    raw_effective_terminal_cfg = effective_terminal_config(raw_terminal_cfg)
 
-    # A caller-supplied config is its own source of explicit keys.  For the
-    # normal merged-config path, only keys present in raw config.yaml may
-    # override existing env values; keys inherited from DEFAULT_CONFIG are
-    # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
-    backend_is_explicit = config is not None or "backend" in raw_terminal_cfg
+    # A caller-supplied config is its own source of explicit keys. For the
+    # normal merged-config path, include the selected raw target's keys so its
+    # backend/cwd overrides are as authoritative as legacy flat keys.
+    explicit_keys = (
+        terminal_cfg.keys()
+        if config is not None
+        else raw_effective_terminal_cfg.keys()
+    )
+    backend_is_explicit = config is not None or any(
+        key in raw_effective_terminal_cfg for key in ("backend", "env_type")
+    )
     if backend_is_explicit:
         terminal_backend = str(
-            terminal_cfg.get("backend") or target.get("TERMINAL_ENV") or ""
+            terminal_cfg.get("backend")
+            or terminal_cfg.get("env_type")
+            or target.get("TERMINAL_ENV")
+            or ""
         )
     else:
         terminal_backend = str(
-            target.get("TERMINAL_ENV") or terminal_cfg.get("backend") or ""
+            target.get("TERMINAL_ENV")
+            or terminal_cfg.get("backend")
+            or terminal_cfg.get("env_type")
+            or ""
         )
 
     for cfg_key, env_var in TERMINAL_CONFIG_ENV_MAP.items():

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -250,6 +250,10 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        # Optional named execution targets. Empty preserves the legacy flat
+        # terminal config and environment-variable behavior.
+        "default_target": "",
+        "targets": {},
         "modal_mode": "auto",
         "cwd": ".",  # Use current directory
         # Terminal font family for the desktop app's embedded xterm.js terminal.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -332,6 +332,10 @@ DEFAULT_CONFIG = {
 
     "terminal": {
         "backend": "local",
+        # Optional named execution targets. Empty preserves the legacy flat
+        # terminal config and environment-variable behavior.
+        "default_target": "",
+        "targets": {},
         "modal_mode": "auto",
         # Remote-backend graceful degradation: when a connection-class
         # infrastructure failure occurs (SSH host unreachable, Docker daemon

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -573,6 +573,12 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     loading (the historical env-driven behavior still applies).
     """
     try:
+        # ``hermes chat --ignore-user-config`` must not let the early dotenv
+        # bootstrap re-apply terminal settings from the very config being
+        # ignored. The classic CLI subsequently bridges its built-in/project
+        # defaults plus managed overlay, preserving that authority boundary.
+        if os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+            return
         if Path(home_path).resolve() != _process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -547,6 +547,12 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     loading (the historical env-driven behavior still applies).
     """
     try:
+        # ``hermes chat --ignore-user-config`` must not let the early dotenv
+        # bootstrap re-apply terminal settings from the very config being
+        # ignored. The classic CLI subsequently bridges its built-in/project
+        # defaults plus managed overlay, preserving that authority boundary.
+        if os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+            return
         if Path(home_path).resolve() != _process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11418,7 +11418,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "prompt-size",
         "resume",
         "send", "sessions", "setup",
-        "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
+        "skin", "skills", "slack", "status", "sync", "targets", "tools", "uninstall", "update",
         "version", "webhook", "whatsapp", "whatsapp-cloud", "chat", "secrets", "security",
         "verify",
         # Help-ish invocations — plugin commands not being listed in
@@ -12516,6 +12516,15 @@ def main():
     # config command  (parser built in hermes_cli/subcommands/config.py)
     # =========================================================================
     build_config_parser(subparsers, cmd_config=cmd_config)
+
+    # Runtime execution-target registry management
+    targets_parser = subparsers.add_parser(
+        "targets",
+        help="Register and manage runtime execution targets without restart",
+    )
+    from hermes_cli.targets import register_cli as _register_targets_cli
+
+    _register_targets_cli(targets_parser)
 
     # =========================================================================
     # skin command  (parser built in hermes_cli/subcommands/skin.py)

--- a/hermes_cli/middleware.py
+++ b/hermes_cli/middleware.py
@@ -213,10 +213,36 @@ def run_tool_execution_middleware(
     callbacks = _get_middleware_callbacks(TOOL_EXECUTION_MIDDLEWARE)
     if not callbacks:
         return next_call(args)
+
+    from tools.execution_targets import (
+        uses_execution_target_argument,
+        validate_execution_target_dispatch_args,
+    )
+
+    if uses_execution_target_argument(tool_name):
+        # Validate before copying so attacker-controlled container subclasses
+        # never get a chance to run __deepcopy__ or redefine key access.
+        validate_execution_target_dispatch_args(tool_name, args, args)
+        authorized_args = dict(args)
+    else:
+        authorized_args = _safe_copy(args)
+
+    def guarded_next_call(dispatch_args: Dict[str, Any]) -> Any:
+        if uses_execution_target_argument(tool_name):
+            validate_execution_target_dispatch_args(
+                tool_name, authorized_args, dispatch_args,
+            )
+            # Dispatch a plain detached object so later sinks cannot observe
+            # polymorphic access or mutation through middleware-owned aliases.
+            final_args = dict(dispatch_args)
+        else:
+            final_args = _safe_copy(dispatch_args)
+        return next_call(final_args)
+
     return _run_execution_chain(
         TOOL_EXECUTION_MIDDLEWARE,
         callbacks,
-        next_call,
+        guarded_next_call,
         tool_name=tool_name,
         args=args,
         original_args=context.pop("original_args", args),

--- a/hermes_cli/targets.py
+++ b/hermes_cli/targets.py
@@ -1,0 +1,608 @@
+"""CLI management for profile-scoped runtime execution targets."""
+
+from __future__ import annotations
+
+import argparse
+from copy import deepcopy
+import json
+import sys
+from typing import Any, Mapping
+
+from tools.execution_target_registry import (
+    REGISTRY_VERSION,
+    RuntimeRegistryError,
+    RuntimeRegistrySnapshot,
+    RuntimeTargetRecord,
+    load_runtime_registry,
+    update_provider_fragment,
+    validate_provider_name,
+)
+from tools.execution_targets import ExecutionTargetError
+
+
+_STRUCTURAL_KEYS = frozenset({
+    "targets",
+    "default_target",
+    "provider",
+    "owner_id",
+    "generation",
+    "state",
+})
+
+
+def _parse_set_value(raw: str) -> tuple[str, Any]:
+    if "=" not in raw:
+        raise RuntimeRegistryError("--set requires KEY=VALUE.")
+    key, value = raw.split("=", 1)
+    key = key.strip()
+    if not key:
+        raise RuntimeRegistryError("--set requires a non-empty key.")
+    if key in _STRUCTURAL_KEYS:
+        raise RuntimeRegistryError(f"--set cannot modify structural field {key!r}.")
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        parsed = value
+    return key, parsed
+
+
+def _build_register_config(args: argparse.Namespace) -> dict[str, Any]:
+    config: dict[str, Any] = {"backend": args.backend}
+    optional = {
+        "ssh_host": args.host,
+        "ssh_user": args.user,
+        "ssh_port": args.port,
+        "ssh_key": args.key,
+        "cwd": args.cwd,
+        "timeout": args.timeout,
+    }
+    for key, value in optional.items():
+        if value is not None:
+            config[key] = value
+    for raw in args.settings:
+        key, value = _parse_set_value(raw)
+        if key in config:
+            raise RuntimeRegistryError(
+                f"Target setting {key!r} was supplied more than once."
+            )
+        config[key] = value
+    return config
+
+
+def _static_target_names(config: Mapping[str, Any]) -> set[str]:
+    terminal = config.get("terminal")
+    targets = terminal.get("targets") if isinstance(terminal, Mapping) else None
+    if not isinstance(targets, Mapping):
+        return set()
+    return {name for name in targets if isinstance(name, str)}
+
+
+def _snapshot_with_provider(
+    snapshot: RuntimeRegistrySnapshot,
+    provider: str,
+    targets: Mapping[str, Mapping[str, Any]],
+) -> RuntimeRegistrySnapshot:
+    provider = validate_provider_name(provider)
+    records = [record for record in snapshot.records if record.provider != provider]
+    for name, record in sorted(targets.items()):
+        records.append(
+            RuntimeTargetRecord(
+                execution_target=name,
+                provider=provider,
+                config=deepcopy(dict(record["config"])),
+                owner_id=str(record["owner_id"]),
+                generation=str(record["generation"]),
+                state=str(record["state"]),
+            )
+        )
+    return RuntimeRegistrySnapshot(
+        records=tuple(records),
+        diagnostics=snapshot.diagnostics,
+        legacy_activated=snapshot.legacy_activated,
+    )
+
+
+def _validate_complete_candidate(
+    static_config: Mapping[str, Any],
+    snapshot: RuntimeRegistrySnapshot,
+    target: str,
+) -> None:
+    from tools.execution_targets import resolve_execution_target
+
+    from tools.execution_target_overlay import overlay_runtime_execution_targets
+
+    candidate = overlay_runtime_execution_targets(
+        static_config,
+        snapshot=snapshot,
+        raise_for_target=target,
+    )
+    resolve_execution_target(config=candidate)
+    resolution = resolve_execution_target(target, config=candidate)
+    if resolution.provider is None:
+        raise RuntimeRegistryError(
+            f"Execution target {target!r} is missing from the candidate."
+        )
+
+
+def _routing_summary(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return only allowlisted, non-secret routing fields."""
+    summary: dict[str, Any] = {}
+    for key in ("backend", "cwd", "ssh_host", "ssh_user", "ssh_port"):
+        value = config.get(key)
+        if value not in (None, ""):
+            summary[key] = value
+    if "backend" not in summary:
+        backend = config.get("env_type")
+        if backend not in (None, ""):
+            summary["backend"] = backend
+    return summary
+
+
+def _payload(
+    record: RuntimeTargetRecord,
+    *,
+    status: str | None = None,
+    config: Mapping[str, Any] | None = None,
+    action: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "execution_target": record.execution_target,
+        "provider": record.provider,
+        "owner_id": record.owner_id,
+        "generation": record.generation,
+        "state": record.state,
+        "status": status or ("active" if record.state == "ready" else "draining"),
+        "routing": _routing_summary(config or record.config),
+    }
+    if action:
+        result["action"] = action
+    return result
+
+
+def _print_payload(payload: Mapping[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True))
+        return
+    action = str(payload.get("action") or "target")
+    routing = payload.get("routing")
+    backend = routing.get("backend") if isinstance(routing, Mapping) else None
+    suffix = f", backend={backend}" if backend else ""
+    print(
+        f"{action.capitalize()} {payload.get('execution_target')!r} "
+        f"(provider={payload.get('provider')}, "
+        f"generation={payload.get('generation')}, "
+        f"state={payload.get('state')}{suffix})"
+    )
+
+
+def _error(args: argparse.Namespace, exc: Exception) -> int:
+    from agent.redact import redact_sensitive_text
+
+    message = redact_sensitive_text(str(exc).strip(), force=True)
+    if not message:
+        message = "Target command failed."
+    if args.json:
+        print(
+            json.dumps(
+                {"status": "error", "message": message},
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        )
+    else:
+        print(f"Error: {message}", file=sys.stderr)
+    return 2
+
+
+def _cmd_register(args: argparse.Namespace) -> int:
+    try:
+        from tools.execution_targets import load_static_execution_target_config
+
+        provider = validate_provider_name(args.provider)
+        name = args.name
+        config = _build_register_config(args)
+        desired = {
+            "config": config,
+            "owner_id": args.owner_id or name,
+            "generation": args.generation or "manual",
+            "state": "ready",
+        }
+        static_config = load_static_execution_target_config()
+        initial = load_runtime_registry()
+        activate_legacy = False
+        terminal = static_config.get("terminal")
+        static_targets = (
+            terminal.get("targets") if isinstance(terminal, Mapping) else None
+        )
+        if not isinstance(static_targets, Mapping) or not static_targets:
+            if not initial.legacy_activated:
+                activate_legacy = True
+        outcome = {"action": "registered"}
+
+        def mutate(
+            snapshot: RuntimeRegistrySnapshot,
+            current: dict[str, dict[str, Any]],
+        ) -> Mapping[str, Any]:
+            static_names = _static_target_names(static_config)
+            if snapshot.legacy_activated and not static_names:
+                static_names.add("default")
+            if name in static_names:
+                raise RuntimeRegistryError(
+                    f"Execution target {name!r} is reserved by static configuration."
+                )
+            other_providers = sorted({
+                record.provider
+                for record in snapshot.records
+                if record.execution_target == name and record.provider != provider
+            })
+            if other_providers:
+                raise RuntimeRegistryError(
+                    f"Execution target {name!r} is already owned by runtime "
+                    f"provider(s) {', '.join(other_providers)}."
+                )
+            existing = current.get(name)
+            if args.if_generation is not None:
+                actual = existing.get("generation") if existing else None
+                if actual != args.if_generation:
+                    raise RuntimeRegistryError(
+                        f"Stale generation for {name!r}: expected "
+                        f"{args.if_generation!r}, found {actual!r}."
+                    )
+            if existing == desired:
+                outcome["action"] = "unchanged"
+                return current
+            if existing is not None and not args.replace:
+                raise RuntimeRegistryError(
+                    f"Execution target {name!r} already exists for provider "
+                    f"{provider!r}; use --replace to repoint it."
+                )
+            current[name] = deepcopy(desired)
+            future = _snapshot_with_provider(snapshot, provider, current)
+            _validate_complete_candidate(static_config, future, name)
+            outcome["action"] = "replaced" if existing is not None else "registered"
+            return current
+
+        updated = update_provider_fragment(
+            provider,
+            mutate,
+            activate_legacy=activate_legacy,
+        )
+        record = _find_runtime_record(updated, name, provider)
+        from tools.execution_target_overlay import overlay_runtime_execution_targets
+        from tools.execution_targets import resolve_execution_target
+
+        merged = overlay_runtime_execution_targets(static_config, snapshot=updated)
+        resolution = resolve_execution_target(name, config=merged)
+        _print_payload(
+            _payload(record, config=resolution.config, action=outcome["action"]),
+            as_json=args.json,
+        )
+        return 0
+    except (OSError, RuntimeRegistryError, ExecutionTargetError) as exc:
+        return _error(args, exc)
+
+
+def _metadata_statuses(merged: Mapping[str, Any]) -> dict[tuple[str, str], str]:
+    from tools.execution_target_overlay import REGISTRY_METADATA_KEY
+
+    registry = merged.get(REGISTRY_METADATA_KEY)
+    records = registry.get("records") if isinstance(registry, Mapping) else None
+    result: dict[tuple[str, str], str] = {}
+    if isinstance(records, list):
+        for item in records:
+            if not isinstance(item, Mapping):
+                continue
+            name = item.get("execution_target")
+            provider = item.get("provider")
+            status = item.get("status")
+            if all(isinstance(value, str) for value in (name, provider, status)):
+                result[(name, provider)] = status
+    return result
+
+
+def _collect_rows(
+    *,
+    include_all: bool,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    from tools.execution_target_overlay import (
+        REGISTRY_METADATA_KEY,
+        overlay_runtime_execution_targets,
+    )
+    from tools.execution_targets import (
+        load_static_execution_target_config,
+        resolve_execution_target,
+    )
+
+    static_config = load_static_execution_target_config()
+    snapshot = load_runtime_registry()
+    merged = overlay_runtime_execution_targets(static_config, snapshot=snapshot)
+    statuses = _metadata_statuses(merged)
+    rows: list[dict[str, Any]] = []
+    static_names = _static_target_names(static_config)
+    if not static_names:
+        static_names.add("default")
+    for name in sorted(static_names):
+        try:
+            resolution = resolve_execution_target(name, config=merged)
+        except ExecutionTargetError:
+            continue
+        rows.append({
+            "execution_target": name,
+            "provider": "static",
+            "owner_id": name,
+            "generation": (
+                ("legacy-activation-v1" if snapshot.legacy_activated else "legacy-flat")
+                if name == "default"
+                else "static"
+            ),
+            "state": "ready",
+            "status": "active",
+            "routing": _routing_summary(resolution.config),
+        })
+    for record in sorted(
+        snapshot.records,
+        key=lambda item: (item.execution_target, item.provider),
+    ):
+        status = statuses.get(
+            (record.execution_target, record.provider),
+            "active" if record.state == "ready" else "draining",
+        )
+        effective: Mapping[str, Any] = record.config
+        if status == "active":
+            try:
+                effective = resolve_execution_target(
+                    record.execution_target,
+                    config=merged,
+                ).config
+            except ExecutionTargetError:
+                pass
+        if include_all or status == "active":
+            rows.append(_payload(record, status=status, config=effective))
+    registry_meta = merged.get(REGISTRY_METADATA_KEY)
+    raw_diagnostics = (
+        registry_meta.get("diagnostics") if isinstance(registry_meta, Mapping) else []
+    )
+    diagnostics = (
+        [dict(item) for item in raw_diagnostics if isinstance(item, Mapping)]
+        if include_all and isinstance(raw_diagnostics, list)
+        else []
+    )
+    return rows, diagnostics
+
+
+def _cmd_list(args: argparse.Namespace) -> int:
+    try:
+        rows, diagnostics = _collect_rows(include_all=args.all)
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "version": REGISTRY_VERSION,
+                        "targets": rows,
+                        "diagnostics": diagnostics,
+                    },
+                    ensure_ascii=False,
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if not rows:
+            print("No execution targets found.")
+        for row in rows:
+            routing = row.get("routing")
+            backend = (
+                routing.get("backend", "-") if isinstance(routing, Mapping) else "-"
+            )
+            print(
+                f"{row['execution_target']}  {row['provider']}  "
+                f"{row['generation']}  {row['state']}  "
+                f"{row['status']}  {backend}"
+            )
+        for diagnostic in diagnostics:
+            print(
+                f"Warning: {diagnostic.get('message', 'Runtime provider unavailable.')}",
+                file=sys.stderr,
+            )
+        return 0
+    except (OSError, RuntimeRegistryError, ExecutionTargetError) as exc:
+        return _error(args, exc)
+
+
+def _cmd_show(args: argparse.Namespace) -> int:
+    try:
+        rows, _diagnostics = _collect_rows(include_all=True)
+        provider = (
+            validate_provider_name(args.provider) if args.provider is not None else None
+        )
+        matches = [
+            row
+            for row in rows
+            if row["execution_target"] == args.name
+            and (provider is None or row["provider"] == provider)
+        ]
+        if not matches:
+            raise RuntimeRegistryError(f"Execution target {args.name!r} was not found.")
+        if len(matches) > 1:
+            providers = ", ".join(sorted(str(row["provider"]) for row in matches))
+            raise RuntimeRegistryError(
+                f"Execution target {args.name!r} is claimed by multiple "
+                f"providers ({providers}); pass --provider."
+            )
+        row = matches[0]
+        if args.json:
+            print(json.dumps(row, ensure_ascii=False, indent=2, sort_keys=True))
+        else:
+            _print_payload(row, as_json=False)
+            print(f"Status: {row['status']}")
+        return 0
+    except (OSError, RuntimeRegistryError, ExecutionTargetError) as exc:
+        return _error(args, exc)
+
+
+def _find_runtime_record(
+    snapshot: RuntimeRegistrySnapshot,
+    name: str,
+    provider: str | None,
+) -> RuntimeTargetRecord:
+    if provider is not None:
+        provider = validate_provider_name(provider)
+    matches = [
+        record
+        for record in snapshot.records
+        if record.execution_target == name
+        and (provider is None or record.provider == provider)
+    ]
+    if not matches:
+        raise RuntimeRegistryError(f"Runtime execution target {name!r} was not found.")
+    if len(matches) > 1:
+        providers = ", ".join(sorted(record.provider for record in matches))
+        raise RuntimeRegistryError(
+            f"Runtime target {name!r} is claimed by {providers}; pass --provider."
+        )
+    return matches[0]
+
+
+def _mutate_lifecycle(args: argparse.Namespace, *, remove: bool) -> int:
+    try:
+        selected = _find_runtime_record(
+            load_runtime_registry(),
+            args.name,
+            args.provider,
+        )
+        provider = selected.provider
+        outcome = {"record": selected}
+
+        def mutate(
+            snapshot: RuntimeRegistrySnapshot,
+            current: dict[str, dict[str, Any]],
+        ) -> Mapping[str, Any]:
+            fresh = _find_runtime_record(snapshot, args.name, args.provider)
+            if fresh.provider != provider:
+                raise RuntimeRegistryError(
+                    f"Runtime target {args.name!r} changed provider; retry."
+                )
+            existing = current.get(args.name)
+            if existing is None:
+                raise RuntimeRegistryError(
+                    f"Runtime target {args.name!r} no longer exists."
+                )
+            if (
+                args.if_generation is not None
+                and existing.get("generation") != args.if_generation
+            ):
+                raise RuntimeRegistryError(
+                    f"Stale generation for {args.name!r}: expected "
+                    f"{args.if_generation!r}, "
+                    f"found {existing.get('generation')!r}."
+                )
+            outcome["record"] = fresh
+            if remove:
+                current.pop(args.name)
+            else:
+                existing["state"] = "draining"
+            return current
+
+        update_provider_fragment(provider, mutate)
+        record = outcome["record"]
+        if not remove:
+            record = RuntimeTargetRecord(
+                execution_target=record.execution_target,
+                provider=record.provider,
+                config=record.config,
+                owner_id=record.owner_id,
+                generation=record.generation,
+                state="draining",
+            )
+        action = "removed" if remove else "drained"
+        _print_payload(_payload(record, action=action), as_json=args.json)
+        return 0
+    except (OSError, RuntimeRegistryError, ExecutionTargetError) as exc:
+        return _error(args, exc)
+
+
+def _cmd_drain(args: argparse.Namespace) -> int:
+    return _mutate_lifecycle(args, remove=False)
+
+
+def _cmd_remove(args: argparse.Namespace) -> int:
+    return _mutate_lifecycle(args, remove=True)
+
+
+def _add_identity_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("name", help="Execution-target name")
+    parser.add_argument(
+        "--provider",
+        help="Owning provider when ambiguous (canonicalized to lowercase)",
+    )
+    parser.add_argument(
+        "--if-generation",
+        metavar="GEN",
+        help="Compare-and-swap generation",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit stable JSON")
+
+
+def register_cli(parent: argparse.ArgumentParser) -> None:
+    """Attach the built-in targets management command."""
+    parent.set_defaults(func=lambda _args: (parent.print_help(), 0)[1])
+    sub = parent.add_subparsers(dest="targets_action")
+    register = sub.add_parser(
+        "register",
+        help="Register or replace a ready runtime target",
+    )
+    register.add_argument("name")
+    register.add_argument("--backend", required=True)
+    register.add_argument("--host", "--ssh-host", dest="host")
+    register.add_argument("--user", "--ssh-user", dest="user")
+    register.add_argument("--port", "--ssh-port", dest="port", type=int)
+    register.add_argument(
+        "--key",
+        "--ssh-key",
+        dest="key",
+        help="SSH private-key path (never contents)",
+    )
+    register.add_argument("--cwd")
+    register.add_argument("--timeout", type=int)
+    register.add_argument(
+        "--provider",
+        default="cli",
+        help="Owning provider (canonicalized to lowercase)",
+    )
+    register.add_argument("--owner-id")
+    register.add_argument("--generation")
+    register.add_argument("--replace", action="store_true")
+    register.add_argument("--if-generation", metavar="OLD")
+    register.add_argument(
+        "--set",
+        dest="settings",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Advanced backend setting; JSON values accepted; repeatable",
+    )
+    register.add_argument("--json", action="store_true")
+    register.set_defaults(func=_cmd_register)
+    listing = sub.add_parser(
+        "list",
+        aliases=["ls"],
+        help="List callable runtime/static targets",
+    )
+    listing.add_argument("--all", action="store_true")
+    listing.add_argument("--json", action="store_true")
+    listing.set_defaults(func=_cmd_list)
+    show = sub.add_parser("show", help="Show one target without secrets")
+    show.add_argument("name")
+    show.add_argument("--provider", help="Owning provider (case-insensitive)")
+    show.add_argument("--json", action="store_true")
+    show.set_defaults(func=_cmd_show)
+    drain = sub.add_parser("drain", help="Reject new calls for one generation")
+    _add_identity_args(drain)
+    drain.set_defaults(func=_cmd_drain)
+    remove = sub.add_parser(
+        "remove",
+        aliases=["unregister"],
+        help="Remove one exact generation",
+    )
+    _add_identity_args(remove)
+    remove.set_defaults(func=_cmd_remove)

--- a/model_tools.py
+++ b/model_tools.py
@@ -742,6 +742,7 @@ def _resolve_active_context_length() -> int:
 # so if something slips through, the LLM sees a sensible message.
 _AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
+_TARGET_SELECTOR_TOOLS = {"terminal", "write_file", "patch", "execute_code"}
 
 
 # =========================================================================
@@ -1366,6 +1367,19 @@ def handle_function_call(
         except Exception as _mw_err:
             logger.debug("tool_request middleware error: %s", _mw_err)
 
+    # Enforce the canonical execution-routing API before pre-tool hooks,
+    # ACP edit approval, guardrails, progress, checkpoints, or dispatch.
+    try:
+        from tools.execution_targets import (
+            ExecutionTargetError,
+            validate_execution_target_args,
+            validate_execution_target_dispatch_args,
+        )
+
+        validate_execution_target_args(function_name, function_args)
+    except ExecutionTargetError as exc:
+        return tool_error(str(exc))
+
     try:
         if function_name in _AGENT_LOOP_TOOLS:
             return tool_error(f"{function_name} must be handled by the agent loop")
@@ -1464,9 +1478,21 @@ def handle_function_call(
         if function_name not in _READ_SEARCH_TOOLS:
             try:
                 from tools.file_tools import notify_other_tool_call
-                notify_other_tool_call(task_id or "default")
+                notify_other_tool_call(
+                    task_id or "default",
+                    (
+                        function_args.get("execution_target")
+                        if function_name in _TARGET_SELECTOR_TOOLS
+                        else None
+                    ),
+                )
             except Exception:
                 pass  # file_tools may not be loaded yet
+
+        # Pin the arguments that hooks and approvals evaluated. Execution
+        # middleware may rewrite ordinary arguments, but changing the routing
+        # selector here would retarget the call after authorization.
+        _authorized_function_args = dict(function_args)
 
         # Measure tool dispatch latency so post_tool_call and
         # transform_tool_result hooks can observe per-tool duration.
@@ -1494,7 +1520,7 @@ def handle_function_call(
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
                 sandbox_enabled = enabled_tools if enabled_tools is not None else _last_resolved_tool_names
-                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                def _registry_dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
@@ -1502,13 +1528,20 @@ def handle_function_call(
                         enabled_tools=sandbox_enabled,
                     )
             else:
-                def _dispatch(next_args: Dict[str, Any]) -> Any:
+                def _registry_dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
                     )
+
+            def _dispatch(next_args: Dict[str, Any]) -> Any:
+                validate_execution_target_dispatch_args(
+                    function_name, _authorized_function_args, next_args,
+                )
+                return _registry_dispatch(next_args)
+
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)
             else:

--- a/model_tools.py
+++ b/model_tools.py
@@ -666,6 +666,7 @@ def _resolve_active_context_length() -> int:
 # so if something slips through, the LLM sees a sensible message.
 _AGENT_LOOP_TOOLS = {"todo", "memory", "session_search", "delegate_task"}
 _READ_SEARCH_TOOLS = {"read_file", "search_files"}
+_TARGET_SELECTOR_TOOLS = {"terminal", "write_file", "patch", "execute_code"}
 
 
 # =========================================================================
@@ -1308,7 +1309,14 @@ def handle_function_call(
         if function_name not in _READ_SEARCH_TOOLS:
             try:
                 from tools.file_tools import notify_other_tool_call
-                notify_other_tool_call(task_id or "default")
+                notify_other_tool_call(
+                    task_id or "default",
+                    (
+                        function_args.get("target")
+                        if function_name in _TARGET_SELECTOR_TOOLS
+                        else None
+                    ),
+                )
             except Exception:
                 pass  # file_tools may not be loaded yet
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -7659,12 +7659,17 @@ class AIAgent:
                 getattr(self, "session_id", None),
             )
             from agent.auxiliary_client import scoped_runtime_main
+            from tools.terminal_tool import logical_environment_turn
 
             # The outer token restores the caller's Context even though turn setup
             # replaces the value with the live runtime after fallback restoration.
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}):
+            with (
+                bind_subagent_parent(self),
+                scoped_runtime_main({}),
+                logical_environment_turn(effective_task_id),
+            ):
                 result = run_conversation(
                     self,
                     user_message,

--- a/run_agent.py
+++ b/run_agent.py
@@ -8688,12 +8688,17 @@ class AIAgent:
                 getattr(self, "session_id", None),
             )
             from agent.auxiliary_client import scoped_runtime_main
+            from tools.terminal_tool import logical_environment_turn
 
             # The outer token restores the caller's Context even though turn setup
             # replaces the value with the live runtime after fallback restoration.
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}):
+            with (
+                bind_subagent_parent(self),
+                scoped_runtime_main({}),
+                logical_environment_turn(effective_task_id),
+            ):
                 try:
                     if durable_turn_lease_thread is not None:
                         with durable_turn_lease_activity_lock:

--- a/tests/agent/test_file_safety_container_mirror.py
+++ b/tests/agent/test_file_safety_container_mirror.py
@@ -77,7 +77,7 @@ class TestFileToolIntegration:
         monkeypatch.setattr(
             file_tools,
             "_get_container_mirror_prefix_for_task",
-            lambda task_id: "/root/.hermes",
+            lambda task_id, execution_target=None, _resolution=None: "/root/.hermes",
         )
 
         warning = file_tools._check_cross_profile_path(

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -44,6 +44,26 @@ def _create(home: Path, rel: str | Path) -> Path:
 
 
 
+def test_execution_target_fingerprint_key_blocked_for_read_and_write(
+    fake_home, tmp_path,
+):
+    from agent.file_safety import build_write_denied_paths, get_read_block_error
+
+    key = _create(fake_home, ".execution-target-fingerprint-key")
+    err = get_read_block_error(str(key))
+    assert err is not None
+    assert "credential store" in err
+    assert str(key.resolve()) in build_write_denied_paths(str(tmp_path))
+
+
+def test_google_oauth_json_blocked(fake_home):
+    """Gemini OAuth tokens live under auth/google_oauth.json — blocked."""
+    from agent.file_safety import get_read_block_error
+
+    oauth = _create(fake_home, Path("auth") / "google_oauth.json")
+    err = get_read_block_error(str(oauth))
+    assert err is not None
+    assert "credential store" in err
 
 
 def test_arbitrary_hermes_home_file_not_blocked(fake_home):
@@ -139,7 +159,10 @@ def test_search_tool_filters_credential_results(fake_home, tmp_path, monkeypatch
             )
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(ft, "_get_file_ops", lambda task_id="default": FakeFileOps())
+    monkeypatch.setattr(
+        ft, "_get_file_ops",
+        lambda task_id="default", target=None, _resolution=None: FakeFileOps(),
+    )
     monkeypatch.setattr(
         terminal_tool, "_session_cwd", {}
     )

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -783,7 +783,9 @@ class TestEnvironmentHints:
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         # Force the probe to fail so we exercise the static fallback path
         # deterministically (the live probe would try to spin up docker).
-        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        monkeypatch.setattr(
+            _pb, "_probe_remote_backend", lambda *args, **kwargs: None,
+        )
         _pb._clear_backend_probe_cache()
         result = _pb.build_environment_hints()
         # Host suppression: none of the local-backend lines should appear.
@@ -793,6 +795,87 @@ class TestEnvironmentHints:
         # Backend info must appear instead.
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
+
+    def test_named_targets_use_default_backend_and_are_listed(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        probe_calls = []
+
+        def _capture_probe(backend, terminal_config=None, target_name=""):
+            probe_calls.append((backend, terminal_config, target_name))
+            return None
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "_probe_remote_backend", _capture_probe)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "backend": "local",
+                    "default_target": "devbox",
+                    "targets": {
+                        "local": {"backend": "local", "cwd": "."},
+                        "devbox": {
+                            "backend": "ssh",
+                            "cwd": "/srv/project",
+                            "ssh_host": "devbox.example.com",
+                            "ssh_user": "agent",
+                        },
+                    },
+                },
+            },
+        )
+
+        result = _pb.build_environment_hints()
+
+        assert "Terminal backend: ssh" in result
+        assert "Host:" not in result
+        assert "Configured execution targets:" in result
+        assert "omit an execution-target selector" in result
+        assert '"devbox" (ssh, default)' in result
+        assert '"local" (local)' in result
+        assert "select one with `execution_target`" in result
+        assert "`search_files.target` remains" in result
+        assert probe_calls == [(
+            "ssh",
+            {
+                "backend": "ssh",
+                "cwd": "/srv/project",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "agent",
+            },
+            "devbox",
+        )]
+
+    def test_named_local_default_uses_target_cwd(self, monkeypatch, tmp_path):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        target_cwd = tmp_path / "named-target"
+        target_cwd.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "default_target": "workspace",
+                    "targets": {
+                        "workspace": {
+                            "backend": "local",
+                            "cwd": str(target_cwd),
+                        },
+                    },
+                },
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = _pb.build_environment_hints()
+
+        assert f"Current working directory: {target_cwd}" in result
 
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -691,7 +691,9 @@ class TestEnvironmentHints:
         monkeypatch.setenv("TERMINAL_ENV", "docker")
         # Force the probe to fail so we exercise the static fallback path
         # deterministically (the live probe would try to spin up docker).
-        monkeypatch.setattr(_pb, "_probe_remote_backend", lambda _t: None)
+        monkeypatch.setattr(
+            _pb, "_probe_remote_backend", lambda *args, **kwargs: None,
+        )
         _pb._clear_backend_probe_cache()
         result = _pb.build_environment_hints()
         # Host suppression: none of the local-backend lines should appear.
@@ -701,6 +703,86 @@ class TestEnvironmentHints:
         # Backend info must appear instead.
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
+
+    def test_named_targets_use_default_backend_and_are_listed(self, monkeypatch):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        probe_calls = []
+
+        def _capture_probe(backend, terminal_config=None, target_name=""):
+            probe_calls.append((backend, terminal_config, target_name))
+            return None
+
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(_pb, "_probe_remote_backend", _capture_probe)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "backend": "local",
+                    "default_target": "devbox",
+                    "targets": {
+                        "local": {"backend": "local", "cwd": "."},
+                        "devbox": {
+                            "backend": "ssh",
+                            "cwd": "/srv/project",
+                            "ssh_host": "devbox.example.com",
+                            "ssh_user": "agent",
+                        },
+                    },
+                },
+            },
+        )
+
+        result = _pb.build_environment_hints()
+
+        assert "Terminal backend: ssh" in result
+        assert "Host:" not in result
+        assert "Configured execution targets:" in result
+        assert "omit an execution-target selector" in result
+        assert '"devbox" (ssh, default)' in result
+        assert '"local" (local)' in result
+        assert "search_files` uses `execution_target" in result
+        assert probe_calls == [(
+            "ssh",
+            {
+                "backend": "ssh",
+                "cwd": "/srv/project",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "agent",
+            },
+            "devbox",
+        )]
+
+    def test_named_local_default_uses_target_cwd(self, monkeypatch, tmp_path):
+        import agent.prompt_builder as _pb
+        import tools.execution_targets as targets_mod
+
+        target_cwd = tmp_path / "named-target"
+        target_cwd.mkdir()
+        monkeypatch.setattr(_pb, "is_wsl", lambda: False)
+        monkeypatch.setattr(
+            targets_mod,
+            "_load_merged_config",
+            lambda: {
+                "terminal": {
+                    "default_target": "workspace",
+                    "targets": {
+                        "workspace": {
+                            "backend": "local",
+                            "cwd": str(target_cwd),
+                        },
+                    },
+                },
+            },
+        )
+        monkeypatch.chdir(tmp_path)
+
+        result = _pb.build_environment_hints()
+
+        assert f"Current working directory: {target_cwd}" in result
 
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()

--- a/tests/agent/test_tool_executor_checkpoint_paths.py
+++ b/tests/agent/test_tool_executor_checkpoint_paths.py
@@ -38,3 +38,72 @@ def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
 
     assert manager.list_checkpoints(str(workspace_cwd))
     assert manager.list_checkpoints(str(process_cwd)) == []
+
+
+def test_named_local_target_checkpoint_uses_target_cwd(tmp_path, monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    target_cwd = tmp_path / "named-local"
+    target_cwd.mkdir()
+    (target_cwd / "pyproject.toml").write_text("[project]\nname = 'target'\n")
+    (target_cwd / "existing.txt").write_text("before\n")
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": str(target_cwd)},
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+
+    _ensure_file_checkpoint(
+        agent,
+        "write_file",
+        {"path": "existing.txt", "target": "alpha"},
+        "gateway-session",
+    )
+
+    assert manager.list_checkpoints(str(target_cwd))
+
+
+def test_remote_target_skips_host_checkpoint(monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "devbox",
+                "targets": {
+                    "devbox": {
+                        "backend": "ssh",
+                        "ssh_host": "example.invalid",
+                        "cwd": "/workspace/project",
+                    },
+                },
+            },
+        },
+    )
+
+    class FailIfCheckpointed:
+        def get_working_dir_for_path(self, path):
+            raise AssertionError(f"host checkpoint attempted for remote path {path}")
+
+    agent = SimpleNamespace(_checkpoint_mgr=FailIfCheckpointed())
+    _ensure_file_checkpoint(
+        agent,
+        "write_file",
+        {"path": "remote.txt", "target": "devbox"},
+        "gateway-session",
+    )

--- a/tests/agent/test_tool_executor_checkpoint_paths.py
+++ b/tests/agent/test_tool_executor_checkpoint_paths.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 
-from agent.tool_executor import _ensure_file_checkpoint
+from agent.tool_executor import _begin_tool_execution, _ensure_file_checkpoint
 from tools.checkpoint_manager import CheckpointManager
 
 
@@ -38,3 +38,130 @@ def test_relative_file_checkpoint_uses_task_workspace(tmp_path, monkeypatch):
 
     assert manager.list_checkpoints(str(workspace_cwd))
     assert manager.list_checkpoints(str(process_cwd)) == []
+
+
+def test_named_local_target_checkpoint_uses_target_cwd(tmp_path, monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    target_cwd = tmp_path / "named-local"
+    target_cwd.mkdir()
+    (target_cwd / "pyproject.toml").write_text("[project]\nname = 'target'\n")
+    (target_cwd / "existing.txt").write_text("before\n")
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": str(target_cwd)},
+                },
+            },
+        },
+    )
+    monkeypatch.setattr(
+        "tools.checkpoint_manager.CHECKPOINT_BASE",
+        tmp_path / "checkpoints",
+    )
+    manager = CheckpointManager(enabled=True)
+    agent = SimpleNamespace(_checkpoint_mgr=manager)
+
+    _ensure_file_checkpoint(
+        agent,
+        "write_file",
+        {"path": "existing.txt", "execution_target": "alpha"},
+        "gateway-session",
+    )
+
+    assert manager.list_checkpoints(str(target_cwd))
+
+
+def test_remote_target_skips_host_checkpoint(monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "devbox",
+                "targets": {
+                    "devbox": {
+                        "backend": "ssh",
+                        "ssh_host": "example.invalid",
+                        "cwd": "/workspace/project",
+                    },
+                },
+            },
+        },
+    )
+
+    class FailIfCheckpointed:
+        def get_working_dir_for_path(self, path):
+            raise AssertionError(f"host checkpoint attempted for remote path {path}")
+
+    agent = SimpleNamespace(_checkpoint_mgr=FailIfCheckpointed())
+    _ensure_file_checkpoint(
+        agent,
+        "write_file",
+        {"path": "remote.txt", "execution_target": "devbox"},
+        "gateway-session",
+    )
+
+
+def test_destructive_terminal_checkpoint_prefers_explicit_workdir(
+    tmp_path, monkeypatch,
+):
+    import tools.execution_targets as targets_mod
+
+    configured = tmp_path / "configured"
+    actual = tmp_path / "actual"
+    configured.mkdir()
+    actual.mkdir()
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "local",
+                "targets": {
+                    "local": {"backend": "local", "cwd": str(configured)},
+                },
+            },
+        },
+    )
+    checkpoints = []
+
+    class Manager:
+        enabled = True
+
+        @staticmethod
+        def ensure_checkpoint(cwd, reason):
+            checkpoints.append((cwd, reason))
+
+    agent = SimpleNamespace(
+        quiet_mode=True,
+        tool_progress_mode="off",
+        verbose_logging=False,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        _checkpoint_mgr=Manager(),
+        _touch_activity=lambda *_args, **_kwargs: None,
+    )
+
+    _begin_tool_execution(
+        agent,
+        function_name="terminal",
+        function_args={
+            "command": "rm -f marker",
+            "workdir": str(actual),
+            "execution_target": "local",
+        },
+        effective_task_id="gateway-session",
+        tool_call_id="call-1",
+        display_index=None,
+    )
+
+    assert checkpoints == [
+        (str(actual), "before terminal: rm -f marker"),
+    ]

--- a/tests/hermes_cli/test_gateway_restart_loop.py
+++ b/tests/hermes_cli/test_gateway_restart_loop.py
@@ -751,6 +751,28 @@ class TestLifecycleGuardModule:
         )
         assert result is False
 
+    @pytest.mark.parametrize(
+        ("host_script", "selected_target_script", "expected"),
+        [
+            ("echo safe\n", "hermes gateway restart\n", True),
+            ("hermes gateway restart\n", "echo safe\n", False),
+        ],
+    )
+    def test_selected_target_reader_is_authoritative_over_host_twin(
+        self, tmp_path, host_script, selected_target_script, expected,
+    ):
+        from cron.lifecycle_guard import (
+            contains_gateway_lifecycle_command_or_referenced_script,
+        )
+
+        (tmp_path / "run.sh").write_text(host_script, encoding="utf-8")
+
+        assert contains_gateway_lifecycle_command_or_referenced_script(
+            "bash run.sh",
+            cwd=str(tmp_path),
+            read_remote_script=lambda _path: selected_target_script,
+        ) is expected
+
     def test_shell_script_reference_walk_still_works(self, tmp_path):
         """The referenced-script walk still applies to real shell scripts:
         a .sh script that itself invokes a lifecycle command is caught."""

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -320,6 +320,160 @@ class TestPluginDiscovery:
 
 
 
+    @pytest.mark.parametrize(
+        ("original_args", "replacement_args"),
+        [
+            (
+                {"command": "true", "execution_target": "alpha"},
+                {"command": "true", "execution_target": "beta"},
+            ),
+            (
+                {"command": "true", "execution_target": "alpha"},
+                {"command": "true"},
+            ),
+            (
+                {"command": "true"},
+                {"command": "true", "execution_target": "alpha"},
+            ),
+        ],
+    )
+    def test_tool_execution_middleware_cannot_replace_remove_or_inject_target(
+        self, monkeypatch, original_args, replacement_args,
+    ):
+        from tools.execution_targets import ExecutionTargetError
+
+        def execution_middleware(**kwargs):
+            return kwargs["next_call"](replacement_args)
+
+        manager = types.SimpleNamespace(
+            _middleware={"tool_execution": [execution_middleware]},
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        dispatched = []
+
+        with pytest.raises(ExecutionTargetError):
+            run_tool_execution_middleware(
+                "terminal",
+                original_args,
+                lambda payload: dispatched.append(payload),
+            )
+
+        assert dispatched == []
+
+    def test_tool_execution_middleware_rejects_polymorphic_routing_payloads(
+        self, monkeypatch,
+    ):
+        from tools.execution_targets import ExecutionTargetError
+
+        class EqualString(str):
+            __hash__ = str.__hash__
+
+            def __eq__(self, _other):
+                return True
+
+        class SplitDict(dict):
+            def __getitem__(self, key):
+                if key == "execution_target":
+                    return "alpha"
+                return super().__getitem__(key)
+
+        replacements = [
+            {"command": "true", "execution_target": EqualString("beta")},
+            SplitDict(command="true", execution_target="beta"),
+        ]
+        dispatched = []
+
+        for replacement in replacements:
+            def execution_middleware(**kwargs):
+                return kwargs["next_call"](replacement)
+
+            manager = types.SimpleNamespace(
+                _middleware={"tool_execution": [execution_middleware]},
+            )
+            monkeypatch.setattr(
+                "hermes_cli.plugins.get_plugin_manager", lambda: manager,
+            )
+
+            with pytest.raises(ExecutionTargetError):
+                run_tool_execution_middleware(
+                    "terminal",
+                    {"command": "true", "execution_target": "alpha"},
+                    lambda payload: dispatched.append(payload),
+                )
+
+        assert dispatched == []
+
+    def test_tool_execution_middleware_validates_before_copying_target_args(
+        self, monkeypatch,
+    ):
+        from tools.execution_targets import ExecutionTargetError
+
+        class DeepcopyTrap(dict):
+            def __deepcopy__(self, _memo):
+                raise AssertionError("target-aware payload must be validated first")
+
+        manager = types.SimpleNamespace(
+            _middleware={"tool_execution": [lambda **kwargs: kwargs["next_call"]()]},
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        with pytest.raises(ExecutionTargetError, match="plain JSON object"):
+            run_tool_execution_middleware(
+                "terminal",
+                DeepcopyTrap(command="true", execution_target="alpha"),
+                lambda payload: payload,
+            )
+
+    def test_tool_execution_middleware_cannot_mutate_target_in_place(
+        self, monkeypatch,
+    ):
+        from tools.execution_targets import ExecutionTargetError
+
+        def execution_middleware(**kwargs):
+            kwargs["args"]["execution_target"] = "beta"
+            return kwargs["next_call"]()
+
+        manager = types.SimpleNamespace(
+            _middleware={"tool_execution": [execution_middleware]},
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+        dispatched = []
+        args = {"command": "true", "execution_target": "alpha"}
+
+        with pytest.raises(ExecutionTargetError):
+            run_tool_execution_middleware(
+                "terminal",
+                args,
+                lambda payload: dispatched.append(payload),
+            )
+
+        assert dispatched == []
+
+    def test_tool_execution_middleware_can_rewrite_non_routing_args(
+        self, monkeypatch,
+    ):
+        def execution_middleware(**kwargs):
+            return kwargs["next_call"]({
+                **kwargs["args"],
+                "command": "printf ok",
+            })
+
+        manager = types.SimpleNamespace(
+            _middleware={"tool_execution": [execution_middleware]},
+        )
+        monkeypatch.setattr("hermes_cli.plugins.get_plugin_manager", lambda: manager)
+
+        result = run_tool_execution_middleware(
+            "terminal",
+            {"command": "true", "execution_target": "alpha"},
+            lambda payload: payload,
+        )
+
+        assert result == {
+            "command": "printf ok",
+            "execution_target": "alpha",
+        }
+
     def test_failed_discovery_is_not_cached(self, tmp_path, monkeypatch):
         """A sweep that raises must not cache 'discovered' with no plugins.
 

--- a/tests/hermes_cli/test_targets_cli.py
+++ b/tests/hermes_cli/test_targets_cli.py
@@ -1,0 +1,745 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from hermes_cli.targets import register_cli
+from tools.execution_target_registry import (
+    invalidate_runtime_registry_cache,
+    load_runtime_registry,
+    registry_directory,
+)
+from tools.execution_targets import (
+    resolve_execution_target,
+    set_execution_target_config_source,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes targets")
+    register_cli(parser)
+    return parser
+
+
+def _run(argv: list[str]) -> int:
+    args = _parser().parse_args(argv)
+    return int(args.func(args) or 0)
+
+
+def _run_subprocess(
+    home: Path,
+    argv: list[str],
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(home)
+    env["HERMES_REDACT_SECRETS"] = "true"
+    env["TERMINAL_ENV"] = "local"
+    env.pop("HERMES_PROFILE", None)
+    return subprocess.run(
+        [sys.executable, "-m", "hermes_cli.main", "targets", *argv],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+
+
+@pytest.fixture
+def cli_home(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    set_execution_target_config_source({
+        "terminal": {
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": str(tmp_path)},
+            },
+        },
+    })
+    invalidate_runtime_registry_cache()
+    try:
+        yield home
+    finally:
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()
+
+
+def test_parser_exposes_required_actions_and_aliases(capsys):
+    parser = _parser()
+    help_text = parser.format_help()
+    assert "register" in help_text
+    assert "list" in help_text
+    assert "show" in help_text
+    assert "drain" in help_text
+    assert "remove" in help_text
+
+    remove = parser.parse_args(["unregister", "box"])
+    assert remove.func.__name__ == "_cmd_remove"
+    register = parser.parse_args([
+        "register",
+        "box",
+        "--backend",
+        "ssh",
+        "--ssh-host",
+        "alias",
+        "--ssh-user",
+        "dev",
+    ])
+    assert register.host == "alias"
+    assert register.user == "dev"
+    capsys.readouterr()
+
+
+def test_register_list_show_and_secret_safe_json(cli_home, capsys):
+    secret_path = "/keys/private-build-17"
+    rc = _run([
+        "register",
+        "hetzner-build-17",
+        "--backend",
+        "ssh",
+        "--host",
+        "hetzner-dev-build-17",
+        "--user",
+        "dev",
+        "--port",
+        "443",
+        "--key",
+        secret_path,
+        "--cwd",
+        "/workspace",
+        "--provider",
+        "hetzner-devbox",
+        "--owner-id",
+        "build-17",
+        "--generation",
+        "server-123",
+        "--json",
+    ])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["execution_target"] == "hetzner-build-17"
+    assert payload["provider"] == "hetzner-devbox"
+    assert payload["owner_id"] == "build-17"
+    assert payload["generation"] == "server-123"
+    assert payload["state"] == "ready"
+    assert payload["routing"]["ssh_host"] == "hetzner-dev-build-17"
+    assert secret_path not in json.dumps(payload)
+
+    assert _run(["list", "--all", "--json"]) == 0
+    listing = json.loads(capsys.readouterr().out)
+    assert listing["version"] == 1
+    assert any(
+        row["execution_target"] == "hetzner-build-17" for row in listing["targets"]
+    )
+    assert (
+        _run([
+            "show",
+            "hetzner-build-17",
+            "--provider",
+            "hetzner-devbox",
+            "--json",
+        ])
+        == 0
+    )
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["routing"]["ssh_port"] == 443
+    assert secret_path not in json.dumps(shown)
+
+
+def test_provider_aliases_canonicalize_to_one_cli_owner(cli_home, capsys):
+    for name, provider in (("first", "Foo"), ("second", "foo")):
+        assert (
+            _run([
+                "register",
+                name,
+                "--backend",
+                "local",
+                "--provider",
+                provider,
+                "--generation",
+                f"{name}-g1",
+                "--json",
+            ])
+            == 0
+        )
+        assert json.loads(capsys.readouterr().out)["provider"] == "foo"
+
+    fragment = registry_directory() / "foo.json"
+    payload = json.loads(fragment.read_text(encoding="utf-8"))
+    assert payload["provider"] == "foo"
+    assert set(payload["targets"]) == {"first", "second"}
+    assert not (registry_directory() / "Foo.json").exists() or (
+        registry_directory() / "Foo.json"
+    ).samefile(fragment)
+
+    assert _run(["show", "second", "--provider", "FOO", "--json"]) == 0
+    shown = json.loads(capsys.readouterr().out)
+    assert shown["provider"] == "foo"
+
+
+def test_register_and_replace_publish_reloadable_0600_files_under_strict_umask(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    home = tmp_path / "strict-umask-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    set_execution_target_config_source({"terminal": {"backend": "local"}})
+    invalidate_runtime_registry_cache()
+    original_umask = os.umask(0o777)
+    try:
+        first = [
+            "register",
+            "box",
+            "--backend",
+            "local",
+            "--provider",
+            "Controller",
+            "--generation",
+            "g1",
+            "--json",
+        ]
+        assert _run(first) == 0
+        assert json.loads(capsys.readouterr().out)["provider"] == "controller"
+
+        replacement = [
+            "register",
+            "box",
+            "--backend",
+            "local",
+            "--provider",
+            "controller",
+            "--generation",
+            "g2",
+            "--replace",
+            "--if-generation",
+            "g1",
+            "--json",
+        ]
+        assert _run(replacement) == 0
+        assert json.loads(capsys.readouterr().out)["generation"] == "g2"
+
+        state_path = registry_directory() / ".registry-state.json"
+        provider_path = registry_directory() / "controller.json"
+        assert state_path.stat().st_mode & 0o777 == 0o600
+        assert provider_path.stat().st_mode & 0o777 == 0o600
+        reloaded = load_runtime_registry(force=True)
+        record = next(
+            item for item in reloaded.records if item.provider == "controller"
+        )
+        assert record.generation == "g2"
+    finally:
+        os.umask(original_umask)
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()
+
+
+def test_post_publication_reload_failure_returns_stable_json_error_under_umask(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    import tools.execution_target_registry as registry_mod
+
+    home = tmp_path / "reload-failure-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    set_execution_target_config_source({
+        "terminal": {
+            "default_target": "local",
+            "targets": {"local": {"backend": "local", "cwd": str(tmp_path)}},
+        },
+    })
+    invalidate_runtime_registry_cache()
+    original_load = registry_mod.load_runtime_registry
+
+    def unavailable_after_publication(*, force=False):
+        snapshot = original_load(force=force)
+        if force and (registry_directory() / "controller.json").exists():
+            return registry_mod.RuntimeRegistrySnapshot()
+        return snapshot
+
+    monkeypatch.setattr(
+        registry_mod,
+        "load_runtime_registry",
+        unavailable_after_publication,
+    )
+    original_umask = os.umask(0o777)
+    try:
+        assert (
+            _run([
+                "register",
+                "box",
+                "--backend",
+                "local",
+                "--provider",
+                "controller",
+                "--generation",
+                "g1",
+                "--json",
+            ])
+            == 2
+        )
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert payload["status"] == "error"
+        assert payload["message"] == ("Runtime execution target 'box' was not found.")
+        assert captured.err == ""
+        assert "StopIteration" not in captured.out
+        provider_path = registry_directory() / "controller.json"
+        assert provider_path.stat().st_mode & 0o777 == 0o600
+        assert original_load(force=True).records[0].generation == "g1"
+    finally:
+        os.umask(original_umask)
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()
+
+
+def test_idempotency_replace_and_generation_cas(cli_home, capsys):
+    base = [
+        "register",
+        "box",
+        "--backend",
+        "local",
+        "--cwd",
+        "/one",
+        "--provider",
+        "controller",
+        "--generation",
+        "g1",
+        "--json",
+    ]
+    assert _run(base) == 0
+    capsys.readouterr()
+    assert _run(base) == 0
+    assert json.loads(capsys.readouterr().out)["action"] == "unchanged"
+
+    replacement = [
+        "register",
+        "box",
+        "--backend",
+        "local",
+        "--cwd",
+        "/two",
+        "--provider",
+        "controller",
+        "--generation",
+        "g2",
+        "--json",
+    ]
+    assert _run(replacement) != 0
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "--replace" in json.loads(captured.out)["message"]
+    assert (
+        _run([
+            *replacement,
+            "--replace",
+            "--if-generation",
+            "stale",
+        ])
+        != 0
+    )
+    captured = capsys.readouterr()
+    assert captured.err == ""
+    assert "Stale generation" in json.loads(captured.out)["message"]
+    assert (
+        _run([
+            *replacement,
+            "--replace",
+            "--if-generation",
+            "g1",
+        ])
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["action"] == "replaced"
+    assert resolve_execution_target("box").generation == "g2"
+
+    assert (
+        _run([
+            "drain",
+            "box",
+            "--provider",
+            "controller",
+            "--if-generation",
+            "g1",
+        ])
+        != 0
+    )
+    capsys.readouterr()
+    assert (
+        _run([
+            "drain",
+            "box",
+            "--provider",
+            "controller",
+            "--if-generation",
+            "g2",
+            "--json",
+        ])
+        == 0
+    )
+    assert json.loads(capsys.readouterr().out)["state"] == "draining"
+    assert (
+        _run([
+            "remove",
+            "box",
+            "--provider",
+            "controller",
+            "--if-generation",
+            "g1",
+        ])
+        != 0
+    )
+    capsys.readouterr()
+    assert (
+        _run([
+            "remove",
+            "box",
+            "--provider",
+            "controller",
+            "--if-generation",
+            "g2",
+            "--json",
+        ])
+        == 0
+    )
+
+
+def test_validation_collision_and_structural_injection_fail_nonzero(
+    cli_home,
+    capsys,
+):
+    assert (
+        _run([
+            "register",
+            "local",
+            "--backend",
+            "local",
+        ])
+        != 0
+    )
+    assert "reserved by static" in capsys.readouterr().err
+    assert (
+        _run([
+            "register",
+            "bad",
+            "--backend",
+            "ssh",
+            "--host",
+            "alias",
+        ])
+        != 0
+    )
+    assert "requires non-empty 'ssh_user'" in capsys.readouterr().err
+    assert (
+        _run([
+            "register",
+            "bad",
+            "--backend",
+            "local",
+            "--set",
+            "default_target=oops",
+        ])
+        != 0
+    )
+    assert "structural field" in capsys.readouterr().err
+    assert (
+        _run([
+            "register",
+            "bad",
+            "--backend",
+            "ssh",
+            "--host",
+            "alias",
+            "--user",
+            "dev",
+            "--key",
+            "-----BEGIN PRIVATE KEY----- secret",
+        ])
+        != 0
+    )
+    assert "not private-key contents" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["register", "bad", "--backend", "ssh", "--host", "alias", "--json"],
+        ["show", "missing", "--json"],
+        ["drain", "missing", "--json"],
+        ["remove", "missing", "--json"],
+        ["unregister", "missing", "--json"],
+    ],
+)
+def test_json_handled_errors_use_stdout_for_every_target_action(
+    cli_home,
+    capsys,
+    argv,
+):
+    assert _run(argv) == 2
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["status"] == "error"
+    assert payload["message"]
+    assert captured.err == ""
+    assert "Error:" not in captured.out
+
+
+def test_list_json_handled_error_uses_shared_contract(
+    cli_home,
+    capsys,
+    monkeypatch,
+):
+    from hermes_cli import targets as targets_cli
+
+    def fail_collect(*, include_all):
+        del include_all
+        raise RuntimeError("programming errors must escape")
+
+    monkeypatch.setattr(targets_cli, "_collect_rows", fail_collect)
+    with pytest.raises(RuntimeError, match="programming errors must escape"):
+        _run(["list", "--json"])
+    assert capsys.readouterr().out == ""
+
+    def fail_domain(*, include_all):
+        del include_all
+        from tools.execution_target_registry import RuntimeRegistryError
+
+        raise RuntimeRegistryError("registry validation failed")
+
+    monkeypatch.setattr(targets_cli, "_collect_rows", fail_domain)
+    assert _run(["list", "--json"]) == 2
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {
+        "status": "error",
+        "message": "registry validation failed",
+    }
+    assert captured.err == ""
+
+
+def test_subprocess_stale_remove_json_contract_preserves_replacement(tmp_path):
+    home = tmp_path / "subprocess-home"
+    home.mkdir()
+    target_cwd = tmp_path / "runtime-target"
+    target_cwd.mkdir()
+    identity = [
+        "box",
+        "--backend",
+        "local",
+        "--cwd",
+        str(target_cwd),
+        "--provider",
+        "controller",
+    ]
+
+    registered = _run_subprocess(
+        home,
+        ["register", *identity, "--generation", "g1", "--json"],
+    )
+    assert registered.returncode == 0, registered.stderr
+    assert json.loads(registered.stdout)["generation"] == "g1"
+
+    replaced = _run_subprocess(
+        home,
+        [
+            "register",
+            *identity,
+            "--generation",
+            "g2",
+            "--replace",
+            "--if-generation",
+            "g1",
+            "--json",
+        ],
+    )
+    assert replaced.returncode == 0, replaced.stderr
+    assert json.loads(replaced.stdout)["generation"] == "g2"
+
+    stale = _run_subprocess(
+        home,
+        [
+            "remove",
+            "box",
+            "--provider",
+            "controller",
+            "--if-generation",
+            "stale",
+            "--json",
+        ],
+    )
+    assert stale.returncode == 2
+    assert stale.stderr == ""
+    error = json.loads(stale.stdout)
+    assert error["status"] == "error"
+    assert "Stale generation" in error["message"]
+    assert "Error:" not in stale.stdout + stale.stderr
+
+    shown = _run_subprocess(
+        home,
+        ["show", "box", "--provider", "controller", "--json"],
+    )
+    assert shown.returncode == 0, shown.stderr
+    assert json.loads(shown.stdout)["generation"] == "g2"
+
+
+def test_subprocess_register_validation_error_is_secret_safe_json(tmp_path):
+    home = tmp_path / "subprocess-validation-home"
+    home.mkdir()
+    private_key = "-----BEGIN PRIVATE KEY----- key-material-must-not-appear"
+    password = "registration-password-must-not-appear"
+    docker_token = "registration-docker-token-must-not-appear"
+
+    invalid = _run_subprocess(
+        home,
+        [
+            "register",
+            "bad",
+            "--backend",
+            "ssh",
+            "--host",
+            "alias",
+            "--user",
+            "dev",
+            "--key",
+            private_key,
+            "--set",
+            f"sudo_password={password}",
+            "--set",
+            f'docker_env={{"PRIVATE_TOKEN":"{docker_token}"}}',
+            "--json",
+        ],
+    )
+
+    assert invalid.returncode == 2
+    assert invalid.stderr == ""
+    payload = json.loads(invalid.stdout)
+    assert payload["status"] == "error"
+    assert "does not apply to backend 'ssh'" in payload["message"]
+    assert "Error:" not in invalid.stdout + invalid.stderr
+    for secret in (private_key, password, docker_token):
+        assert secret not in invalid.stdout + invalid.stderr
+
+
+def test_legacy_activation_does_not_edit_yaml_and_survives_last_remove(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    home = tmp_path / "legacy"
+    home.mkdir()
+    config_path = home / "config.yaml"
+    original = "terminal:\n  backend: local\n  timeout: 77\n"
+    config_path.write_text(original, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_TIMEOUT", "77")
+    password = "activation-password-must-not-persist"
+    token = "activation-token-must-not-persist"
+    key_path = "/keys/activation-private-key"
+    sensitive_cwd = "/workspace/activation-sensitive-cwd"
+    set_execution_target_config_source({
+        "terminal": {
+            "backend": "local",
+            "timeout": 77,
+            "cwd": sensitive_cwd,
+            "sudo_password": password,
+            "ssh_key": key_path,
+            "docker_env": {"PRIVATE_TOKEN": token},
+            "env_passthrough": ["FIRST_SHARED_POLICY"],
+            "shell_init_files": ["/etc/hermes/first-shell-policy"],
+        },
+    })
+    invalidate_runtime_registry_cache()
+    try:
+        assert (
+            _run([
+                "register",
+                "box",
+                "--backend",
+                "local",
+                "--provider",
+                "controller",
+                "--generation",
+                "g1",
+            ])
+            == 0
+        )
+        capsys.readouterr()
+        assert config_path.read_text(encoding="utf-8") == original
+        activated = resolve_execution_target()
+        assert activated.named is True
+        assert activated.target == "default"
+        assert activated.config["timeout"] == 77
+        assert activated.config["env_passthrough"] == ["FIRST_SHARED_POLICY"]
+        assert activated.config["shell_init_files"] == [
+            "/etc/hermes/first-shell-policy"
+        ]
+        state = registry_directory() / ".registry-state.json"
+        state_text = state.read_text(encoding="utf-8")
+        assert json.loads(state_text) == {"legacy_activated": True, "version": 1}
+        for forbidden in (
+            password,
+            token,
+            key_path,
+            sensitive_cwd,
+            "backend",
+            "docker_env",
+        ):
+            assert forbidden not in state_text
+
+        set_execution_target_config_source({
+            "terminal": {
+                "backend": "local",
+                "timeout": 88,
+                "cwd": sensitive_cwd,
+                "sudo_password": password,
+                "ssh_key": key_path,
+                "docker_env": {"PRIVATE_TOKEN": token},
+                "env_passthrough": ["UPDATED_SHARED_POLICY"],
+                "shell_init_files": ["/etc/hermes/updated-shell-policy"],
+            },
+        })
+        refreshed = resolve_execution_target()
+        assert refreshed.named is True
+        assert refreshed.config["timeout"] == 88
+        assert refreshed.config["env_passthrough"] == ["UPDATED_SHARED_POLICY"]
+        assert refreshed.config["shell_init_files"] == [
+            "/etc/hermes/updated-shell-policy"
+        ]
+        assert refreshed.spec_fingerprint != activated.spec_fingerprint
+        assert (
+            _run([
+                "remove",
+                "box",
+                "--provider",
+                "controller",
+                "--if-generation",
+                "g1",
+            ])
+            == 0
+        )
+        capsys.readouterr()
+        still_stable = resolve_execution_target()
+        assert still_stable.named is True
+        assert still_stable.target == "default"
+        assert still_stable.spec_fingerprint == refreshed.spec_fingerprint
+        assert state.exists()
+        assert state.stat().st_mode & 0o777 == 0o600
+        assert registry_directory().stat().st_mode & 0o777 == 0o700
+    finally:
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1765,6 +1765,61 @@ class TestConcurrentToolExecution:
 
 
 
+    def test_explicit_targeted_writes_are_sequential_barriers(self, agent):
+        tc1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/a.py","content":"one","target":"beta"}',
+            call_id="c1",
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/b.py","content":"two","target":"beta"}',
+            call_id="c2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
+    def test_named_default_writes_are_sequential_barriers(self, agent):
+        tc1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"relative.txt","content":"one"}',
+            call_id="c1",
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"/remote/project/relative.txt","content":"two"}',
+            call_id="c2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch(
+            "agent.tool_dispatch_helpers._named_execution_targets_enabled",
+            return_value=True,
+        ):
+            with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+                with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                    agent._execute_tool_calls(mock_msg, messages, "task-1")
+                    mock_seq.assert_called_once()
+                    mock_con.assert_not_called()
+
+    def test_legacy_default_inventory_does_not_enable_named_barrier(self):
+        from agent import tool_dispatch_helpers as helpers
+
+        with patch(
+            "tools.execution_targets.list_execution_targets",
+            return_value=(SimpleNamespace(named=False),),
+        ):
+            assert helpers._named_execution_targets_enabled() is False
+        with patch(
+            "tools.execution_targets.list_execution_targets",
+            return_value=(SimpleNamespace(named=True),),
+        ):
+            assert helpers._named_execution_targets_enabled() is True
 
 
 
@@ -2673,6 +2728,41 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_logical_environment_turn_spans_final_cleanup(
+        self, agent, monkeypatch,
+    ):
+        """The outer AIAgent wrapper owns the lease through final cleanup."""
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        import tools.terminal_tool as terminal_mod
+
+        monkeypatch.setattr(terminal_mod, "_active_turn_counts", {})
+        observed = {}
+
+        def observe_cleanup(task_id):
+            observed["before_release"] = terminal_mod.active_environment_turns(task_id)
+            observed["released"] = terminal_mod.release_logical_environment_turn_for_cleanup(
+                task_id
+            )
+            observed["after_release"] = terminal_mod.active_environment_turns(task_id)
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources", side_effect=observe_cleanup),
+        ):
+            result = agent.run_conversation("hello", task_id="logical-turn-test")
+
+        assert result["completed"] is True
+        assert observed == {
+            "before_release": 1,
+            "released": True,
+            "after_release": 0,
+        }
+        assert terminal_mod.active_environment_turns("logical-turn-test") == 0
 
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1844,6 +1844,61 @@ class TestConcurrentToolExecution:
 
 
 
+    def test_explicit_targeted_writes_are_sequential_barriers(self, agent):
+        tc1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/a.py","content":"one","execution_target":"beta"}',
+            call_id="c1",
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"src/b.py","content":"two","execution_target":"beta"}',
+            call_id="c2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+            with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                agent._execute_tool_calls(mock_msg, messages, "task-1")
+                mock_seq.assert_called_once()
+                mock_con.assert_not_called()
+
+    def test_named_default_writes_are_sequential_barriers(self, agent):
+        tc1 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"relative.txt","content":"one"}',
+            call_id="c1",
+        )
+        tc2 = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"/remote/project/relative.txt","content":"two"}',
+            call_id="c2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc1, tc2])
+        messages = []
+        with patch(
+            "agent.tool_dispatch_helpers._named_execution_targets_enabled",
+            return_value=True,
+        ):
+            with patch.object(agent, "_execute_tool_calls_sequential") as mock_seq:
+                with patch.object(agent, "_execute_tool_calls_concurrent") as mock_con:
+                    agent._execute_tool_calls(mock_msg, messages, "task-1")
+                    mock_seq.assert_called_once()
+                    mock_con.assert_not_called()
+
+    def test_legacy_default_inventory_does_not_enable_named_barrier(self):
+        from agent import tool_dispatch_helpers as helpers
+
+        with patch(
+            "tools.execution_targets.list_execution_targets",
+            return_value=(SimpleNamespace(named=False),),
+        ):
+            assert helpers._named_execution_targets_enabled() is False
+        with patch(
+            "tools.execution_targets.list_execution_targets",
+            return_value=(SimpleNamespace(named=True),),
+        ):
+            assert helpers._named_execution_targets_enabled() is True
 
 
 
@@ -2817,6 +2872,41 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_logical_environment_turn_spans_final_cleanup(
+        self, agent, monkeypatch,
+    ):
+        """The outer AIAgent wrapper owns the lease through final cleanup."""
+        self._setup_agent(agent)
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        import tools.terminal_tool as terminal_mod
+
+        monkeypatch.setattr(terminal_mod, "_active_turn_counts", {})
+        observed = {}
+
+        def observe_cleanup(task_id):
+            observed["before_release"] = terminal_mod.active_environment_turns(task_id)
+            observed["released"] = terminal_mod.release_logical_environment_turn_for_cleanup(
+                task_id
+            )
+            observed["after_release"] = terminal_mod.active_environment_turns(task_id)
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources", side_effect=observe_cleanup),
+        ):
+            result = agent.run_conversation("hello", task_id="logical-turn-test")
+
+        assert result["completed"] is True
+        assert observed == {
+            "before_release": 1,
+            "released": True,
+            "after_release": 0,
+        }
+        assert terminal_mod.active_environment_turns("logical-turn-test") == 0
 
     def test_prompt_cache_marks_static_system_prefix_on_wire(self, agent):
         self._setup_agent(agent)

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -3,6 +3,7 @@
 import json
 from unittest.mock import ANY, call, patch
 
+import pytest
 
 from model_tools import (
     handle_function_call,
@@ -151,6 +152,188 @@ class TestHandleFunctionCall:
         assert pre_call[1]["middleware_trace"] == expected_trace
         assert post_call[1]["middleware_trace"] == expected_trace
 
+    def test_tool_request_middleware_can_select_target_before_authorization(
+        self, monkeypatch,
+    ):
+        policy_checked = []
+        approved = []
+        dispatched = []
+
+        def request_middleware(kind, **kwargs):
+            if kind != "tool_request":
+                return []
+            return [{
+                "args": {
+                    **kwargs["args"],
+                    "execution_target": "beta",
+                },
+                "source": "target-selector",
+            }]
+
+        manager = type("Manager", (), {"_middleware": {}})()
+        monkeypatch.setattr(
+            "hermes_cli.plugins.has_middleware",
+            lambda kind: kind == "tool_request",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.invoke_middleware", request_middleware,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_manager", lambda: manager,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda _name, args, **_kwargs: (
+                policy_checked.append(dict(args)) or None,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "acp_adapter.edit_approval.maybe_require_edit_approval",
+            lambda _name, args: approved.append(dict(args)) or None,
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda name, args, **kwargs: (
+                dispatched.append((name, dict(args), kwargs))
+                or json.dumps({"ok": True})
+            ),
+        )
+
+        result = json.loads(handle_function_call(
+            "terminal",
+            {"command": "true", "execution_target": "alpha"},
+        ))
+        selected = {"command": "true", "execution_target": "beta"}
+
+        assert result == {"ok": True}
+        assert policy_checked == [selected]
+        assert approved == [selected]
+        assert dispatched[0][0:2] == ("terminal", selected)
+
+    def test_tool_execution_middleware_cannot_retarget_after_authorization(
+        self, monkeypatch,
+    ):
+        policy_checked = []
+        approved = []
+        dispatched = []
+
+        def execution_middleware(**kwargs):
+            return kwargs["next_call"]({
+                **kwargs["args"],
+                "execution_target": "beta",
+            })
+
+        manager = type(
+            "Manager",
+            (),
+            {"_middleware": {"tool_execution": [execution_middleware]}},
+        )()
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_manager", lambda: manager,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda _name, args, **_kwargs: (
+                policy_checked.append(dict(args)) or None,
+                None,
+            ),
+        )
+        monkeypatch.setattr(
+            "acp_adapter.edit_approval.maybe_require_edit_approval",
+            lambda _name, args: approved.append(dict(args)) or None,
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda *args, **kwargs: dispatched.append((args, kwargs)) or "{}",
+        )
+
+        original = {
+            "path": "never-written.txt",
+            "content": "x",
+            "execution_target": "alpha",
+        }
+        result = json.loads(handle_function_call("write_file", original))
+
+        assert policy_checked == [original]
+        assert approved == [original]
+        assert "cannot change 'execution_target' after authorization" in result["error"]
+        assert dispatched == []
+
+    def test_tool_execution_middleware_can_rewrite_non_routing_args(
+        self, monkeypatch,
+    ):
+        dispatched = []
+
+        def execution_middleware(**kwargs):
+            return kwargs["next_call"]({
+                **kwargs["args"],
+                "command": "printf ok",
+            })
+
+        manager = type(
+            "Manager",
+            (),
+            {"_middleware": {"tool_execution": [execution_middleware]}},
+        )()
+        monkeypatch.setattr(
+            "hermes_cli.plugins.get_plugin_manager", lambda: manager,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: (None, None),
+        )
+        monkeypatch.setattr(
+            "model_tools.registry.dispatch",
+            lambda name, args, **kwargs: (
+                dispatched.append((name, dict(args), kwargs))
+                or json.dumps({"ok": True})
+            ),
+        )
+
+        result = json.loads(handle_function_call(
+            "terminal",
+            {"command": "true", "execution_target": "alpha"},
+        ))
+
+        assert result == {"ok": True}
+        assert dispatched[0][0:2] == (
+            "terminal",
+            {"command": "printf ok", "execution_target": "alpha"},
+        )
+
+    def test_execution_target_dispatch_guard_preserves_selector_only(self):
+        from tools.execution_targets import (
+            ExecutionTargetError,
+            validate_execution_target_dispatch_args,
+        )
+
+        validate_execution_target_dispatch_args(
+            "terminal",
+            {"command": "true", "execution_target": "alpha"},
+            {"command": "printf ok", "execution_target": "alpha"},
+        )
+        validate_execution_target_dispatch_args(
+            "search_files",
+            {"pattern": "x", "target": "content", "execution_target": "alpha"},
+            {"pattern": "x", "target": "files", "execution_target": "alpha"},
+        )
+
+        changed_selectors = [
+            ({"execution_target": "alpha"}, {"execution_target": "beta"}),
+            ({"execution_target": "alpha"}, {}),
+            ({}, {"execution_target": "alpha"}),
+            (
+                {"execution_target": "alpha"},
+                {"execution_target": "alpha", "target": "beta"},
+            ),
+        ]
+        for authorized, dispatch in changed_selectors:
+            with pytest.raises(ExecutionTargetError):
+                validate_execution_target_dispatch_args(
+                    "terminal", authorized, dispatch,
+                )
+
     def test_registry_exception_emits_terminal_tool_hook(self, monkeypatch):
         from hermes_cli import lifecycle
 
@@ -219,6 +402,28 @@ class TestHandleFunctionCall:
         [post_call] = [call for call in hook_calls if call[0] == "post_tool_call"]
         assert post_call[1]["status"] == "blocked"
         assert post_call[1]["error_type"] == "edit_approval_denied"
+
+    def test_removed_target_selector_fails_before_hooks_or_edit_approval(self):
+        with (
+            patch("hermes_cli.plugins.resolve_pre_tool_block") as pre_hook,
+            patch(
+                "acp_adapter.edit_approval.maybe_require_edit_approval"
+            ) as edit_approval,
+            patch("model_tools.registry.dispatch") as dispatch,
+        ):
+            result = json.loads(handle_function_call(
+                "write_file",
+                {
+                    "path": "private.txt",
+                    "content": "private",
+                    "target": "alpha",
+                },
+            ))
+
+        assert "does not accept 'target'" in result["error"]
+        pre_hook.assert_not_called()
+        edit_approval.assert_not_called()
+        dispatch.assert_not_called()
 
 
 # =========================================================================

--- a/tests/tools/test_approval_plugin_hooks.py
+++ b/tests/tools/test_approval_plugin_hooks.py
@@ -208,6 +208,34 @@ class TestSmartModeFiresHooks:
             assert pre["pattern_keys"] == [pattern_key]
 
     @pytest.mark.parametrize("guard,value", [
+        (check_all_command_guards, "rm -rf /tmp/smart-target-hook"),
+        (check_execute_code_guard, "print('smart target hook')"),
+    ])
+    def test_smart_pre_hook_includes_target_before_aux_decision(
+        self, isolated_session, monkeypatch, guard, value,
+    ):
+        self._configure(monkeypatch, "approve")
+        captured = []
+
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            side_effect=lambda name, **kwargs: captured.append((name, kwargs)),
+        ):
+            result = guard(
+                value,
+                "local",
+                execution_target="alpha",
+                execution_backend="local",
+                execution_target_named=True,
+                execution_target_scope="scope-v1",
+            )
+
+        assert result["approved"] is True
+        pre = next(kwargs for name, kwargs in captured if name == "pre_approval_request")
+        assert pre["target"] == "alpha"
+        assert pre["backend"] == "local"
+
+    @pytest.mark.parametrize("guard,value", [
         (check_all_command_guards, "rm -rf /tmp/smart-order"),
         (check_execute_code_guard, "print('smart order')"),
     ])

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -90,7 +90,9 @@ class TestCleanupTaskResourcesHeadedSkip:
             ),
         ):
             cleanup_task_resources(_make_agent(), "task-x")
-            mock_vm.assert_called_once_with("task-x")
+            mock_vm.assert_called_once_with(
+                "task-x", preserve_persistent=True, include_collapsed=True
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -772,7 +772,10 @@ class TestRpcTokenAuthorization(unittest.TestCase):
     round-trips normally.
     """
 
-    def _drive_server(self, rpc_token, requests):
+    def _drive_server(
+        self, rpc_token, requests, execution_target=None,
+        execution_target_scope=None, execution_target_config=None,
+    ):
         """Run _rpc_server_loop against a real AF_UNIX socketpair.
 
         Sends each dict in *requests* as a newline-delimited JSON message
@@ -819,6 +822,9 @@ class TestRpcTokenAuthorization(unittest.TestCase):
                     allowed_tools=frozenset({"terminal"}),
                     stop_event=stop_event,
                     rpc_token=rpc_token,
+                    execution_target=execution_target,
+                    execution_target_scope=execution_target_scope,
+                    execution_target_config=execution_target_config,
                 )
 
         t = threading.Thread(target=_run, daemon=True)
@@ -854,6 +860,35 @@ class TestRpcTokenAuthorization(unittest.TestCase):
         )
         self.assertEqual(len(resp), 1)
         self.assertIn("Unauthorized", resp[0].get("error", ""))
+
+    def test_rpc_inherits_bound_execution_target(self):
+        resp = self._drive_server(
+            "secret-token",
+            [{
+                "tool": "terminal",
+                "args": {"command": "echo hi"},
+                "token": "secret-token",
+            }],
+            execution_target="sandbox",
+        )
+        self.assertEqual(len(resp), 1)
+        self.assertNotIn("cannot select", json.dumps(resp[0]))
+
+    def test_rpc_rejects_cross_target_pivot(self):
+        resp = self._drive_server(
+            "secret-token",
+            [{
+                "tool": "terminal",
+                "args": {
+                    "command": "echo hi", "execution_target": "host",
+                },
+                "token": "secret-token",
+            }],
+            execution_target="sandbox",
+        )
+        self.assertEqual(len(resp), 1)
+        self.assertIn("bound to target", json.dumps(resp[0]))
+        self.assertIn("cannot select", json.dumps(resp[0]))
 
 
     def test_generated_module_sends_token(self):

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -706,7 +706,10 @@ class TestRpcTokenAuthorization(unittest.TestCase):
     round-trips normally.
     """
 
-    def _drive_server(self, rpc_token, requests):
+    def _drive_server(
+        self, rpc_token, requests, execution_target=None,
+        execution_target_scope=None, execution_target_config=None,
+    ):
         """Run _rpc_server_loop against a real AF_UNIX socketpair.
 
         Sends each dict in *requests* as a newline-delimited JSON message
@@ -753,6 +756,9 @@ class TestRpcTokenAuthorization(unittest.TestCase):
                     allowed_tools=frozenset({"terminal"}),
                     stop_event=stop_event,
                     rpc_token=rpc_token,
+                    execution_target=execution_target,
+                    execution_target_scope=execution_target_scope,
+                    execution_target_config=execution_target_config,
                 )
 
         t = threading.Thread(target=_run, daemon=True)
@@ -788,6 +794,33 @@ class TestRpcTokenAuthorization(unittest.TestCase):
         )
         self.assertEqual(len(resp), 1)
         self.assertIn("Unauthorized", resp[0].get("error", ""))
+
+    def test_rpc_inherits_bound_execution_target(self):
+        resp = self._drive_server(
+            "secret-token",
+            [{
+                "tool": "terminal",
+                "args": {"command": "echo hi"},
+                "token": "secret-token",
+            }],
+            execution_target="sandbox",
+        )
+        self.assertEqual(len(resp), 1)
+        self.assertNotIn("cannot select", json.dumps(resp[0]))
+
+    def test_rpc_rejects_cross_target_pivot(self):
+        resp = self._drive_server(
+            "secret-token",
+            [{
+                "tool": "terminal",
+                "args": {"command": "echo hi", "target": "host"},
+                "token": "secret-token",
+            }],
+            execution_target="sandbox",
+        )
+        self.assertEqual(len(resp), 1)
+        self.assertIn("bound to target", json.dumps(resp[0]))
+        self.assertIn("cannot select", json.dumps(resp[0]))
 
 
     def test_generated_module_sends_token(self):

--- a/tests/tools/test_code_execution_named_target.py
+++ b/tests/tools/test_code_execution_named_target.py
@@ -1,0 +1,41 @@
+def test_execute_code_rpc_uses_frozen_approved_target_config():
+    from tools import code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    approved = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": "/approved"},
+            },
+        },
+    }
+    live = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {
+                    "backend": "ssh",
+                    "ssh_host": "new.example",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    targets_mod.set_execution_target_config_source(live)
+
+    def handler(_name, args, task_id=None):
+        selected = targets_mod.resolve_execution_target(args["target"])
+        current = targets_mod.resolve_live_execution_target(args["target"])
+        return selected.backend, selected.config.get("cwd"), current.backend
+
+    try:
+        assert code_mod._dispatch_rpc_tool(
+            handler,
+            "write_file",
+            {"target": "alpha"},
+            "task",
+            approved,
+        ) == ("local", "/approved", "ssh")
+    finally:
+        targets_mod.set_execution_target_config_source(None)

--- a/tests/tools/test_code_execution_named_target.py
+++ b/tests/tools/test_code_execution_named_target.py
@@ -1,0 +1,41 @@
+def test_execute_code_rpc_uses_frozen_approved_target_config():
+    from tools import code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    approved = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": "/approved"},
+            },
+        },
+    }
+    live = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {
+                    "backend": "ssh",
+                    "ssh_host": "new.example",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    targets_mod.set_execution_target_config_source(live)
+
+    def handler(_name, args, task_id=None):
+        selected = targets_mod.resolve_execution_target(args["execution_target"])
+        current = targets_mod.resolve_live_execution_target(args["execution_target"])
+        return selected.backend, selected.config.get("cwd"), current.backend
+
+    try:
+        assert code_mod._dispatch_rpc_tool(
+            handler,
+            "write_file",
+            {"execution_target": "alpha"},
+            "task",
+            approved,
+        ) == ("local", "/approved", "ssh")
+    finally:
+        targets_mod.set_execution_target_config_source(None)

--- a/tests/tools/test_command_guards.py
+++ b/tests/tools/test_command_guards.py
@@ -153,6 +153,39 @@ class TestTirithAllowDangerous:
         # allow_permanent should be True (no tirith warning)
         assert cb.call_args[1]["allow_permanent"] is True
 
+    @patch(_TIRITH_PATCH, return_value=_tirith_result("allow"))
+    def test_named_target_session_approval_does_not_authorize_sibling_target(
+        self, mock_tirith,
+    ):
+        os.environ["HERMES_INTERACTIVE"] = "1"
+        command = "rm -rf /tmp/hermes-target-scope"
+
+        approve_local = MagicMock(return_value="session")
+        first = check_all_command_guards(
+            command, "local", approval_callback=approve_local,
+            execution_target="local", execution_backend="local",
+            execution_target_named=True,
+        )
+        assert first["approved"] is True
+
+        local_again = MagicMock(return_value="deny")
+        second = check_all_command_guards(
+            command, "local", approval_callback=local_again,
+            execution_target="local", execution_backend="local",
+            execution_target_named=True,
+        )
+        assert second["approved"] is True
+        local_again.assert_not_called()
+
+        deny_prod = MagicMock(return_value="deny")
+        third = check_all_command_guards(
+            command, "local", approval_callback=deny_prod,
+            execution_target="prod", execution_backend="ssh",
+            execution_target_named=True,
+        )
+        assert third["approved"] is False
+        deny_prod.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # tirith warn + safe command

--- a/tests/tools/test_container_cwd_sanitize.py
+++ b/tests/tools/test_container_cwd_sanitize.py
@@ -44,6 +44,23 @@ class TestOverrideCwdSanitizedAtCallSite:
     the (sanitized) config["cwd"] and flowed raw into `docker run -w`.
     """
 
+    def test_explicit_docker_mount_mode_uses_registered_host_workspace(
+        self, tmp_path,
+    ):
+        config = {
+            "env_type": "docker",
+            "cwd": "/workspace",
+            "host_cwd": None,
+            "docker_mount_cwd_to_workspace": True,
+        }
+
+        cwd = tt._apply_task_cwd_override(
+            config, str(tmp_path), str(tmp_path),
+        )
+
+        assert cwd == "/workspace"
+        assert config["host_cwd"] == str(tmp_path)
+
     def _run_and_capture_cwd(self, monkeypatch, override_cwd, config_cwd="/root"):
         """Drive terminal_tool() on the docker backend with a host-path cwd
         override registered, and return the cwd that reached _create_environment

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,7 +1,9 @@
+import gc
 import logging
 import os
 from io import StringIO
 import subprocess
+import weakref
 
 import pytest
 
@@ -45,6 +47,8 @@ def _make_dummy_env(**kwargs):
         disk=kwargs.get("disk", 0),
         persistent_filesystem=kwargs.get("persistent_filesystem", False),
         task_id=kwargs.get("task_id", "test-task"),
+        storage_task_id=kwargs.get("storage_task_id"),
+        legacy_storage_task_id=kwargs.get("legacy_storage_task_id"),
         volumes=kwargs.get("volumes", []),
         forward_env=kwargs.get("forward_env"),
         network=kwargs.get("network", True),
@@ -99,6 +103,253 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert run_calls, "docker run should have been called"
     run_args_str = " ".join(run_calls[0][0])
     assert f"{project_dir}:/workspace" in run_args_str
+
+
+def test_persistent_storage_path_uses_stable_storage_task_id(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="runtime-config-fingerprint",
+        storage_task_id="stable-target-owner",
+    )
+
+    assert env._home_dir == str(
+        tmp_path / "docker" / "stable-target-owner" / "home"
+    )
+    assert env._workspace_dir == str(
+        tmp_path / "docker" / "stable-target-owner" / "workspace"
+    )
+
+
+def test_legacy_named_target_storage_is_migrated(monkeypatch, tmp_path):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    _mock_subprocess_run(monkeypatch)
+    legacy = tmp_path / "docker" / "legacy-runtime"
+    (legacy / "home").mkdir(parents=True)
+    (legacy / "home" / "marker.txt").write_text("kept", encoding="utf-8")
+
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="new-runtime",
+        storage_task_id="stable-owner",
+        legacy_storage_task_id="legacy-runtime",
+    )
+
+    migrated = tmp_path / "docker" / "stable-owner"
+    assert not legacy.exists()
+    assert (migrated / "home" / "marker.txt").read_text(encoding="utf-8") == "kept"
+    assert env._home_dir == str(migrated / "home")
+
+
+def test_persistent_storage_retires_prior_process_runtime_on_spec_change(
+    monkeypatch,
+):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "version":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+        if cmd[1] == "ps" and any(
+            "hermes-storage-id=" in part for part in cmd
+        ):
+            output = "old-container\told-runtime\tprior-process\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=output, stderr="")
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[1] == "run":
+            return subprocess.CompletedProcess(cmd, 0, stdout="new-container\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="new-runtime",
+        storage_task_id="stable-owner",
+    )
+
+    removals = [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]]
+    assert removals == [["/usr/bin/docker", "rm", "-f", "old-container"]]
+    run_cmd = next(cmd for cmd in calls if cmd[1] == "run")
+    assert env._labels["hermes-storage-id"].startswith("storage-")
+    assert f"hermes-storage-id={env._labels['hermes-storage-id']}" in run_cmd
+    assert any("hermes-process-instance=" in part for part in run_cmd)
+
+
+def test_persistent_storage_refuses_to_remove_live_peer_runtime(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "docker" / ".runtime-leases"
+    container_id = "live-peer-container"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout=f"{container_id}\told-runtime\tpeer-process\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    docker_env._hold_container_lease(container_id, env._lease_root)
+    try:
+        with pytest.raises(RuntimeError, match="still used by another Hermes process"):
+            env._remove_superseded_storage_containers(
+                "stable-owner", "default", "new-runtime",
+                allow_exact_reuse=False,
+            )
+    finally:
+        docker_env._release_container_lease(container_id, env._lease_root)
+
+    assert not [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]]
+
+
+def test_persistent_storage_retires_exact_runtime_when_egress_changes(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "leases"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="stale-exact\tcurrent-runtime\tdead-process\told-egress\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env._remove_superseded_storage_containers(
+        "stable-owner", "default", "current-runtime",
+        current_egress_label="new-egress",
+        allow_exact_reuse=True,
+    )
+
+    assert [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]] == [
+        ["/usr/bin/docker", "rm", "-f", "stale-exact"],
+    ]
+
+
+def test_runtime_lease_releases_when_environment_handle_is_dropped(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+
+    class Holder:
+        pass
+
+    holder = Holder()
+    ref = weakref.ref(holder)
+    container_id = "gc-release-container"
+    docker_env._track_environment_container(holder, container_id)
+    assert any(key[1] == container_id for key in docker_env._CONTAINER_LEASES)
+
+    del holder
+    gc.collect()
+
+    assert ref() is None
+    assert not any(key[1] == container_id for key in docker_env._CONTAINER_LEASES)
+    assert container_id not in docker_env._CURRENT_PROCESS_CONTAINER_IDS
+
+
+def test_retracking_environment_replaces_lease_ownership_without_leak(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+
+    class Holder:
+        pass
+
+    holder = Holder()
+    holder._lease_root = tmp_path / "leases"
+    ref = weakref.ref(holder)
+    container_id = "retracked-container"
+    lease_key = (str(holder._lease_root.resolve()), container_id)
+
+    docker_env._track_environment_container(holder, container_id)
+    docker_env._track_environment_container(holder, container_id)
+
+    assert docker_env._CONTAINER_LEASES[lease_key][1] == 1
+    del holder
+    gc.collect()
+    assert ref() is None
+    assert lease_key not in docker_env._CONTAINER_LEASES
+    assert container_id not in docker_env._CURRENT_PROCESS_CONTAINER_IDS
+
+
+def test_storage_owner_lock_serializes_runtime_creation(monkeypatch, tmp_path):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    first = docker_env._acquire_storage_creation_lease("stable-owner")
+    try:
+        with pytest.raises(RuntimeError, match="Timed out waiting"):
+            docker_env._acquire_storage_creation_lease(
+                "stable-owner", timeout=0.01,
+            )
+    finally:
+        docker_env._close_storage_creation_lease(first)
+
+
+def test_persistent_storage_reconciles_exact_runtime_when_reuse_is_disabled(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "docker" / ".runtime-leases"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="stale-exact\tcurrent-runtime\tdead-process\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env._remove_superseded_storage_containers(
+        "stable-owner", "default", "current-runtime",
+        allow_exact_reuse=False,
+    )
+
+    assert [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]] == [
+        ["/usr/bin/docker", "rm", "-f", "stale-exact"],
+    ]
 
 
 def test_non_persistent_cleanup_removes_container(monkeypatch):
@@ -605,6 +856,7 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-process-instance": docker_env._PROCESS_INSTANCE_ID,
     }
 
 
@@ -1488,3 +1740,99 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+def test_force_cleanup_rm_failure_restores_identity_ownership_and_storage(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    _install_fake_thread(monkeypatch)
+    env = _make_dummy_env(task_id="transactional-cleanup")
+    container_id = env._container_id
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    env._workspace_dir = str(workspace)
+    restored = []
+    monkeypatch.setattr(
+        docker_env,
+        "_track_environment_container",
+        lambda owner, runtime_id: restored.append((owner, runtime_id)),
+    )
+
+    def failing_remove(cmd, **kwargs):
+        if cmd[1:3] == ["rm", "-f"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="denied")
+        if cmd[1:3] == ["container", "inspect"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=container_id, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", failing_remove)
+    env.cleanup(force_remove=True)
+
+    with pytest.raises(RuntimeError, match="cleanup failed transactionally"):
+        env.wait_for_cleanup(timeout=1)
+    assert env._container_id == container_id
+    assert workspace.exists()
+    assert restored == [(env, container_id)]
+
+
+def test_force_cleanup_treats_verified_absent_container_as_success(monkeypatch):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    _install_fake_thread(monkeypatch)
+    env = _make_dummy_env(task_id="already-absent-cleanup")
+
+    def already_absent(cmd, **kwargs):
+        if cmd[1:3] == ["rm", "-f"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="failed")
+        if cmd[1:3] == ["container", "inspect"]:
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="Error: No such container",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", already_absent)
+    env.cleanup(force_remove=True)
+
+    assert env.wait_for_cleanup(timeout=1) is True
+    assert env._container_id is None
+
+
+def test_cleanup_worker_start_failure_restores_runtime_ownership(monkeypatch):
+    import threading
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    env = _make_dummy_env(task_id="cleanup-thread-start-failure")
+    container_id = env._container_id
+    restored = []
+    monkeypatch.setattr(
+        docker_env,
+        "_track_environment_container",
+        lambda owner, runtime_id: restored.append((owner, runtime_id)),
+    )
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @staticmethod
+        def is_alive():
+            return False
+
+        @staticmethod
+        def start():
+            raise RuntimeError("thread unavailable")
+
+    monkeypatch.setattr(threading, "Thread", FailingThread)
+
+    with pytest.raises(RuntimeError, match="Could not start Docker cleanup worker"):
+        env.cleanup(force_remove=True)
+    assert env._container_id == container_id
+    assert restored == [(env, container_id)]
+    with pytest.raises(RuntimeError, match="cleanup failed transactionally"):
+        env.wait_for_cleanup(timeout=1)

--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1,7 +1,9 @@
+import gc
 import logging
 import os
 from io import StringIO
 import subprocess
+import weakref
 
 import pytest
 
@@ -45,6 +47,8 @@ def _make_dummy_env(**kwargs):
         disk=kwargs.get("disk", 0),
         persistent_filesystem=kwargs.get("persistent_filesystem", False),
         task_id=kwargs.get("task_id", "test-task"),
+        storage_task_id=kwargs.get("storage_task_id"),
+        legacy_storage_task_id=kwargs.get("legacy_storage_task_id"),
         volumes=kwargs.get("volumes", []),
         forward_env=kwargs.get("forward_env"),
         network=kwargs.get("network", True),
@@ -99,6 +103,226 @@ def test_auto_mount_host_cwd_adds_volume(monkeypatch, tmp_path):
     assert run_calls, "docker run should have been called"
     run_args_str = " ".join(run_calls[0][0])
     assert f"{project_dir}:/workspace" in run_args_str
+
+
+def test_persistent_storage_path_uses_stable_storage_task_id(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    _mock_subprocess_run(monkeypatch)
+
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="runtime-config-fingerprint",
+        storage_task_id="stable-target-owner",
+    )
+
+    assert env._home_dir == str(
+        tmp_path / "docker" / "stable-target-owner" / "home"
+    )
+    assert env._workspace_dir == str(
+        tmp_path / "docker" / "stable-target-owner" / "workspace"
+    )
+
+
+def test_legacy_named_target_storage_is_migrated(monkeypatch, tmp_path):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    _mock_subprocess_run(monkeypatch)
+    legacy = tmp_path / "docker" / "legacy-runtime"
+    (legacy / "home").mkdir(parents=True)
+    (legacy / "home" / "marker.txt").write_text("kept", encoding="utf-8")
+
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="new-runtime",
+        storage_task_id="stable-owner",
+        legacy_storage_task_id="legacy-runtime",
+    )
+
+    migrated = tmp_path / "docker" / "stable-owner"
+    assert not legacy.exists()
+    assert (migrated / "home" / "marker.txt").read_text(encoding="utf-8") == "kept"
+    assert env._home_dir == str(migrated / "home")
+
+
+def test_persistent_storage_retires_prior_process_runtime_on_spec_change(
+    monkeypatch,
+):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "version":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+        if cmd[1] == "ps" and any(
+            "hermes-storage-id=" in part for part in cmd
+        ):
+            output = "old-container\told-runtime\tprior-process\n"
+            return subprocess.CompletedProcess(cmd, 0, stdout=output, stderr="")
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+        if cmd[1] == "run":
+            return subprocess.CompletedProcess(cmd, 0, stdout="new-container\n", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env = _make_dummy_env(
+        persistent_filesystem=True,
+        task_id="new-runtime",
+        storage_task_id="stable-owner",
+    )
+
+    removals = [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]]
+    assert removals == [["/usr/bin/docker", "rm", "-f", "old-container"]]
+    run_cmd = next(cmd for cmd in calls if cmd[1] == "run")
+    assert env._labels["hermes-storage-id"].startswith("storage-")
+    assert f"hermes-storage-id={env._labels['hermes-storage-id']}" in run_cmd
+    assert any("hermes-process-instance=" in part for part in run_cmd)
+
+
+def test_persistent_storage_refuses_to_remove_live_peer_runtime(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "docker" / ".runtime-leases"
+    container_id = "live-peer-container"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout=f"{container_id}\told-runtime\tpeer-process\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    docker_env._hold_container_lease(container_id, env._lease_root)
+    try:
+        with pytest.raises(RuntimeError, match="still used by another Hermes process"):
+            env._remove_superseded_storage_containers(
+                "stable-owner", "default", "new-runtime",
+                allow_exact_reuse=False,
+            )
+    finally:
+        docker_env._release_container_lease(container_id, env._lease_root)
+
+    assert not [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]]
+
+
+def test_persistent_storage_retires_exact_runtime_when_egress_changes(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "leases"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="stale-exact\tcurrent-runtime\tdead-process\told-egress\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env._remove_superseded_storage_containers(
+        "stable-owner", "default", "current-runtime",
+        current_egress_label="new-egress",
+        allow_exact_reuse=True,
+    )
+
+    assert [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]] == [
+        ["/usr/bin/docker", "rm", "-f", "stale-exact"],
+    ]
+
+
+def test_runtime_lease_releases_when_environment_handle_is_dropped(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+
+    class Holder:
+        pass
+
+    holder = Holder()
+    ref = weakref.ref(holder)
+    container_id = "gc-release-container"
+    docker_env._track_environment_container(holder, container_id)
+    assert any(key[1] == container_id for key in docker_env._CONTAINER_LEASES)
+
+    del holder
+    gc.collect()
+
+    assert ref() is None
+    assert not any(key[1] == container_id for key in docker_env._CONTAINER_LEASES)
+    assert container_id not in docker_env._CURRENT_PROCESS_CONTAINER_IDS
+
+
+def test_storage_owner_lock_serializes_runtime_creation(monkeypatch, tmp_path):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    first = docker_env._acquire_storage_creation_lease("stable-owner")
+    try:
+        with pytest.raises(RuntimeError, match="Timed out waiting"):
+            docker_env._acquire_storage_creation_lease(
+                "stable-owner", timeout=0.01,
+            )
+    finally:
+        docker_env._close_storage_creation_lease(first)
+
+
+def test_persistent_storage_reconciles_exact_runtime_when_reuse_is_disabled(
+    monkeypatch, tmp_path,
+):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    env = object.__new__(docker_env.DockerEnvironment)
+    env._docker_exe = "/usr/bin/docker"
+    env._lease_root = tmp_path / "docker" / ".runtime-leases"
+    calls = []
+
+    def _run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[1] == "ps":
+            return subprocess.CompletedProcess(
+                cmd, 0,
+                stdout="stale-exact\tcurrent-runtime\tdead-process\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", _run)
+    env._remove_superseded_storage_containers(
+        "stable-owner", "default", "current-runtime",
+        allow_exact_reuse=False,
+    )
+
+    assert [cmd for cmd in calls if cmd[1:3] == ["rm", "-f"]] == [
+        ["/usr/bin/docker", "rm", "-f", "stale-exact"],
+    ]
 
 
 def test_non_persistent_cleanup_removes_container(monkeypatch):
@@ -605,6 +829,7 @@ def test_labels_attribute_populated_after_init(monkeypatch):
         "hermes-task-id": "abc",
         "hermes-profile": "default",
         "hermes-egress": "off",
+        "hermes-process-instance": docker_env._PROCESS_INSTANCE_ID,
     }
 
 
@@ -1488,3 +1713,99 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size(None) is False
     # non-string entries must not crash (config.yaml can be malformed)
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
+
+
+def test_force_cleanup_rm_failure_restores_identity_ownership_and_storage(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    _install_fake_thread(monkeypatch)
+    env = _make_dummy_env(task_id="transactional-cleanup")
+    container_id = env._container_id
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    env._workspace_dir = str(workspace)
+    restored = []
+    monkeypatch.setattr(
+        docker_env,
+        "_track_environment_container",
+        lambda owner, runtime_id: restored.append((owner, runtime_id)),
+    )
+
+    def failing_remove(cmd, **kwargs):
+        if cmd[1:3] == ["rm", "-f"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="denied")
+        if cmd[1:3] == ["container", "inspect"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout=container_id, stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", failing_remove)
+    env.cleanup(force_remove=True)
+
+    with pytest.raises(RuntimeError, match="cleanup failed transactionally"):
+        env.wait_for_cleanup(timeout=1)
+    assert env._container_id == container_id
+    assert workspace.exists()
+    assert restored == [(env, container_id)]
+
+
+def test_force_cleanup_treats_verified_absent_container_as_success(monkeypatch):
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    _install_fake_thread(monkeypatch)
+    env = _make_dummy_env(task_id="already-absent-cleanup")
+
+    def already_absent(cmd, **kwargs):
+        if cmd[1:3] == ["rm", "-f"]:
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="failed")
+        if cmd[1:3] == ["container", "inspect"]:
+            return subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr="Error: No such container",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", already_absent)
+    env.cleanup(force_remove=True)
+
+    assert env.wait_for_cleanup(timeout=1) is True
+    assert env._container_id is None
+
+
+def test_cleanup_worker_start_failure_restores_runtime_ownership(monkeypatch):
+    import threading
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    _mock_subprocess_run(monkeypatch)
+    env = _make_dummy_env(task_id="cleanup-thread-start-failure")
+    container_id = env._container_id
+    restored = []
+    monkeypatch.setattr(
+        docker_env,
+        "_track_environment_container",
+        lambda owner, runtime_id: restored.append((owner, runtime_id)),
+    )
+
+    class FailingThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        @staticmethod
+        def is_alive():
+            return False
+
+        @staticmethod
+        def start():
+            raise RuntimeError("thread unavailable")
+
+    monkeypatch.setattr(threading, "Thread", FailingThread)
+
+    with pytest.raises(RuntimeError, match="Could not start Docker cleanup worker"):
+        env.cleanup(force_remove=True)
+    assert env._container_id == container_id
+    assert restored == [(env, container_id)]
+    with pytest.raises(RuntimeError, match="cleanup failed transactionally"):
+        env.wait_for_cleanup(timeout=1)

--- a/tests/tools/test_docker_named_storage_owner_race.py
+++ b/tests/tools/test_docker_named_storage_owner_race.py
@@ -1,0 +1,80 @@
+import subprocess
+import threading
+
+from tools.environments import docker as docker_env
+
+
+def test_storage_owner_barrier_is_held_through_init_session(monkeypatch, tmp_path):
+    from tools.environments import base as environment_base
+
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    monkeypatch.setattr(docker_env, "_get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(environment_base, "get_sandbox_dir", lambda: tmp_path)
+    docker_env._cgroup_limits_ok = True
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[1] == "version":
+            return subprocess.CompletedProcess(cmd, 0, stdout="Docker version", stderr="")
+        if cmd[1] == "run":
+            return subprocess.CompletedProcess(
+                cmd, 0, stdout=f"container-{sum(c[1] == 'run' for c in calls)}\n", stderr="",
+            )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(docker_env.subprocess, "run", fake_run)
+    first_init_started = threading.Event()
+    release_first_init = threading.Event()
+    second_init_started = threading.Event()
+    init_lock = threading.Lock()
+    init_count = 0
+
+    def blocking_init(self):
+        nonlocal init_count
+        with init_lock:
+            init_count += 1
+            ordinal = init_count
+        if ordinal == 1:
+            first_init_started.set()
+            assert release_first_init.wait(timeout=5)
+        else:
+            second_init_started.set()
+
+    monkeypatch.setattr(docker_env.DockerEnvironment, "init_session", blocking_init)
+    created = []
+    failures = []
+
+    def construct():
+        try:
+            created.append(docker_env.DockerEnvironment(
+                image="python:3.12-slim",
+                cwd="/workspace",
+                persistent_filesystem=True,
+                persist_across_processes=True,
+                storage_task_id="profile-target-storage",
+                task_id="runtime",
+            ))
+        except Exception as exc:
+            failures.append(exc)
+
+    first = threading.Thread(target=construct)
+    second = threading.Thread(target=construct)
+    first.start()
+    assert first_init_started.wait(timeout=5)
+    second.start()
+
+    assert not second_init_started.wait(timeout=0.2)
+    assert second.is_alive()
+
+    release_first_init.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert failures == []
+    assert second_init_started.is_set()
+    assert len(created) == 2
+    for env in created:
+        env.cleanup()

--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -6,6 +6,8 @@ expose it, so operators could not request networkless Docker execution from
 config.yaml.
 """
 
+import pytest
+
 import tools.terminal_tool as terminal_tool
 from tools.environments import docker as docker_env
 
@@ -47,7 +49,9 @@ def test_sibling_container_config_sites_carry_docker_network():
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 
-def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
+def _reuse_guard_harness(
+    monkeypatch, *, existing_mode: str | None, network: bool,
+):
     """Drive DockerEnvironment through the cross-process reuse path with a
     fake existing container whose NetworkMode is *existing_mode*.
 
@@ -69,7 +73,11 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
             # missing label as "<no value>".
             Result.stdout = "existing-container-id\trunning\t<no value>\n"
         elif len(cmd) > 1 and cmd[1] == "inspect":
-            Result.stdout = f"{existing_mode}\n"
+            if existing_mode is None:
+                Result.returncode = 1
+                Result.stderr = "temporary inspect failure"
+            else:
+                Result.stdout = f"{existing_mode}\n"
         elif len(cmd) > 1 and cmd[1] == "run":
             Result.stdout = "fresh-container-id\n"
         return Result()
@@ -97,6 +105,41 @@ def test_reuse_rejects_networked_container_when_lockdown_requested(monkeypatch):
     )
     run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
     assert "--network=none" in run_cmd
+
+
+def test_reuse_network_mismatch_refuses_to_remove_leased_container(monkeypatch):
+    monkeypatch.setattr(
+        docker_env,
+        "_acquire_exclusive_container_lease",
+        lambda container_id, lease_root=None: None,
+    )
+
+    with pytest.raises(RuntimeError, match="still used.*refusing removal"):
+        _reuse_guard_harness(
+            monkeypatch, existing_mode="bridge", network=False,
+        )
+
+
+def test_reuse_inspect_failure_fails_closed_without_removal(monkeypatch):
+    removal_attempted = False
+
+    def fail_if_removal_attempted(_self, container_id):
+        nonlocal removal_attempted
+        removal_attempted = True
+        raise AssertionError(container_id)
+
+    monkeypatch.setattr(
+        docker_env.DockerEnvironment,
+        "_retire_network_mismatched_container",
+        fail_if_removal_attempted,
+    )
+
+    with pytest.raises(RuntimeError, match="Could not verify NetworkMode"):
+        _reuse_guard_harness(
+            monkeypatch, existing_mode=None, network=False,
+        )
+
+    assert removal_attempted is False
 
 
 def test_reuse_keeps_airgapped_container_when_lockdown_requested(monkeypatch):

--- a/tests/tools/test_docker_orphan_reaper_integration.py
+++ b/tests/tools/test_docker_orphan_reaper_integration.py
@@ -11,6 +11,7 @@ opt-out would silently do nothing.
 """
 
 import os
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import tools.terminal_tool as terminal_tool
@@ -42,6 +43,34 @@ def test_maybe_reap_runs_once_per_process(monkeypatch):
     assert call_count["reap"] == 1, (
         f"reaper must run exactly once per process; got {call_count['reap']} calls"
     )
+
+
+def test_named_targets_use_longest_docker_lifetime(monkeypatch):
+    _reset_reaper_gate()
+    captured_args = {}
+
+    monkeypatch.setattr(
+        "tools.execution_targets.list_execution_targets",
+        lambda: (
+            SimpleNamespace(
+                named=True, backend="docker", config={"lifetime_seconds": 60},
+            ),
+            SimpleNamespace(
+                named=True, backend="docker", config={"lifetime_seconds": 900},
+            ),
+        ),
+    )
+
+    with patch(
+        "tools.environments.docker.reap_orphan_containers",
+        lambda **kwargs: captured_args.update(kwargs) or 0,
+    ):
+        terminal_tool._maybe_reap_docker_orphans({
+            "docker_orphan_reaper": True,
+            "lifetime_seconds": 60,
+        })
+
+    assert captured_args["max_age_seconds"] == 1800
 
 
 def test_maybe_reap_passes_current_profile_as_filter(monkeypatch):

--- a/tests/tools/test_execution_targets.py
+++ b/tests/tools/test_execution_targets.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from contextvars import Context
+
+import pytest
+
+from tools.execution_targets import (
+    ExecutionTargetError,
+    list_execution_targets,
+    resolve_execution_target,
+    set_execution_target_config_source,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_execution_target_config_source():
+    try:
+        yield
+    finally:
+        set_execution_target_config_source(None)
+
+
+def _root(terminal: dict) -> dict:
+    return {"terminal": terminal}
+
+
+def test_legacy_omitted_and_default_select_the_flat_environment():
+    config = _root({"backend": "ssh", "ssh_host": "host", "ssh_user": "user"})
+
+    omitted = resolve_execution_target(config=config)
+    explicit = resolve_execution_target("default", config=config)
+
+    assert omitted.target == explicit.target == "default"
+    assert omitted.backend == explicit.backend == "ssh"
+    assert omitted.named is explicit.named is False
+    assert omitted.config["ssh_host"] == "host"
+
+
+def test_legacy_backend_metadata_respects_terminal_env_override(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    resolution = resolve_execution_target(
+        config=_root({
+            "backend": "ssh",
+            "ssh_host": "configured-but-overridden",
+            "ssh_user": "agent",
+        }),
+    )
+
+    assert resolution.named is False
+    assert resolution.target == "default"
+    assert resolution.backend == "local"
+
+
+def test_legacy_unknown_target_is_actionable():
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("devbox", config=_root({"backend": "local"}))
+
+    message = str(excinfo.value)
+    assert "devbox" in message
+    assert "Available targets: 'default'" in message
+
+
+def test_named_default_and_explicit_target_inherit_top_level_and_override():
+    config = _root({
+        "backend": "local",
+        "timeout": 180,
+        "container_memory": 4096,
+        "default_target": "local",
+        "targets": {
+            "local": {"cwd": "/workspace/local"},
+            "devbox": {
+                "backend": "ssh",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "bruno",
+                "cwd": "/home/bruno/project",
+                "timeout": 45,
+            },
+        },
+    })
+
+    default = resolve_execution_target(config=config)
+    devbox = resolve_execution_target("devbox", config=config)
+
+    assert default.target == "local"
+    assert default.backend == "local"
+    assert default.is_default is True
+    assert default.config["timeout"] == 180
+    assert devbox.target == "devbox"
+    assert devbox.backend == "ssh"
+    assert devbox.is_default is False
+    assert devbox.config["timeout"] == 45
+    assert devbox.config["container_memory"] == 4096
+    assert devbox.config["ssh_host"] == "devbox.example.com"
+    assert "targets" not in devbox.config
+    assert "default_target" not in devbox.config
+
+    inventory = list_execution_targets(config=config)
+    assert [(item.target, item.is_default) for item in inventory] == [
+        ("devbox", False),
+        ("local", True),
+    ]
+
+
+@pytest.mark.parametrize("default_target", [None, "", "missing"])
+def test_named_targets_require_a_valid_default(default_target):
+    terminal = {
+        "backend": "local",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    }
+    if default_target is not None:
+        terminal["default_target"] = default_target
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root(terminal))
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+def test_unknown_named_target_lists_names_deterministically():
+    config = _root({
+        "default_target": "zeta",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    })
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("other", config=config)
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("targets", "expected"),
+    [
+        ({"dev": "ssh"}, "must be a mapping"),
+        ({"": {"backend": "local"}}, "non-empty strings"),
+        ({1: {"backend": "local"}}, "non-empty strings"),
+    ],
+)
+def test_malformed_target_entries_are_clear(targets, expected):
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root({"default_target": "dev", "targets": targets}))
+
+    assert expected in str(excinfo.value)
+
+
+def test_named_target_rejects_unknown_backend():
+    config = _root({
+        "default_target": "dev",
+        "targets": {"dev": {"backend": "telepathy"}},
+    })
+    with pytest.raises(ExecutionTargetError, match="unknown backend 'telepathy'"):
+        resolve_execution_target(config=config)
+
+
+def test_named_target_accepts_current_vercel_sandbox_backend():
+    resolution = resolve_execution_target(config=_root({
+        "default_target": "cloud",
+        "targets": {
+            "cloud": {
+                "backend": "vercel_sandbox",
+                "vercel_runtime": "python3.13",
+                "cwd": "/vercel/sandbox",
+            },
+        },
+    }))
+
+    assert resolution.named is True
+    assert resolution.backend == "vercel_sandbox"
+    assert resolution.config["vercel_runtime"] == "python3.13"
+
+
+@pytest.mark.parametrize(
+    ("setting", "value", "expected"),
+    [
+        ("docker_network", "definitely", "expected boolean"),
+        ("docker_forward_env", {"HOME": True}, "expected list"),
+        ("docker_env", ["NOT_A_MAPPING"], "expected mapping"),
+    ],
+)
+def test_named_target_rejects_malformed_backend_settings(setting, value, expected):
+    config = _root({
+        "default_target": "dev",
+        "targets": {
+            "dev": {"backend": "docker", setting: value},
+        },
+    })
+    with pytest.raises(ExecutionTargetError, match=expected):
+        resolve_execution_target(config=config)
+
+
+def test_target_names_are_otherwise_arbitrary_static_strings():
+    resolution = resolve_execution_target(
+        "prod blue/1",
+        config=_root({
+            "default_target": "prod blue/1",
+            "targets": {"prod blue/1": {"backend": "local"}},
+        }),
+    )
+
+    assert resolution.target == "prod blue/1"
+
+
+def test_tool_schemas_use_static_optional_string_target_fields():
+    from tools.code_execution_tool import EXECUTE_CODE_SCHEMA
+    from tools.file_tools import (
+        PATCH_SCHEMA,
+        READ_FILE_SCHEMA,
+        SEARCH_FILES_SCHEMA,
+        WRITE_FILE_SCHEMA,
+    )
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    for schema in (
+        TERMINAL_SCHEMA,
+        READ_FILE_SCHEMA,
+        WRITE_FILE_SCHEMA,
+        PATCH_SCHEMA,
+        EXECUTE_CODE_SCHEMA,
+    ):
+        target = schema["parameters"]["properties"]["target"]
+        assert target["type"] == "string"
+        assert "enum" not in target
+        assert "target" not in schema["parameters"].get("required", [])
+
+    search_properties = SEARCH_FILES_SCHEMA["parameters"]["properties"]
+    assert search_properties["target"]["enum"] == ["content", "files"]
+    assert search_properties["execution_target"]["type"] == "string"
+    assert "enum" not in search_properties["execution_target"]
+    assert "compatibility" in SEARCH_FILES_SCHEMA["description"].lower()
+
+
+def test_successful_terminal_result_reports_target_backend_and_cwd(monkeypatch, tmp_path):
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local", "cwd": str(tmp_path)}},
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+
+    assert result["exit_code"] == 0
+    assert result["target"] == "local"
+    assert result["backend"] == "local"
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_multiplex_profiles_do_not_share_environment_or_session_keys(monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {
+            "backend": "ssh",
+            "ssh_host": "example.invalid",
+            "ssh_user": "agent",
+        }},
+    })
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_a = resolve_execution_target("devbox", config=config)
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-b")
+    profile_b = resolve_execution_target("devbox", config=config)
+
+    assert profile_a.environment_key("default") != profile_b.environment_key("default")
+    assert profile_a.session_key("chat") != profile_b.session_key("chat")
+
+
+def test_target_spec_fingerprint_changes_with_security_relevant_config():
+    base = _root({
+        "default_target": "devbox",
+        "targets": {
+            "devbox": {
+                "backend": "ssh",
+                "ssh_host": "one.example",
+                "ssh_user": "agent",
+            },
+        },
+    })
+    changed = json.loads(json.dumps(base))
+    changed["terminal"]["targets"]["devbox"]["ssh_host"] = "two.example"
+
+    first = resolve_execution_target(config=base)
+    second = resolve_execution_target(config=changed)
+
+    assert first.spec_fingerprint != second.spec_fingerprint
+    assert first.security_scope != second.security_scope
+    assert first.environment_key("session") == second.environment_key("session")
+
+
+def test_target_fingerprint_is_keyed_when_config_contains_secrets(
+    monkeypatch, tmp_path,
+):
+    import hermes_constants
+    import tools.execution_targets as targets_mod
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    targets_mod._fingerprint_keys.clear()
+    resolution = resolve_execution_target(
+        "alpha",
+        config=_root({
+            "targets": {
+                "alpha": {
+                    "backend": "local",
+                    "sudo_password": "guessable-secret",
+                },
+            },
+        }),
+    )
+    canonical = json.dumps(
+        {
+            "config": dict(resolution.config),
+            "is_default": resolution.is_default,
+        },
+        sort_keys=True, separators=(",", ":"),
+        ensure_ascii=True, default=repr,
+    )
+    plain = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:20]
+
+    assert resolution.spec_fingerprint != plain
+    key_path = tmp_path / ".execution-target-fingerprint-key"
+    assert key_path.stat().st_mode & 0o077 == 0
+
+
+def test_default_status_changes_runtime_and_approval_identity():
+    targets = {
+        "alpha": {"backend": "local", "cwd": "/workspace"},
+        "beta": {"backend": "local", "cwd": "/workspace"},
+    }
+    alpha_default = resolve_execution_target(
+        "alpha", config=_root({"default_target": "alpha", "targets": targets}),
+    )
+    beta_default = resolve_execution_target(
+        "alpha", config=_root({"default_target": "beta", "targets": targets}),
+    )
+
+    assert alpha_default.is_default is True
+    assert beta_default.is_default is False
+    assert alpha_default.spec_fingerprint != beta_default.spec_fingerprint
+    assert alpha_default.security_scope != beta_default.security_scope
+
+
+def test_backend_task_id_is_bounded_and_collision_resistant_for_named_targets():
+    config = _root({
+        "default_target": "alpha",
+        "targets": {
+            "alpha": {"backend": "docker", "docker_image": "image:a"},
+            "beta": {"backend": "docker", "docker_image": "image:b"},
+        },
+    })
+    task_id = "benchmark-" + ("x" * 500)
+    alpha = resolve_execution_target("alpha", config=config).backend_task_id(task_id)
+    beta = resolve_execution_target("beta", config=config).backend_task_id(task_id)
+
+    assert len(alpha) <= 63
+    assert len(beta) <= 63
+    assert alpha != beta
+    assert alpha.startswith("task-") and "-target-" in alpha
+
+
+def test_persistent_storage_id_survives_policy_edits_but_not_owner_changes(
+    monkeypatch, tmp_path,
+):
+    import hermes_constants
+    import tools.execution_targets as targets_mod
+
+    base = _root({
+        "default_target": "alpha",
+        "timeout": 30,
+        "targets": {
+            "alpha": {"backend": "docker", "docker_image": "image:a"},
+            "beta": {"backend": "docker", "docker_image": "image:a"},
+        },
+    })
+    changed = json.loads(json.dumps(base))
+    changed["terminal"]["timeout"] = 90
+    changed["terminal"]["targets"]["alpha"]["docker_image"] = "image:b"
+
+    first = resolve_execution_target("alpha", config=base)
+    edited = resolve_execution_target("alpha", config=changed)
+    beta = resolve_execution_target("beta", config=base)
+
+    assert first.backend_task_id("session") != edited.backend_task_id("session")
+    assert first.storage_task_id("session") == edited.storage_task_id("session")
+    assert first.storage_task_id("session") != beta.storage_task_id("session")
+    assert len(first.storage_task_id("x" * 500)) <= 63
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path / "a")
+    home_a = first.storage_task_id("session")
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path / "b")
+    assert home_a != first.storage_task_id("session")
+
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "other-profile")
+    other_profile = resolve_execution_target("alpha", config=base)
+    assert first.storage_task_id("session") != other_profile.storage_task_id("session")
+
+
+def test_legacy_identity_does_not_require_fingerprint_key(monkeypatch):
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    resolution = resolve_execution_target(
+        config={"terminal": {"backend": "local", "cwd": "."}},
+    )
+    monkeypatch.setattr(
+        targets_mod,
+        "_target_fingerprint_key",
+        lambda: (_ for _ in ()).throw(PermissionError("read-only home")),
+    )
+
+    env = SimpleNamespace()
+    terminal_mod._record_environment_target(env, resolution)
+    assert resolution.backend_task_id("session") == "session"
+    assert resolution.metadata() == {"target": "default", "backend": "local"}
+    assert env._hermes_target_scope is None
+
+
+def test_classic_cli_config_override_is_context_scoped():
+    ssh_config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {
+            "backend": "ssh",
+            "ssh_host": "example.invalid",
+            "ssh_user": "agent",
+        }},
+    })
+    local_config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local"}},
+    })
+
+    def configure_and_resolve(config):
+        set_execution_target_config_source(config)
+        return resolve_execution_target().backend
+
+    assert Context().run(configure_and_resolve, ssh_config) == "ssh"
+    assert Context().run(configure_and_resolve, local_config) == "local"
+
+    import threading
+
+    set_execution_target_config_source(ssh_config)
+    observed = []
+    thread = threading.Thread(
+        target=lambda: observed.append(resolve_execution_target().backend),
+    )
+    thread.start()
+    thread.join(timeout=5)
+    assert observed == ["ssh"]
+
+
+def test_unknown_target_setting_fails_with_target_name_and_suggestion():
+    config = _root({
+        "targets": {
+            "sandbox": {
+                "backend": "docker",
+                "docker_netwrok": "host",
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'sandbox'.*docker_netwrok.*docker_network",
+    ):
+        resolve_execution_target("sandbox", config=config)
+
+
+def test_backend_inapplicable_target_setting_fails_before_environment_creation():
+    config = _root({
+        "targets": {
+            "workstation": {
+                "backend": "local",
+                "ssh_host": "example.invalid",
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'workstation'.*ssh_host.*does not apply.*local",
+    ):
+        resolve_execution_target("workstation", config=config)
+
+
+def test_missing_required_ssh_fields_and_invalid_port_fail_in_resolver():
+    missing = _root({
+        "targets": {"remote": {"backend": "ssh", "ssh_user": "agent"}},
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'remote'.*requires non-empty 'ssh_host'",
+    ):
+        resolve_execution_target("remote", config=missing)
+
+    invalid_port = _root({
+        "targets": {
+            "remote": {
+                "backend": "ssh",
+                "ssh_host": "example.invalid",
+                "ssh_user": "agent",
+                "ssh_port": 70000,
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'remote'.*ssh_port.*1 to 65535",
+    ):
+        resolve_execution_target("remote", config=invalid_port)

--- a/tests/tools/test_execution_targets.py
+++ b/tests/tools/test_execution_targets.py
@@ -1,0 +1,553 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from types import SimpleNamespace
+from contextvars import Context
+
+import pytest
+
+from tools.execution_targets import (
+    ExecutionTargetError,
+    list_execution_targets,
+    resolve_execution_target,
+    set_execution_target_config_source,
+    validate_execution_target_args,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_execution_target_config_source():
+    try:
+        yield
+    finally:
+        set_execution_target_config_source(None)
+
+
+def _root(terminal: dict) -> dict:
+    return {"terminal": terminal}
+
+
+def test_legacy_omitted_and_default_select_the_flat_environment():
+    config = _root({"backend": "ssh", "ssh_host": "host", "ssh_user": "user"})
+
+    omitted = resolve_execution_target(config=config)
+    explicit = resolve_execution_target("default", config=config)
+
+    assert omitted.target == explicit.target == "default"
+    assert omitted.backend == explicit.backend == "ssh"
+    assert omitted.named is explicit.named is False
+    assert omitted.config["ssh_host"] == "host"
+
+
+def test_execution_routing_accepts_only_execution_target():
+    with pytest.raises(ExecutionTargetError, match="does not accept 'target'"):
+        validate_execution_target_args("terminal", {"target": "alpha"})
+    with pytest.raises(ExecutionTargetError, match="does not accept 'target'"):
+        validate_execution_target_args(
+            "write_file", {"execution_target": "alpha", "target": "alpha"},
+        )
+
+    validate_execution_target_args(
+        "search_files", {"target": "files", "execution_target": "alpha"},
+    )
+
+
+def test_legacy_backend_metadata_respects_terminal_env_override(monkeypatch):
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+
+    resolution = resolve_execution_target(
+        config=_root({
+            "backend": "ssh",
+            "ssh_host": "configured-but-overridden",
+            "ssh_user": "agent",
+        }),
+    )
+
+    assert resolution.named is False
+    assert resolution.target == "default"
+    assert resolution.backend == "local"
+
+
+def test_legacy_unknown_target_is_actionable():
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("devbox", config=_root({"backend": "local"}))
+
+    message = str(excinfo.value)
+    assert "devbox" in message
+    assert "Available targets: 'default'" in message
+
+
+def test_named_default_and_explicit_target_inherit_top_level_and_override():
+    config = _root({
+        "backend": "local",
+        "timeout": 180,
+        "container_memory": 4096,
+        "default_target": "local",
+        "targets": {
+            "local": {"cwd": "/workspace/local"},
+            "devbox": {
+                "backend": "ssh",
+                "ssh_host": "devbox.example.com",
+                "ssh_user": "bruno",
+                "cwd": "/home/bruno/project",
+                "timeout": 45,
+            },
+        },
+    })
+
+    default = resolve_execution_target(config=config)
+    devbox = resolve_execution_target("devbox", config=config)
+
+    assert default.target == "local"
+    assert default.backend == "local"
+    assert default.is_default is True
+    assert default.config["timeout"] == 180
+    assert devbox.target == "devbox"
+    assert devbox.backend == "ssh"
+    assert devbox.is_default is False
+    assert devbox.config["timeout"] == 45
+    assert devbox.config["container_memory"] == 4096
+    assert devbox.config["ssh_host"] == "devbox.example.com"
+    assert "targets" not in devbox.config
+    assert "default_target" not in devbox.config
+
+    inventory = list_execution_targets(config=config)
+    assert [(item.target, item.is_default) for item in inventory] == [
+        ("devbox", False),
+        ("local", True),
+    ]
+
+
+@pytest.mark.parametrize("default_target", [None, "", "missing"])
+def test_named_targets_require_a_valid_default(default_target):
+    terminal = {
+        "backend": "local",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    }
+    if default_target is not None:
+        terminal["default_target"] = default_target
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root(terminal))
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+def test_unknown_named_target_lists_names_deterministically():
+    config = _root({
+        "default_target": "zeta",
+        "targets": {"zeta": {"backend": "local"}, "alpha": {"backend": "local"}},
+    })
+
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target("other", config=config)
+
+    assert "Available targets: 'alpha', 'zeta'" in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("targets", "expected"),
+    [
+        ({"dev": "ssh"}, "must be a mapping"),
+        ({"": {"backend": "local"}}, "non-empty strings"),
+        ({1: {"backend": "local"}}, "non-empty strings"),
+    ],
+)
+def test_malformed_target_entries_are_clear(targets, expected):
+    with pytest.raises(ExecutionTargetError) as excinfo:
+        resolve_execution_target(config=_root({"default_target": "dev", "targets": targets}))
+
+    assert expected in str(excinfo.value)
+
+
+def test_named_target_rejects_unknown_backend():
+    config = _root({
+        "default_target": "dev",
+        "targets": {"dev": {"backend": "telepathy"}},
+    })
+    with pytest.raises(ExecutionTargetError, match="unknown backend 'telepathy'"):
+        resolve_execution_target(config=config)
+
+
+@pytest.mark.parametrize("backend", [None, "", False, 0, [], {}])
+def test_named_target_rejects_falsey_malformed_backend(backend):
+    config = _root({
+        "default_target": "dev",
+        "targets": {"dev": {"backend": backend}},
+    })
+
+    with pytest.raises(
+        ExecutionTargetError,
+        match="setting 'backend'.*expected a non-empty string",
+    ):
+        resolve_execution_target(config=config)
+
+
+def test_named_target_accepts_current_vercel_sandbox_backend():
+    resolution = resolve_execution_target(config=_root({
+        "default_target": "cloud",
+        "targets": {
+            "cloud": {
+                "backend": "vercel_sandbox",
+                "vercel_runtime": "python3.13",
+                "cwd": "/vercel/sandbox",
+            },
+        },
+    }))
+
+    assert resolution.named is True
+    assert resolution.backend == "vercel_sandbox"
+    assert resolution.config["vercel_runtime"] == "python3.13"
+
+
+@pytest.mark.parametrize(
+    ("setting", "value", "expected"),
+    [
+        ("docker_network", "definitely", "expected boolean"),
+        ("docker_forward_env", {"HOME": True}, "expected list"),
+        ("docker_env", ["NOT_A_MAPPING"], "expected mapping"),
+    ],
+)
+def test_named_target_rejects_malformed_backend_settings(setting, value, expected):
+    config = _root({
+        "default_target": "dev",
+        "targets": {
+            "dev": {"backend": "docker", setting: value},
+        },
+    })
+    with pytest.raises(ExecutionTargetError, match=expected):
+        resolve_execution_target(config=config)
+
+
+def test_target_names_are_otherwise_arbitrary_static_strings():
+    resolution = resolve_execution_target(
+        "prod blue/1",
+        config=_root({
+            "default_target": "prod blue/1",
+            "targets": {"prod blue/1": {"backend": "local"}},
+        }),
+    )
+
+    assert resolution.target == "prod blue/1"
+
+
+def test_tool_schemas_use_static_optional_execution_target_fields():
+    from tools.code_execution_tool import EXECUTE_CODE_SCHEMA
+    from tools.file_tools import (
+        PATCH_SCHEMA,
+        READ_FILE_SCHEMA,
+        SEARCH_FILES_SCHEMA,
+        WRITE_FILE_SCHEMA,
+    )
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    for schema in (
+        TERMINAL_SCHEMA,
+        READ_FILE_SCHEMA,
+        WRITE_FILE_SCHEMA,
+        PATCH_SCHEMA,
+        EXECUTE_CODE_SCHEMA,
+    ):
+        target = schema["parameters"]["properties"]["execution_target"]
+        assert target["type"] == "string"
+        assert "enum" not in target
+        assert "target" not in schema["parameters"]["properties"]
+        assert "execution_target" not in schema["parameters"].get("required", [])
+
+    search_properties = SEARCH_FILES_SCHEMA["parameters"]["properties"]
+    assert search_properties["target"]["enum"] == ["content", "files"]
+    assert search_properties["execution_target"]["type"] == "string"
+    assert "enum" not in search_properties["execution_target"]
+    description = SEARCH_FILES_SCHEMA["description"].lower()
+    assert "target field selects search mode" in description
+    assert "execution_target separately selects" in description
+
+
+def test_successful_terminal_result_reports_target_backend_and_cwd(monkeypatch, tmp_path):
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local", "cwd": str(tmp_path)}},
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+
+    assert result["exit_code"] == 0
+    assert result["target"] == "local"
+    assert result["backend"] == "local"
+    assert result["cwd"] == str(tmp_path)
+
+
+def test_multiplex_profiles_do_not_share_environment_or_session_keys(monkeypatch):
+    import tools.execution_targets as targets_mod
+
+    config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {
+            "backend": "ssh",
+            "ssh_host": "example.invalid",
+            "ssh_user": "agent",
+        }},
+    })
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_a = resolve_execution_target("devbox", config=config)
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-b")
+    profile_b = resolve_execution_target("devbox", config=config)
+
+    assert profile_a.environment_key("default") != profile_b.environment_key("default")
+    assert profile_a.session_key("chat") != profile_b.session_key("chat")
+
+
+def test_target_spec_fingerprint_changes_with_security_relevant_config():
+    base = _root({
+        "default_target": "devbox",
+        "targets": {
+            "devbox": {
+                "backend": "ssh",
+                "ssh_host": "one.example",
+                "ssh_user": "agent",
+            },
+        },
+    })
+    changed = json.loads(json.dumps(base))
+    changed["terminal"]["targets"]["devbox"]["ssh_host"] = "two.example"
+
+    first = resolve_execution_target(config=base)
+    second = resolve_execution_target(config=changed)
+
+    assert first.spec_fingerprint != second.spec_fingerprint
+    assert first.security_scope != second.security_scope
+    assert first.environment_key("session") == second.environment_key("session")
+
+
+def test_target_fingerprint_is_keyed_when_config_contains_secrets(
+    monkeypatch, tmp_path,
+):
+    import hermes_constants
+    import tools.execution_targets as targets_mod
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    targets_mod._fingerprint_keys.clear()
+    resolution = resolve_execution_target(
+        "alpha",
+        config=_root({
+            "targets": {
+                "alpha": {
+                    "backend": "local",
+                    "sudo_password": "guessable-secret",
+                },
+            },
+        }),
+    )
+    canonical = json.dumps(
+        {
+            "config": dict(resolution.config),
+            "is_default": resolution.is_default,
+        },
+        sort_keys=True, separators=(",", ":"),
+        ensure_ascii=True, default=repr,
+    )
+    plain = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:20]
+
+    assert resolution.spec_fingerprint != plain
+    key_path = tmp_path / ".execution-target-fingerprint-key"
+    assert key_path.stat().st_mode & 0o077 == 0
+
+
+def test_default_status_changes_runtime_and_approval_identity():
+    targets = {
+        "alpha": {"backend": "local", "cwd": "/workspace"},
+        "beta": {"backend": "local", "cwd": "/workspace"},
+    }
+    alpha_default = resolve_execution_target(
+        "alpha", config=_root({"default_target": "alpha", "targets": targets}),
+    )
+    beta_default = resolve_execution_target(
+        "alpha", config=_root({"default_target": "beta", "targets": targets}),
+    )
+
+    assert alpha_default.is_default is True
+    assert beta_default.is_default is False
+    assert alpha_default.spec_fingerprint != beta_default.spec_fingerprint
+    assert alpha_default.security_scope != beta_default.security_scope
+
+
+def test_backend_task_id_is_bounded_and_collision_resistant_for_named_targets():
+    config = _root({
+        "default_target": "alpha",
+        "targets": {
+            "alpha": {"backend": "docker", "docker_image": "image:a"},
+            "beta": {"backend": "docker", "docker_image": "image:b"},
+        },
+    })
+    task_id = "benchmark-" + ("x" * 500)
+    alpha = resolve_execution_target("alpha", config=config).backend_task_id(task_id)
+    beta = resolve_execution_target("beta", config=config).backend_task_id(task_id)
+
+    assert len(alpha) <= 63
+    assert len(beta) <= 63
+    assert alpha != beta
+    assert alpha.startswith("task-") and "-target-" in alpha
+
+
+def test_persistent_storage_id_survives_policy_edits_but_not_owner_changes(
+    monkeypatch, tmp_path,
+):
+    import hermes_constants
+    import tools.execution_targets as targets_mod
+
+    base = _root({
+        "default_target": "alpha",
+        "timeout": 30,
+        "targets": {
+            "alpha": {"backend": "docker", "docker_image": "image:a"},
+            "beta": {"backend": "docker", "docker_image": "image:a"},
+        },
+    })
+    changed = json.loads(json.dumps(base))
+    changed["terminal"]["timeout"] = 90
+    changed["terminal"]["targets"]["alpha"]["docker_image"] = "image:b"
+
+    first = resolve_execution_target("alpha", config=base)
+    edited = resolve_execution_target("alpha", config=changed)
+    beta = resolve_execution_target("beta", config=base)
+
+    assert first.backend_task_id("session") != edited.backend_task_id("session")
+    assert first.storage_task_id("session") == edited.storage_task_id("session")
+    assert first.storage_task_id("session") != beta.storage_task_id("session")
+    assert len(first.storage_task_id("x" * 500)) <= 63
+
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path / "a")
+    home_a = first.storage_task_id("session")
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path / "b")
+    assert home_a != first.storage_task_id("session")
+
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "other-profile")
+    other_profile = resolve_execution_target("alpha", config=base)
+    assert first.storage_task_id("session") != other_profile.storage_task_id("session")
+
+
+def test_legacy_identity_does_not_require_fingerprint_key(monkeypatch):
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    resolution = resolve_execution_target(
+        config={"terminal": {"backend": "local", "cwd": "."}},
+    )
+    monkeypatch.setattr(
+        targets_mod,
+        "_target_fingerprint_key",
+        lambda: (_ for _ in ()).throw(PermissionError("read-only home")),
+    )
+
+    env = SimpleNamespace()
+    terminal_mod._record_environment_target(env, resolution)
+    assert resolution.backend_task_id("session") == "session"
+    assert resolution.metadata() == {"target": "default", "backend": "local"}
+    assert env._hermes_target_scope is None
+
+
+def test_classic_cli_config_override_is_context_scoped():
+    ssh_config = _root({
+        "default_target": "devbox",
+        "targets": {"devbox": {
+            "backend": "ssh",
+            "ssh_host": "example.invalid",
+            "ssh_user": "agent",
+        }},
+    })
+    local_config = _root({
+        "default_target": "local",
+        "targets": {"local": {"backend": "local"}},
+    })
+
+    def configure_and_resolve(config):
+        set_execution_target_config_source(config)
+        return resolve_execution_target().backend
+
+    assert Context().run(configure_and_resolve, ssh_config) == "ssh"
+    assert Context().run(configure_and_resolve, local_config) == "local"
+
+    import threading
+
+    set_execution_target_config_source(ssh_config)
+    observed = []
+    thread = threading.Thread(
+        target=lambda: observed.append(resolve_execution_target().backend),
+    )
+    thread.start()
+    thread.join(timeout=5)
+    assert observed == ["ssh"]
+
+
+def test_unknown_target_setting_fails_with_target_name_and_suggestion():
+    config = _root({
+        "targets": {
+            "sandbox": {
+                "backend": "docker",
+                "docker_netwrok": "host",
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'sandbox'.*docker_netwrok.*docker_network",
+    ):
+        resolve_execution_target("sandbox", config=config)
+
+
+def test_backend_inapplicable_target_setting_fails_before_environment_creation():
+    config = _root({
+        "targets": {
+            "workstation": {
+                "backend": "local",
+                "ssh_host": "example.invalid",
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'workstation'.*ssh_host.*does not apply.*local",
+    ):
+        resolve_execution_target("workstation", config=config)
+
+
+def test_missing_required_ssh_fields_and_invalid_port_fail_in_resolver():
+    missing = _root({
+        "targets": {"remote": {"backend": "ssh", "ssh_user": "agent"}},
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'remote'.*requires non-empty 'ssh_host'",
+    ):
+        resolve_execution_target("remote", config=missing)
+
+    invalid_port = _root({
+        "targets": {
+            "remote": {
+                "backend": "ssh",
+                "ssh_host": "example.invalid",
+                "ssh_user": "agent",
+                "ssh_port": 70000,
+            },
+        },
+    })
+    with pytest.raises(
+        ExecutionTargetError,
+        match="target 'remote'.*ssh_port.*1 to 65535",
+    ):
+        resolve_execution_target("remote", config=invalid_port)

--- a/tests/tools/test_file_cwd.py
+++ b/tests/tools/test_file_cwd.py
@@ -1,0 +1,37 @@
+import json
+from types import SimpleNamespace
+
+
+def test_patch_tool_cache_clear_receives_task_id(monkeypatch, tmp_path):
+    import tools.file_tools as file_mod
+    import tools.execution_targets as targets_mod
+
+    targets_mod.set_execution_target_config_source({"terminal": {"backend": "local"}})
+    path = tmp_path / "sample.txt"
+    path.write_text("before")
+    observed = []
+
+    class FakeFileOps:
+        def patch_replace(self, resolved_path, old_string, new_string, replace_all):
+            assert resolved_path == str(path)
+            assert (old_string, new_string, replace_all) == ("before", "after", False)
+            return SimpleNamespace(to_dict=lambda: {"output": "Done!"})
+
+    def legacy_cache_getter(task_id):
+        observed.append(task_id)
+        return FakeFileOps()
+
+    monkeypatch.setattr(file_mod, "_get_file_ops", legacy_cache_getter)
+
+    result = file_mod.patch_tool(
+        path=str(path),
+        old_string="before",
+        new_string="after",
+        task_id="legacy-task",
+    )
+
+    if isinstance(result, str):
+        result = json.loads(result)
+    assert not result.get("error")
+    assert observed == ["legacy-task"]
+    targets_mod.set_execution_target_config_source(None)

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -71,6 +71,23 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         file_state.note_write("B", p)
         warn = file_state.check_stale("A", p)
         self.assertIsNotNone(warn)
+        assert isinstance(warn, str)
+        self.assertIn("B", warn)
+        self.assertIn("sibling", warn.lower())
+
+    def test_remote_write_records_without_host_stat(self):
+        remote_path = "/remote-only/project/file.txt"
+        namespace = "ssh:physical-host"
+        file_state.record_read(
+            "A", remote_path, namespace=namespace, stat_path=False,
+        )
+        time.sleep(0.01)
+        file_state.note_write(
+            "B", remote_path, namespace=namespace, stat_path=False,
+        )
+        warn = file_state.check_stale("A", remote_path, namespace=namespace)
+        self.assertIsNotNone(warn)
+        assert isinstance(warn, str)
         self.assertIn("B", warn)
         self.assertIn("sibling", warn.lower())
 
@@ -122,6 +139,45 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertTrue(b_entered.wait(timeout=3.0))
         ta.join(timeout=3.0)
         tb.join(timeout=3.0)
+
+    def test_delegate_state_aggregates_task_targets_without_cross_target_conflicts(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        file_state.record_read(("parent", "beta"), path, namespace="beta")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("child", "alpha"), path, namespace="alpha")
+
+        parent_reads = file_state.known_reads("parent")
+
+        self.assertIn(f"alpha\0{path}", parent_reads)
+        self.assertIn(f"beta\0{path}", parent_reads)
+        out = file_state.writes_since("parent", since, [f"alpha\0{path}"])
+        self.assertEqual(out, {"child": [path]})
+
+    def test_writes_since_excludes_all_scopes_of_raw_parent_task(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("parent", "alpha"), path, namespace="alpha")
+
+        out = file_state.writes_since(
+            "parent", since, file_state.known_reads("parent"),
+        )
+
+        self.assertEqual(out, {})
+
+    def test_remote_write_does_not_conflict_with_local_display_path(self):
+        path = "/same/path"
+        since = time.time()
+        file_state.note_write(
+            "child", path, namespace="ssh-scope", stat_path=False,
+        )
+
+        out = file_state.writes_since("parent", since, [path])
+
+        self.assertEqual(out, {})
 
 
     def test_kill_switch_env_var(self):

--- a/tests/tools/test_file_state_registry.py
+++ b/tests/tools/test_file_state_registry.py
@@ -71,6 +71,23 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         file_state.note_write("B", p)
         warn = file_state.check_stale("A", p)
         self.assertIsNotNone(warn)
+        assert isinstance(warn, str)
+        self.assertIn("B", warn)
+        self.assertIn("sibling", warn.lower())
+
+    def test_remote_write_records_without_host_stat(self):
+        remote_path = "/remote-only/project/file.txt"
+        namespace = "ssh:physical-host"
+        file_state.record_read(
+            "A", remote_path, namespace=namespace, stat_path=False,
+        )
+        time.sleep(0.01)
+        file_state.note_write(
+            "B", remote_path, namespace=namespace, stat_path=False,
+        )
+        warn = file_state.check_stale("A", remote_path, namespace=namespace)
+        self.assertIsNotNone(warn)
+        assert isinstance(warn, str)
         self.assertIn("B", warn)
         self.assertIn("sibling", warn.lower())
 
@@ -122,6 +139,34 @@ class FileStateRegistryUnitTests(unittest.TestCase):
         self.assertTrue(b_entered.wait(timeout=3.0))
         ta.join(timeout=3.0)
         tb.join(timeout=3.0)
+
+    def test_delegate_state_aggregates_task_targets_without_cross_target_conflicts(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        file_state.record_read(("parent", "beta"), path, namespace="beta")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("child", "alpha"), path, namespace="alpha")
+
+        parent_reads = file_state.known_reads("parent")
+
+        self.assertIn(f"alpha\0{path}", parent_reads)
+        self.assertIn(f"beta\0{path}", parent_reads)
+        out = file_state.writes_since("parent", since, [f"alpha\0{path}"])
+        self.assertEqual(out, {"child": [path]})
+
+    def test_writes_since_excludes_all_scopes_of_raw_parent_task(self):
+        path = self._mk()
+        file_state.record_read(("parent", "alpha"), path, namespace="alpha")
+        since = time.time()
+        time.sleep(0.01)
+        file_state.note_write(("parent", "alpha"), path, namespace="alpha")
+
+        out = file_state.writes_since(
+            "parent", since, file_state.known_reads("parent"),
+        )
+
+        self.assertEqual(out, {})
 
 
     def test_kill_switch_env_var(self):

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -319,7 +319,7 @@ class TestWindowsMsysPathResolution:
         ``C:\\Users\\...`` — faking ``sys.platform`` left PosixPath in place."""
         import tools.file_tools as file_tools
 
-        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default", execution_target=None, _resolution=None: False)
 
         resolved = file_tools._resolve_path_for_task("/c/Users/Mark/project/app.py")
         assert str(resolved) == r"C:\Users\Mark\project\app.py"
@@ -334,11 +334,11 @@ class TestWindowsMsysPathResolution:
         """
         import tools.file_tools as file_tools
 
-        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default", execution_target=None, _resolution=None: True)
         monkeypatch.setattr(
             file_tools,
             "_authoritative_workspace_root",
-            lambda task_id="default": "/home/don/project",
+            lambda task_id="default", execution_target=None, _resolution=None: "/home/don/project",
         )
 
         resolved = file_tools._resolve_path_for_task("/home/don/.env")

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -316,7 +316,7 @@ class TestWindowsMsysPathResolution:
 
         monkeypatch.setattr(file_tools.sys, "platform", "win32")
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
-        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": False)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default", execution_target=None, _resolution=None: False)
 
         resolved = file_tools._resolve_path_for_task("/c/Users/Mark/project/app.py")
         assert str(resolved) == r"C:\Users\Mark\project\app.py"
@@ -329,11 +329,11 @@ class TestWindowsMsysPathResolution:
 
         monkeypatch.setattr(file_tools.sys, "platform", "win32")
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
-        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default": True)
+        monkeypatch.setattr(file_tools, "_uses_container_paths", lambda task_id="default", execution_target=None, _resolution=None: True)
         monkeypatch.setattr(
             file_tools,
             "_authoritative_workspace_root",
-            lambda task_id="default": "/home/don/project",
+            lambda task_id="default", execution_target=None, _resolution=None: "/home/don/project",
         )
 
         resolved = file_tools._resolve_path_for_task("/home/don/.env")

--- a/tests/tools/test_named_execution_target_routing.py
+++ b/tests/tools/test_named_execution_target_routing.py
@@ -1,0 +1,2040 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+
+def _named_config(cwds: dict[str, str], default: str = "alpha") -> dict:
+    return {
+        "terminal": {
+            "timeout": 60,
+            "lifetime_seconds": 3600,
+            "default_target": default,
+            "targets": {
+                name: {"backend": "local", "cwd": cwd}
+                for name, cwd in cwds.items()
+            },
+        },
+    }
+
+
+@pytest.fixture
+def isolated_target_state(monkeypatch):
+    import tools.file_tools as file_mod
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    targets_mod.set_execution_target_config_source(None)
+
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd_specs", {})
+    monkeypatch.setattr(terminal_mod, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_mod, "_active_turn_counts", {})
+    monkeypatch.setattr(terminal_mod, "_deferred_environment_cleanups", {})
+    monkeypatch.setattr(terminal_mod, "_retired_environments", [])
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(file_mod, "_file_ops_cache", {})
+    monkeypatch.setattr(file_mod, "_read_tracker", {})
+    monkeypatch.setattr(file_mod, "_patch_failure_tracker", {})
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    yield terminal_mod, file_mod
+    targets_mod.set_execution_target_config_source(None)
+    for env in list(terminal_mod._active_environments.values()):
+        try:
+            env.cleanup()
+        except Exception:
+            pass
+
+
+def test_same_task_reuses_within_target_and_isolates_across_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    first = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a"))
+    second = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-b", target="alpha"))
+    third = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a", target="beta"))
+
+    assert first["output"] == second["output"] == str(alpha)
+    assert third["output"] == str(beta)
+    assert set(terminal_mod._active_environments) == {("default", "alpha"), ("default", "beta")}
+
+
+def test_config_change_replaces_environment_instead_of_relabeling_it(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {"backend": "local", "cwd": "/local/project"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+    executed_cwds = []
+    cleanup_calls = []
+    cleanup_waits = []
+
+    class FakeEnvironment:
+        def __init__(self, backend):
+            self.backend = backend
+            self._persistent = True
+            self.cwd = "/remote/project" if backend == "ssh" else "/local/project"
+
+        def execute(self, command, **kwargs):
+            executed_cwds.append(kwargs.get("cwd"))
+            return {"output": f"executed-on-{self.backend}\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            cleanup_calls.append((self.backend, force_remove, self._persistent))
+
+        def wait_for_cleanup(self, timeout):
+            cleanup_waits.append(timeout)
+            return True
+
+    def fake_create(**kwargs):
+        env = FakeEnvironment(kwargs["env_type"])
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    first = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+    first_file_ops = file_mod._get_file_ops("session", "devbox")
+    terminal_mod.record_session_cwd(
+        "session", "/local/old-working-tree", target="devbox",
+    )
+    config["terminal"]["targets"]["devbox"] = {
+        "backend": "ssh",
+        "cwd": "/remote/project",
+        "ssh_host": "devbox.example",
+        "ssh_user": "agent",
+    }
+    second = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+    second_file_ops = file_mod._get_file_ops("session", "devbox")
+
+    assert first["output"].strip() == "executed-on-local"
+    assert first["backend"] == "local"
+    assert second["output"].strip() == "executed-on-ssh"
+    assert second["backend"] == "ssh"
+    assert [env.backend for env in created] == ["local", "ssh"]
+    assert first_file_ops.env is created[0]
+    assert second_file_ops.env is created[1]
+    assert executed_cwds == ["/local/project", "/remote/project"]
+    assert len(terminal_mod._retired_environments) == 1
+    assert terminal_mod._retired_environments[0][1] is created[0]
+    assert terminal_mod._cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=False,
+    ) == 1
+    assert cleanup_calls == [("local", True, False)]
+    assert cleanup_waits == [60.0]
+    assert terminal_mod._retired_environments == []
+
+
+def test_persistent_storage_replacement_waits_for_active_runtime(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    env = SimpleNamespace(_hermes_stable_storage=True)
+    monkeypatch.setattr(terminal_mod, "_active_turn_counts", {"session": 2})
+
+    assert terminal_mod._environment_replacement_is_busy(
+        env, ("session", "devbox"),
+    ) is True
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "code"])
+def test_environment_creation_fails_closed_if_target_changes_before_publish(
+    builder, monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {"alpha": {"backend": "local", "cwd": "/old"}},
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    cleaned = []
+
+    class FakeEnvironment:
+        cwd = "/old"
+
+        def cleanup(self, force_remove=False):
+            cleaned.append(force_remove)
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        config["terminal"]["targets"]["alpha"] = {
+            "backend": "local", "cwd": "/new",
+        }
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    if builder == "terminal":
+        result = json.loads(terminal_mod.terminal_tool(
+            "pwd", task_id="publish-race", target="alpha",
+        ))
+        assert "changed while its environment was being created" in result["error"]
+    elif builder == "file":
+        with pytest.raises(RuntimeError, match="changed while its environment"):
+            file_mod._get_file_ops("publish-race", "alpha")
+    else:
+        with pytest.raises(ValueError, match="changed while its environment"):
+            code_mod._get_or_create_env("publish-race", "alpha")
+
+    assert terminal_mod._active_environments == {}
+    assert cleaned == [True]
+
+
+def test_ssh_target_routes_terminal_and_file_adapter_to_same_environment(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+
+    class FakeSshEnvironment:
+        def __init__(self, cwd):
+            self.cwd = cwd
+            self.is_persistent = True
+
+        def execute(self, command, cwd="", timeout=None, **kwargs):
+            return {"output": self.cwd + "\n", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    def fake_create(**kwargs):
+        created.append(kwargs)
+        return FakeSshEnvironment(kwargs["cwd"])
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    result = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="devbox",
+    ))
+    file_ops = file_mod._get_file_ops("session", "devbox")
+
+    assert result["target"] == "devbox"
+    assert result["backend"] == "ssh"
+    assert result["output"] == "/srv/project"
+    assert created[0]["env_type"] == "ssh"
+    assert created[0]["ssh_config"]["host"] == "devbox.example.com"
+    assert created[0]["cwd"] == "/srv/project"
+    assert file_ops.env is terminal_mod._active_environments[("default", "devbox")]
+
+
+def test_ssh_paths_stay_remote_relative_and_ignore_host_workspace_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": ".",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+                "container": {"backend": "docker", "cwd": "."},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(tmp_path)},
+    )
+
+    assert file_mod._authoritative_workspace_root("session", "devbox") == "."
+    assert file_mod._backend_operation_path(
+        "relative.txt", str(tmp_path / "relative.txt"), "session", "devbox",
+    ) == "relative.txt"
+    assert file_mod._backend_operation_path(
+        "~/notes.txt", str(tmp_path / "notes.txt"), "session", "devbox",
+    ) == "~/notes.txt"
+    assert file_mod._authoritative_workspace_root(
+        "session", "container",
+    ) == "/root"
+
+    terminal_mod.record_session_cwd(
+        "session-a", "/srv/a", target="devbox",
+    )
+    terminal_mod.record_session_cwd(
+        "session-b", "/srv/b", target="devbox",
+    )
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-a", "devbox",
+    ) == "/srv/a/relative.txt"
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-b", "devbox",
+    ) == "/srv/b/relative.txt"
+    rewritten = file_mod._backend_v4a_patch(
+        "*** Begin Patch\n*** Update File: relative.txt\n*** End Patch",
+        "session-a",
+        "devbox",
+    )
+    assert "*** Update File: /srv/a/relative.txt" in rewritten
+
+
+def test_legacy_ssh_search_preserves_relative_path(monkeypatch, isolated_target_state):
+    from tools.file_operations import SearchResult
+
+    _, file_mod = isolated_target_state
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    captured = {}
+
+    class FakeOps:
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return SearchResult(matches=[], total_count=0)
+
+    monkeypatch.setattr(file_mod, "_get_file_ops", lambda *args, **kwargs: FakeOps())
+
+    result = json.loads(file_mod.search_tool("needle", path="."))
+
+    assert not result.get("error")
+    assert captured["path"] == "."
+
+
+def test_ssh_reads_never_use_host_mtime_dedup(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    _, file_mod = isolated_target_state
+    import tools.execution_targets as targets_mod
+    from tools.file_operations import ReadResult
+
+    host_twin = tmp_path / "same.txt"
+    host_twin.write_text("host\n", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": str(tmp_path),
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class FakeOps:
+        calls = 0
+
+        @classmethod
+        def read_file(cls, path, offset, limit):
+            cls.calls += 1
+            return ReadResult(
+                content=f"remote-{cls.calls}", total_lines=1, file_size=8,
+            )
+
+    monkeypatch.setattr(
+        file_mod, "_get_file_ops",
+        lambda task_id, target=None, _resolution=None: FakeOps(),
+    )
+
+    first = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", target="devbox",
+    ))
+    second = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", target="devbox",
+    ))
+
+    assert first["content"] != second["content"]
+    assert second.get("status") != "unchanged"
+    assert FakeOps.calls == 2
+
+
+def test_target_specific_cd_does_not_cross_talk_to_terminal_or_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha_sub = alpha / "sub"
+    beta_sub = beta / "sub"
+    alpha_sub.mkdir(parents=True)
+    beta_sub.mkdir(parents=True)
+    (alpha_sub / "which.txt").write_text("alpha\n", encoding="utf-8")
+    (beta / "which.txt").write_text("beta-root\n", encoding="utf-8")
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    cd_result = json.loads(terminal_mod.terminal_tool("cd sub", task_id="session", target="alpha"))
+    beta_pwd = json.loads(terminal_mod.terminal_tool("pwd", task_id="session", target="beta"))
+    alpha_read = json.loads(file_mod.read_file_tool("which.txt", task_id="session", target="alpha"))
+    beta_read = json.loads(file_mod.read_file_tool("which.txt", task_id="session", target="beta"))
+
+    assert cd_result["exit_code"] == 0
+    assert beta_pwd["output"] == str(beta)
+    assert "alpha" in alpha_read["content"]
+    assert "beta-root" in beta_read["content"]
+
+
+def test_local_targets_route_write_read_patch_search_and_cache_separately(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    write_alpha = json.loads(file_mod.write_file_tool(
+        "shared.txt", "alpha-value\n", task_id="session", target="alpha",
+    ))
+    write_beta = json.loads(file_mod.write_file_tool(
+        "shared.txt", "beta-value\n", task_id="session", target="beta",
+    ))
+    patch_alpha = json.loads(file_mod.patch_tool(
+        path="shared.txt", old_string="alpha-value\n", new_string="alpha-patched\n",
+        task_id="session", target="alpha",
+    ))
+    search_alpha = json.loads(file_mod.search_tool(
+        "alpha-patched", path=".", task_id="session", execution_target="alpha",
+    ))
+    search_beta = json.loads(file_mod.search_tool(
+        "beta-value", path=".", task_id="session", execution_target="beta",
+    ))
+
+    assert not write_alpha.get("error") and not write_beta.get("error")
+    assert not patch_alpha.get("error")
+    assert (alpha / "shared.txt").read_text(encoding="utf-8") == "alpha-patched\n"
+    assert (beta / "shared.txt").read_text(encoding="utf-8") == "beta-value\n"
+    assert search_alpha["matches"] and search_beta["matches"]
+    assert write_alpha["target"] == patch_alpha["target"] == "alpha"
+    assert search_beta["target"] == "beta"
+    assert set(file_mod._file_ops_cache) == {("default", "alpha"), ("default", "beta")}
+    assert ("session", "alpha") in file_mod._read_tracker
+    assert ("session", "beta") in file_mod._read_tracker
+
+
+def test_real_config_loader_routes_terminal_and_files_between_two_local_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import yaml
+
+    import tools.file_tools as file_mod
+    import tools.terminal_tool as terminal_mod
+
+    alpha = tmp_path / "configured-alpha"
+    beta = tmp_path / "configured-beta"
+    alpha.mkdir()
+    beta.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": str(alpha)},
+                    "beta": {"backend": "local", "cwd": str(beta)},
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", target="beta",
+    ))
+    assert alpha_pwd["output"] == str(alpha)
+    assert beta_pwd["output"] == str(beta)
+
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from alpha\n", task_id="configured-session", target="alpha",
+    ))["target"] == "alpha"
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from beta\n", task_id="configured-session", target="beta",
+    ))["target"] == "beta"
+    assert "from alpha" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", target="alpha",
+    ))["content"]
+    assert "from beta" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", target="beta",
+    ))["content"]
+
+
+def test_workspace_override_applies_only_to_default_named_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    host_workspace = tmp_path / "host-workspace"
+    alpha.mkdir()
+    beta.mkdir()
+    host_workspace.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    # ACP/TUI/gateway surfaces register the host workspace as a task override.
+    # It should seed the configured default target, not replace an explicit
+    # remote/container target's own cwd.
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(host_workspace)},
+    )
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", target="beta",
+    ))
+    beta_write = json.loads(file_mod.write_file_tool(
+        "target-only.txt", "beta\n", task_id="session", target="beta",
+    ))
+
+    assert alpha_pwd["output"] == str(host_workspace)
+    assert beta_pwd["output"] == str(beta)
+    assert beta_write["resolved_path"] == str(beta / "target-only.txt")
+    assert (beta / "target-only.txt").read_text(encoding="utf-8") == "beta\n"
+    assert not (host_workspace / "target-only.txt").exists()
+
+
+def test_unknown_target_errors_are_returned_by_execution_and_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha)}),
+    )
+
+    results = [
+        json.loads(terminal_mod.terminal_tool("pwd", target="missing")),
+        json.loads(file_mod.read_file_tool("x.txt", target="missing")),
+        json.loads(file_mod.write_file_tool("x.txt", "x", target="missing")),
+        json.loads(file_mod.search_tool(
+            "x", path=".", execution_target="missing",
+        )),
+        json.loads(code_mod.execute_code("print('x')", target="missing")),
+    ]
+
+    for result in results:
+        assert "missing" in result["error"]
+        assert "Available targets: 'alpha'" in result["error"]
+    assert not (alpha / "x.txt").exists()
+
+
+def test_cleanup_without_target_removes_all_task_scopes_and_explicit_removes_one(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self):
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    config = _named_config({"alpha": "/a", "beta": "/b"})
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    alpha = FakeEnv()
+    beta = FakeEnv()
+    terminal_mod._active_environments.update({
+        ("default", "alpha"): alpha,
+        ("default", "beta"): beta,
+    })
+    terminal_mod._last_activity.update({
+        ("default", "alpha"): time.time(),
+        ("default", "beta"): time.time(),
+    })
+
+    # Unregistered delegate ids collapse to the parent's "default" scope for
+    # execution, but closing a delegate must preserve legacy cleanup semantics
+    # and must not tear down the parent's shared environments.
+    terminal_mod.cleanup_vm("child-a")
+    terminal_mod.cleanup_vm("child-a", target="alpha")
+    assert alpha.cleaned == beta.cleaned == 0
+
+    terminal_mod.cleanup_vm("default", target="alpha")
+    assert alpha.cleaned == 1 and beta.cleaned == 0
+    assert set(terminal_mod._active_environments) == {("default", "beta")}
+
+    terminal_mod.cleanup_vm("default")
+    assert beta.cleaned == 1
+    assert terminal_mod._active_environments == {}
+
+
+def test_per_turn_cleanup_preserves_only_persistent_named_siblings(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self, persistent):
+            self._persistent = persistent
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": "/a", "beta": "/b"}),
+    )
+    key_a = ("default", "alpha")
+    key_b = ("default", "beta")
+    persistent = FakeEnv(True)
+    ephemeral = FakeEnv(False)
+    terminal_mod._active_environments.update({
+        key_a: persistent,
+        key_b: ephemeral,
+    })
+    terminal_mod._last_activity.update({key_a: 1.0, key_b: 1.0})
+    persistent_ops = object()
+    ephemeral_ops = object()
+    file_mod._file_ops_cache.update({
+        key_a: persistent_ops,
+        key_b: ephemeral_ops,
+    })
+
+    terminal_mod.register_environment_turn("turn-a")
+    terminal_mod.register_environment_turn("turn-b")
+    assert terminal_mod.release_environment_turn("turn-a") == 1
+    terminal_mod.cleanup_vm(
+        "turn-a", preserve_persistent=True, include_collapsed=False,
+    )
+    assert key_b in terminal_mod._active_environments
+
+    assert terminal_mod.release_environment_turn("turn-b") == 0
+    terminal_mod.cleanup_vm(
+        "turn-b", preserve_persistent=True, include_collapsed=True,
+    )
+
+    assert terminal_mod._active_environments[key_a] is persistent
+    assert key_b not in terminal_mod._active_environments
+    assert persistent.cleaned == 0
+    assert ephemeral.cleaned == 1
+    assert file_mod._file_ops_cache[key_a] is persistent_ops
+    assert key_b not in file_mod._file_ops_cache
+
+    from tools.process_registry import process_registry
+
+    active_env = FakeEnv(False)
+    terminal_mod._active_environments[key_b] = active_env
+    monkeypatch.setattr(
+        process_registry, "has_active_processes", lambda key: key == key_b,
+    )
+    terminal_mod.cleanup_vm(
+        "turn-c", preserve_persistent=True, include_collapsed=True,
+    )
+    assert terminal_mod._active_environments[key_b] is active_env
+    assert active_env.cleaned == 0
+
+
+def test_complete_logical_turn_cleanup_waits_for_overlapping_turn(
+    monkeypatch, isolated_target_state,
+):
+    """Cleanup releases only its own logical-turn lease.
+
+    Two gateway turns can overlap while their child task ids collapse onto the
+    same shared target environments. The first finisher must not tear down an
+    ephemeral sibling still in use by the other complete logical turn.
+    """
+    from agent import chat_completion_helpers as chat_helpers
+
+    terminal_mod, _ = isolated_target_state
+    vm_calls = []
+    browser_calls = []
+    runtime = SimpleNamespace(
+        cleanup_vm=lambda task_id, **kwargs: vm_calls.append((task_id, kwargs)),
+        cleanup_browser=lambda task_id: browser_calls.append(task_id),
+    )
+    monkeypatch.setattr(chat_helpers, "_ra", lambda: runtime)
+    fake_agent = SimpleNamespace(verbose_logging=False)
+
+    with terminal_mod.logical_environment_turn("turn-a"):
+        assert terminal_mod.active_environment_turns("turn-a") == 1
+        with terminal_mod.logical_environment_turn("turn-b"):
+            assert terminal_mod.active_environment_turns("turn-b") == 2
+            chat_helpers.cleanup_task_resources(fake_agent, "turn-b")
+            assert terminal_mod.active_environment_turns("turn-a") == 1
+            assert vm_calls[-1] == (
+                "turn-b",
+                {"preserve_persistent": True, "include_collapsed": False},
+            )
+        chat_helpers.cleanup_task_resources(fake_agent, "turn-a")
+        assert terminal_mod.active_environment_turns("turn-a") == 0
+        assert vm_calls[-1] == (
+            "turn-a",
+            {"preserve_persistent": True, "include_collapsed": True},
+        )
+
+    # Both context-manager finalizers are idempotent after cleanup released
+    # their leases; no negative count or leaked logical-turn owner remains.
+    assert terminal_mod.active_environment_turns("turn-a") == 0
+    assert browser_calls == ["turn-b", "turn-a"]
+
+
+def test_logical_environment_turn_exception_releases_once(isolated_target_state):
+    terminal_mod, _ = isolated_target_state
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with terminal_mod.logical_environment_turn("turn-exception"):
+            assert terminal_mod.active_environment_turns("turn-exception") == 1
+            raise RuntimeError("boom")
+
+    assert terminal_mod.active_environment_turns("turn-exception") == 0
+
+
+def test_local_persistent_config_marks_environment(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+
+    class FakeLocal:
+        def __init__(self, cwd, timeout):
+            self.cwd = cwd
+            self.timeout = timeout
+
+    monkeypatch.setattr(terminal_mod, "_LocalEnvironment", FakeLocal)
+    env = terminal_mod._create_environment(
+        "local", "", "/workspace", 30,
+        local_config={"persistent": True},
+    )
+
+    assert terminal_mod._environment_is_persistent(env)
+
+
+def test_process_metadata_survives_status_list_and_checkpoint(monkeypatch, tmp_path):
+    import tools.process_registry as process_mod
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(process_mod, "CHECKPOINT_PATH", checkpoint)
+    registry = process_mod.ProcessRegistry()
+    session = process_mod.ProcessSession(
+        id="proc_targeted",
+        command="sleep 30",
+        task_id="default",
+        target="devbox",
+        backend="ssh",
+        timeout_seconds=7,
+        environment_task_key="profile-a:default",
+        pid=4321,
+        host_start_time=99,
+        started_at=time.time(),
+    )
+    registry._running[session.id] = session
+
+    assert registry.has_active_processes(("profile-a:default", "devbox"))
+    assert registry.poll(session.id)["target"] == "devbox"
+    assert registry.list_sessions()[0]["backend"] == "ssh"
+    registry._write_checkpoint()
+    raw = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert raw[0]["target"] == "devbox"
+    assert raw[0]["timeout_seconds"] == 7
+    assert raw[0]["environment_task_key"] == "profile-a:default"
+    assert raw[0]["backend"] == "ssh"
+
+    recovered = process_mod.ProcessRegistry()
+    monkeypatch.setattr(recovered, "_host_pid_is_ours", lambda pid, started: True)
+    assert recovered.recover_from_checkpoint() == 1
+    recovered_session = recovered.get(session.id)
+    assert recovered_session is not None
+    assert recovered_session.target == "devbox"
+    assert recovered_session.backend == "ssh"
+    assert recovered_session.timeout_seconds == 7
+    assert recovered_session.environment_task_key == "profile-a:default"
+
+    recovered_session.exited = True
+    waited = recovered.wait(session.id, timeout=99)
+    assert "configured limit of 7s" in waited["timeout_note"]
+
+
+def test_execute_code_inherits_target_and_rejects_nested_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+    source = code_mod.generate_hermes_tools_module(
+        ["write_file", "read_file", "search_files"],
+    )
+    namespace = {}
+    exec(source, namespace)
+    calls = []
+    namespace["_call"] = lambda name, args: calls.append((name, args)) or {}
+
+    namespace["write_file"]("nested.txt", "alpha-default\n")
+    namespace["write_file"]("nested.txt", "beta-explicit\n", target="beta")
+    namespace["search_files"]("needle")
+
+    inherited_write = code_mod._inherit_execution_target(
+        calls[0][0], calls[0][1], "alpha",
+    )
+    inherited_search = code_mod._inherit_execution_target(
+        calls[2][0], calls[2][1], "alpha",
+    )
+    assert inherited_write["target"] == "alpha"
+    assert inherited_search["execution_target"] == "alpha"
+    with pytest.raises(ValueError, match="cannot select 'beta'"):
+        code_mod._inherit_execution_target(calls[1][0], calls[1][1], "alpha")
+
+    remote_config = _named_config({"alpha": str(alpha), "beta": str(beta)})
+    remote_config["terminal"]["targets"]["alpha"]["backend"] = "ssh"
+    remote_config["terminal"]["targets"]["alpha"]["ssh_host"] = "example.invalid"
+    remote_config["terminal"]["targets"]["alpha"]["ssh_user"] = "agent"
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: remote_config)
+    forwarded = {}
+    monkeypatch.setattr(code_mod, "_get_execution_mode", lambda: "project")
+    monkeypatch.setattr(
+        code_mod, "_execute_remote",
+        lambda code, task_id, enabled_tools, target=None, mode="strict",
+        expected_target_scope=None, expected_target_config=None: (
+            forwarded.update(
+                target=target, mode=mode, scope=expected_target_scope,
+                config=expected_target_config,
+            )
+            or json.dumps({"status": "success"})
+        ),
+    )
+
+    result = json.loads(code_mod.execute_code("print('ok')", target="alpha"))
+    assert result["status"] == "success"
+    assert forwarded["target"] == "alpha"
+    assert forwarded["mode"] == "project"
+    assert forwarded["scope"] == targets_mod.resolve_execution_target("alpha").security_scope
+    assert forwarded["config"]["terminal"]["targets"]["alpha"]["backend"] == "ssh"
+    with pytest.raises(ValueError, match="runtime_scope"):
+        code_mod._inherit_execution_target(
+            "read_file",
+            {"path": "saved.txt", "runtime_scope": "old-scope"},
+            "alpha",
+            forwarded["scope"],
+        )
+
+
+def test_execute_code_rpc_rejects_alias_repointed_during_run(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {"alpha": {"backend": "local", "cwd": "/old"}},
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    approved_scope = targets_mod.resolve_execution_target("alpha").security_scope
+    config["terminal"]["targets"]["alpha"] = {
+        "backend": "ssh", "ssh_host": "new.example", "ssh_user": "agent",
+        "cwd": "/new",
+    }
+
+    with pytest.raises(ValueError, match="changed while execute_code was running"):
+        code_mod._inherit_execution_target(
+            "write_file", {"path": "marker", "content": "x"},
+            "alpha", approved_scope,
+        )
+
+
+def test_execute_code_rpc_dispatch_uses_frozen_approved_target_config(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    live = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {
+                    "backend": "ssh", "ssh_host": "new.example",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    approved = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": "/approved"},
+            },
+        },
+    }
+
+    targets_mod.set_execution_target_config_source(live)
+
+    def handler(_name, args, task_id=None):
+        resolved = targets_mod.resolve_execution_target(args["target"])
+        current = targets_mod.resolve_live_execution_target(args["target"])
+        return resolved.backend, resolved.config.get("cwd"), current.backend
+
+    assert code_mod._dispatch_rpc_tool(
+        handler, "write_file", {"target": "alpha"}, "task", approved,
+    ) == ("local", "/approved", "ssh")
+    assert targets_mod.resolve_execution_target("alpha").backend == "ssh"
+
+
+def test_execute_code_routes_real_nested_file_call_to_selected_local_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    config = _named_config({"alpha": str(alpha), "beta": str(beta)})
+    # Real merged configs contain defaults for unrelated backends.  Freezing the
+    # approved target must preserve them as inherited top-level settings rather
+    # than reclassifying them as explicit local-target fields.
+    config["terminal"]["modal_mode"] = "ephemeral"
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    targets_mod.set_execution_target_config_source(config)
+
+    result = json.loads(code_mod.execute_code(
+        "from hermes_tools import write_file\n"
+        "print(write_file('from-code.txt', 'beta-via-rpc\\n'))\n",
+        task_id="execute-target-session",
+        enabled_tools=["write_file"],
+        target="beta",
+    ))
+
+    assert result["status"] == "success"
+    assert result["target"] == "beta"
+    assert result["backend"] == "local"
+    assert (beta / "from-code.txt").read_text(encoding="utf-8") == "beta-via-rpc\n"
+    assert not (alpha / "from-code.txt").exists()
+
+
+def test_remote_project_mode_executes_from_target_session_cwd(
+    monkeypatch, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    config = _named_config({"alpha": "/srv/configured", "beta": "/b"})
+    config["terminal"]["targets"]["alpha"].update({
+        "backend": "ssh",
+        "ssh_host": "example.invalid",
+        "ssh_user": "agent",
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod, _ = isolated_target_state
+    terminal_mod.record_session_cwd(
+        "remote-project", "/srv/session-project", target="alpha",
+    )
+
+    calls = []
+
+    class FakeEnv:
+        cwd = "/srv/configured"
+
+        def execute(self, command, cwd=None, timeout=None, stdin_data=None):
+            calls.append((command, cwd))
+            if cwd is not None:
+                self.cwd = cwd
+            if "command -v python3" in command:
+                return {"output": "OK\n", "returncode": 0}
+            return {"output": "done\n", "returncode": 0}
+
+        def get_temp_dir(self):
+            return "/remote-tmp"
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    env = FakeEnv()
+    monkeypatch.setattr(
+        code_mod, "_get_or_create_env",
+        lambda task_id, target=None, expected_target_scope=None: (env, "ssh"),
+    )
+    monkeypatch.setattr(code_mod, "_ship_file_to_remote", lambda *args, **kwargs: None)
+    monkeypatch.setattr(code_mod.threading, "Thread", DummyThread)
+    monkeypatch.setattr(
+        code_mod, "_load_config", lambda: {"timeout": 30, "max_tool_calls": 5},
+    )
+
+    result = json.loads(code_mod._execute_remote(
+        "print('ok')", "remote-project", [], target="alpha", mode="project",
+    ))
+    repeated = json.loads(code_mod._execute_remote(
+        "print('again')", "remote-project", [], target="alpha", mode="project",
+    ))
+
+    assert result["status"] == repeated["status"] == "success"
+    assert result["cwd"] == repeated["cwd"] == "/srv/session-project"
+    script_calls = [
+        item for item in calls
+        if "python3 /remote-tmp/hermes_exec_" in item[0]
+    ]
+    assert len(script_calls) == 2
+    assert all(cwd == "/srv/session-project" for _, cwd in script_calls)
+
+
+def test_tool_output_persistence_uses_the_result_target(monkeypatch):
+    import agent.tool_executor as executor
+
+    default_env = object()
+    beta_env = object()
+
+    def fake_get_active_env(_task_id, target=None):
+        return beta_env if target == "beta" else default_env
+
+    monkeypatch.setattr(executor, "get_active_env", fake_get_active_env)
+
+    result = json.dumps({"target": "beta", "output": "x"})
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {}, result,
+    ) is beta_env
+
+    import tools.terminal_tool as terminal_mod
+
+    scoped_env = object()
+    monkeypatch.setattr(
+        terminal_mod, "get_environment_for_target_scope",
+        lambda task_id, target, scope: scoped_env,
+    )
+    scoped_result = json.dumps({
+        "target": "beta", "runtime_scope": "old-scope", "output": "x",
+    })
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {}, scoped_result,
+    ) is scoped_env
+
+    from tools.process_registry import process_registry
+
+    producing_env = object()
+    monkeypatch.setattr(
+        process_registry, "get",
+        lambda session_id: SimpleNamespace(env_ref=producing_env),
+    )
+    assert executor._active_env_for_tool_result(
+        "session", "process", {"session_id": "proc-old"},
+        json.dumps({"target": "beta", "output": "large"}),
+    ) is producing_env
+
+    captured = {}
+
+    def fake_enforce(messages, env=None, env_resolver=None, config=None):
+        assert callable(env_resolver)
+        captured["default"] = env
+        captured["selected"] = env_resolver(messages[0])
+
+    monkeypatch.setattr(executor, "enforce_turn_budget", fake_enforce)
+    messages = [{"content": "large", "tool_call_id": "call-beta"}]
+    target_map = {"call-beta": "beta"}
+    executor._enforce_target_aware_turn_budget(
+        messages, "session", executor.DEFAULT_BUDGET, target_map,
+    )
+
+    assert captured == {"default": default_env, "selected": beta_env}
+    assert target_map == {}
+    assert "_execution_target" not in messages[0]
+
+    captured.clear()
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "web result", "tool_call_id": "call-web"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        {},
+    )
+    assert captured == {"default": default_env, "selected": default_env}
+    persisted = executor._append_persisted_target_hint(
+        f"{executor.PERSISTED_OUTPUT_TAG}\nfull output saved",
+        "beta",
+    )
+    assert 'Execution target for this saved output: "beta"' in persisted
+    assert 'target="beta"' in persisted
+
+    scoped = executor._append_persisted_target_hint(
+        f"saved {executor.PERSISTED_OUTPUT_TAG}", "beta", "scope-v1",
+    )
+    assert 'runtime_scope="scope-v1"' in scoped
+
+    monkeypatch.setattr(
+        executor, "get_active_env",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad target config")),
+    )
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {"target": "broken"},
+    ) is None
+    captured.clear()
+    target_map = {"call-broken": "broken"}
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "error", "tool_call_id": "call-broken"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        target_map,
+    )
+    assert captured == {"default": None, "selected": None}
+
+
+def test_subdirectory_hints_follow_local_target_and_skip_remote_host(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    from types import SimpleNamespace
+
+    import agent.tool_executor as executor
+    import tools.execution_targets as targets_mod
+
+    local_root = tmp_path / "local-target"
+    subdir = local_root / "src"
+    subdir.mkdir(parents=True)
+    (subdir / "AGENTS.md").write_text("LOCAL TARGET HINT", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": str(local_root)},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class DefaultTracker:
+        def __init__(self):
+            self.calls = 0
+
+        def check_tool_call(self, *args, **kwargs):
+            self.calls += 1
+            return "WRONG HOST HINT"
+
+    default_tracker = DefaultTracker()
+    agent = SimpleNamespace(_subdirectory_hints=default_tracker)
+    local_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "local",
+    )
+    remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "devbox",
+    )
+    config["terminal"]["default_target"] = "devbox"
+    omitted_remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, None,
+    )
+
+    assert isinstance(local_hint, str)
+    assert "LOCAL TARGET HINT" in local_hint
+    assert executor._selected_local_target_cwd(
+        "session", "write_file", {"target": "local"},
+    ) == str(local_root)
+    assert executor._selected_local_target_cwd(
+        "session", "terminal", {"target": "devbox"},
+    ) is None
+    assert remote_hint is None
+    assert omitted_remote_hint is None
+    assert default_tracker.calls == 0
+
+
+def test_targetless_intervening_tool_resets_all_target_read_trackers(
+    monkeypatch, isolated_target_state,
+):
+    import model_tools
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    assert "memory" not in model_tools._TARGET_SELECTOR_TOOLS
+    assert "terminal" in model_tools._TARGET_SELECTOR_TOOLS
+    for key in ("session", ("session", "alpha"), ("session", "beta")):
+        file_mod._read_tracker[key] = {
+            "last_key": "same",
+            "consecutive": 4,
+            "dedup_hits": {"same": 2},
+        }
+
+    file_mod.notify_other_tool_call("session")
+
+    for data in file_mod._read_tracker.values():
+        assert data["last_key"] is None
+        assert data["consecutive"] == 0
+        assert data["dedup_hits"] == {}
+
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_key = ("profile-profile-a:session", "alpha")
+    file_mod._read_tracker[profile_key] = {
+        "dedup": {"region": (1.0, 2, "hash")},
+        "dedup_hits": {"region": 3},
+    }
+    file_mod.reset_file_dedup("session")
+    assert file_mod._read_tracker[profile_key]["dedup"] == {}
+    assert file_mod._read_tracker[profile_key]["dedup_hits"] == {}
+
+
+def test_sudo_cache_and_nopasswd_probe_are_target_scoped(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    terminal_mod._reset_cached_sudo_passwords()
+
+    terminal_mod._set_cached_sudo_password("local-secret", "local", "local")
+    assert terminal_mod._get_cached_sudo_password("local", "local") == "local-secret"
+    assert terminal_mod._get_cached_sudo_password("devbox", "ssh") == ""
+
+    calls = []
+
+    class Probe:
+        returncode = 0
+
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or Probe(),
+    )
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh"):
+        assert terminal_mod._sudo_nopasswd_works() is False
+    assert calls == []
+
+    with terminal_mod._scoped_sudo_execution("local", "local"):
+        assert terminal_mod._sudo_nopasswd_works() is True
+    assert len(calls) == 1
+
+    monkeypatch.setenv("SUDO_PASSWORD", "default-secret")
+    with terminal_mod._scoped_sudo_execution(
+        "devbox", "ssh", named=True, sudo_password="target-secret",
+    ):
+        transformed, selected_password = terminal_mod._transform_sudo_command(
+            "sudo id",
+        )
+    assert "target-secret" not in transformed
+    assert "default-secret" not in transformed
+    assert selected_password == "target-secret\n"
+
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh", named=True):
+        terminal_mod._set_cached_sudo_password("cached-target")
+        _, cached_password = terminal_mod._transform_sudo_command("sudo id")
+    assert cached_password == "cached-target\n"
+
+    monkeypatch.delenv("SUDO_PASSWORD")
+    with terminal_mod._scoped_sudo_execution(
+        "devbox", "ssh", named=True, target_scope="config-v2",
+    ):
+        terminal_mod._set_cached_sudo_password("stale-secret")
+    assert terminal_mod._invalidate_cached_sudo_on_auth_failure(
+        "sudo id", "sudo: authentication failed", "devbox", "ssh", "config-v2",
+    ) is True
+    assert terminal_mod._get_cached_sudo_password(
+        "devbox", "ssh", "config-v2",
+    ) == ""
+
+
+def test_requirements_keep_tools_registered_when_any_target_is_usable(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "broken-docker",
+            "targets": {
+                "broken-docker": {"backend": "docker", "cwd": "/workspace"},
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    checked = []
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_terminal_config_requirements",
+        lambda cfg: checked.append(cfg["env_type"]) or cfg["env_type"] == "local",
+    )
+
+    assert terminal_mod.check_terminal_requirements() is True
+    assert checked == ["local"]
+
+
+def test_local_target_aliases_share_file_state_lock_namespace(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import file_state
+
+    _, file_mod = isolated_target_state
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    path = shared / "same.txt"
+    path.write_text("v1", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": str(shared)},
+                "alias": {"backend": "local", "cwd": str(shared)},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    assert file_mod._file_state_namespace("reader", "alpha") is None
+    assert file_mod._file_state_namespace("writer", "alias") is None
+
+    registry = file_state.FileStateRegistry()
+    monkeypatch.setattr(file_state, "_registry", registry)
+    file_state.record_read(("reader", "alpha"), path, namespace=None)
+    file_state.note_write(("writer", "alias"), path, namespace=None)
+    warning = file_state.check_stale(("reader", "alpha"), path, namespace=None)
+    assert warning is not None
+    assert "writer" in warning
+
+
+def test_ssh_target_aliases_share_file_state_lock_namespace(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    ssh = {
+        "backend": "ssh",
+        "ssh_host": "devbox.example",
+        "ssh_user": "agent",
+        "ssh_port": 2222,
+        "cwd": "/srv/project",
+    }
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": dict(ssh),
+                "alias": {**ssh, "cwd": "/different/root"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    alpha = file_mod._file_state_namespace("reader", "alpha")
+    alias = file_mod._file_state_namespace("writer", "alias")
+    assert alpha == alias
+    assert alpha.startswith("ssh:")
+
+
+def test_persistent_docker_replacements_share_storage_lock_namespace(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    before = file_mod._file_state_namespace("session", "sandbox")
+    config["terminal"]["timeout"] = 90
+    after = file_mod._file_state_namespace("session", "sandbox")
+
+    assert before == after
+    assert before.startswith("docker-storage:")
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "execute_code"])
+def test_idle_persistent_docker_hot_edit_cleans_runtime_before_replacement(
+    monkeypatch, isolated_target_state, builder,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+    cleanup_calls = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+
+        def __init__(self):
+            self.cleaned = False
+
+        def execute(self, command, **kwargs):
+            return {"output": "ok\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            self.cleaned = True
+            cleanup_calls.append(force_remove)
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        if created:
+            assert created[0].cleaned is True
+        env = FakeEnvironment()
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    def build():
+        if builder == "terminal":
+            result = json.loads(terminal_mod.terminal_tool(
+                "pwd", task_id="session", target="sandbox",
+            ))
+            if result.get("status") == "error":
+                raise RuntimeError(result["error"])
+            return result
+        if builder == "file":
+            return file_mod._get_file_ops("session", "sandbox")
+        return code_mod._get_or_create_env("session", "sandbox")
+
+    first = build()
+    config["terminal"]["timeout"] = 90
+    terminal_mod._active_turn_counts["default"] = 2
+    expected_error = ValueError if builder == "execute_code" else RuntimeError
+    with pytest.raises(expected_error, match="still active"):
+        build()
+    assert len(created) == 1
+    assert cleanup_calls == []
+    assert terminal_mod._active_environments[("default", "sandbox")] is created[0]
+
+    terminal_mod._active_turn_counts.clear()
+    second = build()
+
+    if builder == "terminal":
+        assert first["output"].strip() == second["output"].strip() == "ok"
+    assert len(created) == 2
+    assert cleanup_calls == [True]
+    assert terminal_mod._retired_environments == []
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "execute_code"])
+def test_persistent_docker_hot_edit_cleanup_failure_restores_runtime_ownership(
+    monkeypatch, isolated_target_state, builder,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+
+        def __init__(self):
+            self._persist_across_processes = True
+            self._persistent = True
+
+        def execute(self, command, **kwargs):
+            return {"output": "ok\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            assert force_remove is True
+            assert self._persist_across_processes is False
+            assert self._persistent is True
+            raise RuntimeError("lease handoff failed")
+
+    def fake_create(**kwargs):
+        env = FakeEnvironment()
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    def build():
+        if builder == "terminal":
+            result = json.loads(terminal_mod.terminal_tool(
+                "pwd", task_id="session", target="sandbox",
+            ))
+            if result.get("status") == "error":
+                raise RuntimeError(result["error"])
+            return result
+        if builder == "file":
+            return file_mod._get_file_ops("session", "sandbox")
+        return code_mod._get_or_create_env("session", "sandbox")
+
+    first = build()
+    old_env = created[0]
+    config["terminal"]["timeout"] = 90
+
+    if builder == "terminal":
+        assert first["output"].strip() == "ok"
+    expected_error = ValueError if builder == "execute_code" else RuntimeError
+    with pytest.raises(expected_error, match="Could not retire"):
+        build()
+    assert len(created) == 1
+    assert terminal_mod._active_environments[("default", "sandbox")] is old_env
+    assert old_env._persist_across_processes is True
+    assert old_env._persistent is True
+
+
+def test_local_background_process_keeps_producing_target_generation(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import agent.tool_executor as executor
+    import tools.execution_targets as targets_mod
+    from tools.process_registry import ProcessSession, process_registry
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    config = _named_config({"alpha": str(alpha)})
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    captured = {}
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return ProcessSession(
+            id="proc-alpha",
+            command=kwargs["command"],
+            pid=123,
+            cwd=kwargs["cwd"],
+            target=kwargs["target"],
+            backend=kwargs["backend"],
+            runtime_scope=kwargs["runtime_scope"],
+            env_ref=kwargs["env_ref"],
+        )
+
+    monkeypatch.setattr(process_registry, "spawn_local", fake_spawn_local)
+    result = json.loads(terminal_mod.terminal_tool(
+        "sleep 1", task_id="session", target="alpha", background=True,
+    ))
+    producing_env = captured["env_ref"]
+    producing_scope = targets_mod.resolve_execution_target("alpha").security_scope
+
+    assert result["session_id"] == "proc-alpha"
+    assert captured["runtime_scope"] == producing_scope
+    assert producing_env is terminal_mod._active_environments[("default", "alpha")]
+
+    config["terminal"]["targets"]["alpha"]["cwd"] = str(tmp_path / "new-alpha")
+    session = ProcessSession(
+        id="proc-alpha",
+        command="sleep 1",
+        target="alpha",
+        backend="local",
+        runtime_scope=producing_scope,
+        env_ref=producing_env,
+    )
+    monkeypatch.setattr(process_registry, "get", lambda session_id: session)
+    process_result = json.dumps({
+        "target": "alpha",
+        "runtime_scope": producing_scope,
+        "output": "large",
+    })
+    assert executor._active_env_for_tool_result(
+        "session", "process", {"session_id": "proc-alpha"}, process_result,
+    ) is producing_env
+
+
+def test_retired_environment_waits_for_base_task_turn_scope(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    env = object()
+    now = time.time()
+    terminal_mod._active_turn_counts["bench"] = 1
+    terminal_mod._retired_environments.append((("bench", "alpha"), env, now - 120))
+    monkeypatch.setattr(
+        terminal_mod, "_cleanup_environment_resource",
+        lambda *args, **kwargs: pytest.fail("active environment was cleaned"),
+    )
+
+    assert terminal_mod._cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=True,
+    ) == 0
+    assert terminal_mod._retired_environments[0][1] is env
+
+
+def test_command_approval_payload_and_observer_include_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    first = approval_mod._execution_scoped_pattern_key(
+        "danger", "devbox", True, "scope-one",
+    )
+    second = approval_mod._execution_scoped_pattern_key(
+        "danger", "devbox", True, "scope-two",
+    )
+    assert first != second
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "detect_hardline_command", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_check_sudo_stdin_guard", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_match_user_deny_rule", lambda command: None)
+    monkeypatch.setattr(approval_mod, "_command_matches_permanent_allowlist", lambda command: False)
+    monkeypatch.setattr(
+        approval_mod, "detect_dangerous_command",
+        lambda command: (True, "danger", "dangerous command"),
+    )
+    monkeypatch.setattr("tools.tirith_security.check_command_security", lambda command: {
+        "action": "allow", "findings": [], "summary": "",
+    })
+    session_key = "approval-target-session"
+    token = approval_mod.set_current_session_key(session_key)
+    seen = {}
+    hooks = []
+
+    def notify(data):
+        seen.update(data)
+        with approval_mod._lock:
+            entry = approval_mod._gateway_queues[session_key][-1]
+            entry.result = "deny"
+            entry.event.set()
+
+    monkeypatch.setattr(approval_mod, "_fire_approval_hook", lambda name, **data: hooks.append((name, data)))
+    approval_mod.register_gateway_notify(session_key, notify)
+    try:
+        approval_mod.check_all_command_guards(
+            "danger", "local", execution_target="alpha", execution_backend="local",
+        )
+    finally:
+        approval_mod.unregister_gateway_notify(session_key)
+        approval_mod.reset_current_session_key(token)
+
+    assert seen["target"] == "alpha"
+    assert seen["backend"] == "local"
+    assert "alpha" in seen["description"] and "local" in seen["description"]
+    pre_hook = next(data for name, data in hooks if name == "pre_approval_request")
+    assert pre_hook["target"] == "alpha"
+    assert pre_hook["backend"] == "local"
+
+
+def test_execute_code_approval_payload_includes_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "is_approved", lambda *args: False)
+    monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(
+        approval_mod, "is_current_session_yolo_enabled", lambda: False,
+    )
+    seen = {}
+    monkeypatch.setattr(
+        approval_mod, "_await_gateway_decision",
+        lambda session_key, notify_cb, approval_data, surface: (
+            seen.update(approval_data) or {"resolved": True, "choice": "once"}
+        ),
+    )
+    session_token = approval_mod.set_current_session_key("target-approval")
+    try:
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs["target-approval"] = lambda data: None
+        result = approval_mod.check_execute_code_guard(
+            "print('ok')", "ssh", execution_target="devbox",
+            execution_backend="ssh",
+        )
+    finally:
+        approval_mod.reset_current_session_key(session_token)
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs.pop("target-approval", None)
+
+    assert result["approved"] is True
+    assert seen["target"] == "devbox"
+    assert seen["backend"] == "ssh"
+    assert "devbox" in seen["description"]
+
+
+def test_legacy_flat_config_still_uses_plain_string_keys(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: {"terminal": {"backend": "local", "cwd": str(tmp_path), "timeout": 60}},
+    )
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="legacy"))
+
+    assert result["exit_code"] == 0
+    assert "default" in terminal_mod._active_environments
+    assert all(not isinstance(key, tuple) for key in terminal_mod._active_environments)
+
+
+def test_gateway_script_guard_reads_selected_named_target_cwd(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    (alpha / "restart.sh").write_text("#!/bin/sh\necho safe\n")
+    (beta / "restart.sh").write_text("#!/bin/sh\nhermes gateway restart\n")
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    result = json.loads(terminal_mod.terminal_tool(
+        "bash restart.sh", task_id="gateway-guard", target="beta",
+    ))
+
+    assert result["status"] == "error"
+    assert "cannot restart or stop the gateway" in result["error"]
+
+
+def test_checkpoint_alias_flip_pins_dispatch_generation(monkeypatch, tmp_path):
+    from agent import tool_executor
+    import tools.execution_targets as targets_mod
+    from tools.file_tools import write_file_tool
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "sample.txt").write_text("before")
+    config_a = _named_config({"dev": str(first)}, default="dev")
+    config_b = _named_config({"dev": str(second)}, default="dev")
+    targets_mod.set_execution_target_config_source(config_a)
+    checkpoints = []
+
+    class CheckpointManager:
+        enabled = True
+
+        @staticmethod
+        def get_working_dir_for_path(path):
+            return str(first)
+
+        def ensure_checkpoint(self, cwd, reason):
+            checkpoints.append((cwd, reason))
+            targets_mod.set_execution_target_config_source(config_b)
+
+    class Guardrails:
+        @staticmethod
+        def before_call(_name, _args):
+            return SimpleNamespace(allows_execution=True)
+
+    agent = SimpleNamespace(
+        session_id="session",
+        _current_turn_id="turn",
+        _current_api_request_id="request",
+        _tool_guardrails=Guardrails(),
+        _guardrail_block_result=lambda decision: decision,
+        quiet_mode=True,
+        tool_progress_mode="off",
+        verbose_logging=False,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        _checkpoint_mgr=CheckpointManager(),
+        _touch_activity=lambda *_args, **_kwargs: None,
+    )
+
+    managed = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="write_file",
+        function_args={
+            "path": "sample.txt",
+            "content": "data",
+            "target": "dev",
+        },
+        effective_task_id="target-race",
+        tool_call_id="call-1",
+        execute=lambda args: write_file_tool(
+            args["path"], args["content"],
+            task_id="target-race", target=args["target"],
+        ),
+    )
+
+    result = json.loads(managed.result)
+    assert checkpoints[0][0] == str(first)
+    assert result["cwd"] == str(first)
+    assert result["target"] == "dev"
+    assert (first / "sample.txt").read_text() == "data"
+    assert not (second / "sample.txt").exists()
+    assert targets_mod.resolve_execution_target("dev").config["cwd"] == str(second)
+    targets_mod.set_execution_target_config_source(None)
+
+
+def test_current_tool_leases_do_not_block_own_replacement_but_other_users_do(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    environment_key = ("default", "dev")
+    env = SimpleNamespace(_hermes_stable_storage=True)
+
+    with terminal_mod.logical_environment_turn("turn-a"):
+        with terminal_mod.environment_turn_usage(
+            "turn-a", environment_key=environment_key,
+        ):
+            assert not terminal_mod._environment_replacement_is_busy(
+                env, environment_key,
+            )
+            other_key = terminal_mod.register_environment_turn("turn-b")
+            try:
+                assert terminal_mod._environment_replacement_is_busy(
+                    env, environment_key,
+                )
+            finally:
+                terminal_mod._release_environment_turn_key(other_key)
+
+
+def test_idle_reaper_and_deferred_cleanup_wait_for_file_only_tool_lease(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    cleaned = []
+    deferred = []
+    environment_key = ("default", "dev")
+
+    class Environment:
+        def cleanup(self, force_remove=False):
+            cleaned.append(force_remove)
+
+    terminal_mod._active_environments[environment_key] = Environment()
+    terminal_mod._last_activity[environment_key] = 0.0
+    monkeypatch.setattr(
+        terminal_mod,
+        "cleanup_vm",
+        lambda task_id, **kw: deferred.append((task_id, kw)),
+    )
+
+    with terminal_mod.logical_environment_turn("file-turn"):
+        with terminal_mod.environment_turn_usage(
+            "file-turn", environment_key=environment_key,
+        ):
+            terminal_mod._cleanup_inactive_envs(lifetime_seconds=0)
+            assert environment_key in terminal_mod._active_environments
+            assert cleaned == []
+            terminal_mod.release_logical_environment_turn_for_cleanup("file-turn")
+            terminal_mod.defer_environment_turn_cleanup("file-turn")
+            assert deferred == []
+        assert deferred == [(
+            "file-turn",
+            {"preserve_persistent": True, "include_collapsed": True},
+        )]
+
+
+def test_negative_not_found_cache_is_target_scoped_and_skips_host_oracle(
+    monkeypatch, isolated_target_state,
+):
+    _, file_mod = isolated_target_state
+    alpha_state = ("default", "alpha")
+    beta_state = ("default", "beta")
+    remote_path = "/srv/project/missing.txt"
+    file_mod._record_not_found(
+        "read_file", remote_path, alpha_state, '{"error": "missing"}',
+    )
+    monkeypatch.setattr(
+        file_mod.os.path,
+        "exists",
+        lambda _path: (_ for _ in ()).throw(
+            AssertionError("remote cache must not inspect the host filesystem")
+        ),
+    )
+
+    assert file_mod._check_not_found_cache(
+        "read_file", remote_path, alpha_state, check_host_filesystem=False,
+    )
+    assert file_mod._check_not_found_cache(
+        "read_file", remote_path, beta_state, check_host_filesystem=False,
+    ) is None
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "code"])
+def test_all_environment_builders_forward_docker_shm_size(
+    builder, monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "cwd": "/workspace",
+                    "docker_image": "python:3.12-slim",
+                    "docker_shm_size": "768m",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    captured = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+        _persistent = False
+
+        def execute(self, _command, **_kwargs):
+            return {"output": "/workspace\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            return None
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        captured.append(kwargs["container_config"])
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+    if builder == "terminal":
+        result = json.loads(terminal_mod.terminal_tool(
+            "pwd", task_id="shm-terminal", target="sandbox",
+        ))
+        assert result["exit_code"] == 0
+    elif builder == "file":
+        file_mod._get_file_ops("shm-file", "sandbox")
+    else:
+        code_mod._get_or_create_env("shm-code", "sandbox")
+
+    assert captured[0]["docker_shm_size"] == "768m"
+
+
+def test_file_tool_lease_key_uses_explicit_nondefault_target(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": "/alpha", "beta": "/beta"}),
+    )
+    expected = targets_mod.resolve_execution_target("beta").session_key("default")
+
+    assert terminal_mod.execution_environment_turn_key(
+        "write_file", {"target": "beta"}, task_id="child-task",
+    ) == expected
+    assert terminal_mod.execution_environment_turn_key(
+        "process", {"session_id": "proc_123"}, task_id="child-task",
+    ) == terminal_mod._turn_scope_key("child-task")

--- a/tests/tools/test_named_execution_target_routing.py
+++ b/tests/tools/test_named_execution_target_routing.py
@@ -1,0 +1,2271 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+import threading
+import time
+
+import pytest
+
+
+def _named_config(cwds: dict[str, str], default: str = "alpha") -> dict:
+    return {
+        "terminal": {
+            "timeout": 60,
+            "lifetime_seconds": 3600,
+            "default_target": default,
+            "targets": {
+                name: {"backend": "local", "cwd": cwd}
+                for name, cwd in cwds.items()
+            },
+        },
+    }
+
+
+@pytest.fixture
+def isolated_target_state(monkeypatch):
+    import tools.file_tools as file_mod
+    import tools.execution_targets as targets_mod
+    import tools.terminal_tool as terminal_mod
+
+    targets_mod.set_execution_target_config_source(None)
+
+    monkeypatch.setattr(terminal_mod, "_active_environments", {})
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd", {})
+    monkeypatch.setattr(terminal_mod, "_session_cwd_specs", {})
+    monkeypatch.setattr(terminal_mod, "_task_env_overrides", {})
+    monkeypatch.setattr(terminal_mod, "_active_turn_counts", {})
+    monkeypatch.setattr(terminal_mod, "_deferred_environment_cleanups", {})
+    monkeypatch.setattr(terminal_mod, "_retired_environments", [])
+    monkeypatch.setattr(terminal_mod, "_start_cleanup_thread", lambda: None)
+    monkeypatch.setattr(file_mod, "_file_ops_cache", {})
+    monkeypatch.setattr(file_mod, "_read_tracker", {})
+    monkeypatch.setattr(file_mod, "_patch_failure_tracker", {})
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_all_guards",
+        lambda command, env_type, **kwargs: {"approved": True},
+    )
+    yield terminal_mod, file_mod
+    targets_mod.set_execution_target_config_source(None)
+    for env in list(terminal_mod._active_environments.values()):
+        try:
+            env.cleanup()
+        except Exception:
+            pass
+
+
+def test_same_task_reuses_within_target_and_isolates_across_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    first = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a"))
+    second = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-b", execution_target="alpha"))
+    third = json.loads(terminal_mod.terminal_tool("pwd", task_id="child-a", execution_target="beta"))
+
+    assert first["output"] == second["output"] == str(alpha)
+    assert third["output"] == str(beta)
+    assert set(terminal_mod._active_environments) == {("default", "alpha"), ("default", "beta")}
+
+
+def test_config_change_replaces_environment_instead_of_relabeling_it(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {"backend": "local", "cwd": "/local/project"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+    executed_cwds = []
+    cleanup_calls = []
+    cleanup_waits = []
+
+    class FakeEnvironment:
+        def __init__(self, backend):
+            self.backend = backend
+            self._persistent = True
+            self.cwd = "/remote/project" if backend == "ssh" else "/local/project"
+
+        def execute(self, command, **kwargs):
+            executed_cwds.append(kwargs.get("cwd"))
+            return {"output": f"executed-on-{self.backend}\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            cleanup_calls.append((self.backend, force_remove, self._persistent))
+
+        def wait_for_cleanup(self, timeout):
+            cleanup_waits.append(timeout)
+            return True
+
+    def fake_create(**kwargs):
+        env = FakeEnvironment(kwargs["env_type"])
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    first = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+    first_file_ops = file_mod._get_file_ops("session", "devbox")
+    terminal_mod.record_session_cwd(
+        "session", "/local/old-working-tree", target="devbox",
+    )
+    config["terminal"]["targets"]["devbox"] = {
+        "backend": "ssh",
+        "cwd": "/remote/project",
+        "ssh_host": "devbox.example",
+        "ssh_user": "agent",
+    }
+    second = json.loads(terminal_mod.terminal_tool("pwd", task_id="session"))
+    second_file_ops = file_mod._get_file_ops("session", "devbox")
+
+    assert first["output"].strip() == "executed-on-local"
+    assert first["backend"] == "local"
+    assert second["output"].strip() == "executed-on-ssh"
+    assert second["backend"] == "ssh"
+    assert [env.backend for env in created] == ["local", "ssh"]
+    assert first_file_ops.env is created[0]
+    assert second_file_ops.env is created[1]
+    assert executed_cwds == ["/local/project", "/remote/project"]
+    assert len(terminal_mod._retired_environments) == 1
+    assert terminal_mod._retired_environments[0][1] is created[0]
+    assert terminal_mod._cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=False,
+    ) == 1
+    assert cleanup_calls == [("local", True, False)]
+    assert cleanup_waits == [60.0]
+    assert terminal_mod._retired_environments == []
+
+
+def test_persistent_storage_replacement_waits_for_active_runtime(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    env = SimpleNamespace(_hermes_stable_storage=True)
+    monkeypatch.setattr(terminal_mod, "_active_turn_counts", {"session": 2})
+
+    assert terminal_mod._environment_replacement_is_busy(
+        env, ("session", "devbox"),
+    ) is True
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "code"])
+def test_environment_creation_fails_closed_if_target_changes_before_publish(
+    builder, monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {"alpha": {"backend": "local", "cwd": "/old"}},
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    cleaned = []
+
+    class FakeEnvironment:
+        cwd = "/old"
+
+        def cleanup(self, force_remove=False):
+            cleaned.append(force_remove)
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        config["terminal"]["targets"]["alpha"] = {
+            "backend": "local", "cwd": "/new",
+        }
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    if builder == "terminal":
+        result = json.loads(terminal_mod.terminal_tool(
+            "pwd", task_id="publish-race", execution_target="alpha",
+        ))
+        assert "changed while its environment was being created" in result["error"]
+    elif builder == "file":
+        with pytest.raises(RuntimeError, match="changed while its environment"):
+            file_mod._get_file_ops("publish-race", "alpha")
+    else:
+        with pytest.raises(ValueError, match="changed while its environment"):
+            code_mod._get_or_create_env("publish-race", "alpha")
+
+    assert terminal_mod._active_environments == {}
+    assert cleaned == [True]
+
+
+def test_ssh_target_routes_terminal_and_file_adapter_to_same_environment(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+
+    class FakeSshEnvironment:
+        def __init__(self, cwd):
+            self.cwd = cwd
+            self.is_persistent = True
+
+        def execute(self, command, cwd="", timeout=None, **kwargs):
+            return {"output": self.cwd + "\n", "returncode": 0}
+
+        def cleanup(self):
+            pass
+
+    def fake_create(**kwargs):
+        created.append(kwargs)
+        return FakeSshEnvironment(kwargs["cwd"])
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    result = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", execution_target="devbox",
+    ))
+    file_ops = file_mod._get_file_ops("session", "devbox")
+
+    assert result["target"] == "devbox"
+    assert result["backend"] == "ssh"
+    assert result["output"] == "/srv/project"
+    assert created[0]["env_type"] == "ssh"
+    assert created[0]["ssh_config"]["host"] == "devbox.example.com"
+    assert created[0]["cwd"] == "/srv/project"
+    assert file_ops.env is terminal_mod._active_environments[("default", "devbox")]
+
+
+def test_ssh_paths_stay_remote_relative_and_ignore_host_workspace_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "backend": "local",
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": ".",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+                "container": {"backend": "docker", "cwd": "."},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(tmp_path)},
+    )
+
+    assert file_mod._authoritative_workspace_root("session", "devbox") == "."
+    assert file_mod._backend_operation_path(
+        "relative.txt", str(tmp_path / "relative.txt"), "session", "devbox",
+    ) == "relative.txt"
+    assert file_mod._backend_operation_path(
+        "~/notes.txt", str(tmp_path / "notes.txt"), "session", "devbox",
+    ) == "~/notes.txt"
+    assert file_mod._authoritative_workspace_root(
+        "session", "container",
+    ) == "/root"
+
+    terminal_mod.record_session_cwd(
+        "session-a", "/srv/a", target="devbox",
+    )
+    terminal_mod.record_session_cwd(
+        "session-b", "/srv/b", target="devbox",
+    )
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-a", "devbox",
+    ) == "/srv/a/relative.txt"
+    assert file_mod._backend_operation_path(
+        "relative.txt", "/host/wrong", "session-b", "devbox",
+    ) == "/srv/b/relative.txt"
+    rewritten = file_mod._backend_v4a_patch(
+        "*** Begin Patch\n*** Update File: relative.txt\n*** End Patch",
+        "session-a",
+        "devbox",
+    )
+    assert "*** Update File: /srv/a/relative.txt" in rewritten
+
+
+def test_fresh_ssh_file_scope_does_not_inherit_shared_environment_cwd(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools.file_operations import ShellFileOperations
+
+    _, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": ".",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    calls = []
+
+    class SharedSshEnvironment:
+        cwd = "/other-session"
+
+        def execute(self, command, cwd=None, **kwargs):
+            calls.append(cwd)
+            return {"output": "", "returncode": 0}
+
+    shared_ops = ShellFileOperations(SharedSshEnvironment())
+    monkeypatch.setattr(file_mod, "_get_file_ops", lambda *args, **kwargs: shared_ops)
+    resolution = targets_mod.resolve_execution_target("devbox")
+
+    fresh_ops = file_mod._file_ops_for_resolution("fresh-session", resolution)
+    fresh_ops._exec("true")
+    terminal_mod, _ = isolated_target_state
+    terminal_mod.record_session_cwd(
+        "recorded-session", "/srv/recorded", target="devbox",
+    )
+    recorded_ops = file_mod._file_ops_for_resolution(
+        "recorded-session", resolution,
+    )
+    recorded_ops._exec("true")
+
+    assert calls == [".", "/srv/recorded"]
+
+
+def test_legacy_ssh_search_preserves_relative_path(monkeypatch, isolated_target_state):
+    from tools.file_operations import SearchResult
+
+    _, file_mod = isolated_target_state
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_CWD", "~")
+    captured = {}
+
+    class FakeOps:
+        def search(self, **kwargs):
+            captured.update(kwargs)
+            return SearchResult(matches=[], total_count=0)
+
+    monkeypatch.setattr(file_mod, "_get_file_ops", lambda *args, **kwargs: FakeOps())
+
+    result = json.loads(file_mod.search_tool("needle", path="."))
+
+    assert not result.get("error")
+    assert captured["path"] == "."
+
+
+def test_ssh_reads_never_use_host_mtime_dedup(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    _, file_mod = isolated_target_state
+    import tools.execution_targets as targets_mod
+    from tools.file_operations import ReadResult
+
+    host_twin = tmp_path / "same.txt"
+    host_twin.write_text("host\n", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "devbox",
+            "targets": {
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": str(tmp_path),
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class FakeOps:
+        calls = 0
+
+        @classmethod
+        def read_file(cls, path, offset, limit):
+            cls.calls += 1
+            return ReadResult(
+                content=f"remote-{cls.calls}", total_lines=1, file_size=8,
+            )
+
+    monkeypatch.setattr(
+        file_mod, "_get_file_ops",
+        lambda task_id, target=None, _resolution=None: FakeOps(),
+    )
+
+    first = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", execution_target="devbox",
+    ))
+    second = json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="session", execution_target="devbox",
+    ))
+
+    assert first["content"] != second["content"]
+    assert second.get("status") != "unchanged"
+    assert FakeOps.calls == 2
+
+
+def test_target_specific_cd_does_not_cross_talk_to_terminal_or_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha_sub = alpha / "sub"
+    beta_sub = beta / "sub"
+    alpha_sub.mkdir(parents=True)
+    beta_sub.mkdir(parents=True)
+    (alpha_sub / "which.txt").write_text("alpha\n", encoding="utf-8")
+    (beta / "which.txt").write_text("beta-root\n", encoding="utf-8")
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    cd_result = json.loads(terminal_mod.terminal_tool(
+        "cd sub", task_id="session", execution_target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", execution_target="beta",
+    ))
+    alpha_read = json.loads(file_mod.read_file_tool(
+        "which.txt", task_id="session", execution_target="alpha",
+    ))
+    beta_read = json.loads(file_mod.read_file_tool(
+        "which.txt", task_id="session", execution_target="beta",
+    ))
+
+    assert cd_result["exit_code"] == 0
+    assert beta_pwd["output"] == str(beta)
+    assert "alpha" in alpha_read["content"]
+    assert "beta-root" in beta_read["content"]
+
+
+def test_local_targets_route_write_read_patch_search_and_cache_separately(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    write_alpha = json.loads(file_mod.write_file_tool(
+        "shared.txt", "alpha-value\n", task_id="session",
+        execution_target="alpha",
+    ))
+    write_beta = json.loads(file_mod.write_file_tool(
+        "shared.txt", "beta-value\n", task_id="session",
+        execution_target="beta",
+    ))
+    patch_alpha = json.loads(file_mod.patch_tool(
+        path="shared.txt", old_string="alpha-value\n", new_string="alpha-patched\n",
+        task_id="session", execution_target="alpha",
+    ))
+    search_alpha = json.loads(file_mod.search_tool(
+        "alpha-patched", path=".", task_id="session", execution_target="alpha",
+    ))
+    search_beta = json.loads(file_mod.search_tool(
+        "beta-value", path=".", task_id="session", execution_target="beta",
+    ))
+
+    assert not write_alpha.get("error") and not write_beta.get("error")
+    assert not patch_alpha.get("error")
+    assert (alpha / "shared.txt").read_text(encoding="utf-8") == "alpha-patched\n"
+    assert (beta / "shared.txt").read_text(encoding="utf-8") == "beta-value\n"
+    assert search_alpha["matches"] and search_beta["matches"]
+    assert write_alpha["target"] == patch_alpha["target"] == "alpha"
+    assert search_beta["target"] == "beta"
+    assert set(file_mod._file_ops_cache) == {("default", "alpha"), ("default", "beta")}
+    assert ("session", "alpha") in file_mod._read_tracker
+    assert ("session", "beta") in file_mod._read_tracker
+
+
+def test_real_config_loader_routes_terminal_and_files_between_two_local_targets(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import yaml
+
+    import tools.file_tools as file_mod
+    import tools.terminal_tool as terminal_mod
+
+    alpha = tmp_path / "configured-alpha"
+    beta = tmp_path / "configured-beta"
+    alpha.mkdir()
+    beta.mkdir()
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": str(alpha)},
+                    "beta": {"backend": "local", "cwd": str(beta)},
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", execution_target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="configured-session", execution_target="beta",
+    ))
+    assert alpha_pwd["output"] == str(alpha)
+    assert beta_pwd["output"] == str(beta)
+
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from alpha\n", task_id="configured-session", execution_target="alpha",
+    ))["target"] == "alpha"
+    assert json.loads(file_mod.write_file_tool(
+        "same.txt", "from beta\n", task_id="configured-session", execution_target="beta",
+    ))["target"] == "beta"
+    assert "from alpha" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", execution_target="alpha",
+    ))["content"]
+    assert "from beta" in json.loads(file_mod.read_file_tool(
+        "same.txt", task_id="configured-session", execution_target="beta",
+    ))["content"]
+
+
+def test_workspace_override_applies_only_to_default_named_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    host_workspace = tmp_path / "host-workspace"
+    alpha.mkdir()
+    beta.mkdir()
+    host_workspace.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+
+    # ACP/TUI/gateway surfaces register the host workspace as a task override.
+    # It should seed the configured default target, not replace an explicit
+    # remote/container target's own cwd.
+    terminal_mod.register_task_env_overrides(
+        "session", {"cwd": str(host_workspace)},
+    )
+
+    alpha_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", execution_target="alpha",
+    ))
+    beta_pwd = json.loads(terminal_mod.terminal_tool(
+        "pwd", task_id="session", execution_target="beta",
+    ))
+    beta_write = json.loads(file_mod.write_file_tool(
+        "target-only.txt", "beta\n", task_id="session", execution_target="beta",
+    ))
+
+    assert alpha_pwd["output"] == str(host_workspace)
+    assert beta_pwd["output"] == str(beta)
+    assert beta_write["resolved_path"] == str(beta / "target-only.txt")
+    assert (beta / "target-only.txt").read_text(encoding="utf-8") == "beta\n"
+    assert not (host_workspace / "target-only.txt").exists()
+
+
+def test_unknown_target_errors_are_returned_by_execution_and_file_tools(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha)}),
+    )
+
+    results = [
+        json.loads(terminal_mod.terminal_tool("pwd", execution_target="missing")),
+        json.loads(file_mod.read_file_tool("x.txt", execution_target="missing")),
+        json.loads(file_mod.write_file_tool(
+            "x.txt", "x", execution_target="missing",
+        )),
+        json.loads(file_mod.search_tool(
+            "x", path=".", execution_target="missing",
+        )),
+        json.loads(code_mod.execute_code(
+            "print('x')", execution_target="missing",
+        )),
+    ]
+
+    for result in results:
+        assert "missing" in result["error"]
+        assert "Available targets: 'alpha'" in result["error"]
+    assert not (alpha / "x.txt").exists()
+
+
+def test_model_facing_handlers_reject_removed_target_selector(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha)}),
+    )
+
+    terminal_result = json.loads(terminal_mod._handle_terminal({
+        "command": "pwd", "target": "alpha",
+    }, task_id="removed-selector"))
+    write_result = json.loads(file_mod._handle_write_file({
+        "path": "alias.txt", "content": "data\n", "target": "alpha",
+    }, task_id="removed-selector"))
+
+    assert "does not accept 'target'" in terminal_result["error"]
+    assert "does not accept 'target'" in write_result["error"]
+    assert not (alpha / "alias.txt").exists()
+
+
+def test_public_execution_routing_signatures_have_no_target_parameter(
+    isolated_target_state,
+):
+    import inspect
+    import tools.code_execution_tool as code_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    for function in (
+        terminal_mod.terminal_tool,
+        file_mod.read_file_tool,
+        file_mod.write_file_tool,
+        file_mod.patch_tool,
+        code_mod.execute_code,
+    ):
+        parameters = inspect.signature(function).parameters
+        assert "execution_target" in parameters
+        assert "target" not in parameters
+
+    search_parameters = inspect.signature(file_mod.search_tool).parameters
+    assert "target" in search_parameters
+    assert "execution_target" in search_parameters
+
+
+def test_cleanup_without_target_removes_all_task_scopes_and_explicit_removes_one(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self):
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    config = _named_config({"alpha": "/a", "beta": "/b"})
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    alpha = FakeEnv()
+    beta = FakeEnv()
+    terminal_mod._active_environments.update({
+        ("default", "alpha"): alpha,
+        ("default", "beta"): beta,
+    })
+    terminal_mod._last_activity.update({
+        ("default", "alpha"): time.time(),
+        ("default", "beta"): time.time(),
+    })
+
+    # Unregistered delegate ids collapse to the parent's "default" scope for
+    # execution, but closing a delegate must preserve legacy cleanup semantics
+    # and must not tear down the parent's shared environments.
+    terminal_mod.cleanup_vm("child-a")
+    terminal_mod.cleanup_vm("child-a", target="alpha")
+    assert alpha.cleaned == beta.cleaned == 0
+
+    terminal_mod.cleanup_vm("default", target="alpha")
+    assert alpha.cleaned == 1 and beta.cleaned == 0
+    assert set(terminal_mod._active_environments) == {("default", "beta")}
+
+    terminal_mod.cleanup_vm("default")
+    assert beta.cleaned == 1
+    assert terminal_mod._active_environments == {}
+
+
+def test_per_turn_cleanup_preserves_only_persistent_named_siblings(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+
+    class FakeEnv:
+        def __init__(self, persistent):
+            self._persistent = persistent
+            self.cleaned = 0
+
+        def cleanup(self):
+            self.cleaned += 1
+
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": "/a", "beta": "/b"}),
+    )
+    key_a = ("default", "alpha")
+    key_b = ("default", "beta")
+    persistent = FakeEnv(True)
+    ephemeral = FakeEnv(False)
+    terminal_mod._active_environments.update({
+        key_a: persistent,
+        key_b: ephemeral,
+    })
+    terminal_mod._last_activity.update({key_a: 1.0, key_b: 1.0})
+    persistent_ops = object()
+    ephemeral_ops = object()
+    file_mod._file_ops_cache.update({
+        key_a: persistent_ops,
+        key_b: ephemeral_ops,
+    })
+
+    terminal_mod.register_environment_turn("turn-a")
+    terminal_mod.register_environment_turn("turn-b")
+    assert terminal_mod.release_environment_turn("turn-a") == 1
+    terminal_mod.cleanup_vm(
+        "turn-a", preserve_persistent=True, include_collapsed=False,
+    )
+    assert key_b in terminal_mod._active_environments
+
+    assert terminal_mod.release_environment_turn("turn-b") == 0
+    terminal_mod.cleanup_vm(
+        "turn-b", preserve_persistent=True, include_collapsed=True,
+    )
+
+    assert terminal_mod._active_environments[key_a] is persistent
+    assert key_b not in terminal_mod._active_environments
+    assert persistent.cleaned == 0
+    assert ephemeral.cleaned == 1
+    assert file_mod._file_ops_cache[key_a] is persistent_ops
+    assert key_b not in file_mod._file_ops_cache
+
+    from tools.process_registry import process_registry
+
+    active_env = FakeEnv(False)
+    terminal_mod._active_environments[key_b] = active_env
+    monkeypatch.setattr(
+        process_registry, "has_active_processes", lambda key: key == key_b,
+    )
+    terminal_mod.cleanup_vm(
+        "turn-c", preserve_persistent=True, include_collapsed=True,
+    )
+    assert terminal_mod._active_environments[key_b] is active_env
+    assert active_env.cleaned == 0
+
+
+def test_complete_logical_turn_cleanup_waits_for_overlapping_turn(
+    monkeypatch, isolated_target_state,
+):
+    """Cleanup releases only its own logical-turn lease.
+
+    Two gateway turns can overlap while their child task ids collapse onto the
+    same shared target environments. The first finisher must not tear down an
+    ephemeral sibling still in use by the other complete logical turn.
+    """
+    from agent import chat_completion_helpers as chat_helpers
+
+    terminal_mod, _ = isolated_target_state
+    vm_calls = []
+    browser_calls = []
+    runtime = SimpleNamespace(
+        cleanup_vm=lambda task_id, **kwargs: vm_calls.append((task_id, kwargs)),
+        cleanup_browser=lambda task_id: browser_calls.append(task_id),
+    )
+    monkeypatch.setattr(chat_helpers, "_ra", lambda: runtime)
+    fake_agent = SimpleNamespace(verbose_logging=False)
+
+    with terminal_mod.logical_environment_turn("turn-a"):
+        assert terminal_mod.active_environment_turns("turn-a") == 1
+        with terminal_mod.logical_environment_turn("turn-b"):
+            assert terminal_mod.active_environment_turns("turn-b") == 2
+            chat_helpers.cleanup_task_resources(fake_agent, "turn-b")
+            assert terminal_mod.active_environment_turns("turn-a") == 1
+            assert vm_calls[-1] == (
+                "turn-b",
+                {"preserve_persistent": True, "include_collapsed": False},
+            )
+        chat_helpers.cleanup_task_resources(fake_agent, "turn-a")
+        assert terminal_mod.active_environment_turns("turn-a") == 0
+        assert vm_calls[-1] == (
+            "turn-a",
+            {"preserve_persistent": True, "include_collapsed": True},
+        )
+
+    # Both context-manager finalizers are idempotent after cleanup released
+    # their leases; no negative count or leaked logical-turn owner remains.
+    assert terminal_mod.active_environment_turns("turn-a") == 0
+    assert browser_calls == ["turn-b", "turn-a"]
+
+
+def test_logical_environment_turn_exception_releases_once(isolated_target_state):
+    terminal_mod, _ = isolated_target_state
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with terminal_mod.logical_environment_turn("turn-exception"):
+            assert terminal_mod.active_environment_turns("turn-exception") == 1
+            raise RuntimeError("boom")
+
+    assert terminal_mod.active_environment_turns("turn-exception") == 0
+
+
+def test_local_persistent_config_marks_environment(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+
+    class FakeLocal:
+        def __init__(self, cwd, timeout):
+            self.cwd = cwd
+            self.timeout = timeout
+
+    monkeypatch.setattr(terminal_mod, "_LocalEnvironment", FakeLocal)
+    env = terminal_mod._create_environment(
+        "local", "", "/workspace", 30,
+        local_config={"persistent": True},
+    )
+
+    assert terminal_mod._environment_is_persistent(env)
+
+
+def test_process_metadata_survives_status_list_and_checkpoint(monkeypatch, tmp_path):
+    import tools.process_registry as process_mod
+
+    checkpoint = tmp_path / "processes.json"
+    monkeypatch.setattr(process_mod, "CHECKPOINT_PATH", checkpoint)
+    registry = process_mod.ProcessRegistry()
+    session = process_mod.ProcessSession(
+        id="proc_targeted",
+        command="sleep 30",
+        task_id="default",
+        target="devbox",
+        backend="ssh",
+        timeout_seconds=7,
+        environment_task_key="profile-a:default",
+        pid=4321,
+        host_start_time=99,
+        started_at=time.time(),
+    )
+    registry._running[session.id] = session
+
+    assert registry.has_active_processes(("profile-a:default", "devbox"))
+    assert registry.poll(session.id)["target"] == "devbox"
+    assert registry.list_sessions()[0]["backend"] == "ssh"
+    registry._write_checkpoint()
+    raw = json.loads(checkpoint.read_text(encoding="utf-8"))
+    assert raw[0]["target"] == "devbox"
+    assert raw[0]["timeout_seconds"] == 7
+    assert raw[0]["environment_task_key"] == "profile-a:default"
+    assert raw[0]["backend"] == "ssh"
+
+    recovered = process_mod.ProcessRegistry()
+    monkeypatch.setattr(recovered, "_host_pid_is_ours", lambda pid, started: True)
+    assert recovered.recover_from_checkpoint() == 1
+    recovered_session = recovered.get(session.id)
+    assert recovered_session is not None
+    assert recovered_session.target == "devbox"
+    assert recovered_session.backend == "ssh"
+    assert recovered_session.timeout_seconds == 7
+    assert recovered_session.environment_task_key == "profile-a:default"
+
+    recovered_session.exited = True
+    waited = recovered.wait(session.id, timeout=99)
+    assert "configured limit of 7s" in waited["timeout_note"]
+
+
+def test_execute_code_inherits_target_and_rejects_nested_override(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+    source = code_mod.generate_hermes_tools_module(
+        ["write_file", "read_file", "search_files"],
+    )
+    namespace = {}
+    exec(source, namespace)
+    calls = []
+    namespace["_call"] = lambda name, args: calls.append((name, args)) or {}
+
+    namespace["write_file"]("nested.txt", "alpha-default\n")
+    namespace["write_file"](
+        "nested.txt", "beta-explicit\n", execution_target="beta",
+    )
+    with pytest.raises(TypeError, match="unexpected keyword argument 'target'"):
+        namespace["write_file"]("nested.txt", "invalid\n", target="beta")
+    namespace["search_files"]("needle")
+
+    inherited_write = code_mod._inherit_execution_target(
+        calls[0][0], calls[0][1], "alpha",
+    )
+    inherited_search = code_mod._inherit_execution_target(
+        calls[2][0], calls[2][1], "alpha",
+    )
+    assert inherited_write["execution_target"] == "alpha"
+    assert inherited_search["execution_target"] == "alpha"
+    with pytest.raises(ValueError, match="cannot select 'beta'"):
+        code_mod._inherit_execution_target(calls[1][0], calls[1][1], "alpha")
+    with pytest.raises(ValueError, match="does not accept 'target'"):
+        code_mod._inherit_execution_target(
+            "write_file", {"path": "x", "target": "beta"}, "alpha",
+        )
+
+    remote_config = _named_config({"alpha": str(alpha), "beta": str(beta)})
+    remote_config["terminal"]["targets"]["alpha"]["backend"] = "ssh"
+    remote_config["terminal"]["targets"]["alpha"]["ssh_host"] = "example.invalid"
+    remote_config["terminal"]["targets"]["alpha"]["ssh_user"] = "agent"
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: remote_config)
+    forwarded = {}
+    monkeypatch.setattr(code_mod, "_get_execution_mode", lambda: "project")
+    monkeypatch.setattr(
+        code_mod, "_execute_remote",
+        lambda code, task_id, enabled_tools, target=None, mode="strict",
+        expected_target_scope=None, expected_target_config=None: (
+            forwarded.update(
+                target=target, mode=mode, scope=expected_target_scope,
+                config=expected_target_config,
+            )
+            or json.dumps({"status": "success"})
+        ),
+    )
+
+    result = json.loads(code_mod.execute_code(
+        "print('ok')", execution_target="alpha",
+    ))
+    assert result["status"] == "success"
+    assert forwarded["target"] == "alpha"
+    assert forwarded["mode"] == "project"
+    assert forwarded["scope"] == targets_mod.resolve_execution_target("alpha").security_scope
+    assert forwarded["config"]["terminal"]["targets"]["alpha"]["backend"] == "ssh"
+    with pytest.raises(ValueError, match="runtime_scope"):
+        code_mod._inherit_execution_target(
+            "read_file",
+            {"path": "saved.txt", "runtime_scope": "old-scope"},
+            "alpha",
+            forwarded["scope"],
+        )
+
+
+def test_execute_code_rpc_rejects_alias_repointed_during_run(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {"alpha": {"backend": "local", "cwd": "/old"}},
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    approved_scope = targets_mod.resolve_execution_target("alpha").security_scope
+    config["terminal"]["targets"]["alpha"] = {
+        "backend": "ssh", "ssh_host": "new.example", "ssh_user": "agent",
+        "cwd": "/new",
+    }
+
+    with pytest.raises(ValueError, match="changed while execute_code was running"):
+        code_mod._inherit_execution_target(
+            "write_file", {"path": "marker", "content": "x"},
+            "alpha", approved_scope,
+        )
+
+
+def test_execute_code_rpc_live_recheck_ignores_frozen_dispatch_snapshot(
+    isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    approved = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {"alpha": {"backend": "local", "cwd": "/old"}},
+        },
+    }
+    live = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {
+                    "backend": "ssh",
+                    "ssh_host": "new.example",
+                    "ssh_user": "agent",
+                    "cwd": "/new",
+                },
+            },
+        },
+    }
+    approved_scope = targets_mod.resolve_execution_target(
+        "alpha", config=approved,
+    ).security_scope
+    targets_mod.set_execution_target_config_source(live)
+
+    with targets_mod.execution_target_config_scope(approved):
+        with pytest.raises(
+            ValueError, match="changed while execute_code was running",
+        ):
+            code_mod._inherit_execution_target(
+                "write_file", {"path": "marker", "content": "x"},
+                "alpha", approved_scope,
+            )
+
+
+def test_execute_code_rpc_dispatch_uses_frozen_approved_target_config(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    live = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {
+                    "backend": "ssh", "ssh_host": "new.example",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    approved = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": "/approved"},
+            },
+        },
+    }
+
+    targets_mod.set_execution_target_config_source(live)
+
+    def handler(_name, args, task_id=None):
+        resolved = targets_mod.resolve_execution_target(args["execution_target"])
+        current = targets_mod.resolve_live_execution_target(args["execution_target"])
+        return resolved.backend, resolved.config.get("cwd"), current.backend
+
+    assert code_mod._dispatch_rpc_tool(
+        handler, "write_file", {"execution_target": "alpha"}, "task", approved,
+    ) == ("local", "/approved", "ssh")
+    assert targets_mod.resolve_execution_target("alpha").backend == "ssh"
+
+
+def test_execute_code_routes_real_nested_file_call_to_selected_local_target(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    config = _named_config({"alpha": str(alpha), "beta": str(beta)})
+    # Real merged configs contain defaults for unrelated backends.  Freezing the
+    # approved target must preserve them as inherited top-level settings rather
+    # than reclassifying them as explicit local-target fields.
+    config["terminal"]["modal_mode"] = "ephemeral"
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    targets_mod.set_execution_target_config_source(config)
+
+    result = json.loads(code_mod.execute_code(
+        "from hermes_tools import write_file\n"
+        "print(write_file('from-code.txt', 'beta-via-rpc\\n'))\n",
+        task_id="execute-target-session",
+        enabled_tools=["write_file"],
+        execution_target="beta",
+    ))
+
+    assert result["status"] == "success"
+    assert result["target"] == "beta"
+    assert result["backend"] == "local"
+    assert (beta / "from-code.txt").read_text(encoding="utf-8") == "beta-via-rpc\n"
+    assert not (alpha / "from-code.txt").exists()
+
+
+def test_remote_project_mode_executes_from_target_session_cwd(
+    monkeypatch, isolated_target_state,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    config = _named_config({"alpha": "/srv/configured", "beta": "/b"})
+    config["terminal"]["targets"]["alpha"].update({
+        "backend": "ssh",
+        "ssh_host": "example.invalid",
+        "ssh_user": "agent",
+    })
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    terminal_mod, _ = isolated_target_state
+    terminal_mod.record_session_cwd(
+        "remote-project", "/srv/session-project", target="alpha",
+    )
+
+    calls = []
+
+    class FakeEnv:
+        cwd = "/srv/configured"
+
+        def execute(self, command, cwd=None, timeout=None, stdin_data=None):
+            calls.append((command, cwd))
+            if cwd is not None:
+                self.cwd = cwd
+            if "command -v python3" in command:
+                return {"output": "OK\n", "returncode": 0}
+            return {"output": "done\n", "returncode": 0}
+
+        def get_temp_dir(self):
+            return "/remote-tmp"
+
+    class DummyThread:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def join(self, timeout=None):
+            pass
+
+    env = FakeEnv()
+    monkeypatch.setattr(
+        code_mod, "_get_or_create_env",
+        lambda task_id, target=None, expected_target_scope=None: (env, "ssh"),
+    )
+    monkeypatch.setattr(code_mod, "_ship_file_to_remote", lambda *args, **kwargs: None)
+    monkeypatch.setattr(code_mod.threading, "Thread", DummyThread)
+    monkeypatch.setattr(
+        code_mod, "_load_config", lambda: {"timeout": 30, "max_tool_calls": 5},
+    )
+
+    result = json.loads(code_mod._execute_remote(
+        "print('ok')", "remote-project", [], target="alpha", mode="project",
+    ))
+    repeated = json.loads(code_mod._execute_remote(
+        "print('again')", "remote-project", [], target="alpha", mode="project",
+    ))
+
+    assert result["status"] == repeated["status"] == "success"
+    assert result["cwd"] == repeated["cwd"] == "/srv/session-project"
+    script_calls = [
+        item for item in calls
+        if "python3 /remote-tmp/hermes_exec_" in item[0]
+    ]
+    assert len(script_calls) == 2
+    assert all(cwd == "/srv/session-project" for _, cwd in script_calls)
+
+
+def test_tool_output_persistence_uses_the_result_target(monkeypatch):
+    import agent.tool_executor as executor
+
+    default_env = object()
+    beta_env = object()
+
+    def fake_get_active_env(_task_id, target=None):
+        return beta_env if target == "beta" else default_env
+
+    monkeypatch.setattr(executor, "get_active_env", fake_get_active_env)
+
+    result = json.dumps({"target": "beta", "output": "x"})
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {}, result,
+    ) is beta_env
+
+    import tools.terminal_tool as terminal_mod
+
+    scoped_env = object()
+    monkeypatch.setattr(
+        terminal_mod, "get_environment_for_target_scope",
+        lambda task_id, target, scope: scoped_env,
+    )
+    scoped_result = json.dumps({
+        "target": "beta", "runtime_scope": "old-scope", "output": "x",
+    })
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {}, scoped_result,
+    ) is scoped_env
+
+    from tools.process_registry import process_registry
+
+    producing_env = object()
+    monkeypatch.setattr(
+        process_registry, "get",
+        lambda session_id: SimpleNamespace(env_ref=producing_env),
+    )
+    assert executor._active_env_for_tool_result(
+        "session", "process", {"session_id": "proc-old"},
+        json.dumps({"target": "beta", "output": "large"}),
+    ) is producing_env
+
+    captured = {}
+
+    def fake_enforce(messages, env=None, env_resolver=None, config=None):
+        assert callable(env_resolver)
+        captured["default"] = env
+        captured["selected"] = env_resolver(messages[0])
+
+    monkeypatch.setattr(executor, "enforce_turn_budget", fake_enforce)
+    messages = [{"content": "large", "tool_call_id": "call-beta"}]
+    target_map = {"call-beta": "beta"}
+    executor._enforce_target_aware_turn_budget(
+        messages, "session", executor.DEFAULT_BUDGET, target_map,
+    )
+
+    assert captured == {"default": default_env, "selected": beta_env}
+    assert target_map == {}
+    assert "_execution_target" not in messages[0]
+
+    captured.clear()
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "web result", "tool_call_id": "call-web"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        {},
+    )
+    assert captured == {"default": default_env, "selected": default_env}
+    persisted = executor._append_persisted_target_hint(
+        f"{executor.PERSISTED_OUTPUT_TAG}\nfull output saved",
+        "beta",
+    )
+    assert 'Execution target for this saved output: "beta"' in persisted
+    assert 'execution_target="beta"' in persisted
+
+    scoped = executor._append_persisted_target_hint(
+        f"saved {executor.PERSISTED_OUTPUT_TAG}", "beta", "scope-v1",
+    )
+    assert 'runtime_scope="scope-v1"' in scoped
+
+    monkeypatch.setattr(
+        executor, "get_active_env",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("bad target config")),
+    )
+    assert executor._active_env_for_tool_result(
+        "session", "terminal", {"execution_target": "broken"},
+    ) is None
+    captured.clear()
+    target_map = {"call-broken": "broken"}
+    executor._enforce_target_aware_turn_budget(
+        [{"content": "error", "tool_call_id": "call-broken"}],
+        "session",
+        executor.DEFAULT_BUDGET,
+        target_map,
+    )
+    assert captured == {"default": None, "selected": None}
+
+
+def test_subdirectory_hints_follow_local_target_and_skip_remote_host(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    from types import SimpleNamespace
+
+    import agent.tool_executor as executor
+    import tools.execution_targets as targets_mod
+
+    local_root = tmp_path / "local-target"
+    subdir = local_root / "src"
+    subdir.mkdir(parents=True)
+    (subdir / "AGENTS.md").write_text("LOCAL TARGET HINT", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "local",
+            "targets": {
+                "local": {"backend": "local", "cwd": str(local_root)},
+                "devbox": {
+                    "backend": "ssh",
+                    "cwd": "/srv/project",
+                    "ssh_host": "devbox.example.com",
+                    "ssh_user": "agent",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    class DefaultTracker:
+        def __init__(self):
+            self.calls = 0
+
+        def check_tool_call(self, *args, **kwargs):
+            self.calls += 1
+            return "WRONG HOST HINT"
+
+    default_tracker = DefaultTracker()
+    agent = SimpleNamespace(_subdirectory_hints=default_tracker)
+    local_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "local",
+    )
+    remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, "devbox",
+    )
+    config["terminal"]["default_target"] = "devbox"
+    omitted_remote_hint = executor._target_subdirectory_hints(
+        agent, "session", "read_file", {"path": "src/main.py"}, None,
+    )
+
+    assert isinstance(local_hint, str)
+    assert "LOCAL TARGET HINT" in local_hint
+    assert executor._selected_local_target_cwd(
+        "session", "write_file", {"execution_target": "local"},
+    ) == str(local_root)
+    assert executor._selected_local_target_cwd(
+        "session", "terminal", {"execution_target": "devbox"},
+    ) is None
+    assert remote_hint is None
+    assert omitted_remote_hint is None
+    assert default_tracker.calls == 0
+
+
+def test_targetless_intervening_tool_resets_all_target_read_trackers(
+    monkeypatch, isolated_target_state,
+):
+    import model_tools
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    assert "memory" not in model_tools._TARGET_SELECTOR_TOOLS
+    assert "terminal" in model_tools._TARGET_SELECTOR_TOOLS
+    for key in ("session", ("session", "alpha"), ("session", "beta")):
+        file_mod._read_tracker[key] = {
+            "last_key": "same",
+            "consecutive": 4,
+            "dedup_hits": {"same": 2},
+        }
+
+    file_mod.notify_other_tool_call("session")
+
+    for data in file_mod._read_tracker.values():
+        assert data["last_key"] is None
+        assert data["consecutive"] == 0
+        assert data["dedup_hits"] == {}
+
+    monkeypatch.setattr(targets_mod, "_active_profile_scope", lambda: "profile-a")
+    profile_key = ("profile-profile-a:session", "alpha")
+    file_mod._read_tracker[profile_key] = {
+        "dedup": {"region": (1.0, 2, "hash")},
+        "dedup_hits": {"region": 3},
+    }
+    file_mod.reset_file_dedup("session")
+    assert file_mod._read_tracker[profile_key]["dedup"] == {}
+    assert file_mod._read_tracker[profile_key]["dedup_hits"] == {}
+
+
+def test_sudo_cache_and_nopasswd_probe_are_target_scoped(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    terminal_mod._reset_cached_sudo_passwords()
+
+    terminal_mod._set_cached_sudo_password("local-secret", "local", "local")
+    assert terminal_mod._get_cached_sudo_password("local", "local") == "local-secret"
+    assert terminal_mod._get_cached_sudo_password("devbox", "ssh") == ""
+
+    calls = []
+
+    class Probe:
+        returncode = 0
+
+    monkeypatch.setattr(
+        terminal_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: calls.append((args, kwargs)) or Probe(),
+    )
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh"):
+        assert terminal_mod._sudo_nopasswd_works() is False
+    assert calls == []
+
+    with terminal_mod._scoped_sudo_execution("local", "local"):
+        assert terminal_mod._sudo_nopasswd_works() is True
+    assert len(calls) == 1
+
+    monkeypatch.setenv("SUDO_PASSWORD", "default-secret")
+    with terminal_mod._scoped_sudo_execution(
+        "devbox", "ssh", named=True, sudo_password="target-secret",
+    ):
+        transformed, selected_password = terminal_mod._transform_sudo_command(
+            "sudo id",
+        )
+    assert "target-secret" not in transformed
+    assert "default-secret" not in transformed
+    assert selected_password == "target-secret\n"
+
+    with terminal_mod._scoped_sudo_execution("devbox", "ssh", named=True):
+        terminal_mod._set_cached_sudo_password("cached-target")
+        _, cached_password = terminal_mod._transform_sudo_command("sudo id")
+    assert cached_password == "cached-target\n"
+
+    monkeypatch.delenv("SUDO_PASSWORD")
+    with terminal_mod._scoped_sudo_execution(
+        "devbox", "ssh", named=True, target_scope="config-v2",
+    ):
+        terminal_mod._set_cached_sudo_password("stale-secret")
+    assert terminal_mod._invalidate_cached_sudo_on_auth_failure(
+        "sudo id", "sudo: authentication failed", "devbox", "ssh", "config-v2",
+    ) is True
+    assert terminal_mod._get_cached_sudo_password(
+        "devbox", "ssh", "config-v2",
+    ) == ""
+
+
+def test_requirements_keep_tools_registered_when_any_target_is_usable(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "broken-docker",
+            "targets": {
+                "broken-docker": {"backend": "docker", "cwd": "/workspace"},
+                "local": {"backend": "local", "cwd": "/workspace/local"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    checked = []
+    monkeypatch.setattr(
+        terminal_mod,
+        "_check_terminal_config_requirements",
+        lambda cfg: checked.append(cfg["env_type"]) or cfg["env_type"] == "local",
+    )
+
+    assert terminal_mod.check_terminal_requirements() is True
+    assert checked == ["local"]
+
+
+def test_local_target_aliases_share_file_state_lock_namespace(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import file_state
+
+    _, file_mod = isolated_target_state
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    path = shared / "same.txt"
+    path.write_text("v1", encoding="utf-8")
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": {"backend": "local", "cwd": str(shared)},
+                "alias": {"backend": "local", "cwd": str(shared)},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    assert file_mod._file_state_namespace("reader", "alpha") is None
+    assert file_mod._file_state_namespace("writer", "alias") is None
+
+    registry = file_state.FileStateRegistry()
+    monkeypatch.setattr(file_state, "_registry", registry)
+    file_state.record_read(("reader", "alpha"), path, namespace=None)
+    file_state.note_write(("writer", "alias"), path, namespace=None)
+    warning = file_state.check_stale(("reader", "alpha"), path, namespace=None)
+    assert warning is not None
+    assert "writer" in warning
+
+
+def test_ssh_target_aliases_share_file_state_lock_namespace(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import file_state
+
+    _, file_mod = isolated_target_state
+    ssh = {
+        "backend": "ssh",
+        "ssh_host": "devbox.example",
+        "ssh_user": "agent",
+        "ssh_port": 2222,
+        "cwd": "/srv/project",
+    }
+    config = {
+        "terminal": {
+            "default_target": "alpha",
+            "targets": {
+                "alpha": dict(ssh),
+                "alias": {**ssh, "cwd": "/different/root"},
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+
+    alpha = file_mod._file_state_namespace("reader", "alpha")
+    alias = file_mod._file_state_namespace("writer", "alias")
+    assert alpha == alias
+    assert alpha.startswith("ssh:")
+
+    alpha_resolution = targets_mod.resolve_execution_target("alpha")
+    alias_resolution = targets_mod.resolve_execution_target("alias")
+    alpha_key = alpha_resolution.file_coordination_key("reader")
+    alias_key = alias_resolution.file_coordination_key("writer")
+    path = "/srv/project/shared.txt"
+    registry = file_state.FileStateRegistry()
+    registry.record_read(alpha_key, path, namespace=alpha, stat_path=False)
+    registry.note_write(alias_key, path, namespace=alias, stat_path=False)
+    warning = registry.check_stale(alpha_key, path, namespace=alpha)
+
+    assert warning is not None
+    assert "writer" in warning
+    assert registry._lock_for(path, alpha) is registry._lock_for(path, alias)
+
+
+def test_persistent_docker_replacements_share_storage_lock_namespace(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    _, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    before = file_mod._file_state_namespace("session", "sandbox")
+    config["terminal"]["timeout"] = 90
+    after = file_mod._file_state_namespace("session", "sandbox")
+
+    assert before == after
+    assert before.startswith("docker-storage:")
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "execute_code"])
+def test_idle_persistent_docker_hot_edit_cleans_runtime_before_replacement(
+    monkeypatch, isolated_target_state, builder,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+    cleanup_calls = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+
+        def __init__(self):
+            self.cleaned = False
+
+        def execute(self, command, **kwargs):
+            return {"output": "ok\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            self.cleaned = True
+            cleanup_calls.append(force_remove)
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        if created:
+            assert created[0].cleaned is True
+        env = FakeEnvironment()
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    def build():
+        if builder == "terminal":
+            result = json.loads(terminal_mod.terminal_tool(
+                "pwd", task_id="session", execution_target="sandbox",
+            ))
+            if result.get("status") == "error":
+                raise RuntimeError(result["error"])
+            return result
+        if builder == "file":
+            return file_mod._get_file_ops("session", "sandbox")
+        return code_mod._get_or_create_env("session", "sandbox")
+
+    first = build()
+    config["terminal"]["timeout"] = 90
+    terminal_mod._active_turn_counts["default"] = 2
+    expected_error = ValueError if builder == "execute_code" else RuntimeError
+    with pytest.raises(expected_error, match="still active"):
+        build()
+    assert len(created) == 1
+    assert cleanup_calls == []
+    assert terminal_mod._active_environments[("default", "sandbox")] is created[0]
+
+    terminal_mod._active_turn_counts.clear()
+    second = build()
+
+    if builder == "terminal":
+        assert first["output"].strip() == second["output"].strip() == "ok"
+    assert len(created) == 2
+    assert cleanup_calls == [True]
+    assert terminal_mod._retired_environments == []
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "execute_code"])
+def test_persistent_docker_hot_edit_cleanup_failure_restores_runtime_ownership(
+    monkeypatch, isolated_target_state, builder,
+):
+    import tools.code_execution_tool as code_mod
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "timeout": 30,
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "container_persistent": True,
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    created = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+
+        def __init__(self):
+            self._persist_across_processes = True
+            self._persistent = True
+
+        def execute(self, command, **kwargs):
+            return {"output": "ok\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            assert force_remove is True
+            assert self._persist_across_processes is False
+            assert self._persistent is True
+            raise RuntimeError("lease handoff failed")
+
+    def fake_create(**kwargs):
+        env = FakeEnvironment()
+        created.append(env)
+        return env
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+
+    def build():
+        if builder == "terminal":
+            result = json.loads(terminal_mod.terminal_tool(
+                "pwd", task_id="session", execution_target="sandbox",
+            ))
+            if result.get("status") == "error":
+                raise RuntimeError(result["error"])
+            return result
+        if builder == "file":
+            return file_mod._get_file_ops("session", "sandbox")
+        return code_mod._get_or_create_env("session", "sandbox")
+
+    first = build()
+    old_env = created[0]
+    config["terminal"]["timeout"] = 90
+
+    if builder == "terminal":
+        assert first["output"].strip() == "ok"
+    expected_error = ValueError if builder == "execute_code" else RuntimeError
+    with pytest.raises(expected_error, match="Could not retire"):
+        build()
+    assert len(created) == 1
+    assert terminal_mod._active_environments[("default", "sandbox")] is old_env
+    assert old_env._persist_across_processes is True
+    assert old_env._persistent is True
+
+
+def test_local_background_process_keeps_producing_target_generation(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import agent.tool_executor as executor
+    import tools.execution_targets as targets_mod
+    from tools.process_registry import ProcessSession, process_registry
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    alpha.mkdir()
+    config = _named_config({"alpha": str(alpha)})
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    captured = {}
+
+    def fake_spawn_local(**kwargs):
+        captured.update(kwargs)
+        return ProcessSession(
+            id="proc-alpha",
+            command=kwargs["command"],
+            pid=123,
+            cwd=kwargs["cwd"],
+            target=kwargs["target"],
+            backend=kwargs["backend"],
+            runtime_scope=kwargs["runtime_scope"],
+            env_ref=kwargs["env_ref"],
+        )
+
+    monkeypatch.setattr(process_registry, "spawn_local", fake_spawn_local)
+    result = json.loads(terminal_mod.terminal_tool(
+        "sleep 1", task_id="session", execution_target="alpha", background=True,
+    ))
+    producing_env = captured["env_ref"]
+    producing_scope = targets_mod.resolve_execution_target("alpha").security_scope
+
+    assert result["session_id"] == "proc-alpha"
+    assert captured["runtime_scope"] == producing_scope
+    assert producing_env is terminal_mod._active_environments[("default", "alpha")]
+
+    config["terminal"]["targets"]["alpha"]["cwd"] = str(tmp_path / "new-alpha")
+    session = ProcessSession(
+        id="proc-alpha",
+        command="sleep 1",
+        target="alpha",
+        backend="local",
+        runtime_scope=producing_scope,
+        env_ref=producing_env,
+    )
+    monkeypatch.setattr(process_registry, "get", lambda session_id: session)
+    process_result = json.dumps({
+        "target": "alpha",
+        "runtime_scope": producing_scope,
+        "output": "large",
+    })
+    assert executor._active_env_for_tool_result(
+        "session", "process", {"session_id": "proc-alpha"}, process_result,
+    ) is producing_env
+
+
+def test_retired_environment_waits_for_base_task_turn_scope(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    env = object()
+    now = time.time()
+    terminal_mod._active_turn_counts["bench"] = 1
+    terminal_mod._retired_environments.append((("bench", "alpha"), env, now - 120))
+    monkeypatch.setattr(
+        terminal_mod, "_cleanup_environment_resource",
+        lambda *args, **kwargs: pytest.fail("active environment was cleaned"),
+    )
+
+    assert terminal_mod._cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=True,
+    ) == 0
+    assert terminal_mod._retired_environments[0][1] is env
+
+
+def test_command_approval_payload_and_observer_include_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    first = approval_mod._execution_scoped_pattern_key(
+        "danger", "devbox", True, "scope-one",
+    )
+    second = approval_mod._execution_scoped_pattern_key(
+        "danger", "devbox", True, "scope-two",
+    )
+    assert first != second
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "detect_hardline_command", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_check_sudo_stdin_guard", lambda command: (False, None))
+    monkeypatch.setattr(approval_mod, "_match_user_deny_rule", lambda command: None)
+    monkeypatch.setattr(approval_mod, "_command_matches_permanent_allowlist", lambda command: False)
+    monkeypatch.setattr(
+        approval_mod, "detect_dangerous_command",
+        lambda command: (True, "danger", "dangerous command"),
+    )
+    monkeypatch.setattr("tools.tirith_security.check_command_security", lambda command: {
+        "action": "allow", "findings": [], "summary": "",
+    })
+    session_key = "approval-target-session"
+    token = approval_mod.set_current_session_key(session_key)
+    seen = {}
+    hooks = []
+
+    def notify(data):
+        seen.update(data)
+        with approval_mod._lock:
+            entry = approval_mod._gateway_queues[session_key][-1]
+            entry.result = "deny"
+            entry.event.set()
+
+    monkeypatch.setattr(approval_mod, "_fire_approval_hook", lambda name, **data: hooks.append((name, data)))
+    approval_mod.register_gateway_notify(session_key, notify)
+    try:
+        approval_mod.check_all_command_guards(
+            "danger", "local", execution_target="alpha", execution_backend="local",
+        )
+    finally:
+        approval_mod.unregister_gateway_notify(session_key)
+        approval_mod.reset_current_session_key(token)
+
+    assert seen["target"] == "alpha"
+    assert seen["backend"] == "local"
+    assert "alpha" in seen["description"] and "local" in seen["description"]
+    pre_hook = next(data for name, data in hooks if name == "pre_approval_request")
+    assert pre_hook["target"] == "alpha"
+    assert pre_hook["backend"] == "local"
+
+
+def test_execute_code_approval_payload_includes_target_metadata(monkeypatch):
+    from tools import approval as approval_mod
+
+    monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "manual")
+    monkeypatch.setattr(approval_mod, "is_approved", lambda *args: False)
+    monkeypatch.setattr(approval_mod, "_YOLO_MODE_FROZEN", False)
+    monkeypatch.setattr(
+        approval_mod, "is_current_session_yolo_enabled", lambda: False,
+    )
+    seen = {}
+    monkeypatch.setattr(
+        approval_mod, "_await_gateway_decision",
+        lambda session_key, notify_cb, approval_data, surface: (
+            seen.update(approval_data) or {"resolved": True, "choice": "once"}
+        ),
+    )
+    session_token = approval_mod.set_current_session_key("target-approval")
+    try:
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs["target-approval"] = lambda data: None
+        result = approval_mod.check_execute_code_guard(
+            "print('ok')", "ssh", execution_target="devbox",
+            execution_backend="ssh",
+        )
+    finally:
+        approval_mod.reset_current_session_key(session_token)
+        with approval_mod._lock:
+            approval_mod._gateway_notify_cbs.pop("target-approval", None)
+
+    assert result["approved"] is True
+    assert seen["target"] == "devbox"
+    assert seen["backend"] == "ssh"
+    assert "devbox" in seen["description"]
+
+
+def test_legacy_flat_config_still_uses_plain_string_keys(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    monkeypatch.setattr(
+        targets_mod, "_load_merged_config",
+        lambda: {"terminal": {"backend": "local", "cwd": str(tmp_path), "timeout": 60}},
+    )
+
+    result = json.loads(terminal_mod.terminal_tool("pwd", task_id="legacy"))
+
+    assert result["exit_code"] == 0
+    assert "default" in terminal_mod._active_environments
+    assert all(not isinstance(key, tuple) for key in terminal_mod._active_environments)
+
+
+def test_gateway_script_guard_reads_selected_named_target_cwd(
+    monkeypatch, tmp_path, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    alpha = tmp_path / "alpha"
+    beta = tmp_path / "beta"
+    alpha.mkdir()
+    beta.mkdir()
+    (alpha / "restart.sh").write_text("#!/bin/sh\necho safe\n")
+    (beta / "restart.sh").write_text("#!/bin/sh\nhermes gateway restart\n")
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": str(alpha), "beta": str(beta)}),
+    )
+    monkeypatch.setenv("_HERMES_GATEWAY", "1")
+
+    result = json.loads(terminal_mod.terminal_tool(
+        "bash restart.sh", task_id="gateway-guard", execution_target="beta",
+    ))
+
+    assert result["status"] == "error"
+    assert "cannot restart or stop the gateway" in result["error"]
+
+
+def test_checkpoint_alias_flip_pins_dispatch_generation(monkeypatch, tmp_path):
+    from agent import tool_executor
+    import tools.execution_targets as targets_mod
+    from tools.file_tools import write_file_tool
+
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    (first / "sample.txt").write_text("before")
+    config_a = _named_config({"dev": str(first)}, default="dev")
+    config_b = _named_config({"dev": str(second)}, default="dev")
+    targets_mod.set_execution_target_config_source(config_a)
+    checkpoints = []
+
+    class CheckpointManager:
+        enabled = True
+
+        @staticmethod
+        def get_working_dir_for_path(path):
+            return str(first)
+
+        def ensure_checkpoint(self, cwd, reason):
+            checkpoints.append((cwd, reason))
+            targets_mod.set_execution_target_config_source(config_b)
+
+    class Guardrails:
+        @staticmethod
+        def before_call(_name, _args):
+            return SimpleNamespace(allows_execution=True)
+
+    agent = SimpleNamespace(
+        session_id="session",
+        _current_turn_id="turn",
+        _current_api_request_id="request",
+        _tool_guardrails=Guardrails(),
+        _guardrail_block_result=lambda decision: decision,
+        quiet_mode=True,
+        tool_progress_mode="off",
+        verbose_logging=False,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        _checkpoint_mgr=CheckpointManager(),
+        _touch_activity=lambda *_args, **_kwargs: None,
+    )
+
+    managed = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="write_file",
+        function_args={
+            "path": "sample.txt",
+            "content": "data",
+            "execution_target": "dev",
+        },
+        effective_task_id="target-race",
+        tool_call_id="call-1",
+        execute=lambda args: write_file_tool(
+            args["path"], args["content"],
+            task_id="target-race",
+            execution_target=args["execution_target"],
+        ),
+    )
+
+    result = json.loads(managed.result)
+    assert checkpoints[0][0] == str(first)
+    assert result["cwd"] == str(first)
+    assert result["target"] == "dev"
+    assert (first / "sample.txt").read_text() == "data"
+    assert not (second / "sample.txt").exists()
+    assert targets_mod.resolve_execution_target("dev").config["cwd"] == str(second)
+    targets_mod.set_execution_target_config_source(None)
+
+
+def test_removed_target_selector_blocks_before_agent_authorization(monkeypatch):
+    from agent import tool_executor
+
+    class Guardrails:
+        @staticmethod
+        def before_call(_name, _args):
+            raise AssertionError("guardrails must not see an invalid selector")
+
+    agent = SimpleNamespace(
+        session_id="session",
+        _current_turn_id="turn",
+        _current_api_request_id="request",
+        _tool_guardrails=Guardrails(),
+        quiet_mode=True,
+        tool_progress_mode="off",
+        verbose_logging=False,
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        _checkpoint_mgr=SimpleNamespace(enabled=True),
+        _touch_activity=lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_pre_tool_block",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pre-tool hooks must not see an invalid selector")
+        ),
+    )
+    monkeypatch.setattr(
+        tool_executor,
+        "_begin_tool_execution",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("progress/checkpoint preflight must not start")
+        ),
+    )
+    execute_calls = []
+
+    managed = tool_executor._run_agent_tool_execution_middleware(
+        agent,
+        function_name="write_file",
+        function_args={
+            "path": "private.txt",
+            "content": "private",
+            "target": "alpha",
+        },
+        effective_task_id="invalid-selector",
+        tool_call_id="call-invalid-selector",
+        execute=lambda args: execute_calls.append(args),
+    )
+
+    assert "does not accept 'target'" in json.loads(managed.result)["error"]
+    assert managed.blocked is True
+    assert execute_calls == []
+
+
+def test_current_tool_leases_do_not_block_own_replacement_but_other_users_do(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    environment_key = ("default", "dev")
+    env = SimpleNamespace(_hermes_stable_storage=True)
+
+    with terminal_mod.logical_environment_turn("turn-a"):
+        with terminal_mod.environment_turn_usage(
+            "turn-a", environment_key=environment_key,
+        ):
+            assert not terminal_mod._environment_replacement_is_busy(
+                env, environment_key,
+            )
+            other_key = terminal_mod.register_environment_turn("turn-b")
+            try:
+                assert terminal_mod._environment_replacement_is_busy(
+                    env, environment_key,
+                )
+            finally:
+                terminal_mod._release_environment_turn_key(other_key)
+
+
+def test_idle_reaper_and_deferred_cleanup_wait_for_file_only_tool_lease(
+    monkeypatch, isolated_target_state,
+):
+    terminal_mod, _ = isolated_target_state
+    cleaned = []
+    deferred = []
+    environment_key = ("default", "dev")
+
+    class Environment:
+        def cleanup(self, force_remove=False):
+            cleaned.append(force_remove)
+
+    terminal_mod._active_environments[environment_key] = Environment()
+    terminal_mod._last_activity[environment_key] = 0.0
+    monkeypatch.setattr(
+        terminal_mod,
+        "cleanup_vm",
+        lambda task_id, **kw: deferred.append((task_id, kw)),
+    )
+
+    with terminal_mod.logical_environment_turn("file-turn"):
+        with terminal_mod.environment_turn_usage(
+            "file-turn", environment_key=environment_key,
+        ):
+            terminal_mod._cleanup_inactive_envs(lifetime_seconds=0)
+            assert environment_key in terminal_mod._active_environments
+            assert cleaned == []
+            terminal_mod.release_logical_environment_turn_for_cleanup("file-turn")
+            terminal_mod.defer_environment_turn_cleanup("file-turn")
+            assert deferred == []
+        assert deferred == [(
+            "file-turn",
+            {"preserve_persistent": True, "include_collapsed": True},
+        )]
+
+
+def test_negative_not_found_cache_is_target_scoped_and_skips_host_oracle(
+    monkeypatch, isolated_target_state,
+):
+    _, file_mod = isolated_target_state
+    alpha_state = ("default", "alpha")
+    beta_state = ("default", "beta")
+    remote_path = "/srv/project/missing.txt"
+    file_mod._record_not_found(
+        "read_file", remote_path, alpha_state, '{"error": "missing"}',
+    )
+    monkeypatch.setattr(
+        file_mod.os.path,
+        "exists",
+        lambda _path: (_ for _ in ()).throw(
+            AssertionError("remote cache must not inspect the host filesystem")
+        ),
+    )
+
+    assert file_mod._check_not_found_cache(
+        "read_file", remote_path, alpha_state, check_host_filesystem=False,
+    )
+    assert file_mod._check_not_found_cache(
+        "read_file", remote_path, beta_state, check_host_filesystem=False,
+    ) is None
+
+
+@pytest.mark.parametrize("builder", ["terminal", "file", "code"])
+def test_all_environment_builders_forward_docker_shm_size(
+    builder, monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+    from tools import code_execution_tool as code_mod
+
+    terminal_mod, file_mod = isolated_target_state
+    config = {
+        "terminal": {
+            "default_target": "sandbox",
+            "targets": {
+                "sandbox": {
+                    "backend": "docker",
+                    "cwd": "/workspace",
+                    "docker_image": "python:3.12-slim",
+                    "docker_shm_size": "768m",
+                },
+            },
+        },
+    }
+    monkeypatch.setattr(targets_mod, "_load_merged_config", lambda: config)
+    captured = []
+
+    class FakeEnvironment:
+        cwd = "/workspace"
+        _persistent = False
+
+        def execute(self, _command, **_kwargs):
+            return {"output": "/workspace\n", "returncode": 0}
+
+        def cleanup(self, force_remove=False):
+            return None
+
+        def wait_for_cleanup(self, timeout):
+            return True
+
+    def fake_create(**kwargs):
+        captured.append(kwargs["container_config"])
+        return FakeEnvironment()
+
+    monkeypatch.setattr(terminal_mod, "_create_environment", fake_create)
+    if builder == "terminal":
+        result = json.loads(terminal_mod.terminal_tool(
+            "pwd", task_id="shm-terminal", execution_target="sandbox",
+        ))
+        assert result["exit_code"] == 0
+    elif builder == "file":
+        file_mod._get_file_ops("shm-file", "sandbox")
+    else:
+        code_mod._get_or_create_env("shm-code", "sandbox")
+
+    assert captured[0]["docker_shm_size"] == "768m"
+
+
+def test_file_tool_lease_key_uses_explicit_nondefault_target(
+    monkeypatch, isolated_target_state,
+):
+    import tools.execution_targets as targets_mod
+
+    terminal_mod, _ = isolated_target_state
+    monkeypatch.setattr(
+        targets_mod,
+        "_load_merged_config",
+        lambda: _named_config({"alpha": "/alpha", "beta": "/beta"}),
+    )
+    expected = targets_mod.resolve_execution_target("beta").session_key("default")
+
+    assert terminal_mod.execution_environment_turn_key(
+        "write_file", {"execution_target": "beta"}, task_id="child-task",
+    ) == expected
+    assert terminal_mod.execution_environment_turn_key(
+        "process", {"session_id": "proc_123"}, task_id="child-task",
+    ) == terminal_mod._turn_scope_key("child-task")

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -661,6 +661,15 @@ class TestActiveQueries:
         assert registry.has_active_processes("t1") is True
         assert registry.has_active_processes("t2") is False
 
+    def test_has_active_environment_uses_object_identity(self, registry):
+        old_env = object()
+        new_env = object()
+        s = _make_session(task_id="t1")
+        s.env_ref = old_env
+        registry._running[s.id] = s
+        assert registry.has_active_environment(old_env) is True
+        assert registry.has_active_environment(new_env) is False
+
     def test_has_active_for_session_with_max_age_stale(self, registry):
         """Stale process (older than max_active_age) is ignored."""
         s = _make_session(started_at=time.time() - 90000)  # 25 hours ago
@@ -949,6 +958,22 @@ class TestSpawnRewriteCompoundBackground:
 # =========================================================================
 
 class TestCheckpoint:
+    def test_write_checkpoint_includes_execution_target_metadata(self, registry, tmp_path):
+        with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
+            s = _make_session()
+            s.target = "alpha"
+            s.backend = "local"
+            s.runtime_scope = "scope-v1"
+            registry._running[s.id] = s
+            registry._write_checkpoint()
+
+            data = json.loads((tmp_path / "procs.json").read_text())
+            assert len(data) == 1
+            assert data[0]["session_id"] == s.id
+            assert data[0]["target"] == "alpha"
+            assert data[0]["backend"] == "local"
+            assert data[0]["runtime_scope"] == "scope-v1"
+
     def test_recover_dead_pid(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{
@@ -1008,6 +1033,41 @@ class TestCheckpoint:
 
         stop_unit.assert_called_once_with(entry["systemd_unit"])
         assert json.loads(checkpoint.read_text()) == []
+
+    def test_recover_enqueues_watchers_with_execution_target_metadata(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_live",
+            "command": "sleep 999",
+            "pid": os.getpid(),  # current process — guaranteed alive
+            "task_id": "t1",
+            "session_key": "sk1",
+            "watcher_platform": "telegram",
+            "watcher_chat_id": "123",
+            "watcher_user_id": "u123",
+            "watcher_user_name": "alice",
+            "watcher_thread_id": "42",
+            "watcher_interval": 60,
+            "target": "alpha",
+            "backend": "local",
+            "runtime_scope": "scope-v1",
+        }]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            recovered = registry.recover_from_checkpoint()
+            assert recovered == 1
+            assert len(registry.pending_watchers) == 1
+            w = registry.pending_watchers[0]
+            assert w["session_id"] == "proc_live"
+            assert w["platform"] == "telegram"
+            assert w["chat_id"] == "123"
+            assert w["user_id"] == "u123"
+            assert w["user_name"] == "alice"
+            assert w["thread_id"] == "42"
+            assert w["check_interval"] == 60
+            session = registry.get("proc_live")
+            assert session.target == "alpha"
+            assert session.backend == "local"
+            assert session.runtime_scope == "scope-v1"
 
 
     def test_recovery_skips_explicit_sandbox_backed_entries(self, registry, tmp_path):
@@ -1097,6 +1157,30 @@ class TestKillProcess:
             assert ("terminate", 424242) in terminate_calls
         finally:
             registry._running.pop(s.id, None)
+
+    def test_kill_error_preserves_execution_target_metadata(self, registry):
+        s = _make_session(sid="proc_kill_error", command="sleep 999")
+        s.process = MagicMock()
+        s.process.pid = 424242
+        s.target = "box"
+        s.backend = "local"
+        s.runtime_scope = "scope-server-1"
+        registry._running[s.id] = s
+
+        with patch.object(
+            registry,
+            "_terminate_host_pid",
+            side_effect=RuntimeError("termination raced with process exit"),
+        ):
+            result = registry.kill_process(s.id)
+
+        assert result == {
+            "status": "error",
+            "error": "termination raced with process exit",
+            "target": "box",
+            "backend": "local",
+            "runtime_scope": "scope-server-1",
+        }
 
 
 # =========================================================================

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -582,6 +582,15 @@ class TestActiveQueries:
         assert registry.has_active_processes("t1") is True
         assert registry.has_active_processes("t2") is False
 
+    def test_has_active_environment_uses_object_identity(self, registry):
+        old_env = object()
+        new_env = object()
+        s = _make_session(task_id="t1")
+        s.env_ref = old_env
+        registry._running[s.id] = s
+        assert registry.has_active_environment(old_env) is True
+        assert registry.has_active_environment(new_env) is False
+
     def test_has_active_for_session_with_max_age_stale(self, registry):
         """Stale process (older than max_active_age) is ignored."""
         s = _make_session(started_at=time.time() - 90000)  # 25 hours ago
@@ -871,6 +880,22 @@ class TestSpawnRewriteCompoundBackground:
 # =========================================================================
 
 class TestCheckpoint:
+    def test_write_checkpoint_includes_execution_target_metadata(self, registry, tmp_path):
+        with patch("tools.process_registry.CHECKPOINT_PATH", tmp_path / "procs.json"):
+            s = _make_session()
+            s.target = "alpha"
+            s.backend = "local"
+            s.runtime_scope = "scope-v1"
+            registry._running[s.id] = s
+            registry._write_checkpoint()
+
+            data = json.loads((tmp_path / "procs.json").read_text())
+            assert len(data) == 1
+            assert data[0]["session_id"] == s.id
+            assert data[0]["target"] == "alpha"
+            assert data[0]["backend"] == "local"
+            assert data[0]["runtime_scope"] == "scope-v1"
+
     def test_recover_dead_pid(self, registry, tmp_path):
         checkpoint = tmp_path / "procs.json"
         checkpoint.write_text(json.dumps([{
@@ -882,6 +907,41 @@ class TestCheckpoint:
         with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
             recovered = registry.recover_from_checkpoint()
             assert recovered == 0
+
+    def test_recover_enqueues_watchers_with_execution_target_metadata(self, registry, tmp_path):
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([{
+            "session_id": "proc_live",
+            "command": "sleep 999",
+            "pid": os.getpid(),  # current process — guaranteed alive
+            "task_id": "t1",
+            "session_key": "sk1",
+            "watcher_platform": "telegram",
+            "watcher_chat_id": "123",
+            "watcher_user_id": "u123",
+            "watcher_user_name": "alice",
+            "watcher_thread_id": "42",
+            "watcher_interval": 60,
+            "target": "alpha",
+            "backend": "local",
+            "runtime_scope": "scope-v1",
+        }]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            recovered = registry.recover_from_checkpoint()
+            assert recovered == 1
+            assert len(registry.pending_watchers) == 1
+            w = registry.pending_watchers[0]
+            assert w["session_id"] == "proc_live"
+            assert w["platform"] == "telegram"
+            assert w["chat_id"] == "123"
+            assert w["user_id"] == "u123"
+            assert w["user_name"] == "alice"
+            assert w["thread_id"] == "42"
+            assert w["check_interval"] == 60
+            session = registry.get("proc_live")
+            assert session.target == "alpha"
+            assert session.backend == "local"
+            assert session.runtime_scope == "scope-v1"
 
 
     def test_recovery_skips_explicit_sandbox_backed_entries(self, registry, tmp_path):

--- a/tests/tools/test_process_target_routing.py
+++ b/tests/tools/test_process_target_routing.py
@@ -1,0 +1,29 @@
+def test_spawn_via_env_forwards_selected_cwd():
+    from tools.process_registry import ProcessRegistry
+
+    calls = []
+
+    class FakeEnvironment:
+        # Simulate another session changing mutable shared-environment cwd.
+        cwd = "/srv/other-session"
+
+        def execute(self, command, **kwargs):
+            calls.append((command, kwargs))
+            return {"output": "", "returncode": 1}
+
+    registry = ProcessRegistry()
+    session = registry.spawn_via_env(
+        env=FakeEnvironment(),
+        command="pwd",
+        cwd="/srv/named-target",
+        task_id="process-cwd",
+        session_key="named-session",
+        target="remote",
+        backend="ssh",
+    )
+
+    assert session.exited is True
+    assert session.cwd == "/srv/named-target"
+    assert calls[0][1]["cwd"] == session.cwd
+    assert calls[0][1]["cwd"] != FakeEnvironment.cwd
+    assert calls[0][1]["rewrite_compound_background"] is False

--- a/tests/tools/test_runtime_execution_target_background.py
+++ b/tests/tools/test_runtime_execution_target_background.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+
+from tools.execution_target_registry import (
+    invalidate_runtime_registry_cache,
+    write_provider_fragment_for_tests,
+)
+from tools.execution_targets import (
+    set_execution_target_config_source,
+)
+
+
+def test_background_handle_survives_target_drain_and_remove(monkeypatch, tmp_path):
+    """Process handles retain their immutable producing runtime after teardown."""
+    from tools.process_registry import process_registry
+    from tools.terminal_tool import terminal_tool
+
+    home = tmp_path / "home"
+    work = tmp_path / "work"
+    home.mkdir()
+    work.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    set_execution_target_config_source({
+        "terminal": {
+            "default_target": "local",
+            "targets": {"local": {"backend": "local", "cwd": str(tmp_path)}},
+        },
+    })
+    record = {
+        "config": {"backend": "local", "cwd": str(work)},
+        "owner_id": "box",
+        "generation": "server-1",
+        "state": "ready",
+    }
+    write_provider_fragment_for_tests("controller", {"box": record})
+    session_id = ""
+    try:
+        started = json.loads(
+            terminal_tool(
+                "sleep 30",
+                execution_target="box",
+                task_id="runtime-background",
+                background=True,
+            )
+        )
+        session_id = started["session_id"]
+        producing_scope = started["runtime_scope"]
+
+        record["state"] = "draining"
+        write_provider_fragment_for_tests("controller", {"box": record})
+        drained_poll = process_registry.poll(session_id)
+        assert drained_poll["runtime_scope"] == producing_scope
+
+        write_provider_fragment_for_tests("controller", {})
+        removed_poll = process_registry.poll(session_id)
+        assert removed_poll["runtime_scope"] == producing_scope
+        killed = process_registry.kill_process(session_id)
+        assert killed["runtime_scope"] == producing_scope
+        assert process_registry.poll(session_id)["runtime_scope"] == producing_scope
+    finally:
+        if session_id:
+            process_registry.kill_process(session_id)
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()

--- a/tests/tools/test_runtime_execution_target_locking.py
+++ b/tests/tools/test_runtime_execution_target_locking.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+
+import pytest
+
+from tools.execution_target_registry import (
+    RuntimeRegistryError,
+    invalidate_runtime_registry_cache,
+    registry_write_lock,
+)
+
+
+def _hold_registry_lock(home: str, ready, release) -> None:
+    os.environ["HERMES_HOME"] = home
+    invalidate_runtime_registry_cache()
+    with registry_write_lock():
+        ready.set()
+        release.wait(10)
+
+
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="fork-based bounded flock acceptance test",
+)
+def test_registry_writer_lock_is_cross_process_and_bounded(monkeypatch, tmp_path):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    context = multiprocessing.get_context("fork")
+    ready = context.Event()
+    release = context.Event()
+    process = context.Process(
+        target=_hold_registry_lock,
+        args=(str(home), ready, release),
+    )
+    process.start()
+    try:
+        assert ready.wait(5)
+        with pytest.raises(RuntimeRegistryError, match="Timed out"):
+            with registry_write_lock(timeout_seconds=0.15):
+                pytest.fail("second writer acquired a held registry lock")
+    finally:
+        release.set()
+        process.join(5)
+        if process.is_alive():
+            process.terminate()
+            process.join(5)
+    assert process.exitcode == 0

--- a/tests/tools/test_runtime_execution_target_registry.py
+++ b/tests/tools/test_runtime_execution_target_registry.py
@@ -1,0 +1,1061 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+import pytest
+
+from hermes_constants import (
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
+from tools.execution_target_registry import (
+    MAX_REGISTRY_FILE_BYTES,
+    MAX_TARGET_CONFIG_BYTES,
+    MAX_TARGETS_PER_PROVIDER,
+    RuntimeRegistryError,
+    invalidate_runtime_registry_cache,
+    load_runtime_registry,
+    registry_directory,
+    update_provider_fragment,
+    validate_provider_name,
+    write_provider_fragment_for_tests,
+)
+from tools.execution_targets import (
+    ExecutionTargetError,
+    frozen_execution_target_config,
+    list_execution_targets,
+    resolve_execution_target,
+    set_execution_target_config_source,
+)
+
+
+def _static_config(cwd: str) -> dict:
+    return {
+        "terminal": {
+            "default_target": "local",
+            "targets": {"local": {"backend": "local", "cwd": cwd}},
+        },
+    }
+
+
+def _record(
+    cwd: str,
+    *,
+    generation: str = "g1",
+    state: str = "ready",
+    backend: str = "local",
+) -> dict:
+    config = {"backend": backend, "cwd": cwd}
+    if backend == "ssh":
+        config.update({"ssh_host": "managed-alias", "ssh_user": "dev"})
+    return {
+        "config": config,
+        "owner_id": "box-17",
+        "generation": generation,
+        "state": state,
+    }
+
+
+@pytest.fixture
+def registry_home(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    invalidate_runtime_registry_cache()
+    set_execution_target_config_source(_static_config(str(tmp_path)))
+    try:
+        yield home
+    finally:
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()
+
+
+def test_new_target_resolves_and_executes_without_process_restart(
+    registry_home,
+    tmp_path,
+):
+    from tools.terminal_tool import terminal_tool
+
+    work = tmp_path / "new-runtime"
+    work.mkdir()
+    with pytest.raises(ExecutionTargetError):
+        resolve_execution_target("box")
+
+    write_provider_fragment_for_tests("hetzner-devbox", {"box": _record(str(work))})
+    resolution = resolve_execution_target("box")
+    assert resolution.provider == "hetzner-devbox"
+    assert resolution.owner_id == "box-17"
+    assert resolution.generation == "g1"
+
+    result = json.loads(terminal_tool("pwd", execution_target="box", task_id="registry-e2e"))
+    assert result["exit_code"] == 0
+    assert Path(result["output"].strip()).resolve() == work.resolve()
+    assert result["target"] == "box"
+    assert result["runtime_scope"] == resolution.security_scope
+
+
+def test_separate_cli_process_hot_registers_for_long_lived_reader(
+    registry_home,
+    tmp_path,
+):
+    from tools.terminal_tool import TERMINAL_SCHEMA, terminal_tool
+
+    work = tmp_path / "cross-process-target"
+    work.mkdir()
+    schema_before = deepcopy(TERMINAL_SCHEMA)
+    assert [item.target for item in list_execution_targets()] == ["local"]
+    with pytest.raises(ExecutionTargetError):
+        resolve_execution_target("hot-local")
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(registry_home)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "hermes_cli.main",
+            "targets",
+            "register",
+            "hot-local",
+            "--backend",
+            "local",
+            "--cwd",
+            str(work),
+            "--provider",
+            "cross-process",
+            "--generation",
+            "child-1",
+            "--json",
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert json.loads(completed.stdout)["execution_target"] == "hot-local"
+
+    resolution = resolve_execution_target("hot-local")
+    assert resolution.provider == "cross-process"
+    assert resolution.generation == "child-1"
+    result = json.loads(
+        terminal_tool("pwd", execution_target="hot-local", task_id="cross-process-e2e")
+    )
+    assert result["exit_code"] == 0
+    assert Path(result["output"].strip()).resolve() == work.resolve()
+    assert TERMINAL_SCHEMA == schema_before
+    target_schema = TERMINAL_SCHEMA["parameters"]["properties"]["execution_target"]
+    assert target_schema["type"] == "string"
+    assert "enum" not in target_schema
+
+
+def test_schema_and_prebuilt_prompt_hint_are_stable_across_registration(
+    registry_home,
+    tmp_path,
+    monkeypatch,
+):
+    import agent.prompt_builder as prompt_builder
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    monkeypatch.setattr(prompt_builder, "is_wsl", lambda: False)
+    before_schema = deepcopy(TERMINAL_SCHEMA)
+    cached_prompt_input = prompt_builder.build_environment_hints()
+
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"ephemeral": _record(str(tmp_path / "ephemeral"))},
+    )
+
+    assert TERMINAL_SCHEMA == before_schema
+    assert "ephemeral" not in cached_prompt_input
+    assert "ephemeral" in prompt_builder.build_environment_hints()
+
+
+def test_drain_and_remove_reject_new_calls(registry_home, tmp_path):
+    fragment = {"box": _record(str(tmp_path))}
+    write_provider_fragment_for_tests("provider-a", fragment)
+    assert resolve_execution_target("box").generation == "g1"
+
+    fragment["box"]["state"] = "draining"
+    write_provider_fragment_for_tests("provider-a", fragment)
+    with pytest.raises(ExecutionTargetError, match="draining"):
+        resolve_execution_target("box")
+
+    write_provider_fragment_for_tests("provider-a", {})
+    with pytest.raises(ExecutionTargetError, match="Unknown execution target"):
+        resolve_execution_target("box")
+
+
+def test_generation_repoint_changes_runtime_identity_even_for_same_alias_config(
+    registry_home,
+    tmp_path,
+):
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="server-1")},
+    )
+    first = resolve_execution_target("box")
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="server-2")},
+    )
+    second = resolve_execution_target("box")
+
+    assert first.config == second.config
+    assert first.spec_fingerprint != second.spec_fingerprint
+    assert first.security_scope != second.security_scope
+    assert first.session_key("session") == second.session_key("session")
+    assert first.backend_task_id("session") != second.backend_task_id("session")
+
+
+def test_nested_dispatch_preserves_complete_runtime_generation_identity(
+    registry_home,
+    tmp_path,
+):
+    from tools import approval as approval_mod
+    from tools import code_execution_tool as code_mod
+
+    write_provider_fragment_for_tests(
+        "Provider-A",
+        {"box": _record(str(tmp_path), generation="server-1")},
+    )
+    outer = resolve_execution_target("box")
+    frozen = code_mod._frozen_target_config(outer)
+
+    def resolve_nested(_name, args, task_id=None):
+        nested = resolve_execution_target(args["execution_target"])
+        approval_key = approval_mod._execution_scoped_pattern_key(
+            "command:deploy",
+            nested.target,
+            nested.named,
+            nested.security_scope,
+        )
+        return nested, approval_key, task_id
+
+    nested, approval_key, nested_task_id = code_mod._dispatch_rpc_tool(
+        resolve_nested,
+        "terminal",
+        {"execution_target": "box"},
+        "nested-session",
+        frozen,
+    )
+
+    assert nested_task_id == "nested-session"
+    assert nested.target == outer.target
+    assert nested.backend == outer.backend
+    assert nested.config == outer.config
+    assert nested.provider == outer.provider == "provider-a"
+    assert nested.owner_id == outer.owner_id == "box-17"
+    assert nested.generation == outer.generation == "server-1"
+    assert nested.spec_fingerprint == outer.spec_fingerprint
+    assert nested.security_scope == outer.security_scope
+    assert nested.environment_key("default") == outer.environment_key("default")
+    assert nested.backend_task_id("default") == outer.backend_task_id("default")
+    assert nested.file_coordination_key("session") == outer.file_coordination_key(
+        "session"
+    )
+    assert approval_key == approval_mod._execution_scoped_pattern_key(
+        "command:deploy",
+        outer.target,
+        outer.named,
+        outer.security_scope,
+    )
+
+
+def test_nested_approval_identity_distinguishes_same_config_generations(
+    registry_home,
+    tmp_path,
+):
+    from tools import approval as approval_mod
+    from tools import code_execution_tool as code_mod
+
+    def nested_approval_key(frozen):
+        def handler(_name, args, task_id=None):
+            del task_id
+            nested = resolve_execution_target(args["execution_target"])
+            return (
+                nested.generation,
+                approval_mod._execution_scoped_pattern_key(
+                    "command:deploy",
+                    nested.target,
+                    nested.named,
+                    nested.security_scope,
+                ),
+            )
+
+        return code_mod._dispatch_rpc_tool(
+            handler,
+            "terminal",
+            {"execution_target": "box"},
+            "nested-session",
+            frozen,
+        )
+
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="g1")},
+    )
+    first = resolve_execution_target("box")
+    first_frozen = code_mod._frozen_target_config(first)
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="g2")},
+    )
+    second = resolve_execution_target("box")
+    second_frozen = code_mod._frozen_target_config(second)
+
+    first_generation, first_key = nested_approval_key(first_frozen)
+    second_generation, second_key = nested_approval_key(second_frozen)
+
+    assert (first_generation, second_generation) == ("g1", "g2")
+    assert first_key != second_key
+
+
+def test_nested_runtime_docker_dispatch_reuses_outer_hosting_environment(
+    registry_home,
+    tmp_path,
+    monkeypatch,
+):
+    from tools import code_execution_tool as code_mod
+    from tools import file_tools as file_mod
+    from tools import terminal_tool as terminal_mod
+
+    record = _record(str(tmp_path), generation="docker-g1", backend="docker")
+    record["config"]["container_persistent"] = True
+    write_provider_fragment_for_tests("provider-a", {"box": record})
+    outer = resolve_execution_target("box")
+
+    class HostingEnvironment:
+        cwd = "/workspace"
+
+        def __init__(self):
+            self.cleanup_calls = 0
+
+        def cleanup(self, force_remove=False):
+            del force_remove
+            self.cleanup_calls += 1
+
+    hosting = HostingEnvironment()
+    terminal_mod._record_environment_target(hosting, outer)
+    environment_key = outer.environment_key("default")
+    monkeypatch.setattr(
+        terminal_mod,
+        "_active_environments",
+        {environment_key: hosting},
+    )
+    monkeypatch.setattr(terminal_mod, "_last_activity", {})
+    monkeypatch.setattr(terminal_mod, "_creation_locks", {})
+    monkeypatch.setattr(file_mod, "_file_ops_cache", {})
+    monkeypatch.setattr(
+        terminal_mod,
+        "_create_environment",
+        lambda **_kwargs: pytest.fail("nested dispatch replaced its hosting runtime"),
+    )
+
+    def nested_file_ops(_name, args, task_id=None):
+        ops = file_mod._get_file_ops(task_id, target=args["execution_target"])
+        return ops.env, resolve_execution_target(args["execution_target"])
+
+    nested_env, nested = code_mod._dispatch_rpc_tool(
+        nested_file_ops,
+        "read_file",
+        {"execution_target": "box"},
+        "outer-script",
+        code_mod._frozen_target_config(outer),
+    )
+
+    assert nested_env is hosting
+    assert nested.spec_fingerprint == outer.spec_fingerprint
+    assert terminal_mod._active_environments[environment_key] is hosting
+    assert hosting.cleanup_calls == 0
+
+
+def test_runtime_generations_isolate_all_file_coordination_state(
+    registry_home,
+    tmp_path,
+    monkeypatch,
+):
+    from tools import file_state
+    from tools import file_tools as file_mod
+
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="g1", backend="ssh")},
+    )
+    first = resolve_execution_target("box")
+    first_key = first.file_coordination_key("reader")
+    first_writer_key = first.file_coordination_key("writer")
+    first_namespace = file_mod._file_state_namespace("reader", "box", _resolution=first)
+
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="g2", backend="ssh")},
+    )
+    second = resolve_execution_target("box")
+    second_key = second.file_coordination_key("reader")
+    second_namespace = file_mod._file_state_namespace(
+        "reader", "box", _resolution=second
+    )
+
+    assert first.session_key("reader") == second.session_key("reader")
+    assert first.storage_task_id("default") == second.storage_task_id("default")
+    assert first_key != second_key
+    assert first_namespace != second_namespace
+
+    registry = file_state.FileStateRegistry()
+    path = "/srv/project/shared.txt"
+    registry.record_read(
+        first_key,
+        path,
+        namespace=first_namespace,
+        stat_path=False,
+    )
+    registry.note_write(
+        first_writer_key,
+        path,
+        namespace=first_namespace,
+        stat_path=False,
+    )
+    assert registry.check_stale(first_key, path, namespace=first_namespace)
+    assert registry.check_stale(second_key, path, namespace=second_namespace) is None
+    assert registry._lock_for(path, first_namespace) is not registry._lock_for(
+        path, second_namespace
+    )
+
+    monkeypatch.setattr(file_mod, "_read_tracker", {})
+    monkeypatch.setattr(file_mod, "_patch_failure_tracker", {})
+    file_mod._record_not_found("read", path, first_key, "g1-miss")
+    assert (
+        file_mod._check_not_found_cache(
+            "read", path, second_key, check_host_filesystem=False
+        )
+        is None
+    )
+    first_data = file_mod._read_tracker[first_key]
+    first_data["dedup"][(path, 1, 20)] = 7.0
+    first_data["read_history"].add((path, 1, 20))
+    assert second_key not in file_mod._read_tracker
+    assert file_mod._record_patch_failure(first_key, path) == 1
+    assert file_mod._record_patch_failure(first_key, path) == 2
+    assert file_mod._record_patch_failure(second_key, path) == 1
+
+
+def test_frozen_dispatch_does_not_pivot_mid_update(registry_home, tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(first_dir), generation="g1")},
+    )
+
+    with frozen_execution_target_config():
+        first = resolve_execution_target("box")
+        write_provider_fragment_for_tests(
+            "provider-a",
+            {"box": _record(str(second_dir), generation="g2")},
+        )
+        still_first = resolve_execution_target("box")
+        assert still_first.generation == first.generation == "g1"
+        assert still_first.config["cwd"] == str(first_dir)
+
+    next_dispatch = resolve_execution_target("box")
+    assert next_dispatch.generation == "g2"
+    assert next_dispatch.config["cwd"] == str(second_dir)
+
+
+def test_static_and_provider_collisions_fail_closed_per_name(registry_home, tmp_path):
+    write_provider_fragment_for_tests(
+        "one",
+        {
+            "local": _record(str(tmp_path / "shadow")),
+            "colliding": _record(str(tmp_path / "one")),
+            "healthy": _record(str(tmp_path / "healthy")),
+        },
+    )
+    write_provider_fragment_for_tests(
+        "two",
+        {
+            "colliding": _record(str(tmp_path / "two")),
+        },
+    )
+
+    assert resolve_execution_target("local").provider is None
+    assert resolve_execution_target("healthy").provider == "one"
+    with pytest.raises(ExecutionTargetError, match="multiple runtime providers"):
+        resolve_execution_target("colliding")
+
+
+def test_malformed_unreadable_and_symlinked_fragments_are_isolated(
+    registry_home,
+    tmp_path,
+):
+    directory = registry_directory()
+    write_provider_fragment_for_tests(
+        "healthy",
+        {"ok": _record(str(tmp_path / "ok"))},
+    )
+    malformed = directory / "broken.json"
+    malformed.write_text("{not json", encoding="utf-8")
+    malformed.chmod(0o600)
+    unreadable = directory / "unreadable.json"
+    unreadable.write_text("{}", encoding="utf-8")
+    unreadable.chmod(0o000)
+    symlink = directory / "linked.json"
+    symlink.symlink_to(directory / "healthy.json")
+    invalidate_runtime_registry_cache()
+
+    assert resolve_execution_target("ok").provider == "healthy"
+    diagnostics = load_runtime_registry().diagnostics
+    providers = {item.provider for item in diagnostics}
+    assert {"broken", "unreadable", "linked"} <= providers
+
+
+def test_oversized_and_overcomplex_providers_are_isolated_secret_safely(
+    registry_home,
+    tmp_path,
+):
+    directory = registry_directory()
+    write_provider_fragment_for_tests(
+        "healthy",
+        {"ok": _record(str(tmp_path / "healthy"))},
+    )
+
+    secret = "provider-token-must-not-appear"
+    oversized = directory / "oversized.json"
+    oversized.write_bytes(secret.encode("utf-8") + b"x" * (MAX_REGISTRY_FILE_BYTES + 1))
+    oversized.chmod(0o600)
+
+    too_many = directory / "too-many.json"
+    too_many.write_text(
+        json.dumps({
+            "version": 1,
+            "provider": "too-many",
+            "targets": {
+                f"target-{index}": _record(str(tmp_path))
+                for index in range(MAX_TARGETS_PER_PROVIDER + 1)
+            },
+        }),
+        encoding="utf-8",
+    )
+    too_many.chmod(0o600)
+
+    nested: object = "leaf"
+    for _ in range(20):
+        nested = {"child": nested}
+    too_deep = directory / "too-deep.json"
+    too_deep.write_text(
+        json.dumps({
+            "version": 1,
+            "provider": "too-deep",
+            "targets": {
+                "deep": {
+                    **_record(str(tmp_path)),
+                    "config": {"backend": "local", "payload": nested},
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    too_deep.chmod(0o600)
+
+    too_large_config = directory / "too-large-config.json"
+    too_large_config.write_text(
+        json.dumps({
+            "version": 1,
+            "provider": "too-large-config",
+            "targets": {
+                "large": {
+                    **_record(str(tmp_path)),
+                    "config": {
+                        "backend": "local",
+                        "payload": "x" * (MAX_TARGET_CONFIG_BYTES + 1),
+                    },
+                },
+            },
+        }),
+        encoding="utf-8",
+    )
+    too_large_config.chmod(0o600)
+    invalidate_runtime_registry_cache()
+
+    assert resolve_execution_target("local").provider is None
+    assert resolve_execution_target("ok").provider == "healthy"
+    snapshot = load_runtime_registry()
+    providers = {item.provider for item in snapshot.diagnostics}
+    assert {"oversized", "too-many", "too-deep", "too-large-config"} <= providers
+    assert secret not in json.dumps([item.as_dict() for item in snapshot.diagnostics])
+
+
+def test_production_update_rejects_oversized_fragment_without_replacing_active_set(
+    registry_home,
+    tmp_path,
+):
+    existing = update_provider_fragment(
+        "provider-a",
+        lambda _snapshot, current: {
+            **current,
+            "existing": _record(str(tmp_path), generation="still-active"),
+        },
+    )
+    assert {item.execution_target for item in existing.records} == {"existing"}
+    assert resolve_execution_target("existing").generation == "still-active"
+
+    path = registry_directory() / "provider-a.json"
+    published = path.read_bytes()
+    directory_entries = {item.name for item in path.parent.iterdir()}
+    secret = "provider-fragment-secret-must-not-appear"
+    chunk = secret + "x" * (MAX_TARGET_CONFIG_BYTES - 16 * 1024)
+    oversized_targets = {
+        f"large-{index}": {
+            "config": {
+                "backend": "docker",
+                "cwd": "/workspace",
+                "docker_env": {"PADDING": chunk},
+            },
+            "owner_id": f"owner-{index}",
+            "generation": "oversized-candidate",
+            "state": "ready",
+        }
+        for index in range(5)
+    }
+
+    with pytest.raises(RuntimeRegistryError) as error:
+        update_provider_fragment(
+            "provider-a",
+            lambda _snapshot, _current: oversized_targets,
+        )
+
+    assert "fragment size limit" in str(error.value)
+    assert secret not in str(error.value)
+    assert path.read_bytes() == published
+    assert {item.name for item in path.parent.iterdir()} == directory_entries
+    visible = load_runtime_registry()
+    assert {
+        (item.execution_target, item.generation)
+        for item in visible.records
+        if item.provider == "provider-a"
+    } == {("existing", "still-active")}
+    assert resolve_execution_target("existing").generation == "still-active"
+
+
+def test_returned_snapshot_nested_mutation_cannot_poison_registry_cache(
+    registry_home,
+    tmp_path,
+):
+    victim = _record(str(tmp_path), backend="docker")
+    victim["config"].update({
+        "docker_env": {"DESTINATION": "trusted"},
+        "docker_volumes": ["trusted:/workspace/trusted"],
+    })
+    write_provider_fragment_for_tests("provider-a", {"victim": victim})
+
+    returned = load_runtime_registry()
+    returned_config = returned.records[0].config
+    returned_config["docker_env"]["DESTINATION"] = "poisoned"
+    returned_config["docker_volumes"].append("poisoned:/workspace/poisoned")
+
+    cached = load_runtime_registry()
+    forced = load_runtime_registry(force=True)
+    for snapshot in (cached, forced):
+        config = snapshot.records[0].config
+        assert config["docker_env"] == {"DESTINATION": "trusted"}
+        assert config["docker_volumes"] == ["trusted:/workspace/trusted"]
+
+
+def test_failing_cross_provider_mutator_cannot_poison_cache_or_disk(
+    registry_home,
+    tmp_path,
+):
+    victim = _record(str(tmp_path), backend="docker")
+    victim["config"].update({
+        "docker_env": {"DESTINATION": "trusted"},
+        "docker_volumes": ["trusted:/workspace/trusted"],
+    })
+    write_provider_fragment_for_tests("victim-provider", {"victim": victim})
+    victim_path = registry_directory() / "victim-provider.json"
+    disk_before = victim_path.read_bytes()
+
+    def poison_then_fail(snapshot, current):
+        del current
+        record = next(
+            item for item in snapshot.records if item.provider == "victim-provider"
+        )
+        record.config["docker_env"]["DESTINATION"] = "poisoned"
+        record.config["docker_volumes"].append("poisoned:/workspace/poisoned")
+        raise RuntimeError("provider callback failed")
+
+    with pytest.raises(RuntimeError, match="provider callback failed"):
+        update_provider_fragment("attacker", poison_then_fail)
+
+    assert victim_path.read_bytes() == disk_before
+    for snapshot in (load_runtime_registry(), load_runtime_registry(force=True)):
+        record = next(
+            item for item in snapshot.records if item.provider == "victim-provider"
+        )
+        assert record.config["docker_env"] == {"DESTINATION": "trusted"}
+        assert record.config["docker_volumes"] == ["trusted:/workspace/trusted"]
+
+
+def test_provider_identity_is_lowercase_in_writer_payload_and_parser(
+    registry_home,
+    tmp_path,
+):
+    assert validate_provider_name("Foo.Bar") == "foo.bar"
+    path = write_provider_fragment_for_tests(
+        "Foo.Bar",
+        {"box": _record(str(tmp_path))},
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    snapshot = load_runtime_registry(force=True)
+
+    assert path.name == "foo.bar.json"
+    assert payload["provider"] == "foo.bar"
+    assert snapshot.records[0].provider == "foo.bar"
+
+
+def test_noncanonical_casefold_alias_fails_safe_without_overwrite(
+    registry_home,
+    tmp_path,
+):
+    directory = registry_directory()
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    directory.chmod(0o700)
+    alias = directory / "Foo.json"
+    alias.write_text(
+        json.dumps({
+            "version": 1,
+            "provider": "Foo",
+            "targets": {"first": _record(str(tmp_path / "first"))},
+        }),
+        encoding="utf-8",
+    )
+    alias.chmod(0o600)
+    original = alias.read_bytes()
+    original_entries = {
+        entry.name for entry in directory.iterdir() if entry.suffix == ".json"
+    }
+    invalidate_runtime_registry_cache()
+
+    snapshot = load_runtime_registry(force=True)
+    assert snapshot.records == ()
+    assert any(diagnostic.provider == "foo" for diagnostic in snapshot.diagnostics)
+    with pytest.raises(RuntimeRegistryError, match="Provider 'foo' is unavailable"):
+        update_provider_fragment(
+            "foo",
+            lambda _snapshot, current: {
+                **current,
+                "second": _record(str(tmp_path / "second")),
+            },
+        )
+
+    assert alias.read_bytes() == original
+    assert {
+        entry.name for entry in directory.iterdir() if entry.suffix == ".json"
+    } == original_entries
+
+
+def test_rapid_same_size_atomic_replacement_is_observed(registry_home, tmp_path):
+    first = _record(str(tmp_path / "one"), generation="11")
+    second = _record(str(tmp_path / "two"), generation="22")
+    write_provider_fragment_for_tests("provider-a", {"box": first})
+    path = registry_directory() / "provider-a.json"
+    before = path.stat()
+    assert resolve_execution_target("box").generation == "11"
+
+    write_provider_fragment_for_tests("provider-a", {"box": second})
+    after = path.stat()
+    assert before.st_size == after.st_size
+    assert before.st_ino != after.st_ino
+    assert resolve_execution_target("box").generation == "22"
+
+
+def test_profile_registry_separation(registry_home, tmp_path):
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path), generation="profile-a")},
+    )
+    other = tmp_path / "other-profile"
+    token = set_hermes_home_override(other)
+    try:
+        invalidate_runtime_registry_cache()
+        with pytest.raises(ExecutionTargetError):
+            resolve_execution_target("box")
+        write_provider_fragment_for_tests(
+            "provider-a",
+            {"other": _record(str(tmp_path), generation="profile-b")},
+        )
+        assert resolve_execution_target("other").generation == "profile-b"
+    finally:
+        reset_hermes_home_override(token)
+        invalidate_runtime_registry_cache()
+    assert resolve_execution_target("box").generation == "profile-a"
+    with pytest.raises(ExecutionTargetError):
+        resolve_execution_target("other")
+
+
+def test_legacy_activation_state_is_valid_if_fragment_publication_crashes(
+    monkeypatch,
+    tmp_path,
+):
+    import tools.execution_target_registry as registry
+
+    home = tmp_path / "legacy-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    set_execution_target_config_source({
+        "terminal": {
+            "backend": "ssh",
+            "ssh_host": "project-fallback-host",
+            "ssh_user": "static-user",
+        },
+    })
+    original = registry._atomic_write_json
+    calls = []
+
+    def fail_after_activation(path, payload):
+        calls.append(path.name)
+        if len(calls) == 2:
+            raise OSError("simulated provider publication crash")
+        return original(path, payload)
+
+    monkeypatch.setattr(registry, "_atomic_write_json", fail_after_activation)
+    try:
+        with pytest.raises(OSError, match="publication crash"):
+            update_provider_fragment(
+                "provider-a",
+                lambda _snapshot, current: {
+                    **current,
+                    "box": _record(str(tmp_path)),
+                },
+                activate_legacy=True,
+            )
+        invalidate_runtime_registry_cache()
+        default = resolve_execution_target()
+        assert default.named is True
+        assert default.target == "default"
+        assert default.backend == "ssh"
+        assert default.config["ssh_host"] == "project-fallback-host"
+        assert calls[0] == ".registry-state.json"
+        state = json.loads(
+            (registry_directory() / ".registry-state.json").read_text(encoding="utf-8")
+        )
+        assert state == {"legacy_activated": True, "version": 1}
+    finally:
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()
+
+
+def test_multiplex_activation_uses_selected_profile_not_ambient_environment(
+    monkeypatch,
+    tmp_path,
+):
+    from agent.secret_scope import set_multiplex_active
+    from tools.execution_target_overlay import overlay_runtime_execution_targets
+
+    home = tmp_path / "selected-profile"
+    home.mkdir()
+    selected_cwd = tmp_path / "selected-workspace"
+    selected_cwd.mkdir()
+    ambient_cwd = tmp_path / "wrong-ambient-profile"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_ENV", "ssh")
+    monkeypatch.setenv("TERMINAL_SSH_HOST", "wrong-profile-host")
+    monkeypatch.setenv("TERMINAL_SSH_USER", "wrong-profile-user")
+    monkeypatch.setenv("TERMINAL_CWD", str(ambient_cwd))
+    invalidate_runtime_registry_cache()
+    set_multiplex_active(True)
+    try:
+        snapshot = update_provider_fragment(
+            "profile-controller",
+            lambda _snapshot, current: current,
+            activate_legacy=True,
+        )
+        selected = {
+            "terminal": {
+                "backend": "local",
+                "cwd": str(selected_cwd),
+                "timeout": 91,
+            },
+        }
+        merged = overlay_runtime_execution_targets(selected, snapshot=snapshot)
+        resolution = resolve_execution_target(config=merged)
+        assert resolution.named is True
+        assert resolution.backend == "local"
+        assert resolution.config["cwd"] == str(selected_cwd)
+        state_text = (registry_directory() / ".registry-state.json").read_text(
+            encoding="utf-8"
+        )
+        assert json.loads(state_text) == {"legacy_activated": True, "version": 1}
+        assert "wrong-profile" not in state_text
+    finally:
+        set_multiplex_active(False)
+        invalidate_runtime_registry_cache()
+
+
+def test_legacy_activation_preserves_env_only_ssh_and_explicit_raw_key_wins(
+    monkeypatch,
+    tmp_path,
+):
+    import tools.terminal_tool as terminal_mod
+    from agent.secret_scope import is_multiplex_active, set_multiplex_active
+    from hermes_cli.config import TERMINAL_CONFIG_ENV_MAP
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    from tools.execution_target_overlay import overlay_runtime_execution_targets
+
+    home = tmp_path / "legacy-env-home"
+    home.mkdir()
+    (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for env_name in set(TERMINAL_CONFIG_ENV_MAP.values()) | {
+        "TERMINAL_LOCAL_PERSISTENT",
+        "TERMINAL_SSH_PERSISTENT",
+    }:
+        monkeypatch.delenv(env_name, raising=False)
+    expected = {
+        "backend": "ssh",
+        "ssh_host": "env-only.example.test",
+        "ssh_user": "env-user",
+        "ssh_port": 2207,
+        "ssh_key": "/keys/env-only-ed25519",
+        "cwd": "/srv/env-only-workspace",
+        "timeout": 347,
+    }
+    monkeypatch.setenv("TERMINAL_ENV", expected["backend"])
+    monkeypatch.setenv("TERMINAL_SSH_HOST", expected["ssh_host"])
+    monkeypatch.setenv("TERMINAL_SSH_USER", expected["ssh_user"])
+    monkeypatch.setenv("TERMINAL_SSH_PORT", str(expected["ssh_port"]))
+    monkeypatch.setenv("TERMINAL_SSH_KEY", expected["ssh_key"])
+    monkeypatch.setenv("TERMINAL_CWD", expected["cwd"])
+    monkeypatch.setenv("TERMINAL_TIMEOUT", str(expected["timeout"]))
+    monkeypatch.setattr(terminal_mod, "_terminal_config_bridge_attempted", False)
+
+    merged_defaults = deepcopy(DEFAULT_CONFIG)
+    merged_defaults["terminal"].update({
+        "ssh_host": "",
+        "ssh_user": "",
+        "ssh_port": 22,
+        "ssh_key": "",
+    })
+    multiplex_before = is_multiplex_active()
+    set_multiplex_active(False)
+    set_execution_target_config_source(merged_defaults)
+    invalidate_runtime_registry_cache()
+    try:
+        snapshot = update_provider_fragment(
+            "profile-controller",
+            lambda _snapshot, current: current,
+            activate_legacy=True,
+        )
+        activated = overlay_runtime_execution_targets(
+            merged_defaults,
+            snapshot=snapshot,
+        )
+        resolution = resolve_execution_target(config=activated)
+        assert resolution.named is True
+        assert {key: resolution.config[key] for key in expected} == expected
+
+        # The bridge is one-shot, so reset it while changing the raw authority
+        # and environment in-process.  monkeypatch restores the original module
+        # state after the test, preventing order-dependent coverage.
+        (home / "config.yaml").write_text(
+            "terminal:\n  ssh_port: 2022\n",
+            encoding="utf-8",
+        )
+        explicit = deepcopy(merged_defaults)
+        explicit["terminal"]["ssh_port"] = 2022
+        set_execution_target_config_source(explicit)
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "2299")
+        monkeypatch.setattr(terminal_mod, "_terminal_config_bridge_attempted", False)
+
+        refreshed = overlay_runtime_execution_targets(explicit, snapshot=snapshot)
+        explicit_resolution = resolve_execution_target(config=refreshed)
+        assert explicit_resolution.config["ssh_port"] == 2022
+        assert os.environ["TERMINAL_SSH_PORT"] == "2022"
+    finally:
+        set_execution_target_config_source(None)
+        set_multiplex_active(multiplex_before)
+        invalidate_runtime_registry_cache()
+
+
+def test_private_key_contents_and_traversal_provider_are_rejected(
+    registry_home,
+    tmp_path,
+):
+    with pytest.raises(RuntimeRegistryError):
+        write_provider_fragment_for_tests("../escape", {})
+    with pytest.raises(RuntimeRegistryError, match="not private-key contents"):
+        write_provider_fragment_for_tests(
+            "provider-a",
+            {
+                "box": {
+                    **_record(str(tmp_path), backend="ssh"),
+                    "config": {
+                        "backend": "ssh",
+                        "ssh_host": "alias",
+                        "ssh_user": "dev",
+                        "ssh_key": "-----BEGIN PRIVATE KEY-----\nsecret",
+                    },
+                },
+            },
+        )
+
+
+def test_malformed_replacement_drops_provider_instead_of_using_stale_snapshot(
+    registry_home,
+    tmp_path,
+):
+    write_provider_fragment_for_tests(
+        "provider-a",
+        {"box": _record(str(tmp_path))},
+    )
+    assert resolve_execution_target("box").provider == "provider-a"
+    path = registry_directory() / "provider-a.json"
+    replacement = path.with_name(".provider-a.replacement")
+    replacement.write_text("{malformed", encoding="utf-8")
+    replacement.chmod(0o600)
+    os.replace(replacement, path)
+
+    with pytest.raises(ExecutionTargetError):
+        resolve_execution_target("box")
+    assert resolve_execution_target("local").provider is None
+    assert any(
+        item.provider == "provider-a" for item in load_runtime_registry().diagnostics
+    )
+
+
+def test_invalid_legacy_activation_state_cannot_break_flat_static_default(
+    monkeypatch,
+    tmp_path,
+):
+    home = tmp_path / "invalid-activation"
+    directory = home / "runtime" / "execution-targets.d"
+    directory.mkdir(parents=True, mode=0o700)
+    state = directory / ".registry-state.json"
+    state.write_text(
+        json.dumps({
+            "version": 1,
+            "legacy_default": {"backend": "telepathy"},
+        }),
+        encoding="utf-8",
+    )
+    state.chmod(0o600)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    set_execution_target_config_source({"terminal": {"backend": "local"}})
+    invalidate_runtime_registry_cache()
+    try:
+        resolution = resolve_execution_target()
+        assert resolution.backend == "local"
+        assert resolution.named is False
+    finally:
+        set_execution_target_config_source(None)
+        invalidate_runtime_registry_cache()

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -206,3 +206,26 @@ class TestCommandCwdReadsTheRecord:
         assert tt.get_session_cwd("sess-a") == "/project"
         json.loads(tt.terminal_tool(command="pwd", task_id="sess-a"))
         assert fake.last_cwd_arg == "/project"
+
+
+def test_inherit_session_cwds_copies_every_named_target_scope(monkeypatch):
+    monkeypatch.setattr(
+        "tools.execution_targets._load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": "/alpha"},
+                    "beta": {"backend": "local", "cwd": "/beta"},
+                },
+            },
+        },
+    )
+    tt.record_session_cwd("parent", "/alpha/work", target="alpha")
+    tt.record_session_cwd("parent", "/beta/work", target="beta")
+
+    count = tt.inherit_session_cwds("parent", "child")
+
+    assert count == 2
+    assert tt.get_session_cwd("child", target="alpha") == "/alpha/work"
+    assert tt.get_session_cwd("child", target="beta") == "/beta/work"

--- a/tests/tools/test_session_cwd_store.py
+++ b/tests/tools/test_session_cwd_store.py
@@ -250,3 +250,26 @@ class TestCommandCwdReadsTheRecord:
         assert tt.get_session_cwd("sess-a") == "/project"
         json.loads(tt.terminal_tool(command="pwd", task_id="sess-a"))
         assert fake.last_cwd_arg == "/project"
+
+
+def test_inherit_session_cwds_copies_every_named_target_scope(monkeypatch):
+    monkeypatch.setattr(
+        "tools.execution_targets._load_merged_config",
+        lambda: {
+            "terminal": {
+                "default_target": "alpha",
+                "targets": {
+                    "alpha": {"backend": "local", "cwd": "/alpha"},
+                    "beta": {"backend": "local", "cwd": "/beta"},
+                },
+            },
+        },
+    )
+    tt.record_session_cwd("parent", "/alpha/work", target="alpha")
+    tt.record_session_cwd("parent", "/beta/work", target="beta")
+
+    count = tt.inherit_session_cwds("parent", "child")
+
+    assert count == 2
+    assert tt.get_session_cwd("child", target="alpha") == "/alpha/work"
+    assert tt.get_session_cwd("child", target="beta") == "/beta/work"

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -250,3 +250,98 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
+
+
+def test_control_socket_identity_includes_key_scope_and_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr(ssh_env, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env,
+        "FileSyncManager",
+        lambda **kw: type(
+            "M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self, **k: None,
+            },
+        )(),
+    )
+    key_a = tmp_path / "keys" / "a"
+    key_b = tmp_path / "keys" / "b"
+    key_a.parent.mkdir()
+    key_a.write_text("a")
+    key_b.write_text("b")
+
+    base = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    equivalent = SSHEnvironment(
+        host="h", user="u", port=22,
+        key_path=str(key_a.parent / ".." / "keys" / "a"),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    different_key = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_b),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    different_scope = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-b", profile_name="profile-a",
+    )
+    different_profile = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-a", profile_name="profile-b",
+    )
+
+    assert base.control_socket == equivalent.control_socket
+    assert len({
+        base.control_socket,
+        different_key.control_socket,
+        different_scope.control_socket,
+        different_profile.control_socket,
+    }) == 4
+
+
+def test_cleanup_of_one_scoped_ssh_socket_does_not_terminate_sibling(
+    monkeypatch, tmp_path,
+):
+    calls = []
+    monkeypatch.setattr(ssh_env, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env.subprocess,
+        "run",
+        lambda cmd, **kw: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0),
+    )
+    monkeypatch.setattr(
+        ssh_env,
+        "FileSyncManager",
+        lambda **kw: type(
+            "M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self, **k: None,
+            },
+        )(),
+    )
+    first = SSHEnvironment(
+        host="h", user="u", runtime_scope="one", profile_name="p",
+    )
+    second = SSHEnvironment(
+        host="h", user="u", runtime_scope="two", profile_name="p",
+    )
+    first.control_socket.touch()
+    second.control_socket.touch()
+
+    first.cleanup()
+
+    assert not first.control_socket.exists()
+    assert second.control_socket.exists()
+    assert len(calls) == 1
+    assert f"ControlPath={first.control_socket}" in calls[0]
+    assert f"ControlPath={second.control_socket}" not in calls[0]

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -231,3 +231,98 @@ class TestPersistentSSH:
         assert len(lines) == 1000
         assert lines[0] == "1"
         assert lines[-1] == "1000"
+
+
+def test_control_socket_identity_includes_key_scope_and_profile(monkeypatch, tmp_path):
+    monkeypatch.setattr(ssh_env, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env,
+        "FileSyncManager",
+        lambda **kw: type(
+            "M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self, **k: None,
+            },
+        )(),
+    )
+    key_a = tmp_path / "keys" / "a"
+    key_b = tmp_path / "keys" / "b"
+    key_a.parent.mkdir()
+    key_a.write_text("a")
+    key_b.write_text("b")
+
+    base = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    equivalent = SSHEnvironment(
+        host="h", user="u", port=22,
+        key_path=str(key_a.parent / ".." / "keys" / "a"),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    different_key = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_b),
+        runtime_scope="scope-a", profile_name="profile-a",
+    )
+    different_scope = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-b", profile_name="profile-a",
+    )
+    different_profile = SSHEnvironment(
+        host="h", user="u", port=22, key_path=str(key_a),
+        runtime_scope="scope-a", profile_name="profile-b",
+    )
+
+    assert base.control_socket == equivalent.control_socket
+    assert len({
+        base.control_socket,
+        different_key.control_socket,
+        different_scope.control_socket,
+        different_profile.control_socket,
+    }) == 4
+
+
+def test_cleanup_of_one_scoped_ssh_socket_does_not_terminate_sibling(
+    monkeypatch, tmp_path,
+):
+    calls = []
+    monkeypatch.setattr(ssh_env, "_ensure_ssh_available", lambda: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/u")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env.subprocess,
+        "run",
+        lambda cmd, **kw: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0),
+    )
+    monkeypatch.setattr(
+        ssh_env,
+        "FileSyncManager",
+        lambda **kw: type(
+            "M", (), {
+                "sync": lambda self, **k: None,
+                "sync_back": lambda self, **k: None,
+            },
+        )(),
+    )
+    first = SSHEnvironment(
+        host="h", user="u", runtime_scope="one", profile_name="p",
+    )
+    second = SSHEnvironment(
+        host="h", user="u", runtime_scope="two", profile_name="p",
+    )
+    first.control_socket.touch()
+    second.control_socket.touch()
+
+    first.cleanup()
+
+    assert not first.control_socket.exists()
+    assert second.control_socket.exists()
+    assert len(calls) == 1
+    assert f"ControlPath={first.control_socket}" in calls[0]
+    assert f"ControlPath={second.control_socket}" not in calls[0]

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -25,6 +25,10 @@ mirrors the pattern used in tests/hermes_cli/test_config_drift.py.
 
 import ast
 import inspect
+import json
+import os
+import subprocess
+import sys
 
 
 def _extract_dict_values(source: str, dict_name: str) -> set[str]:
@@ -68,6 +72,91 @@ def _extract_dict_keys(source: str, dict_name: str) -> set[str]:
                 out.add(k.value)
         return out
     raise AssertionError(f"Could not find `{dict_name} = {{...}}` literal in source")
+
+
+def test_classic_cli_bridges_named_default_target(tmp_path):
+    (tmp_path / "config.yaml").write_text(
+        "terminal:\n"
+        "  default_target: devbox\n"
+        "  targets:\n"
+        "    devbox:\n"
+        "      backend: ssh\n"
+        "      cwd: ~/project\n"
+        "      ssh_host: example.invalid\n"
+        "      ssh_user: agent\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    for key in (
+        "_HERMES_GATEWAY", "TERMINAL_ENV", "TERMINAL_CWD", "HERMES_PROFILE",
+    ):
+        env.pop(key, None)
+    env.update({
+        "HERMES_HOME": str(tmp_path),
+        "HERMES_IGNORE_USER_CONFIG": "0",
+    })
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, os, cli; "
+                "print(json.dumps([os.environ.get('TERMINAL_ENV'), "
+                "os.environ.get('TERMINAL_CWD')]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(proc.stdout.strip().splitlines()[-1]) == ["ssh", "~/project"]
+
+    ignored_env = env.copy()
+    ignored_env["HERMES_IGNORE_USER_CONFIG"] = "1"
+    ignored = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, cli; "
+                "from tools.execution_targets import resolve_execution_target; "
+                "r=resolve_execution_target(); "
+                "print(json.dumps([r.named, r.backend]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=ignored_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(ignored.stdout.strip().splitlines()[-1]) == [False, "local"]
+
+    gateway_env = ignored_env.copy()
+    gateway_env["_HERMES_GATEWAY"] = "1"
+    gateway = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json, cli; "
+                "from tools.execution_targets import resolve_execution_target; "
+                "r=resolve_execution_target(); "
+                "print(json.dumps([r.named, r.backend]))"
+            ),
+        ],
+        cwd=os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+        env=gateway_env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=True,
+    )
+    assert json.loads(gateway.stdout.strip().splitlines()[-1]) == [True, "ssh"]
 
 
 def _cli_env_map_keys() -> set[str]:

--- a/tests/tools/test_terminal_env_bridge.py
+++ b/tests/tools/test_terminal_env_bridge.py
@@ -22,9 +22,13 @@ def _reset_bridge_state(monkeypatch):
         "TERMINAL_ENV",
         "TERMINAL_CWD",
         "TERMINAL_DOCKER_IMAGE",
+        "TERMINAL_TIMEOUT",
         "TERMINAL_SSH_HOST",
+        "TERMINAL_SSH_USER",
     ):
         monkeypatch.delenv(name, raising=False)
+    # The config layer caches by (path, mtime, size); each test writes its own
+    # config.yaml and therefore changes the signature.
     yield
 
 
@@ -68,6 +72,76 @@ def test_partial_terminal_config_preserves_unrelated_env_values(monkeypatch):
     assert config["env_type"] == "docker"
     assert config["docker_image"] == "env/image:2"
     assert os.environ["TERMINAL_DOCKER_IMAGE"] == "env/image:2"
+
+
+def test_bridge_mirrors_named_default_target_for_legacy_consumers():
+    _write_config(
+        "terminal:\n"
+        "  backend: local\n"
+        "  timeout: 77\n"
+        "  default_target: devbox\n"
+        "  targets:\n"
+        "    local:\n"
+        "      backend: local\n"
+        "      cwd: /workspace/local\n"
+        "    devbox:\n"
+        "      backend: ssh\n"
+        "      cwd: /srv/project\n"
+        "      ssh_host: devbox.example.com\n"
+        "      ssh_user: agent\n"
+    )
+
+    from hermes_cli.config import apply_terminal_config_to_env, load_config_readonly
+
+    mirrored = apply_terminal_config_to_env(
+        env={}, config=load_config_readonly(), override=True,
+    )
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "ssh"
+    assert config["cwd"] == "/srv/project"
+    assert config["timeout"] == 77
+    assert config["ssh_host"] == "devbox.example.com"
+    assert mirrored["TERMINAL_ENV"] == "ssh"
+    assert mirrored["TERMINAL_CWD"] == "/srv/project"
+    assert mirrored["TERMINAL_TIMEOUT"] == "77"
+    assert mirrored["TERMINAL_SSH_HOST"] == "devbox.example.com"
+
+
+def test_bridge_preserves_remote_tilde_for_named_ssh_default():
+    from hermes_cli.config import apply_terminal_config_to_env
+
+    mirrored = apply_terminal_config_to_env(
+        env={},
+        config={
+            "terminal": {
+                "default_target": "devbox",
+                "targets": {
+                    "devbox": {
+                        "backend": "ssh",
+                        "cwd": "~/project",
+                        "ssh_host": "devbox.example.com",
+                        "ssh_user": "agent",
+                    },
+                },
+            },
+        },
+        override=True,
+    )
+
+    assert mirrored["TERMINAL_ENV"] == "ssh"
+    assert mirrored["TERMINAL_CWD"] == "~/project"
+
+
+def test_invalid_default_target_type_stays_fail_open():
+    from hermes_cli.config import effective_terminal_config
+
+    effective = effective_terminal_config({
+        "backend": "local",
+        "default_target": ["not", "hashable"],
+        "targets": {"local": {"backend": "local"}},
+    })
+    assert effective == {"backend": "local"}
 
 
 def test_explicit_config_key_overrides_matching_env_value(monkeypatch):

--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -206,3 +206,20 @@ def test_vercel_backend_rejects_malformed_disk_without_raising(monkeypatch, capl
         "Invalid value for TERMINAL_CONTAINER_DISK" in record.getMessage()
         for record in caplog.records
     )
+
+
+def test_check_terminal_requirements_invalid_config_returns_false(monkeypatch):
+    import tools.execution_targets as targets_mod
+    from tools.terminal_tool import check_terminal_requirements
+
+    monkeypatch.setattr(
+        targets_mod,
+        "list_execution_targets",
+        lambda: (_ for _ in ()).throw(
+            targets_mod.ExecutionTargetError(
+                "terminal.targets must be a mapping of target names"
+            )
+        ),
+    )
+
+    assert check_terminal_requirements() is False

--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -283,6 +283,23 @@ class TestEnforceTurnBudget:
         )
         assert persisted_count >= 2  # Need to shed at least ~52K
 
+    def test_target_without_env_does_not_spill_into_default_env(self):
+        default_env = MagicMock()
+        default_env.execute.return_value = {"output": "", "returncode": 0}
+        msgs = [
+            {"role": "tool", "tool_call_id": "targeted", "content": "x" * 250_000},
+        ]
+
+        enforce_turn_budget(
+            msgs,
+            env=default_env,
+            env_resolver=lambda _msg: None,
+            config=BudgetConfig(turn_budget=200_000),
+        )
+
+        default_env.execute.assert_not_called()
+        assert "Truncated" in msgs[0]["content"]
+
 
     def test_empty_messages(self):
         result = enforce_turn_budget([], env=None, config=BudgetConfig(turn_budget=200_000))

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -145,6 +145,8 @@ def _prepare_smart_approval_observer(
     pattern_key: str,
     pattern_keys: list[str],
     session_key: str,
+    execution_target: str = "",
+    execution_backend: str = "",
 ) -> dict | None:
     """Redact and emit the pre-decision smart approval observer hook.
 
@@ -168,6 +170,8 @@ def _prepare_smart_approval_observer(
         "pattern_keys": list(pattern_keys),
         "session_key": session_key,
         "surface": "smart",
+        "target": execution_target,
+        "backend": execution_backend,
     }
     _fire_approval_hook("pre_approval_request", **payload)
     return payload
@@ -4193,6 +4197,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+    execution_target = approval_data.get("target")
+    execution_backend = approval_data.get("backend")
 
     # ── Coalesce identical concurrent approvals (one prompt, one answer) ──
     # Parallel tool calls (a parallel terminal batch, execute_code RPC
@@ -4251,6 +4257,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface=surface,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     # Notify the user (bridges sync agent thread → async gateway)
@@ -4335,13 +4343,41 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         session_key=session_key,
         surface=surface,
         choice=_outcome,
+        target=execution_target,
+        backend=execution_backend,
     )
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def _execution_scoped_pattern_key(
+    pattern_key: str, execution_target: str, named: bool,
+    execution_target_scope: str = "",
+) -> str:
+    """Scope persisted approvals to a named target without key collisions."""
+    if not named:
+        return pattern_key
+    target = str(execution_target or "")
+    if execution_target_scope:
+        return f"target:{execution_target_scope}:{pattern_key}"
+    try:
+        from tools.execution_targets import _active_profile_scope
+
+        profile_scope = _active_profile_scope()
+    except Exception:
+        profile_scope = ""
+    digest = hashlib.sha256(
+        f"{profile_scope}:{target}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"target:{digest}:{pattern_key}"
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: Optional[str] = None,
+                             execution_target_named: bool = False,
+                             execution_target_scope: str = "") -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -4609,12 +4645,19 @@ def check_all_command_guards(command: str, env_type: str,
     if tirith_result["action"] in {"block", "warn"}:
         findings = tirith_result.get("findings") or []
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
-        tirith_key = f"tirith:{rule_id}"
+        tirith_key = _execution_scoped_pattern_key(
+            f"tirith:{rule_id}", execution_target, execution_target_named,
+            execution_target_scope,
+        )
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
             warnings.append((tirith_key, tirith_desc, True))
 
     if is_dangerous:
+        pattern_key = _execution_scoped_pattern_key(
+            pattern_key, execution_target, execution_target_named,
+            execution_target_scope,
+        )
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 
@@ -4622,19 +4665,31 @@ def check_all_command_guards(command: str, env_type: str,
     if not warnings:
         return {"approved": True, "message": None}
 
+    execution_backend = execution_backend or env_type
+
+    def _target_description(description: str) -> str:
+        return (
+            f"{description} [execution target: {execution_target!r}; "
+            f"backend: {execution_backend}]"
+        )
+
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
     if approval_mode == "smart":
-        combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+        combined_desc_for_llm = _target_description(
+            "; ".join(desc for _, desc, _ in warnings)
+        )
         observer_payload = _prepare_smart_approval_observer(
             command=command,
             description=combined_desc_for_llm,
             pattern_key=warnings[0][0],
             pattern_keys=[key for key, _, _ in warnings],
             session_key=session_key,
+            execution_target=execution_target,
+            execution_backend=execution_backend,
         )
         verdict = _smart_approve(command, combined_desc_for_llm)
         _observe_smart_approval_verdict(observer_payload, verdict)
@@ -4670,7 +4725,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = _target_description(
+        "; ".join(desc for _, desc, _ in warnings)
+    )
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
     # "Always" is offered when at least one warning is a dangerous-pattern
@@ -4784,6 +4841,8 @@ def check_all_command_guards(command: str, env_type: str,
                 # already caps scope at session. Adapters use this to render
                 # a session tier independently of the permanent tier.
                 "allow_session": not smart_denied_for_owner,
+                "target": execution_target,
+                "backend": execution_backend,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
@@ -4879,6 +4938,8 @@ def check_all_command_guards(command: str, env_type: str,
                 "pattern_key": primary_key,
                 "pattern_keys": all_keys,
                 "description": _disp_combined_desc,
+                "target": execution_target,
+                "backend": execution_backend,
             }
             if smart_denied_for_owner:
                 pending_data.update(smart_denied=True, allow_permanent=False)
@@ -4893,6 +4954,8 @@ def check_all_command_guards(command: str, env_type: str,
                 "message": (
                     f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
                 ),
+                "target": execution_target,
+                "backend": execution_backend,
             }
             if smart_denied_for_owner:
                 result.update(smart_denied=True, allow_permanent=False)
@@ -4908,6 +4971,8 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface="cli",
+        target=execution_target,
+        backend=execution_backend,
     )
     choice = prompt_dangerous_approval(
         command,
@@ -4925,6 +4990,8 @@ def check_all_command_guards(command: str, env_type: str,
         session_key=session_key,
         surface="cli",
         choice=choice,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     if choice == "timeout":
@@ -4984,7 +5051,11 @@ def check_all_command_guards(command: str, env_type: str,
 
 
 def check_execute_code_guard(code: str, env_type: str,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: str | None = None,
+                             execution_target_named: bool = False,
+                             execution_target_scope: str = "") -> dict:
     """Approve an execute_code script before its child process is spawned.
 
     execute_code runs arbitrary local Python — the script can call
@@ -5002,11 +5073,19 @@ def check_execute_code_guard(code: str, env_type: str,
     trusted-by-config (set a gateway/ask surface or ``approvals.cron_mode`` to
     require approval).
     """
-    pattern_key = "execute_code"
+    pattern_key = _execution_scoped_pattern_key(
+        "execute_code", execution_target, execution_target_named,
+        execution_target_scope,
+    )
     description = (
         "execute_code script execution. The script can spawn subprocesses or "
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
+    )
+    execution_backend = execution_backend or env_type
+    description += (
+        f" [execution target: {execution_target!r}; "
+        f"backend: {execution_backend}]"
     )
 
     # Isolated backends already sandbox the child — matches the container skip
@@ -5101,6 +5180,8 @@ def check_execute_code_guard(code: str, env_type: str,
             pattern_key=pattern_key,
             pattern_keys=[pattern_key],
             session_key=session_key,
+            execution_target=execution_target,
+            execution_backend=execution_backend,
         )
         verdict = _smart_approve(command, description)
         _observe_smart_approval_verdict(observer_payload, verdict)
@@ -5210,6 +5291,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -5221,6 +5304,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "approval_pending": True,
             "command": display_command,
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
             "message": (
                 f"⚠️ {display_description}. Asking the user for approval.\n\n"
                 f"**Code:**\n```python\n{display_code}\n```"
@@ -5237,6 +5322,8 @@ def check_execute_code_guard(code: str, env_type: str,
         "description": display_description,
         "allow_permanent": not smart_denied_for_owner,
         "allow_session": not smart_denied_for_owner,
+        "target": execution_target,
+        "backend": execution_backend,
     }
     if smart_denied_for_owner:
         approval_data["smart_denied"] = True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -127,6 +127,8 @@ def _prepare_smart_approval_observer(
     pattern_key: str,
     pattern_keys: list[str],
     session_key: str,
+    execution_target: str = "",
+    execution_backend: str = "",
 ) -> dict | None:
     """Redact and emit the pre-decision smart approval observer hook.
 
@@ -150,6 +152,8 @@ def _prepare_smart_approval_observer(
         "pattern_keys": list(pattern_keys),
         "session_key": session_key,
         "surface": "smart",
+        "target": execution_target,
+        "backend": execution_backend,
     }
     _fire_approval_hook("pre_approval_request", **payload)
     return payload
@@ -3433,6 +3437,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
     description = approval_data.get("description", "")
     primary_key = approval_data.get("pattern_key", "")
     all_keys = approval_data.get("pattern_keys", [primary_key])
+    execution_target = approval_data.get("target")
+    execution_backend = approval_data.get("backend")
 
     entry = _ApprovalEntry(approval_data)
     with _lock:
@@ -3456,6 +3462,8 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface=surface,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     # Notify the user (bridges sync agent thread → async gateway)
@@ -3525,13 +3533,41 @@ def _await_gateway_decision(session_key: str, notify_cb, approval_data: dict,
         session_key=session_key,
         surface=surface,
         choice=_outcome,
+        target=execution_target,
+        backend=execution_backend,
     )
     return {"resolved": resolved, "choice": choice, "reason": entry.reason}
 
 
+def _execution_scoped_pattern_key(
+    pattern_key: str, execution_target: str, named: bool,
+    execution_target_scope: str = "",
+) -> str:
+    """Scope persisted approvals to a named target without key collisions."""
+    if not named:
+        return pattern_key
+    target = str(execution_target or "")
+    if execution_target_scope:
+        return f"target:{execution_target_scope}:{pattern_key}"
+    try:
+        from tools.execution_targets import _active_profile_scope
+
+        profile_scope = _active_profile_scope()
+    except Exception:
+        profile_scope = ""
+    digest = hashlib.sha256(
+        f"{profile_scope}:{target}".encode("utf-8")
+    ).hexdigest()[:16]
+    return f"target:{digest}:{pattern_key}"
+
+
 def check_all_command_guards(command: str, env_type: str,
                              approval_callback=None,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: Optional[str] = None,
+                             execution_target_named: bool = False,
+                             execution_target_scope: str = "") -> dict:
     """Run all pre-exec security checks and return a single approval decision.
 
     Gathers findings from tirith and dangerous-command detection, then
@@ -3719,12 +3755,19 @@ def check_all_command_guards(command: str, env_type: str,
     if tirith_result["action"] in {"block", "warn"}:
         findings = tirith_result.get("findings") or []
         rule_id = findings[0].get("rule_id", "unknown") if findings else "unknown"
-        tirith_key = f"tirith:{rule_id}"
+        tirith_key = _execution_scoped_pattern_key(
+            f"tirith:{rule_id}", execution_target, execution_target_named,
+            execution_target_scope,
+        )
         tirith_desc = _format_tirith_description(tirith_result)
         if not is_approved(session_key, tirith_key):
             warnings.append((tirith_key, tirith_desc, True))
 
     if is_dangerous:
+        pattern_key = _execution_scoped_pattern_key(
+            pattern_key, execution_target, execution_target_named,
+            execution_target_scope,
+        )
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 
@@ -3732,19 +3775,31 @@ def check_all_command_guards(command: str, env_type: str,
     if not warnings:
         return {"approved": True, "message": None}
 
+    execution_backend = execution_backend or env_type
+
+    def _target_description(description: str) -> str:
+        return (
+            f"{description} [execution target: {execution_target!r}; "
+            f"backend: {execution_backend}]"
+        )
+
     # --- Phase 2.5: Smart approval (auxiliary LLM risk assessment) ---
     # When approvals.mode=smart, ask the aux LLM before prompting the user.
     # Inspired by OpenAI Codex's Smart Approvals guardian subagent
     # (openai/codex#13860).
     smart_denied_for_owner = False
     if approval_mode == "smart":
-        combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+        combined_desc_for_llm = _target_description(
+            "; ".join(desc for _, desc, _ in warnings)
+        )
         observer_payload = _prepare_smart_approval_observer(
             command=command,
             description=combined_desc_for_llm,
             pattern_key=warnings[0][0],
             pattern_keys=[key for key, _, _ in warnings],
             session_key=session_key,
+            execution_target=execution_target,
+            execution_backend=execution_backend,
         )
         verdict = _smart_approve(command, combined_desc_for_llm)
         _observe_smart_approval_verdict(observer_payload, verdict)
@@ -3780,7 +3835,9 @@ def check_all_command_guards(command: str, env_type: str,
     # --- Phase 3: Approval ---
 
     # Combine descriptions for a single approval prompt
-    combined_desc = "; ".join(desc for _, desc, _ in warnings)
+    combined_desc = _target_description(
+        "; ".join(desc for _, desc, _ in warnings)
+    )
     primary_key = warnings[0][0]
     all_keys = [key for key, _, _ in warnings]
     # "Always" is offered when at least one warning is a dangerous-pattern
@@ -3830,6 +3887,8 @@ def check_all_command_guards(command: str, env_type: str,
                 # already caps scope at session. Adapters use this to render
                 # a session tier independently of the permanent tier.
                 "allow_session": not smart_denied_for_owner,
+                "target": execution_target,
+                "backend": execution_backend,
             }
             if smart_denied_for_owner:
                 approval_data["smart_denied"] = True
@@ -3916,6 +3975,8 @@ def check_all_command_guards(command: str, env_type: str,
             "pattern_key": primary_key,
             "pattern_keys": all_keys,
             "description": _disp_combined_desc,
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -3930,6 +3991,8 @@ def check_all_command_guards(command: str, env_type: str,
             "message": (
                 f"⚠️ {_disp_combined_desc}. Asking the user for approval.\n\n**Command:**\n```\n{_disp_command}\n```"
             ),
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             result.update(smart_denied=True, allow_permanent=False)
@@ -3945,6 +4008,8 @@ def check_all_command_guards(command: str, env_type: str,
         pattern_keys=list(all_keys),
         session_key=session_key,
         surface="cli",
+        target=execution_target,
+        backend=execution_backend,
     )
     choice = prompt_dangerous_approval(
         command,
@@ -3962,6 +4027,8 @@ def check_all_command_guards(command: str, env_type: str,
         session_key=session_key,
         surface="cli",
         choice=choice,
+        target=execution_target,
+        backend=execution_backend,
     )
 
     if choice == "timeout":
@@ -4021,7 +4088,11 @@ def check_all_command_guards(command: str, env_type: str,
 
 
 def check_execute_code_guard(code: str, env_type: str,
-                             has_host_access: bool = False) -> dict:
+                             has_host_access: bool = False,
+                             execution_target: str = "default",
+                             execution_backend: str | None = None,
+                             execution_target_named: bool = False,
+                             execution_target_scope: str = "") -> dict:
     """Approve an execute_code script before its child process is spawned.
 
     execute_code runs arbitrary local Python — the script can call
@@ -4039,11 +4110,19 @@ def check_execute_code_guard(code: str, env_type: str,
     trusted-by-config (set a gateway/ask surface or ``approvals.cron_mode`` to
     require approval).
     """
-    pattern_key = "execute_code"
+    pattern_key = _execution_scoped_pattern_key(
+        "execute_code", execution_target, execution_target_named,
+        execution_target_scope,
+    )
     description = (
         "execute_code script execution. The script can spawn subprocesses or "
         "mutate files without passing through terminal command approval; "
         "approval is one-shot for this run."
+    )
+    execution_backend = execution_backend or env_type
+    description += (
+        f" [execution target: {execution_target!r}; "
+        f"backend: {execution_backend}]"
     )
 
     # Isolated backends already sandbox the child — matches the container skip
@@ -4113,6 +4192,8 @@ def check_execute_code_guard(code: str, env_type: str,
             pattern_key=pattern_key,
             pattern_keys=[pattern_key],
             session_key=session_key,
+            execution_target=execution_target,
+            execution_backend=execution_backend,
         )
         verdict = _smart_approve(command, description)
         _observe_smart_approval_verdict(observer_payload, verdict)
@@ -4168,6 +4249,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "pattern_key": pattern_key,
             "pattern_keys": [pattern_key],
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
         }
         if smart_denied_for_owner:
             pending_data.update(smart_denied=True, allow_permanent=False)
@@ -4179,6 +4262,8 @@ def check_execute_code_guard(code: str, env_type: str,
             "approval_pending": True,
             "command": display_command,
             "description": display_description,
+            "target": execution_target,
+            "backend": execution_backend,
             "message": (
                 f"⚠️ {display_description}. Asking the user for approval.\n\n"
                 f"**Code:**\n```python\n{display_code}\n```"
@@ -4195,6 +4280,8 @@ def check_execute_code_guard(code: str, env_type: str,
         "description": display_description,
         "allow_permanent": not smart_denied_for_owner,
         "allow_session": not smart_denied_for_owner,
+        "target": execution_target,
+        "backend": execution_backend,
     }
     if smart_denied_for_owner:
         approval_data["smart_denied"] = True

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -29,6 +29,7 @@ Remote execution additionally requires Python 3 in the terminal backend.
 """
 
 import base64
+from copy import deepcopy
 import json
 import logging
 import os
@@ -342,33 +343,33 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 2000",
+        "path: str, offset: int = 1, limit: int = 2000, execution_target: str = None, runtime_scope: str = None",
         '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        '{"path": path, "offset": offset, "limit": limit, "execution_target": execution_target, "runtime_scope": runtime_scope}',
     ),
     "write_file": (
         "write_file",
-        "path: str, content: str, cross_profile: bool = False",
+        "path: str, content: str, cross_profile: bool = False, execution_target: str = None",
         '"""Write content to a file (always overwrites). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "content": content, "cross_profile": cross_profile}',
+        '{"path": path, "content": content, "cross_profile": cross_profile, "execution_target": execution_target}',
     ),
     "search_files": (
         "search_files",
-        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0',
+        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0, execution_target: str = None',
         '"""Search file contents (target="content") or find files by name (target="files"). Returns dict with "matches"."""',
-        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context}',
+        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context, "execution_target": execution_target}',
     ),
     "patch": (
         "patch",
-        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False',
+        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False, execution_target: str = None',
         '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile}',
+        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile, "execution_target": execution_target}',
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, execution_target: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "execution_target": execution_target}',
     ),
 }
 
@@ -649,6 +650,118 @@ def _call(tool_name, args):
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
 
+def _inherit_execution_target(
+    tool_name: str,
+    tool_args: Any,
+    execution_target: Optional[str],
+    execution_target_scope: Optional[str] = None,
+) -> Any:
+    """Bind target-aware RPC calls to the outer execute_code target.
+
+    The RPC token grants access to host-side Hermes tools. A script approved to
+    run in one sandbox must not use it to pivot a nested file/terminal call onto
+    another target. All target-aware tool APIs use ``execution_target``;
+    ``search_files.target`` remains its independent search-mode argument.
+    """
+    if not execution_target or not isinstance(tool_args, dict):
+        return tool_args
+    selector = "execution_target"
+    if tool_name not in {"terminal", "read_file", "write_file", "patch", "search_files"}:
+        return tool_args
+
+    if execution_target_scope:
+        from tools.execution_targets import resolve_live_execution_target
+
+        try:
+            live_resolution = resolve_live_execution_target(execution_target)
+        except Exception as exc:
+            raise ValueError(
+                f"Execution target {execution_target!r} is no longer available: {exc}"
+            ) from exc
+        if live_resolution.security_scope != execution_target_scope:
+            raise ValueError(
+                f"Execution target {execution_target!r} changed while execute_code "
+                "was running; nested target-aware calls are blocked."
+            )
+
+    inherited = dict(tool_args)
+    if tool_name != "search_files":
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args(tool_name, inherited)
+    requested = inherited.get(selector)
+    if requested is None:
+        inherited[selector] = execution_target
+    elif str(requested) != execution_target:
+        raise ValueError(
+            f"execute_code RPC is bound to target {execution_target!r}; nested "
+            f"{tool_name} cannot select {requested!r}."
+        )
+    else:
+        inherited[selector] = requested
+    if tool_name == "read_file" and execution_target_scope:
+        runtime_scope = inherited.get("runtime_scope")
+        if runtime_scope is not None and runtime_scope != execution_target_scope:
+            raise ValueError(
+                "Nested read_file runtime_scope does not match the outer "
+                f"execute_code runtime for target {execution_target!r}."
+            )
+    return inherited
+
+
+def _frozen_target_config(resolution) -> dict:
+    """Freeze the effective config without making inherited fields explicit."""
+    terminal = deepcopy(dict(resolution.config))
+    targets = {resolution.target: {"backend": resolution.backend}}
+    if resolution.is_default:
+        default_target = resolution.target
+    else:
+        default_target = "__hermes_original_default__"
+        while default_target in targets:
+            default_target += "_"
+        targets[default_target] = {"backend": "local"}
+    terminal["default_target"] = default_target
+    terminal["targets"] = targets
+    frozen = {"terminal": terminal}
+    if resolution.provider is not None:
+        from tools.execution_target_lifecycle import (
+            REGISTRY_METADATA_KEY,
+            runtime_record_metadata_entry,
+        )
+
+        frozen[REGISTRY_METADATA_KEY] = {
+            "records": [
+                runtime_record_metadata_entry(
+                    execution_target=resolution.target,
+                    provider=resolution.provider,
+                    owner_id=resolution.owner_id,
+                    generation=resolution.generation,
+                    state="ready",
+                    status="active",
+                )
+            ],
+            "diagnostics": [],
+        }
+    return frozen
+
+
+def _dispatch_rpc_tool(
+    handler,
+    tool_name: str,
+    tool_args: Any,
+    task_id: str,
+    execution_target_config: Optional[dict],
+):
+    """Dispatch under the immutable target config approved for this script."""
+    if execution_target_config is None:
+        return handler(tool_name, tool_args, task_id=task_id)
+
+    from tools.execution_targets import execution_target_config_scope
+
+    with execution_target_config_scope(execution_target_config):
+        return handler(tool_name, tool_args, task_id=task_id)
+
+
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
@@ -658,6 +771,9 @@ def _rpc_server_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
+    execution_target_scope: Optional[str] = None,
+    execution_target_config: Optional[dict] = None,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -715,6 +831,14 @@ def _rpc_server_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                try:
+                    tool_args = _inherit_execution_target(
+                        tool_name, tool_args, execution_target,
+                        execution_target_scope,
+                    )
+                except ValueError as exc:
+                    conn.sendall((tool_error(str(exc)) + "\n").encode())
+                    continue
 
                 # Enforce the allow-list
                 if tool_name not in allowed_tools:
@@ -745,8 +869,12 @@ def _rpc_server_loop(
                 # their status prints don't leak into the CLI spinner.
                 try:
                     with thread_scoped_silence():
-                        result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                        result = _dispatch_rpc_tool(
+                            handle_function_call,
+                            tool_name,
+                            tool_args,
+                            task_id,
+                            execution_target_config,
                         )
                 except Exception as exc:
                     logger.error("Tool call failed in sandbox: %s", exc, exc_info=True)
@@ -781,7 +909,37 @@ def _rpc_server_loop(
 # Remote execution support (file-based RPC via terminal backend)
 # ---------------------------------------------------------------------------
 
-def _get_or_create_env(task_id: str):
+def _resolve_remote_operation_cwd(task_id: str, resolution: Any, config: dict) -> str:
+    """Resolve the selected target cwd without consulting mutable env state."""
+    from tools.terminal_tool import (
+        _apply_task_cwd_override,
+        get_session_cwd,
+        resolve_task_overrides,
+    )
+
+    raw_task_id = task_id or "default"
+    overrides = resolve_task_overrides(raw_task_id)
+    cwd_override = (
+        overrides.get("cwd")
+        if (
+            not resolution.named
+            or (resolution.is_default and resolution.backend != "ssh")
+        )
+        else None
+    )
+    cwd = (
+        cwd_override
+        or get_session_cwd(raw_task_id, _resolution=resolution)
+        or config["cwd"]
+    )
+    return _apply_task_cwd_override(config, cwd, cwd_override)
+
+
+def _get_or_create_env(
+    task_id: str,
+    target: Optional[str] = None,
+    expected_target_scope: Optional[str] = None,
+):
     """Get or create the terminal environment for *task_id*.
 
     Reuses the same environment (container/sandbox/SSH session) that the
@@ -791,17 +949,46 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id, _resolve_task_host_cwd,
+        _creation_locks, _creation_locks_lock, _resolve_container_task_id,
+        resolve_task_overrides, _record_environment_lifetime,
+        _record_environment_target, _environment_matches_target,
+        _prepare_environment_replacement, _EnvironmentReplacementError,
+        _retire_replaced_environment,
+        _cleanup_environment_resource,
+        _environment_has_stable_storage,
+        _build_environment_constructor_configs,
+        _resolve_task_host_cwd,
+    )
+    from tools.execution_targets import (
+        execution_target_config_is_frozen,
+        resolve_execution_target,
+        resolve_live_execution_target,
     )
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    raw_task_id = task_id or "default"
+    resolution = resolve_execution_target(target)
+    if (
+        expected_target_scope is not None
+        and resolution.security_scope != expected_target_scope
+    ):
+        raise ValueError(
+            f"Execution target {resolution.target!r} changed after approval."
+        )
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    effective_task_id = resolution.environment_key(base_task_id)
+    backend_task_id = resolution.backend_task_id(base_task_id)
+    config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
 
     # Fast path: environment already exists
     with _env_lock:
-        if effective_task_id in _active_environments:
+        active_env = _active_environments.get(effective_task_id)
+        if _environment_matches_target(active_env, resolution):
+            assert active_env is not None
             _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            return active_env, config["env_type"]
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
@@ -811,13 +998,22 @@ def _get_or_create_env(task_id: str):
 
     with task_lock:
         with _env_lock:
-            if effective_task_id in _active_environments:
+            active_env = _active_environments.get(effective_task_id)
+            if _environment_matches_target(active_env, resolution):
+                assert active_env is not None
                 _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+                return active_env, config["env_type"]
+        try:
+            _prepare_environment_replacement(
+                active_env,
+                effective_task_id,
+                target_name=resolution.target,
+            )
+        except _EnvironmentReplacementError as exc:
+            raise ValueError(str(exc)) from exc
 
-        config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(raw_task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -830,39 +1026,42 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
+        cwd = _resolve_remote_operation_cwd(raw_task_id, resolution, config)
 
-        container_config = None
-        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+        container_config, ssh_config, local_config = (
+            _build_environment_constructor_configs(
+                config, resolution, base_task_id,
+            )
+        )
+        if container_config is not None:
+            # Keep an auditable module-local constructor map. The shared
+            # builder remains the normalization source, while this explicit
+            # copy preserves the upstream cross-call-site Docker option
+            # invariant enforced by test_docker_network_config.py.
             container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "vercel_runtime": config.get("vercel_runtime", ""),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_network": config.get("docker_network", True),
-            }
-
-        ssh_config = None
-        if env_type == "ssh":
-            ssh_config = {
-                "host": config.get("ssh_host", ""),
-                "user": config.get("ssh_user", ""),
-                "port": config.get("ssh_port", 22),
-                "key": config.get("ssh_key", ""),
-                "persistent": config.get("ssh_persistent", False),
-            }
-
-        local_config = None
-        if env_type == "local":
-            local_config = {
-                "persistent": config.get("local_persistent", False),
+                "container_cpu": container_config["container_cpu"],
+                "container_memory": container_config["container_memory"],
+                "container_disk": container_config["container_disk"],
+                "container_persistent": container_config["container_persistent"],
+                "vercel_runtime": container_config["vercel_runtime"],
+                "modal_mode": container_config["modal_mode"],
+                "docker_volumes": container_config["docker_volumes"],
+                "docker_mount_cwd_to_workspace": container_config["docker_mount_cwd_to_workspace"],
+                "docker_forward_env": container_config["docker_forward_env"],
+                "docker_env": container_config["docker_env"],
+                "docker_run_as_host_user": container_config["docker_run_as_host_user"],
+                "docker_extra_args": container_config["docker_extra_args"],
+                "docker_network": container_config["docker_network"],
+                "docker_shm_size": container_config["docker_shm_size"],
+                "docker_persist_across_processes": container_config["docker_persist_across_processes"],
+                "docker_orphan_reaper": container_config["docker_orphan_reaper"],
+                "lifetime_seconds": container_config["lifetime_seconds"],
+                "storage_task_id": container_config["storage_task_id"],
+                "legacy_storage_task_id": container_config["legacy_storage_task_id"],
             }
 
         logger.info("Creating new %s environment for execute_code task %s...",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         env = _create_environment(
             env_type=env_type,
             image=image,
@@ -871,17 +1070,47 @@ def _get_or_create_env(task_id: str):
             ssh_config=ssh_config,
             container_config=container_config,
             local_config=local_config,
-            task_id=effective_task_id,
-            host_cwd=_resolve_task_host_cwd(config, task_id),
+            task_id=backend_task_id,
+            host_cwd=_resolve_task_host_cwd(config, raw_task_id),
         )
+        _record_environment_lifetime(env, config)
+        _record_environment_target(env, resolution)
 
+        publish_error = None
         with _env_lock:
-            _active_environments[effective_task_id] = env
-            _last_activity[effective_task_id] = time.time()
+            if resolution.named:
+                try:
+                    live_resolution = (
+                        resolution
+                        if execution_target_config_is_frozen()
+                        else resolve_live_execution_target(target)
+                    )
+                except Exception as exc:
+                    publish_error = str(exc)
+                else:
+                    if live_resolution.security_scope != resolution.security_scope:
+                        publish_error = (
+                            f"Execution target {resolution.target!r} changed "
+                            "while its environment was being created."
+                        )
+            replaced_env = None
+            if publish_error is None:
+                replaced_env = _active_environments.get(effective_task_id)
+                _active_environments[effective_task_id] = env
+                _last_activity[effective_task_id] = time.time()
+        if publish_error is not None:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+            raise ValueError(publish_error + " Retry execute_code.")
+        if replaced_env is not None and replaced_env is not env:
+            _retire_replaced_environment(replaced_env, effective_task_id)
 
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         return env, env_type
 
 
@@ -928,6 +1157,9 @@ def _rpc_poll_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
+    execution_target_scope: Optional[str] = None,
+    execution_target_config: Optional[dict] = None,
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -993,13 +1225,23 @@ def _rpc_poll_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                binding_error = None
+                try:
+                    tool_args = _inherit_execution_target(
+                        tool_name, tool_args, execution_target,
+                        execution_target_scope,
+                    )
+                except ValueError as exc:
+                    binding_error = str(exc)
                 seq = request.get("seq", 0)
                 seq_str = f"{seq:06d}"
                 res_file = f"{rpc_dir}/res_{seq_str}"
                 quoted_res_file = shlex.quote(res_file)
 
-                # Enforce allow-list
-                if tool_name not in allowed_tools:
+                # Enforce target binding, allow-list, then tool call limit.
+                if binding_error is not None:
+                    tool_result = tool_error(binding_error)
+                elif tool_name not in allowed_tools:
                     available = ", ".join(sorted(allowed_tools))
                     tool_result = tool_error(
                         f"Tool '{tool_name}' is not available in execute_code. "
@@ -1020,8 +1262,12 @@ def _rpc_poll_loop(
                     # Dispatch through the standard tool handler
                     try:
                         with thread_scoped_silence():
-                            tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                            tool_result = _dispatch_rpc_tool(
+                                handle_function_call,
+                                tool_name,
+                                tool_args,
+                                task_id,
+                                execution_target_config,
                             )
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",
@@ -1064,6 +1310,10 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    target: Optional[str] = None,
+    mode: str = "strict",
+    expected_target_scope: Optional[str] = None,
+    expected_target_config: Optional[dict] = None,
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -1081,8 +1331,44 @@ def _execute_remote(
     if not sandbox_tools:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
 
+    from tools.execution_targets import resolve_execution_target
+
     effective_task_id = task_id or "default"
-    env, env_type = _get_or_create_env(effective_task_id)
+    resolution = resolve_execution_target(target)
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment.  Keep that path byte-for-byte compatible and
+    # only inject/pass the extra selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+    rpc_target_config = expected_target_config
+    if rpc_target_config is None and resolution.named:
+        rpc_target_config = _frozen_target_config(resolution)
+    if (
+        expected_target_scope is not None
+        and resolution.security_scope != expected_target_scope
+    ):
+        return tool_error(
+            f"Execution target {resolution.target!r} changed after approval; "
+            "execute_code was not started."
+        )
+    from tools.terminal_tool import _get_env_config
+
+    operation_config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
+    operation_cwd = _resolve_remote_operation_cwd(
+        effective_task_id,
+        resolution,
+        operation_config,
+    )
+    try:
+        env, env_type = _get_or_create_env(
+            effective_task_id,
+            inherited_target,
+            expected_target_scope,
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     sandbox_id = uuid.uuid4().hex[:12]
     temp_dir = _env_temp_dir(env)
@@ -1103,7 +1389,7 @@ def _execute_remote(
             cwd="/", timeout=15,
         )
         if "OK" not in py_check.get("output", ""):
-            return json.dumps({
+            result = {
                 "status": "error",
                 "error": (
                     f"Python 3 is not available in the {env_type} terminal "
@@ -1112,7 +1398,9 @@ def _execute_remote(
                 ),
                 "tool_calls_made": 0,
                 "duration_seconds": 0,
-            })
+            }
+            result.update(resolution.metadata(cwd=operation_cwd))
+            return json.dumps(result)
 
         # Create sandbox directory on remote
         env.execute(
@@ -1137,6 +1425,9 @@ def _execute_remote(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event, rpc_token,
+                inherited_target,
+                expected_target_scope,
+                rpc_target_config,
             ),
             daemon=True,
         )
@@ -1146,7 +1437,8 @@ def _execute_remote(
         env_prefix = (
             f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"HERMES_RPC_TOKEN={shlex.quote(rpc_token)} "
-            f"PYTHONDONTWRITEBYTECODE=1"
+            f"PYTHONDONTWRITEBYTECODE=1 "
+            f"PYTHONPATH={shlex.quote(sandbox_dir)}:$PYTHONPATH"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
         if tz:
@@ -1155,8 +1447,18 @@ def _execute_remote(
         # Execute the script on the remote backend
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
+        if mode == "project":
+            run_cwd = operation_cwd
+        else:
+            run_cwd = sandbox_dir
+        script_ref = (
+            shlex.quote(f"{sandbox_dir}/script.py")
+            if mode == "project"
+            else "script.py"
+        )
         script_result = env.execute(
-            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
+            f"{env_prefix} python3 {script_ref}",
+            cwd=run_cwd,
             timeout=timeout,
         )
 
@@ -1177,12 +1479,14 @@ def _execute_remote(
             duration, tool_call_counter[0], type(exc).__name__, exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata(cwd=operation_cwd))
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Stop the polling thread
@@ -1223,6 +1527,7 @@ def _execute_remote(
         "duration_seconds": duration,
     }
     result.update(stdout_metadata)
+    result.update(resolution.metadata(cwd=operation_cwd))
 
     if status == "timeout":
         timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1256,6 +1561,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    execution_target: Optional[str] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1269,6 +1575,8 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        execution_target: Optional named execution target. The configured
+                          default is selected when omitted.
 
     Returns:
         JSON string with execution results.
@@ -1286,9 +1594,27 @@ def execute_code(
             "terminal(command=...) instead."
         )
 
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(execution_target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment. Preserve that call shape and only propagate a
+    # selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+    inherited_target_scope = resolution.security_scope if resolution.named else None
+    inherited_target_config = (
+        _frozen_target_config(resolution) if resolution.named else None
+    )
+
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
-    _env_config = _get_env_config()
+    _env_config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
     env_type = _env_config["env_type"]
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never
@@ -1301,6 +1627,12 @@ def execute_code(
     _guard = check_execute_code_guard(
         code, env_type,
         has_host_access=_docker_has_host_access(_env_config),
+        execution_target=resolution.target,
+        execution_backend=resolution.backend,
+        execution_target_named=resolution.named,
+        execution_target_scope=(
+            resolution.security_scope if resolution.named else ""
+        ),
     )
     if not _guard.get("approved", False):
         return json.dumps({
@@ -1320,8 +1652,28 @@ def execute_code(
         from tools.interrupt import clear_current_thread_interrupt
         clear_current_thread_interrupt()
 
+    if inherited_target_scope is not None:
+        try:
+            live_resolution = resolve_execution_target(inherited_target)
+        except Exception as exc:
+            return tool_error(
+                f"Execution target {inherited_target!r} is no longer available: {exc}"
+            )
+        if live_resolution.security_scope != inherited_target_scope:
+            return tool_error(
+                f"Execution target {inherited_target!r} changed after approval; "
+                "execute_code was not started."
+            )
+
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        mode = _get_execution_mode()
+        if inherited_target is None:
+            return _execute_remote(code, task_id, enabled_tools, mode=mode)
+        return _execute_remote(
+            code, task_id, enabled_tools, inherited_target, mode=mode,
+            expected_target_scope=inherited_target_scope,
+            expected_target_config=inherited_target_config,
+        )
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1416,6 +1768,9 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
+                inherited_target,
+                inherited_target_scope,
+                inherited_target_config,
             ),
             daemon=True,
         )
@@ -1473,7 +1828,10 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
+        _child_cwd = _resolve_child_cwd(
+            _mode, tmpdir, task_id=task_id or "", target=inherited_target,
+            _resolution=resolution,
+        )
         _script_path = os.path.join(tmpdir, "script.py")
 
         # ``hermes_tools.py`` always lives in the staging directory, so that
@@ -1676,6 +2034,7 @@ def execute_code(
             "duration_seconds": duration,
         }
         result.update(stdout_metadata)
+        result.update(resolution.metadata(cwd=_child_cwd))
 
         if status == "timeout":
             timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1719,12 +2078,14 @@ def execute_code(
             exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata())
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Cleanup temp dir and socket
@@ -1993,7 +2354,10 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
+def _resolve_child_cwd(
+    mode: str, staging_dir: str, task_id: str = "",
+    target: str | None = None, *, _resolution=None,
+) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
@@ -2011,16 +2375,46 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """
     if mode != "project":
         return staging_dir
+
+    target_resolution = _resolution
+    target_cwd = ""
+    if target is not None or target_resolution is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            target_resolution = (
+                target_resolution or resolve_execution_target(target)
+            )
+            target_cwd = (
+                str(target_resolution.config.get("cwd") or "").strip()
+                if target_resolution.named else ""
+            )
+        except Exception:
+            target_resolution = None
+
     if task_id:
         # 1. The session's cwd record — IS the session's `cd` state.
         try:
             from tools.terminal_tool import get_session_cwd
 
-            recorded = get_session_cwd(task_id)
+            recorded = get_session_cwd(
+                task_id, target=target, _resolution=target_resolution,
+            )
         except Exception:
             recorded = None
         if recorded and os.path.isdir(recorded):
             return recorded
+        # A non-default target owns its configured cwd. The host workspace
+        # override below belongs to the default target and must not replace it.
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and not target_resolution.is_default
+            and target_cwd
+        ):
+            expanded_target_cwd = os.path.abspath(os.path.expanduser(target_cwd))
+            if os.path.isdir(expanded_target_cwd):
+                return expanded_target_cwd
         # 2. Registered workspace override (session.cwd.set → gateway/TUI/ACP).
         try:
             from tools.file_tools import _registered_task_cwd_override
@@ -2030,7 +2424,9 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = target_cwd
+    if not raw:
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):
@@ -2056,19 +2452,19 @@ _TOOL_DOC_LINES = [
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown.\n"
      "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
     ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 2000) -> dict\n"
+     "  read_file(path: str, offset: int = 1, limit: int = 2000, execution_target: str = None, runtime_scope: str = None) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
     ("write_file",
-     "  write_file(path: str, content: str) -> dict\n"
+     "  write_file(path: str, content: str, execution_target: str = None) -> dict\n"
      "    Always overwrites the entire file."),
     ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
-     "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
+     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50, execution_target: str = None) -> dict\n"
+     "    target selects search mode (\"content\" or \"files\"); execution_target selects the configured environment. Returns {\"matches\": [...]}"),
     ("patch",
-     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
+     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False, execution_target: str = None) -> dict\n"
      "    Replaces old_string with new_string in the file."),
     ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
+     "  terminal(command: str, timeout=None, workdir=None, execution_target: str = None) -> dict\n"
      "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
@@ -2153,6 +2549,13 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                         "and print your final result to stdout."
                     ),
                 },
+                "execution_target": {
+                    "type": "string",
+                    "description": (
+                        "Optional named execution target, for example 'local' "
+                        "or 'devbox'. Uses terminal.default_target when omitted."
+                    ),
+                },
             },
             "required": ["code"],
         },
@@ -2173,8 +2576,15 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
 
     Models sometimes reuse terminal's ``command`` argument or send a
     non-string ``code`` payload; both get an actionable redirect instead
-    of a generic failure.
+    instead of a generic failure.
     """
+    try:
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args("execute_code", args)
+    except Exception as exc:
+        return tool_error(str(exc))
+
     # Help models recover when they reuse terminal's ``command`` argument.
     if "code" not in args and "command" in args:
         logger.warning(
@@ -2200,6 +2610,7 @@ def _execute_code_handler(args: dict, **kwargs) -> str:
         code=code or "",
         task_id=kwargs.get("task_id"),
         enabled_tools=kwargs.get("enabled_tools"),
+        execution_target=args.get("execution_target"),
     )
 
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -29,6 +29,7 @@ Remote execution additionally requires Python 3 in the terminal backend.
 """
 
 import base64
+from copy import deepcopy
 import functools
 import json
 import logging
@@ -342,33 +343,33 @@ _TOOL_STUBS = {
     ),
     "read_file": (
         "read_file",
-        "path: str, offset: int = 1, limit: int = 2000",
+        "path: str, offset: int = 1, limit: int = 2000, target: str = None, runtime_scope: str = None",
         '"""Read a file (1-indexed lines). Returns dict with "content" and "total_lines"."""',
-        '{"path": path, "offset": offset, "limit": limit}',
+        '{"path": path, "offset": offset, "limit": limit, "target": target, "runtime_scope": runtime_scope}',
     ),
     "write_file": (
         "write_file",
-        "path: str, content: str, cross_profile: bool = False",
+        "path: str, content: str, cross_profile: bool = False, target: str = None",
         '"""Write content to a file (always overwrites). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "content": content, "cross_profile": cross_profile}',
+        '{"path": path, "content": content, "cross_profile": cross_profile, "target": target}',
     ),
     "search_files": (
         "search_files",
-        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0',
+        'pattern: str, target: str = "content", path: str = ".", file_glob: str = None, limit: int = 50, offset: int = 0, output_mode: str = "content", context: int = 0, execution_target: str = None',
         '"""Search file contents (target="content") or find files by name (target="files"). Returns dict with "matches"."""',
-        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context}',
+        '{"pattern": pattern, "target": target, "path": path, "file_glob": file_glob, "limit": limit, "offset": offset, "output_mode": output_mode, "context": context, "execution_target": execution_target}',
     ),
     "patch": (
         "patch",
-        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False',
+        'path: str = None, old_string: str = None, new_string: str = None, replace_all: bool = False, mode: str = "replace", patch: str = None, cross_profile: bool = False, target: str = None',
         '"""Targeted find-and-replace (mode="replace") or V4A multi-file patches (mode="patch"). Returns dict with status. cross_profile=True opts out of the cross-Hermes-profile soft guard."""',
-        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile}',
+        '{"path": path, "old_string": old_string, "new_string": new_string, "replace_all": replace_all, "mode": mode, "patch": patch, "cross_profile": cross_profile, "target": target}',
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, target: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "target": target}',
     ),
 }
 
@@ -646,6 +647,92 @@ def _call(tool_name, args):
 _TERMINAL_BLOCKED_PARAMS = {"background", "pty", "notify_on_complete", "watch_patterns"}
 
 
+def _inherit_execution_target(
+    tool_name: str,
+    tool_args: Any,
+    execution_target: Optional[str],
+    execution_target_scope: Optional[str] = None,
+) -> Any:
+    """Bind target-aware RPC calls to the outer execute_code target.
+
+    The RPC token grants access to host-side Hermes tools. A script approved to
+    run in one sandbox must not use it to pivot a nested file/terminal call onto
+    another target. ``search_files`` uses ``execution_target`` because its
+    historical ``target`` argument selects the search mode.
+    """
+    if not execution_target or not isinstance(tool_args, dict):
+        return tool_args
+    selector = "execution_target" if tool_name == "search_files" else "target"
+    if tool_name not in {"terminal", "read_file", "write_file", "patch", "search_files"}:
+        return tool_args
+
+    if execution_target_scope:
+        from tools.execution_targets import resolve_execution_target
+
+        try:
+            live_resolution = resolve_execution_target(execution_target)
+        except Exception as exc:
+            raise ValueError(
+                f"Execution target {execution_target!r} is no longer available: {exc}"
+            ) from exc
+        if live_resolution.security_scope != execution_target_scope:
+            raise ValueError(
+                f"Execution target {execution_target!r} changed while execute_code "
+                "was running; nested target-aware calls are blocked."
+            )
+
+    inherited = dict(tool_args)
+    requested = inherited.get(selector)
+    if requested is None:
+        inherited[selector] = execution_target
+    elif str(requested) != execution_target:
+        raise ValueError(
+            f"execute_code RPC is bound to target {execution_target!r}; "
+            f"nested {tool_name} cannot select {requested!r}"
+        )
+    if tool_name == "read_file" and execution_target_scope:
+        runtime_scope = inherited.get("runtime_scope")
+        if runtime_scope is not None and runtime_scope != execution_target_scope:
+            raise ValueError(
+                "Nested read_file runtime_scope does not match the outer "
+                f"execute_code runtime for target {execution_target!r}."
+            )
+    return inherited
+
+
+def _frozen_target_config(resolution) -> dict:
+    """Freeze the effective config without making inherited fields explicit."""
+    terminal = deepcopy(dict(resolution.config))
+    targets = {resolution.target: {"backend": resolution.backend}}
+    if resolution.is_default:
+        default_target = resolution.target
+    else:
+        default_target = "__hermes_original_default__"
+        while default_target in targets:
+            default_target += "_"
+        targets[default_target] = {"backend": "local"}
+    terminal["default_target"] = default_target
+    terminal["targets"] = targets
+    return {"terminal": terminal}
+
+
+def _dispatch_rpc_tool(
+    handler,
+    tool_name: str,
+    tool_args: Any,
+    task_id: str,
+    execution_target_config: Optional[dict],
+):
+    """Dispatch under the immutable target config approved for this script."""
+    if execution_target_config is None:
+        return handler(tool_name, tool_args, task_id=task_id)
+
+    from tools.execution_targets import execution_target_config_scope
+
+    with execution_target_config_scope(execution_target_config):
+        return handler(tool_name, tool_args, task_id=task_id)
+
+
 def _rpc_server_loop(
     server_sock: socket.socket,
     task_id: str,
@@ -655,6 +742,9 @@ def _rpc_server_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
+    execution_target_scope: Optional[str] = None,
+    execution_target_config: Optional[dict] = None,
 ):
     """
     Accept one client connection and dispatch tool-call requests until
@@ -712,6 +802,14 @@ def _rpc_server_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                try:
+                    tool_args = _inherit_execution_target(
+                        tool_name, tool_args, execution_target,
+                        execution_target_scope,
+                    )
+                except ValueError as exc:
+                    conn.sendall((tool_error(str(exc)) + "\n").encode())
+                    continue
 
                 # Enforce the allow-list
                 if tool_name not in allowed_tools:
@@ -746,8 +844,12 @@ def _rpc_server_loop(
                     try:
                         sys.stdout = devnull
                         sys.stderr = devnull
-                        result = handle_function_call(
-                            tool_name, tool_args, task_id=task_id
+                        result = _dispatch_rpc_tool(
+                            handle_function_call,
+                            tool_name,
+                            tool_args,
+                            task_id,
+                            execution_target_config,
                         )
                     finally:
                         sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -785,7 +887,37 @@ def _rpc_server_loop(
 # Remote execution support (file-based RPC via terminal backend)
 # ---------------------------------------------------------------------------
 
-def _get_or_create_env(task_id: str):
+def _resolve_remote_operation_cwd(task_id: str, resolution: Any, config: dict) -> str:
+    """Resolve the selected target cwd without consulting mutable env state."""
+    from tools.terminal_tool import (
+        _apply_task_cwd_override,
+        get_session_cwd,
+        resolve_task_overrides,
+    )
+
+    raw_task_id = task_id or "default"
+    overrides = resolve_task_overrides(raw_task_id)
+    cwd_override = (
+        overrides.get("cwd")
+        if (
+            not resolution.named
+            or (resolution.is_default and resolution.backend != "ssh")
+        )
+        else None
+    )
+    cwd = (
+        cwd_override
+        or get_session_cwd(raw_task_id, _resolution=resolution)
+        or config["cwd"]
+    )
+    return _apply_task_cwd_override(config, cwd, cwd_override)
+
+
+def _get_or_create_env(
+    task_id: str,
+    target: Optional[str] = None,
+    expected_target_scope: Optional[str] = None,
+):
     """Get or create the terminal environment for *task_id*.
 
     Reuses the same environment (container/sandbox/SSH session) that the
@@ -795,17 +927,45 @@ def _get_or_create_env(task_id: str):
     from tools.terminal_tool import (
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
-        _creation_locks, _creation_locks_lock, _task_env_overrides,
-        _resolve_container_task_id,
+        _creation_locks, _creation_locks_lock, _resolve_container_task_id,
+        resolve_task_overrides, _record_environment_lifetime,
+        _record_environment_target, _environment_matches_target,
+        _prepare_environment_replacement, _EnvironmentReplacementError,
+        _retire_replaced_environment,
+        _cleanup_environment_resource,
+        _environment_has_stable_storage,
+        _build_environment_constructor_configs,
+    )
+    from tools.execution_targets import (
+        execution_target_config_is_frozen,
+        resolve_execution_target,
+        resolve_live_execution_target,
     )
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    raw_task_id = task_id or "default"
+    resolution = resolve_execution_target(target)
+    if (
+        expected_target_scope is not None
+        and resolution.security_scope != expected_target_scope
+    ):
+        raise ValueError(
+            f"Execution target {resolution.target!r} changed after approval."
+        )
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    effective_task_id = resolution.environment_key(base_task_id)
+    backend_task_id = resolution.backend_task_id(base_task_id)
+    config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
 
     # Fast path: environment already exists
     with _env_lock:
-        if effective_task_id in _active_environments:
+        active_env = _active_environments.get(effective_task_id)
+        if _environment_matches_target(active_env, resolution):
+            assert active_env is not None
             _last_activity[effective_task_id] = time.time()
-            return _active_environments[effective_task_id], _get_env_config()["env_type"]
+            return active_env, config["env_type"]
 
     # Slow path: create environment (same pattern as file_tools._get_file_ops)
     with _creation_locks_lock:
@@ -815,13 +975,22 @@ def _get_or_create_env(task_id: str):
 
     with task_lock:
         with _env_lock:
-            if effective_task_id in _active_environments:
+            active_env = _active_environments.get(effective_task_id)
+            if _environment_matches_target(active_env, resolution):
+                assert active_env is not None
                 _last_activity[effective_task_id] = time.time()
-                return _active_environments[effective_task_id], _get_env_config()["env_type"]
+                return active_env, config["env_type"]
+        try:
+            _prepare_environment_replacement(
+                active_env,
+                effective_task_id,
+                target_name=resolution.target,
+            )
+        except _EnvironmentReplacementError as exc:
+            raise ValueError(str(exc)) from exc
 
-        config = _get_env_config()
         env_type = config["env_type"]
-        overrides = _task_env_overrides.get(effective_task_id, {})
+        overrides = resolve_task_overrides(raw_task_id)
 
         if env_type == "docker":
             image = overrides.get("docker_image") or config["docker_image"]
@@ -834,39 +1003,42 @@ def _get_or_create_env(task_id: str):
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or config["cwd"]
+        cwd = _resolve_remote_operation_cwd(raw_task_id, resolution, config)
 
-        container_config = None
-        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+        container_config, ssh_config, local_config = (
+            _build_environment_constructor_configs(
+                config, resolution, base_task_id,
+            )
+        )
+        if container_config is not None:
+            # Keep an auditable module-local constructor map. The shared
+            # builder remains the normalization source, while this explicit
+            # copy preserves the upstream cross-call-site Docker option
+            # invariant enforced by test_docker_network_config.py.
             container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "vercel_runtime": config.get("vercel_runtime", ""),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_network": config.get("docker_network", True),
-            }
-
-        ssh_config = None
-        if env_type == "ssh":
-            ssh_config = {
-                "host": config.get("ssh_host", ""),
-                "user": config.get("ssh_user", ""),
-                "port": config.get("ssh_port", 22),
-                "key": config.get("ssh_key", ""),
-                "persistent": config.get("ssh_persistent", False),
-            }
-
-        local_config = None
-        if env_type == "local":
-            local_config = {
-                "persistent": config.get("local_persistent", False),
+                "container_cpu": container_config["container_cpu"],
+                "container_memory": container_config["container_memory"],
+                "container_disk": container_config["container_disk"],
+                "container_persistent": container_config["container_persistent"],
+                "vercel_runtime": container_config["vercel_runtime"],
+                "modal_mode": container_config["modal_mode"],
+                "docker_volumes": container_config["docker_volumes"],
+                "docker_mount_cwd_to_workspace": container_config["docker_mount_cwd_to_workspace"],
+                "docker_forward_env": container_config["docker_forward_env"],
+                "docker_env": container_config["docker_env"],
+                "docker_run_as_host_user": container_config["docker_run_as_host_user"],
+                "docker_extra_args": container_config["docker_extra_args"],
+                "docker_network": container_config["docker_network"],
+                "docker_shm_size": container_config["docker_shm_size"],
+                "docker_persist_across_processes": container_config["docker_persist_across_processes"],
+                "docker_orphan_reaper": container_config["docker_orphan_reaper"],
+                "lifetime_seconds": container_config["lifetime_seconds"],
+                "storage_task_id": container_config["storage_task_id"],
+                "legacy_storage_task_id": container_config["legacy_storage_task_id"],
             }
 
         logger.info("Creating new %s environment for execute_code task %s...",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         env = _create_environment(
             env_type=env_type,
             image=image,
@@ -875,17 +1047,47 @@ def _get_or_create_env(task_id: str):
             ssh_config=ssh_config,
             container_config=container_config,
             local_config=local_config,
-            task_id=effective_task_id,
+            task_id=backend_task_id,
             host_cwd=config.get("host_cwd"),
         )
+        _record_environment_lifetime(env, config)
+        _record_environment_target(env, resolution)
 
+        publish_error = None
         with _env_lock:
-            _active_environments[effective_task_id] = env
-            _last_activity[effective_task_id] = time.time()
+            if resolution.named:
+                try:
+                    live_resolution = (
+                        resolution
+                        if execution_target_config_is_frozen()
+                        else resolve_live_execution_target(target)
+                    )
+                except Exception as exc:
+                    publish_error = str(exc)
+                else:
+                    if live_resolution.security_scope != resolution.security_scope:
+                        publish_error = (
+                            f"Execution target {resolution.target!r} changed "
+                            "while its environment was being created."
+                        )
+            replaced_env = None
+            if publish_error is None:
+                replaced_env = _active_environments.get(effective_task_id)
+                _active_environments[effective_task_id] = env
+                _last_activity[effective_task_id] = time.time()
+        if publish_error is not None:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+            raise ValueError(publish_error + " Retry execute_code.")
+        if replaced_env is not None and replaced_env is not env:
+            _retire_replaced_environment(replaced_env, effective_task_id)
 
         _start_cleanup_thread()
         logger.info("%s environment ready for execute_code task %s",
-                     env_type, effective_task_id[:8])
+                     env_type, str(effective_task_id)[:48])
         return env, env_type
 
 
@@ -932,6 +1134,9 @@ def _rpc_poll_loop(
     allowed_tools: frozenset,
     stop_event: threading.Event,
     rpc_token: str,
+    execution_target: Optional[str] = None,
+    execution_target_scope: Optional[str] = None,
+    execution_target_config: Optional[dict] = None,
 ):
     """Poll the remote filesystem for tool call requests and dispatch them.
 
@@ -997,13 +1202,23 @@ def _rpc_poll_loop(
 
                 tool_name = request.get("tool", "")
                 tool_args = request.get("args", {})
+                binding_error = None
+                try:
+                    tool_args = _inherit_execution_target(
+                        tool_name, tool_args, execution_target,
+                        execution_target_scope,
+                    )
+                except ValueError as exc:
+                    binding_error = str(exc)
                 seq = request.get("seq", 0)
                 seq_str = f"{seq:06d}"
                 res_file = f"{rpc_dir}/res_{seq_str}"
                 quoted_res_file = shlex.quote(res_file)
 
-                # Enforce allow-list
-                if tool_name not in allowed_tools:
+                # Enforce target binding, allow-list, then tool call limit.
+                if binding_error is not None:
+                    tool_result = tool_error(binding_error)
+                elif tool_name not in allowed_tools:
                     available = ", ".join(sorted(allowed_tools))
                     tool_result = tool_error(
                         f"Tool '{tool_name}' is not available in execute_code. "
@@ -1028,8 +1243,12 @@ def _rpc_poll_loop(
                         try:
                             sys.stdout = devnull
                             sys.stderr = devnull
-                            tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                            tool_result = _dispatch_rpc_tool(
+                                handle_function_call,
+                                tool_name,
+                                tool_args,
+                                task_id,
+                                execution_target_config,
                             )
                         finally:
                             sys.stdout, sys.stderr = _real_stdout, _real_stderr
@@ -1075,6 +1294,10 @@ def _execute_remote(
     code: str,
     task_id: Optional[str],
     enabled_tools: Optional[List[str]],
+    target: Optional[str] = None,
+    mode: str = "strict",
+    expected_target_scope: Optional[str] = None,
+    expected_target_config: Optional[dict] = None,
 ) -> str:
     """Run a script on the remote terminal backend via file-based RPC.
 
@@ -1092,8 +1315,44 @@ def _execute_remote(
     if not sandbox_tools:
         sandbox_tools = SANDBOX_ALLOWED_TOOLS
 
+    from tools.execution_targets import resolve_execution_target
+
     effective_task_id = task_id or "default"
-    env, env_type = _get_or_create_env(effective_task_id)
+    resolution = resolve_execution_target(target)
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment.  Keep that path byte-for-byte compatible and
+    # only inject/pass the extra selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+    rpc_target_config = expected_target_config
+    if rpc_target_config is None and resolution.named:
+        rpc_target_config = _frozen_target_config(resolution)
+    if (
+        expected_target_scope is not None
+        and resolution.security_scope != expected_target_scope
+    ):
+        return tool_error(
+            f"Execution target {resolution.target!r} changed after approval; "
+            "execute_code was not started."
+        )
+    from tools.terminal_tool import _get_env_config
+
+    operation_config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
+    operation_cwd = _resolve_remote_operation_cwd(
+        effective_task_id,
+        resolution,
+        operation_config,
+    )
+    try:
+        env, env_type = _get_or_create_env(
+            effective_task_id,
+            inherited_target,
+            expected_target_scope,
+        )
+    except ValueError as exc:
+        return tool_error(str(exc))
 
     sandbox_id = uuid.uuid4().hex[:12]
     temp_dir = _env_temp_dir(env)
@@ -1114,7 +1373,7 @@ def _execute_remote(
             cwd="/", timeout=15,
         )
         if "OK" not in py_check.get("output", ""):
-            return json.dumps({
+            result = {
                 "status": "error",
                 "error": (
                     f"Python 3 is not available in the {env_type} terminal "
@@ -1123,7 +1382,9 @@ def _execute_remote(
                 ),
                 "tool_calls_made": 0,
                 "duration_seconds": 0,
-            })
+            }
+            result.update(resolution.metadata(cwd=operation_cwd))
+            return json.dumps(result)
 
         # Create sandbox directory on remote
         env.execute(
@@ -1148,6 +1409,9 @@ def _execute_remote(
                 env, f"{sandbox_dir}/rpc", effective_task_id,
                 tool_call_log, tool_call_counter, max_tool_calls,
                 sandbox_tools, stop_event, rpc_token,
+                inherited_target,
+                expected_target_scope,
+                rpc_target_config,
             ),
             daemon=True,
         )
@@ -1157,7 +1421,8 @@ def _execute_remote(
         env_prefix = (
             f"HERMES_RPC_DIR={shlex.quote(f'{sandbox_dir}/rpc')} "
             f"HERMES_RPC_TOKEN={shlex.quote(rpc_token)} "
-            f"PYTHONDONTWRITEBYTECODE=1"
+            f"PYTHONDONTWRITEBYTECODE=1 "
+            f"PYTHONPATH={shlex.quote(sandbox_dir)}:$PYTHONPATH"
         )
         tz = os.getenv("HERMES_TIMEZONE", "").strip()
         if tz:
@@ -1166,8 +1431,18 @@ def _execute_remote(
         # Execute the script on the remote backend
         logger.info("Executing code on %s backend (task %s)...",
                      env_type, effective_task_id[:8])
+        if mode == "project":
+            run_cwd = operation_cwd
+        else:
+            run_cwd = sandbox_dir
+        script_ref = (
+            shlex.quote(f"{sandbox_dir}/script.py")
+            if mode == "project"
+            else "script.py"
+        )
         script_result = env.execute(
-            f"cd {quoted_sandbox_dir} && {env_prefix} python3 script.py",
+            f"{env_prefix} python3 {script_ref}",
+            cwd=run_cwd,
             timeout=timeout,
         )
 
@@ -1188,12 +1463,14 @@ def _execute_remote(
             duration, tool_call_counter[0], type(exc).__name__, exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata(cwd=operation_cwd))
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Stop the polling thread
@@ -1234,6 +1511,7 @@ def _execute_remote(
         "duration_seconds": duration,
     }
     result.update(stdout_metadata)
+    result.update(resolution.metadata(cwd=operation_cwd))
 
     if status == "timeout":
         timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1267,6 +1545,7 @@ def execute_code(
     code: str,
     task_id: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
+    target: Optional[str] = None,
 ) -> str:
     """
     Run a Python script in a sandboxed child process with RPC access
@@ -1280,6 +1559,8 @@ def execute_code(
         task_id:       Session task ID for tool isolation (terminal env, etc.).
         enabled_tools: Tool names enabled in the current session. The sandbox
                        gets the intersection with SANDBOX_ALLOWED_TOOLS.
+        target:        Optional named execution target. The configured default
+                       is selected when omitted.
 
     Returns:
         JSON string with execution results.
@@ -1293,9 +1574,27 @@ def execute_code(
     if not code or not code.strip():
         return tool_error("No code provided.")
 
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    # Legacy omitted/default selection already routes every nested call to the
+    # one existing environment. Preserve that call shape and only propagate a
+    # selector when named targets are configured.
+    inherited_target = resolution.target if resolution.named else None
+    inherited_target_scope = resolution.security_scope if resolution.named else None
+    inherited_target_config = (
+        _frozen_target_config(resolution) if resolution.named else None
+    )
+
     # Dispatch: remote backends use file-based RPC, local uses UDS
     from tools.terminal_tool import _get_env_config, _docker_has_host_access
-    _env_config = _get_env_config()
+    _env_config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
     env_type = _env_config["env_type"]
 
     # execute_code runs arbitrary Python (subprocess/os.system/...) that never
@@ -1308,6 +1607,12 @@ def execute_code(
     _guard = check_execute_code_guard(
         code, env_type,
         has_host_access=_docker_has_host_access(_env_config),
+        execution_target=resolution.target,
+        execution_backend=resolution.backend,
+        execution_target_named=resolution.named,
+        execution_target_scope=(
+            resolution.security_scope if resolution.named else ""
+        ),
     )
     if not _guard.get("approved", False):
         return json.dumps({
@@ -1327,8 +1632,28 @@ def execute_code(
         from tools.interrupt import clear_current_thread_interrupt
         clear_current_thread_interrupt()
 
+    if inherited_target_scope is not None:
+        try:
+            live_resolution = resolve_execution_target(inherited_target)
+        except Exception as exc:
+            return tool_error(
+                f"Execution target {inherited_target!r} is no longer available: {exc}"
+            )
+        if live_resolution.security_scope != inherited_target_scope:
+            return tool_error(
+                f"Execution target {inherited_target!r} changed after approval; "
+                "execute_code was not started."
+            )
+
     if env_type != "local":
-        return _execute_remote(code, task_id, enabled_tools)
+        mode = _get_execution_mode()
+        if inherited_target is None:
+            return _execute_remote(code, task_id, enabled_tools, mode=mode)
+        return _execute_remote(
+            code, task_id, enabled_tools, inherited_target, mode=mode,
+            expected_target_scope=inherited_target_scope,
+            expected_target_config=inherited_target_config,
+        )
 
     # --- Local execution path (UDS) --- below this line is unchanged ---
 
@@ -1423,6 +1748,9 @@ def execute_code(
             args=(
                 server_sock, task_id, tool_call_log,
                 tool_call_counter, max_tool_calls, sandbox_tools, stop_event, rpc_token,
+                inherited_target,
+                inherited_target_scope,
+                inherited_target_config,
             ),
             daemon=True,
         )
@@ -1490,7 +1818,10 @@ def execute_code(
         # Env scrubbing and tool whitelist apply identically in both modes.
         _mode = _get_execution_mode()
         _child_python = _resolve_child_python(_mode)
-        _child_cwd = _resolve_child_cwd(_mode, tmpdir, task_id=task_id or "")
+        _child_cwd = _resolve_child_cwd(
+            _mode, tmpdir, task_id=task_id or "", target=inherited_target,
+            _resolution=resolution,
+        )
         _script_path = os.path.join(tmpdir, "script.py")
 
         proc = subprocess.Popen(
@@ -1658,6 +1989,7 @@ def execute_code(
             "duration_seconds": duration,
         }
         result.update(stdout_metadata)
+        result.update(resolution.metadata(cwd=_child_cwd))
 
         if status == "timeout":
             timeout_msg = f"Script timed out after {timeout}s and was killed."
@@ -1701,12 +2033,14 @@ def execute_code(
             exc,
             exc_info=True,
         )
-        return json.dumps({
+        result = {
             "status": "error",
             "error": str(exc),
             "tool_calls_made": tool_call_counter[0],
             "duration_seconds": duration,
-        }, ensure_ascii=False)
+        }
+        result.update(resolution.metadata())
+        return json.dumps(result, ensure_ascii=False)
 
     finally:
         # Cleanup temp dir and socket
@@ -1899,7 +2233,10 @@ def _resolve_child_python(mode: str) -> str:
     return sys.executable
 
 
-def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
+def _resolve_child_cwd(
+    mode: str, staging_dir: str, task_id: str = "",
+    target: str | None = None, *, _resolution=None,
+) -> str:
     """Resolve the working directory for the execute_code subprocess.
 
     - ``strict``: the staging tmpdir (today's behavior).
@@ -1917,16 +2254,46 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
     """
     if mode != "project":
         return staging_dir
+
+    target_resolution = _resolution
+    target_cwd = ""
+    if target is not None or target_resolution is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            target_resolution = (
+                target_resolution or resolve_execution_target(target)
+            )
+            target_cwd = (
+                str(target_resolution.config.get("cwd") or "").strip()
+                if target_resolution.named else ""
+            )
+        except Exception:
+            target_resolution = None
+
     if task_id:
         # 1. The session's cwd record — IS the session's `cd` state.
         try:
             from tools.terminal_tool import get_session_cwd
 
-            recorded = get_session_cwd(task_id)
+            recorded = get_session_cwd(
+                task_id, target=target, _resolution=target_resolution,
+            )
         except Exception:
             recorded = None
         if recorded and os.path.isdir(recorded):
             return recorded
+        # A non-default target owns its configured cwd. The host workspace
+        # override below belongs to the default target and must not replace it.
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and not target_resolution.is_default
+            and target_cwd
+        ):
+            expanded_target_cwd = os.path.abspath(os.path.expanduser(target_cwd))
+            if os.path.isdir(expanded_target_cwd):
+                return expanded_target_cwd
         # 2. Registered workspace override (session.cwd.set → gateway/TUI/ACP).
         try:
             from tools.file_tools import _registered_task_cwd_override
@@ -1936,7 +2303,9 @@ def _resolve_child_cwd(mode: str, staging_dir: str, task_id: str = "") -> str:
             session_cwd = None
         if session_cwd and os.path.isdir(session_cwd):
             return session_cwd
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
+    raw = target_cwd
+    if not raw:
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:
         expanded = os.path.expanduser(raw)
         if os.path.isdir(expanded):
@@ -1962,19 +2331,19 @@ _TOOL_DOC_LINES = [
      "    Returns {\"results\": [{\"url\", \"title\", \"content\", \"error\"}, ...]} where content is markdown.\n"
      "    No LLM summarization. Pages over char_limit (default 15000) are head+tail truncated; full text stored on disk (path in the content footer)."),
     ("read_file",
-     "  read_file(path: str, offset: int = 1, limit: int = 2000) -> dict\n"
+     "  read_file(path: str, offset: int = 1, limit: int = 2000, target: str = None, runtime_scope: str = None) -> dict\n"
      "    Lines are 1-indexed. Returns {\"content\": \"...\", \"total_lines\": N}"),
     ("write_file",
-     "  write_file(path: str, content: str) -> dict\n"
+     "  write_file(path: str, content: str, target: str = None) -> dict\n"
      "    Always overwrites the entire file."),
     ("search_files",
-     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50) -> dict\n"
-     "    target: \"content\" (search inside files) or \"files\" (find files by name). Returns {\"matches\": [...]}"),
+     "  search_files(pattern: str, target=\"content\", path=\".\", file_glob=None, limit=50, execution_target: str = None) -> dict\n"
+     "    target selects search mode (\"content\" or \"files\"); execution_target selects the configured environment. Returns {\"matches\": [...]}"),
     ("patch",
-     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False) -> dict\n"
+     "  patch(path: str, old_string: str, new_string: str, replace_all: bool = False, target: str = None) -> dict\n"
      "    Replaces old_string with new_string in the file."),
     ("terminal",
-     "  terminal(command: str, timeout=None, workdir=None) -> dict\n"
+     "  terminal(command: str, timeout=None, workdir=None, target: str = None) -> dict\n"
      "    Foreground only (no background/pty). Returns {\"output\": \"...\", \"exit_code\": N}"),
 ]
 
@@ -2059,6 +2428,13 @@ def build_execute_code_schema(enabled_sandbox_tools: set = None,
                         "and print your final result to stdout."
                     ),
                 },
+                "target": {
+                    "type": "string",
+                    "description": (
+                        "Optional named execution target, for example 'local' "
+                        "or 'devbox'. Uses terminal.default_target when omitted."
+                    ),
+                },
             },
             "required": ["code"],
         },
@@ -2080,7 +2456,8 @@ registry.register(
     handler=lambda args, **kw: execute_code(
         code=args.get("code", ""),
         task_id=kw.get("task_id"),
-        enabled_tools=kw.get("enabled_tools")),
+        enabled_tools=kw.get("enabled_tools"),
+        target=args.get("target")),
     check_fn=check_sandbox_requirements,
     emoji="🐍",
     max_result_size_chars=100_000,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2132,9 +2132,10 @@ def _run_single_child(
         # isolated in its own record (a child's cd no longer bleeds back into
         # the parent once readers flip to the record store).
         try:
-            from tools.terminal_tool import get_session_cwd, record_session_cwd
+            from tools.terminal_tool import inherit_session_cwds
 
-            record_session_cwd(child_task_id, get_session_cwd(parent_task_id))
+            if parent_task_id:
+                inherit_session_cwds(parent_task_id, child_task_id)
         except Exception as e:
             logger.debug("Child cwd seed failed: %s", e)
         wall_start = time.time()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2535,12 +2535,12 @@ def _run_single_child(
         # the parent once readers flip to the record store).
         try:
             from tools.terminal_tool import (
-                get_session_cwd,
-                record_session_cwd,
+                inherit_session_cwds,
                 register_container_alias,
             )
 
-            record_session_cwd(child_task_id, get_session_cwd(parent_task_id))
+            if parent_task_id:
+                inherit_session_cwds(parent_task_id, child_task_id)
             # Per-session container isolation (docker + container_persistent:
             # false) keys containers by session task_id. The child must share
             # the PARENT's container — register the alias so the child's

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -14,9 +14,12 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import time
 import uuid
+import weakref
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 from tools.environments.base import (
     BaseEnvironment,
@@ -43,6 +46,208 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_PROCESS_INSTANCE_ID = uuid.uuid4().hex
+_CURRENT_PROCESS_CONTAINER_IDS: set[str] = set()
+_CONTAINER_LEASES: dict[tuple[str, str], tuple[TextIO, int]] = {}
+_CONTAINER_LEASES_LOCK = threading.Lock()
+_ENVIRONMENT_LEASE_TRACKING_LOCK = threading.Lock()
+
+
+def _lease_dir(root: Path | None = None) -> Path:
+    if root is not None:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    from tools.environments.base import get_sandbox_dir
+
+    lease_dir = get_sandbox_dir() / "docker" / ".runtime-leases"
+    lease_dir.mkdir(parents=True, exist_ok=True)
+    return lease_dir
+
+
+def _container_lease_path(
+    container_id: str, lease_root: Path | None = None,
+) -> Path:
+    safe_id = _sanitize_label_value(container_id)
+    return _lease_dir(lease_root) / f"container-{safe_id}.lock"
+
+
+def _storage_lease_path(
+    storage_label: str, lease_root: Path | None = None,
+) -> Path:
+    safe_label = _sanitize_label_value(storage_label)
+    return _lease_dir(lease_root) / f"storage-{safe_label}.lock"
+
+
+def _try_file_lock(handle: TextIO, *, exclusive: bool) -> bool:
+    """Acquire a non-blocking cross-process file lock on POSIX or Windows."""
+    if os.name == "nt":
+        try:
+            import portalocker
+        except ImportError as exc:
+            raise RuntimeError(
+                "Persistent named Docker targets require portalocker on Windows."
+            ) from exc
+        flags = portalocker.LOCK_EX if exclusive else portalocker.LOCK_SH
+        try:
+            portalocker.lock(handle, flags | portalocker.LOCK_NB)
+        except portalocker.exceptions.LockException:
+            return False
+        return True
+
+    import fcntl
+
+    flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    try:
+        fcntl.flock(handle.fileno(), flags | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _unlock_file(handle: TextIO) -> None:
+    if os.name == "nt":
+        import portalocker
+
+        portalocker.unlock(handle)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _hold_container_lease(
+    container_id: str, lease_root: Path | None = None,
+) -> None:
+    """Hold a shared lease while this process can dispatch to a container."""
+    if not container_id:
+        return
+    root = _lease_dir(lease_root).resolve()
+    lease_key = (str(root), container_id)
+    with _CONTAINER_LEASES_LOCK:
+        current = _CONTAINER_LEASES.get(lease_key)
+        if current is not None:
+            handle, count = current
+            _CONTAINER_LEASES[lease_key] = (handle, count + 1)
+            return
+        handle = open(
+            _container_lease_path(container_id, root), "a+", encoding="utf-8",
+        )
+        try:
+            acquired = _try_file_lock(handle, exclusive=False)
+        except Exception:
+            handle.close()
+            raise
+        if not acquired:
+            handle.close()
+            raise RuntimeError(
+                f"Docker runtime {container_id[:12]} is being retired by another "
+                "Hermes process; retry the operation."
+            )
+        _CONTAINER_LEASES[lease_key] = (handle, 1)
+
+
+def _release_container_lease(
+    container_id: str, lease_root: Path | None = None,
+) -> bool:
+    """Release one local holder; return True when the OS lease was closed."""
+    root = _lease_dir(lease_root).resolve()
+    lease_key = (str(root), container_id)
+    with _CONTAINER_LEASES_LOCK:
+        current = _CONTAINER_LEASES.get(lease_key)
+        if current is None:
+            return True
+        handle, count = current
+        if count > 1:
+            _CONTAINER_LEASES[lease_key] = (handle, count - 1)
+            return False
+        _CONTAINER_LEASES.pop(lease_key, None)
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
+    return True
+
+
+def _release_runtime_tracking(
+    container_id: str, lease_root: Path | None = None,
+) -> None:
+    if _release_container_lease(container_id, lease_root):
+        _CURRENT_PROCESS_CONTAINER_IDS.discard(container_id)
+
+
+def _track_environment_container(env, container_id: str) -> None:
+    # Re-tracking can happen during concurrent recovery. Retire the previous
+    # finalizer's ownership before taking a new one, and serialize per-process
+    # finalizer replacement so every lease count always has one live releaser.
+    with _ENVIRONMENT_LEASE_TRACKING_LOCK:
+        previous = getattr(env, "_lease_finalizer", None)
+        if previous is not None and previous.alive:
+            previous()
+        lease_root = getattr(env, "_lease_root", None)
+        _hold_container_lease(container_id, lease_root)
+        _CURRENT_PROCESS_CONTAINER_IDS.add(container_id)
+        env._lease_finalizer = weakref.finalize(
+            env, _release_runtime_tracking, container_id, lease_root,
+        )
+
+
+def _acquire_exclusive_container_lease(
+    container_id: str, lease_root: Path | None = None,
+):
+    """Return an exclusive lease handle, None when another process is live."""
+    handle = open(
+        _container_lease_path(container_id, lease_root), "a+", encoding="utf-8",
+    )
+    try:
+        acquired = _try_file_lock(handle, exclusive=True)
+    except Exception:
+        handle.close()
+        raise
+    if not acquired:
+        handle.close()
+        return None
+    return handle
+
+
+def _close_exclusive_container_lease(handle) -> None:
+    if handle is None:
+        return
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
+
+
+def _acquire_storage_creation_lease(
+    storage_label: str, timeout: float = 30.0, *,
+    lease_root: Path | None = None,
+) -> TextIO:
+    """Serialize inspect/reconcile/create for one stable storage owner."""
+    handle = open(
+        _storage_lease_path(storage_label, lease_root), "a+", encoding="utf-8",
+    )
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if _try_file_lock(handle, exclusive=True):
+                return handle
+        except Exception:
+            handle.close()
+            raise
+        if time.monotonic() >= deadline:
+            handle.close()
+            raise RuntimeError(
+                f"Timed out waiting for Docker storage owner {storage_label}; "
+                "another Hermes process is creating or reconciling it."
+            )
+        time.sleep(0.05)
+
+
+def _close_storage_creation_lease(handle: TextIO) -> None:
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -887,7 +1092,11 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        storage_task_id: str | None = None,
+        legacy_storage_task_id: str | None = None,
     ):
+        from tools.environments.base import get_sandbox_dir
+
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
@@ -897,6 +1106,35 @@ class DockerEnvironment(BaseEnvironment):
         # scoped to a single session (docker + container_persistent: false):
         # survives between turns, removed at session close / idle timeout.
         self._session_scoped = False
+        self._lease_root = (
+            get_sandbox_dir() / "docker" / ".runtime-leases"
+        ).resolve()
+        storage_label = ""
+        if self._persistent and storage_task_id:
+            storage_root = str(get_sandbox_dir().resolve())
+            storage_owner = f"{storage_task_id}\0{storage_root}"
+            storage_label = "storage-" + hashlib.sha256(
+                storage_owner.encode("utf-8")
+            ).hexdigest()[:20]
+        storage_guard = (
+            _acquire_storage_creation_lease(
+                storage_label, lease_root=self._lease_root,
+            )
+            if storage_label else None
+        )
+        storage_guard_finalizer = (
+            weakref.finalize(self, _close_storage_creation_lease, storage_guard)
+            if storage_guard is not None else None
+        )
+
+        def _release_storage_guard_early() -> None:
+            nonlocal storage_guard
+            if storage_guard is None:
+                return
+            if storage_guard_finalizer is not None:
+                storage_guard_finalizer.detach()
+            _close_storage_creation_lease(storage_guard)
+            storage_guard = None
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
@@ -947,8 +1185,6 @@ class DockerEnvironment(BaseEnvironment):
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
-        from tools.environments.base import get_sandbox_dir
-
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
         workspace_explicitly_mounted = False
@@ -980,7 +1216,41 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            docker_root = get_sandbox_dir() / "docker"
+            sandbox = docker_root / (storage_task_id or task_id)
+            if legacy_storage_task_id and legacy_storage_task_id != (storage_task_id or task_id):
+                legacy_sandbox = docker_root / legacy_storage_task_id
+                if legacy_sandbox.exists() and not sandbox.exists():
+                    docker = find_docker() or "docker"
+                    legacy_result = subprocess.run(
+                        [
+                            docker, "ps", "-a", "--no-trunc",
+                            "--filter", (
+                                "label=hermes-task-id="
+                                f"{_sanitize_label_value(legacy_storage_task_id)}"
+                            ),
+                            "--filter", (
+                                "label=hermes-profile="
+                                f"{_sanitize_label_value(_get_active_profile_name())}"
+                            ),
+                            "--format", "{{.ID}}",
+                        ],
+                        capture_output=True, text=True, timeout=10,
+                        stdin=subprocess.DEVNULL,
+                    )
+                    if legacy_result.returncode != 0:
+                        raise RuntimeError(
+                            "Could not inspect the legacy named-target Docker runtime "
+                            "before migrating persistent storage."
+                        )
+                    if legacy_result.stdout.strip():
+                        raise RuntimeError(
+                            "A legacy named-target Docker container still owns this "
+                            "persistent workspace. Stop/remove that container, then retry; "
+                            "the workspace data will be migrated automatically."
+                        )
+                    sandbox.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(legacy_sandbox, sandbox)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
@@ -1370,12 +1640,18 @@ class DockerEnvironment(BaseEnvironment):
         # container-start time and never changes for the container's lifetime.
         profile_name = _sanitize_label_value(_get_active_profile_name())
         task_label = _sanitize_label_value(task_id)
+        process_label = _sanitize_label_value(_PROCESS_INSTANCE_ID)
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"hermes-process-instance={process_label}",
         ]
+        if storage_label:
+            label_args.extend([
+                "--label", f"hermes-storage-id={storage_label}",
+            ])
         # Save args for container recreation on "No such container" recovery.
         self._image = image
         self._container_name = container_name
@@ -1387,7 +1663,10 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            "hermes-process-instance": process_label,
         }
+        if storage_label:
+            self._labels["hermes-storage-id"] = storage_label
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
         # container shared across sessions").  If a prior Hermes process
@@ -1400,6 +1679,23 @@ class DockerEnvironment(BaseEnvironment):
         # because env vars, CA mounts, and host mappings are immutable after
         # container creation — reusing a pre-egress or pre-rotation container
         # would silently bypass the credential firewall.
+        # Reuse matches the runtime task label, which named targets derive from
+        # their complete effective spec. Config edits therefore start a fresh
+        # runtime; the stable storage label above reconciles superseded
+        # prior-process containers without discarding persistent data.
+        if storage_label:
+            try:
+                self._remove_superseded_storage_containers(
+                    storage_label, profile_name, task_label,
+                    current_egress_label=egress_label,
+                    allow_exact_reuse=persist_across_processes,
+                )
+            except Exception:
+                if storage_guard_finalizer is not None:
+                    storage_guard_finalizer.detach()
+                if storage_guard is not None:
+                    _close_storage_creation_lease(storage_guard)
+                raise
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
@@ -1422,6 +1718,14 @@ class DockerEnvironment(BaseEnvironment):
                 actual_mode = None
                 if not network:
                     actual_mode = self._container_network_mode(container_id)
+                    if actual_mode is None:
+                        _release_storage_guard_early()
+                        raise RuntimeError(
+                            f"Could not verify NetworkMode for reusable Docker "
+                            f"runtime {container_id[:12]}; refusing reuse while "
+                            "docker_network=false is configured. Retry after "
+                            "Docker inspection is available."
+                        )
                     mode_mismatch = actual_mode != "none"
                 if mode_mismatch:
                     logger.warning(
@@ -1433,16 +1737,10 @@ class DockerEnvironment(BaseEnvironment):
                         task_label, profile_name,
                     )
                     try:
-                        subprocess.run(
-                            [self._docker_exe, "rm", "-f", container_id],
-                            capture_output=True,
-                            text=True, encoding="utf-8", errors="replace",
-                            timeout=30,
-                            check=False,
-                            stdin=subprocess.DEVNULL,
-                        )
-                    except (subprocess.TimeoutExpired, OSError) as e:
-                        logger.warning("Failed to remove mismatched container %s: %s", container_id[:12], e)
+                        self._retire_network_mismatched_container(container_id)
+                    except Exception:
+                        _release_storage_guard_early()
+                        raise
                     existing = None
             if existing is not None:
                 container_id, state = existing
@@ -1513,15 +1811,50 @@ class DockerEnvironment(BaseEnvironment):
                     capture_output=True, timeout=10,
                     stdin=subprocess.DEVNULL,
                 )
+                if storage_guard is not None:
+                    if storage_guard_finalizer is not None:
+                        storage_guard_finalizer.detach()
+                    _close_storage_creation_lease(storage_guard)
                 raise
             self._container_id = result.stdout.strip()
             logger.info("Started container %s (%s)", container_name, self._container_id[:12])
 
-        # Build the init-time env forwarding args used to seed the snapshot.
-        self._init_env_args = self._build_init_env_args()
-
-        # Initialize session snapshot inside the container
-        self.init_session()
+        if self._container_id:
+            try:
+                _track_environment_container(self, self._container_id)
+            except Exception:
+                if storage_guard is not None:
+                    if storage_guard_finalizer is not None:
+                        storage_guard_finalizer.detach()
+                    _close_storage_creation_lease(storage_guard)
+                raise
+        # Keep the storage-owner creation barrier until initialization is
+        # complete. Docker labels publish before init_session is ready, so a
+        # sibling constructor must remain blocked until success or failure.
+        try:
+            self._init_env_args = self._build_init_env_args()
+            self.init_session()
+        except Exception as init_error:
+            # Do not publish an uninitialized labeled container after dropping
+            # the creation barrier. Retire it while the barrier is still held;
+            # transactional cleanup restores ownership if removal itself fails.
+            try:
+                self.cleanup(force_remove=True)
+                if not self.wait_for_cleanup(timeout=60.0):
+                    raise RuntimeError(
+                        "container cleanup timed out after initialization failure"
+                    )
+            except Exception as cleanup_error:
+                raise RuntimeError(
+                    f"Docker initialization failed and its container could not "
+                    f"be retired safely: {cleanup_error}"
+                ) from init_error
+            raise
+        finally:
+            if storage_guard is not None:
+                if storage_guard_finalizer is not None:
+                    storage_guard_finalizer.detach()
+                _close_storage_creation_lease(storage_guard)
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.
@@ -1653,13 +1986,45 @@ class DockerEnvironment(BaseEnvironment):
         on success, False if recreation fails (caller should surface the
         original error).
         """
-        old_id = (self._container_id or "")[:12]
+        old_container_id = self._container_id or ""
+        old_id = old_container_id[:12]
         logger.warning(
             "Container %s appears to be gone — attempting recovery", old_id,
         )
         self._container_id = None
+        _release_runtime_tracking(old_container_id, self._lease_root)
 
-        # 1. Try label-based reuse (another process may have recreated it).
+        storage_label = self._labels.get("hermes-storage-id", "")
+        storage_guard = (
+            _acquire_storage_creation_lease(
+                storage_label, lease_root=self._lease_root,
+            )
+            if storage_label else None
+        )
+
+        def _release_storage_guard() -> None:
+            nonlocal storage_guard
+            if storage_guard is not None:
+                _close_storage_creation_lease(storage_guard)
+                storage_guard = None
+
+        if storage_label:
+            try:
+                self._remove_superseded_storage_containers(
+                    storage_label,
+                    self._labels.get("hermes-profile", "default"),
+                    self._labels.get("hermes-task-id", ""),
+                    current_egress_label=self._labels.get(
+                        _EGRESS_LABEL_KEY, "off",
+                    ),
+                    allow_exact_reuse=self._persist_across_processes,
+                )
+            except RuntimeError as exc:
+                logger.error("Recovery: persistent storage is in use: %s", exc)
+                _release_storage_guard()
+                return False
+
+        # 1. Look for an existing container
         task_label = self._labels.get("hermes-task-id", "")
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
@@ -1686,6 +2051,7 @@ class DockerEnvironment(BaseEnvironment):
         if not self._container_id:
             if not self._image:
                 logger.error("Recovery: no saved image name, cannot recreate container")
+                _release_storage_guard()
                 return False
             try:
                 import uuid as _uuid
@@ -1716,7 +2082,14 @@ class DockerEnvironment(BaseEnvironment):
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
                 logger.error("Recovery: failed to create new container: %s", e)
+                _release_storage_guard()
                 return False
+
+        try:
+            if self._container_id:
+                _track_environment_container(self, self._container_id)
+        finally:
+            _release_storage_guard()
 
         # 3. Re-initialize session snapshot in the (re)created container.
         try:
@@ -1823,6 +2196,148 @@ class DockerEnvironment(BaseEnvironment):
         mode = result.stdout.strip()
         return mode or None
 
+    def _retire_network_mismatched_container(self, container_id: str) -> None:
+        """Remove a confirmed network-mismatched reuse candidate safely."""
+        lease = _acquire_exclusive_container_lease(
+            container_id, self._lease_root,
+        )
+        if lease is None:
+            raise RuntimeError(
+                f"Docker runtime {container_id[:12]} has a network mode that "
+                "conflicts with docker_network=false, but it is still used by "
+                "another environment or Hermes process; refusing removal."
+            )
+        try:
+            try:
+                removed = subprocess.run(
+                    [self._docker_exe, "rm", "-f", container_id],
+                    capture_output=True,
+                    text=True, encoding="utf-8", errors="replace",
+                    timeout=30,
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                )
+            except (subprocess.TimeoutExpired, OSError) as exc:
+                raise RuntimeError(
+                    f"Failed to remove network-mismatched Docker runtime "
+                    f"{container_id[:12]}: {exc}"
+                ) from exc
+            if removed.returncode != 0:
+                raise RuntimeError(
+                    f"Failed to remove network-mismatched Docker runtime "
+                    f"{container_id[:12]}: "
+                    f"{removed.stderr.strip() or removed.stdout.strip()}"
+                )
+        finally:
+            _close_exclusive_container_lease(lease)
+
+    def _remove_superseded_storage_containers(
+        self,
+        storage_label: str,
+        profile_label: str,
+        current_task_label: str,
+        current_egress_label: str = "off",
+        *,
+        allow_exact_reuse: bool,
+    ) -> None:
+        """Remove prior-process runtimes sharing this stable storage owner.
+
+        A config-derived runtime task label changes when a named target is
+        edited. Persistent storage has a deliberately stable label, so a new
+        Hermes process must retire any old-spec container before mounting that
+        storage into the replacement. Containers already managed by this process
+        are skipped; hot edits retire those through terminal_tool after in-flight
+        users release them.
+        """
+        format_expr = (
+            '{{.ID}}\t{{.Label "hermes-task-id"}}\t'
+            '{{.Label "hermes-process-instance"}}\t'
+            '{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
+        )
+        try:
+            result = subprocess.run(
+                [
+                    self._docker_exe, "ps", "-a", "--no-trunc",
+                    "--filter", "label=hermes-agent=1",
+                    "--filter", f"label=hermes-storage-id={storage_label}",
+                    "--filter", f"label=hermes-profile={profile_label}",
+                    "--format", format_expr,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            raise RuntimeError(
+                "Could not inspect prior Docker runtimes for persistent storage "
+                f"{storage_label}: {exc}"
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Could not inspect prior Docker runtimes for persistent storage "
+                f"{storage_label}: {result.stderr.strip()}"
+            )
+
+        for line in result.stdout.splitlines():
+            parts = line.strip().split("\t")
+            if len(parts) not in (3, 4):
+                continue
+            container_id, task_label, process_label = parts[:3]
+            egress_label = parts[3] if len(parts) == 4 else ""
+            if not container_id:
+                continue
+            egress_matches = (
+                egress_label == current_egress_label
+                if current_egress_label != "off"
+                else egress_label in ("", "<no value>", "off")
+            )
+            if (
+                allow_exact_reuse
+                and task_label == current_task_label
+                and egress_matches
+            ):
+                continue
+            if container_id in _CURRENT_PROCESS_CONTAINER_IDS:
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} for persistent storage "
+                    f"{storage_label} is still cached by this Hermes process. "
+                    "Clean up that target or restart Hermes before applying "
+                    "the changed Docker target config."
+                )
+            lease = _acquire_exclusive_container_lease(
+                container_id, self._lease_root,
+            )
+            if lease is None:
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} for persistent storage "
+                    f"{storage_label} is still used by another Hermes process "
+                    f"({process_label or 'unknown owner'}). Stop that process or "
+                    "restore the previous target config before retrying."
+                )
+            try:
+                removed = subprocess.run(
+                    [self._docker_exe, "rm", "-f", container_id],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                )
+                if removed.returncode != 0:
+                    raise RuntimeError(
+                        f"Could not retire superseded Docker runtime "
+                        f"{container_id[:12]} for persistent storage "
+                        f"{storage_label}: {removed.stderr.strip()}"
+                    )
+                logger.info(
+                    "Retired superseded Docker runtime %s before mounting storage %s",
+                    container_id[:12], storage_label,
+                )
+            finally:
+                _close_exclusive_container_lease(lease)
+
     def _find_reusable_container(
         self,
         task_label: str,
@@ -1861,7 +2376,7 @@ class DockerEnvironment(BaseEnvironment):
                 fmt = '{{.ID}}\t{{.State}}\t{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
             result = subprocess.run(
                 [
-                    self._docker_exe, "ps", "-a",
+                    self._docker_exe, "ps", "-a", "--no-trunc",
                     *filters,
                     "--format", fmt,
                 ],
@@ -1957,6 +2472,9 @@ class DockerEnvironment(BaseEnvironment):
         thread to finish before the interpreter exits, so ``docker stop`` /
         ``docker rm`` actually completes when we do trigger it.
         """
+        existing_thread = getattr(self, "_cleanup_thread", None)
+        if existing_thread is not None and existing_thread.is_alive():
+            return
         container_id = self._container_id
         if not container_id:
             # Still drop the bind-mount dirs if any were allocated and we're
@@ -1976,63 +2494,155 @@ class DockerEnvironment(BaseEnvironment):
         # The persist-mode no-op is the issue-#20561 contract: the container
         # outlives Hermes processes, processes inside it stay alive, and
         # reuse on next startup is instant.
+        exclusive_lease = None
         if force_remove:
+            finalizer = getattr(self, "_lease_finalizer", None)
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
+            _release_runtime_tracking(container_id, self._lease_root)
+            exclusive_lease = _acquire_exclusive_container_lease(
+                container_id, self._lease_root,
+            )
+            if exclusive_lease is None:
+                _track_environment_container(self, container_id)
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} is still used by "
+                    "another environment or Hermes process; retry cleanup "
+                    "after those users finish."
+                )
             should_stop = True
             should_remove = True
         elif self._persist_across_processes:
             # No-op for the container. Drop the in-process handle so a fresh
             # __init__ will re-probe via labels (and find the running
             # container) instead of trying to reuse a stale Python reference.
+            finalizer = getattr(self, "_lease_finalizer", None)
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
+            _release_runtime_tracking(container_id, self._lease_root)
             self._container_id = None
             return
         else:
             should_stop = True
             should_remove = True
 
-        # Capture state needed by the worker before we null out the attrs —
-        # the worker thread can outlive ``self``.
         docker_exe = self._docker_exe
         log_id = container_id[:12]
+        workspace_dirs = (self._workspace_dir, self._home_dir)
+        self._cleanup_error = None
+
+        def _container_is_absent() -> bool:
+            try:
+                inspected = subprocess.run(
+                    [docker_exe, "container", "inspect", container_id],
+                    capture_output=True, timeout=15,
+                    stdin=subprocess.DEVNULL,
+                )
+            except (subprocess.TimeoutExpired, OSError):
+                return False
+            if getattr(inspected, "returncode", 0) == 0:
+                return False
+            detail = (
+                f"{getattr(inspected, 'stdout', '')} "
+                f"{getattr(inspected, 'stderr', '')}"
+            ).lower()
+            return any(marker in detail for marker in (
+                "no such", "not found", "does not exist",
+            ))
 
         def _do_cleanup() -> None:
-            if should_stop:
-                try:
-                    subprocess.run(
-                        [docker_exe, "stop", "-t", "10", container_id],
-                        capture_output=True, timeout=30,
-                        stdin=subprocess.DEVNULL,
+            cleanup_error = None
+            try:
+                if should_stop:
+                    try:
+                        stopped = subprocess.run(
+                            [docker_exe, "stop", "-t", "10", container_id],
+                            capture_output=True, timeout=30,
+                            stdin=subprocess.DEVNULL,
+                        )
+                        if getattr(stopped, "returncode", 0) != 0:
+                            logger.warning(
+                                "docker stop %s failed (continuing with rm): %s",
+                                log_id, getattr(stopped, "stderr", ""),
+                            )
+                    except (subprocess.TimeoutExpired, OSError) as exc:
+                        logger.warning(
+                            "docker stop %s timed out / failed: %s", log_id, exc,
+                        )
+                if should_remove:
+                    remove_error = None
+                    try:
+                        removed = subprocess.run(
+                            [docker_exe, "rm", "-f", container_id],
+                            capture_output=True, timeout=30,
+                            stdin=subprocess.DEVNULL,
+                        )
+                        if getattr(removed, "returncode", 0) != 0:
+                            remove_error = RuntimeError(
+                                f"docker rm -f {log_id} failed: "
+                                f"{getattr(removed, 'stderr', '') or getattr(removed, 'stdout', '')}"
+                            )
+                    except (subprocess.TimeoutExpired, OSError) as exc:
+                        remove_error = RuntimeError(
+                            f"docker rm -f {log_id} failed: {exc}"
+                        )
+                    if remove_error is not None and not _container_is_absent():
+                        raise remove_error
+            except Exception as exc:
+                cleanup_error = exc
+            finally:
+                if exclusive_lease is not None:
+                    _close_exclusive_container_lease(exclusive_lease)
+                if cleanup_error is None:
+                    if exclusive_lease is None:
+                        _release_runtime_tracking(container_id, self._lease_root)
+                    self._container_id = None
+                    if should_remove and not self._persistent:
+                        for directory in workspace_dirs:
+                            if directory:
+                                shutil.rmtree(directory, ignore_errors=True)
+                else:
+                    self._container_id = container_id
+                    if exclusive_lease is not None:
+                        try:
+                            _track_environment_container(self, container_id)
+                        except Exception as restore_exc:
+                            cleanup_error = RuntimeError(
+                                f"{cleanup_error}; could not restore runtime ownership: "
+                                f"{restore_exc}"
+                            )
+                    logger.error(
+                        "Docker cleanup failed for %s; runtime ownership retained: %s",
+                        log_id, cleanup_error,
                     )
-                except (subprocess.TimeoutExpired, OSError) as e:
-                    logger.warning("docker stop %s timed out / failed: %s", log_id, e)
-            if should_remove:
-                try:
-                    subprocess.run(
-                        [docker_exe, "rm", "-f", container_id],
-                        capture_output=True, timeout=30,
-                        stdin=subprocess.DEVNULL,
-                    )
-                except (subprocess.TimeoutExpired, OSError) as e:
-                    logger.warning("docker rm -f %s failed: %s", log_id, e)
+                self._cleanup_error = cleanup_error
 
-        # Daemon thread: doesn't block interpreter exit (atexit returns
-        # promptly), but unlike the old ``Popen(... &)`` shell trick the
-        # Python-level join semantics let the thread actually run to
-        # completion if the interpreter is still alive. atexit registers
-        # ``_atexit_cleanup`` in terminal_tool.py which waits up to ~60s for
-        # outstanding cleanups, so most exits complete the work cleanly.
+        # Keep the bounded worker for graceful-exit behavior. The container id,
+        # storage directories, and runtime lease are committed only after rm is
+        # confirmed; wait_for_cleanup propagates any transactional failure.
         import threading
-        t = threading.Thread(target=_do_cleanup, daemon=True, name=f"hermes-cleanup-{log_id}")
-        t.start()
+        t = threading.Thread(
+            target=_do_cleanup, daemon=True, name=f"hermes-cleanup-{log_id}",
+        )
         self._cleanup_thread = t
-        self._container_id = None
-
-        # Bind-mount dir teardown only runs when we actually removed the
-        # container (the dirs are the container's filesystem state; keeping
-        # them around with no container would orphan the data on disk).
-        if should_remove and not self._persistent:
-            for d in (self._workspace_dir, self._home_dir):
-                if d:
-                    shutil.rmtree(d, ignore_errors=True)
+        try:
+            t.start()
+        except Exception as start_error:
+            if exclusive_lease is not None:
+                _close_exclusive_container_lease(exclusive_lease)
+                try:
+                    _track_environment_container(self, container_id)
+                except Exception as restore_error:
+                    start_error = RuntimeError(
+                        f"{start_error}; could not restore runtime ownership: "
+                        f"{restore_error}"
+                    )
+            self._container_id = container_id
+            self._cleanup_error = start_error
+            raise RuntimeError(
+                f"Could not start Docker cleanup worker for {log_id}: "
+                f"{start_error}"
+            ) from start_error
 
     def wait_for_cleanup(self, timeout: float = 30.0) -> bool:
         """Block up to *timeout* seconds for the cleanup worker thread.
@@ -2044,7 +2654,13 @@ class DockerEnvironment(BaseEnvironment):
         races the interpreter shutdown and leaves stopped containers behind.
         """
         thread = getattr(self, "_cleanup_thread", None)
-        if thread is None or not thread.is_alive():
-            return True
-        thread.join(timeout=timeout)
-        return not thread.is_alive()
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                return False
+        cleanup_error = getattr(self, "_cleanup_error", None)
+        if cleanup_error is not None:
+            raise RuntimeError(
+                f"Docker cleanup failed transactionally: {cleanup_error}"
+            ) from cleanup_error
+        return True

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -14,9 +14,12 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
+import time
 import uuid
+import weakref
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TextIO
 
 from tools.environments.base import BaseEnvironment, _popen_bash
 from tools.environments.local import (
@@ -39,6 +42,203 @@ _DOCKER_SEARCH_PATHS = [
 _docker_executable: Optional[str] = None  # resolved once, cached
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _EGRESS_LABEL_KEY = "hermes-egress"
+_PROCESS_INSTANCE_ID = uuid.uuid4().hex
+_CURRENT_PROCESS_CONTAINER_IDS: set[str] = set()
+_CONTAINER_LEASES: dict[tuple[str, str], tuple[TextIO, int]] = {}
+_CONTAINER_LEASES_LOCK = threading.Lock()
+
+
+def _lease_dir(root: Path | None = None) -> Path:
+    if root is not None:
+        root.mkdir(parents=True, exist_ok=True)
+        return root
+    from tools.environments.base import get_sandbox_dir
+
+    lease_dir = get_sandbox_dir() / "docker" / ".runtime-leases"
+    lease_dir.mkdir(parents=True, exist_ok=True)
+    return lease_dir
+
+
+def _container_lease_path(
+    container_id: str, lease_root: Path | None = None,
+) -> Path:
+    safe_id = _sanitize_label_value(container_id)
+    return _lease_dir(lease_root) / f"container-{safe_id}.lock"
+
+
+def _storage_lease_path(
+    storage_label: str, lease_root: Path | None = None,
+) -> Path:
+    safe_label = _sanitize_label_value(storage_label)
+    return _lease_dir(lease_root) / f"storage-{safe_label}.lock"
+
+
+def _try_file_lock(handle: TextIO, *, exclusive: bool) -> bool:
+    """Acquire a non-blocking cross-process file lock on POSIX or Windows."""
+    if os.name == "nt":
+        try:
+            import portalocker
+        except ImportError as exc:
+            raise RuntimeError(
+                "Persistent named Docker targets require portalocker on Windows."
+            ) from exc
+        flags = portalocker.LOCK_EX if exclusive else portalocker.LOCK_SH
+        try:
+            portalocker.lock(handle, flags | portalocker.LOCK_NB)
+        except portalocker.exceptions.LockException:
+            return False
+        return True
+
+    import fcntl
+
+    flags = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+    try:
+        fcntl.flock(handle.fileno(), flags | fcntl.LOCK_NB)
+    except BlockingIOError:
+        return False
+    return True
+
+
+def _unlock_file(handle: TextIO) -> None:
+    if os.name == "nt":
+        import portalocker
+
+        portalocker.unlock(handle)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _hold_container_lease(
+    container_id: str, lease_root: Path | None = None,
+) -> None:
+    """Hold a shared lease while this process can dispatch to a container."""
+    if not container_id:
+        return
+    root = _lease_dir(lease_root).resolve()
+    lease_key = (str(root), container_id)
+    with _CONTAINER_LEASES_LOCK:
+        current = _CONTAINER_LEASES.get(lease_key)
+        if current is not None:
+            handle, count = current
+            _CONTAINER_LEASES[lease_key] = (handle, count + 1)
+            return
+        handle = open(
+            _container_lease_path(container_id, root), "a+", encoding="utf-8",
+        )
+        try:
+            acquired = _try_file_lock(handle, exclusive=False)
+        except Exception:
+            handle.close()
+            raise
+        if not acquired:
+            handle.close()
+            raise RuntimeError(
+                f"Docker runtime {container_id[:12]} is being retired by another "
+                "Hermes process; retry the operation."
+            )
+        _CONTAINER_LEASES[lease_key] = (handle, 1)
+
+
+def _release_container_lease(
+    container_id: str, lease_root: Path | None = None,
+) -> bool:
+    """Release one local holder; return True when the OS lease was closed."""
+    root = _lease_dir(lease_root).resolve()
+    lease_key = (str(root), container_id)
+    with _CONTAINER_LEASES_LOCK:
+        current = _CONTAINER_LEASES.get(lease_key)
+        if current is None:
+            return True
+        handle, count = current
+        if count > 1:
+            _CONTAINER_LEASES[lease_key] = (handle, count - 1)
+            return False
+        _CONTAINER_LEASES.pop(lease_key, None)
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
+    return True
+
+
+def _release_runtime_tracking(
+    container_id: str, lease_root: Path | None = None,
+) -> None:
+    if _release_container_lease(container_id, lease_root):
+        _CURRENT_PROCESS_CONTAINER_IDS.discard(container_id)
+
+
+def _track_environment_container(env, container_id: str) -> None:
+    previous = getattr(env, "_lease_finalizer", None)
+    if previous is not None and previous.alive:
+        previous.detach()
+    lease_root = getattr(env, "_lease_root", None)
+    _hold_container_lease(container_id, lease_root)
+    _CURRENT_PROCESS_CONTAINER_IDS.add(container_id)
+    env._lease_finalizer = weakref.finalize(
+        env, _release_runtime_tracking, container_id, lease_root,
+    )
+
+
+def _acquire_exclusive_container_lease(
+    container_id: str, lease_root: Path | None = None,
+):
+    """Return an exclusive lease handle, None when another process is live."""
+    handle = open(
+        _container_lease_path(container_id, lease_root), "a+", encoding="utf-8",
+    )
+    try:
+        acquired = _try_file_lock(handle, exclusive=True)
+    except Exception:
+        handle.close()
+        raise
+    if not acquired:
+        handle.close()
+        return None
+    return handle
+
+
+def _close_exclusive_container_lease(handle) -> None:
+    if handle is None:
+        return
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
+
+
+def _acquire_storage_creation_lease(
+    storage_label: str, timeout: float = 30.0, *,
+    lease_root: Path | None = None,
+) -> TextIO:
+    """Serialize inspect/reconcile/create for one stable storage owner."""
+    handle = open(
+        _storage_lease_path(storage_label, lease_root), "a+", encoding="utf-8",
+    )
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if _try_file_lock(handle, exclusive=True):
+                return handle
+        except Exception:
+            handle.close()
+            raise
+        if time.monotonic() >= deadline:
+            handle.close()
+            raise RuntimeError(
+                f"Timed out waiting for Docker storage owner {storage_label}; "
+                "another Hermes process is creating or reconciling it."
+            )
+        time.sleep(0.05)
+
+
+def _close_storage_creation_lease(handle: TextIO) -> None:
+    try:
+        _unlock_file(handle)
+    finally:
+        handle.close()
 
 
 def _normalize_forward_env_names(forward_env: list[str] | None) -> list[str]:
@@ -864,18 +1064,42 @@ class DockerEnvironment(BaseEnvironment):
         forward_env: list[str] | None = None,
         env: dict | None = None,
         network: bool = True,
-        host_cwd: str = None,
+        host_cwd: str | None = None,
         auto_mount_cwd: bool = False,
         run_as_host_user: bool = False,
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        storage_task_id: str | None = None,
+        legacy_storage_task_id: str | None = None,
     ):
+        from tools.environments.base import get_sandbox_dir
+
         if cwd == "~":
             cwd = "/root"
         super().__init__(cwd=cwd, timeout=timeout)
         self._persistent = persistent_filesystem
         self._persist_across_processes = persist_across_processes
+        self._lease_root = (
+            get_sandbox_dir() / "docker" / ".runtime-leases"
+        ).resolve()
+        storage_label = ""
+        if self._persistent and storage_task_id:
+            storage_root = str(get_sandbox_dir().resolve())
+            storage_owner = f"{storage_task_id}\0{storage_root}"
+            storage_label = "storage-" + hashlib.sha256(
+                storage_owner.encode("utf-8")
+            ).hexdigest()[:20]
+        storage_guard = (
+            _acquire_storage_creation_lease(
+                storage_label, lease_root=self._lease_root,
+            )
+            if storage_label else None
+        )
+        storage_guard_finalizer = (
+            weakref.finalize(self, _close_storage_creation_lease, storage_guard)
+            if storage_guard is not None else None
+        )
         self._task_id = task_id
         self._forward_env = _normalize_forward_env_names(forward_env)
         self._env = _normalize_env_dict(env)
@@ -926,8 +1150,6 @@ class DockerEnvironment(BaseEnvironment):
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent
         # mode uses tmpfs (ephemeral, fast, gone on cleanup).
-        from tools.environments.base import get_sandbox_dir
-
         # User-configured volume mounts (from config.yaml docker_volumes)
         volume_args = []
         workspace_explicitly_mounted = False
@@ -959,7 +1181,41 @@ class DockerEnvironment(BaseEnvironment):
         self._home_dir: Optional[str] = None
         writable_args = []
         if self._persistent:
-            sandbox = get_sandbox_dir() / "docker" / task_id
+            docker_root = get_sandbox_dir() / "docker"
+            sandbox = docker_root / (storage_task_id or task_id)
+            if legacy_storage_task_id and legacy_storage_task_id != (storage_task_id or task_id):
+                legacy_sandbox = docker_root / legacy_storage_task_id
+                if legacy_sandbox.exists() and not sandbox.exists():
+                    docker = find_docker() or "docker"
+                    legacy_result = subprocess.run(
+                        [
+                            docker, "ps", "-a", "--no-trunc",
+                            "--filter", (
+                                "label=hermes-task-id="
+                                f"{_sanitize_label_value(legacy_storage_task_id)}"
+                            ),
+                            "--filter", (
+                                "label=hermes-profile="
+                                f"{_sanitize_label_value(_get_active_profile_name())}"
+                            ),
+                            "--format", "{{.ID}}",
+                        ],
+                        capture_output=True, text=True, timeout=10,
+                        stdin=subprocess.DEVNULL,
+                    )
+                    if legacy_result.returncode != 0:
+                        raise RuntimeError(
+                            "Could not inspect the legacy named-target Docker runtime "
+                            "before migrating persistent storage."
+                        )
+                    if legacy_result.stdout.strip():
+                        raise RuntimeError(
+                            "A legacy named-target Docker container still owns this "
+                            "persistent workspace. Stop/remove that container, then retry; "
+                            "the workspace data will be migrated automatically."
+                        )
+                    sandbox.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(legacy_sandbox, sandbox)
             self._home_dir = str(sandbox / "home")
             os.makedirs(self._home_dir, exist_ok=True)
             writable_args.extend([
@@ -1349,12 +1605,18 @@ class DockerEnvironment(BaseEnvironment):
         # container-start time and never changes for the container's lifetime.
         profile_name = _sanitize_label_value(_get_active_profile_name())
         task_label = _sanitize_label_value(task_id)
+        process_label = _sanitize_label_value(_PROCESS_INSTANCE_ID)
         label_args = [
             "--label", "hermes-agent=1",
             "--label", f"hermes-task-id={task_label}",
             "--label", f"hermes-profile={profile_name}",
             "--label", f"{_EGRESS_LABEL_KEY}={egress_label}",
+            "--label", f"hermes-process-instance={process_label}",
         ]
+        if storage_label:
+            label_args.extend([
+                "--label", f"hermes-storage-id={storage_label}",
+            ])
         # Save args for container recreation on "No such container" recovery.
         self._image = image
         self._container_name = container_name
@@ -1366,7 +1628,10 @@ class DockerEnvironment(BaseEnvironment):
             "hermes-task-id": task_label,
             "hermes-profile": profile_name,
             _EGRESS_LABEL_KEY: egress_label,
+            "hermes-process-instance": process_label,
         }
+        if storage_label:
+            self._labels["hermes-storage-id"] = storage_label
 
         # Cross-process container reuse (issue #20561 — docs claim "ONE long-lived
         # container shared across sessions").  If a prior Hermes process
@@ -1379,6 +1644,23 @@ class DockerEnvironment(BaseEnvironment):
         # because env vars, CA mounts, and host mappings are immutable after
         # container creation — reusing a pre-egress or pre-rotation container
         # would silently bypass the credential firewall.
+        # Reuse matches the runtime task label, which named targets derive from
+        # their complete effective spec. Config edits therefore start a fresh
+        # runtime; the stable storage label above reconciles superseded
+        # prior-process containers without discarding persistent data.
+        if storage_label:
+            try:
+                self._remove_superseded_storage_containers(
+                    storage_label, profile_name, task_label,
+                    current_egress_label=egress_label,
+                    allow_exact_reuse=persist_across_processes,
+                )
+            except Exception:
+                if storage_guard_finalizer is not None:
+                    storage_guard_finalizer.detach()
+                if storage_guard is not None:
+                    _close_storage_creation_lease(storage_guard)
+                raise
         reused = False
         if persist_across_processes:
             existing = self._find_reusable_container(
@@ -1492,15 +1774,50 @@ class DockerEnvironment(BaseEnvironment):
                     capture_output=True, timeout=10,
                     stdin=subprocess.DEVNULL,
                 )
+                if storage_guard is not None:
+                    if storage_guard_finalizer is not None:
+                        storage_guard_finalizer.detach()
+                    _close_storage_creation_lease(storage_guard)
                 raise
             self._container_id = result.stdout.strip()
             logger.info("Started container %s (%s)", container_name, self._container_id[:12])
 
-        # Build the init-time env forwarding args used to seed the snapshot.
-        self._init_env_args = self._build_init_env_args()
-
-        # Initialize session snapshot inside the container
-        self.init_session()
+        if self._container_id:
+            try:
+                _track_environment_container(self, self._container_id)
+            except Exception:
+                if storage_guard is not None:
+                    if storage_guard_finalizer is not None:
+                        storage_guard_finalizer.detach()
+                    _close_storage_creation_lease(storage_guard)
+                raise
+        # Keep the storage-owner creation barrier until initialization is
+        # complete. Docker labels publish before init_session is ready, so a
+        # sibling constructor must remain blocked until success or failure.
+        try:
+            self._init_env_args = self._build_init_env_args()
+            self.init_session()
+        except Exception as init_error:
+            # Do not publish an uninitialized labeled container after dropping
+            # the creation barrier. Retire it while the barrier is still held;
+            # transactional cleanup restores ownership if removal itself fails.
+            try:
+                self.cleanup(force_remove=True)
+                if not self.wait_for_cleanup(timeout=60.0):
+                    raise RuntimeError(
+                        "container cleanup timed out after initialization failure"
+                    )
+            except Exception as cleanup_error:
+                raise RuntimeError(
+                    f"Docker initialization failed and its container could not "
+                    f"be retired safely: {cleanup_error}"
+                ) from init_error
+            raise
+        finally:
+            if storage_guard is not None:
+                if storage_guard_finalizer is not None:
+                    storage_guard_finalizer.detach()
+                _close_storage_creation_lease(storage_guard)
 
     def _build_init_env_args(self) -> list[str]:
         """Build -e KEY=VALUE args for injecting host env vars into init_session.
@@ -1632,13 +1949,45 @@ class DockerEnvironment(BaseEnvironment):
         on success, False if recreation fails (caller should surface the
         original error).
         """
-        old_id = (self._container_id or "")[:12]
+        old_container_id = self._container_id or ""
+        old_id = old_container_id[:12]
         logger.warning(
             "Container %s appears to be gone — attempting recovery", old_id,
         )
         self._container_id = None
+        _release_runtime_tracking(old_container_id, self._lease_root)
 
-        # 1. Try label-based reuse (another process may have recreated it).
+        storage_label = self._labels.get("hermes-storage-id", "")
+        storage_guard = (
+            _acquire_storage_creation_lease(
+                storage_label, lease_root=self._lease_root,
+            )
+            if storage_label else None
+        )
+
+        def _release_storage_guard() -> None:
+            nonlocal storage_guard
+            if storage_guard is not None:
+                _close_storage_creation_lease(storage_guard)
+                storage_guard = None
+
+        if storage_label:
+            try:
+                self._remove_superseded_storage_containers(
+                    storage_label,
+                    self._labels.get("hermes-profile", "default"),
+                    self._labels.get("hermes-task-id", ""),
+                    current_egress_label=self._labels.get(
+                        _EGRESS_LABEL_KEY, "off",
+                    ),
+                    allow_exact_reuse=self._persist_across_processes,
+                )
+            except RuntimeError as exc:
+                logger.error("Recovery: persistent storage is in use: %s", exc)
+                _release_storage_guard()
+                return False
+
+        # 1. Look for an existing container
         task_label = self._labels.get("hermes-task-id", "")
         profile_label = self._labels.get("hermes-profile", "")
         existing = self._find_reusable_container(
@@ -1665,6 +2014,7 @@ class DockerEnvironment(BaseEnvironment):
         if not self._container_id:
             if not self._image:
                 logger.error("Recovery: no saved image name, cannot recreate container")
+                _release_storage_guard()
                 return False
             try:
                 import uuid as _uuid
@@ -1695,7 +2045,14 @@ class DockerEnvironment(BaseEnvironment):
                 )
             except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as e:
                 logger.error("Recovery: failed to create new container: %s", e)
+                _release_storage_guard()
                 return False
+
+        try:
+            if self._container_id:
+                _track_environment_container(self, self._container_id)
+        finally:
+            _release_storage_guard()
 
         # 3. Re-initialize session snapshot in the (re)created container.
         try:
@@ -1802,6 +2159,113 @@ class DockerEnvironment(BaseEnvironment):
         mode = result.stdout.strip()
         return mode or None
 
+    def _remove_superseded_storage_containers(
+        self,
+        storage_label: str,
+        profile_label: str,
+        current_task_label: str,
+        current_egress_label: str = "off",
+        *,
+        allow_exact_reuse: bool,
+    ) -> None:
+        """Remove prior-process runtimes sharing this stable storage owner.
+
+        A config-derived runtime task label changes when a named target is
+        edited. Persistent storage has a deliberately stable label, so a new
+        Hermes process must retire any old-spec container before mounting that
+        storage into the replacement. Containers already managed by this process
+        are skipped; hot edits retire those through terminal_tool after in-flight
+        users release them.
+        """
+        format_expr = (
+            '{{.ID}}\t{{.Label "hermes-task-id"}}\t'
+            '{{.Label "hermes-process-instance"}}\t'
+            '{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
+        )
+        try:
+            result = subprocess.run(
+                [
+                    self._docker_exe, "ps", "-a", "--no-trunc",
+                    "--filter", "label=hermes-agent=1",
+                    "--filter", f"label=hermes-storage-id={storage_label}",
+                    "--filter", f"label=hermes-profile={profile_label}",
+                    "--format", format_expr,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+                stdin=subprocess.DEVNULL,
+            )
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            raise RuntimeError(
+                "Could not inspect prior Docker runtimes for persistent storage "
+                f"{storage_label}: {exc}"
+            ) from exc
+        if result.returncode != 0:
+            raise RuntimeError(
+                "Could not inspect prior Docker runtimes for persistent storage "
+                f"{storage_label}: {result.stderr.strip()}"
+            )
+
+        for line in result.stdout.splitlines():
+            parts = line.strip().split("\t")
+            if len(parts) not in (3, 4):
+                continue
+            container_id, task_label, process_label = parts[:3]
+            egress_label = parts[3] if len(parts) == 4 else ""
+            if not container_id:
+                continue
+            egress_matches = (
+                egress_label == current_egress_label
+                if current_egress_label != "off"
+                else egress_label in ("", "<no value>", "off")
+            )
+            if (
+                allow_exact_reuse
+                and task_label == current_task_label
+                and egress_matches
+            ):
+                continue
+            if container_id in _CURRENT_PROCESS_CONTAINER_IDS:
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} for persistent storage "
+                    f"{storage_label} is still cached by this Hermes process. "
+                    "Clean up that target or restart Hermes before applying "
+                    "the changed Docker target config."
+                )
+            lease = _acquire_exclusive_container_lease(
+                container_id, self._lease_root,
+            )
+            if lease is None:
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} for persistent storage "
+                    f"{storage_label} is still used by another Hermes process "
+                    f"({process_label or 'unknown owner'}). Stop that process or "
+                    "restore the previous target config before retrying."
+                )
+            try:
+                removed = subprocess.run(
+                    [self._docker_exe, "rm", "-f", container_id],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                    stdin=subprocess.DEVNULL,
+                )
+                if removed.returncode != 0:
+                    raise RuntimeError(
+                        f"Could not retire superseded Docker runtime "
+                        f"{container_id[:12]} for persistent storage "
+                        f"{storage_label}: {removed.stderr.strip()}"
+                    )
+                logger.info(
+                    "Retired superseded Docker runtime %s before mounting storage %s",
+                    container_id[:12], storage_label,
+                )
+            finally:
+                _close_exclusive_container_lease(lease)
+
     def _find_reusable_container(
         self,
         task_label: str,
@@ -1840,7 +2304,7 @@ class DockerEnvironment(BaseEnvironment):
                 fmt = '{{.ID}}\t{{.State}}\t{{.Label "' + _EGRESS_LABEL_KEY + '"}}'
             result = subprocess.run(
                 [
-                    self._docker_exe, "ps", "-a",
+                    self._docker_exe, "ps", "-a", "--no-trunc",
                     *filters,
                     "--format", fmt,
                 ],
@@ -1936,6 +2400,9 @@ class DockerEnvironment(BaseEnvironment):
         thread to finish before the interpreter exits, so ``docker stop`` /
         ``docker rm`` actually completes when we do trigger it.
         """
+        existing_thread = getattr(self, "_cleanup_thread", None)
+        if existing_thread is not None and existing_thread.is_alive():
+            return
         container_id = self._container_id
         if not container_id:
             # Still drop the bind-mount dirs if any were allocated and we're
@@ -1955,63 +2422,155 @@ class DockerEnvironment(BaseEnvironment):
         # The persist-mode no-op is the issue-#20561 contract: the container
         # outlives Hermes processes, processes inside it stay alive, and
         # reuse on next startup is instant.
+        exclusive_lease = None
         if force_remove:
+            finalizer = getattr(self, "_lease_finalizer", None)
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
+            _release_runtime_tracking(container_id, self._lease_root)
+            exclusive_lease = _acquire_exclusive_container_lease(
+                container_id, self._lease_root,
+            )
+            if exclusive_lease is None:
+                _track_environment_container(self, container_id)
+                raise RuntimeError(
+                    f"Docker runtime {container_id[:12]} is still used by "
+                    "another environment or Hermes process; retry cleanup "
+                    "after those users finish."
+                )
             should_stop = True
             should_remove = True
         elif self._persist_across_processes:
             # No-op for the container. Drop the in-process handle so a fresh
             # __init__ will re-probe via labels (and find the running
             # container) instead of trying to reuse a stale Python reference.
+            finalizer = getattr(self, "_lease_finalizer", None)
+            if finalizer is not None and finalizer.alive:
+                finalizer.detach()
+            _release_runtime_tracking(container_id, self._lease_root)
             self._container_id = None
             return
         else:
             should_stop = True
             should_remove = True
 
-        # Capture state needed by the worker before we null out the attrs —
-        # the worker thread can outlive ``self``.
         docker_exe = self._docker_exe
         log_id = container_id[:12]
+        workspace_dirs = (self._workspace_dir, self._home_dir)
+        self._cleanup_error = None
+
+        def _container_is_absent() -> bool:
+            try:
+                inspected = subprocess.run(
+                    [docker_exe, "container", "inspect", container_id],
+                    capture_output=True, timeout=15,
+                    stdin=subprocess.DEVNULL,
+                )
+            except (subprocess.TimeoutExpired, OSError):
+                return False
+            if getattr(inspected, "returncode", 0) == 0:
+                return False
+            detail = (
+                f"{getattr(inspected, 'stdout', '')} "
+                f"{getattr(inspected, 'stderr', '')}"
+            ).lower()
+            return any(marker in detail for marker in (
+                "no such", "not found", "does not exist",
+            ))
 
         def _do_cleanup() -> None:
-            if should_stop:
-                try:
-                    subprocess.run(
-                        [docker_exe, "stop", "-t", "10", container_id],
-                        capture_output=True, timeout=30,
-                        stdin=subprocess.DEVNULL,
+            cleanup_error = None
+            try:
+                if should_stop:
+                    try:
+                        stopped = subprocess.run(
+                            [docker_exe, "stop", "-t", "10", container_id],
+                            capture_output=True, timeout=30,
+                            stdin=subprocess.DEVNULL,
+                        )
+                        if getattr(stopped, "returncode", 0) != 0:
+                            logger.warning(
+                                "docker stop %s failed (continuing with rm): %s",
+                                log_id, getattr(stopped, "stderr", ""),
+                            )
+                    except (subprocess.TimeoutExpired, OSError) as exc:
+                        logger.warning(
+                            "docker stop %s timed out / failed: %s", log_id, exc,
+                        )
+                if should_remove:
+                    remove_error = None
+                    try:
+                        removed = subprocess.run(
+                            [docker_exe, "rm", "-f", container_id],
+                            capture_output=True, timeout=30,
+                            stdin=subprocess.DEVNULL,
+                        )
+                        if getattr(removed, "returncode", 0) != 0:
+                            remove_error = RuntimeError(
+                                f"docker rm -f {log_id} failed: "
+                                f"{getattr(removed, 'stderr', '') or getattr(removed, 'stdout', '')}"
+                            )
+                    except (subprocess.TimeoutExpired, OSError) as exc:
+                        remove_error = RuntimeError(
+                            f"docker rm -f {log_id} failed: {exc}"
+                        )
+                    if remove_error is not None and not _container_is_absent():
+                        raise remove_error
+            except Exception as exc:
+                cleanup_error = exc
+            finally:
+                if exclusive_lease is not None:
+                    _close_exclusive_container_lease(exclusive_lease)
+                if cleanup_error is None:
+                    if exclusive_lease is None:
+                        _release_runtime_tracking(container_id, self._lease_root)
+                    self._container_id = None
+                    if should_remove and not self._persistent:
+                        for directory in workspace_dirs:
+                            if directory:
+                                shutil.rmtree(directory, ignore_errors=True)
+                else:
+                    self._container_id = container_id
+                    if exclusive_lease is not None:
+                        try:
+                            _track_environment_container(self, container_id)
+                        except Exception as restore_exc:
+                            cleanup_error = RuntimeError(
+                                f"{cleanup_error}; could not restore runtime ownership: "
+                                f"{restore_exc}"
+                            )
+                    logger.error(
+                        "Docker cleanup failed for %s; runtime ownership retained: %s",
+                        log_id, cleanup_error,
                     )
-                except (subprocess.TimeoutExpired, OSError) as e:
-                    logger.warning("docker stop %s timed out / failed: %s", log_id, e)
-            if should_remove:
-                try:
-                    subprocess.run(
-                        [docker_exe, "rm", "-f", container_id],
-                        capture_output=True, timeout=30,
-                        stdin=subprocess.DEVNULL,
-                    )
-                except (subprocess.TimeoutExpired, OSError) as e:
-                    logger.warning("docker rm -f %s failed: %s", log_id, e)
+                self._cleanup_error = cleanup_error
 
-        # Daemon thread: doesn't block interpreter exit (atexit returns
-        # promptly), but unlike the old ``Popen(... &)`` shell trick the
-        # Python-level join semantics let the thread actually run to
-        # completion if the interpreter is still alive. atexit registers
-        # ``_atexit_cleanup`` in terminal_tool.py which waits up to ~60s for
-        # outstanding cleanups, so most exits complete the work cleanly.
+        # Keep the bounded worker for graceful-exit behavior. The container id,
+        # storage directories, and runtime lease are committed only after rm is
+        # confirmed; wait_for_cleanup propagates any transactional failure.
         import threading
-        t = threading.Thread(target=_do_cleanup, daemon=True, name=f"hermes-cleanup-{log_id}")
-        t.start()
+        t = threading.Thread(
+            target=_do_cleanup, daemon=True, name=f"hermes-cleanup-{log_id}",
+        )
         self._cleanup_thread = t
-        self._container_id = None
-
-        # Bind-mount dir teardown only runs when we actually removed the
-        # container (the dirs are the container's filesystem state; keeping
-        # them around with no container would orphan the data on disk).
-        if should_remove and not self._persistent:
-            for d in (self._workspace_dir, self._home_dir):
-                if d:
-                    shutil.rmtree(d, ignore_errors=True)
+        try:
+            t.start()
+        except Exception as start_error:
+            if exclusive_lease is not None:
+                _close_exclusive_container_lease(exclusive_lease)
+                try:
+                    _track_environment_container(self, container_id)
+                except Exception as restore_error:
+                    start_error = RuntimeError(
+                        f"{start_error}; could not restore runtime ownership: "
+                        f"{restore_error}"
+                    )
+            self._container_id = container_id
+            self._cleanup_error = start_error
+            raise RuntimeError(
+                f"Could not start Docker cleanup worker for {log_id}: "
+                f"{start_error}"
+            ) from start_error
 
     def wait_for_cleanup(self, timeout: float = 30.0) -> bool:
         """Block up to *timeout* seconds for the cleanup worker thread.
@@ -2023,7 +2582,13 @@ class DockerEnvironment(BaseEnvironment):
         races the interpreter shutdown and leaves stopped containers behind.
         """
         thread = getattr(self, "_cleanup_thread", None)
-        if thread is None or not thread.is_alive():
-            return True
-        thread.join(timeout=timeout)
-        return not thread.is_alive()
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout)
+            if thread.is_alive():
+                return False
+        cleanup_error = getattr(self, "_cleanup_error", None)
+        if cleanup_error is not None:
+            raise RuntimeError(
+                f"Docker cleanup failed transactionally: {cleanup_error}"
+            ) from cleanup_error
+        return True

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -31,6 +31,16 @@ from tools.environments.file_sync import (
 logger = logging.getLogger(__name__)
 
 
+def _active_profile_identity() -> str:
+    """Return the current Hermes profile without exposing it in socket paths."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return str(os.environ.get("HERMES_PROFILE") or "default")
+
+
 def _ensure_ssh_available() -> None:
     """Fail fast with a clear error when the SSH client is unavailable."""
     if not shutil.which("ssh"):
@@ -53,12 +63,15 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 runtime_scope: str = "", profile_name: str | None = None):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        self.runtime_scope = str(runtime_scope or "")
+        self.profile_name = str(profile_name or _active_profile_identity())
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -68,10 +81,23 @@ class SSHEnvironment(BaseEnvironment):
         # IPv6 host — plus the 16-byte random suffix SSH appends in
         # ControlMaster mode easily exceeds the limit under macOS's
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
-        # triple keeps the path stable across reconnects so ControlMaster
-        # reuse still works.
+        # connection identity keeps the path stable across reconnects so
+        # ControlMaster reuse still works. Credential, profile, and opaque target
+        # scope are included in the digest: OpenSSH reuses a master before
+        # authenticating later ``-i`` options, so sharing across any of those
+        # boundaries would silently execute with the wrong credential authority.
+        normalized_key = (
+            os.path.normcase(
+                os.path.abspath(os.path.expanduser(os.path.expandvars(key_path)))
+            )
+            if key_path else "<ssh-agent-or-default>"
+        )
+        socket_identity = "\0".join((
+            str(user), str(host), str(port), normalized_key,
+            self.profile_name, self.runtime_scope,
+        ))
         _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
+            socket_identity.encode("utf-8", errors="surrogatepass")
         ).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -21,6 +21,16 @@ from tools.environments.file_sync import (
 logger = logging.getLogger(__name__)
 
 
+def _active_profile_identity() -> str:
+    """Return the current Hermes profile without exposing it in socket paths."""
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return str(get_active_profile_name() or "default")
+    except Exception:
+        return str(os.environ.get("HERMES_PROFILE") or "default")
+
+
 def _ensure_ssh_available() -> None:
     """Fail fast with a clear error when the SSH client is unavailable."""
     if not shutil.which("ssh"):
@@ -43,12 +53,15 @@ class SSHEnvironment(BaseEnvironment):
     """
 
     def __init__(self, host: str, user: str, cwd: str = "~",
-                 timeout: int = 60, port: int = 22, key_path: str = ""):
+                 timeout: int = 60, port: int = 22, key_path: str = "",
+                 runtime_scope: str = "", profile_name: str | None = None):
         super().__init__(cwd=cwd, timeout=timeout)
         self.host = host
         self.user = user
         self.port = port
         self.key_path = key_path
+        self.runtime_scope = str(runtime_scope or "")
+        self.profile_name = str(profile_name or _active_profile_identity())
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
         self.control_dir.mkdir(parents=True, exist_ok=True)
@@ -58,10 +71,23 @@ class SSHEnvironment(BaseEnvironment):
         # IPv6 host — plus the 16-byte random suffix SSH appends in
         # ControlMaster mode easily exceeds the limit under macOS's
         # deeply-nested $TMPDIR (e.g. /var/folders/xx/yy/T/). Hashing the
-        # triple keeps the path stable across reconnects so ControlMaster
-        # reuse still works.
+        # connection identity keeps the path stable across reconnects so
+        # ControlMaster reuse still works. Credential, profile, and opaque target
+        # scope are included in the digest: OpenSSH reuses a master before
+        # authenticating later ``-i`` options, so sharing across any of those
+        # boundaries would silently execute with the wrong credential authority.
+        normalized_key = (
+            os.path.normcase(
+                os.path.abspath(os.path.expanduser(os.path.expandvars(key_path)))
+            )
+            if key_path else "<ssh-agent-or-default>"
+        )
+        socket_identity = "\0".join((
+            str(user), str(host), str(port), normalized_key,
+            self.profile_name, self.runtime_scope,
+        ))
         _socket_id = hashlib.sha256(
-            f"{user}@{host}:{port}".encode()
+            socket_identity.encode("utf-8", errors="surrogatepass")
         ).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
         _ensure_ssh_available()

--- a/tools/execution_target_lifecycle.py
+++ b/tools/execution_target_lifecycle.py
@@ -1,0 +1,77 @@
+"""Runtime lifecycle metadata helpers for execution-target resolution."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+REGISTRY_METADATA_KEY = "__execution_target_registry_v1__"
+
+
+def runtime_record_metadata_entry(
+    *,
+    execution_target: str,
+    provider: str,
+    owner_id: str,
+    generation: str,
+    state: str,
+    status: str,
+) -> dict[str, str]:
+    """Build the canonical runtime-record sidecar shape used by resolvers."""
+    return {
+        "execution_target": execution_target,
+        "provider": provider,
+        "owner_id": owner_id,
+        "generation": generation,
+        "state": state,
+        "status": status,
+    }
+
+
+def runtime_record_metadata(
+    root: Mapping[str, Any],
+    target: str,
+    *,
+    status: str | None = None,
+) -> list[Mapping[str, Any]]:
+    registry = root.get(REGISTRY_METADATA_KEY)
+    records = registry.get("records") if isinstance(registry, Mapping) else None
+    if not isinstance(records, list):
+        return []
+    return [
+        item
+        for item in records
+        if isinstance(item, Mapping)
+        and item.get("execution_target") == target
+        and (status is None or item.get("status") == status)
+    ]
+
+
+def unavailable_runtime_target_message(
+    root: Mapping[str, Any],
+    target: str,
+) -> str | None:
+    statuses = {
+        str(item.get("status")) for item in runtime_record_metadata(root, target)
+    }
+    if "draining" in statuses:
+        return (
+            f"Execution target {target!r} is draining and rejects new calls. "
+            "Use hermes targets show or register a ready replacement."
+        )
+    if "provider_collision" in statuses:
+        return (
+            f"Execution target {target!r} is unavailable because multiple runtime "
+            "providers claim it. Run hermes targets list --all to reconcile ownership."
+        )
+    if "invalid_config" in statuses:
+        return (
+            f"Execution target {target!r} is unavailable because its runtime provider "
+            "published invalid backend configuration. Run hermes targets list --all."
+        )
+    if "inactive_legacy" in statuses:
+        return (
+            f"Execution target {target!r} is not active because legacy flat terminal "
+            "mode has not been initialized. Use hermes targets register."
+        )
+    return None

--- a/tools/execution_target_overlay.py
+++ b/tools/execution_target_overlay.py
@@ -1,0 +1,222 @@
+"""Merge runtime execution-target records with effective static config."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Mapping
+
+from tools.execution_target_registry import (
+    RegistryDiagnostic,
+    RuntimeRegistrySnapshot,
+    load_runtime_registry,
+)
+from tools.execution_target_lifecycle import (
+    REGISTRY_METADATA_KEY,
+    runtime_record_metadata_entry,
+)
+
+
+def _metadata_entry(record: Any, status: str) -> dict[str, str]:
+    return runtime_record_metadata_entry(
+        execution_target=record.execution_target,
+        provider=record.provider,
+        owner_id=record.owner_id,
+        generation=record.generation,
+        state=record.state,
+        status=status,
+    )
+
+
+def _available(names: list[str]) -> str:
+    return ", ".join(repr(name) for name in sorted(names)) or "(none)"
+
+
+def overlay_runtime_execution_targets(
+    config: Mapping[str, Any],
+    *,
+    snapshot: RuntimeRegistrySnapshot | None = None,
+    raise_for_target: str | None = None,
+) -> dict[str, Any]:
+    """Return static config plus one consistent profile-registry snapshot.
+
+    Static names reserve their aliases.  Provider/provider collisions,
+    draining records, and invalid provider configs are represented in the
+    sidecar metadata but withheld from ``terminal.targets``.
+    """
+    root = deepcopy(dict(config))
+    root.pop(REGISTRY_METADATA_KEY, None)
+    if snapshot is None:
+        snapshot = load_runtime_registry()
+    if (
+        not snapshot.records
+        and not snapshot.legacy_activated
+        and not snapshot.diagnostics
+    ):
+        return root
+
+    diagnostics = list(snapshot.diagnostics)
+    records_metadata: list[dict[str, Any]] = []
+    raw_terminal = root.get("terminal", {})
+    if raw_terminal is None:
+        raw_terminal = {}
+    if not isinstance(raw_terminal, Mapping):
+        root[REGISTRY_METADATA_KEY] = {
+            "records": records_metadata,
+            "diagnostics": [diag.as_dict() for diag in diagnostics],
+        }
+        return root
+
+    terminal = deepcopy(dict(raw_terminal))
+    raw_static_targets = terminal.get("targets")
+    static_named = isinstance(raw_static_targets, Mapping) and bool(raw_static_targets)
+    if raw_static_targets not in (None, {}) and not isinstance(
+        raw_static_targets, Mapping
+    ):
+        diagnostics.append(
+            RegistryDiagnostic(
+                code="static_targets_invalid",
+                message="Runtime targets are unavailable because terminal.targets is not a mapping.",
+            )
+        )
+        root[REGISTRY_METADATA_KEY] = {
+            "records": records_metadata,
+            "diagnostics": [diag.as_dict() for diag in diagnostics],
+        }
+        return root
+
+    if static_named:
+        targets = deepcopy(dict(raw_static_targets))
+    elif snapshot.legacy_activated:
+        # Durable state is marker-only. Build the named default live from this
+        # dispatch's static/profile authority while retaining shared policy.
+        from tools.execution_targets import (
+            ExecutionTargetError,
+            resolve_execution_target,
+            synthesize_legacy_default_target,
+        )
+
+        try:
+            synthetic = synthesize_legacy_default_target(root)
+            if synthetic is None:
+                raise ExecutionTargetError("legacy terminal config is already named")
+            targets = {"default": synthetic}
+            terminal["default_target"] = "default"
+            terminal["targets"] = targets
+            candidate = deepcopy(root)
+            candidate["terminal"] = terminal
+            resolve_execution_target("default", config=candidate)
+        except (ExecutionTargetError, ValueError):
+            if raise_for_target is not None:
+                raise
+            for record in snapshot.records:
+                records_metadata.append(_metadata_entry(record, "inactive_legacy"))
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="activation_state_invalid",
+                    message=(
+                        "Runtime targets are unavailable because legacy activation "
+                        "state has invalid backend configuration."
+                    ),
+                )
+            )
+            root[REGISTRY_METADATA_KEY] = {
+                "records": records_metadata,
+                "diagnostics": [diag.as_dict() for diag in diagnostics],
+            }
+            return root
+        static_named = True
+    else:
+        for record in snapshot.records:
+            records_metadata.append(_metadata_entry(record, "inactive_legacy"))
+        if snapshot.records:
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="legacy_not_activated",
+                    message=(
+                        "Runtime targets are unavailable in legacy flat terminal mode; "
+                        "register one with 'hermes targets register' to activate a stable default."
+                    ),
+                )
+            )
+        root[REGISTRY_METADATA_KEY] = {
+            "records": records_metadata,
+            "diagnostics": [diag.as_dict() for diag in diagnostics],
+        }
+        return root
+
+    static_names = set(targets)
+    by_name: dict[str, list[Any]] = {}
+    for record in snapshot.records:
+        by_name.setdefault(record.execution_target, []).append(record)
+
+    runtime_records: dict[str, Any] = {}
+    for name, records in sorted(by_name.items()):
+        if name in static_names:
+            for record in records:
+                records_metadata.append(_metadata_entry(record, "shadowed_static"))
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="static_name_reserved",
+                    message=f"Static execution target {name!r} reserves its name over runtime providers.",
+                )
+            )
+            continue
+        if len(records) > 1:
+            providers = sorted(record.provider for record in records)
+            for record in records:
+                records_metadata.append(_metadata_entry(record, "provider_collision"))
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="provider_name_collision",
+                    message=(
+                        f"Runtime execution target {name!r} is unavailable because multiple "
+                        f"providers claim it: {_available(providers)}."
+                    ),
+                )
+            )
+            continue
+        record = records[0]
+        status = "active" if record.state == "ready" else "draining"
+        records_metadata.append(_metadata_entry(record, status))
+        if record.state == "ready":
+            targets[name] = deepcopy(dict(record.config))
+            runtime_records[name] = record
+
+    terminal["targets"] = targets
+    root["terminal"] = terminal
+    root[REGISTRY_METADATA_KEY] = {
+        "records": records_metadata,
+        "diagnostics": [diag.as_dict() for diag in diagnostics],
+    }
+
+    # Provider JSON is an external control-plane boundary. Validate through
+    # the production resolver and isolate only the bad provider record.
+    from tools.execution_targets import ExecutionTargetError, resolve_execution_target
+
+    for name, record in runtime_records.items():
+        try:
+            resolve_execution_target(name, config=root)
+        except ExecutionTargetError:
+            if name == raise_for_target:
+                raise
+            targets.pop(name, None)
+            for metadata in records_metadata:
+                if (
+                    metadata["execution_target"] == name
+                    and metadata["provider"] == record.provider
+                ):
+                    metadata["status"] = "invalid_config"
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="runtime_target_invalid",
+                    provider=record.provider,
+                    message=(
+                        f"Runtime execution target {name!r} from provider "
+                        f"{record.provider!r} has invalid backend configuration."
+                    ),
+                )
+            )
+    root[REGISTRY_METADATA_KEY]["diagnostics"] = [
+        diag.as_dict() for diag in diagnostics
+    ]
+    return root

--- a/tools/execution_target_registry.py
+++ b/tools/execution_target_registry.py
@@ -1,0 +1,947 @@
+"""Profile-scoped runtime registry for named execution targets.
+
+Each provider owns one versioned JSON fragment below
+``$HERMES_HOME/runtime/execution-targets.d``.  Readers cache only a parsed
+snapshot whose key includes directory membership plus each fragment's
+device/inode/nanosecond-mtime/size tuple.  Writers take a bounded
+cross-process lock and publish same-directory atomic replacements.
+
+This module owns storage and schema validation only.  Merging with static
+Hermes configuration and backend validation live in :mod:`execution_targets`
+so there remains one production target validator.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from copy import deepcopy
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import stat
+import threading
+import time
+from typing import Any, Callable, Iterator, Mapping
+
+
+REGISTRY_VERSION = 1
+MAX_REGISTRY_FILE_BYTES = 1024 * 1024
+MAX_TARGETS_PER_PROVIDER = 1024
+MAX_TARGET_CONFIG_DEPTH = 16
+MAX_TARGET_CONFIG_NODES = 8192
+MAX_TARGET_CONFIG_BYTES = 256 * 1024
+_PROVIDER_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,63}\Z")
+_RECORD_FIELDS = frozenset({"config", "owner_id", "generation", "state"})
+_STATES = frozenset({"ready", "draining"})
+_STRUCTURAL_CONFIG_KEYS = frozenset({
+    "targets",
+    "default_target",
+    "provider",
+    "owner_id",
+    "generation",
+    "state",
+})
+_STATE_FILENAME = ".registry-state.json"
+_LOCK_FILENAME = ".registry.lock"
+
+
+class RuntimeRegistryError(ValueError):
+    """Raised for an invalid or conflicting runtime-registry operation."""
+
+
+@dataclass(frozen=True)
+class RegistryDiagnostic:
+    code: str
+    message: str
+    provider: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        result: dict[str, Any] = {"code": self.code, "message": self.message}
+        if self.provider is not None:
+            result["provider"] = self.provider
+        return result
+
+
+@dataclass(frozen=True)
+class RuntimeTargetRecord:
+    execution_target: str
+    provider: str
+    config: Mapping[str, Any]
+    owner_id: str
+    generation: str
+    state: str
+
+    def as_fragment_record(self) -> dict[str, Any]:
+        return {
+            "config": deepcopy(dict(self.config)),
+            "owner_id": self.owner_id,
+            "generation": self.generation,
+            "state": self.state,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeRegistrySnapshot:
+    records: tuple[RuntimeTargetRecord, ...] = ()
+    diagnostics: tuple[RegistryDiagnostic, ...] = ()
+    legacy_activated: bool = False
+
+
+_cache_lock = threading.RLock()
+_snapshot_cache: dict[Path, tuple[tuple[Any, ...], RuntimeRegistrySnapshot]] = {}
+
+
+def _clone_snapshot(snapshot: RuntimeRegistrySnapshot) -> RuntimeRegistrySnapshot:
+    """Return a caller-owned copy without exposing cached nested JSON values."""
+    return RuntimeRegistrySnapshot(
+        records=tuple(
+            RuntimeTargetRecord(
+                execution_target=record.execution_target,
+                provider=record.provider,
+                config=deepcopy(dict(record.config)),
+                owner_id=record.owner_id,
+                generation=record.generation,
+                state=record.state,
+            )
+            for record in snapshot.records
+        ),
+        diagnostics=snapshot.diagnostics,
+        legacy_activated=snapshot.legacy_activated,
+    )
+
+
+def registry_directory() -> Path:
+    """Return the active profile's runtime target-fragment directory."""
+    from hermes_constants import get_hermes_home
+
+    return Path(get_hermes_home()) / "runtime" / "execution-targets.d"
+
+
+def validate_provider_name(provider: str) -> str:
+    """Validate and canonicalize the provider identity used in storage."""
+    if not isinstance(provider, str) or not _PROVIDER_RE.fullmatch(provider):
+        raise RuntimeRegistryError(
+            "Provider must be 1-64 characters using only letters, digits, '.', "
+            "'_', or '-', and must start with a letter or digit."
+        )
+    return provider.lower()
+
+
+def _validate_target_name(name: Any) -> str:
+    if not isinstance(name, str) or not name or len(name) > 256:
+        raise RuntimeRegistryError(
+            "Execution target names must be non-empty strings of at most 256 characters."
+        )
+    if any(ord(char) < 32 or ord(char) == 127 for char in name):
+        raise RuntimeRegistryError(
+            "Execution target names cannot contain control characters."
+        )
+    return name
+
+
+def _validate_record_identifier(label: str, value: Any, target: str) -> str:
+    if not isinstance(value, str) or not value or len(value) > 512:
+        raise RuntimeRegistryError(
+            f"Target {target!r} {label} must be a non-empty string of at most 512 characters."
+        )
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise RuntimeRegistryError(
+            f"Target {target!r} {label} cannot contain control characters."
+        )
+    return value
+
+
+def _looks_like_private_key_contents(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip().upper()
+    return (
+        "\n" in value or "-----BEGIN " in normalized or "PRIVATE KEY-----" in normalized
+    )
+
+
+def _validate_config_complexity(config: Mapping[str, Any], target: str) -> None:
+    """Bound provider-controlled config before copying or backend use."""
+    stack: list[tuple[Any, int]] = [(config, 0)]
+    seen_containers: set[int] = set()
+    nodes = 0
+    encoded_bytes = 0
+    while stack:
+        value, depth = stack.pop()
+        nodes += 1
+        if nodes > MAX_TARGET_CONFIG_NODES:
+            raise RuntimeRegistryError(f"Target {target!r} config is too complex.")
+        if depth > MAX_TARGET_CONFIG_DEPTH:
+            raise RuntimeRegistryError(
+                f"Target {target!r} config is nested too deeply."
+            )
+        if isinstance(value, Mapping):
+            identity = id(value)
+            if identity in seen_containers:
+                raise RuntimeRegistryError(
+                    f"Target {target!r} config contains a recursive container."
+                )
+            seen_containers.add(identity)
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise RuntimeRegistryError(
+                        f"Target {target!r} config keys must be strings."
+                    )
+                encoded_bytes += len(key.encode("utf-8"))
+                stack.append((item, depth + 1))
+        elif isinstance(value, list):
+            identity = id(value)
+            if identity in seen_containers:
+                raise RuntimeRegistryError(
+                    f"Target {target!r} config contains a recursive container."
+                )
+            seen_containers.add(identity)
+            stack.extend((item, depth + 1) for item in value)
+        elif isinstance(value, str):
+            encoded_bytes += len(value.encode("utf-8"))
+        elif value is not None and not isinstance(value, (bool, int, float)):
+            raise RuntimeRegistryError(
+                f"Target {target!r} config contains a non-JSON value."
+            )
+        if encoded_bytes > MAX_TARGET_CONFIG_BYTES:
+            raise RuntimeRegistryError(f"Target {target!r} config is too large.")
+
+
+def validate_fragment_targets(
+    provider: str,
+    targets: Mapping[str, Any],
+) -> dict[str, dict[str, Any]]:
+    """Return a normalized provider target mapping or raise safely."""
+    validate_provider_name(provider)
+    if not isinstance(targets, Mapping):
+        raise RuntimeRegistryError("Provider fragment 'targets' must be an object.")
+    if len(targets) > MAX_TARGETS_PER_PROVIDER:
+        raise RuntimeRegistryError(
+            f"Provider fragment exceeds the {MAX_TARGETS_PER_PROVIDER}-target limit."
+        )
+
+    normalized: dict[str, dict[str, Any]] = {}
+    for raw_name, raw_record in targets.items():
+        name = _validate_target_name(raw_name)
+        if not isinstance(raw_record, Mapping):
+            raise RuntimeRegistryError(f"Target {name!r} record must be an object.")
+        extra = set(raw_record) - _RECORD_FIELDS
+        missing = _RECORD_FIELDS - set(raw_record)
+        if extra or missing:
+            raise RuntimeRegistryError(
+                f"Target {name!r} record must contain exactly: "
+                "config, generation, owner_id, state."
+            )
+        config = raw_record.get("config")
+        if not isinstance(config, Mapping):
+            raise RuntimeRegistryError(f"Target {name!r} config must be an object.")
+        _validate_config_complexity(config, name)
+        for key in config:
+            if key in _STRUCTURAL_CONFIG_KEYS:
+                raise RuntimeRegistryError(
+                    f"Target {name!r} cannot set structural field {key!r}."
+                )
+        if _looks_like_private_key_contents(config.get("ssh_key")):
+            raise RuntimeRegistryError(
+                f"Target {name!r} ssh_key must be a path or SSH alias setting, "
+                "not private-key contents."
+            )
+        owner_id = raw_record.get("owner_id")
+        generation = raw_record.get("generation")
+        state = raw_record.get("state")
+        owner_id = _validate_record_identifier("owner_id", owner_id, name)
+        generation = _validate_record_identifier("generation", generation, name)
+        if state not in _STATES:
+            raise RuntimeRegistryError(
+                f"Target {name!r} state must be 'ready' or 'draining'."
+            )
+        normalized[name] = {
+            "config": deepcopy(dict(config)),
+            "owner_id": owner_id,
+            "generation": generation,
+            "state": state,
+        }
+    return normalized
+
+
+def _fragment_payload(provider: str, targets: Mapping[str, Any]) -> dict[str, Any]:
+    provider = validate_provider_name(provider)
+    return {
+        "version": REGISTRY_VERSION,
+        "provider": provider,
+        "targets": validate_fragment_targets(provider, targets),
+    }
+
+
+def _user_only_error(path: Path, mode: int, owner: int | None) -> str | None:
+    if os.name == "nt":
+        return None
+    if mode & 0o077:
+        return f"{path.name} must not be accessible by group or other users"
+    if not mode & 0o400:
+        return f"{path.name} is not readable by its owner"
+    geteuid = getattr(os, "geteuid", None)
+    if owner is not None and callable(geteuid) and owner != geteuid():
+        return f"{path.name} is not owned by the current user"
+    return None
+
+
+def _lstat_signature(path: Path) -> tuple[Any, ...]:
+    st = path.lstat()
+    return (
+        path.name,
+        st.st_dev,
+        st.st_ino,
+        st.st_mtime_ns,
+        st.st_size,
+        stat.S_IFMT(st.st_mode),
+        stat.S_IMODE(st.st_mode),
+        getattr(st, "st_uid", None),
+    )
+
+
+def _registry_signature(directory: Path) -> tuple[Any, ...]:
+    try:
+        directory_sig = _lstat_signature(directory)
+    except FileNotFoundError:
+        return ("missing",)
+    except OSError as exc:
+        return ("unreadable", type(exc).__name__, getattr(exc, "errno", None))
+    if directory_sig[5] != stat.S_IFDIR:
+        return (directory_sig,)
+
+    try:
+        names = sorted(
+            entry.name
+            for entry in directory.iterdir()
+            if entry.name == _STATE_FILENAME
+            or (entry.suffix == ".json" and not entry.name.startswith("."))
+        )
+    except OSError as exc:
+        return (
+            *directory_sig,
+            "unreadable",
+            type(exc).__name__,
+            getattr(exc, "errno", None),
+        )
+
+    entries: list[tuple[Any, ...]] = []
+    for name in names:
+        try:
+            entries.append(_lstat_signature(directory / name))
+        except FileNotFoundError:
+            entries.append((name, "vanished"))
+        except OSError as exc:
+            entries.append((
+                name,
+                "unreadable",
+                type(exc).__name__,
+                getattr(exc, "errno", None),
+            ))
+    return (directory_sig, *entries)
+
+
+def _read_secure_json(path: Path) -> Any:
+    """Read one owner-only regular JSON file without a symlink race."""
+    try:
+        before = path.lstat()
+    except OSError as exc:
+        raise RuntimeRegistryError(f"{path.name} is unreadable or malformed") from exc
+    if stat.S_ISLNK(before.st_mode):
+        raise RuntimeRegistryError(f"{path.name} is a symlink; refusing to follow it")
+    if not stat.S_ISREG(before.st_mode):
+        raise RuntimeRegistryError(f"{path.name} is not a regular file")
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = -1
+    try:
+        fd = os.open(path, flags)
+        opened = os.fstat(fd)
+        if (before.st_dev, before.st_ino) != (opened.st_dev, opened.st_ino):
+            raise RuntimeRegistryError(f"{path.name} changed while being opened")
+        if not stat.S_ISREG(opened.st_mode):
+            raise RuntimeRegistryError(f"{path.name} is not a regular file")
+        if opened.st_size > MAX_REGISTRY_FILE_BYTES:
+            raise RuntimeRegistryError(f"{path.name} exceeds the size limit")
+        permission_error = _user_only_error(
+            path,
+            stat.S_IMODE(opened.st_mode),
+            getattr(opened, "st_uid", None),
+        )
+        if permission_error:
+            raise RuntimeRegistryError(permission_error)
+        handle = os.fdopen(fd, "rb")
+        fd = -1
+        with handle:
+            raw = handle.read(MAX_REGISTRY_FILE_BYTES + 1)
+            if len(raw) > MAX_REGISTRY_FILE_BYTES:
+                raise RuntimeRegistryError(f"{path.name} exceeds the size limit")
+            return json.loads(raw)
+    except RuntimeRegistryError:
+        raise
+    except (OSError, UnicodeError, json.JSONDecodeError, RecursionError) as exc:
+        raise RuntimeRegistryError(f"{path.name} is unreadable or malformed") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+
+def _parse_state(path: Path) -> bool:
+    data = _read_secure_json(path)
+    if (
+        not isinstance(data, Mapping)
+        or type(data.get("version")) is not int
+        or data.get("version") != REGISTRY_VERSION
+    ):
+        raise RuntimeRegistryError(
+            "registry activation state has an unsupported schema"
+        )
+    if set(data) != {"version", "legacy_activated"}:
+        raise RuntimeRegistryError("registry activation state has unexpected fields")
+    if data.get("legacy_activated") is not True:
+        raise RuntimeRegistryError("registry activation marker must be true")
+    return True
+
+
+def _parse_fragment(path: Path) -> tuple[RuntimeTargetRecord, ...]:
+    provider_from_name = validate_provider_name(path.stem)
+    if path.stem != provider_from_name:
+        raise RuntimeRegistryError(
+            "provider fragment filename must use its canonical lowercase identity"
+        )
+    data = _read_secure_json(path)
+    if not isinstance(data, Mapping):
+        raise RuntimeRegistryError("provider fragment root must be an object")
+    if set(data) != {"version", "provider", "targets"}:
+        raise RuntimeRegistryError("provider fragment has unexpected or missing fields")
+    if type(data.get("version")) is not int or data.get("version") != REGISTRY_VERSION:
+        raise RuntimeRegistryError("provider fragment has an unsupported version")
+    if data.get("provider") != provider_from_name:
+        raise RuntimeRegistryError(
+            "provider fragment name does not match its provider field"
+        )
+    targets = validate_fragment_targets(provider_from_name, data.get("targets"))
+    return tuple(
+        RuntimeTargetRecord(
+            execution_target=name,
+            provider=provider_from_name,
+            config=record["config"],
+            owner_id=record["owner_id"],
+            generation=record["generation"],
+            state=record["state"],
+        )
+        for name, record in sorted(targets.items())
+    )
+
+
+def _load_snapshot_uncached(directory: Path) -> RuntimeRegistrySnapshot:
+    diagnostics: list[RegistryDiagnostic] = []
+    records: list[RuntimeTargetRecord] = []
+    legacy_activated = False
+
+    try:
+        st = directory.lstat()
+    except FileNotFoundError:
+        return RuntimeRegistrySnapshot()
+    except OSError:
+        return RuntimeRegistrySnapshot(
+            diagnostics=(
+                RegistryDiagnostic(
+                    code="registry_unreadable",
+                    message="Runtime execution-target registry is unreadable.",
+                ),
+            )
+        )
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+        return RuntimeRegistrySnapshot(
+            diagnostics=(
+                RegistryDiagnostic(
+                    code="registry_unsafe",
+                    message="Runtime execution-target registry is not a secure directory.",
+                ),
+            )
+        )
+    permission_error = _user_only_error(
+        directory,
+        stat.S_IMODE(st.st_mode),
+        getattr(st, "st_uid", None),
+    )
+    if permission_error:
+        return RuntimeRegistrySnapshot(
+            diagnostics=(
+                RegistryDiagnostic(
+                    code="registry_permissions",
+                    message="Runtime execution-target registry permissions are not user-only.",
+                ),
+            )
+        )
+
+    state_path = directory / _STATE_FILENAME
+    try:
+        if os.path.lexists(state_path):
+            legacy_activated = _parse_state(state_path)
+    except RuntimeRegistryError:
+        diagnostics.append(
+            RegistryDiagnostic(
+                code="activation_state_invalid",
+                message="Runtime registry activation state is malformed or unsafe.",
+            )
+        )
+
+    try:
+        entries = sorted(directory.iterdir(), key=lambda item: item.name)
+    except OSError:
+        return RuntimeRegistrySnapshot(
+            diagnostics=tuple(diagnostics)
+            + (
+                RegistryDiagnostic(
+                    code="registry_unreadable",
+                    message="Runtime execution-target registry is unreadable.",
+                ),
+            ),
+            legacy_activated=legacy_activated,
+        )
+    fragment_entries = [
+        path
+        for path in entries
+        if not path.name.startswith(".") and path.suffix == ".json"
+    ]
+    casefold_groups: dict[str, list[Path]] = {}
+    for path in fragment_entries:
+        casefold_groups.setdefault(path.name.casefold(), []).append(path)
+    colliding_paths: set[Path] = set()
+    for paths in casefold_groups.values():
+        if len(paths) < 2:
+            continue
+        colliding_paths.update(paths)
+        try:
+            provider = validate_provider_name(paths[0].stem)
+        except RuntimeRegistryError:
+            provider = None
+        diagnostics.append(
+            RegistryDiagnostic(
+                code="provider_identity_collision",
+                provider=provider,
+                message=(
+                    f"Runtime target provider {provider!r} is unavailable because "
+                    "multiple fragment filenames have the same canonical identity."
+                    if provider is not None
+                    else "Runtime provider fragments have colliding unsafe filenames."
+                ),
+            )
+        )
+
+    for path in fragment_entries:
+        if path in colliding_paths:
+            continue
+        try:
+            provider = validate_provider_name(path.stem)
+        except RuntimeRegistryError:
+            provider = None
+        try:
+            records.extend(_parse_fragment(path))
+        except (OSError, RuntimeRegistryError):
+            diagnostics.append(
+                RegistryDiagnostic(
+                    code="provider_fragment_invalid",
+                    provider=provider,
+                    message=(
+                        f"Runtime target provider {provider!r} is unavailable because "
+                        "its fragment is malformed, unreadable, insecure, or symlinked."
+                        if provider is not None
+                        else "A runtime target provider fragment has an unsafe filename or schema."
+                    ),
+                )
+            )
+    return RuntimeRegistrySnapshot(
+        records=tuple(records),
+        diagnostics=tuple(diagnostics),
+        legacy_activated=legacy_activated,
+    )
+
+
+def load_runtime_registry(*, force: bool = False) -> RuntimeRegistrySnapshot:
+    """Load the active profile's registry with strong atomic-replace freshness."""
+    directory = registry_directory()
+    for _attempt in range(3):
+        before = _registry_signature(directory)
+        with _cache_lock:
+            cached = _snapshot_cache.get(directory)
+            if not force and cached is not None and cached[0] == before:
+                cached_snapshot = cached[1]
+            else:
+                cached_snapshot = None
+        if cached_snapshot is not None:
+            return _clone_snapshot(cached_snapshot)
+        snapshot = _load_snapshot_uncached(directory)
+        after = _registry_signature(directory)
+        if before == after:
+            with _cache_lock:
+                _snapshot_cache[directory] = (after, snapshot)
+            return _clone_snapshot(snapshot)
+    # A continuously changing provider should not make static targets fail.
+    return RuntimeRegistrySnapshot(
+        diagnostics=(
+            RegistryDiagnostic(
+                code="registry_changing",
+                message="Runtime execution-target registry changed while being read; retry the command.",
+            ),
+        )
+    )
+
+
+def invalidate_runtime_registry_cache() -> None:
+    directory = registry_directory()
+    with _cache_lock:
+        _snapshot_cache.pop(directory, None)
+
+
+def _ensure_registry_directory() -> Path:
+    directory = registry_directory()
+    runtime_directory = directory.parent
+    runtime_directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    runtime_st = runtime_directory.lstat()
+    if stat.S_ISLNK(runtime_st.st_mode) or not stat.S_ISDIR(runtime_st.st_mode):
+        raise RuntimeRegistryError("Runtime state path is not a secure directory.")
+    try:
+        runtime_directory.chmod(0o700)
+    except OSError:
+        pass
+    runtime_st = runtime_directory.lstat()
+    if _user_only_error(
+        runtime_directory,
+        stat.S_IMODE(runtime_st.st_mode),
+        getattr(runtime_st, "st_uid", None),
+    ):
+        raise RuntimeRegistryError("Runtime state directory is not user-only.")
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    st = directory.lstat()
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+        raise RuntimeRegistryError("Runtime registry path is not a secure directory.")
+    try:
+        directory.chmod(0o700)
+    except OSError:
+        pass
+    st = directory.lstat()
+    if stat.S_ISLNK(st.st_mode) or not stat.S_ISDIR(st.st_mode):
+        raise RuntimeRegistryError("Runtime registry path changed while being secured.")
+    permission_error = _user_only_error(
+        directory,
+        stat.S_IMODE(st.st_mode),
+        getattr(st, "st_uid", None),
+    )
+    if permission_error:
+        raise RuntimeRegistryError("Runtime registry directory is not user-only.")
+    return directory
+
+
+def _try_lock(handle: Any) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock(handle: Any) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def registry_write_lock(*, timeout_seconds: float = 5.0) -> Iterator[Path]:
+    """Acquire the bounded global registry lock for a read-modify-write."""
+    directory = _ensure_registry_directory()
+    lock_path = directory / _LOCK_FILENAME
+    before = None
+    if os.path.lexists(lock_path):
+        before = lock_path.lstat()
+        if stat.S_ISLNK(before.st_mode) or not stat.S_ISREG(before.st_mode):
+            raise RuntimeRegistryError("Runtime registry lock is not a regular file.")
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise RuntimeRegistryError(
+            "Could not safely open the runtime registry lock."
+        ) from exc
+    try:
+        opened = os.fstat(fd)
+        if before is not None and (
+            before.st_dev,
+            before.st_ino,
+        ) != (opened.st_dev, opened.st_ino):
+            raise RuntimeRegistryError("Runtime registry lock changed while opening.")
+        if not stat.S_ISREG(opened.st_mode):
+            raise RuntimeRegistryError("Runtime registry lock is not a regular file.")
+        try:
+            os.fchmod(fd, 0o600)
+        except OSError:
+            pass
+        opened = os.fstat(fd)
+        if _user_only_error(
+            lock_path,
+            stat.S_IMODE(opened.st_mode),
+            getattr(opened, "st_uid", None),
+        ):
+            raise RuntimeRegistryError("Runtime registry lock is not user-only.")
+    except Exception:
+        os.close(fd)
+        raise
+    handle = os.fdopen(fd, "a+b", buffering=0)
+    try:
+        if os.name == "nt" and opened.st_size == 0:
+            handle.write(b"0")
+            handle.flush()
+        deadline = time.monotonic() + max(0.1, timeout_seconds)
+        while not _try_lock(handle):
+            if time.monotonic() >= deadline:
+                raise RuntimeRegistryError(
+                    "Timed out waiting for another execution-target registry writer."
+                )
+            time.sleep(0.05)
+        try:
+            yield directory
+        finally:
+            _unlock(handle)
+    finally:
+        handle.close()
+
+
+def _serialized_json_bytes(payload: Mapping[str, Any]) -> bytes:
+    data = (
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+            separators=(",", ": "),
+        )
+        + "\n"
+    ).encode("utf-8")
+    if len(data) > MAX_REGISTRY_FILE_BYTES:
+        raise RuntimeRegistryError(
+            "Runtime registry data exceeds the total fragment size limit."
+        )
+    return data
+
+
+def _assert_no_casefold_alias(path: Path) -> None:
+    """Refuse a noncanonical directory entry that aliases *path*."""
+    try:
+        entries = path.parent.iterdir()
+        for entry in entries:
+            if (
+                entry.name.casefold() == path.name.casefold()
+                and entry.name != path.name
+            ):
+                raise RuntimeRegistryError(
+                    f"Refusing to replace noncanonical registry entry {entry.name!r}; "
+                    f"provider filenames must use {path.name!r}."
+                )
+    except RuntimeRegistryError:
+        raise
+    except OSError as exc:
+        raise RuntimeRegistryError(
+            "Could not verify runtime registry filename ownership."
+        ) from exc
+
+
+def _set_owner_only_mode(fd: int, path: Path) -> None:
+    """Apply mode 0600 despite the process umask, with a Windows fallback."""
+    fchmod = getattr(os, "fchmod", None)
+    if callable(fchmod):
+        try:
+            fchmod(fd, 0o600)
+            return
+        except (OSError, NotImplementedError):
+            pass
+    try:
+        os.chmod(path, 0o600, follow_symlinks=False)
+    except (TypeError, NotImplementedError):
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        if os.name != "nt":
+            raise RuntimeRegistryError(
+                f"Could not secure temporary registry file {path.name}."
+            ) from exc
+
+
+def _verify_publication_file(path: Path, *, fd: int | None = None) -> None:
+    """Verify one publication is a single-link, owner-only regular file."""
+    try:
+        linked = path.lstat()
+        opened = os.fstat(fd) if fd is not None else linked
+    except OSError as exc:
+        raise RuntimeRegistryError(
+            f"Registry publication {path.name} became unavailable."
+        ) from exc
+    if fd is not None and (linked.st_dev, linked.st_ino) != (
+        opened.st_dev,
+        opened.st_ino,
+    ):
+        raise RuntimeRegistryError(
+            f"Registry publication {path.name} changed while being written."
+        )
+    if not stat.S_ISREG(linked.st_mode) or not stat.S_ISREG(opened.st_mode):
+        raise RuntimeRegistryError(
+            f"Registry publication {path.name} is not a regular file."
+        )
+    if getattr(linked, "st_nlink", 1) != 1 or getattr(opened, "st_nlink", 1) != 1:
+        raise RuntimeRegistryError(
+            f"Registry publication {path.name} has an unsafe link count."
+        )
+    permission_error = _user_only_error(
+        path,
+        stat.S_IMODE(opened.st_mode),
+        getattr(opened, "st_uid", None),
+    )
+    if permission_error:
+        raise RuntimeRegistryError(permission_error)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    data = _serialized_json_bytes(payload)
+    _assert_no_casefold_alias(path)
+    temp = path.with_name(f".{path.name}.{os.getpid()}.{os.urandom(6).hex()}.tmp")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    fd = os.open(temp, flags, 0o600)
+    try:
+        _set_owner_only_mode(fd, temp)
+        _verify_publication_file(temp, fd=fd)
+        with os.fdopen(fd, "wb", closefd=False) as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _verify_publication_file(temp, fd=fd)
+        os.close(fd)
+        fd = -1
+        os.replace(temp, path)
+        _verify_publication_file(path)
+        try:
+            directory_fd = os.open(path.parent, os.O_RDONLY)
+        except OSError:
+            directory_fd = -1
+        if directory_fd >= 0:
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+
+
+RegistryMutator = Callable[
+    [RuntimeRegistrySnapshot, dict[str, dict[str, Any]]],
+    Mapping[str, Any],
+]
+
+
+def update_provider_fragment(
+    provider: str,
+    mutator: RegistryMutator,
+    *,
+    activate_legacy: bool = False,
+) -> RuntimeRegistrySnapshot:
+    """Atomically read/validate/update one provider-owned fragment.
+
+    The callback runs while the global cross-process lock is held.  If legacy
+    activation is requested, the callback sees the proposed activation in its
+    snapshot; only after it succeeds is activation state durably written,
+    followed by the provider fragment.  A crash between those writes therefore
+    leaves a valid live synthetic default and never a half-published target.
+    """
+    provider = validate_provider_name(provider)
+
+    with registry_write_lock() as directory:
+        snapshot = load_runtime_registry(force=True)
+        if any(diag.provider == provider for diag in snapshot.diagnostics):
+            raise RuntimeRegistryError(
+                f"Provider {provider!r} is unavailable; repair or remove its invalid fragment first."
+            )
+        current = {
+            record.execution_target: record.as_fragment_record()
+            for record in snapshot.records
+            if record.provider == provider
+        }
+        callback_snapshot = snapshot
+        if not snapshot.legacy_activated and activate_legacy:
+            callback_snapshot = RuntimeRegistrySnapshot(
+                records=snapshot.records,
+                diagnostics=snapshot.diagnostics,
+                legacy_activated=True,
+            )
+        new_targets = validate_fragment_targets(
+            provider,
+            mutator(callback_snapshot, deepcopy(current)),
+        )
+        fragment_payload = _fragment_payload(provider, new_targets)
+
+        # Validate the complete publication before the marker write below.  The
+        # atomic writer repeats this check for its own safety, but this preflight
+        # keeps legacy activation marker-only and preserves the complete visible
+        # target set when a provider's individually-valid configs exceed the
+        # fragment-wide byte limit.
+        _serialized_json_bytes(fragment_payload)
+
+        if not snapshot.legacy_activated and activate_legacy:
+            _atomic_write_json(
+                directory / _STATE_FILENAME,
+                {
+                    "version": REGISTRY_VERSION,
+                    "legacy_activated": True,
+                },
+            )
+        _atomic_write_json(
+            directory / f"{provider}.json",
+            fragment_payload,
+        )
+        invalidate_runtime_registry_cache()
+        return load_runtime_registry(force=True)
+
+
+def write_provider_fragment_for_tests(
+    provider: str,
+    targets: Mapping[str, Any],
+) -> Path:
+    """Publish a valid fragment through the production atomic writer.
+
+    This deliberately remains useful to provider integrations and acceptance
+    tests without exposing an unsafe partial-record mutation API.
+    """
+    provider = validate_provider_name(provider)
+    with registry_write_lock() as directory:
+        path = directory / f"{provider}.json"
+        _atomic_write_json(path, _fragment_payload(provider, targets))
+        invalidate_runtime_registry_cache()
+        return path

--- a/tools/execution_targets.py
+++ b/tools/execution_targets.py
@@ -1,0 +1,607 @@
+"""Resolve static named terminal execution targets.
+
+The resolver is deliberately small and lazy: importing tool schemas never reads
+user configuration, and configured names never enter a schema.  Legacy flat
+terminal configuration stays on the existing environment-variable path.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+import difflib
+import hashlib
+import hmac
+import json
+import math
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Any, Hashable, Iterable, Mapping, Optional
+
+
+class ExecutionTargetError(ValueError):
+    """Raised when terminal target configuration or selection is invalid."""
+
+
+_NAMED_TARGET_BACKENDS = frozenset({
+    "local", "docker", "ssh", "modal", "daytona", "singularity",
+    "vercel_sandbox",
+})
+
+_TARGET_COMMON_SETTINGS = frozenset({
+    "backend", "cwd", "timeout", "lifetime_seconds", "sudo_password",
+})
+_TARGET_CONTAINER_SETTINGS = frozenset({
+    "container_cpu", "container_memory", "container_disk",
+    "container_persistent",
+})
+_TARGET_BACKEND_SETTINGS = {
+    "local": frozenset({"local_persistent"}),
+    "ssh": frozenset({
+        "ssh_host", "ssh_user", "ssh_port", "ssh_key",
+        "ssh_persistent", "persistent_shell",
+    }),
+    "docker": _TARGET_CONTAINER_SETTINGS | frozenset({
+        "docker_image", "docker_forward_env", "docker_env",
+        "docker_volumes", "docker_mount_cwd_to_workspace",
+        "docker_network", "docker_extra_args", "docker_shm_size",
+        "docker_run_as_host_user", "docker_persist_across_processes",
+        "docker_orphan_reaper",
+    }),
+    "singularity": _TARGET_CONTAINER_SETTINGS | frozenset({"singularity_image"}),
+    "modal": _TARGET_CONTAINER_SETTINGS | frozenset({"modal_image", "modal_mode"}),
+    "daytona": _TARGET_CONTAINER_SETTINGS | frozenset({"daytona_image"}),
+    "vercel_sandbox": _TARGET_CONTAINER_SETTINGS | frozenset({"vercel_runtime"}),
+}
+_TARGET_ENTRY_SETTINGS = frozenset().union(
+    _TARGET_COMMON_SETTINGS, *_TARGET_BACKEND_SETTINGS.values()
+)
+_TARGET_BOOLEAN_SETTINGS = frozenset({
+    "container_persistent", "local_persistent", "ssh_persistent",
+    "persistent_shell", "docker_mount_cwd_to_workspace", "docker_network",
+    "docker_run_as_host_user", "docker_persist_across_processes",
+    "docker_orphan_reaper",
+})
+_TARGET_LIST_SETTINGS = frozenset({
+    "docker_forward_env", "docker_volumes", "docker_extra_args",
+})
+_TARGET_STRING_SETTINGS = frozenset({
+    "cwd", "docker_image", "singularity_image", "modal_image",
+    "daytona_image", "vercel_runtime", "ssh_host", "ssh_user", "ssh_key",
+    "docker_shm_size", "modal_mode", "sudo_password",
+})
+
+
+_effective_config_override: ContextVar[dict[str, Any] | None] = ContextVar(
+    "hermes_execution_target_config", default=None,
+)
+_frozen_config_active: ContextVar[bool] = ContextVar(
+    "hermes_execution_target_frozen", default=False,
+)
+_classic_config_lock = threading.RLock()
+_classic_config_override: dict[str, Any] | None = None
+_fingerprint_keys: dict[Path, bytes] = {}
+_fingerprint_key_lock = threading.Lock()
+
+
+def _target_fingerprint_key() -> bytes:
+    """Return a stable, private machine/profile key for exposed target digests."""
+    from hermes_constants import get_hermes_home
+
+    path = Path(get_hermes_home()) / ".execution-target-fingerprint-key"
+    with _fingerprint_key_lock:
+        cached = _fingerprint_keys.get(path)
+        if cached is not None:
+            return cached
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        candidate = os.urandom(32)
+        temp = path.with_name(
+            f".{path.name}.{os.getpid()}.{os.urandom(6).hex()}.tmp"
+        )
+        try:
+            fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(candidate)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temp, path)
+            except FileExistsError:
+                pass
+            except OSError:
+                # Filesystems without hard-link support still get O_EXCL
+                # publication; readers below wait for the winning writer.
+                try:
+                    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                except FileExistsError:
+                    pass
+                else:
+                    with os.fdopen(fd, "wb") as handle:
+                        handle.write(candidate)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+        finally:
+            try:
+                temp.unlink()
+            except OSError:
+                pass
+
+        key = b""
+        for _ in range(20):
+            try:
+                key = path.read_bytes()
+            except OSError:
+                key = b""
+            if len(key) >= 32:
+                break
+            time.sleep(0.01)
+        if len(key) < 32:
+            raise ExecutionTargetError(
+                f"Could not initialize private execution-target key at {path}."
+            )
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+        key = key[:32]
+        _fingerprint_keys[path] = key
+        return key
+
+
+def set_execution_target_config_source(config: Mapping[str, Any] | None) -> None:
+    """Use an entry point's already-effective config for target resolution.
+
+    The classic CLI has project-fallback and ``--ignore-user-config`` rules
+    that differ from the shared loader. Registering its merged result here
+    keeps tool routing on the same authority boundary. A live reload updates
+    the process-wide source, but never replaces an in-flight frozen snapshot.
+    """
+    global _classic_config_override
+    value = deepcopy(dict(config)) if isinstance(config, Mapping) else None
+    if not _frozen_config_active.get():
+        _effective_config_override.set(value)
+    with _classic_config_lock:
+        _classic_config_override = deepcopy(value)
+
+
+@contextmanager
+def execution_target_config_scope(config: Mapping[str, Any]):
+    """Temporarily pin target resolution in the current context only."""
+    prior_override = deepcopy(_effective_config_override.get())
+    token = _effective_config_override.set(deepcopy(dict(config)))
+    frozen_token = _frozen_config_active.set(True)
+    try:
+        yield
+    finally:
+        _frozen_config_active.reset(frozen_token)
+        _effective_config_override.reset(token)
+        # A reload that occurred during the frozen dispatch is the authority
+        # for the next call. Adopt it only when leaving the outermost scope;
+        # nested execute-code scopes remain pinned to their outer generation.
+        if not _frozen_config_active.get():
+            with _classic_config_lock:
+                live_override = deepcopy(_classic_config_override)
+            if live_override != prior_override:
+                _effective_config_override.set(live_override)
+
+
+def execution_target_config_is_frozen() -> bool:
+    """Return whether this call is pinned to one dispatch generation."""
+    return _frozen_config_active.get()
+
+
+@contextmanager
+def frozen_execution_target_config():
+    """Freeze the current merged target config for one complete tool dispatch."""
+    with execution_target_config_scope(_load_merged_config()):
+        yield
+
+
+def _active_profile_scope() -> str:
+    """Return a stable multiplex-profile scope, empty in legacy mode."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+        if not is_multiplex_active():
+            return ""
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home().resolve())
+        return hashlib.sha256(home.encode("utf-8")).hexdigest()[:12]
+    except Exception:
+        return ""
+
+
+@dataclass(frozen=True)
+class ExecutionTargetResolution:
+    """A resolved execution target and its inherited terminal configuration."""
+
+    target: str
+    backend: str
+    config: Mapping[str, Any]
+    named: bool
+    is_default: bool = True
+    profile_scope: str = ""
+
+    @property
+    def spec_fingerprint(self) -> str:
+        """Hash the fully inherited target spec used to create resources.
+
+        Target names are mutable configuration aliases, not security identities.
+        Including the complete resolved spec prevents a hot config edit from
+        reusing an environment created for a different host/backend/image.
+        """
+        canonical = json.dumps(
+            {
+                "config": dict(self.config),
+                "is_default": self.is_default,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=repr,
+        )
+        return hmac.new(
+            _target_fingerprint_key(),
+            canonical.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()[:20]
+
+    @property
+    def security_scope(self) -> str:
+        """Return the profile/name/spec identity for approvals and credentials."""
+        value = f"{self.profile_scope}:{self.target}:{self.spec_fingerprint}"
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:20]
+
+    def scope_task_key(self, task_key: Hashable) -> Hashable:
+        if not self.profile_scope:
+            return task_key
+        return f"profile-{self.profile_scope}:{task_key}"
+
+    def environment_key(self, task_key: Hashable) -> Hashable:
+        """Scope an already-collapsed environment key to this target."""
+        scoped = self.scope_task_key(task_key)
+        return (scoped, self.target) if self.named else scoped
+
+    def session_key(self, raw_session_key: Optional[str]) -> Hashable:
+        """Scope per-session state without changing legacy string keys."""
+        key = str(self.scope_task_key(str(raw_session_key or "default")))
+        return (key, self.target) if self.named else key
+
+    def backend_task_id(self, task_key: Hashable) -> str:
+        """Return a bounded backend-safe isolation id.
+
+        Docker labels are limited to 63 characters. Keep fixed hash suffixes of
+        both the complete task identity and target spec so long task IDs cannot
+        truncate away the only target-distinguishing bytes.
+        """
+        base = str(self.scope_task_key(task_key))
+        if not self.named:
+            return base
+        base_digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
+        return f"task-{base_digest}-target-{self.security_scope}"
+
+    def storage_task_id(self, base_task_id: str) -> str:
+        """Stable, bounded identity for persistent storage owned by a target.
+
+        Runtime identity includes the full effective config so a repointed
+        target cannot reuse a stale container. Persistent filesystem ownership
+        intentionally depends only on profile + target name, keeping data stable
+        across timeout, lifetime, image, and other policy edits.
+        """
+        if not self.named:
+            return base_task_id
+        base_digest = hashlib.sha256(
+            base_task_id.encode("utf-8", errors="surrogatepass")
+        ).hexdigest()[:16]
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home().resolve())
+        owner = f"{self.profile_scope}\0{home}\0{self.target}"
+        owner_digest = hashlib.sha256(owner.encode("utf-8")).hexdigest()[:20]
+        return f"task-{base_digest}-storage-{owner_digest}"
+
+    def legacy_backend_task_id(self, base_task_id: str) -> str:
+        """Return the pre-fingerprint named-target backend ID for migration."""
+        base = str(self.scope_task_key(base_task_id))
+        if not self.named:
+            return base
+        target_digest = hashlib.sha256(
+            self.target.encode("utf-8")
+        ).hexdigest()[:12]
+        return f"{base}-target-{target_digest}"
+
+    def metadata(self, *, cwd: Optional[str] = None) -> dict[str, Any]:
+        data: dict[str, Any] = {"target": self.target, "backend": self.backend}
+        if self.named:
+            data["runtime_scope"] = self.security_scope
+        if cwd:
+            data["cwd"] = cwd
+        return data
+
+
+def _load_unscoped_config() -> dict[str, Any]:
+    """Load the live source while ignoring a nested frozen RPC snapshot."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        multiplex = is_multiplex_active()
+    except Exception:
+        multiplex = False
+    if not multiplex:
+        with _classic_config_lock:
+            override = deepcopy(_classic_config_override)
+        if override is not None:
+            return override
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly()
+    return config if isinstance(config, dict) else {}
+
+
+def _load_merged_config() -> dict[str, Any]:
+    """Load merged config lazily so importing fixed tool schemas stays cheap."""
+    override = _effective_config_override.get()
+    if override is not None:
+        return deepcopy(override)
+    return _load_unscoped_config()
+
+
+def _available(names: Iterable[str]) -> str:
+    return ", ".join(repr(name) for name in sorted(names)) or "(none)"
+
+
+
+def _validate_named_target_entry(
+    name: str,
+    entry: Mapping[str, Any],
+    effective: Mapping[str, Any],
+    backend: str,
+) -> None:
+    """Fail fast on misspelled, inapplicable, or malformed target settings."""
+    allowed = _TARGET_COMMON_SETTINGS | _TARGET_BACKEND_SETTINGS[backend]
+    for key in entry:
+        if not isinstance(key, str):
+            raise ExecutionTargetError(
+                f"Execution target {name!r} setting names must be strings; got {key!r}."
+            )
+        if key not in allowed:
+            if key in _TARGET_ENTRY_SETTINGS:
+                raise ExecutionTargetError(
+                    f"Execution target {name!r} setting {key!r} does not apply "
+                    f"to backend {backend!r}."
+                )
+            match = difflib.get_close_matches(
+                key, sorted(_TARGET_ENTRY_SETTINGS), n=1, cutoff=0.7,
+            )
+            hint = f" Did you mean {match[0]!r}?" if match else ""
+            raise ExecutionTargetError(
+                f"Execution target {name!r} has unknown setting {key!r}.{hint}"
+            )
+
+    def invalid(key: str, expected: str) -> None:
+        raise ExecutionTargetError(
+            f"Execution target {name!r} setting {key!r} has an invalid shape; "
+            f"expected {expected}."
+        )
+
+    for key in allowed & set(effective):
+        value = effective[key]
+        if key in _TARGET_BOOLEAN_SETTINGS:
+            if isinstance(value, bool):
+                continue
+            if str(value).strip().lower() not in {
+                "true", "false", "1", "0", "yes", "no",
+            }:
+                invalid(key, "boolean")
+        elif key in _TARGET_LIST_SETTINGS:
+            if not isinstance(value, list) or any(
+                not isinstance(item, str) for item in value
+            ):
+                invalid(key, "list of strings")
+        elif key == "docker_env":
+            if not isinstance(value, Mapping) or any(
+                not isinstance(item_key, str) or not isinstance(item_value, str)
+                for item_key, item_value in value.items()
+            ):
+                invalid(key, "mapping of string keys to string values")
+        elif key in _TARGET_STRING_SETTINGS:
+            if not isinstance(value, str):
+                invalid(key, "a string")
+        elif key == "container_cpu":
+            if isinstance(value, bool):
+                invalid(key, "a non-negative number")
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                invalid(key, "a finite non-negative number")
+            if not math.isfinite(number) or number < 0:
+                invalid(key, "a finite non-negative number")
+        elif key in {"container_memory", "container_disk"}:
+            if isinstance(value, bool):
+                invalid(key, "a non-negative integer")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "a non-negative integer")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "a non-negative integer")
+            if number < 0:
+                invalid(key, "a non-negative integer")
+        elif key in {"timeout", "lifetime_seconds"}:
+            if isinstance(value, bool):
+                invalid(key, "a positive integer")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "a positive integer")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "a positive integer")
+            if number <= 0:
+                invalid(key, "a positive integer")
+        elif key == "ssh_port":
+            if isinstance(value, bool):
+                invalid(key, "an integer from 1 to 65535")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "an integer from 1 to 65535")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "an integer from 1 to 65535")
+            if not 1 <= number <= 65535:
+                invalid(key, "an integer from 1 to 65535")
+
+    if backend == "ssh":
+        for key in ("ssh_host", "ssh_user"):
+            value = effective.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ExecutionTargetError(
+                    f"Execution target {name!r} with backend 'ssh' requires "
+                    f"non-empty {key!r}."
+                )
+    if backend == "modal" and "modal_mode" in effective:
+        if str(effective["modal_mode"]).strip().lower() not in {
+            "auto", "direct", "managed",
+        }:
+            invalid("modal_mode", "one of 'auto', 'direct', or 'managed'")
+
+
+def resolve_execution_target(
+    target: Optional[str] = None,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+) -> ExecutionTargetResolution:
+    """Resolve *target* against merged ``terminal`` configuration.
+
+    With no non-empty ``terminal.targets`` mapping, only omitted target and
+    explicit ``"default"`` are valid and the returned configuration marks the
+    legacy env-driven path.  With named targets, top-level terminal settings
+    are inherited and the selected target mapping overrides them.
+    """
+    if target is not None and (not isinstance(target, str) or not target):
+        raise ExecutionTargetError("Execution target must be a non-empty string.")
+
+    root = config if config is not None else _load_merged_config()
+    profile_scope = _active_profile_scope()
+    if not isinstance(root, Mapping):
+        raise ExecutionTargetError("Terminal configuration must be a mapping.")
+    terminal = root.get("terminal", {})
+    if terminal is None:
+        terminal = {}
+    if not isinstance(terminal, Mapping):
+        raise ExecutionTargetError("terminal must be a mapping.")
+
+    raw_targets = terminal.get("targets")
+    if raw_targets is None or raw_targets == {}:
+        if target not in (None, "default"):
+            raise ExecutionTargetError(
+                f"Unknown execution target {target!r}. Named targets are not configured. "
+                f"Available targets: {_available(['default'])}."
+            )
+        flat = dict(terminal)
+        flat.pop("targets", None)
+        flat.pop("default_target", None)
+        # Legacy flat mode preserves the historical TERMINAL_ENV precedence.
+        # Metadata must describe the backend that will actually execute, not a
+        # stale config.yaml value hidden by an explicit launcher/.env override.
+        backend = str(
+            os.getenv("TERMINAL_ENV")
+            or flat.get("backend")
+            or flat.get("env_type")
+            or "local"
+        ).strip().lower() or "local"
+        return ExecutionTargetResolution(
+            target="default", backend=backend, config=flat, named=False,
+            is_default=True, profile_scope=profile_scope,
+        )
+
+    if not isinstance(raw_targets, Mapping):
+        raise ExecutionTargetError("terminal.targets must be a mapping.")
+
+    invalid_names = [
+        name for name in raw_targets
+        if not isinstance(name, str) or not name
+    ]
+    if invalid_names:
+        raise ExecutionTargetError("terminal.targets names must be non-empty strings.")
+
+    names = sorted(raw_targets)
+    for name in names:
+        if not isinstance(raw_targets[name], Mapping):
+            raise ExecutionTargetError(
+                f"terminal.targets[{name!r}] must be a mapping. "
+                f"Available targets: {_available(names)}."
+            )
+
+    selected = target if target is not None else terminal.get("default_target")
+    if not isinstance(selected, str) or not selected or selected not in raw_targets:
+        if target is not None:
+            prefix = f"Unknown execution target {target!r}."
+        else:
+            prefix = (
+                "terminal.default_target must be a non-empty name present in "
+                "terminal.targets."
+            )
+        raise ExecutionTargetError(
+            f"{prefix} Available targets: {_available(names)}."
+        )
+
+    merged = {
+        key: value
+        for key, value in terminal.items()
+        if key not in {"targets", "default_target"}
+    }
+    merged.update(dict(raw_targets[selected]))
+    backend = str(
+        merged.get("backend") or merged.get("env_type") or "local"
+    ).strip().lower() or "local"
+    if backend not in _NAMED_TARGET_BACKENDS:
+        available_backends = ", ".join(sorted(_NAMED_TARGET_BACKENDS))
+        raise ExecutionTargetError(
+            f"Execution target {selected!r} has unknown backend {backend!r}. "
+            f"Available backends: {available_backends}."
+        )
+    _validate_named_target_entry(
+        selected, raw_targets[selected], merged, backend,
+    )
+    return ExecutionTargetResolution(
+        target=selected, backend=backend, config=merged, named=True,
+        is_default=selected == terminal.get("default_target"),
+        profile_scope=profile_scope,
+    )
+
+
+def resolve_live_execution_target(
+    target: Optional[str] = None,
+) -> ExecutionTargetResolution:
+    """Resolve against the live source when nested RPC routing is frozen."""
+    if not _frozen_config_active.get():
+        return resolve_execution_target(target)
+    return resolve_execution_target(target, config=_load_unscoped_config())
+
+
+def list_execution_targets(
+    *, config: Optional[Mapping[str, Any]] = None,
+) -> tuple[ExecutionTargetResolution, ...]:
+    """Return configured targets in deterministic order for runtime guidance.
+
+    Tool schemas remain static for prompt-cache stability; callers such as the
+    system-prompt environment hint can use this lightweight runtime inventory
+    to tell the model which fixed-string target values are available.
+    """
+    root = config if config is not None else _load_merged_config()
+    terminal = root.get("terminal", {}) if isinstance(root, Mapping) else {}
+    targets = terminal.get("targets") if isinstance(terminal, Mapping) else None
+    if not isinstance(targets, Mapping) or not targets:
+        return (resolve_execution_target(config=root),)
+    # Resolve the default first so name/default validation uses the same clear
+    # ExecutionTargetError shape as an ordinary omitted-selector tool call.
+    resolve_execution_target(config=root)
+    return tuple(
+        resolve_execution_target(name, config=root)
+        for name in sorted(targets)
+    )

--- a/tools/execution_targets.py
+++ b/tools/execution_targets.py
@@ -1,0 +1,904 @@
+"""Resolve static and profile-scoped runtime terminal execution targets.
+
+The resolver is deliberately small and lazy: importing tool schemas never reads
+user configuration, and configured names never enter a schema.  Legacy flat
+terminal configuration stays on the existing environment-variable path.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+import difflib
+import hashlib
+import hmac
+import json
+import math
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Any, Hashable, Iterable, Mapping, Optional
+
+
+class ExecutionTargetError(ValueError):
+    """Raised when terminal target configuration or selection is invalid."""
+
+
+_EXECUTION_TARGET_ARGUMENT_TOOLS = frozenset({
+    "terminal", "read_file", "write_file", "patch",
+    "search_files", "execute_code",
+})
+
+
+def uses_execution_target_argument(tool_name: str) -> bool:
+    """Return whether *tool_name* exposes model-facing execution routing."""
+    return tool_name in _EXECUTION_TARGET_ARGUMENT_TOOLS
+
+
+def validate_execution_target_args(
+    tool_name: str, arguments: Mapping[str, Any],
+) -> None:
+    """Enforce canonical, non-polymorphic execution-routing arguments.
+
+    ``search_files.target`` is a separate content/files selector. Every other
+    target-aware model tool routes only through ``execution_target``. Exact
+    built-in container and string types are required at this trust boundary so
+    middleware-controlled subclasses cannot redefine key access or equality.
+    """
+    if tool_name not in _EXECUTION_TARGET_ARGUMENT_TOOLS:
+        return
+    if type(arguments) is not dict:
+        raise ExecutionTargetError(
+            f"{tool_name} arguments must be a plain JSON object for execution routing."
+        )
+    if any(type(key) is not str for key in arguments):
+        raise ExecutionTargetError(
+            f"{tool_name} argument names must be plain strings for execution routing."
+        )
+    if tool_name != "search_files" and "target" in arguments:
+        raise ExecutionTargetError(
+            f"{tool_name} does not accept 'target'; use 'execution_target' "
+            "for execution routing."
+        )
+    if "execution_target" in arguments:
+        value = arguments["execution_target"]
+        if value is not None and type(value) is not str:
+            raise ExecutionTargetError(
+                f"{tool_name} 'execution_target' must be a plain string when provided."
+            )
+
+
+def validate_execution_target_dispatch_args(
+    tool_name: str,
+    authorized_arguments: Mapping[str, Any],
+    dispatch_arguments: Mapping[str, Any],
+) -> None:
+    """Prevent execution middleware from changing routing after authorization.
+
+    Tool request middleware runs before hooks and approvals, so it may select an
+    execution target. Tool execution middleware may still rewrite ordinary
+    arguments, but it must not add, remove, or replace that routing selector.
+    """
+    validate_execution_target_args(tool_name, authorized_arguments)
+    validate_execution_target_args(tool_name, dispatch_arguments)
+    if tool_name not in _EXECUTION_TARGET_ARGUMENT_TOOLS:
+        return
+
+    authorized_has_target = "execution_target" in authorized_arguments
+    dispatch_has_target = "execution_target" in dispatch_arguments
+    if authorized_has_target != dispatch_has_target or (
+        authorized_has_target
+        and authorized_arguments["execution_target"]
+        != dispatch_arguments["execution_target"]
+    ):
+        raise ExecutionTargetError(
+            f"{tool_name} execution middleware cannot change "
+            "'execution_target' after authorization; use tool request "
+            "middleware to select the execution target before authorization."
+        )
+
+
+_NAMED_TARGET_BACKENDS = frozenset({
+    "local", "docker", "ssh", "modal", "daytona", "singularity",
+    "vercel_sandbox",
+})
+
+_TARGET_COMMON_SETTINGS = frozenset({
+    "backend", "cwd", "timeout", "lifetime_seconds", "sudo_password",
+})
+_TARGET_CONTAINER_SETTINGS = frozenset({
+    "container_cpu", "container_memory", "container_disk",
+    "container_persistent",
+})
+_TARGET_BACKEND_SETTINGS = {
+    "local": frozenset({"local_persistent"}),
+    "ssh": frozenset({
+        "ssh_host", "ssh_user", "ssh_port", "ssh_key",
+        "ssh_persistent", "persistent_shell",
+    }),
+    "docker": _TARGET_CONTAINER_SETTINGS | frozenset({
+        "docker_image", "docker_forward_env", "docker_env",
+        "docker_volumes", "docker_mount_cwd_to_workspace",
+        "docker_network", "docker_extra_args", "docker_shm_size",
+        "docker_run_as_host_user", "docker_persist_across_processes",
+        "docker_orphan_reaper",
+    }),
+    "singularity": _TARGET_CONTAINER_SETTINGS | frozenset({"singularity_image"}),
+    "modal": _TARGET_CONTAINER_SETTINGS | frozenset({"modal_image", "modal_mode"}),
+    "daytona": _TARGET_CONTAINER_SETTINGS | frozenset({"daytona_image"}),
+    "vercel_sandbox": _TARGET_CONTAINER_SETTINGS | frozenset({"vercel_runtime"}),
+}
+_TARGET_ENTRY_SETTINGS = frozenset().union(
+    _TARGET_COMMON_SETTINGS, *_TARGET_BACKEND_SETTINGS.values()
+)
+_TARGET_BOOLEAN_SETTINGS = frozenset({
+    "container_persistent", "local_persistent", "ssh_persistent",
+    "persistent_shell", "docker_mount_cwd_to_workspace", "docker_network",
+    "docker_run_as_host_user", "docker_persist_across_processes",
+    "docker_orphan_reaper",
+})
+_TARGET_LIST_SETTINGS = frozenset({
+    "docker_forward_env", "docker_volumes", "docker_extra_args",
+})
+_TARGET_STRING_SETTINGS = frozenset({
+    "cwd", "docker_image", "singularity_image", "modal_image",
+    "daytona_image", "vercel_runtime", "ssh_host", "ssh_user", "ssh_key",
+    "docker_shm_size", "modal_mode", "sudo_password",
+})
+_REGISTRY_METADATA_KEY = "__execution_target_registry_v1__"
+
+
+_effective_config_override: ContextVar[dict[str, Any] | None] = ContextVar(
+    "hermes_execution_target_config", default=None,
+)
+_frozen_config_active: ContextVar[bool] = ContextVar(
+    "hermes_execution_target_frozen", default=False,
+)
+_classic_config_lock = threading.RLock()
+_classic_config_override: dict[str, Any] | None = None
+_fingerprint_keys: dict[Path, bytes] = {}
+_fingerprint_key_lock = threading.Lock()
+
+
+def _target_fingerprint_key() -> bytes:
+    """Return a stable, private machine/profile key for exposed target digests."""
+    from hermes_constants import get_hermes_home
+
+    path = Path(get_hermes_home()) / ".execution-target-fingerprint-key"
+    with _fingerprint_key_lock:
+        cached = _fingerprint_keys.get(path)
+        if cached is not None:
+            return cached
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        candidate = os.urandom(32)
+        temp = path.with_name(
+            f".{path.name}.{os.getpid()}.{os.urandom(6).hex()}.tmp"
+        )
+        try:
+            fd = os.open(temp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(candidate)
+                handle.flush()
+                os.fsync(handle.fileno())
+            try:
+                os.link(temp, path)
+            except FileExistsError:
+                pass
+            except OSError:
+                # Filesystems without hard-link support still get O_EXCL
+                # publication; readers below wait for the winning writer.
+                try:
+                    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                except FileExistsError:
+                    pass
+                else:
+                    with os.fdopen(fd, "wb") as handle:
+                        handle.write(candidate)
+                        handle.flush()
+                        os.fsync(handle.fileno())
+        finally:
+            try:
+                temp.unlink()
+            except OSError:
+                pass
+
+        key = b""
+        for _ in range(20):
+            try:
+                key = path.read_bytes()
+            except OSError:
+                key = b""
+            if len(key) >= 32:
+                break
+            time.sleep(0.01)
+        if len(key) < 32:
+            raise ExecutionTargetError(
+                f"Could not initialize private execution-target key at {path}."
+            )
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+        key = key[:32]
+        _fingerprint_keys[path] = key
+        return key
+
+
+def set_execution_target_config_source(config: Mapping[str, Any] | None) -> None:
+    """Use an entry point's already-effective config for target resolution.
+
+    The classic CLI has project-fallback and ``--ignore-user-config`` rules
+    that differ from the shared loader. Registering its merged result here
+    keeps tool routing on the same authority boundary. A live reload updates
+    the process-wide source, but never replaces an in-flight frozen snapshot.
+    """
+    global _classic_config_override
+    value = deepcopy(dict(config)) if isinstance(config, Mapping) else None
+    if not _frozen_config_active.get():
+        _effective_config_override.set(value)
+    with _classic_config_lock:
+        _classic_config_override = deepcopy(value)
+
+
+@contextmanager
+def execution_target_config_scope(config: Mapping[str, Any]):
+    """Temporarily pin target resolution in the current context only."""
+    prior_override = deepcopy(_effective_config_override.get())
+    token = _effective_config_override.set(deepcopy(dict(config)))
+    frozen_token = _frozen_config_active.set(True)
+    try:
+        yield
+    finally:
+        _frozen_config_active.reset(frozen_token)
+        _effective_config_override.reset(token)
+        # A reload that occurred during the frozen dispatch is the authority
+        # for the next call. Adopt it only when leaving the outermost scope;
+        # nested execute-code scopes remain pinned to their outer generation.
+        if not _frozen_config_active.get():
+            with _classic_config_lock:
+                live_override = deepcopy(_classic_config_override)
+            if live_override != prior_override:
+                _effective_config_override.set(live_override)
+
+
+def execution_target_config_is_frozen() -> bool:
+    """Return whether this call is pinned to one dispatch generation."""
+    return _frozen_config_active.get()
+
+
+@contextmanager
+def frozen_execution_target_config():
+    """Freeze the current merged target config for one complete tool dispatch."""
+    with execution_target_config_scope(_load_merged_config()):
+        yield
+
+
+def _active_profile_scope() -> str:
+    """Return a stable multiplex-profile scope, empty in legacy mode."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+        if not is_multiplex_active():
+            return ""
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home().resolve())
+        return hashlib.sha256(home.encode("utf-8")).hexdigest()[:12]
+    except Exception:
+        return ""
+
+
+@dataclass(frozen=True)
+class ExecutionTargetResolution:
+    """A resolved execution target and its inherited terminal configuration."""
+
+    target: str
+    backend: str
+    config: Mapping[str, Any]
+    named: bool
+    is_default: bool = True
+    profile_scope: str = ""
+    provider: str | None = None
+    owner_id: str | None = None
+    generation: str | None = None
+
+    @property
+    def spec_fingerprint(self) -> str:
+        """Hash the fully inherited target spec used to create resources.
+
+        Target names are mutable configuration aliases, not security identities.
+        Including the complete resolved spec prevents a hot config edit from
+        reusing an environment created for a different host/backend/image.
+        """
+        canonical = json.dumps(
+            {
+                "config": dict(self.config),
+                "is_default": self.is_default,
+                "runtime_registry": {
+                    "provider": self.provider,
+                    "owner_id": self.owner_id,
+                    "generation": self.generation,
+                } if self.provider is not None else None,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            default=repr,
+        )
+        return hmac.new(
+            _target_fingerprint_key(),
+            canonical.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()[:20]
+
+    @property
+    def security_scope(self) -> str:
+        """Return the profile/name/spec identity for approvals and credentials."""
+        value = f"{self.profile_scope}:{self.target}:{self.spec_fingerprint}"
+        return hashlib.sha256(value.encode("utf-8")).hexdigest()[:20]
+
+    def scope_task_key(self, task_key: Hashable) -> Hashable:
+        if not self.profile_scope:
+            return task_key
+        return f"profile-{self.profile_scope}:{task_key}"
+
+    def environment_key(self, task_key: Hashable) -> Hashable:
+        """Scope an already-collapsed environment key to this target."""
+        scoped = self.scope_task_key(task_key)
+        return (scoped, self.target) if self.named else scoped
+
+    def session_key(self, raw_session_key: Optional[str]) -> Hashable:
+        """Scope per-session state without changing legacy string keys."""
+        key = str(self.scope_task_key(str(raw_session_key or "default")))
+        return (key, self.target) if self.named else key
+
+    def file_coordination_key(self, raw_session_key: Optional[str]) -> Hashable:
+        """Return file-operation state identity, generation-scoped at runtime.
+
+        Static named targets retain their historical per-alias session key.
+        Runtime aliases add their immutable security scope so a provider
+        repoint cannot inherit repeated-read, stale-write, or patch state.
+        """
+        key = self.session_key(raw_session_key)
+        if self.provider is None or not isinstance(key, tuple):
+            return key
+        return (key[0], f"{key[1]}@runtime-{self.security_scope}")
+
+    def backend_task_id(self, task_key: Hashable) -> str:
+        """Return a bounded backend-safe isolation id.
+
+        Docker labels are limited to 63 characters. Keep fixed hash suffixes of
+        both the complete task identity and target spec so long task IDs cannot
+        truncate away the only target-distinguishing bytes.
+        """
+        base = str(self.scope_task_key(task_key))
+        if not self.named:
+            return base
+        base_digest = hashlib.sha256(base.encode("utf-8")).hexdigest()[:16]
+        return f"task-{base_digest}-target-{self.security_scope}"
+
+    def storage_task_id(self, base_task_id: str) -> str:
+        """Stable, bounded identity for persistent storage owned by a target.
+
+        Runtime identity includes the full effective config so a repointed
+        target cannot reuse a stale container. Persistent filesystem ownership
+        intentionally depends only on profile + target name, keeping data stable
+        across timeout, lifetime, image, and other policy edits.
+        """
+        if not self.named:
+            return base_task_id
+        base_digest = hashlib.sha256(
+            base_task_id.encode("utf-8", errors="surrogatepass")
+        ).hexdigest()[:16]
+        from hermes_constants import get_hermes_home
+
+        home = str(get_hermes_home().resolve())
+        owner = f"{self.profile_scope}\0{home}\0{self.target}"
+        owner_digest = hashlib.sha256(owner.encode("utf-8")).hexdigest()[:20]
+        return f"task-{base_digest}-storage-{owner_digest}"
+
+    def legacy_backend_task_id(self, base_task_id: str) -> str:
+        """Return the pre-fingerprint named-target backend ID for migration."""
+        base = str(self.scope_task_key(base_task_id))
+        if not self.named:
+            return base
+        target_digest = hashlib.sha256(
+            self.target.encode("utf-8")
+        ).hexdigest()[:12]
+        return f"{base}-target-{target_digest}"
+
+    def metadata(self, *, cwd: Optional[str] = None) -> dict[str, Any]:
+        data: dict[str, Any] = {"target": self.target, "backend": self.backend}
+        if self.named:
+            data["runtime_scope"] = self.security_scope
+        if cwd:
+            data["cwd"] = cwd
+        return data
+
+
+def _load_static_unscoped_config() -> dict[str, Any]:
+    """Load static effective config without runtime target fragments."""
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        multiplex = is_multiplex_active()
+    except Exception:
+        multiplex = False
+    if not multiplex:
+        with _classic_config_lock:
+            override = deepcopy(_classic_config_override)
+        if override is not None:
+            return override
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly()
+    return config if isinstance(config, dict) else {}
+
+
+def load_static_execution_target_config() -> dict[str, Any]:
+    """Return current effective static config for registry management."""
+    return deepcopy(_load_static_unscoped_config())
+
+
+def _load_unscoped_config() -> dict[str, Any]:
+    """Load live static config plus the current profile registry."""
+    from tools.execution_target_overlay import overlay_runtime_execution_targets
+
+    return overlay_runtime_execution_targets(_load_static_unscoped_config())
+
+
+def _load_merged_config() -> dict[str, Any]:
+    """Load merged config lazily so importing fixed tool schemas stays cheap."""
+    override = _effective_config_override.get()
+    if override is not None:
+        if _frozen_config_active.get():
+            return deepcopy(override)
+        from tools.execution_target_overlay import overlay_runtime_execution_targets
+
+        return overlay_runtime_execution_targets(override)
+    return _load_unscoped_config()
+
+
+def _available(names: Iterable[str]) -> str:
+    return ", ".join(repr(name) for name in sorted(names)) or "(none)"
+
+
+
+def _validate_named_target_entry(
+    name: str,
+    entry: Mapping[str, Any],
+    effective: Mapping[str, Any],
+    backend: str,
+) -> None:
+    """Fail fast on misspelled, inapplicable, or malformed target settings."""
+    allowed = _TARGET_COMMON_SETTINGS | _TARGET_BACKEND_SETTINGS[backend]
+    for key in entry:
+        if not isinstance(key, str):
+            raise ExecutionTargetError(
+                f"Execution target {name!r} setting names must be strings; got {key!r}."
+            )
+        if key not in allowed:
+            if key in _TARGET_ENTRY_SETTINGS:
+                raise ExecutionTargetError(
+                    f"Execution target {name!r} setting {key!r} does not apply "
+                    f"to backend {backend!r}."
+                )
+            match = difflib.get_close_matches(
+                key, sorted(_TARGET_ENTRY_SETTINGS), n=1, cutoff=0.7,
+            )
+            hint = f" Did you mean {match[0]!r}?" if match else ""
+            raise ExecutionTargetError(
+                f"Execution target {name!r} has unknown setting {key!r}.{hint}"
+            )
+
+    def invalid(key: str, expected: str) -> None:
+        raise ExecutionTargetError(
+            f"Execution target {name!r} setting {key!r} has an invalid shape; "
+            f"expected {expected}."
+        )
+
+    for key in allowed & set(effective):
+        value = effective[key]
+        if key in _TARGET_BOOLEAN_SETTINGS:
+            if isinstance(value, bool):
+                continue
+            if str(value).strip().lower() not in {
+                "true", "false", "1", "0", "yes", "no",
+            }:
+                invalid(key, "boolean")
+        elif key in _TARGET_LIST_SETTINGS:
+            if not isinstance(value, list) or any(
+                not isinstance(item, str) for item in value
+            ):
+                invalid(key, "list of strings")
+        elif key == "docker_env":
+            if not isinstance(value, Mapping) or any(
+                not isinstance(item_key, str) or not isinstance(item_value, str)
+                for item_key, item_value in value.items()
+            ):
+                invalid(key, "mapping of string keys to string values")
+        elif key in _TARGET_STRING_SETTINGS:
+            if not isinstance(value, str):
+                invalid(key, "a string")
+        elif key == "container_cpu":
+            if isinstance(value, bool):
+                invalid(key, "a non-negative number")
+            try:
+                number = float(value)
+            except (TypeError, ValueError):
+                invalid(key, "a finite non-negative number")
+            if not math.isfinite(number) or number < 0:
+                invalid(key, "a finite non-negative number")
+        elif key in {"container_memory", "container_disk"}:
+            if isinstance(value, bool):
+                invalid(key, "a non-negative integer")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "a non-negative integer")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "a non-negative integer")
+            if number < 0:
+                invalid(key, "a non-negative integer")
+        elif key in {"timeout", "lifetime_seconds"}:
+            if isinstance(value, bool):
+                invalid(key, "a positive integer")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "a positive integer")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "a positive integer")
+            if number <= 0:
+                invalid(key, "a positive integer")
+        elif key == "ssh_port":
+            if isinstance(value, bool):
+                invalid(key, "an integer from 1 to 65535")
+            if isinstance(value, float) and not value.is_integer():
+                invalid(key, "an integer from 1 to 65535")
+            try:
+                number = int(value)
+            except (TypeError, ValueError):
+                invalid(key, "an integer from 1 to 65535")
+            if not 1 <= number <= 65535:
+                invalid(key, "an integer from 1 to 65535")
+
+    if backend == "ssh":
+        for key in ("ssh_host", "ssh_user"):
+            value = effective.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ExecutionTargetError(
+                    f"Execution target {name!r} with backend 'ssh' requires "
+                    f"non-empty {key!r}."
+                )
+    if backend == "modal" and "modal_mode" in effective:
+        if str(effective["modal_mode"]).strip().lower() not in {
+            "auto", "direct", "managed",
+        }:
+            invalid("modal_mode", "one of 'auto', 'direct', or 'managed'")
+
+
+def _explicit_legacy_terminal_keys(
+    flat: Mapping[str, Any],
+    canonical_defaults: Mapping[str, Any],
+) -> set[str]:
+    """Identify flat terminal settings with real legacy authority.
+
+    Raw profile config and managed scope retain exact presence information.
+    The classic CLI's project-fallback source does not, so remaining values are
+    considered explicit only when they differ from both shared config defaults
+    and the terminal tool's canonical defaults.  This deliberately prefers an
+    existing environment value when project provenance is ambiguous.
+    """
+    from hermes_cli.config import effective_terminal_config, read_raw_config
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    authority: set[str] = set()
+
+    def _collect_authority(source: Any) -> None:
+        if not isinstance(source, Mapping):
+            return
+        terminal = source.get("terminal")
+        if isinstance(terminal, Mapping):
+            authority.update(effective_terminal_config(dict(terminal)))
+
+    if os.environ.get("HERMES_IGNORE_USER_CONFIG") != "1":
+        _collect_authority(read_raw_config())
+    try:
+        from hermes_cli import managed_scope
+
+        _collect_authority(managed_scope.load_managed_config())
+    except Exception:
+        # Provenance discovery must not make terminal activation unavailable
+        # when the optional managed scope cannot be read.
+        pass
+    if "env_type" in authority:
+        authority.add("backend")
+
+    values: dict[str, Any] = {
+        key: flat[key] for key in _TARGET_ENTRY_SETTINGS if key in flat
+    }
+    if "backend" not in values and "env_type" in flat:
+        values["backend"] = flat["env_type"]
+
+    shared = DEFAULT_CONFIG.get("terminal", {})
+    shared = shared if isinstance(shared, Mapping) else {}
+    explicit: set[str] = set()
+    missing = object()
+    for key, value in values.items():
+        if key in authority:
+            explicit.add(key)
+            continue
+        candidates: list[Any] = []
+        shared_value = shared.get(key, missing)
+        if shared_value is not missing:
+            candidates.append(shared_value)
+        canonical_key = "env_type" if key == "backend" else key
+        canonical_value = canonical_defaults.get(canonical_key, missing)
+        if canonical_value is not missing:
+            candidates.append(canonical_value)
+        if not candidates or all(value != candidate for candidate in candidates):
+            explicit.add(key)
+    return explicit
+
+
+def synthesize_legacy_default_target(
+    config: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Build the live named ``default`` spec for activated flat config.
+
+    Multiplexed dispatches derive exclusively from the selected profile mapping.
+    Single-profile dispatches retain the legacy process-environment backend
+    selection, while current static/managed values refresh the effective spec.
+    Nothing returned here is persisted by the runtime registry.
+    """
+    legacy = resolve_execution_target(config=config)
+    if legacy.named:
+        return None
+    from tools.terminal_tool import _get_env_config
+
+    try:
+        from agent.secret_scope import is_multiplex_active
+
+        multiplex = is_multiplex_active()
+    except Exception:
+        multiplex = False
+
+    flat = dict(legacy.config)
+    if multiplex:
+        # Process-global TERMINAL_* belongs to no profile in multiplex mode.
+        effective = _get_env_config(flat)
+        explicit_keys = set(_TARGET_ENTRY_SETTINGS) & set(flat)
+    else:
+        # Start with the canonical environment that legacy terminal execution
+        # actually uses.  Only raw/managed authority (or a conservative
+        # non-default project fallback) may replace an ambient value.
+        ambient = _get_env_config()
+        ambient_backend = (
+            str(ambient.get("env_type") or legacy.backend or "local").strip().lower()
+        )
+        canonical_defaults = _get_env_config({})
+        explicit_keys = _explicit_legacy_terminal_keys(flat, canonical_defaults)
+        seeded = {
+            "backend": ambient_backend,
+            **{
+                key: deepcopy(value)
+                for key, value in ambient.items()
+                if key in _TARGET_ENTRY_SETTINGS
+            },
+        }
+        for key in explicit_keys:
+            source_key = (
+                "backend"
+                if key == "backend" and "backend" in flat
+                else "env_type"
+                if key == "backend" and "env_type" in flat
+                else key
+            )
+            if source_key not in flat:
+                continue
+            value = flat[source_key]
+            if key == "cwd" and str(value or "").strip() in {".", "auto", "cwd"}:
+                # Match apply_terminal_config_to_env(): placeholders do not
+                # erase a concrete legacy TERMINAL_CWD value.
+                continue
+            seeded[key] = deepcopy(value)
+        effective = _get_env_config(seeded)
+
+    backend = (
+        str(effective.get("env_type") or legacy.backend or "local").strip().lower()
+    )
+    if backend not in _NAMED_TARGET_BACKENDS:
+        raise ExecutionTargetError(
+            f"Cannot activate runtime targets for unknown legacy backend {backend!r}."
+        )
+    allowed = _TARGET_COMMON_SETTINGS | _TARGET_BACKEND_SETTINGS[backend]
+    target_config: dict[str, Any] = {"backend": backend}
+    for key in allowed - {"backend"}:
+        if key in effective:
+            target_config[key] = deepcopy(effective[key])
+        elif (
+            key == "sudo_password"
+            and key in legacy.config
+            and (multiplex or key in explicit_keys)
+        ):
+            target_config[key] = deepcopy(legacy.config[key])
+    candidate = {
+        "terminal": {
+            "default_target": "default",
+            "targets": {"default": target_config},
+        },
+    }
+    resolve_execution_target("default", config=candidate)
+    return target_config
+
+
+def resolve_execution_target(
+    target: Optional[str] = None,
+    *,
+    config: Optional[Mapping[str, Any]] = None,
+) -> ExecutionTargetResolution:
+    """Resolve *target* against merged ``terminal`` configuration.
+
+    With no non-empty ``terminal.targets`` mapping, only omitted target and
+    explicit ``"default"`` are valid and the returned configuration marks the
+    legacy env-driven path.  With named targets, top-level terminal settings
+    are inherited and the selected target mapping overrides them.
+    """
+    if target is not None and (not isinstance(target, str) or not target):
+        raise ExecutionTargetError("Execution target must be a non-empty string.")
+
+    root = config if config is not None else _load_merged_config()
+    profile_scope = _active_profile_scope()
+    if not isinstance(root, Mapping):
+        raise ExecutionTargetError("Terminal configuration must be a mapping.")
+    terminal = root.get("terminal", {})
+    if terminal is None:
+        terminal = {}
+    if not isinstance(terminal, Mapping):
+        raise ExecutionTargetError("terminal must be a mapping.")
+
+    raw_targets = terminal.get("targets")
+    if raw_targets is None or raw_targets == {}:
+        if target not in (None, "default"):
+            from tools.execution_target_lifecycle import (
+                unavailable_runtime_target_message,
+            )
+
+            unavailable = unavailable_runtime_target_message(root, target)
+            if unavailable:
+                raise ExecutionTargetError(unavailable)
+            raise ExecutionTargetError(
+                f"Unknown execution target {target!r}. Named targets are not configured. "
+                f"Available targets: {_available(['default'])}."
+            )
+        flat = dict(terminal)
+        flat.pop("targets", None)
+        flat.pop("default_target", None)
+        # Legacy flat mode preserves the historical TERMINAL_ENV precedence.
+        # Metadata must describe the backend that will actually execute, not a
+        # stale config.yaml value hidden by an explicit launcher/.env override.
+        backend = str(
+            os.getenv("TERMINAL_ENV")
+            or flat.get("backend")
+            or flat.get("env_type")
+            or "local"
+        ).strip().lower() or "local"
+        return ExecutionTargetResolution(
+            target="default", backend=backend, config=flat, named=False,
+            is_default=True, profile_scope=profile_scope,
+        )
+
+    if not isinstance(raw_targets, Mapping):
+        raise ExecutionTargetError("terminal.targets must be a mapping.")
+
+    invalid_names = [
+        name for name in raw_targets
+        if not isinstance(name, str) or not name
+    ]
+    if invalid_names:
+        raise ExecutionTargetError("terminal.targets names must be non-empty strings.")
+
+    names = sorted(raw_targets)
+    for name in names:
+        if not isinstance(raw_targets[name], Mapping):
+            raise ExecutionTargetError(
+                f"terminal.targets[{name!r}] must be a mapping. "
+                f"Available targets: {_available(names)}."
+            )
+
+    selected = target if target is not None else terminal.get("default_target")
+    if not isinstance(selected, str) or not selected or selected not in raw_targets:
+        if target is not None:
+            from tools.execution_target_lifecycle import (
+                unavailable_runtime_target_message,
+            )
+
+            unavailable = unavailable_runtime_target_message(root, target)
+            if unavailable:
+                raise ExecutionTargetError(unavailable)
+            prefix = f"Unknown execution target {target!r}."
+        else:
+            prefix = (
+                "terminal.default_target must be a non-empty name present in "
+                "terminal.targets."
+            )
+        raise ExecutionTargetError(
+            f"{prefix} Available targets: {_available(names)}."
+        )
+
+    merged = {
+        key: value
+        for key, value in terminal.items()
+        if key not in {"targets", "default_target"}
+    }
+    merged.update(dict(raw_targets[selected]))
+    backend_setting = (
+        "backend" if "backend" in merged
+        else "env_type" if "env_type" in merged
+        else None
+    )
+    raw_backend = merged[backend_setting] if backend_setting else "local"
+    if not isinstance(raw_backend, str) or not raw_backend.strip():
+        setting = backend_setting or "backend"
+        raise ExecutionTargetError(
+            f"Execution target {selected!r} setting {setting!r} has an invalid "
+            "shape; expected a non-empty string."
+        )
+    backend = raw_backend.strip().lower()
+    if backend not in _NAMED_TARGET_BACKENDS:
+        available_backends = ", ".join(sorted(_NAMED_TARGET_BACKENDS))
+        raise ExecutionTargetError(
+            f"Execution target {selected!r} has unknown backend {backend!r}. "
+            f"Available backends: {available_backends}."
+        )
+    _validate_named_target_entry(
+        selected, raw_targets[selected], merged, backend,
+    )
+    from tools.execution_target_lifecycle import runtime_record_metadata
+
+    runtime_records = runtime_record_metadata(root, selected, status="active")
+    runtime_record = runtime_records[0] if len(runtime_records) == 1 else {}
+    return ExecutionTargetResolution(
+        target=selected, backend=backend, config=merged, named=True,
+        is_default=selected == terminal.get("default_target"),
+        profile_scope=profile_scope,
+        provider=runtime_record.get("provider"),
+        owner_id=runtime_record.get("owner_id"),
+        generation=runtime_record.get("generation"),
+    )
+
+
+def resolve_live_execution_target(
+    target: Optional[str] = None,
+) -> ExecutionTargetResolution:
+    """Resolve against the live source when nested RPC routing is frozen."""
+    if not _frozen_config_active.get():
+        return resolve_execution_target(target)
+    return resolve_execution_target(target, config=_load_unscoped_config())
+
+
+def list_execution_targets(
+    *, config: Optional[Mapping[str, Any]] = None,
+) -> tuple[ExecutionTargetResolution, ...]:
+    """Return configured targets in deterministic order for runtime guidance.
+
+    Tool schemas remain static for prompt-cache stability; callers such as the
+    system-prompt environment hint can use this lightweight runtime inventory
+    to tell the model which fixed-string target values are available.
+    """
+    root = config if config is not None else _load_merged_config()
+    terminal = root.get("terminal", {}) if isinstance(root, Mapping) else {}
+    targets = terminal.get("targets") if isinstance(terminal, Mapping) else None
+    if not isinstance(targets, Mapping) or not targets:
+        return (resolve_execution_target(config=root),)
+    # Resolve the default first so name/default validation uses the same clear
+    # ExecutionTargetError shape as an ordinary omitted-selector tool call.
+    resolve_execution_target(config=root)
+    return tuple(
+        resolve_execution_target(name, config=root)
+        for name in sorted(targets)
+    )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -884,7 +884,9 @@ class ShellFileOperations(FileOperations):
     This includes local, docker, singularity, ssh, modal, and daytona environments.
     """
     
-    def __init__(self, terminal_env, cwd: str = None):
+    def __init__(
+        self, terminal_env, cwd: str = None, *, fixed_cwd: str = None,
+    ):
         """
         Initialize file operations with a terminal environment.
 
@@ -895,11 +897,11 @@ class ShellFileOperations(FileOperations):
                  no cwd attribute (rare — most backends track cwd live).
 
         Note:
-            Every _exec() call prefers the LIVE ``terminal_env.cwd`` over
-            ``self.cwd`` so ``cd`` commands run via the terminal tool are
-            picked up immediately.  ``self.cwd`` is only used as a fallback
-            when the env has no cwd at all — it is NOT the authoritative
-            cwd, despite being settable at init time.
+            By default every _exec() call prefers the LIVE
+            ``terminal_env.cwd`` over ``self.cwd`` so ``cd`` commands run via
+            the terminal tool are picked up immediately. ``fixed_cwd`` pins
+            operations to a caller-owned runtime scope; named SSH targets use
+            it because their environment object is shared across sessions.
 
             Historical bug (fixed): prior versions of this class used the
             init-time cwd for every _exec() call, which caused relative
@@ -915,6 +917,7 @@ class ShellFileOperations(FileOperations):
         # If nothing provides a cwd, use "/" as a safe universal default.
         self.cwd = cwd or getattr(terminal_env, 'cwd', None) or \
                    getattr(getattr(terminal_env, 'config', None), 'cwd', None) or "/"
+        self.fixed_cwd = fixed_cwd
 
         # Cache for command availability checks
         self._command_cache: Dict[str, bool] = {}
@@ -929,8 +932,9 @@ class ShellFileOperations(FileOperations):
 
         Cwd resolution order (critical — see class docstring):
           1. Explicit ``cwd`` arg (if provided)
-          2. Live ``self.env.cwd`` (tracks ``cd`` commands run via terminal)
-          3. Init-time ``self.cwd`` (fallback when env has no cwd attribute)
+          2. Scope-pinned ``self.fixed_cwd`` (when configured)
+          3. Live ``self.env.cwd`` (tracks ``cd`` commands run via terminal)
+          4. Init-time ``self.cwd`` (fallback when env has no cwd attribute)
 
         This ordering ensures relative paths in file operations follow the
         terminal's current directory — not the directory this file_ops was
@@ -944,7 +948,9 @@ class ShellFileOperations(FileOperations):
 
         # Resolve cwd from the live env so `cd` commands are picked up.
         # Fall through to init-time self.cwd only if the env doesn't track cwd.
-        effective_cwd = cwd or getattr(self.env, 'cwd', None) or self.cwd
+        effective_cwd = (
+            cwd or self.fixed_cwd or getattr(self.env, 'cwd', None) or self.cwd
+        )
         result = self.env.execute(command, cwd=effective_cwd, **kwargs)
         exit_code = result.get("returncode", 0)
         # A stdin write failure with an otherwise-clean child exit is still

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -38,14 +38,15 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Hashable, Iterable, List, Optional, Tuple
 
 
 # ── Public stamp type ────────────────────────────────────────────────
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+ReadStamp = Tuple[Optional[float], float, bool]
+TaskKey = Hashable
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -56,33 +57,49 @@ _MAX_PATHS_PER_AGENT = 4096
 _MAX_GLOBAL_WRITERS = 4096
 
 
+def _raw_task_id(task_id: TaskKey) -> TaskKey:
+    if isinstance(task_id, tuple) and len(task_id) == 2:
+        return task_id[0]
+    return task_id
+
+
 class FileStateRegistry:
     """Process-wide coordinator for cross-agent file edits."""
 
     def __init__(self) -> None:
-        self._reads: Dict[str, Dict[str, ReadStamp]] = defaultdict(dict)
-        self._last_writer: Dict[str, Tuple[str, float]] = {}
+        self._reads: Dict[TaskKey, Dict[str, ReadStamp]] = defaultdict(dict)
+        self._last_writer: Dict[str, Tuple[TaskKey, float]] = {}
         self._path_locks: Dict[str, threading.Lock] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
 
     # ── Path lock management ────────────────────────────────────────
-    def _lock_for(self, resolved: str) -> threading.Lock:
+    @staticmethod
+    def _state_path(resolved: str, namespace: Optional[str] = None) -> str:
+        return f"{namespace}\0{resolved}" if namespace else resolved
+
+    @staticmethod
+    def _display_path(state_path: str) -> str:
+        return state_path.split("\0", 1)[-1]
+
+    def _lock_for(self, resolved: str,
+                  namespace: Optional[str] = None) -> threading.Lock:
+        state_path = self._state_path(resolved, namespace)
         with self._meta_lock:
-            lock = self._path_locks.get(resolved)
+            lock = self._path_locks.get(state_path)
             if lock is None:
                 lock = threading.Lock()
-                self._path_locks[resolved] = lock
+                self._path_locks[state_path] = lock
             return lock
 
     @contextmanager
-    def lock_path(self, resolved: str):
+    def lock_path(self, resolved: str, namespace: Optional[str] = None):
         """Acquire the per-path lock for a read→modify→write section.
 
         Same process, same filesystem — threads on the same path serialize.
         Different paths proceed in parallel.
         """
-        lock = self._lock_for(resolved)
+        lock = self._lock_for(resolved, namespace)
         lock.acquire()
         try:
             yield
@@ -92,54 +109,70 @@ class FileStateRegistry:
     # ── Read/write accounting ───────────────────────────────────────
     def record_read(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         partial: bool = False,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
+        stat_path: bool = True,
     ) -> None:
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and stat_path:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
             agent_reads = self._reads[task_id]
-            agent_reads[resolved] = (float(mtime), now, bool(partial))
+            agent_reads[state_path] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                bool(partial),
+            )
             _cap_dict(agent_reads, _MAX_PATHS_PER_AGENT)
 
     def note_write(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
+        stat_path: bool = True,
     ) -> None:
         """Record a successful write.
 
         Updates the global last-writer map AND this agent's own read stamp
         (a write is an implicit read — the agent now knows the current
-        content).
+        content). Remote callers set ``stat_path=False`` so an identically
+        named host-local path cannot influence remote freshness state.
         """
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and stat_path:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            self._last_writer[resolved] = (task_id, now)
+            self._last_writer[state_path] = (task_id, now)
             _cap_dict(self._last_writer, _MAX_GLOBAL_WRITERS)
             # Writer's own view is now up-to-date.
-            self._reads[task_id][resolved] = (float(mtime), now, False)
+            self._reads[task_id][state_path] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                False,
+            )
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(self, task_id: TaskKey, resolved: str,
+                    namespace: Optional[str] = None) -> Optional[str]:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -153,20 +186,15 @@ class FileStateRegistry:
         """
         if _disabled():
             return None
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            stamp = self._reads.get(task_id, {}).get(resolved)
-            last_writer = self._last_writer.get(resolved)
+            stamp = self._reads.get(task_id, {}).get(state_path)
+            last_writer = self._last_writer.get(state_path)
 
         # Case 3: never read AND we have no write record — net-new file or
         # first touch by this agent.  Let existing _check_sensitive_path
         # and file-exists logic handle it; nothing to warn about here.
         if stamp is None and last_writer is None:
-            return None
-
-        try:
-            current_mtime = os.path.getmtime(resolved)
-        except OSError:
-            # File doesn't exist — write will create it; not stale.
             return None
 
         # Case 1: sibling subagent modified after our last read.
@@ -192,12 +220,18 @@ class FileStateRegistry:
         # Case 2: external / unknown modification (mtime drifted).
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
-                return (
-                    f"{resolved} was modified since you last read it "
-                    "on disk (external edit or unrecorded writer). "
-                    "Re-read the file before writing."
-                )
+            if read_mtime is not None:
+                try:
+                    current_mtime = os.path.getmtime(resolved)
+                except OSError:
+                    # File doesn't exist — write will create it; not stale.
+                    return None
+                if current_mtime != read_mtime:
+                    return (
+                        f"{resolved} was modified since you last read it "
+                        "on disk (external edit or unrecorded writer). "
+                        "Re-read the file before writing."
+                    )
             if partial:
                 return (
                     f"{resolved} was last read with offset/limit pagination "
@@ -217,7 +251,7 @@ class FileStateRegistry:
     # ── Reminder helper for delegate_tool ───────────────────────────
     def writes_since(
         self,
-        exclude_task_id: str,
+        exclude_task_id: TaskKey,
         since_ts: float,
         paths: Iterable[str],
     ) -> Dict[str, List[str]]:
@@ -230,23 +264,39 @@ class FileStateRegistry:
         if _disabled():
             return {}
         paths_set = set(paths)
+        exclude_raw = _raw_task_id(exclude_task_id)
         out: Dict[str, List[str]] = defaultdict(list)
         with self._state_lock:
-            for p, (writer_tid, ts) in self._last_writer.items():
-                if writer_tid == exclude_task_id:
+            for state_path, (writer_tid, ts) in self._last_writer.items():
+                writer_raw = _raw_task_id(writer_tid)
+                if writer_raw == exclude_raw:
                     continue
                 if ts < since_ts:
                     continue
-                if p in paths_set:
-                    out[writer_tid].append(p)
+                display_path = self._display_path(state_path)
+                if state_path in paths_set or display_path in paths_set:
+                    out[str(writer_raw)].append(display_path)
         return dict(out)
 
-    def known_reads(self, task_id: str) -> List[str]:
-        """Return the list of resolved paths this agent has read."""
+    def known_reads(self, task_id: TaskKey) -> List[str]:
+        """Return reads for a raw task across all named-target scopes."""
         if _disabled():
             return []
         with self._state_lock:
-            return list(self._reads.get(task_id, {}).keys())
+            reads: list[str] = []
+            seen: set[str] = set()
+            for key, paths in self._reads.items():
+                if key != task_id and _raw_task_id(key) != task_id:
+                    continue
+                for path in paths:
+                    # Preserve the internal target namespace for delegate
+                    # coordination; writes_since strips it before user-facing
+                    # output but uses it to avoid cross-host false conflicts.
+                    read_path = path if "\0" in path else self._display_path(path)
+                    if read_path not in seen:
+                        reads.append(read_path)
+                        seen.add(read_path)
+            return reads
 
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
@@ -292,32 +342,62 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(task_id: TaskKey, resolved_or_path: str | Path, *,
+                partial: bool = False, namespace: Optional[str] = None,
+                stat_path: bool = True) -> None:
+    _registry.record_read(
+        task_id, str(resolved_or_path), partial=partial, namespace=namespace,
+        stat_path=stat_path,
+    )
 
 
-def note_write(task_id: str, resolved_or_path: str | Path) -> None:
-    _registry.note_write(task_id, str(resolved_or_path))
+def note_write(task_id: TaskKey, resolved_or_path: str | Path, *,
+               namespace: Optional[str] = None,
+               stat_path: bool = True) -> None:
+    _registry.note_write(
+        task_id, str(resolved_or_path), namespace=namespace,
+        stat_path=stat_path,
+    )
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
-    return _registry.check_stale(task_id, str(resolved_or_path))
+def check_stale(task_id: TaskKey, resolved_or_path: str | Path, *,
+                namespace: Optional[str] = None) -> Optional[str]:
+    return _registry.check_stale(
+        task_id, str(resolved_or_path), namespace=namespace,
+    )
 
 
-def lock_path(resolved_or_path: str | Path):
-    return _registry.lock_path(str(resolved_or_path))
+def lock_path(resolved_or_path: str | Path, *, namespace: Optional[str] = None):
+    return _registry.lock_path(str(resolved_or_path), namespace=namespace)
 
 
 def writes_since(
-    exclude_task_id: str,
+    exclude_task_id: TaskKey,
     since_ts: float,
     paths: Iterable[str | Path],
 ) -> Dict[str, List[str]]:
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        exclude_task_id = resolve_execution_target().scope_task_key(exclude_task_id)
+    except Exception:
+        pass
     return _registry.writes_since(exclude_task_id, since_ts, [str(p) for p in paths])
 
 
-def known_reads(task_id: str) -> List[str]:
-    return _registry.known_reads(task_id)
+def known_reads(task_id: TaskKey) -> List[str]:
+    reads = _registry.known_reads(task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        scoped = resolve_execution_target().scope_task_key(task_id)
+    except Exception:
+        scoped = task_id
+    if scoped != task_id:
+        for path in _registry.known_reads(scoped):
+            if path not in reads:
+                reads.append(path)
+    return reads
 
 
 __all__ = [

--- a/tools/file_state.py
+++ b/tools/file_state.py
@@ -38,14 +38,15 @@ import time
 from collections import defaultdict
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Hashable, Iterable, List, Optional, Tuple
 
 
 # ── Public stamp type ────────────────────────────────────────────────
 # (mtime, read_ts, partial).  partial=True when read_file returned a
 # windowed view (offset > 1 or limit < total_lines) — writes that happen
 # after a partial read should still warn so the model re-reads in full.
-ReadStamp = Tuple[float, float, bool]
+ReadStamp = Tuple[Optional[float], float, bool]
+TaskKey = Hashable
 
 # Number of resolved-path entries retained per agent.  Bounded to keep
 # long sessions from accumulating unbounded state.  On overflow we drop
@@ -56,33 +57,49 @@ _MAX_PATHS_PER_AGENT = 4096
 _MAX_GLOBAL_WRITERS = 4096
 
 
+def _raw_task_id(task_id: TaskKey) -> TaskKey:
+    if isinstance(task_id, tuple) and len(task_id) == 2:
+        return task_id[0]
+    return task_id
+
+
 class FileStateRegistry:
     """Process-wide coordinator for cross-agent file edits."""
 
     def __init__(self) -> None:
-        self._reads: Dict[str, Dict[str, ReadStamp]] = defaultdict(dict)
-        self._last_writer: Dict[str, Tuple[str, float]] = {}
+        self._reads: Dict[TaskKey, Dict[str, ReadStamp]] = defaultdict(dict)
+        self._last_writer: Dict[str, Tuple[TaskKey, float]] = {}
         self._path_locks: Dict[str, threading.Lock] = {}
         self._meta_lock = threading.Lock()  # guards _path_locks
         self._state_lock = threading.Lock()  # guards _reads + _last_writer
 
     # ── Path lock management ────────────────────────────────────────
-    def _lock_for(self, resolved: str) -> threading.Lock:
+    @staticmethod
+    def _state_path(resolved: str, namespace: Optional[str] = None) -> str:
+        return f"{namespace}\0{resolved}" if namespace else resolved
+
+    @staticmethod
+    def _display_path(state_path: str) -> str:
+        return state_path.split("\0", 1)[-1]
+
+    def _lock_for(self, resolved: str,
+                  namespace: Optional[str] = None) -> threading.Lock:
+        state_path = self._state_path(resolved, namespace)
         with self._meta_lock:
-            lock = self._path_locks.get(resolved)
+            lock = self._path_locks.get(state_path)
             if lock is None:
                 lock = threading.Lock()
-                self._path_locks[resolved] = lock
+                self._path_locks[state_path] = lock
             return lock
 
     @contextmanager
-    def lock_path(self, resolved: str):
+    def lock_path(self, resolved: str, namespace: Optional[str] = None):
         """Acquire the per-path lock for a read→modify→write section.
 
         Same process, same filesystem — threads on the same path serialize.
         Different paths proceed in parallel.
         """
-        lock = self._lock_for(resolved)
+        lock = self._lock_for(resolved, namespace)
         lock.acquire()
         try:
             yield
@@ -92,54 +109,70 @@ class FileStateRegistry:
     # ── Read/write accounting ───────────────────────────────────────
     def record_read(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         partial: bool = False,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
+        stat_path: bool = True,
     ) -> None:
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and stat_path:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
             agent_reads = self._reads[task_id]
-            agent_reads[resolved] = (float(mtime), now, bool(partial))
+            agent_reads[state_path] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                bool(partial),
+            )
             _cap_dict(agent_reads, _MAX_PATHS_PER_AGENT)
 
     def note_write(
         self,
-        task_id: str,
+        task_id: TaskKey,
         resolved: str,
         *,
         mtime: Optional[float] = None,
+        namespace: Optional[str] = None,
+        stat_path: bool = True,
     ) -> None:
         """Record a successful write.
 
         Updates the global last-writer map AND this agent's own read stamp
         (a write is an implicit read — the agent now knows the current
-        content).
+        content). Remote callers set ``stat_path=False`` so an identically
+        named host-local path cannot influence remote freshness state.
         """
         if _disabled():
             return
-        if mtime is None:
+        if mtime is None and stat_path:
             try:
                 mtime = os.path.getmtime(resolved)
             except OSError:
                 return
         now = time.time()
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            self._last_writer[resolved] = (task_id, now)
+            self._last_writer[state_path] = (task_id, now)
             _cap_dict(self._last_writer, _MAX_GLOBAL_WRITERS)
             # Writer's own view is now up-to-date.
-            self._reads[task_id][resolved] = (float(mtime), now, False)
+            self._reads[task_id][state_path] = (
+                float(mtime) if mtime is not None else None,
+                now,
+                False,
+            )
             _cap_dict(self._reads[task_id], _MAX_PATHS_PER_AGENT)
 
-    def check_stale(self, task_id: str, resolved: str) -> Optional[str]:
+    def check_stale(self, task_id: TaskKey, resolved: str,
+                    namespace: Optional[str] = None) -> Optional[str]:
         """Return a model-facing warning if this write would be stale.
 
         Three staleness classes, in order of severity:
@@ -153,20 +186,15 @@ class FileStateRegistry:
         """
         if _disabled():
             return None
+        state_path = self._state_path(resolved, namespace)
         with self._state_lock:
-            stamp = self._reads.get(task_id, {}).get(resolved)
-            last_writer = self._last_writer.get(resolved)
+            stamp = self._reads.get(task_id, {}).get(state_path)
+            last_writer = self._last_writer.get(state_path)
 
         # Case 3: never read AND we have no write record — net-new file or
         # first touch by this agent.  Let existing _check_sensitive_path
         # and file-exists logic handle it; nothing to warn about here.
         if stamp is None and last_writer is None:
-            return None
-
-        try:
-            current_mtime = os.path.getmtime(resolved)
-        except OSError:
-            # File doesn't exist — write will create it; not stale.
             return None
 
         # Case 1: sibling subagent modified after our last read.
@@ -192,12 +220,18 @@ class FileStateRegistry:
         # Case 2: external / unknown modification (mtime drifted).
         if stamp is not None:
             read_mtime, _read_ts, partial = stamp
-            if current_mtime != read_mtime:
-                return (
-                    f"{resolved} was modified since you last read it "
-                    "on disk (external edit or unrecorded writer). "
-                    "Re-read the file before writing."
-                )
+            if read_mtime is not None:
+                try:
+                    current_mtime = os.path.getmtime(resolved)
+                except OSError:
+                    # File doesn't exist — write will create it; not stale.
+                    return None
+                if current_mtime != read_mtime:
+                    return (
+                        f"{resolved} was modified since you last read it "
+                        "on disk (external edit or unrecorded writer). "
+                        "Re-read the file before writing."
+                    )
             if partial:
                 return (
                     f"{resolved} was last read with offset/limit pagination "
@@ -217,7 +251,7 @@ class FileStateRegistry:
     # ── Reminder helper for delegate_tool ───────────────────────────
     def writes_since(
         self,
-        exclude_task_id: str,
+        exclude_task_id: TaskKey,
         since_ts: float,
         paths: Iterable[str],
     ) -> Dict[str, List[str]]:
@@ -230,23 +264,44 @@ class FileStateRegistry:
         if _disabled():
             return {}
         paths_set = set(paths)
+        exclude_raw = _raw_task_id(exclude_task_id)
         out: Dict[str, List[str]] = defaultdict(list)
         with self._state_lock:
-            for p, (writer_tid, ts) in self._last_writer.items():
-                if writer_tid == exclude_task_id:
+            for state_path, (writer_tid, ts) in self._last_writer.items():
+                writer_raw = _raw_task_id(writer_tid)
+                if writer_raw == exclude_raw:
                     continue
                 if ts < since_ts:
                     continue
-                if p in paths_set:
-                    out[writer_tid].append(p)
+                display_path = self._display_path(state_path)
+                # A namespaced remote/container path matches only its complete
+                # state identity. Falling back to its display path would make
+                # ``ssh-scope\0/path`` conflict with an unrelated local
+                # ``/path`` read. Unnamespaced local/legacy paths retain their
+                # ordinary display-path behavior because both forms coincide.
+                if state_path in paths_set:
+                    out[str(writer_raw)].append(display_path)
         return dict(out)
 
-    def known_reads(self, task_id: str) -> List[str]:
-        """Return the list of resolved paths this agent has read."""
+    def known_reads(self, task_id: TaskKey) -> List[str]:
+        """Return reads for a raw task across all named-target scopes."""
         if _disabled():
             return []
         with self._state_lock:
-            return list(self._reads.get(task_id, {}).keys())
+            reads: list[str] = []
+            seen: set[str] = set()
+            for key, paths in self._reads.items():
+                if key != task_id and _raw_task_id(key) != task_id:
+                    continue
+                for path in paths:
+                    # Preserve the internal target namespace for delegate
+                    # coordination; writes_since strips it before user-facing
+                    # output but uses it to avoid cross-host false conflicts.
+                    read_path = path if "\0" in path else self._display_path(path)
+                    if read_path not in seen:
+                        reads.append(read_path)
+                        seen.add(read_path)
+            return reads
 
     # ── Testing hooks ───────────────────────────────────────────────
     def clear(self) -> None:
@@ -292,32 +347,62 @@ def _cap_dict(d: dict, limit: int) -> None:
 
 
 # ── Convenience wrappers (short names used at call sites) ────────────
-def record_read(task_id: str, resolved_or_path: str | Path, *, partial: bool = False) -> None:
-    _registry.record_read(task_id, str(resolved_or_path), partial=partial)
+def record_read(task_id: TaskKey, resolved_or_path: str | Path, *,
+                partial: bool = False, namespace: Optional[str] = None,
+                stat_path: bool = True) -> None:
+    _registry.record_read(
+        task_id, str(resolved_or_path), partial=partial, namespace=namespace,
+        stat_path=stat_path,
+    )
 
 
-def note_write(task_id: str, resolved_or_path: str | Path) -> None:
-    _registry.note_write(task_id, str(resolved_or_path))
+def note_write(task_id: TaskKey, resolved_or_path: str | Path, *,
+               namespace: Optional[str] = None,
+               stat_path: bool = True) -> None:
+    _registry.note_write(
+        task_id, str(resolved_or_path), namespace=namespace,
+        stat_path=stat_path,
+    )
 
 
-def check_stale(task_id: str, resolved_or_path: str | Path) -> Optional[str]:
-    return _registry.check_stale(task_id, str(resolved_or_path))
+def check_stale(task_id: TaskKey, resolved_or_path: str | Path, *,
+                namespace: Optional[str] = None) -> Optional[str]:
+    return _registry.check_stale(
+        task_id, str(resolved_or_path), namespace=namespace,
+    )
 
 
-def lock_path(resolved_or_path: str | Path):
-    return _registry.lock_path(str(resolved_or_path))
+def lock_path(resolved_or_path: str | Path, *, namespace: Optional[str] = None):
+    return _registry.lock_path(str(resolved_or_path), namespace=namespace)
 
 
 def writes_since(
-    exclude_task_id: str,
+    exclude_task_id: TaskKey,
     since_ts: float,
     paths: Iterable[str | Path],
 ) -> Dict[str, List[str]]:
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        exclude_task_id = resolve_execution_target().scope_task_key(exclude_task_id)
+    except Exception:
+        pass
     return _registry.writes_since(exclude_task_id, since_ts, [str(p) for p in paths])
 
 
-def known_reads(task_id: str) -> List[str]:
-    return _registry.known_reads(task_id)
+def known_reads(task_id: TaskKey) -> List[str]:
+    reads = _registry.known_reads(task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        scoped = resolve_execution_target().scope_task_key(task_id)
+    except Exception:
+        scoped = task_id
+    if scoped != task_id:
+        for path in _registry.known_reads(scoped):
+            if path not in reads:
+                reads.append(path)
+    return reads
 
 
 __all__ = [

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -3,6 +3,7 @@
 
 import base64
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -10,6 +11,7 @@ import posixpath
 import sys
 import threading
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import (
@@ -153,11 +155,13 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
-def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> Path | PurePosixPath:
     """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
     instead of the main repository root.
     """
-    return _resolve_path_for_task(filepath, task_id)
+    return _resolve_path_for_task(filepath, task_id, execution_target)
 
 
 # Sentinel ``TERMINAL_CWD`` values that mean "not configured", NOT a literal
@@ -172,7 +176,10 @@ _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
 _CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
 
-def _terminal_env_type_for_task(task_id: str = "default") -> str:
+def _terminal_env_type_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str:
     """Best-effort terminal backend type for path-resolution decisions."""
     try:
         from tools.terminal_tool import (
@@ -181,13 +188,19 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
+        resolution = _resolution or resolve_execution_target(execution_target)
         try:
-            container_key = _resolve_container_task_id(task_id)
+            container_key = resolution.environment_key(
+                _resolve_container_task_id(task_id)
+            )
+            raw_key = resolution.environment_key(task_id)
         except Exception:
             container_key = task_id
+            raw_key = task_id
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -202,19 +215,178 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
                 return "modal"
             if "daytona" in name:
                 return "daytona"
-        cfg = _get_env_config()
+        cfg = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
         return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
         return str(os.getenv("TERMINAL_ENV") or "local").lower()
 
 
-def _uses_container_paths(task_id: str = "default") -> bool:
+def _uses_container_paths(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> bool:
     try:
         from tools.terminal_tool import _CONTAINER_BACKENDS
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    return _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) in container_backends
+
+
+def _file_state_namespace(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
+    """Namespace remote/container paths, but share locks for local aliases."""
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = _resolution or resolve_execution_target(execution_target)
+        runtime_prefix = (
+            f"runtime-{resolution.security_scope}:"
+            if resolution.provider is not None
+            else ""
+        )
+        if resolution.backend == "local":
+            return f"{profile}{runtime_prefix}local" if runtime_prefix else None
+        # Preserve the pre-target single-profile legacy state key.
+        if not resolution.named:
+            return None
+        profile = f"profile-{resolution.profile_scope}:" if resolution.profile_scope else ""
+        if resolution.backend == "ssh":
+            # Two names for the same SSH account/root address the same physical
+            # filesystem and must share stale-write locks/read state.
+            cfg = resolution.config
+            physical = json.dumps({
+                "host": str(cfg.get("ssh_host") or ""),
+                "user": str(cfg.get("ssh_user") or ""),
+                "port": int(cfg.get("ssh_port") or 22),
+            }, sort_keys=True, separators=(",", ":"))
+            digest = hashlib.sha256(physical.encode("utf-8")).hexdigest()[:20]
+            return f"{profile}{runtime_prefix}ssh:{digest}"
+        if resolution.backend == "docker":
+            persistent = resolution.config.get("container_persistent", True)
+            if isinstance(persistent, str):
+                persistent = persistent.strip().lower() in {"true", "1", "yes"}
+            if persistent:
+                from tools.terminal_tool import _resolve_container_task_id
+
+                owner = resolution.storage_task_id(
+                    _resolve_container_task_id(str(task_id)),
+                )
+                return f"{profile}{runtime_prefix}docker-storage:{owner}"
+        # Other remote/container targets create distinct backend resources even
+        # when their visible path strings happen to match.
+        return (
+            f"{profile}{runtime_prefix}{resolution.backend}:"
+            f"{resolution.security_scope}"
+        )
+    except Exception:
+        # Unknown targets are reported by the tool resolver before state access.
+        return execution_target
+
+
+def _backend_operation_path(
+    original: str,
+    resolved: str | Path | PurePosixPath,
+    task_id: str = "default",
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> str:
+    """Return the path that should be sent to the selected backend.
+
+    SSH owns relative and ``~`` expansion. Resolving those paths on the Hermes
+    host first creates a host-absolute path that may name a different file (or
+    no file) on the remote machine. Container/local backends retain the existing
+    exact resolved-path contract.
+    """
+    if _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) == "ssh":
+        original = str(original)
+        if posixpath.isabs(original) or original.startswith("~"):
+            return original
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            recorded_cwd = get_session_cwd(
+                task_id, target=execution_target, _resolution=_resolution,
+            )
+        except Exception:
+            recorded_cwd = None
+        if recorded_cwd and posixpath.isabs(str(recorded_cwd)):
+            return posixpath.normpath(posixpath.join(str(recorded_cwd), original))
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            resolution = _resolution or resolve_execution_target(execution_target)
+        except Exception:
+            resolution = None
+        # Legacy SSH file operations historically followed the live env cwd.
+        # Only a named target has a stable configured root we can anchor before
+        # a session-specific terminal cwd has been recorded.
+        if resolution is not None and resolution.named:
+            session_cwd = _authoritative_workspace_root(
+                task_id, execution_target, _resolution=resolution,
+            )
+            if session_cwd and posixpath.isabs(str(session_cwd)):
+                return posixpath.normpath(posixpath.join(str(session_cwd), original))
+        return original
+    return str(resolved)
+
+
+def _backend_v4a_patch(
+    patch_text: str,
+    task_id: str,
+    execution_target: str | None,
+    *,
+    _resolution: Any = None,
+) -> str:
+    """Anchor relative V4A headers to the calling SSH session's cwd."""
+    if _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) != "ssh":
+        return patch_text
+    import re
+
+    def _single(match):
+        path = match.group(2).strip()
+        routed = _backend_operation_path(
+            path, path, task_id, execution_target, _resolution=_resolution,
+        )
+        return match.group(1) + routed
+
+    rewritten = re.sub(
+        r"^(\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*)(.+)$",
+        _single,
+        patch_text,
+        flags=re.MULTILINE,
+    )
+
+    def _move(match):
+        source = match.group(2).strip()
+        destination = match.group(3).strip()
+        routed_source = _backend_operation_path(
+            source, source, task_id, execution_target, _resolution=_resolution,
+        )
+        routed_destination = _backend_operation_path(
+            destination, destination, task_id, execution_target,
+            _resolution=_resolution,
+        )
+        return f"{match.group(1)}{routed_source} -> {routed_destination}"
+
+    return re.sub(
+        r"^(\*\*\*\s*Move\s+File:\s*)(.+?)\s*->\s*(.+)$",
+        _move,
+        rewritten,
+        flags=re.MULTILINE,
+    )
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -274,7 +446,10 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     return _sentinel_free_abs_cwd(overrides.get("cwd"))
 
 
-def _authoritative_workspace_root(task_id: str = "default") -> str | None:
+def _authoritative_workspace_root(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Best-effort absolute workspace root for divergence checks.
 
     Resolution:
@@ -284,11 +459,12 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
          registration, keyed by the raw session id. Because the record is
          per-session, one session's ``cd`` can never leak into another
          session's resolution.
-      2. A registered task/session cwd override (TUI/Desktop/ACP sessions
+      2. For an explicit non-default named target, that target's configured
+         cwd. Host workspace overrides must not leak into remote targets.
+      3. A registered task/session cwd override (TUI/Desktop/ACP sessions
          register a raw-keyed cwd before any tool runs). Normally already
-         mirrored into the record at registration; kept as a direct fallback
-         so a cleared/never-written record still resolves the workspace.
-      3. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
+         mirrored into the default target's record; kept as a fallback.
+      4. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
          ``cli.py``/``main.py`` for ``-w`` sessions).
 
     Returns ``None`` only when there is genuinely no reliable anchor, in which
@@ -297,14 +473,79 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     try:
         from tools.terminal_tool import get_session_cwd
 
-        recorded = get_session_cwd(task_id)
+        recorded = get_session_cwd(
+            task_id, target=execution_target, _resolution=_resolution,
+        )
     except Exception:
         recorded = None
     if recorded:
         return recorded
-    registered = _registered_task_cwd_override(task_id)
+
+    target_resolution = _resolution
+    configured_target_cwd = None
+    if target_resolution is None and execution_target is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            target_resolution = resolve_execution_target(execution_target)
+        except Exception:
+            target_resolution = None
+    if target_resolution is not None and target_resolution.named:
+        try:
+            from tools.terminal_tool import _get_env_config
+
+            configured = _get_env_config(
+                dict(target_resolution.config)
+            ).get("cwd")
+            if isinstance(configured, str) and configured.strip():
+                if (
+                    target_resolution.backend == "ssh"
+                    and (
+                        configured in {".", "./", "auto", "cwd", "~"}
+                        or configured.startswith("~/")
+                    )
+                ):
+                    # Keep relative/tilde SSH paths on the remote side. Before
+                    # the SSH environment exists there is no truthful absolute
+                    # host-side anchor; actual file operations preserve the raw
+                    # path, and a later terminal call records the resolved remote
+                    # cwd for this session.
+                    configured_target_cwd = configured
+                elif configured in {".", "./", "auto", "cwd"}:
+                    configured_target_cwd = os.getcwd()
+                elif configured == "~" or configured.startswith("~/"):
+                    # SSH expands this remotely; local targets expand here.
+                    configured_target_cwd = (
+                        configured
+                        if target_resolution.backend == "ssh"
+                        else _expand_tilde(configured)
+                    )
+                else:
+                    configured_target_cwd = configured
+        except Exception:
+            target_resolution = None
+
+    if (
+        target_resolution is not None
+        and target_resolution.named
+        and not target_resolution.is_default
+        and configured_target_cwd
+    ):
+        return configured_target_cwd
+
+    registered = (
+        None
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and target_resolution.backend == "ssh"
+        )
+        else _registered_task_cwd_override(task_id)
+    )
     if registered:
         return registered
+    if configured_target_cwd:
+        return configured_target_cwd
     return _configured_terminal_cwd()
 
 
@@ -312,6 +553,8 @@ def _resolve_base_dir(
     task_id: str = "default",
     *,
     container_paths: bool | None = None,
+    execution_target: str | None = None,
+    _resolution: Any = None,
 ) -> Path | PurePosixPath:
     """Return the ABSOLUTE base directory for resolving relative paths.
 
@@ -335,9 +578,13 @@ def _resolve_base_dir(
     outright (rather than anchoring them to the process cwd) and fall through to
     the process cwd only as a last resort, deterministically.
     """
-    root = _authoritative_workspace_root(task_id)
+    root = _authoritative_workspace_root(
+        task_id, execution_target, _resolution=_resolution,
+    )
     if container_paths is None:
-        container_paths = _uses_container_paths(task_id)
+        container_paths = _uses_container_paths(
+            task_id, execution_target, _resolution=_resolution,
+        )
     if root:
         base_text = _expand_tilde(root)
     else:
@@ -366,7 +613,10 @@ def _resolve_base_dir(
     return base.resolve()
 
 
-def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path_for_task(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
@@ -376,12 +626,17 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     translated to ``C:\\Users\\...`` before resolution so file tools don't
     treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
-    container_paths = _uses_container_paths(task_id)
+    container_paths = _uses_container_paths(
+        task_id, execution_target, _resolution=_resolution,
+    )
     if container_paths:
         expanded = _expand_tilde(filepath)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
-        resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
+        resolved = _resolve_base_dir(
+            task_id, container_paths=True, execution_target=execution_target,
+            _resolution=_resolution,
+        ) / expanded
         return _normalize_without_host_deref(resolved)
 
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
@@ -393,17 +648,27 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
         if ntpath.isabs(expanded):
             return Path(ntpath.normpath(expanded))
-        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
+        joined = ntpath.join(str(_resolve_base_dir(
+            task_id, container_paths=False, execution_target=execution_target,
+            _resolution=_resolution,
+        )), expanded)
         return Path(ntpath.normpath(joined))
 
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
-    resolved = _resolve_base_dir(task_id, container_paths=False) / p
+    resolved = _resolve_base_dir(
+        task_id, container_paths=False, execution_target=execution_target,
+        _resolution=_resolution,
+    ) / p
     return resolved.resolve()
 
 
-def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
+def _path_resolution_warning(
+    filepath: str, resolved: Path, task_id: str = "default",
+    execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
     Surfaces the worktree-cwd divergence the moment it would matter: if the
@@ -421,10 +686,14 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     try:
         if Path(_expand_tilde(filepath)).is_absolute():
             return None
-        workspace_root = _authoritative_workspace_root(task_id)
+        workspace_root = _authoritative_workspace_root(
+            task_id, execution_target, _resolution=_resolution,
+        )
         if not workspace_root:
             return None  # No authoritative workspace root to compare against.
-        if _uses_container_paths(task_id):
+        if _uses_container_paths(
+            task_id, execution_target, _resolution=_resolution,
+        ):
             root = _normalize_without_host_deref(Path(_expand_tilde(workspace_root)))
         else:
             root = Path(_expand_tilde(workspace_root)).resolve()
@@ -593,7 +862,10 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
-def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
+def _search_result_read_block_error(
+    path: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return the read-safety error for a search result path.
 
     Search backends may return paths relative to the task cwd, while
@@ -602,20 +874,27 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     resolution before applying the shared read guard.
     """
     try:
-        resolved = _resolve_path_for_task(path, task_id)
+        resolved = _resolve_path_for_task(
+            path, task_id, execution_target, _resolution=_resolution,
+        )
     except (OSError, ValueError, RuntimeError):
         return get_read_block_error(path)
     return get_read_block_error(str(resolved))
 
 
-def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
+def _filter_read_blocked_search_results(
+    result, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> int:
     """Remove credential/cache/env paths from a SearchResult in-place."""
     omitted = 0
 
     if hasattr(result, "matches") and result.matches:
         allowed_matches = []
         for match in result.matches:
-            if _search_result_read_block_error(match.path, task_id):
+            if _search_result_read_block_error(
+                match.path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_matches.append(match)
@@ -624,7 +903,9 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "files") and result.files:
         allowed_files = []
         for file_path in result.files:
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_files.append(file_path)
@@ -633,7 +914,9 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "counts") and result.counts:
         allowed_counts = {}
         for file_path, count in result.counts.items():
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_counts[file_path] = count
@@ -677,10 +960,15 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_sensitive_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, execution_target, _resolution=_resolution,
+        ))
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
@@ -704,7 +992,12 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
-    return None
+    try:
+        from agent.file_safety import get_write_denied_error
+
+        return get_write_denied_error(resolved, verb="Write")
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -1019,7 +1312,10 @@ def _check_approval_required_write(paths: list[str],
     return result.get("message") or blocked.format(why="was denied.")
 
 
-def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | None:
+def _get_container_mirror_prefix_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return the container-side Hermes mirror prefix for Docker file tools."""
     try:
         from tools.terminal_tool import (
@@ -1028,14 +1324,17 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
-        container_key = _resolve_container_task_id(task_id)
+        resolution = _resolution or resolve_execution_target(execution_target)
+        container_key = resolution.environment_key(_resolve_container_task_id(task_id))
+        raw_key = resolution.environment_key(task_id)
     except Exception:
         return None
 
     try:
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -1044,7 +1343,10 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
                 return "/root/.hermes"
             return None
 
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
     except Exception:
         return None
 
@@ -1053,7 +1355,10 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     return None
 
 
-def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_cross_profile_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return a soft-guard warning when ``filepath`` lands in another Hermes
     profile's scoped area, a host-side sandbox-mirror of authoritative profile
     state, or the Docker container's sandbox mirror of Hermes state.
@@ -1095,7 +1400,9 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     # in a session that cd'd into ``~/.hermes/profiles/other/`` is
     # classified against the right base.
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, execution_target, _resolution=_resolution,
+        ))
     except (OSError, ValueError):
         resolved = filepath
 
@@ -1107,9 +1414,12 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     if warning is not None:
         return warning
 
+    mirror_prefix = _get_container_mirror_prefix_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    )
     return get_container_mirror_warning(
         resolved,
-        mirror_prefix=_get_container_mirror_prefix_for_task(task_id),
+        mirror_prefix=mirror_prefix,
     )
 
 
@@ -1258,7 +1568,9 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 break
 
 
-def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | None:
+def _check_not_found_cache(
+    op: str, resolved_str: str, task_id: str, *, check_host_filesystem: bool = True,
+) -> str | None:
     """Return cached not-found JSON for *(op, resolved_str)* if still fresh.
 
     Skips the expensive subprocess + suggestion walk when the model retries
@@ -1298,7 +1610,7 @@ def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | No
     # check below in read_file_tool): the lock is global across all tasks,
     # and a hung stat on a dead network mount must not stall every other
     # task's read/search bookkeeping.
-    if _os.path.exists(resolved_str):
+    if check_host_filesystem and _os.path.exists(resolved_str):
         with _read_tracker_lock:
             task_data = _read_tracker.get(task_id)
             nf = task_data.get("not_found") if task_data else None
@@ -1396,7 +1708,9 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
-def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
+def _get_file_ops(
+    task_id: str = "default", target: str | None = None, *, _resolution: Any = None,
+) -> ShellFileOperations:
     """Get or create ShellFileOperations for a terminal environment.
 
     Respects the TERMINAL_ENV setting -- if the task_id doesn't have an
@@ -1418,13 +1732,28 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks_lock,
         _resolve_container_task_id,
         _resolve_task_host_cwd,
-        _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        _record_environment_lifetime,
+        _record_environment_target,
+        _environment_matches_target,
+        _prepare_environment_replacement,
+        _retire_replaced_environment,
+        _cleanup_environment_resource,
+        _environment_has_stable_storage,
+        _apply_task_cwd_override,
+        _build_environment_constructor_configs,
+    )
+    from tools.execution_targets import (
+        execution_target_config_is_frozen,
+        resolve_execution_target,
+        resolve_live_execution_target,
     )
     import time
 
     raw_task_id = task_id or "default"
-    task_id = _resolve_container_task_id(raw_task_id)
+    resolution = _resolution or resolve_execution_target(target)
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    task_id = resolution.environment_key(base_task_id)  # type: ignore[assignment]
+    backend_task_id = resolution.backend_task_id(base_task_id)
 
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
@@ -1432,7 +1761,11 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         cached = _file_ops_cache.get(task_id)
     if cached is not None:
         with _env_lock:
-            if task_id in _active_environments:
+            active_env = _active_environments.get(task_id)
+            if (
+                _environment_matches_target(active_env, resolution)
+                and getattr(cached, "env", None) is active_env
+            ):
                 _last_activity[task_id] = time.time()
                 return cached
             else:
@@ -1448,14 +1781,18 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 # Rescue a session that has no record, but never overwrite a
                 # record the session wrote for itself.
                 old_cwd = getattr(cached, "cwd", None)
-                if old_cwd:
+                if active_env is None and old_cwd:
                     try:
                         from tools.terminal_tool import (
                             get_session_cwd,
                             record_session_cwd,
                         )
-                        if get_session_cwd(raw_task_id) is None:
-                            record_session_cwd(raw_task_id, old_cwd)
+                        if get_session_cwd(
+                            raw_task_id, _resolution=resolution,
+                        ) is None:
+                            record_session_cwd(
+                                raw_task_id, old_cwd, _resolution=resolution,
+                            )
                     except Exception:
                         pass
                 with _file_ops_lock:
@@ -1471,16 +1808,25 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     with task_lock:
         # Double-check: another thread may have created it while we waited
         with _env_lock:
-            if task_id in _active_environments:
+            active_env = _active_environments.get(task_id)
+            if _environment_matches_target(active_env, resolution):
                 _last_activity[task_id] = time.time()
-                terminal_env = _active_environments[task_id]
+                terminal_env = active_env
             else:
                 terminal_env = None
 
         if terminal_env is None:
+            _prepare_environment_replacement(
+                active_env,
+                task_id,
+                target_name=resolution.target,
+            )
             from tools.terminal_tool import resolve_task_overrides
 
-            config = _get_env_config()
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named else _get_env_config()
+            )
             env_type = config["env_type"]
             overrides = resolve_task_overrides(raw_task_id)
 
@@ -1497,61 +1843,53 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             try:
                 from tools.terminal_tool import get_session_cwd
-                recorded_cwd = get_session_cwd(raw_task_id)
+                recorded_cwd = get_session_cwd(
+                    raw_task_id, _resolution=resolution,
+                )
             except Exception:
                 recorded_cwd = None
-            cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
-            # Re-apply the container cwd guard that _get_env_config() already
-            # ran on config["cwd"] (see #50636).  A per-task cwd override
-            # registered by the gateway/TUI/ACP for workspace tracking is a
-            # raw host path (e.g. a Desktop session's /Users/<me>/workspace or
-            # C:\\Users\\<me>). On a container backend that reaches
-            # ``docker run -w <host-path>`` and the container starts in a
-            # directory that doesn't exist inside the sandbox, so search_files
-            # and friends silently return empty results (#54447).  Sanitize it
-            # back to the already-validated config["cwd"] so the override can't
-            # bypass the guard.  Valid in-container override paths (RL/benchmark
-            # sandboxes that set cwd to /workspace, /root, etc.) are absolute
-            # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-                if cwd != config["cwd"]:
-                    logger.info(
-                        "Ignoring host/relative cwd override %r for %s backend "
-                        "(won't exist in sandbox). Using %r instead.",
-                        cwd, env_type, config["cwd"],
-                    )
-                cwd = config["cwd"]
-            logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
+            cwd_override = (
+                overrides.get("cwd")
+                if (
+                    not resolution.named
+                    or (resolution.is_default and resolution.backend != "ssh")
+                )
+                else None
+            )
+            cwd = cwd_override or recorded_cwd or config["cwd"]
+            cwd = _apply_task_cwd_override(config, cwd, cwd_override)
+            logger.info("Creating new %s environment for task %s...", env_type, task_id)
 
-            container_config = None
-            if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+            container_config, ssh_config, local_config = (
+                _build_environment_constructor_configs(
+                    config, resolution, base_task_id,
+                )
+            )
+            if container_config is not None:
+                # Keep an auditable module-local constructor map. The shared
+                # builder remains the normalization source, while this explicit
+                # copy preserves the upstream cross-call-site Docker option
+                # invariant enforced by test_docker_network_config.py.
                 container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "vercel_runtime": config.get("vercel_runtime", ""),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
-
-            ssh_config = None
-            if env_type == "ssh":
-                ssh_config = {
-                    "host": config.get("ssh_host", ""),
-                    "user": config.get("ssh_user", ""),
-                    "port": config.get("ssh_port", 22),
-                    "key": config.get("ssh_key", ""),
-                    "persistent": config.get("ssh_persistent", False),
-                }
-
-            local_config = None
-            if env_type == "local":
-                local_config = {
-                    "persistent": config.get("local_persistent", False),
+                    "container_cpu": container_config["container_cpu"],
+                    "container_memory": container_config["container_memory"],
+                    "container_disk": container_config["container_disk"],
+                    "container_persistent": container_config["container_persistent"],
+                    "vercel_runtime": container_config["vercel_runtime"],
+                    "modal_mode": container_config["modal_mode"],
+                    "docker_volumes": container_config["docker_volumes"],
+                    "docker_mount_cwd_to_workspace": container_config["docker_mount_cwd_to_workspace"],
+                    "docker_forward_env": container_config["docker_forward_env"],
+                    "docker_env": container_config["docker_env"],
+                    "docker_run_as_host_user": container_config["docker_run_as_host_user"],
+                    "docker_extra_args": container_config["docker_extra_args"],
+                    "docker_network": container_config["docker_network"],
+                    "docker_shm_size": container_config["docker_shm_size"],
+                    "docker_persist_across_processes": container_config["docker_persist_across_processes"],
+                    "docker_orphan_reaper": container_config["docker_orphan_reaper"],
+                    "lifetime_seconds": container_config["lifetime_seconds"],
+                    "storage_task_id": container_config["storage_task_id"],
+                    "legacy_storage_task_id": container_config["legacy_storage_task_id"],
                 }
 
             terminal_env = _create_environment(
@@ -1562,16 +1900,46 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 ssh_config=ssh_config,
                 container_config=container_config,
                 local_config=local_config,
-                task_id=task_id,
+                task_id=backend_task_id,
                 host_cwd=_resolve_task_host_cwd(config, raw_task_id),
             )
+            _record_environment_lifetime(terminal_env, config)
+            _record_environment_target(terminal_env, resolution)
 
+            publish_error = None
             with _env_lock:
-                _active_environments[task_id] = terminal_env
-                _last_activity[task_id] = time.time()
+                if resolution.named:
+                    try:
+                        live_resolution = (
+                            resolution
+                            if execution_target_config_is_frozen()
+                            else resolve_live_execution_target(target)
+                        )
+                    except Exception as exc:
+                        publish_error = str(exc)
+                    else:
+                        if live_resolution.security_scope != resolution.security_scope:
+                            publish_error = (
+                                f"Execution target {resolution.target!r} changed "
+                                "while its environment was being created."
+                            )
+                replaced_env = None
+                if publish_error is None:
+                    replaced_env = _active_environments.get(task_id)
+                    _active_environments[task_id] = terminal_env
+                    _last_activity[task_id] = time.time()
+            if publish_error is not None:
+                _cleanup_environment_resource(
+                    terminal_env,
+                    force_remove=True,
+                    preserve_storage=_environment_has_stable_storage(terminal_env),
+                )
+                raise RuntimeError(publish_error + " Retry the file operation.")
+            if replaced_env is not None and replaced_env is not terminal_env:
+                _retire_replaced_environment(replaced_env, task_id)
 
             _start_cleanup_thread()
-            logger.info("%s environment ready for task %s", env_type, task_id[:8])
+            logger.info("%s environment ready for task %s", env_type, task_id)
 
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
@@ -1580,7 +1948,37 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     return file_ops
 
 
-def clear_file_ops_cache(task_id: str = None):
+
+def _file_ops_for_resolution(task_id: str, resolution: Any):
+    # Preserve the established one-argument seam in legacy mode.
+    if resolution.named:
+        file_ops = _get_file_ops(
+            task_id, target=resolution.target, _resolution=resolution,
+        )
+        if resolution.backend == "ssh":
+            # Named SSH environments are shared across conversations, so the
+            # environment's mutable cwd belongs to whichever session ran most
+            # recently. Pin every file operation to this session's cwd record,
+            # falling back to the target's configured remote root for a fresh
+            # session. Values such as "." and "~" intentionally remain remote
+            # shell paths and therefore do not inherit another session's cwd.
+            operation_cwd = _authoritative_workspace_root(
+                task_id, resolution.target, _resolution=resolution,
+            )
+            environment = getattr(file_ops, "env", None)
+            if operation_cwd and environment is not None:
+                scoped_ops = ShellFileOperations(
+                    environment,
+                    cwd=operation_cwd,
+                    fixed_cwd=operation_cwd,
+                )
+                scoped_ops._command_cache = file_ops._command_cache
+                return scoped_ops
+        return file_ops
+    return _get_file_ops(task_id)
+
+
+def clear_file_ops_cache(task_id=None):
     """Clear the file operations cache."""
     with _file_ops_lock:
         if task_id:
@@ -1621,28 +2019,75 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str, offset: int = 1, limit: int = 2000,
+    task_id: str = "default", execution_target: str | None = None,
+    runtime_scope: str | None = None,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
+        from tools.execution_targets import resolve_execution_target
+        selected_execution_target = execution_target
+
+        pinned_file_ops = None
+        if runtime_scope:
+            from tools.terminal_tool import get_environment_for_target_scope
+
+            selected_name = str(selected_execution_target or "")
+            if not selected_name:
+                return tool_error(
+                    "read_file runtime_scope requires execution_target from the saved-output hint."
+                )
+            pinned_env = get_environment_for_target_scope(
+                task_id, selected_name, runtime_scope,
+            )
+            if pinned_env is None:
+                return tool_error(
+                    "The producing execution environment for this saved output "
+                    "is no longer available. Re-run the originating tool."
+                )
+            resolution = getattr(pinned_env, "_hermes_target_resolution", None)
+            if resolution is None:
+                return tool_error(
+                    "The producing environment lacks immutable target metadata. "
+                    "Re-run the originating tool."
+                )
+            pinned_file_ops = ShellFileOperations(
+                pinned_env, str(getattr(pinned_env, "cwd", ".")),
+            )
+        else:
+            resolution = resolve_execution_target(selected_execution_target)
+        selected_target = resolution.target if resolution.named else None
+        host_mtime_tracking = resolution.backend == "local"
+        state_task_id = resolution.file_coordination_key(task_id)
+        state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
         offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(
+            task_id, execution_target=selected_target,
+            _resolution=resolution,
+        )
         if _is_blocked_device(path, base_dir=device_base):
             return tool_error(
                 f"Cannot read '{path}': this is a device file that would "
                 "block or produce infinite output."
             )
 
-        _resolved = _resolve_path_for_task(path, task_id)
+        _resolved = _resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            )
+        file_ops = pinned_file_ops or _file_ops_for_resolution(task_id, resolution)
 
         # ── Special-file type guard (stat-based) ──────────────────────
         # The name blocklist above catches /dev/* and /proc/* aliases; this
         # catches the class — any FIFO/socket/device wherever it lives. A
         # read on a FIFO blocks until the exec timeout: a self-shipped DoS.
-        if _file_ops_uses_host_paths(_get_file_ops(task_id)):
+        if _file_ops_uses_host_paths(file_ops):
             kind = _special_file_kind(_resolved)
             if kind is not None:
                 return json.dumps({
@@ -1668,7 +2113,6 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         )
 
         if is_extractable_document(str(_resolved)):
-            file_ops = _get_file_ops(task_id)
             try:
                 binary = file_ops.read_file_bytes(
                     str(_resolved), max_bytes=MAX_DOCUMENT_BYTES
@@ -1752,6 +2196,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                         )
                 if result_dict["content"]:
                     result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                result_dict.update(resolution.metadata(
+                    cwd=_authoritative_workspace_root(task_id, selected_target),
+                ))
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1782,7 +2229,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # return the cached error without spawning the subprocess +
         # similar-files walk. Cleared by write_file/patch on the same path.
         resolved_str_for_neg = str(_resolved)
-        cached_not_found = _check_not_found_cache("read", resolved_str_for_neg, task_id)
+        cached_not_found = _check_not_found_cache(
+            "read", resolved_str_for_neg, state_task_id,
+            check_host_filesystem=resolution.backend == "local",
+        )
         if cached_not_found is not None:
             return cached_not_found
 
@@ -1793,7 +2243,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
@@ -1805,7 +2255,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["dedup_hits"] = {}
             if "read_timestamps" not in task_data:
                 task_data["read_timestamps"] = {}
-            cached_mtime = task_data.get("dedup", {}).get(dedup_key)
+            cached_mtime = (
+                task_data.get("dedup", {}).get(dedup_key)
+                if host_mtime_tracking
+                else None
+            )
 
         if cached_mtime is not None:
             try:
@@ -1834,20 +2288,31 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                             already_read=hits + 1,
                         )
 
-                    return json.dumps({
+                    unchanged = {
                         "status": "unchanged",
                         "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,
                         "dedup": True,
                         "content_returned": False,
-                    }, ensure_ascii=False)
+                    }
+                    unchanged.update(resolution.metadata(
+                        cwd=_authoritative_workspace_root(
+                            task_id, selected_target, _resolution=resolution,
+                        ),
+                    ))
+                    return json.dumps(unchanged, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        file_ops = pinned_file_ops or _file_ops_for_resolution(task_id, resolution)
+        operation_path = _backend_operation_path(
+            path, _resolved, task_id, selected_target,
+            _resolution=resolution,
+        )
+        result = file_ops.read_file(operation_path, offset, limit)
         result_dict = result.to_dict()
+        result_dict.setdefault("resolved_path", operation_path)
 
         # ── Populate negative-result cache on not-found ───────────────
         # _suggest_similar_files returns ReadResult(error="File not found: ..").
@@ -1861,7 +2326,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         _err = result_dict.get("error") or ""
         if isinstance(_err, str) and _err.startswith("File not found:"):
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
-            _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
+            _record_not_found(
+                "read", resolved_str_for_neg, state_task_id, _not_found_json,
+            )
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
@@ -1946,12 +2413,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             # 1. Dedup: skip identical re-reads of unchanged files.
             # 2. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
+            if host_mtime_tracking:
+                try:
+                    _mtime_now = os.path.getmtime(resolved_str)
+                    task_data["dedup"][dedup_key] = _mtime_now
+                    task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
+                except OSError:
+                    pass  # Can't stat — skip tracking for this entry
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
@@ -1966,7 +2434,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # isn't nested under ours.
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            file_state.record_read(
+                state_task_id, resolved_str, partial=_partial,
+                namespace=state_namespace,
+                stat_path=host_mtime_tracking,
+            )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -1985,6 +2457,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 "The content has not changed since your last read. Use the information you already have. "
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
+
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
 
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
@@ -2006,8 +2482,25 @@ def reset_file_dedup(task_id: str = None):
     """
     with _read_tracker_lock:
         if task_id:
-            task_data = _read_tracker.get(task_id)
-            if task_data:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            task_ids = {task_id, scoped_task_id}
+            keys = list(task_ids) + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in task_ids
+                )
+            ]
+            for key in keys:
+                task_data = _read_tracker.get(key)
+                if not task_data:
+                    continue
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
@@ -2020,7 +2513,9 @@ def reset_file_dedup(task_id: str = None):
                     task_data["dedup_hits"].clear()
 
 
-def notify_other_tool_call(task_id: str = "default"):
+def notify_other_tool_call(
+    task_id: str = "default", execution_target: str | None = None,
+):
     """Reset consecutive read/search counter for a task.
 
     Called by the tool dispatcher (model_tools.py) whenever a tool OTHER
@@ -2030,8 +2525,36 @@ def notify_other_tool_call(task_id: str = "default"):
     resets and the next read is treated as fresh.
     """
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
-        if task_data:
+        if execution_target is None:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            keys = [task_id, scoped_task_id] + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in {task_id, scoped_task_id}
+                )
+            ]
+        else:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                keys = [
+                    resolve_execution_target(execution_target).file_coordination_key(
+                        task_id
+                    )
+                ]
+            except Exception:
+                keys = [task_id]
+        for key in keys:
+            task_data = _read_tracker.get(key)
+            if not task_data:
+                continue
             task_data["last_key"] = None
             task_data["consecutive"] = 0
             # An intervening non-read tool call breaks any stub-loop in
@@ -2049,7 +2572,13 @@ def notify_other_tool_call(task_id: str = "default"):
                 nf.clear()
 
 
-def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
+def _invalidate_dedup_for_path(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> None:
     """Remove all dedup cache entries whose resolved path matches *filepath*.
 
     Called after write_file and patch so that a subsequent read_file on
@@ -2062,12 +2591,18 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     Must be called with ``_read_tracker_lock`` **not** held — acquires it
     internally.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.file_coordination_key(task_id)
     try:
-        resolved = str(_resolve_path(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is None:
             return
         dedup = task_data.get("dedup")
@@ -2085,7 +2620,13 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
             nf.pop(("search", resolved), None)
 
 
-def _update_read_timestamp(filepath: str, task_id: str) -> None:
+def _update_read_timestamp(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> None:
     """Record the file's current modification time after a successful write.
 
     Called after write_file and patch so that consecutive edits by the
@@ -2096,32 +2637,52 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     subsequent reads return fresh content (fixes #13144).
     """
     # Invalidate dedup first (before acquiring lock for timestamp update).
-    _invalidate_dedup_for_path(filepath, task_id)
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.file_coordination_key(task_id)
+    _invalidate_dedup_for_path(
+        filepath, task_id, selected_target, _resolution=resolution,
+    )
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is not None:
             task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
             _cap_read_tracker_data(task_data)
 
 
-def _check_file_staleness(filepath: str, task_id: str) -> str | None:
+def _check_file_staleness(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> str | None:
     """Check whether a file was modified since the agent last read it.
 
     Returns a warning string if the file is stale (mtime changed since
     the last read_file call for this task), or None if the file is fresh
     or was never read.  Does not block — the write still proceeds.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.file_coordination_key(task_id)
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if not task_data:
             return None
         read_mtime = task_data.get("read_timestamps", {}).get(resolved)
@@ -2144,6 +2705,9 @@ def _mark_verification_stale(
     task_id: str,
     resolved_paths: list[str],
     session_id: str | None = None,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
 ) -> None:
     """Best-effort note that successful edits made prior verification stale."""
     paths = [p for p in resolved_paths if p]
@@ -2163,7 +2727,9 @@ def _mark_verification_stale(
                 cwd = candidate
                 break
         if cwd is None:
-            cwd = _authoritative_workspace_root(task_id)
+            cwd = _authoritative_workspace_root(
+                task_id, execution_target, _resolution=_resolution,
+            )
         if cwd is None:
             try:
                 cwd = str(Path(paths[0]).parent)
@@ -2221,7 +2787,8 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
 
 def write_file_tool(path: str, content: str, task_id: str = "default",
                     cross_profile: bool = False,
-                    session_id: str | None = None) -> str:
+                    session_id: str | None = None,
+                    execution_target: str = None) -> str:
     """Write content to a file.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard. The
@@ -2230,7 +2797,20 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
-    sensitive_err = _check_sensitive_path(path, task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(execution_target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    host_mtime_tracking = resolution.backend == "local"
+    state_task_id = resolution.file_coordination_key(task_id)
+    state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
+    sensitive_err = _check_sensitive_path(
+        path, task_id, selected_target, _resolution=resolution,
+    )
     if sensitive_err:
         return tool_error(sensitive_err)
     binary_doc_err = _check_binary_document_write(path, task_id)
@@ -2243,7 +2823,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     if approval_err:
         return tool_error(approval_err)
     if not cross_profile:
-        cross_warning = _check_cross_profile_path(path, task_id)
+        cross_warning = _check_cross_profile_path(
+            path, task_id, selected_target, _resolution=resolution,
+        )
         if cross_warning:
             return tool_error(cross_warning)
     if _is_internal_file_tool_content(content):
@@ -2257,35 +2839,59 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # fall back to the legacy path — write proceeds, per-task staleness
         # check below still runs.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _resolved = str(_resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            ))
         except Exception:
             _resolved = None
 
         if _resolved is None:
-            stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
+            stale_warning = _check_file_staleness(
+                path, task_id, selected_target, _resolution=resolution,
+            )
+            file_ops = _file_ops_for_resolution(task_id, resolution)
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
-                _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
+                _mark_verification_stale(
+                    task_id, [path], session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
+            _update_read_timestamp(
+                path, task_id, selected_target, _resolution=resolution,
+            )
+            result_dict.update(resolution.metadata(
+                cwd=_authoritative_workspace_root(task_id, selected_target),
+            ))
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
-        with file_state.lock_path(_resolved):
+        with file_state.lock_path(_resolved, namespace=state_namespace):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
-            stale_warning = _check_file_staleness(path, task_id)
+            cross_warning = file_state.check_stale(
+                state_task_id, _resolved, namespace=state_namespace,
+            )
+            stale_warning = _check_file_staleness(
+                path, task_id, selected_target, _resolution=resolution,
+            )
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
-            cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            cwd_warning = _path_resolution_warning(
+                path, Path(_resolved), task_id, selected_target,
+                _resolution=resolution,
+            )
+            file_ops = _file_ops_for_resolution(task_id, resolution)
+            operation_path = _backend_operation_path(
+                path, _resolved, task_id, selected_target,
+                _resolution=resolution,
+            )
+            result = file_ops.write_file(operation_path, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -2293,15 +2899,27 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Always report the ABSOLUTE path actually written, so a wrong-cwd
             # mismatch is visible in the response instead of silently routing
             # the edit to the wrong checkout.
-            result_dict["resolved_path"] = _resolved
+            result_dict["resolved_path"] = operation_path
             if not result_dict.get("error"):
-                result_dict["files_modified"] = [_resolved]
-                _mark_verification_stale(task_id, [_resolved], session_id=session_id)
+                result_dict["files_modified"] = [operation_path]
+                _mark_verification_stale(
+                    task_id, [operation_path], session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.
-            _update_read_timestamp(path, task_id)
+            _update_read_timestamp(
+                path, task_id, selected_target, _resolution=resolution,
+            )
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(
+                    state_task_id, _resolved, namespace=state_namespace,
+                    stat_path=host_mtime_tracking,
+                )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -2314,13 +2932,26 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
-               session_id: str | None = None) -> str:
+               session_id: str | None = None,
+               execution_target: str = None) -> str:
     """Patch a file using replace mode or V4A patch format.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard for
     targets under another profile's skills/plugins/cron/memories
     directory. Same shape as ``write_file``'s flag.
     """
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(execution_target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    host_mtime_tracking = resolution.backend == "local"
+    state_task_id = resolution.file_coordination_key(task_id)
+    state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
+
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     # Paths whose CONTENT will be text-written (Update/Add + explicit path).
@@ -2374,11 +3005,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return _err
                 _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p, task_id)
+        sensitive_err = _check_sensitive_path(
+            _p, task_id, selected_target, _resolution=resolution,
+        )
         if sensitive_err:
             return tool_error(sensitive_err)
         if not cross_profile:
-            cross_warning = _check_cross_profile_path(_p, task_id)
+            cross_warning = _check_cross_profile_path(
+                _p, task_id, selected_target, _resolution=resolution,
+            )
             if cross_warning:
                 return tool_error(cross_warning)
     for _p in _content_write_paths:
@@ -2401,7 +3036,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _seen: set[str] = set()
         for _p in _paths_to_check:
             try:
-                _r = str(_resolve_path_for_task(_p, task_id))
+                _r = str(_resolve_path_for_task(
+                    _p, task_id, selected_target, _resolution=resolution,
+                ))
             except Exception:
                 _r = None
             if _r and _r not in _seen:
@@ -2415,7 +3052,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         from contextlib import ExitStack
         with ExitStack() as _locks:
             for _r in _resolved_paths:
-                _locks.enter_context(file_state.lock_path(_r))
+                _locks.enter_context(
+                    file_state.lock_path(_r, namespace=state_namespace)
+                )
 
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
@@ -2423,20 +3062,29 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
                 try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
+                    _r = str(_resolve_path_for_task(
+                    _p, task_id, selected_target, _resolution=resolution,
+                ))
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
-                _cross = file_state.check_stale(task_id, _r) if _r else None
-                _sw = _cross or _check_file_staleness(_p, task_id)
+                _cross = file_state.check_stale(
+                    state_task_id, _r, namespace=state_namespace,
+                ) if _r else None
+                _sw = _cross or _check_file_staleness(
+                    _p, task_id, selected_target, _resolution=resolution,
+                )
                 if not _sw and _r:
                     # Workspace-divergence warning (worktree-cwd bug): relative
                     # path resolving outside the terminal's cwd.
-                    _sw = _path_resolution_warning(_p, Path(_r), task_id)
+                    _sw = _path_resolution_warning(
+                        _p, Path(_r), task_id, selected_target,
+                        _resolution=resolution,
+                    )
                 if _sw:
                     stale_warnings.append(_sw)
 
-            file_ops = _get_file_ops(task_id)
+            file_ops = _file_ops_for_resolution(task_id, resolution)
 
             if mode == "replace":
                 if not path:
@@ -2448,19 +3096,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
                 # path would let the two layers disagree about which file is
                 # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
+                _replace_target = _backend_operation_path(
+                    path, _path_to_resolved.get(path) or path,
+                    task_id, selected_target,
+                    _resolution=resolution,
+                )
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                # Rewrite V4A headers to the resolved absolute paths so the
-                # shell layer patches the exact files the tool layer resolved
-                # (locked/reported). Without this a relative header re-resolves
-                # against the shell's cwd, which can differ from the workspace
-                # (git-worktree cwd bug) — landing the edit elsewhere.
-                patch_for_ops = _rewrite_v4a_patch_paths_for_host(
-                    patch, _path_to_resolved, file_ops
-                )
+                if resolution.backend == "ssh":
+                    patch_for_ops = _backend_v4a_patch(
+                        patch, task_id, selected_target, _resolution=resolution,
+                    )
+                else:
+                    # Preserve current-upstream absolute-path reconciliation for
+                    # local/container backends; SSH paths must stay remote.
+                    patch_for_ops = _rewrite_v4a_patch_paths_for_host(
+                        patch, _path_to_resolved, file_ops
+                    )
                 result = file_ops.patch_v4a(patch_for_ops)
             else:
                 return tool_error(f"Unknown mode: {mode}")
@@ -2472,7 +3126,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # mismatch (e.g. a worktree session editing the main checkout) is
             # visible in the response instead of silently landing elsewhere.
             _resolved_modified = [
-                _path_to_resolved.get(_p) or _p for _p in _paths_to_check
+                _backend_operation_path(
+                    _p, _path_to_resolved.get(_p) or _p,
+                    task_id, selected_target,
+                    _resolution=resolution,
+                )
+                for _p in _paths_to_check
             ]
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
@@ -2480,16 +3139,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
-                _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
+                _mark_verification_stale(
+                    task_id, _resolved_modified, session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
                 for _p in _paths_to_check:
-                    _update_read_timestamp(_p, task_id)
+                    _update_read_timestamp(
+                        _p, task_id, selected_target, _resolution=resolution,
+                    )
                     _r = _path_to_resolved.get(_p)
                     if _r:
-                        file_state.note_write(task_id, _r)
+                        file_state.note_write(
+                            state_task_id, _r, namespace=state_namespace,
+                            stat_path=host_mtime_tracking,
+                        )
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
-                _reset_patch_failures(task_id, [
+                _reset_patch_failures(state_task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
         # Hint when old_string not found — saves iterations where the agent
@@ -2504,7 +3172,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             failure_count = 0
             if mode == "replace" and path:
                 resolved = _path_to_resolved.get(path) or path
-                failure_count = _record_patch_failure(task_id, resolved)
+                failure_count = _record_patch_failure(state_task_id, resolved)
 
             if failure_count >= 3:
                 # Escalating hint after multiple consecutive failures on the
@@ -2527,6 +3195,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
                 )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -2535,9 +3206,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                task_id: str = "default", execution_target: str = None) -> str:
     """Search for content or files."""
     try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(execution_target)
+        selected_target = resolution.target if resolution.named else None
+        state_task_id = resolution.file_coordination_key(task_id)
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Track searches to detect *consecutive* repeated search loops.
@@ -2553,7 +3229,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             offset,
         )
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set(),
             })
             if task_data["last_key"] == search_key:
@@ -2573,7 +3249,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             )
 
         try:
-            resolved_path = _resolve_path_for_task(path, task_id)
+            resolved_path = _resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            )
         except (OSError, ValueError, RuntimeError):
             resolved_path = None
         block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
@@ -2585,20 +3263,27 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         # doesn't exist. The error path also lists the parent directory
         # (file_operations.py:1402) — expensive to repeat. Cache so the
         # next call to a known-missing root skips both shells.
-        try:
-            resolved_search_path = str(_resolve_path_for_task(path, task_id))
-        except (OSError, ValueError):
-            resolved_search_path = path
-        cached_search_nf = _check_not_found_cache("search", resolved_search_path, task_id)
+        resolved_search_path = str(resolved_path) if resolved_path is not None else path
+        cached_search_nf = _check_not_found_cache(
+            "search", resolved_search_path, state_task_id,
+            check_host_filesystem=resolution.backend == "local",
+        )
         if cached_search_nf is not None:
             return cached_search_nf
 
-        file_ops = _get_file_ops(task_id)
+        file_ops = _file_ops_for_resolution(task_id, resolution)
+        operation_path = _backend_operation_path(
+            path, resolved_path or path, task_id, selected_target,
+            _resolution=resolution,
+        )
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=operation_path, target=target,
+            file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
-        omitted = _filter_read_blocked_search_results(result, task_id)
+        omitted = _filter_read_blocked_search_results(
+            result, task_id, selected_target, _resolution=resolution,
+        )
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
@@ -2617,13 +3302,19 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         _search_err = result_dict.get("error") or ""
         if isinstance(_search_err, str) and _search_err.startswith("Path not found:"):
             _search_nf_json = json.dumps(result_dict, ensure_ascii=False)
-            _record_not_found("search", resolved_search_path, task_id, _search_nf_json)
+            _record_not_found(
+                "search", resolved_search_path, state_task_id, _search_nf_json,
+            )
 
         if count >= 3:
             result_dict["_warning"] = (
                 f"You have run this exact search {count} times consecutively. "
                 "The results have not changed. Use the information you already have."
             )
+
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
 
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
@@ -2657,7 +3348,9 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000},
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
+            "runtime_scope": {"type": "string", "description": "Immutable producing-runtime scope from a saved-output hint. Pass only when the hint supplies it."},
         },
         "required": ["path"]
     }
@@ -2671,6 +3364,7 @@ WRITE_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
             "content": {"type": "string", "description": "Complete content to write to the file"},
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
@@ -2727,6 +3421,7 @@ PATCH_SCHEMA = {
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories.",
                 "default": False,
             },
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
         },
         "required": ["mode"],
     },
@@ -2734,7 +3429,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nThe target field selects search mode ('content' or 'files'); execution_target separately selects the named terminal execution target.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2745,7 +3440,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. This is separate from target, which selects content/files search mode."},
         },
         "required": ["pattern"]
     }
@@ -2753,11 +3449,28 @@ SEARCH_FILES_SCHEMA = {
 
 
 def _handle_read_file(args, **kw):
+    try:
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args("read_file", args)
+    except Exception as exc:
+        return tool_error(str(exc))
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""), offset=args.get("offset", 1),
+        limit=args.get("limit", 500), task_id=tid,
+        execution_target=args.get("execution_target"),
+        runtime_scope=args.get("runtime_scope"),
+    )
 
 
 def _handle_write_file(args, **kw):
+    try:
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args("write_file", args)
+    except Exception as exc:
+        return tool_error(str(exc))
     tid = kw.get("task_id") or "default"
     if not args.get("path") or not isinstance(args.get("path"), str):
         return tool_error(
@@ -2781,10 +3494,17 @@ def _handle_write_file(args, **kw):
         path=args["path"], content=args["content"], task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        execution_target=args.get("execution_target"),
     )
 
 
 def _handle_patch(args, **kw):
+    try:
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args("patch", args)
+    except Exception as exc:
+        return tool_error(str(exc))
     tid = kw.get("task_id") or "default"
     return patch_tool(
         mode=args.get("mode", "replace"), path=args.get("path"),
@@ -2792,6 +3512,7 @@ def _handle_patch(args, **kw):
         replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        execution_target=args.get("execution_target"),
     )
 
 
@@ -2803,7 +3524,10 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"),
+        context=args.get("context", 0), task_id=tid,
+        execution_target=args.get("execution_target"),
+    )
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2,6 +2,7 @@
 """File Tools Module - LLM agent file manipulation tools."""
 
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -9,6 +10,7 @@ import posixpath
 import sys
 import threading
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 from agent.file_safety import get_read_block_error
 from tools.binary_extensions import has_binary_extension
@@ -148,11 +150,13 @@ _BLOCKED_DEVICE_PATHS = frozenset({
 })
 
 
-def _resolve_path(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+) -> Path | PurePosixPath:
     """Resolve a path relative to TERMINAL_CWD (the worktree base directory)
     instead of the main repository root.
     """
-    return _resolve_path_for_task(filepath, task_id)
+    return _resolve_path_for_task(filepath, task_id, execution_target)
 
 
 # Sentinel ``TERMINAL_CWD`` values that mean "not configured", NOT a literal
@@ -167,7 +171,10 @@ _TERMINAL_CWD_SENTINELS = frozenset({"", ".", "./", "auto", "cwd"})
 _CONTAINER_PATH_BACKENDS_FALLBACK = frozenset({"docker", "singularity", "modal", "daytona", "vercel_sandbox"})
 
 
-def _terminal_env_type_for_task(task_id: str = "default") -> str:
+def _terminal_env_type_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str:
     """Best-effort terminal backend type for path-resolution decisions."""
     try:
         from tools.terminal_tool import (
@@ -176,13 +183,19 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
+        resolution = _resolution or resolve_execution_target(execution_target)
         try:
-            container_key = _resolve_container_task_id(task_id)
+            container_key = resolution.environment_key(
+                _resolve_container_task_id(task_id)
+            )
+            raw_key = resolution.environment_key(task_id)
         except Exception:
             container_key = task_id
+            raw_key = task_id
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
         if env is not None:
             name = env.__class__.__name__.lower()
             if "local" in name:
@@ -197,19 +210,170 @@ def _terminal_env_type_for_task(task_id: str = "default") -> str:
                 return "modal"
             if "daytona" in name:
                 return "daytona"
-        cfg = _get_env_config()
+        cfg = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
         return str(cfg.get("env_type") or os.getenv("TERMINAL_ENV") or "local").lower()
     except Exception:
         return str(os.getenv("TERMINAL_ENV") or "local").lower()
 
 
-def _uses_container_paths(task_id: str = "default") -> bool:
+def _uses_container_paths(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> bool:
     try:
         from tools.terminal_tool import _CONTAINER_BACKENDS
         container_backends = _CONTAINER_BACKENDS
     except Exception:
         container_backends = _CONTAINER_PATH_BACKENDS_FALLBACK
-    return _terminal_env_type_for_task(task_id) in container_backends
+    return _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) in container_backends
+
+
+def _file_state_namespace(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
+    """Namespace remote/container paths, but share locks for local aliases."""
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = _resolution or resolve_execution_target(execution_target)
+        if resolution.backend == "local":
+            return None
+        # Preserve the pre-target single-profile legacy state key.
+        if not resolution.named:
+            return None
+        profile = f"profile-{resolution.profile_scope}:" if resolution.profile_scope else ""
+        if resolution.backend == "ssh":
+            # Two names for the same SSH account/root address the same physical
+            # filesystem and must share stale-write locks/read state.
+            cfg = resolution.config
+            physical = json.dumps({
+                "host": str(cfg.get("ssh_host") or ""),
+                "user": str(cfg.get("ssh_user") or ""),
+                "port": int(cfg.get("ssh_port") or 22),
+            }, sort_keys=True, separators=(",", ":"))
+            digest = hashlib.sha256(physical.encode("utf-8")).hexdigest()[:20]
+            return f"{profile}ssh:{digest}"
+        if resolution.backend == "docker":
+            persistent = resolution.config.get("container_persistent", True)
+            if isinstance(persistent, str):
+                persistent = persistent.strip().lower() in {"true", "1", "yes"}
+            if persistent:
+                from tools.terminal_tool import _resolve_container_task_id
+
+                owner = resolution.storage_task_id(
+                    _resolve_container_task_id(str(task_id)),
+                )
+                return f"{profile}docker-storage:{owner}"
+        # Other remote/container targets create distinct backend resources even
+        # when their visible path strings happen to match.
+        return f"{profile}{resolution.backend}:{resolution.security_scope}"
+    except Exception:
+        # Unknown targets are reported by the tool resolver before state access.
+        return execution_target
+
+
+def _backend_operation_path(
+    original: str,
+    resolved: str | Path | PurePosixPath,
+    task_id: str = "default",
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> str:
+    """Return the path that should be sent to the selected backend.
+
+    SSH owns relative and ``~`` expansion. Resolving those paths on the Hermes
+    host first creates a host-absolute path that may name a different file (or
+    no file) on the remote machine. Container/local backends retain the existing
+    exact resolved-path contract.
+    """
+    if _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) == "ssh":
+        original = str(original)
+        if posixpath.isabs(original) or original.startswith("~"):
+            return original
+        try:
+            from tools.terminal_tool import get_session_cwd
+
+            recorded_cwd = get_session_cwd(
+                task_id, target=execution_target, _resolution=_resolution,
+            )
+        except Exception:
+            recorded_cwd = None
+        if recorded_cwd and posixpath.isabs(str(recorded_cwd)):
+            return posixpath.normpath(posixpath.join(str(recorded_cwd), original))
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            resolution = _resolution or resolve_execution_target(execution_target)
+        except Exception:
+            resolution = None
+        # Legacy SSH file operations historically followed the live env cwd.
+        # Only a named target has a stable configured root we can anchor before
+        # a session-specific terminal cwd has been recorded.
+        if resolution is not None and resolution.named:
+            session_cwd = _authoritative_workspace_root(
+                task_id, execution_target, _resolution=resolution,
+            )
+            if session_cwd and posixpath.isabs(str(session_cwd)):
+                return posixpath.normpath(posixpath.join(str(session_cwd), original))
+        return original
+    return str(resolved)
+
+
+def _backend_v4a_patch(
+    patch_text: str,
+    task_id: str,
+    execution_target: str | None,
+    *,
+    _resolution: Any = None,
+) -> str:
+    """Anchor relative V4A headers to the calling SSH session's cwd."""
+    if _terminal_env_type_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    ) != "ssh":
+        return patch_text
+    import re
+
+    def _single(match):
+        path = match.group(2).strip()
+        routed = _backend_operation_path(
+            path, path, task_id, execution_target, _resolution=_resolution,
+        )
+        return match.group(1) + routed
+
+    rewritten = re.sub(
+        r"^(\*\*\*\s*(?:Update|Add|Delete)\s+File:\s*)(.+)$",
+        _single,
+        patch_text,
+        flags=re.MULTILINE,
+    )
+
+    def _move(match):
+        source = match.group(2).strip()
+        destination = match.group(3).strip()
+        routed_source = _backend_operation_path(
+            source, source, task_id, execution_target, _resolution=_resolution,
+        )
+        routed_destination = _backend_operation_path(
+            destination, destination, task_id, execution_target,
+            _resolution=_resolution,
+        )
+        return f"{match.group(1)}{routed_source} -> {routed_destination}"
+
+    return re.sub(
+        r"^(\*\*\*\s*Move\s+File:\s*)(.+?)\s*->\s*(.+)$",
+        _move,
+        rewritten,
+        flags=re.MULTILINE,
+    )
 
 
 def _normalize_without_host_deref(path: str | Path | PurePosixPath) -> PurePosixPath:
@@ -269,7 +433,10 @@ def _registered_task_cwd_override(task_id: str = "default") -> str | None:
     return _sentinel_free_abs_cwd(overrides.get("cwd"))
 
 
-def _authoritative_workspace_root(task_id: str = "default") -> str | None:
+def _authoritative_workspace_root(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Best-effort absolute workspace root for divergence checks.
 
     Resolution:
@@ -279,11 +446,12 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
          registration, keyed by the raw session id. Because the record is
          per-session, one session's ``cd`` can never leak into another
          session's resolution.
-      2. A registered task/session cwd override (TUI/Desktop/ACP sessions
+      2. For an explicit non-default named target, that target's configured
+         cwd. Host workspace overrides must not leak into remote targets.
+      3. A registered task/session cwd override (TUI/Desktop/ACP sessions
          register a raw-keyed cwd before any tool runs). Normally already
-         mirrored into the record at registration; kept as a direct fallback
-         so a cleared/never-written record still resolves the workspace.
-      3. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
+         mirrored into the default target's record; kept as a fallback.
+      4. A sentinel-free absolute ``$TERMINAL_CWD`` (the worktree path set by
          ``cli.py``/``main.py`` for ``-w`` sessions).
 
     Returns ``None`` only when there is genuinely no reliable anchor, in which
@@ -292,14 +460,79 @@ def _authoritative_workspace_root(task_id: str = "default") -> str | None:
     try:
         from tools.terminal_tool import get_session_cwd
 
-        recorded = get_session_cwd(task_id)
+        recorded = get_session_cwd(
+            task_id, target=execution_target, _resolution=_resolution,
+        )
     except Exception:
         recorded = None
     if recorded:
         return recorded
-    registered = _registered_task_cwd_override(task_id)
+
+    target_resolution = _resolution
+    configured_target_cwd = None
+    if target_resolution is None and execution_target is not None:
+        try:
+            from tools.execution_targets import resolve_execution_target
+
+            target_resolution = resolve_execution_target(execution_target)
+        except Exception:
+            target_resolution = None
+    if target_resolution is not None and target_resolution.named:
+        try:
+            from tools.terminal_tool import _get_env_config
+
+            configured = _get_env_config(
+                dict(target_resolution.config)
+            ).get("cwd")
+            if isinstance(configured, str) and configured.strip():
+                if (
+                    target_resolution.backend == "ssh"
+                    and (
+                        configured in {".", "./", "auto", "cwd", "~"}
+                        or configured.startswith("~/")
+                    )
+                ):
+                    # Keep relative/tilde SSH paths on the remote side. Before
+                    # the SSH environment exists there is no truthful absolute
+                    # host-side anchor; actual file operations preserve the raw
+                    # path, and a later terminal call records the resolved remote
+                    # cwd for this session.
+                    configured_target_cwd = configured
+                elif configured in {".", "./", "auto", "cwd"}:
+                    configured_target_cwd = os.getcwd()
+                elif configured == "~" or configured.startswith("~/"):
+                    # SSH expands this remotely; local targets expand here.
+                    configured_target_cwd = (
+                        configured
+                        if target_resolution.backend == "ssh"
+                        else _expand_tilde(configured)
+                    )
+                else:
+                    configured_target_cwd = configured
+        except Exception:
+            target_resolution = None
+
+    if (
+        target_resolution is not None
+        and target_resolution.named
+        and not target_resolution.is_default
+        and configured_target_cwd
+    ):
+        return configured_target_cwd
+
+    registered = (
+        None
+        if (
+            target_resolution is not None
+            and target_resolution.named
+            and target_resolution.backend == "ssh"
+        )
+        else _registered_task_cwd_override(task_id)
+    )
     if registered:
         return registered
+    if configured_target_cwd:
+        return configured_target_cwd
     return _configured_terminal_cwd()
 
 
@@ -307,6 +540,8 @@ def _resolve_base_dir(
     task_id: str = "default",
     *,
     container_paths: bool | None = None,
+    execution_target: str | None = None,
+    _resolution: Any = None,
 ) -> Path | PurePosixPath:
     """Return the ABSOLUTE base directory for resolving relative paths.
 
@@ -330,9 +565,13 @@ def _resolve_base_dir(
     outright (rather than anchoring them to the process cwd) and fall through to
     the process cwd only as a last resort, deterministically.
     """
-    root = _authoritative_workspace_root(task_id)
+    root = _authoritative_workspace_root(
+        task_id, execution_target, _resolution=_resolution,
+    )
     if container_paths is None:
-        container_paths = _uses_container_paths(task_id)
+        container_paths = _uses_container_paths(
+            task_id, execution_target, _resolution=_resolution,
+        )
     if root:
         base_text = _expand_tilde(root)
     else:
@@ -361,7 +600,10 @@ def _resolve_base_dir(
     return base.resolve()
 
 
-def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | PurePosixPath:
+def _resolve_path_for_task(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> Path | PurePosixPath:
     """Resolve *filepath* against the task's absolute base directory.
 
     See :func:`_resolve_base_dir` for how the base is chosen. Absolute input
@@ -371,12 +613,17 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
     translated to ``C:\\Users\\...`` before resolution so file tools don't
     treat them as relative ``\\c\\Users\\...`` under the process cwd.
     """
-    container_paths = _uses_container_paths(task_id)
+    container_paths = _uses_container_paths(
+        task_id, execution_target, _resolution=_resolution,
+    )
     if container_paths:
         expanded = _expand_tilde(filepath)
         if posixpath.isabs(expanded):
             return _normalize_without_host_deref(expanded)
-        resolved = _resolve_base_dir(task_id, container_paths=True) / expanded
+        resolved = _resolve_base_dir(
+            task_id, container_paths=True, execution_target=execution_target,
+            _resolution=_resolution,
+        ) / expanded
         return _normalize_without_host_deref(resolved)
 
     # Host paths only — never rewrite Linux paths inside a container/WSL env.
@@ -388,17 +635,27 @@ def _resolve_path_for_task(filepath: str, task_id: str = "default") -> Path | Pu
 
         if ntpath.isabs(expanded):
             return Path(ntpath.normpath(expanded))
-        joined = ntpath.join(str(_resolve_base_dir(task_id, container_paths=False)), expanded)
+        joined = ntpath.join(str(_resolve_base_dir(
+            task_id, container_paths=False, execution_target=execution_target,
+            _resolution=_resolution,
+        )), expanded)
         return Path(ntpath.normpath(joined))
 
     p = Path(expanded)
     if p.is_absolute():
         return p.resolve()
-    resolved = _resolve_base_dir(task_id, container_paths=False) / p
+    resolved = _resolve_base_dir(
+        task_id, container_paths=False, execution_target=execution_target,
+        _resolution=_resolution,
+    ) / p
     return resolved.resolve()
 
 
-def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "default") -> str | None:
+def _path_resolution_warning(
+    filepath: str, resolved: Path, task_id: str = "default",
+    execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Warn when a relative path resolved OUTSIDE the task's workspace root.
 
     Surfaces the worktree-cwd divergence the moment it would matter: if the
@@ -416,10 +673,14 @@ def _path_resolution_warning(filepath: str, resolved: Path, task_id: str = "defa
     try:
         if Path(_expand_tilde(filepath)).is_absolute():
             return None
-        workspace_root = _authoritative_workspace_root(task_id)
+        workspace_root = _authoritative_workspace_root(
+            task_id, execution_target, _resolution=_resolution,
+        )
         if not workspace_root:
             return None  # No authoritative workspace root to compare against.
-        if _uses_container_paths(task_id):
+        if _uses_container_paths(
+            task_id, execution_target, _resolution=_resolution,
+        ):
             root = _normalize_without_host_deref(Path(_expand_tilde(workspace_root)))
         else:
             root = Path(_expand_tilde(workspace_root)).resolve()
@@ -588,7 +849,10 @@ def _is_blocked_device(filepath: str, base_dir: str | Path | None = None) -> boo
     return False
 
 
-def _search_result_read_block_error(path: str, task_id: str = "default") -> str | None:
+def _search_result_read_block_error(
+    path: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return the read-safety error for a search result path.
 
     Search backends may return paths relative to the task cwd, while
@@ -597,20 +861,27 @@ def _search_result_read_block_error(path: str, task_id: str = "default") -> str 
     resolution before applying the shared read guard.
     """
     try:
-        resolved = _resolve_path_for_task(path, task_id)
+        resolved = _resolve_path_for_task(
+            path, task_id, execution_target, _resolution=_resolution,
+        )
     except (OSError, ValueError, RuntimeError):
         return get_read_block_error(path)
     return get_read_block_error(str(resolved))
 
 
-def _filter_read_blocked_search_results(result, task_id: str = "default") -> int:
+def _filter_read_blocked_search_results(
+    result, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> int:
     """Remove credential/cache/env paths from a SearchResult in-place."""
     omitted = 0
 
     if hasattr(result, "matches") and result.matches:
         allowed_matches = []
         for match in result.matches:
-            if _search_result_read_block_error(match.path, task_id):
+            if _search_result_read_block_error(
+                match.path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_matches.append(match)
@@ -619,7 +890,9 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "files") and result.files:
         allowed_files = []
         for file_path in result.files:
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_files.append(file_path)
@@ -628,7 +901,9 @@ def _filter_read_blocked_search_results(result, task_id: str = "default") -> int
     if hasattr(result, "counts") and result.counts:
         allowed_counts = {}
         for file_path, count in result.counts.items():
-            if _search_result_read_block_error(file_path, task_id):
+            if _search_result_read_block_error(
+                file_path, task_id, execution_target, _resolution=_resolution,
+            ):
                 omitted += 1
                 continue
             allowed_counts[file_path] = count
@@ -672,10 +947,15 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
-def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_sensitive_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, execution_target, _resolution=_resolution,
+        ))
     except (OSError, ValueError):
         resolved = filepath
     normalized = os.path.normpath(_expand_tilde(filepath))
@@ -699,10 +979,18 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
-    return None
+    try:
+        from agent.file_safety import get_write_denied_error
+
+        return get_write_denied_error(resolved, verb="Write")
+    except Exception:
+        return None
 
 
-def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | None:
+def _get_container_mirror_prefix_for_task(
+    task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return the container-side Hermes mirror prefix for Docker file tools."""
     try:
         from tools.terminal_tool import (
@@ -711,14 +999,17 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
             _get_env_config,
             _resolve_container_task_id,
         )
+        from tools.execution_targets import resolve_execution_target
 
-        container_key = _resolve_container_task_id(task_id)
+        resolution = _resolution or resolve_execution_target(execution_target)
+        container_key = resolution.environment_key(_resolve_container_task_id(task_id))
+        raw_key = resolution.environment_key(task_id)
     except Exception:
         return None
 
     try:
         with _env_lock:
-            env = _active_environments.get(container_key) or _active_environments.get(task_id)
+            env = _active_environments.get(container_key) or _active_environments.get(raw_key)
 
         if env is not None:
             if env.__class__.__name__ == "DockerEnvironment" and bool(
@@ -727,7 +1018,10 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
                 return "/root/.hermes"
             return None
 
-        config = _get_env_config()
+        config = (
+            _get_env_config(dict(resolution.config))
+            if resolution.named else _get_env_config()
+        )
     except Exception:
         return None
 
@@ -736,7 +1030,10 @@ def _get_container_mirror_prefix_for_task(task_id: str = "default") -> str | Non
     return None
 
 
-def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | None:
+def _check_cross_profile_path(
+    filepath: str, task_id: str = "default", execution_target: str | None = None,
+    *, _resolution: Any = None,
+) -> str | None:
     """Return a soft-guard warning when ``filepath`` lands in another Hermes
     profile's scoped area, a host-side sandbox-mirror of authoritative profile
     state, or the Docker container's sandbox mirror of Hermes state.
@@ -778,7 +1075,9 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     # in a session that cd'd into ``~/.hermes/profiles/other/`` is
     # classified against the right base.
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, execution_target, _resolution=_resolution,
+        ))
     except (OSError, ValueError):
         resolved = filepath
 
@@ -790,9 +1089,12 @@ def _check_cross_profile_path(filepath: str, task_id: str = "default") -> str | 
     if warning is not None:
         return warning
 
+    mirror_prefix = _get_container_mirror_prefix_for_task(
+        task_id, execution_target, _resolution=_resolution,
+    )
     return get_container_mirror_warning(
         resolved,
-        mirror_prefix=_get_container_mirror_prefix_for_task(task_id),
+        mirror_prefix=mirror_prefix,
     )
 
 
@@ -941,7 +1243,9 @@ def _cap_read_tracker_data(task_data: dict) -> None:
                 break
 
 
-def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | None:
+def _check_not_found_cache(
+    op: str, resolved_str: str, task_id: str, *, check_host_filesystem: bool = True,
+) -> str | None:
     """Return cached not-found JSON for *(op, resolved_str)* if still fresh.
 
     Skips the expensive subprocess + suggestion walk when the model retries
@@ -981,7 +1285,7 @@ def _check_not_found_cache(op: str, resolved_str: str, task_id: str) -> str | No
     # check below in read_file_tool): the lock is global across all tasks,
     # and a hung stat on a dead network mount must not stall every other
     # task's read/search bookkeeping.
-    if _os.path.exists(resolved_str):
+    if check_host_filesystem and _os.path.exists(resolved_str):
         with _read_tracker_lock:
             task_data = _read_tracker.get(task_id)
             nf = task_data.get("not_found") if task_data else None
@@ -1079,7 +1383,9 @@ def _is_internal_file_tool_content(content: str) -> bool:
     )
 
 
-def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
+def _get_file_ops(
+    task_id: str = "default", target: str | None = None, *, _resolution: Any = None,
+) -> ShellFileOperations:
     """Get or create ShellFileOperations for a terminal environment.
 
     Respects the TERMINAL_ENV setting -- if the task_id doesn't have an
@@ -1100,13 +1406,28 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _creation_locks,
         _creation_locks_lock,
         _resolve_container_task_id,
-        _is_unusable_container_cwd,
-        _CONTAINER_BACKENDS,
+        _record_environment_lifetime,
+        _record_environment_target,
+        _environment_matches_target,
+        _prepare_environment_replacement,
+        _retire_replaced_environment,
+        _cleanup_environment_resource,
+        _environment_has_stable_storage,
+        _apply_task_cwd_override,
+        _build_environment_constructor_configs,
+    )
+    from tools.execution_targets import (
+        execution_target_config_is_frozen,
+        resolve_execution_target,
+        resolve_live_execution_target,
     )
     import time
 
     raw_task_id = task_id or "default"
-    task_id = _resolve_container_task_id(raw_task_id)
+    resolution = _resolution or resolve_execution_target(target)
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    task_id = resolution.environment_key(base_task_id)  # type: ignore[assignment]
+    backend_task_id = resolution.backend_task_id(base_task_id)
 
     # Fast path: check cache -- but also verify the underlying environment
     # is still alive (it may have been killed by the cleanup thread).
@@ -1114,7 +1435,11 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         cached = _file_ops_cache.get(task_id)
     if cached is not None:
         with _env_lock:
-            if task_id in _active_environments:
+            active_env = _active_environments.get(task_id)
+            if (
+                _environment_matches_target(active_env, resolution)
+                and getattr(cached, "env", None) is active_env
+            ):
                 _last_activity[task_id] = time.time()
                 return cached
             else:
@@ -1124,10 +1449,12 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 # conversations). Usually a no-op: every completed command
                 # already recorded its cwd.
                 old_cwd = getattr(cached, "cwd", None)
-                if old_cwd:
+                if active_env is None and old_cwd:
                     try:
                         from tools.terminal_tool import record_session_cwd
-                        record_session_cwd(raw_task_id, old_cwd)
+                        record_session_cwd(
+                            raw_task_id, old_cwd, _resolution=resolution,
+                        )
                     except Exception:
                         pass
                 with _file_ops_lock:
@@ -1143,16 +1470,25 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     with task_lock:
         # Double-check: another thread may have created it while we waited
         with _env_lock:
-            if task_id in _active_environments:
+            active_env = _active_environments.get(task_id)
+            if _environment_matches_target(active_env, resolution):
                 _last_activity[task_id] = time.time()
-                terminal_env = _active_environments[task_id]
+                terminal_env = active_env
             else:
                 terminal_env = None
 
         if terminal_env is None:
+            _prepare_environment_replacement(
+                active_env,
+                task_id,
+                target_name=resolution.target,
+            )
             from tools.terminal_tool import resolve_task_overrides
 
-            config = _get_env_config()
+            config = (
+                _get_env_config(dict(resolution.config))
+                if resolution.named else _get_env_config()
+            )
             env_type = config["env_type"]
             overrides = resolve_task_overrides(raw_task_id)
 
@@ -1169,61 +1505,53 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
 
             try:
                 from tools.terminal_tool import get_session_cwd
-                recorded_cwd = get_session_cwd(raw_task_id)
+                recorded_cwd = get_session_cwd(
+                    raw_task_id, _resolution=resolution,
+                )
             except Exception:
                 recorded_cwd = None
-            cwd = overrides.get("cwd") or recorded_cwd or config["cwd"]
-            # Re-apply the container cwd guard that _get_env_config() already
-            # ran on config["cwd"] (see #50636).  A per-task cwd override
-            # registered by the gateway/TUI/ACP for workspace tracking is a
-            # raw host path (e.g. a Desktop session's /Users/<me>/workspace or
-            # C:\\Users\\<me>). On a container backend that reaches
-            # ``docker run -w <host-path>`` and the container starts in a
-            # directory that doesn't exist inside the sandbox, so search_files
-            # and friends silently return empty results (#54447).  Sanitize it
-            # back to the already-validated config["cwd"] so the override can't
-            # bypass the guard.  Valid in-container override paths (RL/benchmark
-            # sandboxes that set cwd to /workspace, /root, etc.) are absolute
-            # non-host paths and pass through untouched.
-            if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-                if cwd != config["cwd"]:
-                    logger.info(
-                        "Ignoring host/relative cwd override %r for %s backend "
-                        "(won't exist in sandbox). Using %r instead.",
-                        cwd, env_type, config["cwd"],
-                    )
-                cwd = config["cwd"]
-            logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
+            cwd_override = (
+                overrides.get("cwd")
+                if (
+                    not resolution.named
+                    or (resolution.is_default and resolution.backend != "ssh")
+                )
+                else None
+            )
+            cwd = cwd_override or recorded_cwd or config["cwd"]
+            cwd = _apply_task_cwd_override(config, cwd, cwd_override)
+            logger.info("Creating new %s environment for task %s...", env_type, task_id)
 
-            container_config = None
-            if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
+            container_config, ssh_config, local_config = (
+                _build_environment_constructor_configs(
+                    config, resolution, base_task_id,
+                )
+            )
+            if container_config is not None:
+                # Keep an auditable module-local constructor map. The shared
+                # builder remains the normalization source, while this explicit
+                # copy preserves the upstream cross-call-site Docker option
+                # invariant enforced by test_docker_network_config.py.
                 container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "vercel_runtime": config.get("vercel_runtime", ""),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
-
-            ssh_config = None
-            if env_type == "ssh":
-                ssh_config = {
-                    "host": config.get("ssh_host", ""),
-                    "user": config.get("ssh_user", ""),
-                    "port": config.get("ssh_port", 22),
-                    "key": config.get("ssh_key", ""),
-                    "persistent": config.get("ssh_persistent", False),
-                }
-
-            local_config = None
-            if env_type == "local":
-                local_config = {
-                    "persistent": config.get("local_persistent", False),
+                    "container_cpu": container_config["container_cpu"],
+                    "container_memory": container_config["container_memory"],
+                    "container_disk": container_config["container_disk"],
+                    "container_persistent": container_config["container_persistent"],
+                    "vercel_runtime": container_config["vercel_runtime"],
+                    "modal_mode": container_config["modal_mode"],
+                    "docker_volumes": container_config["docker_volumes"],
+                    "docker_mount_cwd_to_workspace": container_config["docker_mount_cwd_to_workspace"],
+                    "docker_forward_env": container_config["docker_forward_env"],
+                    "docker_env": container_config["docker_env"],
+                    "docker_run_as_host_user": container_config["docker_run_as_host_user"],
+                    "docker_extra_args": container_config["docker_extra_args"],
+                    "docker_network": container_config["docker_network"],
+                    "docker_shm_size": container_config["docker_shm_size"],
+                    "docker_persist_across_processes": container_config["docker_persist_across_processes"],
+                    "docker_orphan_reaper": container_config["docker_orphan_reaper"],
+                    "lifetime_seconds": container_config["lifetime_seconds"],
+                    "storage_task_id": container_config["storage_task_id"],
+                    "legacy_storage_task_id": container_config["legacy_storage_task_id"],
                 }
 
             terminal_env = _create_environment(
@@ -1234,16 +1562,46 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
                 ssh_config=ssh_config,
                 container_config=container_config,
                 local_config=local_config,
-                task_id=task_id,
+                task_id=backend_task_id,
                 host_cwd=config.get("host_cwd"),
             )
+            _record_environment_lifetime(terminal_env, config)
+            _record_environment_target(terminal_env, resolution)
 
+            publish_error = None
             with _env_lock:
-                _active_environments[task_id] = terminal_env
-                _last_activity[task_id] = time.time()
+                if resolution.named:
+                    try:
+                        live_resolution = (
+                            resolution
+                            if execution_target_config_is_frozen()
+                            else resolve_live_execution_target(target)
+                        )
+                    except Exception as exc:
+                        publish_error = str(exc)
+                    else:
+                        if live_resolution.security_scope != resolution.security_scope:
+                            publish_error = (
+                                f"Execution target {resolution.target!r} changed "
+                                "while its environment was being created."
+                            )
+                replaced_env = None
+                if publish_error is None:
+                    replaced_env = _active_environments.get(task_id)
+                    _active_environments[task_id] = terminal_env
+                    _last_activity[task_id] = time.time()
+            if publish_error is not None:
+                _cleanup_environment_resource(
+                    terminal_env,
+                    force_remove=True,
+                    preserve_storage=_environment_has_stable_storage(terminal_env),
+                )
+                raise RuntimeError(publish_error + " Retry the file operation.")
+            if replaced_env is not None and replaced_env is not terminal_env:
+                _retire_replaced_environment(replaced_env, task_id)
 
             _start_cleanup_thread()
-            logger.info("%s environment ready for task %s", env_type, task_id[:8])
+            logger.info("%s environment ready for task %s", env_type, task_id)
 
     # Build file_ops from the (guaranteed live) environment and cache it
     file_ops = ShellFileOperations(terminal_env)
@@ -1252,7 +1610,17 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
     return file_ops
 
 
-def clear_file_ops_cache(task_id: str = None):
+
+def _file_ops_for_resolution(task_id: str, resolution: Any):
+    # Preserve the established one-argument seam in legacy mode.
+    if resolution.named:
+        return _get_file_ops(
+            task_id, target=resolution.target, _resolution=resolution,
+        )
+    return _get_file_ops(task_id)
+
+
+def clear_file_ops_cache(task_id=None):
     """Clear the file operations cache."""
     with _file_ops_lock:
         if task_id:
@@ -1261,35 +1629,85 @@ def clear_file_ops_cache(task_id: str = None):
             _file_ops_cache.clear()
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str, offset: int = 1, limit: int = 2000,
+    task_id: str = "default", target: str | None = None,
+    runtime_scope: str | None = None,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
+        from tools.execution_targets import resolve_execution_target
+
+        pinned_file_ops = None
+        if runtime_scope:
+            from tools.terminal_tool import get_environment_for_target_scope
+
+            selected_name = str(target or "")
+            if not selected_name:
+                return tool_error(
+                    "read_file runtime_scope requires the target from the saved-output hint."
+                )
+            pinned_env = get_environment_for_target_scope(
+                task_id, selected_name, runtime_scope,
+            )
+            if pinned_env is None:
+                return tool_error(
+                    "The producing execution environment for this saved output "
+                    "is no longer available. Re-run the originating tool."
+                )
+            resolution = getattr(pinned_env, "_hermes_target_resolution", None)
+            if resolution is None:
+                return tool_error(
+                    "The producing environment lacks immutable target metadata. "
+                    "Re-run the originating tool."
+                )
+            pinned_file_ops = ShellFileOperations(
+                pinned_env, str(getattr(pinned_env, "cwd", ".")),
+            )
+        else:
+            resolution = resolve_execution_target(target)
+        selected_target = resolution.target if resolution.named else None
+        host_mtime_tracking = resolution.backend == "local"
+        state_task_id = resolution.session_key(task_id)
+        state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
         offset, limit = normalize_read_pagination(offset, limit)
 
         # ── Device path guard ─────────────────────────────────────────
         # Block paths that would hang the process (infinite output,
         # blocking on input).  Pure path check — no I/O.
-        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(task_id)
+        device_base = None if Path(path).expanduser().is_absolute() else _resolve_base_dir(
+            task_id, execution_target=selected_target,
+            _resolution=resolution,
+        )
         if _is_blocked_device(path, base_dir=device_base):
             return tool_error(
                 f"Cannot read '{path}': this is a device file that would "
                 "block or produce infinite output."
             )
 
-        _resolved = _resolve_path_for_task(path, task_id)
+        _resolved = _resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            )
 
         # ── Structured-document extraction ────────────────────────────
         # Try before the binary-extension guard so .docx/.xlsx can render as text.
         # Malformed documents fall through to the normal path/binary guard.
         from tools.read_extract import ExtractionError, extract_document_text, is_extractable_document
 
-        if is_extractable_document(str(_resolved)):
+        if (
+            _terminal_env_type_for_task(
+                task_id, selected_target, _resolution=resolution,
+            ) == "local"
+            and is_extractable_document(str(_resolved))
+        ):
             try:
                 extracted_text = extract_document_text(str(_resolved))
             except ExtractionError:
                 logger.debug("document extraction failed for %s", path, exc_info=True)
             else:
-                file_ops = _get_file_ops(task_id)
+                file_ops = pinned_file_ops or _file_ops_for_resolution(task_id, resolution)
                 lines = extracted_text.splitlines()
                 total_lines = len(lines)
                 end_line = offset + limit - 1
@@ -1335,6 +1753,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                         )
                 if result_dict["content"]:
                     result_dict["content"] = redact_sensitive_text(result_dict["content"], file_read=True)
+                result_dict.update(resolution.metadata(
+                    cwd=_authoritative_workspace_root(task_id, selected_target),
+                ))
                 return json.dumps(result_dict, ensure_ascii=False)
 
         # ── Binary file guard ─────────────────────────────────────────
@@ -1362,7 +1783,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # return the cached error without spawning the subprocess +
         # similar-files walk. Cleared by write_file/patch on the same path.
         resolved_str_for_neg = str(_resolved)
-        cached_not_found = _check_not_found_cache("read", resolved_str_for_neg, task_id)
+        cached_not_found = _check_not_found_cache(
+            "read", resolved_str_for_neg, state_task_id,
+            check_host_filesystem=resolution.backend == "local",
+        )
         if cached_not_found is not None:
             return cached_not_found
 
@@ -1373,7 +1797,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         resolved_str = str(_resolved)
         dedup_key = (resolved_str, offset, limit)
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0,
                 "read_history": set(), "dedup": {},
                 "dedup_hits": {}, "read_timestamps": {},
@@ -1385,7 +1809,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 task_data["dedup_hits"] = {}
             if "read_timestamps" not in task_data:
                 task_data["read_timestamps"] = {}
-            cached_mtime = task_data.get("dedup", {}).get(dedup_key)
+            cached_mtime = (
+                task_data.get("dedup", {}).get(dedup_key)
+                if host_mtime_tracking
+                else None
+            )
 
         if cached_mtime is not None:
             try:
@@ -1414,20 +1842,31 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                             already_read=hits + 1,
                         )
 
-                    return json.dumps({
+                    unchanged = {
                         "status": "unchanged",
                         "message": _READ_DEDUP_STATUS_MESSAGE,
                         "path": path,
                         "dedup": True,
                         "content_returned": False,
-                    }, ensure_ascii=False)
+                    }
+                    unchanged.update(resolution.metadata(
+                        cwd=_authoritative_workspace_root(
+                            task_id, selected_target, _resolution=resolution,
+                        ),
+                    ))
+                    return json.dumps(unchanged, ensure_ascii=False)
             except OSError:
                 pass  # stat failed — fall through to full read
 
         # ── Perform the read ──────────────────────────────────────────
-        file_ops = _get_file_ops(task_id)
-        result = file_ops.read_file(path, offset, limit)
+        file_ops = pinned_file_ops or _file_ops_for_resolution(task_id, resolution)
+        operation_path = _backend_operation_path(
+            path, _resolved, task_id, selected_target,
+            _resolution=resolution,
+        )
+        result = file_ops.read_file(operation_path, offset, limit)
         result_dict = result.to_dict()
+        result_dict.setdefault("resolved_path", operation_path)
 
         # ── Populate negative-result cache on not-found ───────────────
         # _suggest_similar_files returns ReadResult(error="File not found: ..").
@@ -1441,7 +1880,9 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         _err = result_dict.get("error") or ""
         if isinstance(_err, str) and _err.startswith("File not found:"):
             _not_found_json = json.dumps(result_dict, ensure_ascii=False)
-            _record_not_found("read", resolved_str_for_neg, task_id, _not_found_json)
+            _record_not_found(
+                "read", resolved_str_for_neg, state_task_id, _not_found_json,
+            )
 
         # ── Character-count guard ─────────────────────────────────────
         # We're model-agnostic so we can't count tokens; characters are
@@ -1526,12 +1967,13 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             # 1. Dedup: skip identical re-reads of unchanged files.
             # 2. Staleness: warn on write/patch if the file changed since
             #    the agent last read it (external edit, concurrent agent, etc.).
-            try:
-                _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
-                task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
-            except OSError:
-                pass  # Can't stat — skip tracking for this entry
+            if host_mtime_tracking:
+                try:
+                    _mtime_now = os.path.getmtime(resolved_str)
+                    task_data["dedup"][dedup_key] = _mtime_now
+                    task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
+                except OSError:
+                    pass  # Can't stat — skip tracking for this entry
 
             # Bound the per-task containers so a long CLI session doesn't
             # accumulate megabytes of dict/set state.  See _cap_read_tracker_data.
@@ -1546,7 +1988,11 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
         # isn't nested under ours.
         try:
             _partial = (offset > 1) or bool(result_dict.get("truncated"))
-            file_state.record_read(task_id, resolved_str, partial=_partial)
+            file_state.record_read(
+                state_task_id, resolved_str, partial=_partial,
+                namespace=state_namespace,
+                stat_path=host_mtime_tracking,
+            )
         except Exception:
             logger.debug("file_state.record_read failed", exc_info=True)
 
@@ -1565,6 +2011,10 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
                 "The content has not changed since your last read. Use the information you already have. "
                 "If you are stuck in a loop, stop reading and proceed with writing or responding."
             )
+
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
 
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
@@ -1586,8 +2036,25 @@ def reset_file_dedup(task_id: str = None):
     """
     with _read_tracker_lock:
         if task_id:
-            task_data = _read_tracker.get(task_id)
-            if task_data:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            task_ids = {task_id, scoped_task_id}
+            keys = list(task_ids) + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in task_ids
+                )
+            ]
+            for key in keys:
+                task_data = _read_tracker.get(key)
+                if not task_data:
+                    continue
                 if "dedup" in task_data:
                     task_data["dedup"].clear()
                 if "dedup_hits" in task_data:
@@ -1600,7 +2067,9 @@ def reset_file_dedup(task_id: str = None):
                     task_data["dedup_hits"].clear()
 
 
-def notify_other_tool_call(task_id: str = "default"):
+def notify_other_tool_call(
+    task_id: str = "default", execution_target: str | None = None,
+):
     """Reset consecutive read/search counter for a task.
 
     Called by the tool dispatcher (model_tools.py) whenever a tool OTHER
@@ -1610,8 +2079,34 @@ def notify_other_tool_call(task_id: str = "default"):
     resets and the next read is treated as fresh.
     """
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
-        if task_data:
+        if execution_target is None:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                scoped_task_id = resolve_execution_target().scope_task_key(task_id)
+            except Exception:
+                scoped_task_id = task_id
+            keys = [task_id, scoped_task_id] + [
+                key for key in _read_tracker
+                if (
+                    isinstance(key, tuple)
+                    and len(key) == 2
+                    and key[0] in {task_id, scoped_task_id}
+                )
+            ]
+        else:
+            try:
+                from tools.execution_targets import resolve_execution_target
+
+                keys = [
+                    resolve_execution_target(execution_target).session_key(task_id)
+                ]
+            except Exception:
+                keys = [task_id]
+        for key in keys:
+            task_data = _read_tracker.get(key)
+            if not task_data:
+                continue
             task_data["last_key"] = None
             task_data["consecutive"] = 0
             # An intervening non-read tool call breaks any stub-loop in
@@ -1629,7 +2124,13 @@ def notify_other_tool_call(task_id: str = "default"):
                 nf.clear()
 
 
-def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
+def _invalidate_dedup_for_path(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> None:
     """Remove all dedup cache entries whose resolved path matches *filepath*.
 
     Called after write_file and patch so that a subsequent read_file on
@@ -1642,12 +2143,18 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
     Must be called with ``_read_tracker_lock`` **not** held — acquires it
     internally.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
     try:
-        resolved = str(_resolve_path(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is None:
             return
         dedup = task_data.get("dedup")
@@ -1665,7 +2172,13 @@ def _invalidate_dedup_for_path(filepath: str, task_id: str) -> None:
             nf.pop(("search", resolved), None)
 
 
-def _update_read_timestamp(filepath: str, task_id: str) -> None:
+def _update_read_timestamp(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> None:
     """Record the file's current modification time after a successful write.
 
     Called after write_file and patch so that consecutive edits by the
@@ -1676,32 +2189,52 @@ def _update_read_timestamp(filepath: str, task_id: str) -> None:
     subsequent reads return fresh content (fixes #13144).
     """
     # Invalidate dedup first (before acquiring lock for timestamp update).
-    _invalidate_dedup_for_path(filepath, task_id)
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
+    _invalidate_dedup_for_path(
+        filepath, task_id, selected_target, _resolution=resolution,
+    )
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
         current_mtime = os.path.getmtime(resolved)
     except (OSError, ValueError):
         return
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if task_data is not None:
             task_data.setdefault("read_timestamps", {})[resolved] = current_mtime
             _cap_read_tracker_data(task_data)
 
 
-def _check_file_staleness(filepath: str, task_id: str) -> str | None:
+def _check_file_staleness(
+    filepath: str,
+    task_id: str,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
+) -> str | None:
     """Check whether a file was modified since the agent last read it.
 
     Returns a warning string if the file is stale (mtime changed since
     the last read_file call for this task), or None if the file is fresh
     or was never read.  Does not block — the write still proceeds.
     """
+    from tools.execution_targets import resolve_execution_target
+    resolution = _resolution or resolve_execution_target(execution_target)
+    selected_target = resolution.target if resolution.named else None
+    state_task_id = resolution.session_key(task_id)
     try:
-        resolved = str(_resolve_path_for_task(filepath, task_id))
+        resolved = str(_resolve_path_for_task(
+            filepath, task_id, selected_target, _resolution=resolution,
+        ))
     except (OSError, ValueError):
         return None
     with _read_tracker_lock:
-        task_data = _read_tracker.get(task_id)
+        task_data = _read_tracker.get(state_task_id)
         if not task_data:
             return None
         read_mtime = task_data.get("read_timestamps", {}).get(resolved)
@@ -1724,6 +2257,9 @@ def _mark_verification_stale(
     task_id: str,
     resolved_paths: list[str],
     session_id: str | None = None,
+    execution_target: str | None = None,
+    *,
+    _resolution: Any = None,
 ) -> None:
     """Best-effort note that successful edits made prior verification stale."""
     paths = [p for p in resolved_paths if p]
@@ -1743,7 +2279,9 @@ def _mark_verification_stale(
                 cwd = candidate
                 break
         if cwd is None:
-            cwd = _authoritative_workspace_root(task_id)
+            cwd = _authoritative_workspace_root(
+                task_id, execution_target, _resolution=_resolution,
+            )
         if cwd is None:
             try:
                 cwd = str(Path(paths[0]).parent)
@@ -1756,7 +2294,8 @@ def _mark_verification_stale(
 
 def write_file_tool(path: str, content: str, task_id: str = "default",
                     cross_profile: bool = False,
-                    session_id: str | None = None) -> str:
+                    session_id: str | None = None,
+                    target: str = None) -> str:
     """Write content to a file.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard. The
@@ -1765,11 +2304,26 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
     Pass ``True`` after explicit user direction — same shape as ``force``
     on the terminal tool.
     """
-    sensitive_err = _check_sensitive_path(path, task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    host_mtime_tracking = resolution.backend == "local"
+    state_task_id = resolution.session_key(task_id)
+    state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
+    sensitive_err = _check_sensitive_path(
+        path, task_id, selected_target, _resolution=resolution,
+    )
     if sensitive_err:
         return tool_error(sensitive_err)
     if not cross_profile:
-        cross_warning = _check_cross_profile_path(path, task_id)
+        cross_warning = _check_cross_profile_path(
+            path, task_id, selected_target, _resolution=resolution,
+        )
         if cross_warning:
             return tool_error(cross_warning)
     if _is_internal_file_tool_content(content):
@@ -1783,35 +2337,59 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
         # fall back to the legacy path — write proceeds, per-task staleness
         # check below still runs.
         try:
-            _resolved = str(_resolve_path_for_task(path, task_id))
+            _resolved = str(_resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            ))
         except Exception:
             _resolved = None
 
         if _resolved is None:
-            stale_warning = _check_file_staleness(path, task_id)
-            file_ops = _get_file_ops(task_id)
+            stale_warning = _check_file_staleness(
+                path, task_id, selected_target, _resolution=resolution,
+            )
+            file_ops = _file_ops_for_resolution(task_id, resolution)
             result = file_ops.write_file(path, content)
             result_dict = result.to_dict()
             if stale_warning:
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
-                _mark_verification_stale(task_id, [path], session_id=session_id)
-            _update_read_timestamp(path, task_id)
+                _mark_verification_stale(
+                    task_id, [path], session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
+            _update_read_timestamp(
+                path, task_id, selected_target, _resolution=resolution,
+            )
+            result_dict.update(resolution.metadata(
+                cwd=_authoritative_workspace_root(task_id, selected_target),
+            ))
             return json.dumps(result_dict, ensure_ascii=False)
 
         # Serialize the read→modify→write region per-path so concurrent
         # subagents can't interleave on the same file.  Different paths
         # remain fully parallel.
-        with file_state.lock_path(_resolved):
+        with file_state.lock_path(_resolved, namespace=state_namespace):
             # Cross-agent staleness wins over per-task warning when both
             # fire — its message names the sibling subagent.
-            cross_warning = file_state.check_stale(task_id, _resolved)
-            stale_warning = _check_file_staleness(path, task_id)
+            cross_warning = file_state.check_stale(
+                state_task_id, _resolved, namespace=state_namespace,
+            )
+            stale_warning = _check_file_staleness(
+                path, task_id, selected_target, _resolution=resolution,
+            )
             # Workspace-divergence warning: relative path resolving outside the
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
-            cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
-            file_ops = _get_file_ops(task_id)
-            result = file_ops.write_file(_resolved, content)
+            cwd_warning = _path_resolution_warning(
+                path, Path(_resolved), task_id, selected_target,
+                _resolution=resolution,
+            )
+            file_ops = _file_ops_for_resolution(task_id, resolution)
+            operation_path = _backend_operation_path(
+                path, _resolved, task_id, selected_target,
+                _resolution=resolution,
+            )
+            result = file_ops.write_file(operation_path, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
             if effective_warning:
@@ -1819,15 +2397,27 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # Always report the ABSOLUTE path actually written, so a wrong-cwd
             # mismatch is visible in the response instead of silently routing
             # the edit to the wrong checkout.
-            result_dict["resolved_path"] = _resolved
+            result_dict["resolved_path"] = operation_path
             if not result_dict.get("error"):
-                result_dict["files_modified"] = [_resolved]
-                _mark_verification_stale(task_id, [_resolved], session_id=session_id)
+                result_dict["files_modified"] = [operation_path]
+                _mark_verification_stale(
+                    task_id, [operation_path], session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
             # Refresh stamps after the successful write so consecutive
             # writes by this task don't trigger false staleness warnings.
-            _update_read_timestamp(path, task_id)
+            _update_read_timestamp(
+                path, task_id, selected_target, _resolution=resolution,
+            )
             if not result_dict.get("error"):
-                file_state.note_write(task_id, _resolved)
+                file_state.note_write(
+                    state_task_id, _resolved, namespace=state_namespace,
+                    stat_path=host_mtime_tracking,
+                )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -1840,13 +2430,25 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
 def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                new_string: str = None, replace_all: bool = False, patch: str = None,
                task_id: str = "default", cross_profile: bool = False,
-               session_id: str | None = None) -> str:
+               session_id: str | None = None, target: str = None) -> str:
     """Patch a file using replace mode or V4A patch format.
 
     ``cross_profile`` opts out of the soft cross-Hermes-profile guard for
     targets under another profile's skills/plugins/cron/memories
     directory. Same shape as ``write_file``'s flag.
     """
+    try:
+        from tools.execution_targets import resolve_execution_target
+        resolution = resolve_execution_target(target)
+    except Exception as exc:
+        return tool_error(str(exc))
+    selected_target = resolution.target if resolution.named else None
+    host_mtime_tracking = resolution.backend == "local"
+    state_task_id = resolution.session_key(task_id)
+    state_namespace = _file_state_namespace(
+            task_id, selected_target, _resolution=resolution,
+        )
+
     # Check sensitive paths for both replace (explicit path) and V4A patch (extract paths)
     _paths_to_check = []
     if path:
@@ -1893,11 +2495,15 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     return _err
                 _paths_to_check.append(v4a_path)
     for _p in _paths_to_check:
-        sensitive_err = _check_sensitive_path(_p, task_id)
+        sensitive_err = _check_sensitive_path(
+            _p, task_id, selected_target, _resolution=resolution,
+        )
         if sensitive_err:
             return tool_error(sensitive_err)
         if not cross_profile:
-            cross_warning = _check_cross_profile_path(_p, task_id)
+            cross_warning = _check_cross_profile_path(
+                _p, task_id, selected_target, _resolution=resolution,
+            )
             if cross_warning:
                 return tool_error(cross_warning)
     try:
@@ -1908,7 +2514,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         _seen: set[str] = set()
         for _p in _paths_to_check:
             try:
-                _r = str(_resolve_path_for_task(_p, task_id))
+                _r = str(_resolve_path_for_task(
+                    _p, task_id, selected_target, _resolution=resolution,
+                ))
             except Exception:
                 _r = None
             if _r and _r not in _seen:
@@ -1922,7 +2530,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
         from contextlib import ExitStack
         with ExitStack() as _locks:
             for _r in _resolved_paths:
-                _locks.enter_context(file_state.lock_path(_r))
+                _locks.enter_context(
+                    file_state.lock_path(_r, namespace=state_namespace)
+                )
 
             # Collect warnings — cross-agent registry first (names sibling),
             # then per-task tracker as a fallback.
@@ -1930,20 +2540,29 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             _path_to_resolved: dict[str, str] = {}
             for _p in _paths_to_check:
                 try:
-                    _r = str(_resolve_path_for_task(_p, task_id))
+                    _r = str(_resolve_path_for_task(
+                    _p, task_id, selected_target, _resolution=resolution,
+                ))
                 except Exception:
                     _r = None
                 _path_to_resolved[_p] = _r
-                _cross = file_state.check_stale(task_id, _r) if _r else None
-                _sw = _cross or _check_file_staleness(_p, task_id)
+                _cross = file_state.check_stale(
+                    state_task_id, _r, namespace=state_namespace,
+                ) if _r else None
+                _sw = _cross or _check_file_staleness(
+                    _p, task_id, selected_target, _resolution=resolution,
+                )
                 if not _sw and _r:
                     # Workspace-divergence warning (worktree-cwd bug): relative
                     # path resolving outside the terminal's cwd.
-                    _sw = _path_resolution_warning(_p, Path(_r), task_id)
+                    _sw = _path_resolution_warning(
+                        _p, Path(_r), task_id, selected_target,
+                        _resolution=resolution,
+                    )
                 if _sw:
                     stale_warnings.append(_sw)
 
-            file_ops = _get_file_ops(task_id)
+            file_ops = _file_ops_for_resolution(task_id, resolution)
 
             if mode == "replace":
                 if not path:
@@ -1955,19 +2574,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 # shell's own cwd may differ (worktree-cwd bug), and a relative
                 # path would let the two layers disagree about which file is
                 # being edited.
-                _replace_target = _path_to_resolved.get(path) or path
+                _replace_target = _backend_operation_path(
+                    path, _path_to_resolved.get(path) or path,
+                    task_id, selected_target,
+                    _resolution=resolution,
+                )
                 result = file_ops.patch_replace(_replace_target, old_string, new_string, replace_all)
             elif mode == "patch":
                 if not patch:
                     return tool_error("patch content required")
-                # Rewrite V4A headers to the resolved absolute paths so the
-                # shell layer patches the exact files the tool layer resolved
-                # (locked/reported). Without this a relative header re-resolves
-                # against the shell's cwd, which can differ from the workspace
-                # (git-worktree cwd bug) — landing the edit elsewhere.
-                patch_for_ops = _rewrite_v4a_patch_paths_for_host(
-                    patch, _path_to_resolved, file_ops
-                )
+                if resolution.backend == "ssh":
+                    patch_for_ops = _backend_v4a_patch(
+                        patch, task_id, selected_target, _resolution=resolution,
+                    )
+                else:
+                    # Preserve current-upstream absolute-path reconciliation for
+                    # local/container backends; SSH paths must stay remote.
+                    patch_for_ops = _rewrite_v4a_patch_paths_for_host(
+                        patch, _path_to_resolved, file_ops
+                    )
                 result = file_ops.patch_v4a(patch_for_ops)
             else:
                 return tool_error(f"Unknown mode: {mode}")
@@ -1979,7 +2604,12 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             # mismatch (e.g. a worktree session editing the main checkout) is
             # visible in the response instead of silently landing elsewhere.
             _resolved_modified = [
-                _path_to_resolved.get(_p) or _p for _p in _paths_to_check
+                _backend_operation_path(
+                    _p, _path_to_resolved.get(_p) or _p,
+                    task_id, selected_target,
+                    _resolution=resolution,
+                )
+                for _p in _paths_to_check
             ]
             # Refresh stored timestamps for all successfully-patched paths so
             # consecutive edits by this task don't trigger false warnings.
@@ -1987,16 +2617,25 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 result_dict["files_modified"] = _resolved_modified
                 if len(_resolved_modified) == 1:
                     result_dict["resolved_path"] = _resolved_modified[0]
-                _mark_verification_stale(task_id, _resolved_modified, session_id=session_id)
+                _mark_verification_stale(
+                    task_id, _resolved_modified, session_id=session_id,
+                    execution_target=selected_target,
+                    _resolution=resolution,
+                )
                 for _p in _paths_to_check:
-                    _update_read_timestamp(_p, task_id)
+                    _update_read_timestamp(
+                        _p, task_id, selected_target, _resolution=resolution,
+                    )
                     _r = _path_to_resolved.get(_p)
                     if _r:
-                        file_state.note_write(task_id, _r)
+                        file_state.note_write(
+                            state_task_id, _r, namespace=state_namespace,
+                            stat_path=host_mtime_tracking,
+                        )
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.
-                _reset_patch_failures(task_id, [
+                _reset_patch_failures(state_task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
         # Hint when old_string not found — saves iterations where the agent
@@ -2011,7 +2650,7 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
             failure_count = 0
             if mode == "replace" and path:
                 resolved = _path_to_resolved.get(path) or path
-                failure_count = _record_patch_failure(task_id, resolved)
+                failure_count = _record_patch_failure(state_task_id, resolved)
 
             if failure_count >= 3:
                 # Escalating hint after multiple consecutive failures on the
@@ -2034,6 +2673,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     "old_string not found. Use read_file to verify the current "
                     "content, or search_files to locate the text."
                 )
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         return tool_error(str(e))
@@ -2042,9 +2684,14 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
 def search_tool(pattern: str, target: str = "content", path: str = ".",
                 file_glob: str = None, limit: int = 50, offset: int = 0,
                 output_mode: str = "content", context: int = 0,
-                task_id: str = "default") -> str:
+                task_id: str = "default", execution_target: str = None) -> str:
     """Search for content or files."""
     try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(execution_target)
+        selected_target = resolution.target if resolution.named else None
+        state_task_id = resolution.session_key(task_id)
         offset, limit = normalize_search_pagination(offset, limit)
 
         # Track searches to detect *consecutive* repeated search loops.
@@ -2060,7 +2707,7 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             offset,
         )
         with _read_tracker_lock:
-            task_data = _read_tracker.setdefault(task_id, {
+            task_data = _read_tracker.setdefault(state_task_id, {
                 "last_key": None, "consecutive": 0, "read_history": set(),
             })
             if task_data["last_key"] == search_key:
@@ -2080,7 +2727,9 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             )
 
         try:
-            resolved_path = _resolve_path_for_task(path, task_id)
+            resolved_path = _resolve_path_for_task(
+                path, task_id, selected_target, _resolution=resolution,
+            )
         except (OSError, ValueError, RuntimeError):
             resolved_path = None
         block_error = get_read_block_error(str(resolved_path) if resolved_path else path)
@@ -2092,20 +2741,27 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         # doesn't exist. The error path also lists the parent directory
         # (file_operations.py:1402) — expensive to repeat. Cache so the
         # next call to a known-missing root skips both shells.
-        try:
-            resolved_search_path = str(_resolve_path_for_task(path, task_id))
-        except (OSError, ValueError):
-            resolved_search_path = path
-        cached_search_nf = _check_not_found_cache("search", resolved_search_path, task_id)
+        resolved_search_path = str(resolved_path) if resolved_path is not None else path
+        cached_search_nf = _check_not_found_cache(
+            "search", resolved_search_path, state_task_id,
+            check_host_filesystem=resolution.backend == "local",
+        )
         if cached_search_nf is not None:
             return cached_search_nf
 
-        file_ops = _get_file_ops(task_id)
+        file_ops = _file_ops_for_resolution(task_id, resolution)
+        operation_path = _backend_operation_path(
+            path, resolved_path or path, task_id, selected_target,
+            _resolution=resolution,
+        )
         result = file_ops.search(
-            pattern=pattern, path=path, target=target, file_glob=file_glob,
+            pattern=pattern, path=operation_path, target=target,
+            file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
-        omitted = _filter_read_blocked_search_results(result, task_id)
+        omitted = _filter_read_blocked_search_results(
+            result, task_id, selected_target, _resolution=resolution,
+        )
         if hasattr(result, 'matches'):
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
@@ -2124,13 +2780,19 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
         _search_err = result_dict.get("error") or ""
         if isinstance(_search_err, str) and _search_err.startswith("Path not found:"):
             _search_nf_json = json.dumps(result_dict, ensure_ascii=False)
-            _record_not_found("search", resolved_search_path, task_id, _search_nf_json)
+            _record_not_found(
+                "search", resolved_search_path, state_task_id, _search_nf_json,
+            )
 
         if count >= 3:
             result_dict["_warning"] = (
                 f"You have run this exact search {count} times consecutively. "
                 "The results have not changed. Use the information you already have."
             )
+
+        result_dict.update(resolution.metadata(
+            cwd=_authoritative_workspace_root(task_id, selected_target),
+        ))
 
         result_json = json.dumps(result_dict, ensure_ascii=False)
         # Hint when results were truncated — explicit next offset is clearer
@@ -2164,7 +2826,9 @@ READ_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to read (absolute, relative, or ~/path)"},
             "offset": {"type": "integer", "description": "Line number to start reading from (1-indexed, default: 1)", "default": 1, "minimum": 1},
-            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000}
+            "limit": {"type": "integer", "description": "Maximum number of lines to read (default: 2000, max: 2000). Reads are additionally capped at a ~100K-character budget with a next_offset continuation.", "default": 2000, "maximum": 2000},
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
+            "runtime_scope": {"type": "string", "description": "Immutable producing-runtime scope from a saved-output hint. Pass only when the hint supplies it."},
         },
         "required": ["path"]
     }
@@ -2178,6 +2842,7 @@ WRITE_FILE_SCHEMA = {
         "properties": {
             "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
             "content": {"type": "string", "description": "Complete content to write to the file"},
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
             "cross_profile": {
                 "type": "boolean",
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories — by default these writes are blocked with a warning because they affect a different profile than the one this session is running under.",
@@ -2234,6 +2899,7 @@ PATCH_SCHEMA = {
                 "description": "Opt out of the cross-profile soft guard. Defaults to false. Set true ONLY after explicit user direction to edit another Hermes profile's skills/plugins/cron/memories.",
                 "default": False,
             },
+            "target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. Uses terminal.default_target when omitted."},
         },
         "required": ["mode"],
     },
@@ -2241,7 +2907,7 @@ PATCH_SCHEMA = {
 
 SEARCH_FILES_SCHEMA = {
     "name": "search_files",
-    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
+    "description": "Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents.\n\nCompatibility exception: target still selects search mode ('content' or 'files'); execution_target selects the named terminal execution target.\n\nContent search (target='content'): Regex search inside files. Output modes: full matches with line numbers, file paths only, or match counts.\n\nFile search (target='files'): Find files by glob pattern (e.g., '*.py', '*config*'). Also use this instead of ls — results sorted by modification time.",
     "parameters": {
         "type": "object",
         "properties": {
@@ -2252,7 +2918,8 @@ SEARCH_FILES_SCHEMA = {
             "limit": {"type": "integer", "description": "Maximum number of results to return (default: 50)", "default": 50},
             "offset": {"type": "integer", "description": "Skip first N results for pagination (default: 0)", "default": 0},
             "output_mode": {"type": "string", "enum": ["content", "files_only", "count"], "description": "Output format for grep mode: 'content' shows matching lines with line numbers, 'files_only' lists file paths, 'count' shows match counts per file", "default": "content"},
-            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0}
+            "context": {"type": "integer", "description": "Number of context lines before and after each match (grep mode only)", "default": 0},
+            "execution_target": {"type": "string", "description": "Optional named execution target, for example 'local' or 'devbox'. This is separate from target, which selects content/files search mode."},
         },
         "required": ["pattern"]
     }
@@ -2261,7 +2928,11 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""), offset=args.get("offset", 1),
+        limit=args.get("limit", 500), task_id=tid, target=args.get("target"),
+        runtime_scope=args.get("runtime_scope"),
+    )
 
 
 def _handle_write_file(args, **kw):
@@ -2288,6 +2959,7 @@ def _handle_write_file(args, **kw):
         path=args["path"], content=args["content"], task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        target=args.get("target"),
     )
 
 
@@ -2299,6 +2971,7 @@ def _handle_patch(args, **kw):
         replace_all=args.get("replace_all", False), patch=args.get("patch"), task_id=tid,
         cross_profile=bool(args.get("cross_profile", False)),
         session_id=kw.get("session_id"),
+        target=args.get("target"),
     )
 
 
@@ -2310,7 +2983,10 @@ def _handle_search_files(args, **kw):
     return search_tool(
         pattern=args.get("pattern", ""), target=target, path=args.get("path", "."),
         file_glob=args.get("file_glob"), limit=args.get("limit", 50), offset=args.get("offset", 0),
-        output_mode=args.get("output_mode", "content"), context=args.get("context", 0), task_id=tid)
+        output_mode=args.get("output_mode", "content"),
+        context=args.get("context", 0), task_id=tid,
+        execution_target=args.get("execution_target"),
+    )
 
 
 registry.register(name="read_file", toolset="file", schema=READ_FILE_SCHEMA, handler=_handle_read_file, check_fn=_check_file_reqs, emoji="📖", max_result_size_chars=100_000)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -138,6 +138,13 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    # Trailing fields preserve the positional constructor contract for every
+    # pre-existing ProcessSession field.
+    target: str = ""                           # Named execution target (empty in legacy mode)
+    backend: str = ""                          # Resolved terminal backend
+    timeout_seconds: int = 0                   # Selected target's wait ceiling
+    environment_task_key: str = ""            # Profile-scoped env ownership key
+    runtime_scope: str = ""                   # Producing target generation/scope
 
 
 class ProcessRegistry:
@@ -213,6 +220,22 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    @staticmethod
+    def _with_execution_metadata(result: dict, session: ProcessSession) -> dict:
+        """Add stable target/backend identity to a process result."""
+        if session.target:
+            result["target"] = session.target
+        if session.backend:
+            result["backend"] = session.backend
+        runtime_scope = session.runtime_scope or getattr(
+            session.env_ref, "_hermes_target_scope", None
+        )
+        if isinstance(runtime_scope, str) and runtime_scope:
+            result["runtime_scope"] = runtime_scope
+        if session.cwd and "cwd" not in result:
+            result["cwd"] = session.cwd
+        return result
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -326,6 +349,9 @@ class ProcessRegistry:
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
+                    **({"target": session.target} if session.target else {}),
+                    **({"backend": session.backend} if session.backend else {}),
+                    **({"cwd": session.cwd} if session.cwd else {}),
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -359,6 +385,9 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
+            **({"target": session.target} if session.target else {}),
+            **({"backend": session.backend} if session.backend else {}),
+            **({"cwd": session.cwd} if session.cwd else {}),
         })
 
     def _global_watch_admit(self, now: float) -> bool:
@@ -695,6 +724,12 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
+        runtime_scope: str = "",
+        env_ref: Any = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -721,6 +756,12 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
+            target=target,
+            backend=backend or "local",
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
+            runtime_scope=runtime_scope,
+            env_ref=env_ref,
             started_at=time.time(),
         )
 
@@ -843,6 +884,11 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
+        runtime_scope: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -861,6 +907,11 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=cwd,
+            target=target,
+            backend=backend,
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
+            runtime_scope=runtime_scope,
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
@@ -886,6 +937,7 @@ class ProcessRegistry:
         try:
             result = env.execute(
                 bg_command,
+                cwd=cwd,
                 timeout=timeout,
                 rewrite_compound_background=False,
             )
@@ -1210,6 +1262,9 @@ class ProcessRegistry:
                 # a consumer-observed completion timestamp, this does not vary
                 # based on which watcher notices exit first.
                 "started_at": session.started_at,
+                **({"target": session.target} if session.target else {}),
+                **({"backend": session.backend} if session.backend else {}),
+                **({"cwd": session.cwd} if session.cwd else {}),
             })
 
     # ----- Query Methods -----
@@ -1461,6 +1516,7 @@ class ProcessRegistry:
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
         }
+        self._with_execution_metadata(result, session)
         if session.exited:
             result["exit_code"] = session.exit_code
             result["completion_reason"] = session.completion_reason
@@ -1514,6 +1570,7 @@ class ProcessRegistry:
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
+        self._with_execution_metadata(result, session)
         if session.exited and observed_completion_output:
             self._completion_consumed.add(session_id)
         return result
@@ -1524,7 +1581,7 @@ class ProcessRegistry:
 
         Args:
             session_id: The process to wait for.
-            timeout: Max seconds to block. Falls back to TERMINAL_TIMEOUT config.
+            timeout: Max seconds to block. Falls back to the process target's timeout.
 
         Returns:
             dict with status ("exited", "timeout", "interrupted", "not_found")
@@ -1533,8 +1590,16 @@ class ProcessRegistry:
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
 
+        session = self.get(session_id)
+        if session is None:
+            return {"status": "not_found", "error": f"No process with ID {session_id}"}
+
         try:
-            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            default_timeout = (
+                int(session.timeout_seconds)
+                if int(session.timeout_seconds) > 0
+                else int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            )
         except (ValueError, TypeError):
             default_timeout = 180
         max_timeout = default_timeout
@@ -1549,10 +1614,6 @@ class ProcessRegistry:
             )
         else:
             effective_timeout = requested_timeout or max_timeout
-
-        session = self.get(session_id)
-        if session is None:
-            return {"status": "not_found", "error": f"No process with ID {session_id}"}
 
         deadline = time.monotonic() + effective_timeout
 
@@ -1574,6 +1635,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -1585,6 +1647,7 @@ class ProcessRegistry:
                     "output": strip_ansi(session.output_buffer[-1000:]),
                     "note": "User sent a new message -- wait interrupted",
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -1603,6 +1666,7 @@ class ProcessRegistry:
             # identical waits after misreading this result as an error.
             "process_running": True,
         }
+        self._with_execution_metadata(result, session)
         uptime = time.time() - session.started_at if session.started_at else None
         base_note = (
             f"Wait window of {effective_timeout}s elapsed — the process is "
@@ -1659,6 +1723,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+            self._with_execution_metadata(result, session)
             # Only suppress the autonomous turn after its output is present in
             # the explicit kill result, matching wait/log consumption.
             if consume_output:
@@ -1694,11 +1759,12 @@ class ProcessRegistry:
                     if consume_output:
                         self._completion_consumed.add(session_id)
                     self._move_to_finished(session)
-                    return {
+                    result = {
                         "status": "already_exited",
                         "exit_code": session.exit_code,
                         "output": output,
                     }
+                    return self._with_execution_metadata(result, session)
                 self._terminate_host_pid(session.pid, session.host_start_time)
             else:
                 return {
@@ -1721,13 +1787,14 @@ class ProcessRegistry:
                 session.termination_source = source
             self._move_to_finished(session)
             self._write_checkpoint()
-            return {
+            result = {
                 "status": "killed",
                 "session_id": session.id,
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output,
             }
+            return self._with_execution_metadata(result, session)
         except Exception as e:
             return {"status": "error", "error": str(e)}
 
@@ -1868,6 +1935,7 @@ class ProcessRegistry:
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
+            self._with_execution_metadata(entry, s)
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived
             # background processes a user may have forgotten about (#29177).
@@ -1890,8 +1958,27 @@ class ProcessRegistry:
 
     # ----- Session/Task Queries (for gateway integration) -----
 
-    def has_active_processes(self, task_id: str) -> bool:
+    def has_active_processes(self, task_id: Any) -> bool:
         """Check if there are active (running) processes for a task_id."""
+        with self._lock:
+            sessions = list(self._running.values())
+
+        for session in sessions:
+            self._refresh_detached_session(session)
+
+        if isinstance(task_id, tuple) and len(task_id) == 2:
+            base_task_id, target = task_id
+            matches = lambda s: (
+                (s.environment_task_key or s.task_id) == base_task_id
+                and s.target == target
+            )
+        else:
+            matches = lambda s: (s.environment_task_key or s.task_id) == task_id
+        with self._lock:
+            return any(matches(s) and not s.exited for s in self._running.values())
+
+    def has_active_environment(self, env: Any) -> bool:
+        """Return whether a running session still references *env* by identity."""
         with self._lock:
             sessions = list(self._running.values())
 
@@ -1900,8 +1987,8 @@ class ProcessRegistry:
 
         with self._lock:
             return any(
-                s.task_id == task_id and not s.exited
-                for s in self._running.values()
+                session.env_ref is env and not session.exited
+                for session in self._running.values()
             )
 
     def has_active_for_session(
@@ -2075,6 +2162,11 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "target": s.target,
+                            "backend": s.backend,
+                            "timeout_seconds": s.timeout_seconds,
+                            "environment_task_key": s.environment_task_key,
+                            "runtime_scope": s.runtime_scope,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -2151,6 +2243,11 @@ class ProcessRegistry:
                 host_start_time=recorded_start,
                 pid_scope=pid_scope,
                 cwd=entry.get("cwd"),
+                target=entry.get("target", ""),
+                backend=entry.get("backend", ""),
+                timeout_seconds=int(entry.get("timeout_seconds") or 0),
+                environment_task_key=entry.get("environment_task_key", ""),
+                runtime_scope=entry.get("runtime_scope", ""),
                 started_at=entry.get("started_at", time.time()),
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
@@ -2512,11 +2609,15 @@ def _handle_process(args, **kw):
                 ensure_ascii=False,
             )
         elif action == "write":
-            return json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.write_stdin(session_id, str(args.get("data", "")))
         elif action == "submit":
-            return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.submit_stdin(session_id, str(args.get("data", "")))
         elif action == "close":
-            return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
+            result = process_registry.close_stdin(session_id)
+        session = process_registry.get(session_id)
+        if session is not None:
+            process_registry._with_execution_metadata(result, session)
+        return json.dumps(result, ensure_ascii=False)
     return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
 
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -419,6 +419,13 @@ class ProcessSession:
     _lock: threading.Lock = field(default_factory=threading.Lock)
     _reader_thread: Optional[threading.Thread] = field(default=None, repr=False)
     _pty: Any = field(default=None, repr=False)  # ptyprocess handle (when use_pty=True)
+    # Trailing fields preserve the positional constructor contract for every
+    # pre-existing ProcessSession field.
+    target: str = ""                           # Named execution target (empty in legacy mode)
+    backend: str = ""                          # Resolved terminal backend
+    timeout_seconds: int = 0                   # Selected target's wait ceiling
+    environment_task_key: str = ""            # Profile-scoped env ownership key
+    runtime_scope: str = ""                   # Producing target generation/scope
 
 
 class ProcessRegistry:
@@ -494,6 +501,22 @@ class ProcessRegistry:
         # terminal tab. Distinct from kill — the process keeps running; only the
         # UI view is dropped (the user can reopen it from the status stack).
         self.on_close = None
+
+    @staticmethod
+    def _with_execution_metadata(result: dict, session: ProcessSession) -> dict:
+        """Add stable target/backend identity to a process result."""
+        if session.target:
+            result["target"] = session.target
+        if session.backend:
+            result["backend"] = session.backend
+        runtime_scope = session.runtime_scope or getattr(
+            session.env_ref, "_hermes_target_scope", None
+        )
+        if isinstance(runtime_scope, str) and runtime_scope:
+            result["runtime_scope"] = runtime_scope
+        if session.cwd and "cwd" not in result:
+            result["cwd"] = session.cwd
+        return result
 
     @staticmethod
     def _clean_shell_noise(text: str) -> str:
@@ -607,6 +630,9 @@ class ProcessRegistry:
                     "user_name": session.watcher_user_name,
                     "thread_id": session.watcher_thread_id,
                     "message_id": session.watcher_message_id,
+                    **({"target": session.target} if session.target else {}),
+                    **({"backend": session.backend} if session.backend else {}),
+                    **({"cwd": session.cwd} if session.cwd else {}),
                     "message": (
                         f"Watch patterns disabled for process {session.id} — "
                         f"{WATCH_STRIKE_LIMIT} consecutive rate-limit windows triggered "
@@ -640,6 +666,9 @@ class ProcessRegistry:
             "user_name": session.watcher_user_name,
             "thread_id": session.watcher_thread_id,
             "message_id": session.watcher_message_id,
+            **({"target": session.target} if session.target else {}),
+            **({"backend": session.backend} if session.backend else {}),
+            **({"cwd": session.cwd} if session.cwd else {}),
         }
         _redact_process_result(notification)
         self.completion_queue.put(notification)
@@ -978,6 +1007,12 @@ class ProcessRegistry:
         session_key: str = "",
         env_vars: dict = None,
         use_pty: bool = False,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
+        runtime_scope: str = "",
+        env_ref: Any = None,
     ) -> ProcessSession:
         """
         Spawn a background process locally.
@@ -1004,6 +1039,12 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=_resolve_safe_cwd(cwd or os.getcwd()),
+            target=target,
+            backend=backend or "local",
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
+            runtime_scope=runtime_scope,
+            env_ref=env_ref,
             started_at=time.time(),
         )
 
@@ -1216,6 +1257,11 @@ class ProcessRegistry:
         task_id: str = "",
         session_key: str = "",
         timeout: int = 10,
+        target: str = "",
+        backend: str = "",
+        timeout_seconds: int = 0,
+        environment_task_key: str = "",
+        runtime_scope: str = "",
     ) -> ProcessSession:
         """
         Spawn a background process through a non-local environment backend.
@@ -1234,6 +1280,11 @@ class ProcessRegistry:
             task_id=task_id,
             session_key=session_key,
             cwd=cwd,
+            target=target,
+            backend=backend,
+            timeout_seconds=timeout_seconds,
+            environment_task_key=environment_task_key,
+            runtime_scope=runtime_scope,
             started_at=time.time(),
             env_ref=env,
             pid_scope="sandbox",
@@ -1259,6 +1310,7 @@ class ProcessRegistry:
         try:
             result = env.execute(
                 bg_command,
+                cwd=cwd,
                 timeout=timeout,
                 rewrite_compound_background=False,
             )
@@ -1583,6 +1635,9 @@ class ProcessRegistry:
                 # a consumer-observed completion timestamp, this does not vary
                 # based on which watcher notices exit first.
                 "started_at": session.started_at,
+                **({"target": session.target} if session.target else {}),
+                **({"backend": session.backend} if session.backend else {}),
+                **({"cwd": session.cwd} if session.cwd else {}),
             }
             _redact_process_result(notification)
             self.completion_queue.put(notification)
@@ -1880,6 +1935,7 @@ class ProcessRegistry:
             "uptime_seconds": int(time.time() - session.started_at),
             "output_preview": output_preview,
         }
+        self._with_execution_metadata(result, session)
         if session.exited:
             result["exit_code"] = session.exit_code
             result["completion_reason"] = session.completion_reason
@@ -1938,6 +1994,7 @@ class ProcessRegistry:
             "total_lines": total_lines,
             "showing": f"{len(selected)} lines",
         }
+        self._with_execution_metadata(result, session)
         if session.exited and observed_completion_output:
             self._completion_consumed.add(session_id)
         return result
@@ -1948,7 +2005,7 @@ class ProcessRegistry:
 
         Args:
             session_id: The process to wait for.
-            timeout: Max seconds to block. Falls back to TERMINAL_TIMEOUT config.
+            timeout: Max seconds to block. Falls back to the process target's timeout.
 
         Returns:
             dict with status ("exited", "timeout", "interrupted", "not_found")
@@ -1957,8 +2014,16 @@ class ProcessRegistry:
         from tools.ansi_strip import strip_ansi
         from tools.interrupt import is_interrupted as _is_interrupted
 
+        session = self.get(session_id)
+        if session is None:
+            return {"status": "not_found", "error": f"No process with ID {session_id}"}
+
         try:
-            default_timeout = int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            default_timeout = (
+                int(session.timeout_seconds)
+                if int(session.timeout_seconds) > 0
+                else int(os.getenv("TERMINAL_TIMEOUT", "180"))
+            )
         except (ValueError, TypeError):
             default_timeout = 180
         max_timeout = default_timeout
@@ -1985,10 +2050,6 @@ class ProcessRegistry:
         else:
             effective_timeout = requested_timeout or max_timeout
 
-        session = self.get(session_id)
-        if session is None:
-            return {"status": "not_found", "error": f"No process with ID {session_id}"}
-
         deadline = time.monotonic() + effective_timeout
 
         while time.monotonic() < deadline:
@@ -2009,6 +2070,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -2020,6 +2082,7 @@ class ProcessRegistry:
                     "output": strip_ansi(session.output_buffer[-1000:]),
                     "note": "User sent a new message -- wait interrupted",
                 }
+                self._with_execution_metadata(result, session)
                 if timeout_note:
                     result["timeout_note"] = timeout_note
                 return result
@@ -2038,6 +2101,7 @@ class ProcessRegistry:
             # identical waits after misreading this result as an error.
             "process_running": True,
         }
+        self._with_execution_metadata(result, session)
         uptime = time.time() - session.started_at if session.started_at else None
         base_note = (
             f"Wait window of {effective_timeout}s elapsed — the process is "
@@ -2100,6 +2164,7 @@ class ProcessRegistry:
                     "termination_source": session.termination_source,
                     "output": strip_ansi(session.output_buffer[-2000:]),
                 }
+            self._with_execution_metadata(result, session)
             # Only suppress the autonomous turn after its output is present in
             # the explicit kill result, matching wait/log consumption.
             if consume_output:
@@ -2141,20 +2206,22 @@ class ProcessRegistry:
                     if consume_output:
                         self._completion_consumed.add(session_id)
                     self._move_to_finished(session)
-                    return {
+                    result = {
                         "status": "already_exited",
                         "exit_code": session.exit_code,
                         "output": output,
                     }
+                    return self._with_execution_metadata(result, session)
                 self._terminate_host_pid(session.pid, session.host_start_time)
             else:
-                return {
+                result = {
                     "status": "error",
                     "error": (
                         "Recovered process cannot be killed after restart because "
                         "its original runtime handle is no longer available"
                     ),
                 }
+                return self._with_execution_metadata(result, session)
 
             # If the worker was spawned in its own systemd scope (#70716),
             # stop the entire unit to reap any double-forked descendants that
@@ -2178,15 +2245,18 @@ class ProcessRegistry:
                 session.termination_source = source
             self._move_to_finished(session)
             self._write_checkpoint()
-            return {
+            result = {
                 "status": "killed",
                 "session_id": session.id,
                 "completion_reason": session.completion_reason,
                 "termination_source": session.termination_source,
                 "output": output,
             }
+            return self._with_execution_metadata(result, session)
         except Exception as e:
-            return {"status": "error", "error": str(e)}
+            return self._with_execution_metadata(
+                {"status": "error", "error": str(e)}, session,
+            )
 
     def write_stdin(self, session_id: str, data: str) -> dict:
         """Send raw data to a running process's stdin (no newline appended)."""
@@ -2345,6 +2415,7 @@ class ProcessRegistry:
                 "status": "exited" if s.exited else "running",
                 "output_preview": s.output_buffer[-200:] if s.output_buffer else "",
             }
+            self._with_execution_metadata(entry, s)
             # Flag processes surfaced only because they share the gateway
             # session (not the current task) — these are the long-lived
             # background processes a user may have forgotten about (#29177).
@@ -2367,8 +2438,27 @@ class ProcessRegistry:
 
     # ----- Session/Task Queries (for gateway integration) -----
 
-    def has_active_processes(self, task_id: str) -> bool:
+    def has_active_processes(self, task_id: Any) -> bool:
         """Check if there are active (running) processes for a task_id."""
+        with self._lock:
+            sessions = list(self._running.values())
+
+        for session in sessions:
+            self._refresh_detached_session(session)
+
+        if isinstance(task_id, tuple) and len(task_id) == 2:
+            base_task_id, target = task_id
+            matches = lambda s: (
+                (s.environment_task_key or s.task_id) == base_task_id
+                and s.target == target
+            )
+        else:
+            matches = lambda s: (s.environment_task_key or s.task_id) == task_id
+        with self._lock:
+            return any(matches(s) and not s.exited for s in self._running.values())
+
+    def has_active_environment(self, env: Any) -> bool:
+        """Return whether a running session still references *env* by identity."""
         with self._lock:
             sessions = list(self._running.values())
 
@@ -2377,8 +2467,8 @@ class ProcessRegistry:
 
         with self._lock:
             return any(
-                s.task_id == task_id and not s.exited
-                for s in self._running.values()
+                session.env_ref is env and not session.exited
+                for session in self._running.values()
             )
 
     def has_active_for_session(
@@ -2563,6 +2653,11 @@ class ProcessRegistry:
                             "started_at": s.started_at,
                             "task_id": s.task_id,
                             "session_key": s.session_key,
+                            "target": s.target,
+                            "backend": s.backend,
+                            "timeout_seconds": s.timeout_seconds,
+                            "environment_task_key": s.environment_task_key,
+                            "runtime_scope": s.runtime_scope,
                             "watcher_platform": s.watcher_platform,
                             "watcher_chat_id": s.watcher_chat_id,
                             "watcher_user_id": s.watcher_user_id,
@@ -2658,6 +2753,11 @@ class ProcessRegistry:
                 pid_scope=pid_scope,
                 systemd_unit=entry.get("systemd_unit", ""),
                 cwd=entry.get("cwd"),
+                target=entry.get("target", ""),
+                backend=entry.get("backend", ""),
+                timeout_seconds=int(entry.get("timeout_seconds") or 0),
+                environment_task_key=entry.get("environment_task_key", ""),
+                runtime_scope=entry.get("runtime_scope", ""),
                 started_at=entry.get("started_at", time.time()),
                 detached=True,  # Can't read output, but can report status + kill
                 watcher_platform=entry.get("watcher_platform", ""),
@@ -3049,11 +3149,15 @@ def _handle_process(args, **kw):
                 ensure_ascii=False,
             )
         elif action == "write":
-            return json.dumps(process_registry.write_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.write_stdin(session_id, str(args.get("data", "")))
         elif action == "submit":
-            return json.dumps(process_registry.submit_stdin(session_id, str(args.get("data", ""))), ensure_ascii=False)
+            result = process_registry.submit_stdin(session_id, str(args.get("data", "")))
         elif action == "close":
-            return json.dumps(process_registry.close_stdin(session_id), ensure_ascii=False)
+            result = process_registry.close_stdin(session_id)
+        session = process_registry.get(session_id)
+        if session is not None:
+            process_registry._with_execution_metadata(result, session)
+        return json.dumps(result, ensure_ascii=False)
     return tool_error(f"Unknown process action: {action}. Use: list, poll, log, wait, kill, write, submit, close")
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,8 +46,10 @@ import threading
 import atexit
 import shutil
 import subprocess
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Hashable, Mapping
 
 from utils import env_var_enabled
 
@@ -287,8 +289,37 @@ def set_approval_callback(cb):
     _callback_tls.approval = cb
 
 
-def _get_sudo_password_cache_scope() -> str:
-    """Return the cache scope for interactive sudo passwords."""
+_sudo_execution_context: ContextVar[
+    tuple[str, str, bool, Optional[str], str] | None
+] = ContextVar(
+    "hermes_sudo_execution_context", default=None,
+)
+
+
+@contextmanager
+def _scoped_sudo_execution(
+    target: str,
+    backend: str,
+    *,
+    named: bool = False,
+    sudo_password: Optional[str] = None,
+    target_scope: str = "",
+):
+    token = _sudo_execution_context.set(
+        (target, backend, named, sudo_password, target_scope),
+    )
+    try:
+        yield
+    finally:
+        _sudo_execution_context.reset(token)
+
+
+def _get_sudo_password_cache_scope(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> str:
+    """Return the session + target scope for interactive sudo passwords."""
     try:
         from gateway.session_context import get_session_env
 
@@ -296,29 +327,64 @@ def _get_sudo_password_cache_scope() -> str:
     except Exception:
         session_key = os.getenv("HERMES_SESSION_KEY", "")
     if session_key:
-        return f"session:{session_key}"
+        base_scope = f"session:{session_key}"
+    else:
+        callback = _get_sudo_password_callback()
+        if callback is not None:
+            owner = getattr(callback, "__self__", None)
+            func = getattr(callback, "__func__", None)
+            if owner is not None and func is not None:
+                base_scope = f"callback-owner:{id(owner)}:{id(func)}"
+            else:
+                base_scope = f"callback:{id(callback)}"
+        else:
+            base_scope = f"thread:{threading.get_ident()}"
 
-    callback = _get_sudo_password_callback()
-    if callback is not None:
-        owner = getattr(callback, "__self__", None)
-        func = getattr(callback, "__func__", None)
-        if owner is not None and func is not None:
-            return f"callback-owner:{id(owner)}:{id(func)}"
-        return f"callback:{id(callback)}"
+    active_context = _sudo_execution_context.get()
+    if execution_target is None and active_context is not None:
+        execution_target = active_context[0]
+    if execution_backend is None and active_context is not None:
+        execution_backend = active_context[1]
+    if execution_target is None and execution_backend is None:
+        return base_scope
+    target_scope = execution_target_scope or ""
+    if (
+        execution_target_scope is None
+        and active_context is not None
+        and execution_target == active_context[0]
+        and execution_backend == active_context[1]
+    ):
+        target_scope = active_context[4]
+    return (
+        f"{base_scope}|target:{execution_target!r}"
+        f"|backend:{str(execution_backend or '').lower()}"
+        f"|scope:{target_scope}"
+    )
 
-    return f"thread:{threading.get_ident()}"
 
-
-def _get_cached_sudo_password() -> str:
-    """Return the cached sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _get_cached_sudo_password(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> str:
+    """Return the cached sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(
+        execution_target, execution_backend, execution_target_scope,
+    )
     with _sudo_password_cache_lock:
         return _sudo_password_cache.get(scope, "")
 
 
-def _set_cached_sudo_password(password: str) -> None:
-    """Persist a sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _set_cached_sudo_password(
+    password: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> None:
+    """Persist a sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(
+        execution_target, execution_backend, execution_target_scope,
+    )
     with _sudo_password_cache_lock:
         if password:
             _sudo_password_cache[scope] = password
@@ -366,11 +432,19 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
-                      has_host_access: bool = False) -> dict:
+                      has_host_access: bool = False,
+                      execution_target: str = "default",
+                      execution_backend: Optional[str] = None,
+                      execution_target_named: bool = False,
+                      execution_target_scope: str = "") -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access,
+                                  execution_target=execution_target,
+                                  execution_backend=execution_backend or env_type,
+                                  execution_target_named=execution_target_named,
+                                  execution_target_scope=execution_target_scope)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -457,7 +531,11 @@ def _sudo_wrong_password_failure(output: str) -> bool:
 
 
 def _invalidate_cached_sudo_on_auth_failure(
-    command: str | None, output: str
+    command: str | None,
+    output: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
 ) -> bool:
     """Drop a session-cached sudo password after sudo rejects it.
 
@@ -470,9 +548,13 @@ def _invalidate_cached_sudo_on_auth_failure(
         return False
     if _count_real_sudo_invocations(command or "") == 0:
         return False
-    if not _get_cached_sudo_password():
+    if not _get_cached_sudo_password(
+        execution_target, execution_backend, execution_target_scope,
+    ):
         return False
-    _set_cached_sudo_password("")
+    _set_cached_sudo_password(
+        "", execution_target, execution_backend, execution_target_scope,
+    )
     return True
 
 
@@ -783,7 +865,11 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    active_context = _sudo_execution_context.get()
+    if active_context is not None:
+        terminal_env = active_context[1].strip().lower() or "local"
+    else:
+        terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1008,24 +1094,22 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if sudo_count == 0:
         return command, None
 
-    # Scope-aware read (Slack pattern): under multiplex the process env may
-    # hold another profile's SUDO_PASSWORD, so honor the installed scope's
-    # verdict; unscoped callers keep the legacy os.environ read.
-    try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
-
+    active_context = _sudo_execution_context.get()
+    if active_context is not None and active_context[2]:
+        configured_password = active_context[3]
+        has_configured_password = configured_password is not None
+        sudo_password = str(configured_password) if has_configured_password else _get_cached_sudo_password()
+    else:
         try:
-            _configured_password = get_secret("SUDO_PASSWORD")
-        except UnscopedSecretError:
-            _configured_password = os.environ.get("SUDO_PASSWORD")
-    except Exception:
-        _configured_password = os.environ.get("SUDO_PASSWORD")
-    has_configured_password = _configured_password is not None
-    sudo_password = (
-        _configured_password
-        if has_configured_password
-        else _get_cached_sudo_password()
-    )
+            from agent.secret_scope import UnscopedSecretError, get_secret
+            try:
+                configured_password = get_secret("SUDO_PASSWORD")
+            except UnscopedSecretError:
+                configured_password = os.environ.get("SUDO_PASSWORD")
+        except Exception:
+            configured_password = os.environ.get("SUDO_PASSWORD")
+        has_configured_password = configured_password is not None
+        sudo_password = configured_password if has_configured_password else _get_cached_sudo_password()
 
     # Local hosts with sudoers NOPASSWD should not be forced through the
     # interactive Hermes password prompt or the sudo -S password-pipe path.
@@ -1066,7 +1150,7 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 Environment state persists: activate a virtualenv or export variables once per session, not before every command.
@@ -1078,10 +1162,12 @@ PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output t
 """
 
 # Global state for environment lifecycle management
-_active_environments: Dict[str, Any] = {}
-_last_activity: Dict[str, float] = {}
+_active_environments: Dict[Hashable, Any] = {}
+_last_activity: Dict[Hashable, float] = {}
 _env_lock = threading.Lock()
-_creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
+_retired_environments: list[tuple[Hashable, Any, float]] = []
+_retired_environments_lock = threading.Lock()
+_creation_locks: Dict[Hashable, threading.Lock] = {}  # Per-target locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
@@ -1125,15 +1211,32 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
             return
         _docker_orphan_reaper_ran = True
 
-    # 2 × lifetime_seconds gives sibling Hermes processes a generous grace
-    # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
-    # doesn't get an instant-reap that races their own setup.
-    # ``container_config`` only carries container_* keys, so read
-    # lifetime_seconds from the env var the rest of the module uses.
+    # 2 × the longest configured Docker-target lifetime gives every named
+    # sibling a conservative grace window. A process-wide reaper runs only
+    # once, so using the first-created target's value could reap a longer-lived
+    # target prematurely.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(container_config.get(
+            "lifetime_seconds", os.getenv("TERMINAL_LIFETIME_SECONDS", "300"),
+        ))
     except (TypeError, ValueError):
         lifetime = 300
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        targets = list_execution_targets()
+        if targets and targets[0].named:
+            for target in targets:
+                if target.backend != "docker":
+                    continue
+                try:
+                    lifetime = max(
+                        lifetime, int(target.config.get("lifetime_seconds", 300)),
+                    )
+                except (TypeError, ValueError):
+                    continue
+    except Exception:
+        logger.debug("Could not resolve Docker target lifetimes", exc_info=True)
     lifetime = max(60, lifetime)
     max_age = lifetime * 2
 
@@ -1166,7 +1269,12 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 #
 # This is never exposed to the model -- only infrastructure code calls it.
 # Thread-safe because each task_id is unique per rollout.
-_task_env_overrides: Dict[str, Dict[str, Any]] = {}
+_task_env_overrides: Dict[Hashable, Dict[str, Any]] = {}
+_task_env_overrides_lock = threading.Lock()
+_active_turn_counts: Dict[Hashable, int] = {}
+_active_turn_counts_lock = threading.RLock()
+_deferred_environment_cleanups: Dict[Hashable, Hashable] = {}
+
 
 # ── Per-session cwd records (cwd rearchitecture, step 1) ────────────────────
 #
@@ -1182,11 +1290,263 @@ _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 # here. Readers still use the legacy env.cwd ladder. Later steps flip
 # file_tools and _resolve_command_cwd to read this store, then delete the
 # env-side tracking + ownership guards.
-_session_cwd: Dict[str, str] = {}
+_session_cwd: Dict[Hashable, str] = {}
+_session_cwd_specs: Dict[Hashable, str] = {}
 _session_cwd_lock = threading.Lock()
 
 
-def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
+def _target_resolution(target=None):
+    from tools.execution_targets import resolve_execution_target
+
+    return resolve_execution_target(target)
+
+
+def _environment_scope_key(task_key: Hashable, resolution) -> Hashable:
+    return resolution.environment_key(task_key)
+
+
+def _profile_scoped_task_key(task_key: Hashable) -> Hashable:
+    try:
+        return _target_resolution(None).scope_task_key(task_key)
+    except Exception:
+        return task_key
+
+
+def _turn_scope_key(task_id: Hashable) -> Hashable:
+    collapsed = _resolve_container_task_id(str(task_id))
+    return _profile_scoped_task_key(collapsed)
+
+
+def _run_deferred_environment_cleanup(task_id: Hashable) -> None:
+    try:
+        cleanup_vm(
+            task_id,
+            preserve_persistent=True,
+            include_collapsed=True,
+        )
+    except Exception:
+        logger.warning(
+            "Deferred environment cleanup failed for task %s",
+            task_id,
+            exc_info=True,
+        )
+
+
+def _turn_keys_overlap(left: Hashable, right: Hashable) -> bool:
+    if left == right:
+        return True
+    if isinstance(left, tuple) and left and left[0] == right:
+        return True
+    if isinstance(right, tuple) and right and right[0] == left:
+        return True
+    return False
+
+
+def _related_active_turns_unlocked(environment_key: Hashable) -> int:
+    return sum(
+        count for key, count in _active_turn_counts.items()
+        if _turn_keys_overlap(key, environment_key)
+    )
+
+
+def _register_environment_turn_key(key: Hashable) -> Hashable:
+    with _active_turn_counts_lock:
+        _active_turn_counts[key] = _active_turn_counts.get(key, 0) + 1
+    return key
+
+
+def register_environment_turn(task_id: Hashable) -> Hashable:
+    return _register_environment_turn_key(_turn_scope_key(task_id))
+
+
+def _release_environment_turn_key(key: Hashable) -> int:
+    deferred_task_ids = []
+    with _active_turn_counts_lock:
+        current = _active_turn_counts.get(key, 0)
+        if current <= 1:
+            _active_turn_counts.pop(key, None)
+        else:
+            _active_turn_counts[key] = current - 1
+        remaining = _related_active_turns_unlocked(key)
+        for deferred_key, deferred_task_id in list(
+            _deferred_environment_cleanups.items()
+        ):
+            if _related_active_turns_unlocked(deferred_key) == 0:
+                deferred_task_ids.append(deferred_task_id)
+                _deferred_environment_cleanups.pop(deferred_key, None)
+    for deferred_task_id in deferred_task_ids:
+        _run_deferred_environment_cleanup(deferred_task_id)
+    return remaining
+
+
+def release_environment_turn(task_id: Hashable) -> int:
+    return _release_environment_turn_key(_turn_scope_key(task_id))
+
+
+def defer_environment_turn_cleanup(task_id: Hashable) -> None:
+    # Run collapsed cleanup when the final overlapping lease releases.
+    key = _turn_scope_key(task_id)
+    run_now = False
+    with _active_turn_counts_lock:
+        if _related_active_turns_unlocked(key) > 0:
+            _deferred_environment_cleanups.setdefault(key, task_id)
+        else:
+            run_now = True
+    if run_now:
+        _run_deferred_environment_cleanup(task_id)
+
+
+def active_environment_turns(task_id: Hashable) -> int:
+    return _active_turns_for_environment_key(_turn_scope_key(task_id))
+
+
+def _active_turns_for_environment_key(environment_key: Hashable) -> int:
+    with _active_turn_counts_lock:
+        return _related_active_turns_unlocked(environment_key)
+
+
+class _EnvironmentTurnLease:
+    def __init__(
+        self,
+        task_id: Hashable,
+        *,
+        environment_key: Hashable | None = None,
+    ):
+        self._key = (
+            _register_environment_turn_key(environment_key)
+            if environment_key is not None
+            else register_environment_turn(task_id)
+        )
+        self._released = False
+        self._lock = threading.Lock()
+
+    @property
+    def key(self) -> Hashable:
+        return self._key
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return not self._released
+
+    def release(self) -> int:
+        with self._lock:
+            if self._released:
+                return _active_turns_for_environment_key(self._key)
+            self._released = True
+        return _release_environment_turn_key(self._key)
+
+
+_logical_environment_lease: ContextVar[Optional[_EnvironmentTurnLease]] = ContextVar(
+    "logical_environment_lease", default=None,
+)
+_tool_environment_lease: ContextVar[Optional[_EnvironmentTurnLease]] = ContextVar(
+    "tool_environment_lease", default=None,
+)
+
+
+@contextmanager
+def logical_environment_turn(task_id: Hashable):
+    # Hold the shared environment for one complete logical conversation turn.
+    lease = _EnvironmentTurnLease(task_id)
+    token = _logical_environment_lease.set(lease)
+    try:
+        yield lease
+    finally:
+        lease.release()
+        _logical_environment_lease.reset(token)
+
+
+def release_logical_environment_turn(task_id: Hashable) -> int:
+    # Release this context's logical lease before final cleanup.
+    lease = _logical_environment_lease.get()
+    key = _turn_scope_key(task_id)
+    if lease is not None and lease.key == key:
+        return lease.release()
+    return active_environment_turns(task_id)
+
+
+def release_logical_environment_turn_for_cleanup(task_id: Hashable) -> bool:
+    # Preserve the established boolean cleanup-hook contract.
+    lease = _logical_environment_lease.get()
+    if lease is None or lease.key != _turn_scope_key(task_id):
+        return False
+    lease.release()
+    return True
+
+
+def execution_environment_turn_key(
+    function_name: str,
+    arguments: Mapping[str, Any],
+    *,
+    task_id: Hashable | None = None,
+) -> Hashable | None:
+    if function_name not in {
+        "terminal", "read_file", "write_file", "patch", "search_files",
+        "execute_code", "process",
+    }:
+        return None
+    task_id = arguments.get("task_id") or task_id
+    if not task_id:
+        return None
+    if function_name == "process":
+        # Follow-up calls select a persisted session_id rather than a target.
+        # A parent-scope lease safely covers whichever named runtime owns it.
+        return _turn_scope_key(task_id)
+    target = arguments.get("target")
+    if function_name == "search_files":
+        target = arguments.get("execution_target")
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(target)
+        base_task_id = _resolve_container_task_id(str(task_id))
+        return resolution.session_key(base_task_id)
+    except Exception:
+        # Invalid-target tools still execute to return their normal user-visible
+        # validation error; the raw logical lease remains the safe fallback.
+        return None
+
+
+@contextmanager
+def environment_turn_usage(
+    task_id: Hashable,
+    *,
+    environment_key: Hashable | None = None,
+):
+    # Protect one terminal, file, or code invocation from idle cleanup.
+    lease = _EnvironmentTurnLease(task_id, environment_key=environment_key)
+    token = _tool_environment_lease.set(lease)
+    try:
+        yield
+    finally:
+        lease.release()
+        _tool_environment_lease.reset(token)
+
+
+def _current_owned_environment_turns(environment_key: Hashable) -> int:
+    # Count this call's own logical/tool leases for replacement checks.
+    owned = 0
+    for lease in (
+        _logical_environment_lease.get(),
+        _tool_environment_lease.get(),
+    ):
+        if (
+            lease is not None
+            and lease.active
+            and _turn_keys_overlap(lease.key, environment_key)
+        ):
+            owned += 1
+    return owned
+
+
+def record_session_cwd(
+    session_key: Optional[str],
+    cwd: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> None:
     """Record *cwd* as the working directory of *session_key*.
 
     Called wherever a session's live cwd becomes known: after a terminal
@@ -1197,28 +1557,87 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """
     if not isinstance(cwd, str) or not cwd.strip():
         return
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
         if _session_cwd.get(key) != cwd:
             _session_cwd[key] = cwd
+        if resolution.named:
+            _session_cwd_specs[key] = resolution.spec_fingerprint
+        else:
+            _session_cwd_specs.pop(key, None)
 
 
-def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
+def get_session_cwd(
+    session_key: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> Optional[str]:
     """Return the recorded working directory for *session_key*, if any.
 
     No fallback chain here on purpose: callers decide what an absent record
     means (config default, TERMINAL_CWD seed, process cwd). ``None``/empty
     keys read the ``"default"`` record.
     """
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
+        recorded_spec = _session_cwd_specs.get(key)
+        if (
+            resolution.named
+            and recorded_spec is not None
+            and recorded_spec != resolution.spec_fingerprint
+        ):
+            return None
         return _session_cwd.get(key)
 
 
-def clear_session_cwd(session_key: str) -> None:
-    """Drop a session's cwd record (session teardown)."""
+def inherit_session_cwds(parent_task_id: str, child_task_id: str) -> int:
+    """Seed a child with every cwd scope currently owned by its parent."""
+    if not parent_task_id or not child_task_id:
+        return 0
+    parent_key = _profile_scoped_task_key(parent_task_id)
+    child_key = _profile_scoped_task_key(child_task_id)
+    inherited: Dict[Hashable, str] = {}
+    inherited_specs: Dict[Hashable, str] = {}
     with _session_cwd_lock:
-        _session_cwd.pop(session_key, None)
+        for key, cwd in _session_cwd.items():
+            if key == parent_key:
+                inherited[child_key] = cwd
+                if key in _session_cwd_specs:
+                    inherited_specs[child_key] = _session_cwd_specs[key]
+            elif (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] == parent_key
+            ):
+                child_target_key = (child_key, key[1])
+                inherited[child_target_key] = cwd
+                if key in _session_cwd_specs:
+                    inherited_specs[child_target_key] = _session_cwd_specs[key]
+        _session_cwd.update(inherited)
+        _session_cwd_specs.update(inherited_specs)
+    return len(inherited)
+
+
+def clear_session_cwd(session_key: str) -> None:
+    """Drop all legacy and named-target cwd records for a raw session."""
+    raw = str(session_key or "default")
+    scoped = _profile_scoped_task_key(raw)
+    with _session_cwd_lock:
+        _session_cwd.pop(raw, None)
+        _session_cwd.pop(scoped, None)
+        _session_cwd_specs.pop(raw, None)
+        _session_cwd_specs.pop(scoped, None)
+        for key in list(_session_cwd):
+            if (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] in {raw, scoped}
+            ):
+                _session_cwd.pop(key, None)
+                _session_cwd_specs.pop(key, None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1237,7 +1656,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    _task_env_overrides[_profile_scoped_task_key(task_id)] = overrides
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -1247,8 +1666,23 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     new_cwd = overrides.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         # A registered workspace cwd IS the session's working directory until
-        # a `cd` changes it.
-        record_session_cwd(task_id, new_cwd)
+        # a `cd` changes it. With named targets this host/workspace override
+        # belongs to the configured default target only; applying it to every
+        # explicit remote/container target would replace that target's own cwd.
+        try:
+            default_resolution = _target_resolution(None)
+        except Exception:
+            default_resolution = None
+        if (
+            default_resolution is not None
+            and not (
+                default_resolution.named
+                and default_resolution.backend == "ssh"
+            )
+        ):
+            record_session_cwd(
+                task_id, new_cwd, _resolution=default_resolution,
+            )
         # The live env is cached under the raw task_id for per-session surfaces
         # (ACP/gateway/dashboard) and under the collapsed container id for
         # isolation-keyed rollouts. Try the raw id first, then the container id,
@@ -1256,9 +1690,24 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # updates the originating session's env.
         container_id = _resolve_container_task_id(task_id)
         with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
-        if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            if (
+                default_resolution is not None
+                and default_resolution.named
+                and default_resolution.backend != "ssh"
+            ):
+                candidate_keys = {
+                    default_resolution.environment_key(task_id),
+                    default_resolution.environment_key(container_id),
+                }
+            else:
+                candidate_keys = {task_id, container_id}
+            envs = [
+                env for key, env in _active_environments.items()
+                if key in candidate_keys
+            ]
+        for env in envs:
+            if getattr(env, "cwd", None) is not None:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):
@@ -1267,7 +1716,7 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
-    _task_env_overrides.pop(task_id, None)
+    _task_env_overrides.pop(_profile_scoped_task_key(task_id), None)
     clear_session_cwd(task_id)
 
 
@@ -1299,10 +1748,11 @@ def _resolve_container_task_id(task_id: Optional[str]) -> str:
         "docker_image", "modal_image", "singularity_image",
         "daytona_image", "env_type",
     })
-    if task_id and task_id in _task_env_overrides:
-        overrides = _task_env_overrides[task_id]
+    scoped_task_id = _profile_scoped_task_key(task_id) if task_id else None
+    if scoped_task_id and scoped_task_id in _task_env_overrides:
+        overrides = _task_env_overrides[scoped_task_id]
         if set(overrides.keys()) & _ISOLATION_KEYS:
-            return task_id
+            return str(task_id)
     return "default"
 
 
@@ -1319,9 +1769,11 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     source of that lookup so the terminal and file layers can't drift apart.
     """
     raw = task_id or "default"
+    scoped_raw = _profile_scoped_task_key(raw)
+    scoped_collapsed = _profile_scoped_task_key(_resolve_container_task_id(raw))
     return (
-        _task_env_overrides.get(raw)
-        or _task_env_overrides.get(_resolve_container_task_id(raw))
+        _task_env_overrides.get(scoped_raw)
+        or _task_env_overrides.get(scoped_collapsed)
         or {}
     )
 
@@ -1404,6 +1856,39 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _apply_task_cwd_override(
+    config: Dict[str, Any], cwd: str, cwd_override: Optional[str],
+) -> str:
+    """Apply a task workspace cwd without leaking host paths into containers.
+
+    Docker's explicit mount-cwd mode is the exception: a registered host
+    workspace should become the bind source and commands should run in
+    ``/workspace``. Other container backends fall back to the target's already
+    sanitized configured cwd.
+    """
+    env_type = config.get("env_type")
+    if (
+        env_type == "docker"
+        and config.get("docker_mount_cwd_to_workspace")
+        and isinstance(cwd_override, str)
+        and cwd_override.strip()
+    ):
+        candidate = os.path.abspath(os.path.expanduser(cwd_override))
+        is_host_path = (
+            any(candidate.startswith(prefix) for prefix in _HOST_CWD_PREFIXES)
+            or (
+                os.path.isabs(candidate)
+                and os.path.isdir(candidate)
+            )
+        )
+        if is_host_path:
+            config["host_cwd"] = candidate
+            return "/workspace"
+    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+        return config["cwd"]
+    return cwd
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
@@ -1458,14 +1943,82 @@ def _ensure_terminal_env_bridged() -> None:
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
 
 
-def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
-    # Default image with Python and Node.js for maximum compatibility
+def _get_env_config(terminal_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return canonical terminal config for legacy env vars or a target mapping.
+
+    ``terminal_config is None`` is the historical flat/env-driven path.  A
+    selected named target passes its inherited mapping here directly; values
+    are parsed without mutating ``os.environ`` so concurrent target calls
+    cannot affect each other.
+    """
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    if terminal_config is None:
+        _ensure_terminal_env_bridged()
+
+    def _get(key: str, env_name: str, default: Any) -> Any:
+        if terminal_config is None:
+            return os.getenv(env_name, str(default) if not isinstance(default, (list, dict)) else json.dumps(default))
+        return terminal_config.get(key, default)
+
+    def _coerce(value: Any, converter: Any, label: str, key: str) -> Any:
+        if converter is json.loads and isinstance(value, (list, dict)):
+            return value
+        try:
+            return converter(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            source = (
+                f"terminal target setting {key}"
+                if terminal_config is not None
+                else f"TERMINAL_{key.upper()}"
+            )
+            raise ValueError(f"Invalid value for {source}: {value!r} (expected {label}).")
+
+    def _bool(key: str, env_name: str, default: bool) -> bool:
+        value = _get(key, env_name, default)
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+        if terminal_config is not None:
+            raise ValueError(
+                f"Invalid value for terminal target setting {key}: {value!r} "
+                "(expected boolean)."
+            )
+        # Preserve the legacy env-var behavior for unknown strings.
+        return False
+
+    def _json_shape(
+        key: str,
+        env_name: str,
+        default: Any,
+        expected_type: type,
+        label: str,
+    ) -> Any:
+        value = _coerce(_get(key, env_name, default), json.loads, "valid JSON", key)
+        if not isinstance(value, expected_type):
+            source = (
+                f"terminal target setting {key}"
+                if terminal_config is not None
+                else env_name
+            )
+            raise ValueError(
+                f"Invalid value for {source}: {value!r} (expected {label})."
+            )
+        return value
+
+    env_type = str(
+        _get(
+            "backend", "TERMINAL_ENV",
+            terminal_config.get("env_type", "local") if terminal_config else "local",
+        )
+    ).strip().lower() or "local"
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _bool(
+        "docker_mount_cwd_to_workspace", "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", False,
+    )
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1474,20 +2027,28 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _coerce(_get("container_cpu", "TERMINAL_CONTAINER_CPU", 1), float, "number", "container_cpu")
+        container_memory = _coerce(_get("container_memory", "TERMINAL_CONTAINER_MEMORY", 5120), int, "integer", "container_memory")
+        container_disk = _coerce(_get("container_disk", "TERMINAL_CONTAINER_DISK", 51200), int, "integer", "container_disk")
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _json_shape(
+            "docker_forward_env", "TERMINAL_DOCKER_FORWARD_ENV", [], list, "list",
+        )
+        docker_volumes = _json_shape(
+            "docker_volumes", "TERMINAL_DOCKER_VOLUMES", [], list, "list",
+        )
+        docker_env = _json_shape(
+            "docker_env", "TERMINAL_DOCKER_ENV", {}, dict, "mapping",
+        )
+        docker_extra_args = _json_shape(
+            "docker_extra_args", "TERMINAL_DOCKER_EXTRA_ARGS", [], list, "list",
+        )
+        docker_shm_size = str(_get("docker_shm_size", "TERMINAL_DOCKER_SHM_SIZE", "1g") or "")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1511,12 +2072,18 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
+    cwd = str(_get("cwd", "TERMINAL_CWD", default_cwd) or default_cwd)
+    if env_type == "local" and cwd in {".", "./", "auto", "cwd"}:
+        cwd = _safe_getcwd()
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = (
+            (os.getenv("TERMINAL_CWD") or _safe_getcwd())
+            if terminal_config is None
+            else (cwd or _safe_getcwd())
+        )
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1534,41 +2101,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_get("modal_mode", "TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": str(_get("docker_image", "TERMINAL_DOCKER_IMAGE", default_image)),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": str(_get("singularity_image", "TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}")),
+        "modal_image": str(_get("modal_image", "TERMINAL_MODAL_IMAGE", default_image)),
+        "daytona_image": str(_get("daytona_image", "TERMINAL_DAYTONA_IMAGE", default_image)),
+        "vercel_runtime": str(_get("vercel_runtime", "TERMINAL_VERCEL_RUNTIME", "")).strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _coerce(_get("timeout", "TERMINAL_TIMEOUT", 180), int, "integer", "timeout"),
+        "lifetime_seconds": _coerce(_get("lifetime_seconds", "TERMINAL_LIFETIME_SECONDS", 300), int, "integer", "lifetime_seconds"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": str(_get("ssh_host", "TERMINAL_SSH_HOST", "")),
+        "ssh_user": str(_get("ssh_user", "TERMINAL_SSH_USER", "")),
+        "ssh_port": _coerce(_get("ssh_port", "TERMINAL_SSH_PORT", 22), int, "integer", "ssh_port"),
+        "ssh_key": str(_get("ssh_key", "TERMINAL_SSH_KEY", "")),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
-            "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
-        ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "ssh_persistent": _bool(
+            "ssh_persistent", "TERMINAL_SSH_PERSISTENT",
+            _bool("persistent_shell", "TERMINAL_PERSISTENT_SHELL", True),
+        ),
+        "local_persistent": _bool("local_persistent", "TERMINAL_LOCAL_PERSISTENT", False),
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _bool("container_persistent", "TERMINAL_CONTAINER_PERSISTENT", True),
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _bool("docker_run_as_host_user", "TERMINAL_DOCKER_RUN_AS_HOST_USER", False),
+        "docker_network": _bool("docker_network", "TERMINAL_DOCKER_NETWORK", True),
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1577,17 +2144,381 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
-            "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_persist_across_processes": _bool(
+            "docker_persist_across_processes", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", True,
+        ),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
-            "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_orphan_reaper": _bool(
+            "docker_orphan_reaper", "TERMINAL_DOCKER_ORPHAN_REAPER", True,
+        ),
     }
+
+
+
+def _build_environment_constructor_configs(
+    config: Dict[str, Any],
+    resolution: 'ExecutionTargetResolution',
+    base_task_id: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Build backend constructor inputs from one canonical normalized config."""
+    env_type = config["env_type"]
+    container_config: Optional[Dict[str, Any]] = None
+    if env_type in _CONTAINER_BACKENDS:
+        container_config = {
+            "container_cpu": config.get("container_cpu", 1),
+            "container_memory": config.get("container_memory", 5120),
+            "container_disk": config.get("container_disk", 51200),
+            "container_persistent": config.get("container_persistent", True),
+            "vercel_runtime": config.get("vercel_runtime", ""),
+            "modal_mode": config.get("modal_mode", "auto"),
+            "docker_volumes": config.get("docker_volumes", []),
+            "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+            "docker_forward_env": config.get("docker_forward_env", []),
+            "docker_env": config.get("docker_env", {}),
+            "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+            "docker_extra_args": config.get("docker_extra_args", []),
+            "docker_network": config.get("docker_network", True),
+            "docker_shm_size": config.get("docker_shm_size", "1g"),
+            "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+            "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+            "lifetime_seconds": config.get("lifetime_seconds", 300),
+            "storage_task_id": resolution.storage_task_id(base_task_id),
+            "legacy_storage_task_id": resolution.legacy_backend_task_id(base_task_id),
+        }
+
+    ssh_config: Optional[Dict[str, Any]] = None
+    if env_type == "ssh":
+        ssh_config = {
+            "host": config.get("ssh_host", ""),
+            "user": config.get("ssh_user", ""),
+            "port": config.get("ssh_port", 22),
+            "key": config.get("ssh_key", ""),
+            "persistent": config.get("ssh_persistent", False),
+            "runtime_scope": resolution.security_scope if resolution.named else "",
+        }
+
+    local_config: Optional[Dict[str, Any]] = None
+    if env_type == "local":
+        local_config = {"persistent": config.get("local_persistent", False)}
+    return container_config, ssh_config, local_config
+
+
+def _record_environment_lifetime(env: Any, config: Dict[str, Any]) -> None:
+    """Attach the resolved target's idle lifetime to its environment."""
+    try:
+        env._hermes_lifetime_seconds = int(config["lifetime_seconds"])
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+
+
+def _record_environment_target(env: Any, resolution: Any) -> None:
+    """Bind a created environment to the exact resolved named-target spec."""
+    try:
+        setattr(env, "_hermes_target_name", resolution.target)
+        setattr(
+            env, "_hermes_target_fingerprint",
+            resolution.spec_fingerprint if resolution.named else None,
+        )
+        setattr(env, "_hermes_target_backend", resolution.backend)
+        setattr(
+            env, "_hermes_target_scope",
+            resolution.security_scope if resolution.named else None,
+        )
+        setattr(env, "_hermes_target_resolution", resolution)
+        persistent = resolution.config.get("container_persistent", True)
+        if isinstance(persistent, str):
+            persistent = persistent.strip().lower() in {"1", "true", "yes", "on"}
+        setattr(
+            env,
+            "_hermes_stable_storage",
+            resolution.backend == "docker" and bool(persistent),
+        )
+    except (AttributeError, TypeError):
+        pass
+
+
+def _environment_matches_target(env: Any, resolution: Any) -> bool:
+    """Reject cache reuse after a named target's effective config changes."""
+    if env is None or not resolution.named:
+        return env is not None
+    fingerprint = getattr(env, "_hermes_target_fingerprint", None)
+    # Third-party/test-provided environments predating named targets have no
+    # binding metadata. Preserve their registration contract; every environment
+    # created by core Hermes is stamped before entering the cache.
+    if fingerprint is None:
+        return True
+    return (
+        fingerprint == resolution.spec_fingerprint
+        and getattr(env, "_hermes_target_name", resolution.target) == resolution.target
+        and getattr(env, "_hermes_target_backend", resolution.backend) == resolution.backend
+    )
+
+
+def _environment_has_stable_storage(env: Any) -> bool:
+    return bool(getattr(env, "_hermes_stable_storage", False))
+
+
+def _environment_replacement_is_busy(env: Any, environment_key: Hashable) -> bool:
+    """Protect shared persistent storage while the old runtime is still active."""
+    if not _environment_has_stable_storage(env):
+        return False
+    active = _active_turns_for_environment_key(environment_key)
+    owned = _current_owned_environment_turns(environment_key)
+    if active > owned:
+        return True
+    try:
+        from tools.process_registry import process_registry
+
+        return process_registry.has_active_environment(env)
+    except Exception:
+        return False
+
+
+def _cleanup_environment_resource(
+    env: Any,
+    *,
+    force_remove: bool = False,
+    preserve_storage: bool = False,
+) -> None:
+    """Stop one environment, optionally preserving its persistent storage."""
+    import inspect
+
+    ownership_attrs = {}
+    if force_remove:
+        # A replaced environment is unreachable by configuration and must not
+        # retain persist-mode lifecycle semantics. Persistent storage can remain
+        # owned by the stable profile/target storage identity while the obsolete
+        # runtime is removed.
+        attrs = ["_persist_across_processes"]
+        if not preserve_storage:
+            attrs.extend(["_persistent", "persistent_filesystem"])
+        for attr in attrs:
+            if hasattr(env, attr):
+                try:
+                    ownership_attrs[attr] = getattr(env, attr)
+                    setattr(env, attr, False)
+                except (AttributeError, TypeError):
+                    pass
+
+    try:
+        if hasattr(env, "cleanup"):
+            cleanup = env.cleanup
+            kwargs = {}
+            if force_remove:
+                try:
+                    if "force_remove" in inspect.signature(cleanup).parameters:
+                        kwargs["force_remove"] = True
+                except (TypeError, ValueError):
+                    pass
+            result = cleanup(**kwargs)
+        elif hasattr(env, "stop"):
+            result = env.stop()
+        elif hasattr(env, "terminate"):
+            result = env.terminate()
+        else:
+            return
+
+        if inspect.isawaitable(result):
+            import asyncio
+
+            try:
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(result)
+                loop.close()
+            except Exception:
+                try:
+                    close = getattr(result, "close", None)
+                    if close is not None:
+                        close()
+                except Exception:
+                    pass
+                raise
+
+        wait_fn = getattr(env, "wait_for_cleanup", None)
+        if wait_fn is not None and not wait_fn(timeout=60.0):
+            raise RuntimeError("environment cleanup did not finish within 60 seconds")
+    except BaseException:
+        # Cleanup can fail before the obsolete runtime is actually removed. In
+        # that case the caller restores the handle to the active cache, so also
+        # restore its persistence ownership flags rather than leaving a live
+        # runtime reachable but disowned by this process.
+        for attr, value in ownership_attrs.items():
+            try:
+                setattr(env, attr, value)
+            except (AttributeError, TypeError):
+                pass
+        raise
+
+
+class _EnvironmentReplacementError(RuntimeError):
+    """Base error for a fail-closed named-target runtime replacement."""
+
+
+class _EnvironmentReplacementBusyError(_EnvironmentReplacementError):
+    """The previous stable-storage runtime still has active users."""
+
+
+class _EnvironmentReplacementCleanupError(_EnvironmentReplacementError):
+    """The previous stable-storage runtime could not be retired safely."""
+
+
+def _prepare_environment_replacement(
+    env: Any,
+    environment_key: Hashable,
+    *,
+    target_name: str,
+) -> bool:
+    """Retire an idle stable-storage runtime before creating its replacement.
+
+    Persistent Docker generations share one storage identity, so the obsolete
+    runtime must be gone before the replacement container is created. The
+    caller holds the per-environment creation lock; this helper owns the shared
+    detach/cleanup/restore handoff used by terminal, file, and execute_code.
+    """
+    if env is None:
+        return False
+    if _environment_replacement_is_busy(env, environment_key):
+        raise _EnvironmentReplacementBusyError(
+            f"Execution target {target_name!r} changed while its persistent "
+            "Docker runtime is still active. Wait for its commands/background "
+            "processes to finish, then retry."
+        )
+    if not _environment_has_stable_storage(env):
+        return False
+
+    with _env_lock:
+        if _active_environments.get(environment_key) is not env:
+            raise _EnvironmentReplacementBusyError(
+                f"Execution target {target_name!r} changed again while its "
+                "previous runtime was being retired. Retry the operation."
+            )
+        owned_keys = [
+            (key, key in _last_activity, _last_activity.get(key, 0.0))
+            for key, candidate in list(_active_environments.items())
+            if candidate is env
+        ]
+        for key, _, _ in owned_keys:
+            _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+
+    try:
+        _cleanup_environment_resource(
+            env,
+            force_remove=True,
+            preserve_storage=True,
+        )
+    except BaseException as exc:
+        with _env_lock:
+            for key, had_activity, activity in owned_keys:
+                if key not in _active_environments:
+                    _active_environments[key] = env
+                    if had_activity:
+                        _last_activity[key] = activity
+        if isinstance(exc, Exception):
+            raise _EnvironmentReplacementCleanupError(
+                "Could not retire the previous persistent Docker runtime for "
+                f"execution target {target_name!r}: {exc}"
+            ) from exc
+        raise
+    return True
+
+
+def _retire_replaced_environment(env: Any, task_key: Hashable) -> None:
+    """Defer teardown until no operation/process can still reference *env*."""
+    if env is None:
+        return
+    with _retired_environments_lock:
+        if all(existing_env is not env for _, existing_env, _ in _retired_environments):
+            _retired_environments.append((task_key, env, time.time()))
+
+
+def _collect_retired_environments(
+    *,
+    task_key: Hashable | None = None,
+    min_age_seconds: float = 60.0,
+    require_idle: bool = True,
+) -> list[tuple[Hashable, Any]]:
+    """Detach retired resources that are old enough and no longer in use."""
+    now = time.time()
+    ready: list[tuple[Hashable, Any]] = []
+    keep: list[tuple[Hashable, Any, float]] = []
+    try:
+        from tools.process_registry import process_registry
+    except ImportError:
+        process_registry = None
+
+    with _retired_environments_lock:
+        candidates = list(_retired_environments)
+        _retired_environments.clear()
+
+    for retired_key, env, retired_at in candidates:
+        if task_key is not None and retired_key != task_key:
+            keep.append((retired_key, env, retired_at))
+            continue
+        busy = False
+        if require_idle:
+            busy = _active_turns_for_environment_key(retired_key) > 0
+            if not busy and process_registry is not None:
+                busy = process_registry.has_active_environment(env)
+        if busy or now - retired_at < min_age_seconds:
+            keep.append((retired_key, env, retired_at))
+        else:
+            ready.append((retired_key, env))
+
+    # Merge records retired concurrently while we performed potentially slow
+    # process liveness checks. Avoid duplicate records by environment identity.
+    ready_ids = {id(env) for _, env in ready}
+    with _retired_environments_lock:
+        concurrent = [
+            record for record in _retired_environments
+            if id(record[1]) not in ready_ids
+        ]
+        seen = {id(record[1]) for record in concurrent}
+        concurrent.extend(
+            record for record in keep
+            if id(record[1]) not in seen
+        )
+        _retired_environments[:] = concurrent
+    return ready
+
+
+def _cleanup_retired_environments(
+    *,
+    task_key: Hashable | None = None,
+    min_age_seconds: float = 60.0,
+    require_idle: bool = True,
+) -> int:
+    """Force-remove retired environments selected by lifecycle policy."""
+    ready = _collect_retired_environments(
+        task_key=task_key,
+        min_age_seconds=min_age_seconds,
+        require_idle=require_idle,
+    )
+    cleaned = 0
+    for retired_key, env in ready:
+        try:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+            cleaned += 1
+            logger.info("Cleaned retired environment for task: %s", retired_key)
+        except Exception as exc:
+            error_str = str(exc)
+            if "404" in error_str or "not found" in error_str.lower():
+                cleaned += 1
+                logger.info("Retired environment for task %s was already gone", retired_key)
+            else:
+                logger.warning(
+                    "Error cleaning retired environment for task %s: %s",
+                    retired_key, exc,
+                )
+                _retire_replaced_environment(env, retired_key)
+    return cleaned
 
 
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
@@ -1599,11 +2530,17 @@ def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     )
 
 
-def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
-                        ssh_config: dict = None, container_config: dict = None,
-                        local_config: dict = None,
-                        task_id: str = "default",
-                        host_cwd: str = None):
+def _create_environment(
+    env_type: str,
+    image: str,
+    cwd: str,
+    timeout: int,
+    ssh_config: Optional[dict] = None,
+    container_config: Optional[dict] = None,
+    local_config: Optional[dict] = None,
+    task_id: str = "default",
+    host_cwd: Optional[str] = None,
+):
     """
     Create an execution environment for sandboxed command execution.
     
@@ -1633,7 +2570,12 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        env = _LocalEnvironment(cwd=cwd, timeout=timeout)
+        setattr(
+            env, "_persistent",
+            bool((local_config or {}).get("persistent", False)),
+        )
+        return env
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -1647,6 +2589,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
+            storage_task_id=cc.get("storage_task_id"),
+            legacy_storage_task_id=cc.get("legacy_storage_task_id"),
             volumes=volumes,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
@@ -1758,6 +2702,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             key_path=ssh_config.get("key", ""),
             cwd=cwd,
             timeout=timeout,
+            runtime_scope=ssh_config.get("runtime_scope", ""),
         )
 
     else:
@@ -1789,7 +2734,16 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
 
     with _env_lock:
         for task_id, last_time in list(_last_activity.items()):
-            if current_time - last_time > lifetime_seconds:
+            if _active_turns_for_environment_key(task_id) > 0:
+                # An active tool or overlapping logical turn owns this runtime.
+                # Refresh activity so it gets a complete idle window afterward.
+                _last_activity[task_id] = current_time
+                continue
+            tracked_env = _active_environments.get(task_id)
+            effective_lifetime = getattr(
+                tracked_env, "_hermes_lifetime_seconds", lifetime_seconds,
+            )
+            if current_time - last_time > effective_lifetime:
                 env = _active_environments.pop(task_id, None)
                 _last_activity.pop(task_id, None)
                 if env is not None:
@@ -1827,6 +2781,11 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
                 logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+
+    # Replaced environments are no longer selectable. Give concurrent foreground
+    # calls a one-minute grace period, then force-remove them once no tool turn or
+    # background process still references their task scope.
+    _cleanup_retired_environments(min_age_seconds=60.0, require_idle=True)
 
 
 def _cleanup_thread_worker():
@@ -1866,14 +2825,55 @@ def _stop_cleanup_thread():
             pass
 
 
-def get_active_env(task_id: str):
+def get_active_env(task_id: str, target: Optional[str] = None):
     """Return the active BaseEnvironment for *task_id*, or None."""
-    lookup = _resolve_container_task_id(task_id)
+    resolution = _target_resolution(target)
+    lookup = _environment_scope_key(_resolve_container_task_id(task_id), resolution)
+    raw_lookup = _environment_scope_key(task_id, resolution)
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        return _active_environments.get(lookup) or _active_environments.get(raw_lookup)
 
 
-def is_persistent_env(task_id: str) -> bool:
+def get_environment_for_target_scope(
+    task_id: str, target: str, runtime_scope: str,
+):
+    """Find the active/retired environment that produced a scoped result."""
+    raw = task_id or "default"
+    collapsed = _resolve_container_task_id(raw)
+    bases = {
+        _profile_scoped_task_key(raw),
+        _profile_scoped_task_key(collapsed),
+    }
+
+    def _matches(key: Hashable, env: Any) -> bool:
+        belongs = key in bases or (
+            isinstance(key, tuple) and len(key) == 2 and key[0] in bases
+        )
+        return bool(
+            belongs
+            and getattr(env, "_hermes_target_name", None) == target
+            and getattr(env, "_hermes_target_scope", None) == runtime_scope
+        )
+
+    with _env_lock:
+        for key, env in _active_environments.items():
+            if _matches(key, env):
+                return env
+    with _retired_environments_lock:
+        for key, env, _retired_at in _retired_environments:
+            if _matches(key, env):
+                return env
+    return None
+
+
+def _environment_is_persistent(env: Any) -> bool:
+    return bool(
+        getattr(env, "_persistent", False)
+        or getattr(env, "persistent_filesystem", False)
+    )
+
+
+def is_persistent_env(task_id: str, target: Optional[str] = None) -> bool:
     """Return True if the active environment for task_id is configured for
     cross-turn persistence (``persistent_filesystem=True``).
 
@@ -1884,10 +2884,10 @@ def is_persistent_env(task_id: str) -> bool:
     (``_cleanup_inactive_envs``) handles persistent envs once they exceed
     ``terminal.lifetime_seconds``.
     """
-    env = get_active_env(task_id)
+    env = get_active_env(task_id, target=target)
     if env is None:
         return False
-    return bool(getattr(env, "_persistent", False))
+    return _environment_is_persistent(env)
 
 
 
@@ -1903,7 +2903,11 @@ def cleanup_all_environments():
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
-    
+
+    cleaned += _cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=False,
+    )
+
     # Also clean any orphaned directories
     scratch_dir = _get_scratch_dir()
     import glob
@@ -1919,11 +2923,20 @@ def cleanup_all_environments():
     return cleaned
 
 
-def cleanup_vm(task_id: str, *, force_remove: bool = False):
+def cleanup_vm(
+    task_id: Hashable,
+    *,
+    force_remove: bool = False,
+    preserve_persistent: bool = False,
+    target: Optional[str] = None,
+    include_collapsed: bool = False,
+):
     """Manually clean up a specific environment by task_id.
 
     *force_remove* (default False) is forwarded to backends that accept it
-    — currently only ``DockerEnvironment``. The default of False matches
+    — currently only ``DockerEnvironment``. ``preserve_persistent`` is used
+    by per-turn cleanup to keep each persistent named sibling live while
+    removing only non-persistent targets. The default of False matches
     session-lifecycle semantics: this function is called from
     ``AIAgent.close()`` (TUI session close, gateway session teardown) and the
     per-turn cleanup branch for non-persistent envs, both of which should
@@ -1940,76 +2953,166 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
-    # Remove from tracking dicts while holding the lock, but defer the
-    # actual (potentially slow) env.cleanup() call to outside the lock
-    # so other tool calls aren't blocked.
-    env = None
+    # Direct tuple keys are used by global/idle cleanup. For a raw task,
+    # omitted target cleans every target scope owned by that exact raw key;
+    # an explicit target cleans exactly that scope. Do not collapse arbitrary
+    # subagent ids to "default" here: legacy cleanup_vm(child_id) never tore
+    # down the parent's shared environment, and doing so in named mode would
+    # let a delegate's close race/disrupt its parent.
+    if isinstance(task_id, tuple):
+        keys = [task_id]
+    elif target is None:
+        try:
+            resolution = _target_resolution(None)
+            scoped_task_id = resolution.scope_task_key(task_id)
+            collapsed_task_id = _resolve_container_task_id(str(task_id))
+            scoped_collapsed_task_id = resolution.scope_task_key(collapsed_task_id)
+        except Exception:
+            scoped_task_id = task_id
+            collapsed_task_id = task_id
+            scoped_collapsed_task_id = task_id
+        matching_task_ids = {task_id, scoped_task_id}
+        if include_collapsed:
+            matching_task_ids.update({
+                collapsed_task_id, scoped_collapsed_task_id,
+            })
+        with _env_lock:
+            keys = [
+                key for key in _active_environments
+                if key in matching_task_ids
+                or (
+                    isinstance(key, tuple) and len(key) == 2
+                    and key[0] in matching_task_ids
+                )
+            ]
+        if not keys:
+            keys = [task_id]
+    else:
+        resolution = _target_resolution(target)
+        if resolution.named:
+            keys = [resolution.environment_key(task_id)]
+        else:
+            keys = [task_id]
+
+    active_process_keys = set()
+    if preserve_persistent:
+        try:
+            from tools.process_registry import process_registry
+
+            active_process_keys = {
+                key for key in keys
+                if process_registry.has_active_processes(key)
+            }
+        except Exception:
+            logger.debug(
+                "Failed to inspect active processes before cleanup",
+                exc_info=True,
+            )
+
+    envs = []
+    removed_keys = []
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for key in keys:
+            existing = _active_environments.get(key)
+            if key in active_process_keys:
+                continue
+            if (
+                preserve_persistent
+                and existing is not None
+                and _environment_is_persistent(existing)
+            ):
+                continue
+            env = _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+            removed_keys.append(key)
+            if env is not None:
+                envs.append((key, env))
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for key in removed_keys:
+            _creation_locks.pop(key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        for key in removed_keys:
+            clear_file_ops_cache(key)
     except ImportError:
         pass
 
-    if env is None:
+    for key in keys:
+        _cleanup_retired_environments(
+            task_key=key,
+            min_age_seconds=0.0,
+            require_idle=preserve_persistent,
+        )
+
+    if not envs:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
+    for key, env in envs:
+        try:
+            if hasattr(env, 'cleanup'):
+                # Pass force_remove only if the env's cleanup() accepts it
+                # (DockerEnvironment after issue #20561; other backends don't).
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=force_remove)
+                else:
+                    env.cleanup()
+            elif hasattr(env, 'stop'):
+                env.stop()
+            elif hasattr(env, 'terminate'):
+                env.terminate()
+
+            logger.info("Manually cleaned up environment for task: %s", key)
+
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "not found" in error_str.lower():
+                logger.info("Environment for task %s already cleaned up", key)
             else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", key, e)
 
 
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
-    if _active_environments:
-        count = len(_active_environments)
-        logger.info("Shutting down %d remaining sandbox(es)...", count)
-        # Snapshot the env objects BEFORE cleanup_all_environments empties
-        # the dict; we need them to wait on docker cleanup threads after the
-        # registry has been cleared.
-        envs_to_wait = list(_active_environments.values())
+    with _retired_environments_lock:
+        retired = list(_retired_environments)
+        _retired_environments.clear()
+    envs_to_wait = list(_active_environments.values())
+    if envs_to_wait:
+        logger.info("Shutting down %d remaining sandbox(es)...", len(envs_to_wait))
         cleanup_all_environments()
-        # Block briefly so docker stop/rm actually completes before the
-        # interpreter exits. Issue #20561 — without this join, the daemon
-        # cleanup threads were getting torn down mid-`docker stop`, leaving
-        # Exited containers piled up on the host.
-        for env in envs_to_wait:
-            wait_fn = getattr(env, "wait_for_cleanup", None)
-            if wait_fn is None:
-                continue
-            try:
-                wait_fn(timeout=15.0)
-            except Exception as e:  # never block shutdown on a bad backend
-                logger.debug("wait_for_cleanup raised on exit: %s", e)
+    seen = {id(env) for env in envs_to_wait}
+    for _, env, _ in retired:
+        if id(env) in seen:
+            continue
+        seen.add(id(env))
+        try:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+        except Exception as exc:
+            logger.debug("retired environment cleanup raised on exit: %s", exc)
+        envs_to_wait.append(env)
+
+    # Block briefly so docker stop/rm actually completes before the interpreter
+    # exits. Issue #20561 — without this join, daemon cleanup threads can be
+    # torn down mid-`docker stop`, leaving exited containers on the host.
+    for env in envs_to_wait:
+        wait_fn = getattr(env, "wait_for_cleanup", None)
+        if wait_fn is None:
+            continue
+        try:
+            wait_fn(timeout=15.0)
+        except Exception as exc:  # never block shutdown on a bad backend
+            logger.debug("wait_for_cleanup raised on exit: %s", exc)
 
 atexit.register(_atexit_cleanup)
 
@@ -2218,6 +3321,8 @@ def _resolve_command_cwd(
     workdir: Optional[str],
     default_cwd: str,
     session_key: Optional[str] = None,
+    target: Optional[str] = None,
+    _resolution=None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
 
@@ -2230,7 +3335,9 @@ def _resolve_command_cwd(
     """
     if workdir:
         return workdir
-    return get_session_cwd(session_key) or default_cwd
+    return get_session_cwd(
+        session_key, target=target, _resolution=_resolution,
+    ) or default_cwd
 
 
 def terminal_tool(
@@ -2244,6 +3351,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    target: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2259,6 +3367,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        target: Named execution target. Omit to use the configured default.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2289,15 +3398,33 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
-        # Get configuration
-        config = _get_env_config()
+        # Resolve configuration per call. Named targets read merged config
+        # directly; legacy flat config keeps the existing env-driven path.
+        from tools.execution_targets import ExecutionTargetError
+        try:
+            target_resolution = _target_resolution(target)
+        except ExecutionTargetError as exc:
+            return json.dumps({
+                "output": "", "exit_code": -1, "error": str(exc), "status": "error",
+            }, ensure_ascii=False)
+        config = (
+            _get_env_config(dict(target_resolution.config))
+            if target_resolution.named else _get_env_config()
+        )
         env_type = config["env_type"]
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
+        effective_base_task_id = _resolve_container_task_id(task_id)
+        effective_task_id = _environment_scope_key(
+            effective_base_task_id, target_resolution,
+        )
+        raw_environment_key = _environment_scope_key(
+            task_id, target_resolution,
+        ) if task_id else None
+        backend_task_id = target_resolution.backend_task_id(effective_base_task_id)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``
@@ -2319,26 +3446,21 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-        # A per-task cwd override (registered by the gateway/TUI for workspace
-        # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
-        # config["cwd"] was already sanitized for container backends in
-        # _get_env_config() while the override is raw. On a container backend a
-        # raw host path (e.g. a Windows desktop session's C:\Users\<user>, or a
-        # POSIX /home/<user>) reaches `docker run -w <host-path>` and the
-        # container fails to start (exit 125). Re-apply the same host/relative
-        # path guard to the *resolved* cwd so the override can't bypass it.
-        # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-            if cwd != config["cwd"]:
-                logger.info(
-                    "Ignoring host/relative cwd override %r for %s backend "
-                    "(won't exist in sandbox). Using %r instead.",
-                    cwd, env_type, config["cwd"],
+        cwd_override = (
+            overrides.get("cwd")
+            if (
+                not target_resolution.named
+                or (
+                    target_resolution.is_default
+                    and target_resolution.backend != "ssh"
                 )
-            cwd = config["cwd"]
+            )
+            else None
+        )
+        cwd = cwd_override or get_session_cwd(
+            task_id, _resolution=target_resolution,
+        ) or config["cwd"]
+        cwd = _apply_task_cwd_override(config, cwd, cwd_override)
         default_timeout = config["timeout"]
 
         # Validate an explicit timeout before it flows into deadline math.
@@ -2389,9 +3511,14 @@ def terminal_tool(
             # task_id; honor it instead of spawning a duplicate.
             _existing_key = (
                 effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
+                else (raw_environment_key if raw_environment_key in _active_environments else None)
             )
-            if _existing_key is not None:
+            if (
+                _existing_key is not None
+                and _environment_matches_target(
+                    _active_environments[_existing_key], target_resolution,
+                )
+            ):
                 _last_activity[_existing_key] = time.time()
                 env = _active_environments[_existing_key]
                 needs_creation = False
@@ -2407,57 +3534,50 @@ def terminal_tool(
 
             with task_lock:
                 # Double-check after acquiring the per-task lock
+                existing_env = None
+                existing_key = effective_task_id
                 with _env_lock:
                     _existing_key = (
                         effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
+                        else (raw_environment_key if raw_environment_key in _active_environments else None)
                     )
-                    if _existing_key is not None:
+                    if (
+                        _existing_key is not None
+                        and _environment_matches_target(
+                            _active_environments[_existing_key], target_resolution,
+                        )
+                    ):
                         _last_activity[_existing_key] = time.time()
                         env = _active_environments[_existing_key]
                         needs_creation = False
+                    elif _existing_key is not None:
+                        existing_env = _active_environments[_existing_key]
+                        existing_key = _existing_key
+
+                try:
+                    _prepare_environment_replacement(
+                        existing_env,
+                        existing_key,
+                        target_name=target_resolution.target,
+                    )
+                except _EnvironmentReplacementError as exc:
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": str(exc),
+                        "status": "error",
+                    }, ensure_ascii=False)
 
                 if needs_creation:
                     if env_type == "singularity":
                         _check_disk_usage_warning()
-                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
+                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id)
                     try:
-                        ssh_config = None
-                        if env_type == "ssh":
-                            ssh_config = {
-                                "host": config.get("ssh_host", ""),
-                                "user": config.get("ssh_user", ""),
-                                "port": config.get("ssh_port", 22),
-                                "key": config.get("ssh_key", ""),
-                                "persistent": config.get("ssh_persistent", False),
-                            }
-
-                        container_config = None
-                        if env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}:
-                            container_config = {
-                                "container_cpu": config.get("container_cpu", 1),
-                                "container_memory": config.get("container_memory", 5120),
-                                "container_disk": config.get("container_disk", 51200),
-                                "container_persistent": config.get("container_persistent", True),
-                                "modal_mode": config.get("modal_mode", "auto"),
-                                "vercel_runtime": config.get("vercel_runtime", ""),
-                                "docker_volumes": config.get("docker_volumes", []),
-                                "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                                "docker_forward_env": config.get("docker_forward_env", []),
-                                "docker_env": config.get("docker_env", {}),
-                                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                                "docker_extra_args": config.get("docker_extra_args", []),
-                                "docker_shm_size": config.get("docker_shm_size", "1g"),
-                                "docker_network": config.get("docker_network", True),
-                                "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-                                "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-                            }
-
-                        local_config = None
-                        if env_type == "local":
-                            local_config = {
-                                "persistent": config.get("local_persistent", False),
-                            }
+                        container_config, ssh_config, local_config = (
+                            _build_environment_constructor_configs(
+                                config, target_resolution, effective_base_task_id,
+                            )
+                        )
 
                         new_env = _create_environment(
                             env_type=env_type,
@@ -2467,9 +3587,11 @@ def terminal_tool(
                             ssh_config=ssh_config,
                             container_config=container_config,
                             local_config=local_config,
-                            task_id=effective_task_id,
+                            task_id=backend_task_id,
                             host_cwd=config.get("host_cwd"),
                         )
+                        _record_environment_lifetime(new_env, config)
+                        _record_environment_target(new_env, target_resolution)
                     except ImportError as e:
                         return json.dumps({
                             "output": "",
@@ -2478,11 +3600,69 @@ def terminal_tool(
                             "status": "disabled"
                         }, ensure_ascii=False)
 
+                    publish_error = None
                     with _env_lock:
-                        _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
-                        env = new_env
-                    logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+                        if target_resolution.named:
+                            try:
+                                from tools.execution_targets import (
+                                    execution_target_config_is_frozen,
+                                    resolve_live_execution_target,
+                                )
+
+                                live_resolution = (
+                                    target_resolution
+                                    if execution_target_config_is_frozen()
+                                    else resolve_live_execution_target(target)
+                                )
+                            except Exception as exc:
+                                publish_error = str(exc)
+                            else:
+                                if (
+                                    live_resolution.security_scope
+                                    != target_resolution.security_scope
+                                ):
+                                    publish_error = (
+                                        f"Execution target {target_resolution.target!r} "
+                                        "changed while its environment was being created."
+                                    )
+                        replaced_envs = []
+                        if publish_error is None:
+                            current = _active_environments.get(effective_task_id)
+                            if current is not None and current is not new_env:
+                                replaced_envs.append((effective_task_id, current))
+                            if (
+                                raw_environment_key is not None
+                                and raw_environment_key != effective_task_id
+                            ):
+                                raw_env = _active_environments.get(raw_environment_key)
+                                if (
+                                    raw_env is not None
+                                    and not _environment_matches_target(
+                                        raw_env, target_resolution,
+                                    )
+                                ):
+                                    _active_environments.pop(raw_environment_key, None)
+                                    _last_activity.pop(raw_environment_key, None)
+                                    replaced_envs.append((raw_environment_key, raw_env))
+                            _active_environments[effective_task_id] = new_env
+                            _last_activity[effective_task_id] = time.time()
+                            env = new_env
+                    if publish_error is not None:
+                        _cleanup_environment_resource(
+                            new_env,
+                            force_remove=True,
+                            preserve_storage=_environment_has_stable_storage(new_env),
+                        )
+                        return json.dumps({
+                            "output": "",
+                            "exit_code": -1,
+                            "error": publish_error + " Retry the command.",
+                            "status": "error",
+                        }, ensure_ascii=False)
+                    for replaced_key, replaced_env in replaced_envs:
+                        if replaced_env is not new_env:
+                            _retire_replaced_environment(replaced_env, replaced_key)
+                    logger.info("%s environment ready for task %s", env_type, effective_task_id)
 
         assert env is not None  # all creation failure paths return above
 
@@ -2518,41 +3698,53 @@ def terminal_tool(
                     ),
                     "status": "error",
                 }, ensure_ascii=False)
-            guard_cwd_base = get_session_cwd(session_key)
+            selected_target = (
+                target_resolution.target if target_resolution.named else None
+            )
+            guard_cwd_base = get_session_cwd(
+                session_key, selected_target, _resolution=target_resolution,
+            )
             if guard_cwd_base is None:
                 guard_cwd_base = getattr(env, "cwd", None) or cwd
             guard_cwd = _resolve_command_cwd(
                 workdir=workdir,
                 default_cwd=guard_cwd_base,
                 session_key=session_key,
+                _resolution=target_resolution,
             )
 
             def _read_script_in_env(script_path: str) -> Optional[str]:
-                """Best-effort script read; uses env.execute only when local read fails.
-
-                For local backends the script path is on the host filesystem. For
-                SSH/Modal/Daytona the same path is remote; the local read misses, so we
-                fall back to ``env.execute('cat ...')``.
-                """
+                # Read only through the selected target and selected cwd.
                 if env is None:
                     return None
+                if target_resolution.backend == "local":
+                    try:
+                        local_path = Path(script_path).expanduser()
+                        if not local_path.is_absolute():
+                            local_path = Path(guard_cwd) / local_path
+                        if local_path.is_file():
+                            metadata = local_path.stat()
+                            if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
+                                data = local_path.read_bytes()
+                                if len(data) <= 1024 * 1024:
+                                    return data.decode("utf-8", errors="replace")
+                    except Exception:
+                        pass
                 try:
-                    local_path = Path(script_path).expanduser()
-                    if not local_path.is_absolute():
-                        local_path = Path(guard_cwd) / local_path
-                    if local_path.is_file():
-                        metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= 1024 * 1024:
-                            data = local_path.read_bytes()
-                            if len(data) <= 1024 * 1024:
-                                return data.decode("utf-8", errors="replace")
-                except Exception:
-                    pass
-                # Remote / sandboxed backend: read via the environment's shell.
-                try:
-                    result = env.execute(f"cat {shlex.quote(script_path)}")
-                    if result.get("returncode", -1) == 0:
-                        return result.get("output", "")
+                    result = env.execute(
+                        f"cat {shlex.quote(script_path)}", cwd=guard_cwd,
+                    )
+                    returncode = (
+                        result.get("returncode", result.get("exit_code", -1))
+                        if isinstance(result, dict)
+                        else getattr(result, "exit_code", -1)
+                    )
+                    if returncode == 0:
+                        return (
+                            result.get("output", "")
+                            if isinstance(result, dict)
+                            else getattr(result, "output", "")
+                        )
                 except Exception:
                     pass
                 return None
@@ -2587,11 +3779,18 @@ def terminal_tool(
             approval = _check_all_guards(
                 command, env_type,
                 has_host_access=_docker_has_host_access(config),
+                execution_target=target_resolution.target,
+                execution_backend=target_resolution.backend,
+                execution_target_named=target_resolution.named,
+                execution_target_scope=(
+                    target_resolution.security_scope
+                    if target_resolution.named else ""
+                ),
             )
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "pending_approval":
-                    return json.dumps({
+                    pending_result = {
                         "output": "",
                         "exit_code": -1,
                         "error": "",
@@ -2602,7 +3801,11 @@ def terminal_tool(
                         "pattern_key": approval.get("pattern_key", ""),
                         "smart_denied": approval.get("smart_denied", False),
                         "allow_permanent": approval.get("allow_permanent", True),
-                    }, ensure_ascii=False)
+                    }
+                    pending_result.update(target_resolution.metadata(
+                        cwd=cwd if target_resolution.named else None,
+                    ))
+                    return json.dumps(pending_result, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")
                 fallback_msg = (
@@ -2660,25 +3863,64 @@ def terminal_tool(
                 workdir=workdir,
                 default_cwd=cwd,
                 session_key=session_key,
+                _resolution=target_resolution,
             )
             try:
-                if env_type == "local":
-                    proc_session = process_registry.spawn_local(
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=effective_pty,
-                    )
-                else:
-                    proc_session = process_registry.spawn_via_env(
-                        env=env,
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                    )
+                spawn_metadata = {}
+                environment_task_key = str(
+                    target_resolution.scope_task_key(effective_base_task_id)
+                )
+                if target_resolution.named:
+                    spawn_metadata = {
+                        "target": target_resolution.target,
+                        "backend": target_resolution.backend,
+                        "timeout_seconds": effective_timeout,
+                        "environment_task_key": environment_task_key,
+                        "runtime_scope": target_resolution.security_scope,
+                    }
+                    if env_type == "local":
+                        spawn_metadata["env_ref"] = env
+                with _scoped_sudo_execution(
+                    target_resolution.target,
+                    target_resolution.backend,
+                    named=target_resolution.named,
+                    sudo_password=target_resolution.config.get("sudo_password"),
+                    target_scope=(
+                        target_resolution.security_scope
+                        if target_resolution.named else ""
+                    ),
+                ):
+                    if env_type == "local":
+                        proc_session = process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            env_vars=env.env if hasattr(env, 'env') else None,
+                            use_pty=effective_pty,
+                            **spawn_metadata,
+                        )
+                    else:
+                        proc_session = process_registry.spawn_via_env(
+                            env=env,
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            timeout=effective_timeout,
+                            **spawn_metadata,
+                        )
+
+                # Preserve the exact legacy spawn call signature while still
+                # attaching additive metadata to subsequent process results.
+                if not target_resolution.named:
+                    proc_session.target = target_resolution.target
+                    proc_session.backend = target_resolution.backend
+                    proc_session.timeout_seconds = effective_timeout
+                    proc_session.environment_task_key = environment_task_key
+                    checkpoint = getattr(process_registry, "_write_checkpoint", None)
+                    if callable(checkpoint):
+                        checkpoint()
 
                 result_data = {
                     "output": "Background process started",
@@ -2687,6 +3929,9 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                result_data.update(target_resolution.metadata(
+                    cwd=effective_cwd if target_resolution.named else None,
+                ))
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -2920,6 +4165,7 @@ def terminal_tool(
                         workdir=workdir,
                         default_cwd=cwd,
                         session_key=session_key,
+                        _resolution=target_resolution,
                     )
                     execute_kwargs = {
                         "timeout": effective_timeout,
@@ -2931,7 +4177,17 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    with _scoped_sudo_execution(
+                        target_resolution.target,
+                        target_resolution.backend,
+                        named=target_resolution.named,
+                        sudo_password=target_resolution.config.get("sudo_password"),
+                        target_scope=(
+                            target_resolution.security_scope
+                            if target_resolution.named else ""
+                        ),
+                    ):
+                        result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -2967,13 +4223,11 @@ def terminal_tool(
             # session — record it under the session key so the durable record
             # never depends on the shared env surviving or on who drives the
             # env next.
-            #
-            # BUT: a per-command ``workdir`` override is transient by contract
-            # (docstring: "Working directory for this command"). Recording it
-            # would hijack the session's durable cwd for every later command
-            # that doesn't pass ``workdir``. Skip the dual-write in that case.
             if not workdir:
-                record_session_cwd(session_key, getattr(env, "cwd", None))
+                record_session_cwd(
+                    session_key, getattr(env, "cwd", None),
+                    _resolution=target_resolution,
+                )
 
             # Extract output
             output = result.get("output", "")
@@ -2988,7 +4242,14 @@ def terminal_tool(
 
             sudo_auth_failed = _sudo_wrong_password_failure(output)
             sudo_cache_cleared = _invalidate_cached_sudo_on_auth_failure(
-                command, output
+                command,
+                output,
+                target_resolution.target,
+                target_resolution.backend,
+                (
+                    target_resolution.security_scope
+                    if target_resolution.named else ""
+                ),
             )
             if sudo_cache_cleared:
                 has_sudo_prompt_callback = _get_sudo_password_callback() is not None
@@ -3006,13 +4267,21 @@ def terminal_tool(
             # The hook is fail-open, and the first valid string return wins.
             try:
                 from hermes_cli.lifecycle import invoke_hook
+                hook_kwargs = {
+                    "command": command,
+                    "output": output,
+                    "returncode": returncode,
+                    "task_id": effective_base_task_id or "",
+                    "env_type": env_type,
+                }
+                if target_resolution.named:
+                    hook_kwargs.update({
+                        "execution_target": target_resolution.target,
+                        "execution_backend": target_resolution.backend,
+                    })
                 hook_results = invoke_hook(
                     "transform_terminal_output",
-                    command=command,
-                    output=output,
-                    returncode=returncode,
-                    task_id=effective_task_id or "",
-                    env_type=env_type,
+                    **hook_kwargs,
                 )
                 for hook_result in hook_results:
                     if isinstance(hook_result, str):
@@ -3073,24 +4342,15 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
-            # cwd echo: when the command changed the session's working
-            # directory (cd, pushd, ...), tell the model where it ended up.
-            # Production mining shows 60% of terminal calls carry a
-            # defensive 'cd X && ' prefix because the model can't see cwd
-            # state; echoing it on change removes the guesswork (pattern
-            # borrowed from crush's <cwd> injection).
+            result_dict.update(target_resolution.metadata(
+                cwd=command_cwd if target_resolution.named else None,
+            ))
             try:
                 post_cwd = getattr(env, "cwd", None)
                 if post_cwd and command_cwd and os.path.realpath(str(post_cwd)) != os.path.realpath(str(command_cwd)):
                     result_dict["cwd"] = str(post_cwd)
             except Exception:
                 pass
-            # Truncation metadata (codex/opencode/goose pattern): report the
-            # pre-truncation size and a spill-file handle so the model can
-            # retrieve the omitted middle with read_file/search_files instead
-            # of re-running the command. The spill was written raw by the
-            # collector; redact it here with the same pass as the visible
-            # output so no secret persists unmasked on disk.
             if spill_file_path:
                 try:
                     _sp = Path(spill_file_path)
@@ -3113,25 +4373,30 @@ def terminal_tool(
                         Path(spill_file_path).unlink()
                     except OSError:
                         pass
-            try:
-                from agent.verification_evidence import record_terminal_result
+            if target_resolution.backend == "local":
+                try:
+                    from agent.verification_evidence import record_terminal_result
 
-                evidence = record_terminal_result(
-                    command=command,
-                    cwd=command_cwd,
-                    session_id=session_id or task_id or effective_task_id or "default",
-                    exit_code=returncode,
-                    output=output,
-                )
-                if evidence:
-                    result_dict["verification_evidence"] = {
-                        "status": evidence.get("status"),
-                        "kind": evidence.get("kind"),
-                        "scope": evidence.get("scope"),
-                        "canonical_command": evidence.get("canonical_command"),
-                    }
-            except Exception:
-                logger.debug("verification evidence recording failed", exc_info=True)
+                    evidence = record_terminal_result(
+                        command=command,
+                        cwd=command_cwd,
+                        session_id=(
+                            session_id or task_id or backend_task_id or "default"
+                        ),
+                        exit_code=returncode,
+                        output=output,
+                    )
+                    if evidence:
+                        result_dict["verification_evidence"] = {
+                            "status": evidence.get("status"),
+                            "kind": evidence.get("kind"),
+                            "scope": evidence.get("scope"),
+                            "canonical_command": evidence.get("canonical_command"),
+                        }
+                except Exception:
+                    logger.debug(
+                        "verification evidence recording failed", exc_info=True,
+                    )
             if approval_note:
                 # Treat rc=130 as an interrupt only when the executor's marker is
                 # present.  A command can legitimately exit 130 on its own
@@ -3170,10 +4435,9 @@ def terminal_tool(
         }, ensure_ascii=False)
 
 
-def check_terminal_requirements() -> bool:
-    """Check if all requirements for the terminal tool are met."""
+def _check_terminal_config_requirements(config: Dict[str, Any]) -> bool:
+    """Check one already-resolved backend configuration."""
     try:
-        config = _get_env_config()
         env_type = config["env_type"]
 
         if env_type == "local":
@@ -3284,6 +4548,43 @@ def check_terminal_requirements() -> bool:
         return False
 
 
+def check_terminal_requirements() -> bool:
+    """Keep tools available when any configured execution target is usable."""
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        inventory = list_execution_targets()
+    except Exception as exc:
+        # Registration checks have always failed closed for invalid terminal
+        # configuration. Keep that contract; individual tool handlers still
+        # produce actionable target errors when invoked directly.
+        logger.error("Invalid execution target config: %s", exc)
+        return False
+
+    if inventory and inventory[0].named:
+        # Cheap/always-available local targets first, so an unavailable Docker
+        # daemon or cloud credential on another target does not emit a scary
+        # startup error when at least one target is healthy.
+        ordered = sorted(
+            inventory,
+            key=lambda item: (item.backend != "local", not item.is_default, item.target),
+        )
+        for resolution in ordered:
+            try:
+                config = _get_env_config(dict(resolution.config))
+            except Exception:
+                continue
+            if _check_terminal_config_requirements(config):
+                return True
+        return False
+
+    try:
+        return _check_terminal_config_requirements(_get_env_config())
+    except Exception as exc:
+        logger.error("Invalid terminal configuration: %s", exc)
+        return False
+
+
 if __name__ == "__main__":
     # Simple test when run directly
     print("Terminal Tool Module")
@@ -3360,6 +4661,10 @@ TERMINAL_SCHEMA = {
                 "type": "string",
                 "description": "Working directory for this command (absolute path). Defaults to the session working directory."
             },
+            "target": {
+                "type": "string",
+                "description": "Named execution target from terminal.targets (for example 'local' or 'devbox'). Omit to use terminal.default_target; legacy flat config accepts only 'default'.",
+            },
             "pty": {
                 "type": "boolean",
                 "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
@@ -3392,6 +4697,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        target=args.get("target"),
     )
 
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -40,14 +40,15 @@ import os
 import platform
 import re
 import shlex
-import stat
 import time
 import threading
 import atexit
 import shutil
 import subprocess
+from contextlib import contextmanager
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Hashable, Mapping
 
 from utils import env_var_enabled
 
@@ -295,8 +296,37 @@ def set_approval_callback(cb):
     _callback_tls.approval = cb
 
 
-def _get_sudo_password_cache_scope() -> str:
-    """Return the cache scope for interactive sudo passwords."""
+_sudo_execution_context: ContextVar[
+    tuple[str, str, bool, Optional[str], str] | None
+] = ContextVar(
+    "hermes_sudo_execution_context", default=None,
+)
+
+
+@contextmanager
+def _scoped_sudo_execution(
+    target: str,
+    backend: str,
+    *,
+    named: bool = False,
+    sudo_password: Optional[str] = None,
+    target_scope: str = "",
+):
+    token = _sudo_execution_context.set(
+        (target, backend, named, sudo_password, target_scope),
+    )
+    try:
+        yield
+    finally:
+        _sudo_execution_context.reset(token)
+
+
+def _get_sudo_password_cache_scope(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> str:
+    """Return the session + target scope for interactive sudo passwords."""
     try:
         from gateway.session_context import get_session_env
 
@@ -304,29 +334,64 @@ def _get_sudo_password_cache_scope() -> str:
     except Exception:
         session_key = os.getenv("HERMES_SESSION_KEY", "")
     if session_key:
-        return f"session:{session_key}"
+        base_scope = f"session:{session_key}"
+    else:
+        callback = _get_sudo_password_callback()
+        if callback is not None:
+            owner = getattr(callback, "__self__", None)
+            func = getattr(callback, "__func__", None)
+            if owner is not None and func is not None:
+                base_scope = f"callback-owner:{id(owner)}:{id(func)}"
+            else:
+                base_scope = f"callback:{id(callback)}"
+        else:
+            base_scope = f"thread:{threading.get_ident()}"
 
-    callback = _get_sudo_password_callback()
-    if callback is not None:
-        owner = getattr(callback, "__self__", None)
-        func = getattr(callback, "__func__", None)
-        if owner is not None and func is not None:
-            return f"callback-owner:{id(owner)}:{id(func)}"
-        return f"callback:{id(callback)}"
+    active_context = _sudo_execution_context.get()
+    if execution_target is None and active_context is not None:
+        execution_target = active_context[0]
+    if execution_backend is None and active_context is not None:
+        execution_backend = active_context[1]
+    if execution_target is None and execution_backend is None:
+        return base_scope
+    target_scope = execution_target_scope or ""
+    if (
+        execution_target_scope is None
+        and active_context is not None
+        and execution_target == active_context[0]
+        and execution_backend == active_context[1]
+    ):
+        target_scope = active_context[4]
+    return (
+        f"{base_scope}|target:{execution_target!r}"
+        f"|backend:{str(execution_backend or '').lower()}"
+        f"|scope:{target_scope}"
+    )
 
-    return f"thread:{threading.get_ident()}"
 
-
-def _get_cached_sudo_password() -> str:
-    """Return the cached sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _get_cached_sudo_password(
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> str:
+    """Return the cached sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(
+        execution_target, execution_backend, execution_target_scope,
+    )
     with _sudo_password_cache_lock:
         return _sudo_password_cache.get(scope, "")
 
 
-def _set_cached_sudo_password(password: str) -> None:
-    """Persist a sudo password for the current scope."""
-    scope = _get_sudo_password_cache_scope()
+def _set_cached_sudo_password(
+    password: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
+) -> None:
+    """Persist a sudo password for the current target scope."""
+    scope = _get_sudo_password_cache_scope(
+        execution_target, execution_backend, execution_target_scope,
+    )
     with _sudo_password_cache_lock:
         if password:
             _sudo_password_cache[scope] = password
@@ -374,11 +439,19 @@ def _docker_has_host_access(config: Dict[str, Any]) -> bool:
 
 
 def _check_all_guards(command: str, env_type: str,
-                      has_host_access: bool = False) -> dict:
+                      has_host_access: bool = False,
+                      execution_target: str = "default",
+                      execution_backend: Optional[str] = None,
+                      execution_target_named: bool = False,
+                      execution_target_scope: str = "") -> dict:
     """Delegate to consolidated guard (tirith + dangerous cmd) with CLI callback."""
     return _check_all_guards_impl(command, env_type,
                                   approval_callback=_get_approval_callback(),
-                                  has_host_access=has_host_access)
+                                  has_host_access=has_host_access,
+                                  execution_target=execution_target,
+                                  execution_backend=execution_backend or env_type,
+                                  execution_target_named=execution_target_named,
+                                  execution_target_scope=execution_target_scope)
 
 
 # Allowlist: characters that can legitimately appear in directory paths.
@@ -465,7 +538,11 @@ def _sudo_wrong_password_failure(output: str) -> bool:
 
 
 def _invalidate_cached_sudo_on_auth_failure(
-    command: str | None, output: str
+    command: str | None,
+    output: str,
+    execution_target: str | None = None,
+    execution_backend: str | None = None,
+    execution_target_scope: str | None = None,
 ) -> bool:
     """Drop a session-cached sudo password after sudo rejects it.
 
@@ -478,9 +555,13 @@ def _invalidate_cached_sudo_on_auth_failure(
         return False
     if _count_real_sudo_invocations(command or "") == 0:
         return False
-    if not _get_cached_sudo_password():
+    if not _get_cached_sudo_password(
+        execution_target, execution_backend, execution_target_scope,
+    ):
         return False
-    _set_cached_sudo_password("")
+    _set_cached_sudo_password(
+        "", execution_target, execution_backend, execution_target_scope,
+    )
     return True
 
 
@@ -791,7 +872,11 @@ def _sudo_nopasswd_works() -> bool:
     cache) so an expired sudo timestamp cannot make a later command silently
     block waiting for a password.
     """
-    terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
+    active_context = _sudo_execution_context.get()
+    if active_context is not None:
+        terminal_env = active_context[1].strip().lower() or "local"
+    else:
+        terminal_env = os.getenv("TERMINAL_ENV", "local").strip().lower() or "local"
     if terminal_env != "local":
         return False
 
@@ -1016,24 +1101,22 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
     if sudo_count == 0:
         return command, None
 
-    # Scope-aware read (Slack pattern): under multiplex the process env may
-    # hold another profile's SUDO_PASSWORD, so honor the installed scope's
-    # verdict; unscoped callers keep the legacy os.environ read.
-    try:
-        from agent.secret_scope import UnscopedSecretError, get_secret
-
+    active_context = _sudo_execution_context.get()
+    if active_context is not None and active_context[2]:
+        configured_password = active_context[3]
+        has_configured_password = configured_password is not None
+        sudo_password = str(configured_password) if has_configured_password else _get_cached_sudo_password()
+    else:
         try:
-            _configured_password = get_secret("SUDO_PASSWORD")
-        except UnscopedSecretError:
-            _configured_password = os.environ.get("SUDO_PASSWORD")
-    except Exception:
-        _configured_password = os.environ.get("SUDO_PASSWORD")
-    has_configured_password = _configured_password is not None
-    sudo_password = (
-        _configured_password
-        if has_configured_password
-        else _get_cached_sudo_password()
-    )
+            from agent.secret_scope import UnscopedSecretError, get_secret
+            try:
+                configured_password = get_secret("SUDO_PASSWORD")
+            except UnscopedSecretError:
+                configured_password = os.environ.get("SUDO_PASSWORD")
+        except Exception:
+            configured_password = os.environ.get("SUDO_PASSWORD")
+        has_configured_password = configured_password is not None
+        sudo_password = configured_password if has_configured_password else _get_cached_sudo_password()
 
     # Local hosts with sudoers NOPASSWD should not be forced through the
     # interactive Hermes password prompt or the sudo -S password-pipe path.
@@ -1075,7 +1158,7 @@ import sys
 
 
 # Tool description for LLM
-TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on a Linux environment. Filesystem, current working directory, and exported environment variables persist between calls.
+TERMINAL_TOOL_DESCRIPTION = """Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem, current working directory, and exported environment variables persist between calls.
 
 Do NOT use cat/head/tail (use read_file), grep/rg/find/ls (use search_files), sed/awk (use patch), or echo/heredoc file creation (use write_file). Reserve terminal for: builds, installs, git, processes, scripts, network, package managers, and anything that needs a shell.
 NEVER pipe a build/test command through tail/head/cat to shorten output (e.g. `cargo build | tail -20`): output is auto-truncated with the full text saved to a file, and the pipe makes exit_code report the LAST pipeline command's status (tail's 0), masking real failures. Run the command bare; the same applies to `cmd || echo failed`, which also masks the exit code.
@@ -1088,10 +1171,12 @@ PTY: set pty=true for interactive CLIs (they hang without it). Pipe git output t
 """
 
 # Global state for environment lifecycle management
-_active_environments: Dict[str, Any] = {}
-_last_activity: Dict[str, float] = {}
+_active_environments: Dict[Hashable, Any] = {}
+_last_activity: Dict[Hashable, float] = {}
 _env_lock = threading.Lock()
-_creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox creation
+_retired_environments: list[tuple[Hashable, Any, float]] = []
+_retired_environments_lock = threading.Lock()
+_creation_locks: Dict[Hashable, threading.Lock] = {}  # Per-target locks for sandbox creation
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
@@ -1135,15 +1220,32 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
             return
         _docker_orphan_reaper_ran = True
 
-    # 2 × lifetime_seconds gives sibling Hermes processes a generous grace
-    # window. Floor at 60s so an operator with TERMINAL_LIFETIME_SECONDS=0
-    # doesn't get an instant-reap that races their own setup.
-    # ``container_config`` only carries container_* keys, so read
-    # lifetime_seconds from the env var the rest of the module uses.
+    # 2 × the longest configured Docker-target lifetime gives every named
+    # sibling a conservative grace window. A process-wide reaper runs only
+    # once, so using the first-created target's value could reap a longer-lived
+    # target prematurely.
     try:
-        lifetime = int(os.getenv("TERMINAL_LIFETIME_SECONDS", "300"))
+        lifetime = int(container_config.get(
+            "lifetime_seconds", os.getenv("TERMINAL_LIFETIME_SECONDS", "300"),
+        ))
     except (TypeError, ValueError):
         lifetime = 300
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        targets = list_execution_targets()
+        if targets and targets[0].named:
+            for target in targets:
+                if target.backend != "docker":
+                    continue
+                try:
+                    lifetime = max(
+                        lifetime, int(target.config.get("lifetime_seconds", 300)),
+                    )
+                except (TypeError, ValueError):
+                    continue
+    except Exception:
+        logger.debug("Could not resolve Docker target lifetimes", exc_info=True)
     lifetime = max(60, lifetime)
     max_age = lifetime * 2
 
@@ -1176,7 +1278,12 @@ def _maybe_reap_docker_orphans(container_config: Dict[str, Any]) -> None:
 #
 # This is never exposed to the model -- only infrastructure code calls it.
 # Thread-safe because each task_id is unique per rollout.
-_task_env_overrides: Dict[str, Dict[str, Any]] = {}
+_task_env_overrides: Dict[Hashable, Dict[str, Any]] = {}
+_task_env_overrides_lock = threading.Lock()
+_active_turn_counts: Dict[Hashable, int] = {}
+_active_turn_counts_lock = threading.RLock()
+_deferred_environment_cleanups: Dict[Hashable, Hashable] = {}
+
 
 # ── Per-session cwd records (cwd rearchitecture, step 1) ────────────────────
 #
@@ -1192,11 +1299,260 @@ _task_env_overrides: Dict[str, Dict[str, Any]] = {}
 # here. Readers still use the legacy env.cwd ladder. Later steps flip
 # file_tools and _resolve_command_cwd to read this store, then delete the
 # env-side tracking + ownership guards.
-_session_cwd: Dict[str, str] = {}
+_session_cwd: Dict[Hashable, str] = {}
+_session_cwd_specs: Dict[Hashable, str] = {}
 _session_cwd_lock = threading.Lock()
 
 
-def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
+def _target_resolution(target=None):
+    from tools.execution_targets import resolve_execution_target
+
+    return resolve_execution_target(target)
+
+
+def _environment_scope_key(task_key: Hashable, resolution) -> Hashable:
+    return resolution.environment_key(task_key)
+
+
+def _profile_scoped_task_key(task_key: Hashable) -> Hashable:
+    try:
+        return _target_resolution(None).scope_task_key(task_key)
+    except Exception:
+        return task_key
+
+
+def _turn_scope_key(task_id: Hashable) -> Hashable:
+    collapsed = _resolve_container_task_id(str(task_id))
+    return _profile_scoped_task_key(collapsed)
+
+
+def _run_deferred_environment_cleanup(task_id: Hashable) -> None:
+    try:
+        cleanup_vm(
+            task_id,
+            preserve_persistent=True,
+            include_collapsed=True,
+        )
+    except Exception:
+        logger.warning(
+            "Deferred environment cleanup failed for task %s",
+            task_id,
+            exc_info=True,
+        )
+
+
+def _turn_keys_overlap(left: Hashable, right: Hashable) -> bool:
+    if left == right:
+        return True
+    if isinstance(left, tuple) and left and left[0] == right:
+        return True
+    if isinstance(right, tuple) and right and right[0] == left:
+        return True
+    return False
+
+
+def _related_active_turns_unlocked(environment_key: Hashable) -> int:
+    return sum(
+        count for key, count in _active_turn_counts.items()
+        if _turn_keys_overlap(key, environment_key)
+    )
+
+
+def _register_environment_turn_key(key: Hashable) -> Hashable:
+    with _active_turn_counts_lock:
+        _active_turn_counts[key] = _active_turn_counts.get(key, 0) + 1
+    return key
+
+
+def register_environment_turn(task_id: Hashable) -> Hashable:
+    return _register_environment_turn_key(_turn_scope_key(task_id))
+
+
+def _release_environment_turn_key(key: Hashable) -> int:
+    deferred_task_ids = []
+    with _active_turn_counts_lock:
+        current = _active_turn_counts.get(key, 0)
+        if current <= 1:
+            _active_turn_counts.pop(key, None)
+        else:
+            _active_turn_counts[key] = current - 1
+        remaining = _related_active_turns_unlocked(key)
+        for deferred_key, deferred_task_id in list(
+            _deferred_environment_cleanups.items()
+        ):
+            if _related_active_turns_unlocked(deferred_key) == 0:
+                deferred_task_ids.append(deferred_task_id)
+                _deferred_environment_cleanups.pop(deferred_key, None)
+    for deferred_task_id in deferred_task_ids:
+        _run_deferred_environment_cleanup(deferred_task_id)
+    return remaining
+
+
+def release_environment_turn(task_id: Hashable) -> int:
+    return _release_environment_turn_key(_turn_scope_key(task_id))
+
+
+def defer_environment_turn_cleanup(task_id: Hashable) -> None:
+    # Run collapsed cleanup when the final overlapping lease releases.
+    key = _turn_scope_key(task_id)
+    run_now = False
+    with _active_turn_counts_lock:
+        if _related_active_turns_unlocked(key) > 0:
+            _deferred_environment_cleanups.setdefault(key, task_id)
+        else:
+            run_now = True
+    if run_now:
+        _run_deferred_environment_cleanup(task_id)
+
+
+def active_environment_turns(task_id: Hashable) -> int:
+    return _active_turns_for_environment_key(_turn_scope_key(task_id))
+
+
+def _active_turns_for_environment_key(environment_key: Hashable) -> int:
+    with _active_turn_counts_lock:
+        return _related_active_turns_unlocked(environment_key)
+
+
+class _EnvironmentTurnLease:
+    def __init__(
+        self,
+        task_id: Hashable,
+        *,
+        environment_key: Hashable | None = None,
+    ):
+        self._key = (
+            _register_environment_turn_key(environment_key)
+            if environment_key is not None
+            else register_environment_turn(task_id)
+        )
+        self._released = False
+        self._lock = threading.Lock()
+
+    @property
+    def key(self) -> Hashable:
+        return self._key
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return not self._released
+
+    def release(self) -> int:
+        with self._lock:
+            if self._released:
+                return _active_turns_for_environment_key(self._key)
+            self._released = True
+        return _release_environment_turn_key(self._key)
+
+
+_logical_environment_lease: ContextVar[Optional[_EnvironmentTurnLease]] = ContextVar(
+    "logical_environment_lease", default=None,
+)
+_tool_environment_lease: ContextVar[Optional[_EnvironmentTurnLease]] = ContextVar(
+    "tool_environment_lease", default=None,
+)
+
+
+@contextmanager
+def logical_environment_turn(task_id: Hashable):
+    # Hold the shared environment for one complete logical conversation turn.
+    lease = _EnvironmentTurnLease(task_id)
+    token = _logical_environment_lease.set(lease)
+    try:
+        yield lease
+    finally:
+        lease.release()
+        _logical_environment_lease.reset(token)
+
+
+def release_logical_environment_turn(task_id: Hashable) -> int:
+    # Release this context's logical lease before final cleanup.
+    lease = _logical_environment_lease.get()
+    key = _turn_scope_key(task_id)
+    if lease is not None and lease.key == key:
+        return lease.release()
+    return active_environment_turns(task_id)
+
+
+def release_logical_environment_turn_for_cleanup(task_id: Hashable) -> bool:
+    # Preserve the established boolean cleanup-hook contract.
+    lease = _logical_environment_lease.get()
+    if lease is None or lease.key != _turn_scope_key(task_id):
+        return False
+    lease.release()
+    return True
+
+
+def execution_environment_turn_key(
+    function_name: str,
+    arguments: Mapping[str, Any],
+    *,
+    task_id: Hashable | None = None,
+) -> Hashable | None:
+    if function_name not in {
+        "terminal", "read_file", "write_file", "patch", "search_files",
+        "execute_code", "process",
+    }:
+        return None
+    task_id = arguments.get("task_id") or task_id
+    if not task_id:
+        return None
+    if function_name == "process":
+        # Follow-up calls select a persisted session_id rather than a target.
+        # A parent-scope lease safely covers whichever named runtime owns it.
+        return _turn_scope_key(task_id)
+    try:
+        from tools.execution_targets import resolve_execution_target
+
+        resolution = resolve_execution_target(arguments.get("execution_target"))
+        base_task_id = _resolve_container_task_id(str(task_id))
+        return resolution.session_key(base_task_id)
+    except Exception:
+        # Invalid-target tools still execute to return their normal user-visible
+        # validation error; the raw logical lease remains the safe fallback.
+        return None
+
+
+@contextmanager
+def environment_turn_usage(
+    task_id: Hashable,
+    *,
+    environment_key: Hashable | None = None,
+):
+    # Protect one terminal, file, or code invocation from idle cleanup.
+    lease = _EnvironmentTurnLease(task_id, environment_key=environment_key)
+    token = _tool_environment_lease.set(lease)
+    try:
+        yield
+    finally:
+        lease.release()
+        _tool_environment_lease.reset(token)
+
+
+def _current_owned_environment_turns(environment_key: Hashable) -> int:
+    # Count this call's own logical/tool leases for replacement checks.
+    owned = 0
+    for lease in (
+        _logical_environment_lease.get(),
+        _tool_environment_lease.get(),
+    ):
+        if (
+            lease is not None
+            and lease.active
+            and _turn_keys_overlap(lease.key, environment_key)
+        ):
+            owned += 1
+    return owned
+
+
+def record_session_cwd(
+    session_key: Optional[str],
+    cwd: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> None:
     """Record *cwd* as the working directory of *session_key*.
 
     Called wherever a session's live cwd becomes known: after a terminal
@@ -1207,28 +1563,87 @@ def record_session_cwd(session_key: Optional[str], cwd: Optional[str]) -> None:
     """
     if not isinstance(cwd, str) or not cwd.strip():
         return
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
         if _session_cwd.get(key) != cwd:
             _session_cwd[key] = cwd
+        if resolution.named:
+            _session_cwd_specs[key] = resolution.spec_fingerprint
+        else:
+            _session_cwd_specs.pop(key, None)
 
 
-def get_session_cwd(session_key: Optional[str]) -> Optional[str]:
+def get_session_cwd(
+    session_key: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> Optional[str]:
     """Return the recorded working directory for *session_key*, if any.
 
     No fallback chain here on purpose: callers decide what an absent record
     means (config default, TERMINAL_CWD seed, process cwd). ``None``/empty
     keys read the ``"default"`` record.
     """
-    key = str(session_key or "default")
+    resolution = _resolution or _target_resolution(target)
+    key = resolution.session_key(session_key)
     with _session_cwd_lock:
+        recorded_spec = _session_cwd_specs.get(key)
+        if (
+            resolution.named
+            and recorded_spec is not None
+            and recorded_spec != resolution.spec_fingerprint
+        ):
+            return None
         return _session_cwd.get(key)
 
 
-def clear_session_cwd(session_key: str) -> None:
-    """Drop a session's cwd record (session teardown)."""
+def inherit_session_cwds(parent_task_id: str, child_task_id: str) -> int:
+    """Seed a child with every cwd scope currently owned by its parent."""
+    if not parent_task_id or not child_task_id:
+        return 0
+    parent_key = _profile_scoped_task_key(parent_task_id)
+    child_key = _profile_scoped_task_key(child_task_id)
+    inherited: Dict[Hashable, str] = {}
+    inherited_specs: Dict[Hashable, str] = {}
     with _session_cwd_lock:
-        _session_cwd.pop(session_key, None)
+        for key, cwd in _session_cwd.items():
+            if key == parent_key:
+                inherited[child_key] = cwd
+                if key in _session_cwd_specs:
+                    inherited_specs[child_key] = _session_cwd_specs[key]
+            elif (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] == parent_key
+            ):
+                child_target_key = (child_key, key[1])
+                inherited[child_target_key] = cwd
+                if key in _session_cwd_specs:
+                    inherited_specs[child_target_key] = _session_cwd_specs[key]
+        _session_cwd.update(inherited)
+        _session_cwd_specs.update(inherited_specs)
+    return len(inherited)
+
+
+def clear_session_cwd(session_key: str) -> None:
+    """Drop all legacy and named-target cwd records for a raw session."""
+    raw = str(session_key or "default")
+    scoped = _profile_scoped_task_key(raw)
+    with _session_cwd_lock:
+        _session_cwd.pop(raw, None)
+        _session_cwd.pop(scoped, None)
+        _session_cwd_specs.pop(raw, None)
+        _session_cwd_specs.pop(scoped, None)
+        for key in list(_session_cwd):
+            if (
+                isinstance(key, tuple)
+                and len(key) == 2
+                and key[0] in {raw, scoped}
+            ):
+                _session_cwd.pop(key, None)
+                _session_cwd_specs.pop(key, None)
 
 
 def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
@@ -1247,7 +1662,7 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         task_id: The rollout's unique task identifier
         overrides: Dict of config keys to override
     """
-    _task_env_overrides[task_id] = overrides
+    _task_env_overrides[_profile_scoped_task_key(task_id)] = overrides
 
     # If a live environment already exists for this task, a freshly registered
     # ``cwd`` override (e.g. the ACP client switching the editor's project root
@@ -1257,8 +1672,23 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
     new_cwd = overrides.get("cwd")
     if isinstance(new_cwd, str) and new_cwd.strip():
         # A registered workspace cwd IS the session's working directory until
-        # a `cd` changes it.
-        record_session_cwd(task_id, new_cwd)
+        # a `cd` changes it. With named targets this host/workspace override
+        # belongs to the configured default target only; applying it to every
+        # explicit remote/container target would replace that target's own cwd.
+        try:
+            default_resolution = _target_resolution(None)
+        except Exception:
+            default_resolution = None
+        if (
+            default_resolution is not None
+            and not (
+                default_resolution.named
+                and default_resolution.backend == "ssh"
+            )
+        ):
+            record_session_cwd(
+                task_id, new_cwd, _resolution=default_resolution,
+            )
         # The live env is cached under the raw task_id for per-session surfaces
         # (ACP/gateway/dashboard) and under the collapsed container id for
         # isolation-keyed rollouts. Try the raw id first, then the container id,
@@ -1266,9 +1696,24 @@ def register_task_env_overrides(task_id: str, overrides: Dict[str, Any]):
         # updates the originating session's env.
         container_id = _resolve_container_task_id(task_id)
         with _env_lock:
-            env = _active_environments.get(task_id) or _active_environments.get(container_id)
-        if env is not None and getattr(env, "cwd", None) is not None:
-            env.cwd = new_cwd
+            if (
+                default_resolution is not None
+                and default_resolution.named
+                and default_resolution.backend != "ssh"
+            ):
+                candidate_keys = {
+                    default_resolution.environment_key(task_id),
+                    default_resolution.environment_key(container_id),
+                }
+            else:
+                candidate_keys = {task_id, container_id}
+            envs = [
+                env for key, env in _active_environments.items()
+                if key in candidate_keys
+            ]
+        for env in envs:
+            if getattr(env, "cwd", None) is not None:
+                env.cwd = new_cwd
 
 
 def clear_task_env_overrides(task_id: str):
@@ -1277,7 +1722,7 @@ def clear_task_env_overrides(task_id: str):
 
     Called during cleanup to avoid stale entries accumulating.
     """
-    _task_env_overrides.pop(task_id, None)
+    _task_env_overrides.pop(_profile_scoped_task_key(task_id), None)
     clear_session_cwd(task_id)
     with _container_alias_lock:
         _container_aliases.pop(task_id, None)
@@ -1346,9 +1791,10 @@ def _has_isolation_overrides(task_id: Optional[str]) -> bool:
     predicate — shared by container-key resolution and container creation so
     the two can't drift.
     """
-    if not task_id or task_id not in _task_env_overrides:
+    if not task_id:
         return False
-    return bool(set(_task_env_overrides[task_id].keys()) & _ISOLATION_OVERRIDE_KEYS)
+    overrides = _task_env_overrides.get(_profile_scoped_task_key(task_id), {})
+    return bool(set(overrides.keys()) & _ISOLATION_OVERRIDE_KEYS)
 
 
 def _resolve_container_task_id(task_id: Optional[str]) -> str:
@@ -1402,9 +1848,11 @@ def resolve_task_overrides(task_id: Optional[str]) -> Dict[str, Any]:
     source of that lookup so the terminal and file layers can't drift apart.
     """
     raw = task_id or "default"
+    scoped_raw = _profile_scoped_task_key(raw)
+    scoped_collapsed = _profile_scoped_task_key(_resolve_container_task_id(raw))
     return (
-        _task_env_overrides.get(raw)
-        or _task_env_overrides.get(_resolve_container_task_id(raw))
+        _task_env_overrides.get(scoped_raw)
+        or _task_env_overrides.get(scoped_collapsed)
         or {}
     )
 
@@ -1515,6 +1963,39 @@ def _is_unusable_container_cwd(cwd: str) -> bool:
     return False
 
 
+def _apply_task_cwd_override(
+    config: Dict[str, Any], cwd: str, cwd_override: Optional[str],
+) -> str:
+    """Apply a task workspace cwd without leaking host paths into containers.
+
+    Docker's explicit mount-cwd mode is the exception: a registered host
+    workspace should become the bind source and commands should run in
+    ``/workspace``. Other container backends fall back to the target's already
+    sanitized configured cwd.
+    """
+    env_type = config.get("env_type")
+    if (
+        env_type == "docker"
+        and config.get("docker_mount_cwd_to_workspace")
+        and isinstance(cwd_override, str)
+        and cwd_override.strip()
+    ):
+        candidate = os.path.abspath(os.path.expanduser(cwd_override))
+        is_host_path = (
+            any(candidate.startswith(prefix) for prefix in _HOST_CWD_PREFIXES)
+            or (
+                os.path.isabs(candidate)
+                and os.path.isdir(candidate)
+            )
+        )
+        if is_host_path:
+            config["host_cwd"] = candidate
+            return "/workspace"
+    if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
+        return config["cwd"]
+    return cwd
+
+
 # One-shot guard for the config-fallback bridge below.  Purely an
 # optimization: after the first attempt either TERMINAL_ENV is set (bridge
 # succeeded — merged config always carries terminal.backend) or the import
@@ -1569,14 +2050,82 @@ def _ensure_terminal_env_bridged() -> None:
         logger.debug("terminal config → env fallback bridge failed", exc_info=True)
 
 
-def _get_env_config() -> Dict[str, Any]:
-    """Get terminal environment configuration from environment variables."""
-    # Default image with Python and Node.js for maximum compatibility
+def _get_env_config(terminal_config: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return canonical terminal config for legacy env vars or a target mapping.
+
+    ``terminal_config is None`` is the historical flat/env-driven path.  A
+    selected named target passes its inherited mapping here directly; values
+    are parsed without mutating ``os.environ`` so concurrent target calls
+    cannot affect each other.
+    """
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
-    _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    if terminal_config is None:
+        _ensure_terminal_env_bridged()
+
+    def _get(key: str, env_name: str, default: Any) -> Any:
+        if terminal_config is None:
+            return os.getenv(env_name, str(default) if not isinstance(default, (list, dict)) else json.dumps(default))
+        return terminal_config.get(key, default)
+
+    def _coerce(value: Any, converter: Any, label: str, key: str) -> Any:
+        if converter is json.loads and isinstance(value, (list, dict)):
+            return value
+        try:
+            return converter(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            source = (
+                f"terminal target setting {key}"
+                if terminal_config is not None
+                else f"TERMINAL_{key.upper()}"
+            )
+            raise ValueError(f"Invalid value for {source}: {value!r} (expected {label}).")
+
+    def _bool(key: str, env_name: str, default: bool) -> bool:
+        value = _get(key, env_name, default)
+        if isinstance(value, bool):
+            return value
+        normalized = str(value).strip().lower()
+        if normalized in {"true", "1", "yes"}:
+            return True
+        if normalized in {"false", "0", "no"}:
+            return False
+        if terminal_config is not None:
+            raise ValueError(
+                f"Invalid value for terminal target setting {key}: {value!r} "
+                "(expected boolean)."
+            )
+        # Preserve the legacy env-var behavior for unknown strings.
+        return False
+
+    def _json_shape(
+        key: str,
+        env_name: str,
+        default: Any,
+        expected_type: type,
+        label: str,
+    ) -> Any:
+        value = _coerce(_get(key, env_name, default), json.loads, "valid JSON", key)
+        if not isinstance(value, expected_type):
+            source = (
+                f"terminal target setting {key}"
+                if terminal_config is not None
+                else env_name
+            )
+            raise ValueError(
+                f"Invalid value for {source}: {value!r} (expected {label})."
+            )
+        return value
+
+    env_type = str(
+        _get(
+            "backend", "TERMINAL_ENV",
+            terminal_config.get("env_type", "local") if terminal_config else "local",
+        )
+    ).strip().lower() or "local"
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = _bool(
+        "docker_mount_cwd_to_workspace", "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", False,
+    )
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1585,20 +2134,28 @@ def _get_env_config() -> Dict[str, Any]:
     # until a backend that can consume them is selected; a stale or invalid
     # Docker value should not make local terminal/execute_code unusable.
     if container_backend:
-        container_cpu = _parse_env_var("TERMINAL_CONTAINER_CPU", "1", float, "number")
-        container_memory = _parse_env_var("TERMINAL_CONTAINER_MEMORY", "5120")
-        container_disk = _parse_env_var("TERMINAL_CONTAINER_DISK", "51200")
+        container_cpu = _coerce(_get("container_cpu", "TERMINAL_CONTAINER_CPU", 1), float, "number", "container_cpu")
+        container_memory = _coerce(_get("container_memory", "TERMINAL_CONTAINER_MEMORY", 5120), int, "integer", "container_memory")
+        container_disk = _coerce(_get("container_disk", "TERMINAL_CONTAINER_DISK", 51200), int, "integer", "container_disk")
     else:
         container_cpu = 1.0
         container_memory = 5120
         container_disk = 51200
 
     if docker_backend:
-        docker_forward_env = _parse_env_var("TERMINAL_DOCKER_FORWARD_ENV", "[]", json.loads, "valid JSON")
-        docker_volumes = _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON")
-        docker_env = _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON")
-        docker_extra_args = _parse_env_var("TERMINAL_DOCKER_EXTRA_ARGS", "[]", json.loads, "valid JSON")
-        docker_shm_size = os.getenv("TERMINAL_DOCKER_SHM_SIZE", "1g")
+        docker_forward_env = _json_shape(
+            "docker_forward_env", "TERMINAL_DOCKER_FORWARD_ENV", [], list, "list",
+        )
+        docker_volumes = _json_shape(
+            "docker_volumes", "TERMINAL_DOCKER_VOLUMES", [], list, "list",
+        )
+        docker_env = _json_shape(
+            "docker_env", "TERMINAL_DOCKER_ENV", {}, dict, "mapping",
+        )
+        docker_extra_args = _json_shape(
+            "docker_extra_args", "TERMINAL_DOCKER_EXTRA_ARGS", [], list, "list",
+        )
+        docker_shm_size = str(_get("docker_shm_size", "TERMINAL_DOCKER_SHM_SIZE", "1g") or "")
     else:
         docker_forward_env = []
         docker_volumes = []
@@ -1622,13 +2179,19 @@ def _get_env_config() -> Dict[str, Any]:
     # If Docker cwd passthrough is explicitly enabled, remap the host path to
     # /workspace and track the original host path separately. Otherwise keep the
     # normal sandbox behavior and discard host paths.
-    cwd = os.getenv("TERMINAL_CWD", default_cwd)
     from hermes_cli.config import _is_ssh_remote_tilde_cwd
+    cwd = str(_get("cwd", "TERMINAL_CWD", default_cwd) or default_cwd)
+    if env_type == "local" and cwd in {".", "./", "auto", "cwd"}:
+        cwd = _safe_getcwd()
     if cwd and not _is_ssh_remote_tilde_cwd(env_type, cwd):
         cwd = os.path.expanduser(cwd)
     host_cwd = None
     if env_type == "docker" and mount_docker_cwd:
-        docker_cwd_source = os.getenv("TERMINAL_CWD") or _safe_getcwd()
+        docker_cwd_source = (
+            (os.getenv("TERMINAL_CWD") or _safe_getcwd())
+            if terminal_config is None
+            else (cwd or _safe_getcwd())
+        )
         candidate = os.path.abspath(os.path.expanduser(docker_cwd_source))
         if (
             any(candidate.startswith(p) for p in _HOST_CWD_PREFIXES)
@@ -1646,41 +2209,41 @@ def _get_env_config() -> Dict[str, Any]:
 
     return {
         "env_type": env_type,
-        "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "modal_mode": coerce_modal_mode(_get("modal_mode", "TERMINAL_MODAL_MODE", "auto")),
+        "docker_image": str(_get("docker_image", "TERMINAL_DOCKER_IMAGE", default_image)),
         "docker_forward_env": docker_forward_env,
-        "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
-        "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
-        "daytona_image": os.getenv("TERMINAL_DAYTONA_IMAGE", default_image),
-        "vercel_runtime": os.getenv("TERMINAL_VERCEL_RUNTIME", "").strip(),
+        "singularity_image": str(_get("singularity_image", "TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}")),
+        "modal_image": str(_get("modal_image", "TERMINAL_MODAL_IMAGE", default_image)),
+        "daytona_image": str(_get("daytona_image", "TERMINAL_DAYTONA_IMAGE", default_image)),
+        "vercel_runtime": str(_get("vercel_runtime", "TERMINAL_VERCEL_RUNTIME", "")).strip(),
         "cwd": cwd,
         "host_cwd": host_cwd,
         "docker_mount_cwd_to_workspace": mount_docker_cwd,
-        "timeout": _parse_env_var("TERMINAL_TIMEOUT", "180"),
-        "lifetime_seconds": _parse_env_var("TERMINAL_LIFETIME_SECONDS", "300"),
+        "timeout": _coerce(_get("timeout", "TERMINAL_TIMEOUT", 180), int, "integer", "timeout"),
+        "lifetime_seconds": _coerce(_get("lifetime_seconds", "TERMINAL_LIFETIME_SECONDS", 300), int, "integer", "lifetime_seconds"),
         # SSH-specific config
-        "ssh_host": os.getenv("TERMINAL_SSH_HOST", ""),
-        "ssh_user": os.getenv("TERMINAL_SSH_USER", ""),
-        "ssh_port": _parse_env_var("TERMINAL_SSH_PORT", "22"),
-        "ssh_key": os.getenv("TERMINAL_SSH_KEY", ""),
+        "ssh_host": str(_get("ssh_host", "TERMINAL_SSH_HOST", "")),
+        "ssh_user": str(_get("ssh_user", "TERMINAL_SSH_USER", "")),
+        "ssh_port": _coerce(_get("ssh_port", "TERMINAL_SSH_PORT", 22), int, "integer", "ssh_port"),
+        "ssh_key": str(_get("ssh_key", "TERMINAL_SSH_KEY", "")),
         # Persistent shell: SSH defaults to the config-level persistent_shell
         # setting (true by default for non-local backends); local is always opt-in.
         # Per-backend env vars override if explicitly set.
-        "ssh_persistent": os.getenv(
-            "TERMINAL_SSH_PERSISTENT",
-            os.getenv("TERMINAL_PERSISTENT_SHELL", "true"),
-        ).lower() in {"true", "1", "yes"},
-        "local_persistent": os.getenv("TERMINAL_LOCAL_PERSISTENT", "false").lower() in {"true", "1", "yes"},
+        "ssh_persistent": _bool(
+            "ssh_persistent", "TERMINAL_SSH_PERSISTENT",
+            _bool("persistent_shell", "TERMINAL_PERSISTENT_SHELL", True),
+        ),
+        "local_persistent": _bool("local_persistent", "TERMINAL_LOCAL_PERSISTENT", False),
         # Container resource config (applies to docker, singularity, modal,
         # daytona, and vercel_sandbox -- ignored for local/ssh)
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": _bool("container_persistent", "TERMINAL_CONTAINER_PERSISTENT", True),
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": _bool("docker_run_as_host_user", "TERMINAL_DOCKER_RUN_AS_HOST_USER", False),
+        "docker_network": _bool("docker_network", "TERMINAL_DOCKER_NETWORK", True),
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1689,17 +2252,381 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
-            "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_persist_across_processes": _bool(
+            "docker_persist_across_processes", "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", True,
+        ),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
-            "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_orphan_reaper": _bool(
+            "docker_orphan_reaper", "TERMINAL_DOCKER_ORPHAN_REAPER", True,
+        ),
     }
+
+
+
+def _build_environment_constructor_configs(
+    config: Dict[str, Any],
+    resolution: 'ExecutionTargetResolution',
+    base_task_id: str,
+) -> tuple[Optional[Dict[str, Any]], Optional[Dict[str, Any]], Optional[Dict[str, Any]]]:
+    """Build backend constructor inputs from one canonical normalized config."""
+    env_type = config["env_type"]
+    container_config: Optional[Dict[str, Any]] = None
+    if env_type in _CONTAINER_BACKENDS:
+        container_config = {
+            "container_cpu": config.get("container_cpu", 1),
+            "container_memory": config.get("container_memory", 5120),
+            "container_disk": config.get("container_disk", 51200),
+            "container_persistent": config.get("container_persistent", True),
+            "vercel_runtime": config.get("vercel_runtime", ""),
+            "modal_mode": config.get("modal_mode", "auto"),
+            "docker_volumes": config.get("docker_volumes", []),
+            "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
+            "docker_forward_env": config.get("docker_forward_env", []),
+            "docker_env": config.get("docker_env", {}),
+            "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
+            "docker_extra_args": config.get("docker_extra_args", []),
+            "docker_network": config.get("docker_network", True),
+            "docker_shm_size": config.get("docker_shm_size", "1g"),
+            "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
+            "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
+            "lifetime_seconds": config.get("lifetime_seconds", 300),
+            "storage_task_id": resolution.storage_task_id(base_task_id),
+            "legacy_storage_task_id": resolution.legacy_backend_task_id(base_task_id),
+        }
+
+    ssh_config: Optional[Dict[str, Any]] = None
+    if env_type == "ssh":
+        ssh_config = {
+            "host": config.get("ssh_host", ""),
+            "user": config.get("ssh_user", ""),
+            "port": config.get("ssh_port", 22),
+            "key": config.get("ssh_key", ""),
+            "persistent": config.get("ssh_persistent", False),
+            "runtime_scope": resolution.security_scope if resolution.named else "",
+        }
+
+    local_config: Optional[Dict[str, Any]] = None
+    if env_type == "local":
+        local_config = {"persistent": config.get("local_persistent", False)}
+    return container_config, ssh_config, local_config
+
+
+def _record_environment_lifetime(env: Any, config: Dict[str, Any]) -> None:
+    """Attach the resolved target's idle lifetime to its environment."""
+    try:
+        env._hermes_lifetime_seconds = int(config["lifetime_seconds"])
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+
+
+def _record_environment_target(env: Any, resolution: Any) -> None:
+    """Bind a created environment to the exact resolved named-target spec."""
+    try:
+        setattr(env, "_hermes_target_name", resolution.target)
+        setattr(
+            env, "_hermes_target_fingerprint",
+            resolution.spec_fingerprint if resolution.named else None,
+        )
+        setattr(env, "_hermes_target_backend", resolution.backend)
+        setattr(
+            env, "_hermes_target_scope",
+            resolution.security_scope if resolution.named else None,
+        )
+        setattr(env, "_hermes_target_resolution", resolution)
+        persistent = resolution.config.get("container_persistent", True)
+        if isinstance(persistent, str):
+            persistent = persistent.strip().lower() in {"1", "true", "yes", "on"}
+        setattr(
+            env,
+            "_hermes_stable_storage",
+            resolution.backend == "docker" and bool(persistent),
+        )
+    except (AttributeError, TypeError):
+        pass
+
+
+def _environment_matches_target(env: Any, resolution: Any) -> bool:
+    """Reject cache reuse after a named target's effective config changes."""
+    if env is None or not resolution.named:
+        return env is not None
+    fingerprint = getattr(env, "_hermes_target_fingerprint", None)
+    # Third-party/test-provided environments predating named targets have no
+    # binding metadata. Preserve their registration contract; every environment
+    # created by core Hermes is stamped before entering the cache.
+    if fingerprint is None:
+        return True
+    return (
+        fingerprint == resolution.spec_fingerprint
+        and getattr(env, "_hermes_target_name", resolution.target) == resolution.target
+        and getattr(env, "_hermes_target_backend", resolution.backend) == resolution.backend
+    )
+
+
+def _environment_has_stable_storage(env: Any) -> bool:
+    return bool(getattr(env, "_hermes_stable_storage", False))
+
+
+def _environment_replacement_is_busy(env: Any, environment_key: Hashable) -> bool:
+    """Protect shared persistent storage while the old runtime is still active."""
+    if not _environment_has_stable_storage(env):
+        return False
+    active = _active_turns_for_environment_key(environment_key)
+    owned = _current_owned_environment_turns(environment_key)
+    if active > owned:
+        return True
+    try:
+        from tools.process_registry import process_registry
+
+        return process_registry.has_active_environment(env)
+    except Exception:
+        return False
+
+
+def _cleanup_environment_resource(
+    env: Any,
+    *,
+    force_remove: bool = False,
+    preserve_storage: bool = False,
+) -> None:
+    """Stop one environment, optionally preserving its persistent storage."""
+    import inspect
+
+    ownership_attrs = {}
+    if force_remove:
+        # A replaced environment is unreachable by configuration and must not
+        # retain persist-mode lifecycle semantics. Persistent storage can remain
+        # owned by the stable profile/target storage identity while the obsolete
+        # runtime is removed.
+        attrs = ["_persist_across_processes"]
+        if not preserve_storage:
+            attrs.extend(["_persistent", "persistent_filesystem"])
+        for attr in attrs:
+            if hasattr(env, attr):
+                try:
+                    ownership_attrs[attr] = getattr(env, attr)
+                    setattr(env, attr, False)
+                except (AttributeError, TypeError):
+                    pass
+
+    try:
+        if hasattr(env, "cleanup"):
+            cleanup = env.cleanup
+            kwargs = {}
+            if force_remove:
+                try:
+                    if "force_remove" in inspect.signature(cleanup).parameters:
+                        kwargs["force_remove"] = True
+                except (TypeError, ValueError):
+                    pass
+            result = cleanup(**kwargs)
+        elif hasattr(env, "stop"):
+            result = env.stop()
+        elif hasattr(env, "terminate"):
+            result = env.terminate()
+        else:
+            return
+
+        if inspect.isawaitable(result):
+            import asyncio
+
+            try:
+                loop = asyncio.new_event_loop()
+                loop.run_until_complete(result)
+                loop.close()
+            except Exception:
+                try:
+                    close = getattr(result, "close", None)
+                    if close is not None:
+                        close()
+                except Exception:
+                    pass
+                raise
+
+        wait_fn = getattr(env, "wait_for_cleanup", None)
+        if wait_fn is not None and not wait_fn(timeout=60.0):
+            raise RuntimeError("environment cleanup did not finish within 60 seconds")
+    except BaseException:
+        # Cleanup can fail before the obsolete runtime is actually removed. In
+        # that case the caller restores the handle to the active cache, so also
+        # restore its persistence ownership flags rather than leaving a live
+        # runtime reachable but disowned by this process.
+        for attr, value in ownership_attrs.items():
+            try:
+                setattr(env, attr, value)
+            except (AttributeError, TypeError):
+                pass
+        raise
+
+
+class _EnvironmentReplacementError(RuntimeError):
+    """Base error for a fail-closed named-target runtime replacement."""
+
+
+class _EnvironmentReplacementBusyError(_EnvironmentReplacementError):
+    """The previous stable-storage runtime still has active users."""
+
+
+class _EnvironmentReplacementCleanupError(_EnvironmentReplacementError):
+    """The previous stable-storage runtime could not be retired safely."""
+
+
+def _prepare_environment_replacement(
+    env: Any,
+    environment_key: Hashable,
+    *,
+    target_name: str,
+) -> bool:
+    """Retire an idle stable-storage runtime before creating its replacement.
+
+    Persistent Docker generations share one storage identity, so the obsolete
+    runtime must be gone before the replacement container is created. The
+    caller holds the per-environment creation lock; this helper owns the shared
+    detach/cleanup/restore handoff used by terminal, file, and execute_code.
+    """
+    if env is None:
+        return False
+    if _environment_replacement_is_busy(env, environment_key):
+        raise _EnvironmentReplacementBusyError(
+            f"Execution target {target_name!r} changed while its persistent "
+            "Docker runtime is still active. Wait for its commands/background "
+            "processes to finish, then retry."
+        )
+    if not _environment_has_stable_storage(env):
+        return False
+
+    with _env_lock:
+        if _active_environments.get(environment_key) is not env:
+            raise _EnvironmentReplacementBusyError(
+                f"Execution target {target_name!r} changed again while its "
+                "previous runtime was being retired. Retry the operation."
+            )
+        owned_keys = [
+            (key, key in _last_activity, _last_activity.get(key, 0.0))
+            for key, candidate in list(_active_environments.items())
+            if candidate is env
+        ]
+        for key, _, _ in owned_keys:
+            _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+
+    try:
+        _cleanup_environment_resource(
+            env,
+            force_remove=True,
+            preserve_storage=True,
+        )
+    except BaseException as exc:
+        with _env_lock:
+            for key, had_activity, activity in owned_keys:
+                if key not in _active_environments:
+                    _active_environments[key] = env
+                    if had_activity:
+                        _last_activity[key] = activity
+        if isinstance(exc, Exception):
+            raise _EnvironmentReplacementCleanupError(
+                "Could not retire the previous persistent Docker runtime for "
+                f"execution target {target_name!r}: {exc}"
+            ) from exc
+        raise
+    return True
+
+
+def _retire_replaced_environment(env: Any, task_key: Hashable) -> None:
+    """Defer teardown until no operation/process can still reference *env*."""
+    if env is None:
+        return
+    with _retired_environments_lock:
+        if all(existing_env is not env for _, existing_env, _ in _retired_environments):
+            _retired_environments.append((task_key, env, time.time()))
+
+
+def _collect_retired_environments(
+    *,
+    task_key: Hashable | None = None,
+    min_age_seconds: float = 60.0,
+    require_idle: bool = True,
+) -> list[tuple[Hashable, Any]]:
+    """Detach retired resources that are old enough and no longer in use."""
+    now = time.time()
+    ready: list[tuple[Hashable, Any]] = []
+    keep: list[tuple[Hashable, Any, float]] = []
+    try:
+        from tools.process_registry import process_registry
+    except ImportError:
+        process_registry = None
+
+    with _retired_environments_lock:
+        candidates = list(_retired_environments)
+        _retired_environments.clear()
+
+    for retired_key, env, retired_at in candidates:
+        if task_key is not None and retired_key != task_key:
+            keep.append((retired_key, env, retired_at))
+            continue
+        busy = False
+        if require_idle:
+            busy = _active_turns_for_environment_key(retired_key) > 0
+            if not busy and process_registry is not None:
+                busy = process_registry.has_active_environment(env)
+        if busy or now - retired_at < min_age_seconds:
+            keep.append((retired_key, env, retired_at))
+        else:
+            ready.append((retired_key, env))
+
+    # Merge records retired concurrently while we performed potentially slow
+    # process liveness checks. Avoid duplicate records by environment identity.
+    ready_ids = {id(env) for _, env in ready}
+    with _retired_environments_lock:
+        concurrent = [
+            record for record in _retired_environments
+            if id(record[1]) not in ready_ids
+        ]
+        seen = {id(record[1]) for record in concurrent}
+        concurrent.extend(
+            record for record in keep
+            if id(record[1]) not in seen
+        )
+        _retired_environments[:] = concurrent
+    return ready
+
+
+def _cleanup_retired_environments(
+    *,
+    task_key: Hashable | None = None,
+    min_age_seconds: float = 60.0,
+    require_idle: bool = True,
+) -> int:
+    """Force-remove retired environments selected by lifecycle policy."""
+    ready = _collect_retired_environments(
+        task_key=task_key,
+        min_age_seconds=min_age_seconds,
+        require_idle=require_idle,
+    )
+    cleaned = 0
+    for retired_key, env in ready:
+        try:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+            cleaned += 1
+            logger.info("Cleaned retired environment for task: %s", retired_key)
+        except Exception as exc:
+            error_str = str(exc)
+            if "404" in error_str or "not found" in error_str.lower():
+                cleaned += 1
+                logger.info("Retired environment for task %s was already gone", retired_key)
+            else:
+                logger.warning(
+                    "Error cleaning retired environment for task %s: %s",
+                    retired_key, exc,
+                )
+                _retire_replaced_environment(env, retired_key)
+    return cleaned
 
 
 def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
@@ -1711,53 +2638,17 @@ def _get_modal_backend_state(modal_mode: object | None) -> Dict[str, Any]:
     )
 
 
-def _ssh_config_from_config(config: Dict[str, Any]) -> dict:
-    """Build the ``ssh_config`` dict passed to :func:`_create_environment`.
-
-    Shared by the terminal tool's own get-or-create path and the lazy
-    :func:`ensure_task_env` bring-up so both derive SSH connection settings
-    from the resolved config identically.
-    """
-    return {
-        "host": config.get("ssh_host", ""),
-        "user": config.get("ssh_user", ""),
-        "port": config.get("ssh_port", 22),
-        "key": config.get("ssh_key", ""),
-        "persistent": config.get("ssh_persistent", False),
-    }
-
-
-def _container_config_from_config(config: Dict[str, Any]) -> dict:
-    """Build the ``container_config`` dict passed to :func:`_create_environment`.
-
-    Shared by the terminal tool's own get-or-create path and the lazy
-    :func:`ensure_task_env` bring-up (see :func:`_ssh_config_from_config`).
-    """
-    return {
-        "container_cpu": config.get("container_cpu", 1),
-        "container_memory": config.get("container_memory", 5120),
-        "container_disk": config.get("container_disk", 51200),
-        "container_persistent": config.get("container_persistent", True),
-        "modal_mode": config.get("modal_mode", "auto"),
-        "vercel_runtime": config.get("vercel_runtime", ""),
-        "docker_volumes": config.get("docker_volumes", []),
-        "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-        "docker_forward_env": config.get("docker_forward_env", []),
-        "docker_env": config.get("docker_env", {}),
-        "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-        "docker_extra_args": config.get("docker_extra_args", []),
-        "docker_shm_size": config.get("docker_shm_size", "1g"),
-        "docker_network": config.get("docker_network", True),
-        "docker_persist_across_processes": config.get("docker_persist_across_processes", True),
-        "docker_orphan_reaper": config.get("docker_orphan_reaper", True),
-    }
-
-
-def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
-                        ssh_config: dict = None, container_config: dict = None,
-                        local_config: dict = None,
-                        task_id: str = "default",
-                        host_cwd: Optional[str] = None):
+def _create_environment(
+    env_type: str,
+    image: str,
+    cwd: str,
+    timeout: int,
+    ssh_config: Optional[dict] = None,
+    container_config: Optional[dict] = None,
+    local_config: Optional[dict] = None,
+    task_id: str = "default",
+    host_cwd: Optional[str] = None,
+):
     """
     Create an execution environment for sandboxed command execution.
     
@@ -1787,7 +2678,12 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
     docker_network = cc.get("docker_network", True)
 
     if env_type == "local":
-        return _LocalEnvironment(cwd=cwd, timeout=timeout)
+        env = _LocalEnvironment(cwd=cwd, timeout=timeout)
+        setattr(
+            env, "_persistent",
+            bool((local_config or {}).get("persistent", False)),
+        )
+        return env
     
     elif env_type == "docker":
         # One-shot orphan reaper: clean up labeled containers left behind by
@@ -1812,6 +2708,8 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             image=image, cwd=cwd, timeout=timeout,
             cpu=cpu, memory=memory, disk=disk,
             persistent_filesystem=persistent, task_id=task_id,
+            storage_task_id=cc.get("storage_task_id"),
+            legacy_storage_task_id=cc.get("legacy_storage_task_id"),
             volumes=volumes,
             host_cwd=host_cwd,
             auto_mount_cwd=cc.get("docker_mount_cwd_to_workspace", False),
@@ -1936,6 +2834,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             key_path=ssh_config.get("key", ""),
             cwd=cwd,
             timeout=timeout,
+            runtime_scope=ssh_config.get("runtime_scope", ""),
         )
 
     else:
@@ -1967,7 +2866,16 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
 
     with _env_lock:
         for task_id, last_time in list(_last_activity.items()):
-            if current_time - last_time > lifetime_seconds:
+            if _active_turns_for_environment_key(task_id) > 0:
+                # An active tool or overlapping logical turn owns this runtime.
+                # Refresh activity so it gets a complete idle window afterward.
+                _last_activity[task_id] = current_time
+                continue
+            tracked_env = _active_environments.get(task_id)
+            effective_lifetime = getattr(
+                tracked_env, "_hermes_lifetime_seconds", lifetime_seconds,
+            )
+            if current_time - last_time > effective_lifetime:
                 env = _active_environments.pop(task_id, None)
                 _last_activity.pop(task_id, None)
                 if env is not None:
@@ -2005,6 +2913,11 @@ def _cleanup_inactive_envs(lifetime_seconds: int = 300):
                 logger.info("Environment for task %s already cleaned up", task_id)
             else:
                 logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+
+    # Replaced environments are no longer selectable. Give concurrent foreground
+    # calls a one-minute grace period, then force-remove them once no tool turn or
+    # background process still references their task scope.
+    _cleanup_retired_environments(min_age_seconds=60.0, require_idle=True)
 
 
 def _cleanup_thread_worker():
@@ -2044,43 +2957,78 @@ def _stop_cleanup_thread():
             pass
 
 
-def get_active_env(task_id: str):
+def get_active_env(task_id: str, target: Optional[str] = None):
     """Return the active BaseEnvironment for *task_id*, or None."""
-    lookup = _resolve_container_task_id(task_id)
+    resolution = _target_resolution(target)
+    lookup = _environment_scope_key(_resolve_container_task_id(task_id), resolution)
+    raw_lookup = _environment_scope_key(task_id, resolution)
     with _env_lock:
-        return _active_environments.get(lookup) or _active_environments.get(task_id)
+        return _active_environments.get(lookup) or _active_environments.get(raw_lookup)
 
 
-def ensure_task_env(task_id: Optional[str] = None):
-    """Lazily create and cache the sandbox env for *task_id* if none is active.
+def get_environment_for_target_scope(
+    task_id: str, target: str, runtime_scope: str,
+):
+    """Find the active/retired environment that produced a scoped result."""
+    raw = task_id or "default"
+    collapsed = _resolve_container_task_id(raw)
+    bases = {
+        _profile_scoped_task_key(raw),
+        _profile_scoped_task_key(collapsed),
+    }
 
-    :func:`terminal_tool` creates the environment on the first terminal command,
-    but nothing else did — so under a non-local backend (ssh, docker, …) a
-    session whose first action is ``vision_analyze`` on a container-only path hit
-    "no active sandbox session" because the SSH/Docker handshake never ran
-    (issue #62825). vision reads such paths inside the sandbox (see
-    ``tools.image_source``), so it calls this to bring the env up on demand,
-    reusing the same creation machinery as the terminal tool.
+    def _matches(key: Hashable, env: Any) -> bool:
+        belongs = key in bases or (
+            isinstance(key, tuple) and len(key) == 2 and key[0] in bases
+        )
+        return bool(
+            belongs
+            and getattr(env, "_hermes_target_name", None) == target
+            and getattr(env, "_hermes_target_scope", None) == runtime_scope
+        )
 
-    No-op on the local backend (images are read host-side). Returns the env
-    instance, or ``None`` when local or when creation fails (best-effort: a
-    failure leaves the caller's fail-closed error path intact).
+    with _env_lock:
+        for key, env in _active_environments.items():
+            if _matches(key, env):
+                return env
+    with _retired_environments_lock:
+        for key, env, _retired_at in _retired_environments:
+            if _matches(key, env):
+                return env
+    return None
+
+
+def ensure_task_env(
+    task_id: Optional[str] = None,
+    target: Optional[str] = None,
+):
+    """Lazily create and cache a selected non-local task environment.
+
+    This best-effort path lets consumers such as ``vision_analyze`` bring up
+    the same target-scoped SSH/container runtime before the first terminal
+    command. Local targets remain host-side and return ``None``.
     """
-    config = _get_env_config()
+    raw_task_id = task_id or "default"
+    resolution = _target_resolution(target)
+    config = (
+        _get_env_config(dict(resolution.config))
+        if resolution.named else _get_env_config()
+    )
     env_type = config["env_type"]
     if env_type == "local":
         return None
 
-    effective_task_id = _resolve_container_task_id(task_id)
+    base_task_id = _resolve_container_task_id(raw_task_id)
+    effective_task_id = resolution.environment_key(base_task_id)
+    backend_task_id = resolution.backend_task_id(base_task_id)
 
-    # Fast path: already active — mirror terminal_tool and refresh activity.
-    existing = get_active_env(effective_task_id)
-    if existing is not None:
-        with _env_lock:
+    with _env_lock:
+        existing = _active_environments.get(effective_task_id)
+        if _environment_matches_target(existing, resolution):
             _last_activity[effective_task_id] = time.time()
-        return existing
+            return existing
 
-    overrides = resolve_task_overrides(task_id)
+    overrides = resolve_task_overrides(raw_task_id)
     if env_type == "docker":
         image = overrides.get("docker_image") or config["docker_image"]
     elif env_type == "singularity":
@@ -2092,50 +3040,122 @@ def ensure_task_env(task_id: Optional[str] = None):
     else:
         image = ""
 
-    _start_cleanup_thread()
+    cwd_override = (
+        overrides.get("cwd")
+        if (
+            not resolution.named
+            or (resolution.is_default and resolution.backend != "ssh")
+        )
+        else None
+    )
+    cwd = (
+        cwd_override
+        or get_session_cwd(raw_task_id, _resolution=resolution)
+        or config["cwd"]
+    )
+    cwd = _apply_task_cwd_override(config, cwd, cwd_override)
+    host_cwd = _resolve_task_host_cwd(config, raw_task_id)
+    container_config, ssh_config, local_config = (
+        _build_environment_constructor_configs(
+            config, resolution, base_task_id,
+        )
+    )
 
-    # Per-task creation lock so a concurrent terminal_tool call and this helper
-    # don't each spawn a sandbox for the same task.
+    # Per-target creation lock prevents this lazy path and a concurrent
+    # terminal/file call from each creating a runtime for the same scope.
     with _creation_locks_lock:
-        task_lock = _creation_locks.setdefault(effective_task_id, threading.Lock())
+        task_lock = _creation_locks.setdefault(
+            effective_task_id, threading.Lock(),
+        )
 
     with task_lock:
-        existing = get_active_env(effective_task_id)
-        if existing is not None:
-            return existing
+        with _env_lock:
+            existing = _active_environments.get(effective_task_id)
+            if _environment_matches_target(existing, resolution):
+                _last_activity[effective_task_id] = time.time()
+                return existing
         try:
+            _prepare_environment_replacement(
+                existing,
+                effective_task_id,
+                target_name=resolution.target,
+            )
             new_env = _create_environment(
                 env_type=env_type,
                 image=image,
-                cwd=config["cwd"],
+                cwd=cwd,
                 timeout=config["timeout"],
-                ssh_config=_ssh_config_from_config(config) if env_type == "ssh" else None,
-                container_config=(
-                    _container_config_from_config(config)
-                    if env_type in _CONTAINER_BACKENDS else None
-                ),
-                local_config=None,
-                task_id=effective_task_id,
-                host_cwd=_resolve_task_host_cwd(config, task_id),
+                ssh_config=ssh_config,
+                container_config=container_config,
+                local_config=local_config,
+                task_id=backend_task_id,
+                host_cwd=host_cwd,
             )
+            _record_environment_lifetime(new_env, config)
+            _record_environment_target(new_env, resolution)
         except Exception as exc:  # noqa: BLE001 — best-effort bring-up
             logger.warning(
                 "Lazy %s environment init failed for task %s: %s",
-                env_type, effective_task_id[:8], exc,
+                env_type, str(effective_task_id)[:48], exc,
             )
             return None
 
+        publish_error = None
         with _env_lock:
-            _active_environments[effective_task_id] = new_env
-            _last_activity[effective_task_id] = time.time()
+            if resolution.named:
+                try:
+                    from tools.execution_targets import (
+                        execution_target_config_is_frozen,
+                        resolve_live_execution_target,
+                    )
+
+                    live_resolution = (
+                        resolution
+                        if execution_target_config_is_frozen()
+                        else resolve_live_execution_target(target)
+                    )
+                except Exception as exc:
+                    publish_error = str(exc)
+                else:
+                    if live_resolution.security_scope != resolution.security_scope:
+                        publish_error = (
+                            f"Execution target {resolution.target!r} changed "
+                            "while its environment was being created."
+                        )
+            replaced_env = None
+            if publish_error is None:
+                replaced_env = _active_environments.get(effective_task_id)
+                _active_environments[effective_task_id] = new_env
+                _last_activity[effective_task_id] = time.time()
+
+        if publish_error is not None:
+            _cleanup_environment_resource(
+                new_env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(new_env),
+            )
+            logger.warning("Lazy environment publish failed: %s", publish_error)
+            return None
+        if replaced_env is not None and replaced_env is not new_env:
+            _retire_replaced_environment(replaced_env, effective_task_id)
+
+        _start_cleanup_thread()
         logger.info(
             "%s environment lazily initialized for task %s",
-            env_type, effective_task_id[:8],
+            env_type, str(effective_task_id)[:48],
         )
         return new_env
 
 
-def is_persistent_env(task_id: str) -> bool:
+def _environment_is_persistent(env: Any) -> bool:
+    return bool(
+        getattr(env, "_session_scoped", False)
+        or getattr(env, "_persistent", False)
+        or getattr(env, "persistent_filesystem", False)
+    )
+
+
+def is_persistent_env(task_id: str, target: Optional[str] = None) -> bool:
     """Return True if the active environment for task_id is configured for
     cross-turn persistence (``persistent_filesystem=True``).
 
@@ -2151,12 +3171,10 @@ def is_persistent_env(task_id: str) -> bool:
     are removed by ``AIAgent.close()`` → ``cleanup_vm`` at session teardown
     and by the idle reaper, not per-turn.
     """
-    env = get_active_env(task_id)
+    env = get_active_env(task_id, target=target)
     if env is None:
         return False
-    if getattr(env, "_session_scoped", False):
-        return True
-    return bool(getattr(env, "_persistent", False))
+    return _environment_is_persistent(env)
 
 
 
@@ -2172,7 +3190,11 @@ def cleanup_all_environments():
             cleaned += 1
         except Exception as e:
             logger.error("Error cleaning %s: %s", task_id, e, exc_info=True)
-    
+
+    cleaned += _cleanup_retired_environments(
+        min_age_seconds=0.0, require_idle=False,
+    )
+
     # Also clean any orphaned directories
     scratch_dir = _get_scratch_dir()
     import glob
@@ -2188,11 +3210,20 @@ def cleanup_all_environments():
     return cleaned
 
 
-def cleanup_vm(task_id: str, *, force_remove: bool = False):
+def cleanup_vm(
+    task_id: Hashable,
+    *,
+    force_remove: bool = False,
+    preserve_persistent: bool = False,
+    target: Optional[str] = None,
+    include_collapsed: bool = False,
+):
     """Manually clean up a specific environment by task_id.
 
     *force_remove* (default False) is forwarded to backends that accept it
-    — currently only ``DockerEnvironment``. The default of False matches
+    — currently only ``DockerEnvironment``. ``preserve_persistent`` is used
+    by per-turn cleanup to keep each persistent named sibling live while
+    removing only non-persistent targets. The default of False matches
     session-lifecycle semantics: this function is called from
     ``AIAgent.close()`` (TUI session close, gateway session teardown) and the
     per-turn cleanup branch for non-persistent envs, both of which should
@@ -2209,76 +3240,166 @@ def cleanup_vm(task_id: str, *, force_remove: bool = False):
     via this function), so persist-mode idle envs are similarly no-op'd —
     only the orphan reaper at next startup reclaims them.
     """
-    # Remove from tracking dicts while holding the lock, but defer the
-    # actual (potentially slow) env.cleanup() call to outside the lock
-    # so other tool calls aren't blocked.
-    env = None
+    # Direct tuple keys are used by global/idle cleanup. For a raw task,
+    # omitted target cleans every target scope owned by that exact raw key;
+    # an explicit target cleans exactly that scope. Do not collapse arbitrary
+    # subagent ids to "default" here: legacy cleanup_vm(child_id) never tore
+    # down the parent's shared environment, and doing so in named mode would
+    # let a delegate's close race/disrupt its parent.
+    if isinstance(task_id, tuple):
+        keys = [task_id]
+    elif target is None:
+        try:
+            resolution = _target_resolution(None)
+            scoped_task_id = resolution.scope_task_key(task_id)
+            collapsed_task_id = _resolve_container_task_id(str(task_id))
+            scoped_collapsed_task_id = resolution.scope_task_key(collapsed_task_id)
+        except Exception:
+            scoped_task_id = task_id
+            collapsed_task_id = task_id
+            scoped_collapsed_task_id = task_id
+        matching_task_ids = {task_id, scoped_task_id}
+        if include_collapsed:
+            matching_task_ids.update({
+                collapsed_task_id, scoped_collapsed_task_id,
+            })
+        with _env_lock:
+            keys = [
+                key for key in _active_environments
+                if key in matching_task_ids
+                or (
+                    isinstance(key, tuple) and len(key) == 2
+                    and key[0] in matching_task_ids
+                )
+            ]
+        if not keys:
+            keys = [task_id]
+    else:
+        resolution = _target_resolution(target)
+        if resolution.named:
+            keys = [resolution.environment_key(task_id)]
+        else:
+            keys = [task_id]
+
+    active_process_keys = set()
+    if preserve_persistent:
+        try:
+            from tools.process_registry import process_registry
+
+            active_process_keys = {
+                key for key in keys
+                if process_registry.has_active_processes(key)
+            }
+        except Exception:
+            logger.debug(
+                "Failed to inspect active processes before cleanup",
+                exc_info=True,
+            )
+
+    envs = []
+    removed_keys = []
     with _env_lock:
-        env = _active_environments.pop(task_id, None)
-        _last_activity.pop(task_id, None)
+        for key in keys:
+            existing = _active_environments.get(key)
+            if key in active_process_keys:
+                continue
+            if (
+                preserve_persistent
+                and existing is not None
+                and _environment_is_persistent(existing)
+            ):
+                continue
+            env = _active_environments.pop(key, None)
+            _last_activity.pop(key, None)
+            removed_keys.append(key)
+            if env is not None:
+                envs.append((key, env))
 
     # Clean up per-task creation lock
     with _creation_locks_lock:
-        _creation_locks.pop(task_id, None)
+        for key in removed_keys:
+            _creation_locks.pop(key, None)
 
     # Invalidate stale file_ops cache entry
     try:
         from tools.file_tools import clear_file_ops_cache
-        clear_file_ops_cache(task_id)
+        for key in removed_keys:
+            clear_file_ops_cache(key)
     except ImportError:
         pass
 
-    if env is None:
+    for key in keys:
+        _cleanup_retired_environments(
+            task_key=key,
+            min_age_seconds=0.0,
+            require_idle=preserve_persistent,
+        )
+
+    if not envs:
         return
 
-    try:
-        if hasattr(env, 'cleanup'):
-            # Pass force_remove only if the env's cleanup() accepts it
-            # (DockerEnvironment after issue #20561; other backends don't).
-            import inspect
-            sig = inspect.signature(env.cleanup)
-            if "force_remove" in sig.parameters:
-                env.cleanup(force_remove=force_remove)
+    for key, env in envs:
+        try:
+            if hasattr(env, 'cleanup'):
+                # Pass force_remove only if the env's cleanup() accepts it
+                # (DockerEnvironment after issue #20561; other backends don't).
+                import inspect
+                sig = inspect.signature(env.cleanup)
+                if "force_remove" in sig.parameters:
+                    env.cleanup(force_remove=force_remove)
+                else:
+                    env.cleanup()
+            elif hasattr(env, 'stop'):
+                env.stop()
+            elif hasattr(env, 'terminate'):
+                env.terminate()
+
+            logger.info("Manually cleaned up environment for task: %s", key)
+
+        except Exception as e:
+            error_str = str(e)
+            if "404" in error_str or "not found" in error_str.lower():
+                logger.info("Environment for task %s already cleaned up", key)
             else:
-                env.cleanup()
-        elif hasattr(env, 'stop'):
-            env.stop()
-        elif hasattr(env, 'terminate'):
-            env.terminate()
-
-        logger.info("Manually cleaned up environment for task: %s", task_id)
-
-    except Exception as e:
-        error_str = str(e)
-        if "404" in error_str or "not found" in error_str.lower():
-            logger.info("Environment for task %s already cleaned up", task_id)
-        else:
-            logger.warning("Error cleaning up environment for task %s: %s", task_id, e)
+                logger.warning("Error cleaning up environment for task %s: %s", key, e)
 
 
 def _atexit_cleanup():
     """Stop cleanup thread and shut down all remaining sandboxes on exit."""
     _stop_cleanup_thread()
-    if _active_environments:
-        count = len(_active_environments)
-        logger.info("Shutting down %d remaining sandbox(es)...", count)
-        # Snapshot the env objects BEFORE cleanup_all_environments empties
-        # the dict; we need them to wait on docker cleanup threads after the
-        # registry has been cleared.
-        envs_to_wait = list(_active_environments.values())
+    with _retired_environments_lock:
+        retired = list(_retired_environments)
+        _retired_environments.clear()
+    envs_to_wait = list(_active_environments.values())
+    if envs_to_wait:
+        logger.info("Shutting down %d remaining sandbox(es)...", len(envs_to_wait))
         cleanup_all_environments()
-        # Block briefly so docker stop/rm actually completes before the
-        # interpreter exits. Issue #20561 — without this join, the daemon
-        # cleanup threads were getting torn down mid-`docker stop`, leaving
-        # Exited containers piled up on the host.
-        for env in envs_to_wait:
-            wait_fn = getattr(env, "wait_for_cleanup", None)
-            if wait_fn is None:
-                continue
-            try:
-                wait_fn(timeout=15.0)
-            except Exception as e:  # never block shutdown on a bad backend
-                logger.debug("wait_for_cleanup raised on exit: %s", e)
+    seen = {id(env) for env in envs_to_wait}
+    for _, env, _ in retired:
+        if id(env) in seen:
+            continue
+        seen.add(id(env))
+        try:
+            _cleanup_environment_resource(
+                env,
+                force_remove=True,
+                preserve_storage=_environment_has_stable_storage(env),
+            )
+        except Exception as exc:
+            logger.debug("retired environment cleanup raised on exit: %s", exc)
+        envs_to_wait.append(env)
+
+    # Block briefly so docker stop/rm actually completes before the interpreter
+    # exits. Issue #20561 — without this join, daemon cleanup threads can be
+    # torn down mid-`docker stop`, leaving exited containers on the host.
+    for env in envs_to_wait:
+        wait_fn = getattr(env, "wait_for_cleanup", None)
+        if wait_fn is None:
+            continue
+        try:
+            wait_fn(timeout=15.0)
+        except Exception as exc:  # never block shutdown on a bad backend
+            logger.debug("wait_for_cleanup raised on exit: %s", exc)
 
 atexit.register(_atexit_cleanup)
 
@@ -2567,6 +3688,8 @@ def _resolve_command_cwd(
     default_cwd: str,
     session_key: Optional[str] = None,
     env_type: Optional[str] = None,
+    target: Optional[str] = None,
+    _resolution=None,
 ) -> str:
     """Return the cwd for a command. Explicit ``workdir=`` overrides everything.
 
@@ -2586,7 +3709,9 @@ def _resolve_command_cwd(
     """
     if workdir:
         return workdir
-    recorded = get_session_cwd(session_key)
+    recorded = get_session_cwd(
+        session_key, target=target, _resolution=_resolution,
+    )
     if (
         recorded
         and env_type in _CONTAINER_BACKENDS
@@ -2612,6 +3737,7 @@ def terminal_tool(
     pty: bool = False,
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
+    execution_target: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2627,6 +3753,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row, watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        execution_target: Named execution target. Omit to use the configured default.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -2657,15 +3784,33 @@ def terminal_tool(
                 "status": "error",
             }, ensure_ascii=False)
 
-        # Get configuration
-        config = _get_env_config()
+        # Resolve configuration per call. Named targets read merged config
+        # directly; legacy flat config keeps the existing env-driven path.
+        from tools.execution_targets import ExecutionTargetError
+        try:
+            target_resolution = _target_resolution(execution_target)
+        except ExecutionTargetError as exc:
+            return json.dumps({
+                "output": "", "exit_code": -1, "error": str(exc), "status": "error",
+            }, ensure_ascii=False)
+        config = (
+            _get_env_config(dict(target_resolution.config))
+            if target_resolution.named else _get_env_config()
+        )
         env_type = config["env_type"]
 
         # Use task_id for environment isolation. By default all subagent
         # task_ids collapse back to "default" so the top-level agent and
         # every delegate_task child share one container; only task_ids with
         # a registered env override (RL benchmarks) get isolated sandboxes.
-        effective_task_id = _resolve_container_task_id(task_id)
+        effective_base_task_id = _resolve_container_task_id(task_id)
+        effective_task_id = _environment_scope_key(
+            effective_base_task_id, target_resolution,
+        )
+        raw_environment_key = _environment_scope_key(
+            task_id, target_resolution,
+        ) if task_id else None
+        backend_task_id = target_resolution.backend_task_id(effective_base_task_id)
 
         # Check per-task overrides (set by environments like TerminalBench2Env)
         # before falling back to global env var config. ``resolve_task_overrides``
@@ -2687,33 +3832,25 @@ def terminal_tool(
         else:
             image = ""
 
-        cwd = overrides.get("cwd") or get_session_cwd(task_id) or config["cwd"]
-        # Session-scoped mount resolution (single owner: _resolve_task_host_cwd).
-        # Under per-session isolation a fresh session must not inherit the
-        # process-global TERMINAL_CWD mount left behind by a previous session.
-        host_cwd = _resolve_task_host_cwd(config, task_id)
-        # A per-task cwd override (registered by the gateway/TUI for workspace
-        # tracking, or by RL/benchmark envs) wins over config["cwd"] — but
-        # config["cwd"] was already sanitized for container backends in
-        # _get_env_config() while the override is raw. On a container backend a
-        # raw host path (e.g. a Windows desktop session's C:\Users\<user>, or a
-        # POSIX /home/<user>) reaches `docker run -w <host-path>` and the
-        # container fails to start (exit 125). Re-apply the same host/relative
-        # path guard to the *resolved* cwd so the override can't bypass it.
-        # When the host path IS this session's mounted workspace, remap it to
-        # /workspace (where the mount lands) instead of discarding it.
-        # Valid in-container override paths (RL/benchmark sandboxes that set
-        # cwd to /workspace, /root, etc.) are absolute non-host paths and pass
-        # through untouched.
-        if env_type in _CONTAINER_BACKENDS and _is_unusable_container_cwd(cwd):
-            remapped = "/workspace" if host_cwd else config["cwd"]
-            if cwd != remapped:
-                logger.info(
-                    "Remapping host/relative cwd override %r for %s backend "
-                    "(won't exist in sandbox). Using %r instead.",
-                    cwd, env_type, remapped,
+        cwd_override = (
+            overrides.get("cwd")
+            if (
+                not target_resolution.named
+                or (
+                    target_resolution.is_default
+                    and target_resolution.backend != "ssh"
                 )
-            cwd = remapped
+            )
+            else None
+        )
+        cwd = cwd_override or get_session_cwd(
+            task_id, _resolution=target_resolution,
+        ) or config["cwd"]
+        cwd = _apply_task_cwd_override(config, cwd, cwd_override)
+        # Session-scoped mount resolution is deliberately computed after the
+        # selected target's cwd override has been applied, so a stale global
+        # TERMINAL_CWD cannot leak another session's host mount.
+        host_cwd = _resolve_task_host_cwd(config, task_id)
         default_timeout = config["timeout"]
 
         # Validate an explicit timeout before it flows into deadline math.
@@ -2764,9 +3901,14 @@ def terminal_tool(
             # task_id; honor it instead of spawning a duplicate.
             _existing_key = (
                 effective_task_id if effective_task_id in _active_environments
-                else (task_id if task_id and task_id in _active_environments else None)
+                else (raw_environment_key if raw_environment_key in _active_environments else None)
             )
-            if _existing_key is not None:
+            if (
+                _existing_key is not None
+                and _environment_matches_target(
+                    _active_environments[_existing_key], target_resolution,
+                )
+            ):
                 _last_activity[_existing_key] = time.time()
                 env = _active_environments[_existing_key]
                 needs_creation = False
@@ -2782,32 +3924,50 @@ def terminal_tool(
 
             with task_lock:
                 # Double-check after acquiring the per-task lock
+                existing_env = None
+                existing_key = effective_task_id
                 with _env_lock:
                     _existing_key = (
                         effective_task_id if effective_task_id in _active_environments
-                        else (task_id if task_id and task_id in _active_environments else None)
+                        else (raw_environment_key if raw_environment_key in _active_environments else None)
                     )
-                    if _existing_key is not None:
+                    if (
+                        _existing_key is not None
+                        and _environment_matches_target(
+                            _active_environments[_existing_key], target_resolution,
+                        )
+                    ):
                         _last_activity[_existing_key] = time.time()
                         env = _active_environments[_existing_key]
                         needs_creation = False
+                    elif _existing_key is not None:
+                        existing_env = _active_environments[_existing_key]
+                        existing_key = _existing_key
+
+                try:
+                    _prepare_environment_replacement(
+                        existing_env,
+                        existing_key,
+                        target_name=target_resolution.target,
+                    )
+                except _EnvironmentReplacementError as exc:
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "error": str(exc),
+                        "status": "error",
+                    }, ensure_ascii=False)
 
                 if needs_creation:
                     if env_type == "singularity":
                         _check_disk_usage_warning()
-                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id[:8])
+                    logger.info("Creating new %s environment for task %s...", env_type, effective_task_id)
                     try:
-                        ssh_config = _ssh_config_from_config(config) if env_type == "ssh" else None
-                        container_config = (
-                            _container_config_from_config(config)
-                            if env_type in _CONTAINER_BACKENDS else None
+                        container_config, ssh_config, local_config = (
+                            _build_environment_constructor_configs(
+                                config, target_resolution, effective_base_task_id,
+                            )
                         )
-
-                        local_config = None
-                        if env_type == "local":
-                            local_config = {
-                                "persistent": config.get("local_persistent", False),
-                            }
 
                         new_env = _create_environment(
                             env_type=env_type,
@@ -2817,9 +3977,11 @@ def terminal_tool(
                             ssh_config=ssh_config,
                             container_config=container_config,
                             local_config=local_config,
-                            task_id=effective_task_id,
+                            task_id=backend_task_id,
                             host_cwd=host_cwd,
                         )
+                        _record_environment_lifetime(new_env, config)
+                        _record_environment_target(new_env, target_resolution)
                     except ImportError as e:
                         return json.dumps({
                             "output": "",
@@ -2830,11 +3992,71 @@ def terminal_tool(
                             "status": "disabled"
                         }, ensure_ascii=False)
 
+                    publish_error = None
                     with _env_lock:
-                        _active_environments[effective_task_id] = new_env
-                        _last_activity[effective_task_id] = time.time()
-                        env = new_env
-                    logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
+                        if target_resolution.named:
+                            try:
+                                from tools.execution_targets import (
+                                    execution_target_config_is_frozen,
+                                    resolve_live_execution_target,
+                                )
+
+                                live_resolution = (
+                                    target_resolution
+                                    if execution_target_config_is_frozen()
+                                    else resolve_live_execution_target(
+                                        execution_target
+                                    )
+                                )
+                            except Exception as exc:
+                                publish_error = str(exc)
+                            else:
+                                if (
+                                    live_resolution.security_scope
+                                    != target_resolution.security_scope
+                                ):
+                                    publish_error = (
+                                        f"Execution target {target_resolution.target!r} "
+                                        "changed while its environment was being created."
+                                    )
+                        replaced_envs = []
+                        if publish_error is None:
+                            current = _active_environments.get(effective_task_id)
+                            if current is not None and current is not new_env:
+                                replaced_envs.append((effective_task_id, current))
+                            if (
+                                raw_environment_key is not None
+                                and raw_environment_key != effective_task_id
+                            ):
+                                raw_env = _active_environments.get(raw_environment_key)
+                                if (
+                                    raw_env is not None
+                                    and not _environment_matches_target(
+                                        raw_env, target_resolution,
+                                    )
+                                ):
+                                    _active_environments.pop(raw_environment_key, None)
+                                    _last_activity.pop(raw_environment_key, None)
+                                    replaced_envs.append((raw_environment_key, raw_env))
+                            _active_environments[effective_task_id] = new_env
+                            _last_activity[effective_task_id] = time.time()
+                            env = new_env
+                    if publish_error is not None:
+                        _cleanup_environment_resource(
+                            new_env,
+                            force_remove=True,
+                            preserve_storage=_environment_has_stable_storage(new_env),
+                        )
+                        return json.dumps({
+                            "output": "",
+                            "exit_code": -1,
+                            "error": publish_error + " Retry the command.",
+                            "status": "error",
+                        }, ensure_ascii=False)
+                    for replaced_key, replaced_env in replaced_envs:
+                        if replaced_env is not new_env:
+                            _retire_replaced_environment(replaced_env, replaced_key)
+                    logger.info("%s environment ready for task %s", env_type, effective_task_id)
 
         assert env is not None  # all creation failure paths return above
 
@@ -2871,7 +4093,12 @@ def terminal_tool(
                     ),
                     "status": "error",
                 }, ensure_ascii=False)
-            guard_cwd_base = get_session_cwd(session_key)
+            selected_target = (
+                target_resolution.target if target_resolution.named else None
+            )
+            guard_cwd_base = get_session_cwd(
+                session_key, selected_target, _resolution=target_resolution,
+            )
             if guard_cwd_base is None:
                 guard_cwd_base = getattr(env, "cwd", None) or cwd
             guard_cwd = _resolve_command_cwd(
@@ -2879,37 +4106,33 @@ def terminal_tool(
                 default_cwd=guard_cwd_base,
                 session_key=session_key,
                 env_type=env_type,
+                _resolution=target_resolution,
             )
 
-            def _read_script_in_env(script_path: str) -> Optional[str]:
-                """Best-effort script read; uses env.execute only when local read fails.
+            def _read_script_in_env(
+                script_path: str,
+            ) -> Optional[str] | tuple[Optional[str], bool]:
+                """Read a script without crossing the selected target boundary.
 
-                For local backends the script path is on the host filesystem. For
-                SSH/Modal/Daytona the same path is remote; the local read misses, so we
-                fall back to a bounded ``env.execute('head -c ... < path')`` read.
+                Host filesystem reads are allowed only for a local target. Other
+                targets, and local-read misses, use the selected environment at
+                ``guard_cwd``. All reads are bounded and NUL-bearing binary content
+                is skipped before it can re-enter the lifecycle-command scanner.
                 """
                 if env is None:
                     return None
-                try:
-                    local_path = Path(script_path).expanduser()
-                    if not local_path.is_absolute():
-                        local_path = Path(guard_cwd) / local_path
-                    if local_path.is_file():
-                        metadata = local_path.stat()
-                        if stat.S_ISREG(metadata.st_mode) and metadata.st_size <= _MAX_REFERENCED_SCRIPT_BYTES:
-                            data = local_path.read_bytes()
-                            if len(data) <= _MAX_REFERENCED_SCRIPT_BYTES:
-                                if b"\x00" in data:
-                                    # Binary (ELF/Mach-O/PE), not a shell script:
-                                    # feeding its decoded bytes back into the guard
-                                    # tokenizes machine code into bogus NUL-bearing
-                                    # paths and crashes the scanner (#77703). Mirror
-                                    # lifecycle_guard._read_referenced_script and
-                                    # treat it as nothing to scan.
-                                    return None
-                                return data.decode("utf-8", errors="replace")
-                except Exception:
-                    pass
+                if target_resolution.backend == "local":
+                    try:
+                        from cron.lifecycle_guard import _read_referenced_script
+
+                        local_path = Path(script_path).expanduser()
+                        if not local_path.is_absolute():
+                            local_path = Path(guard_cwd) / local_path
+                        local_result = _read_referenced_script(local_path)
+                        if local_result[0] is not None or local_result[1]:
+                            return local_result
+                    except Exception:
+                        return None
                 # Remote / sandboxed backend: read via the environment's shell.
                 # Bound the read at the source with `head -c` so an oversized
                 # file (e.g. a 166MB ELF invoked by absolute path) never
@@ -2923,10 +4146,22 @@ def terminal_tool(
                 try:
                     result = env.execute(
                         f"head -c {_MAX_REFERENCED_SCRIPT_BYTES + 1} "
-                        f"< {shlex.quote(script_path)}"
+                        f"< {shlex.quote(script_path)}",
+                        cwd=guard_cwd,
                     )
-                    if result.get("returncode", -1) == 0:
+                    if isinstance(result, dict):
+                        returncode = result.get(
+                            "returncode", result.get("exit_code", -1)
+                        )
                         output = result.get("output", "")
+                    else:
+                        returncode = getattr(
+                            result,
+                            "returncode",
+                            getattr(result, "exit_code", -1),
+                        )
+                        output = getattr(result, "output", "")
+                    if returncode == 0:
                         if output and "\x00" in output:
                             # Binary content from a remote read: skip for the
                             # same reason as the local branch above (#77703).
@@ -3004,11 +4239,18 @@ def terminal_tool(
             approval = _check_all_guards(
                 command, env_type,
                 has_host_access=_docker_has_host_access(config),
+                execution_target=target_resolution.target,
+                execution_backend=target_resolution.backend,
+                execution_target_named=target_resolution.named,
+                execution_target_scope=(
+                    target_resolution.security_scope
+                    if target_resolution.named else ""
+                ),
             )
             if not approval["approved"]:
                 # Check if this is an approval_required (gateway ask mode)
                 if approval.get("status") == "pending_approval":
-                    return json.dumps({
+                    pending_result = {
                         "output": "",
                         "exit_code": -1,
                         "error": "",
@@ -3019,7 +4261,11 @@ def terminal_tool(
                         "pattern_key": approval.get("pattern_key", ""),
                         "smart_denied": approval.get("smart_denied", False),
                         "allow_permanent": approval.get("allow_permanent", True),
-                    }, ensure_ascii=False)
+                    }
+                    pending_result.update(target_resolution.metadata(
+                        cwd=cwd if target_resolution.named else None,
+                    ))
+                    return json.dumps(pending_result, ensure_ascii=False)
                 # Command was blocked
                 desc = approval.get("description", "command flagged")
                 fallback_msg = (
@@ -3065,25 +4311,64 @@ def terminal_tool(
                 default_cwd=cwd,
                 session_key=session_key,
                 env_type=env_type,
+                _resolution=target_resolution,
             )
             try:
-                if env_type == "local":
-                    proc_session = process_registry.spawn_local(
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                        env_vars=env.env if hasattr(env, 'env') else None,
-                        use_pty=effective_pty,
-                    )
-                else:
-                    proc_session = process_registry.spawn_via_env(
-                        env=env,
-                        command=command,
-                        cwd=effective_cwd,
-                        task_id=effective_task_id,
-                        session_key=session_key,
-                    )
+                spawn_metadata = {}
+                environment_task_key = str(
+                    target_resolution.scope_task_key(effective_base_task_id)
+                )
+                if target_resolution.named:
+                    spawn_metadata = {
+                        "target": target_resolution.target,
+                        "backend": target_resolution.backend,
+                        "timeout_seconds": effective_timeout,
+                        "environment_task_key": environment_task_key,
+                        "runtime_scope": target_resolution.security_scope,
+                    }
+                    if env_type == "local":
+                        spawn_metadata["env_ref"] = env
+                with _scoped_sudo_execution(
+                    target_resolution.target,
+                    target_resolution.backend,
+                    named=target_resolution.named,
+                    sudo_password=target_resolution.config.get("sudo_password"),
+                    target_scope=(
+                        target_resolution.security_scope
+                        if target_resolution.named else ""
+                    ),
+                ):
+                    if env_type == "local":
+                        proc_session = process_registry.spawn_local(
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            env_vars=env.env if hasattr(env, 'env') else None,
+                            use_pty=effective_pty,
+                            **spawn_metadata,
+                        )
+                    else:
+                        proc_session = process_registry.spawn_via_env(
+                            env=env,
+                            command=command,
+                            cwd=effective_cwd,
+                            task_id=effective_base_task_id,
+                            session_key=session_key,
+                            timeout=effective_timeout,
+                            **spawn_metadata,
+                        )
+
+                # Preserve the exact legacy spawn call signature while still
+                # attaching additive metadata to subsequent process results.
+                if not target_resolution.named:
+                    proc_session.target = target_resolution.target
+                    proc_session.backend = target_resolution.backend
+                    proc_session.timeout_seconds = effective_timeout
+                    proc_session.environment_task_key = environment_task_key
+                    checkpoint = getattr(process_registry, "_write_checkpoint", None)
+                    if callable(checkpoint):
+                        checkpoint()
 
                 result_data = {
                     "output": "Background process started",
@@ -3092,6 +4377,9 @@ def terminal_tool(
                     "exit_code": 0,
                     "error": None,
                 }
+                result_data.update(target_resolution.metadata(
+                    cwd=effective_cwd if target_resolution.named else None,
+                ))
                 # Background spawns detached and returns exit_code 0 immediately;
                 # it never inline-polls is_interrupted(), so the stale-bit kill
                 # cannot occur here and this note never co-occurs with rc=130.
@@ -3338,6 +4626,7 @@ def terminal_tool(
                         default_cwd=cwd,
                         session_key=session_key,
                         env_type=env_type,
+                        _resolution=target_resolution,
                     )
                     execute_kwargs = {
                         "timeout": effective_timeout,
@@ -3349,7 +4638,17 @@ def terminal_tool(
                         # reads, RPC reads) intentionally stay unbounded.
                         "bounded_capture": True,
                     }
-                    result = env.execute(command, **execute_kwargs)
+                    with _scoped_sudo_execution(
+                        target_resolution.target,
+                        target_resolution.backend,
+                        named=target_resolution.named,
+                        sudo_password=target_resolution.config.get("sudo_password"),
+                        target_scope=(
+                            target_resolution.security_scope
+                            if target_resolution.named else ""
+                        ),
+                    ):
+                        result = env.execute(command, **execute_kwargs)
                 except Exception as e:
                     error_str = str(e).lower()
                     if "timeout" in error_str:
@@ -3400,7 +4699,10 @@ def terminal_tool(
             # another session's directory. Recording it silently re-homes this
             # session into a directory the user never opened.
             if not workdir and (result or {}).get("cwd_observed"):
-                record_session_cwd(session_key, getattr(env, "cwd", None))
+                record_session_cwd(
+                    session_key, getattr(env, "cwd", None),
+                    _resolution=target_resolution,
+                )
 
             # Extract output
             output = result.get("output", "")
@@ -3415,7 +4717,14 @@ def terminal_tool(
 
             sudo_auth_failed = _sudo_wrong_password_failure(output)
             sudo_cache_cleared = _invalidate_cached_sudo_on_auth_failure(
-                command, output
+                command,
+                output,
+                target_resolution.target,
+                target_resolution.backend,
+                (
+                    target_resolution.security_scope
+                    if target_resolution.named else ""
+                ),
             )
             if sudo_cache_cleared:
                 has_sudo_prompt_callback = _get_sudo_password_callback() is not None
@@ -3433,13 +4742,21 @@ def terminal_tool(
             # The hook is fail-open, and the first valid string return wins.
             try:
                 from hermes_cli.lifecycle import invoke_hook
+                hook_kwargs = {
+                    "command": command,
+                    "output": output,
+                    "returncode": returncode,
+                    "task_id": effective_base_task_id or "",
+                    "env_type": env_type,
+                }
+                if target_resolution.named:
+                    hook_kwargs.update({
+                        "execution_target": target_resolution.target,
+                        "execution_backend": target_resolution.backend,
+                    })
                 hook_results = invoke_hook(
                     "transform_terminal_output",
-                    command=command,
-                    output=output,
-                    returncode=returncode,
-                    task_id=effective_task_id or "",
-                    env_type=env_type,
+                    **hook_kwargs,
                 )
                 for hook_result in hook_results:
                     if isinstance(hook_result, str):
@@ -3513,6 +4830,9 @@ def terminal_tool(
                 "exit_code": returncode,
                 "error": None,
             }
+            result_dict.update(target_resolution.metadata(
+                cwd=command_cwd if target_resolution.named else None,
+            ))
             # cwd echo: when the command changed the session's working
             # directory (cd, pushd, ...), tell the model where it ended up.
             # Production mining shows 60% of terminal calls carry a
@@ -3530,12 +4850,6 @@ def terminal_tool(
                     result_dict["cwd"] = str(post_cwd)
             except Exception:
                 pass
-            # Truncation metadata (codex/opencode/goose pattern): report the
-            # pre-truncation size and a spill-file handle so the model can
-            # retrieve the omitted middle with read_file/search_files instead
-            # of re-running the command. The spill was written raw by the
-            # collector; redact it here with the same pass as the visible
-            # output so no secret persists unmasked on disk.
             if spill_file_path:
                 try:
                     _sp = Path(spill_file_path)
@@ -3566,25 +4880,30 @@ def terminal_tool(
                         Path(spill_file_path).unlink()
                     except OSError:
                         pass
-            try:
-                from agent.verification_evidence import record_terminal_result
+            if target_resolution.backend == "local":
+                try:
+                    from agent.verification_evidence import record_terminal_result
 
-                evidence = record_terminal_result(
-                    command=command,
-                    cwd=command_cwd,
-                    session_id=session_id or task_id or effective_task_id or "default",
-                    exit_code=returncode,
-                    output=output,
-                )
-                if evidence:
-                    result_dict["verification_evidence"] = {
-                        "status": evidence.get("status"),
-                        "kind": evidence.get("kind"),
-                        "scope": evidence.get("scope"),
-                        "canonical_command": evidence.get("canonical_command"),
-                    }
-            except Exception:
-                logger.debug("verification evidence recording failed", exc_info=True)
+                    evidence = record_terminal_result(
+                        command=command,
+                        cwd=command_cwd,
+                        session_id=(
+                            session_id or task_id or backend_task_id or "default"
+                        ),
+                        exit_code=returncode,
+                        output=output,
+                    )
+                    if evidence:
+                        result_dict["verification_evidence"] = {
+                            "status": evidence.get("status"),
+                            "kind": evidence.get("kind"),
+                            "scope": evidence.get("scope"),
+                            "canonical_command": evidence.get("canonical_command"),
+                        }
+                except Exception:
+                    logger.debug(
+                        "verification evidence recording failed", exc_info=True,
+                    )
             if approval_note:
                 # Treat rc=130 as an interrupt only when the executor's marker is
                 # present.  A command can legitimately exit 130 on its own
@@ -3637,7 +4956,9 @@ def terminal_tool(
         # call re-creates the environment from scratch and simply works once
         # the backend is reachable again.
         try:
-            _evict_environment_for_task(task_id)
+            _evict_environment_for_task(
+                task_id, _resolution=target_resolution,
+            )
         except Exception:
             logger.debug("degraded-env eviction failed", exc_info=True)
         return json.dumps({
@@ -3664,16 +4985,26 @@ def terminal_tool(
         }, ensure_ascii=False)
 
 
-def _evict_environment_for_task(task_id: Optional[str]) -> None:
-    """Drop any cached environment for *task_id* (and its collapsed key).
+def _evict_environment_for_task(
+    task_id: Optional[str],
+    target: Optional[str] = None,
+    *,
+    _resolution=None,
+) -> None:
+    """Drop cached environments for one selected task/target scope.
 
     Used when a backend reports an infrastructure failure: keeping the dead
     env cached would make every subsequent call fail against a stale
     connection, defeating automatic recovery.
     """
-    keys = {_resolve_container_task_id(task_id)}
-    if task_id:
-        keys.add(task_id)
+    resolution = _resolution or _target_resolution(target)
+    raw_task_id = task_id or "default"
+    keys = {
+        _environment_scope_key(raw_task_id, resolution),
+        _environment_scope_key(
+            _resolve_container_task_id(raw_task_id), resolution,
+        ),
+    }
     evicted = []
     with _env_lock:
         for key in keys:
@@ -3688,10 +5019,9 @@ def _evict_environment_for_task(task_id: Optional[str]) -> None:
             logger.debug("cleanup of degraded environment failed", exc_info=True)
 
 
-def check_terminal_requirements() -> bool:
-    """Check if all requirements for the terminal tool are met."""
+def _check_terminal_config_requirements(config: Dict[str, Any]) -> bool:
+    """Check one already-resolved backend configuration."""
     try:
-        config = _get_env_config()
         env_type = config["env_type"]
 
         if env_type == "local":
@@ -3802,6 +5132,43 @@ def check_terminal_requirements() -> bool:
         return False
 
 
+def check_terminal_requirements() -> bool:
+    """Keep tools available when any configured execution target is usable."""
+    try:
+        from tools.execution_targets import list_execution_targets
+
+        inventory = list_execution_targets()
+    except Exception as exc:
+        # Registration checks have always failed closed for invalid terminal
+        # configuration. Keep that contract; individual tool handlers still
+        # produce actionable target errors when invoked directly.
+        logger.error("Invalid execution target config: %s", exc)
+        return False
+
+    if inventory and inventory[0].named:
+        # Cheap/always-available local targets first, so an unavailable Docker
+        # daemon or cloud credential on another target does not emit a scary
+        # startup error when at least one target is healthy.
+        ordered = sorted(
+            inventory,
+            key=lambda item: (item.backend != "local", not item.is_default, item.target),
+        )
+        for resolution in ordered:
+            try:
+                config = _get_env_config(dict(resolution.config))
+            except Exception:
+                continue
+            if _check_terminal_config_requirements(config):
+                return True
+        return False
+
+    try:
+        return _check_terminal_config_requirements(_get_env_config())
+    except Exception as exc:
+        logger.error("Invalid terminal configuration: %s", exc)
+        return False
+
+
 if __name__ == "__main__":
     # Simple test when run directly
     print("Terminal Tool Module")
@@ -3878,6 +5245,10 @@ TERMINAL_SCHEMA = {
                 "type": "string",
                 "description": "Working directory for this command (absolute path). Defaults to the session working directory."
             },
+            "execution_target": {
+                "type": "string",
+                "description": "Named execution target from terminal.targets (for example 'local' or 'devbox'). Omit to use terminal.default_target; legacy flat config accepts only 'default'.",
+            },
             "pty": {
                 "type": "boolean",
                 "description": "Run in pseudo-terminal (PTY) mode for interactive CLI tools like Codex, Claude Code, or Python REPL. Only works with local and SSH backends. Default: false.",
@@ -3900,6 +5271,13 @@ TERMINAL_SCHEMA = {
 
 
 def _handle_terminal(args, **kw):
+    try:
+        from tools.execution_targets import validate_execution_target_args
+
+        validate_execution_target_args("terminal", args)
+    except Exception as exc:
+        return tool_error(str(exc))
+
     # Mirror of execute_code's misplaced-argument recovery: models sometimes
     # send execute_code's ``code`` argument here. Without this, the call
     # falls through to command=None and fails with "Invalid command:
@@ -3921,6 +5299,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=args.get("notify_on_complete", False),
         watch_patterns=args.get("watch_patterns"),
+        execution_target=args.get("execution_target"),
     )
 
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -203,6 +203,7 @@ def maybe_persist_tool_result(
 def enforce_turn_budget(
     tool_messages: list[dict],
     env=None,
+    env_resolver=None,
     config: BudgetConfig = DEFAULT_BUDGET,
 ) -> list[dict]:
     """Layer 3: enforce aggregate budget across all tool results in a turn.
@@ -211,7 +212,9 @@ def enforce_turn_budget(
     first (via sandbox write) until under budget. Already-persisted results
     are skipped.
 
-    Mutates the list in-place and returns it.
+    ``env_resolver`` may return the producing environment for each message;
+    this keeps saved outputs on the same named execution target as the tool
+    call. Mutates the list in-place and returns it.
     """
     candidates = []
     total_size = 0
@@ -234,11 +237,12 @@ def enforce_turn_budget(
         content = msg["content"]
         tool_use_id = msg.get("tool_call_id", f"budget_{idx}")
 
+        message_env = env_resolver(msg) if callable(env_resolver) else env
         replacement = maybe_persist_tool_result(
             content=content,
             tool_name=_BUDGET_TOOL_NAME,
             tool_use_id=tool_use_id,
-            env=env,
+            env=message_env if callable(env_resolver) else env,
             config=config,
             threshold=0,
         )

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -84,6 +84,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes mcp` | Manage MCP server configurations and run Hermes as an MCP server. |
 | `hermes plugins` | Manage Hermes Agent plugins (install, enable, disable, remove). |
 | `hermes portal` | Nous Portal status, subscription link, and Tool Gateway routing. See [Tool Gateway](../user-guide/features/tool-gateway.md). |
+| `hermes targets` | Register, list, drain, and remove profile-scoped runtime execution targets without a gateway restart. |
 | `hermes tools` | Configure enabled tools per platform. |
 | `hermes computer-use` | Install or check the Computer Use (cua-driver) backend (macOS/Windows/Linux). |
 | `hermes pets` | Browse, install, and select [petdex](../user-guide/features/pets.md) animated pets shown across the CLI, TUI, and desktop app. Subcommands: `list`, `install`, `select`, `show`, `off`, `scale`, `remove`, `doctor`. |
@@ -1396,6 +1397,25 @@ pin status in the profile-local `plugins/.install-metadata.json` sidecar. It doe
 not contain plugin config, environment values, secrets, or capability grants.
 
 See [Plugins](../user-guide/features/plugins.md) and [Build a Hermes Plugin](../developer-guide/plugins/index.md).
+
+## `hermes targets`
+
+```bash
+hermes targets register NAME --backend ssh --host HOST --user USER \
+  [--port PORT] [--key PATH] [--cwd PATH] [--timeout SECONDS] \
+  [--provider PROVIDER] [--owner-id ID] [--generation GEN] \
+  [--replace] [--if-generation OLD] [--set KEY=VALUE] [--json]
+hermes targets list [--all] [--json]
+hermes targets show NAME [--provider PROVIDER] [--json]
+hermes targets drain NAME [--provider PROVIDER] [--if-generation GEN] [--json]
+hermes targets remove NAME [--provider PROVIDER] [--if-generation GEN] [--json]
+```
+
+`unregister` aliases `remove`; `--ssh-host`, `--ssh-user`, `--ssh-port`, and `--ssh-key` alias the shorter SSH flags. The default provider is `cli`, the default owner ID is the target name, and an omitted generation uses the stable value `manual`. Use a controller-supplied generation for ephemeral infrastructure so drain/remove can compare-and-swap the exact resource. `--set` accepts repeatable backend-specific `KEY=VALUE` settings, parsing JSON values where possible; structural target/default/provider fields are rejected.
+
+Handled target validation, configuration, domain, and compare-and-swap failures exit with status 2. Without `--json`, they print a concise `Error: ...` message to stderr. With `--json`, stdout contains one secret-safe object with `status: "error"` and a human-readable `message`, and stderr remains empty.
+
+Runtime targets are profile-scoped provider fragments, not edits to `config.yaml`. Registration becomes available to a running gateway on the next independent dispatch. See [Named Execution Targets](../user-guide/configuration.md#named-execution-targets) for precedence, lifecycle, security, prompt-cache behavior, and the Hetzner example.
 
 ## `hermes tools`
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -90,6 +90,19 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | `search_files` | Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Content search (target='content'): Regex search inside files. Output modes: full matches with line… | — |
 | `write_file` | Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by the write are surfaced. | — |
 
+### File execution targets
+
+`read_file`, `write_file`, and `patch` accept an optional static string `target` selecting a configured `terminal.targets` entry. `search_files` preserves its existing `target="content"|"files"` argument and uses `execution_target` for environment selection:
+
+```text
+read_file(path="README.md", target="local")
+write_file(path="build.txt", content="ready\n", target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+Relative paths use the selected target's own session working directory and FileOperations adapter. Results include resolved `target` and `backend` metadata, plus `cwd` when available. See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for configuration, default, and legacy behavior.
+
 ## `homeassistant` toolset
 
 | Tool | Description | Requires environment |
@@ -170,11 +183,28 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
-| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
+| `terminal` | Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
 | `read_terminal` | Read what's currently shown in the in-app terminal pane of the Hermes desktop GUI (the embedded shell beside this chat). Desktop-app only. | — |
 | `close_terminal` | Close the read-only terminal tab for a background process in the Hermes desktop GUI. Does NOT kill the process — only drops the tab/view; use process(action='kill') to stop it. Desktop-app only. | — |
 | `open_preview` | Open a web URL, localhost dev-server URL, or file path in the preview pane beside the chat in the Hermes desktop app. Desktop-app only. | — |
 | `focus_pane` | Reveal and focus a pane in the Hermes desktop app (chat, files, terminal, review, sessions). Desktop-app only. | — |
+
+### Terminal and code-execution targets
+
+`terminal` and `execute_code` accept an optional static string `target`, for example:
+
+```text
+terminal(command="git status", target="devbox")
+execute_code(code="print('hello')", target="devbox")
+```
+
+Omitting the selector uses `terminal.default_target` when named targets exist. Without named targets, omission and `target="default"` preserve the legacy environment; other names fail. Successful results and approval prompts identify the resolved `target` and `backend`. Background process follow-ups need only their `session_id`; process results retain the spawn target/backend across poll, list, log, wait, and kill. Local checkpointed processes can recover after restart; remote/container handles are reported as unavailable rather than rebound to a different environment.
+
+Saved-output hints can include an opaque `runtime_scope`. Pass it back to `read_file` together with the shown `target`; this pins retrieval to the exact producing environment even if that target alias changes later.
+
+Inside `execute_code`, nested target-aware `hermes_tools` calls inherit and are bound to the script's selected target. A nested call that explicitly selects another target is rejected server-side; start a separate top-level `execute_code` call for cross-target orchestration. Python itself runs on the selected environment, and project mode resolves its cwd from that target's session/config state.
+
+See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for the complete config shape and inheritance rules.
 
 ## `todo` toolset
 
@@ -273,5 +303,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -90,6 +90,19 @@ Scoped to the Feishu document-comment handler. Drives comment read/write operati
 | `search_files` | Search file contents or find files by name. Use this instead of grep/rg/find/ls in terminal. Ripgrep-backed, faster than shell equivalents. Content search (target='content'): Regex search inside files. Output modes: full matches with line… | — |
 | `write_file` | Write content to a file, completely replacing existing content. Use this instead of echo/cat heredoc in terminal. Creates parent directories automatically. OVERWRITES the entire file — use 'patch' for targeted edits. Auto-runs syntax checks on .py/.json/.yaml/.toml and other linted languages; only NEW errors introduced by the write are surfaced. | — |
 
+### File execution targets
+
+`read_file`, `write_file`, and `patch` accept an optional static string `execution_target` selecting a configured `terminal.targets` entry. `search_files` preserves its existing `target="content"|"files"` argument and also uses `execution_target` for environment selection:
+
+```text
+read_file(path="README.md", execution_target="local")
+write_file(path="build.txt", content="ready\n", execution_target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", execution_target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+Relative paths use the selected target's own session working directory and FileOperations adapter. Results include resolved `target` and `backend` metadata, plus `cwd` when available. See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for configuration, default, and legacy behavior.
+
 ## `homeassistant` toolset
 
 | Tool | Description | Requires environment |
@@ -172,7 +185,7 @@ Tools for driving desktop [Projects](../user-guide/cli.md) — named, multi-fold
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
-| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
+| `terminal` | Execute shell commands on the selected execution target (using bash/Linux shell semantics). Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
 
 ## `desktop_ui` toolset
 
@@ -189,6 +202,23 @@ messaging, and cron sessions.
 | `read_window_below` | Identify the OS window directly underneath the Hermes desktop window — app name, title, bounds (metadata only, never pixels). On macOS, other apps' titles appear only when Screen Recording is already granted; the tool never prompts for it. | — |
 | `focus_pane` | Reveal and focus a pane in the Hermes desktop app (chat, files, terminal, review, sessions). | — |
 | `react_to_message` | React to a message with a single emoji, iMessage-tapback style. Opt-in via Settings → Appearance (`display.message_reactions`). | — |
+
+### Terminal and code-execution targets
+
+`terminal` and `execute_code` accept an optional static string `execution_target`, for example:
+
+```text
+terminal(command="git status", execution_target="devbox")
+execute_code(code="print('hello')", execution_target="devbox")
+```
+
+Omitting the selector uses `terminal.default_target` when named targets exist. Without named targets, omission and `execution_target="default"` preserve the legacy environment; other names fail. Successful results and approval prompts identify the resolved `target` and `backend`. Background process follow-ups need only their `session_id`; process results retain the spawn target/backend across poll, list, log, wait, and kill. Local checkpointed processes can recover after restart; remote/container handles are reported as unavailable rather than rebound to a different environment.
+
+Saved-output hints can include an opaque `runtime_scope`. Pass it back to `read_file` together with the shown `execution_target`; this pins retrieval to the exact producing environment even if that target registration changes later.
+
+Inside `execute_code`, nested target-aware `hermes_tools` calls inherit and are bound to the script's selected target. A nested call that explicitly selects another target is rejected server-side; start a separate top-level `execute_code` call for cross-target orchestration. Python itself runs on the selected environment, and project mode resolves its cwd from that target's session/config state.
+
+See [Named Execution Targets](/user-guide/configuration#named-execution-targets) for the complete config shape and inheritance rules.
 
 ## `todo` toolset
 
@@ -287,5 +317,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -135,6 +135,49 @@ terminal:
 
 For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 
+### Named Execution Targets
+
+A single Hermes process can route terminal, file, and Python execution calls to several configured environments. Recognized backend settings under `terminal` are inherited by every target, and target entries can override backend-scoped values such as `backend`, `cwd`, `timeout`, image/resource fields, Docker options, and SSH connection fields. Keep process-wide policy such as shell initialization, environment-passthrough, approval, and code-execution settings at the top level: arbitrary nested keys are not automatically target-aware.
+
+```yaml
+terminal:
+  timeout: 180
+  container_memory: 5120
+  default_target: local
+  targets:
+    local:
+      backend: local
+      cwd: /workspace/local
+    devbox:
+      backend: ssh
+      ssh_host: devbox.example.com
+      ssh_user: bruno
+      cwd: /home/bruno/project
+```
+
+When `targets` is non-empty, a tool call with no selector uses `default_target`. The default must name an entry; invalid defaults and unknown explicit names fail with an error listing the available names. Target names are arbitrary non-empty strings.
+
+The tools use fixed string parameters so changing config does not change the model tool schema:
+
+```text
+terminal(command="git status", target="devbox")
+read_file(path="README.md", target="local")
+write_file(path="notes.txt", content="...", target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", target="devbox")
+execute_code(code="print('hello')", target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+`search_files` is the compatibility exception: its existing `target` argument still selects `content` or `files` search mode, while `execution_target` selects the named environment. A target's terminal and file operations share the same environment and per-session working directory. A `cd` on one target does not change another target; an explicit `workdir` on a terminal call still wins.
+
+Background process follow-up actions remain keyed only by `session_id`. Process start, list, poll, log, wait, kill, and checkpoint results expose the selected `target` and `backend`. Local background processes can be recovered from checkpoints after a Hermes restart; remote/container process handles are currently reported as unavailable after restart rather than silently attaching to a newly created environment. Successful terminal/file/code-execution results expose target metadata (and `cwd` when available). The system prompt lists configured names and marks the default without changing tool schemas.
+
+Command and execute-code approval prompts identify the resolved target/backend. Session and UI-created permanent pattern approvals are scoped to the target's profile/name/effective configuration, so approving a command on one host does not silently authorize the same pattern after that target name is repointed. Explicit entries an operator writes in the global `approvals.command_allowlist` remain global by design. An `execute_code` RPC session is bound to its outer target and effective configuration: nested terminal/file calls inherit that target, cannot pivot to another one, and fail closed if the alias is repointed while the script is running.
+
+If `targets` is absent or empty, Hermes preserves the existing flat config and environment-variable behavior exactly. In that legacy mode, omitted `target` and `target="default"` select the existing environment; every other explicit name is an error. Environment variables remain the legacy single-backend interface and do not select named targets. In named mode Hermes mirrors the resolved default target into `TERMINAL_*` for older internal consumers, but explicit tool selection still comes only from `target` / `execution_target`. Once an entry point reloads or updates its effective configuration, new calls create a replacement environment for any changed target; already-running operations and background sessions remain bound to the environment in which they started. The classic interactive CLI snapshots its merged configuration at startup, so restart that CLI after editing `config.yaml`; runtime replacement is not a promise of automatic disk watching. A persistent named Docker runtime is replaced only when no other logical turn, tool call, or process is using its shared storage; the replacing call's own nested leases do not block it. Retirement is transactional and fail-closed, so a failed container removal retains the prior runtime identity and returns an actionable retry error instead of publishing a replacement. Its separate stable profile/target storage identity keeps persistent home/workspace data across policy, timeout, or image changes.
+
+Target entries are validated strictly before environment creation. Unknown, misspelled, backend-inapplicable, malformed, or missing required settings return an error naming the target and field; documented top-level compatibility and policy fields remain supported.
+
 ### Backend Overview
 
 | Backend | Where commands run | Isolation | Best for |
@@ -295,7 +338,7 @@ Parallel subagents spawned via `delegate_task(tasks=[...])` share this one conta
 
 #### Environment variable overrides
 
-Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_UPPERCASE>`. The most useful ones for the Docker backend:
+Legacy single-backend terminal settings have `TERMINAL_*` environment-variable overrides. Named `default_target` / `targets` selection is config-only; environment variables do not switch targets. The most useful Docker overrides are:
 
 | Env var | Maps to | Notes |
 |---|---|---|

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -153,6 +153,122 @@ terminal:
 
 For cloud sandboxes such as Modal, Daytona, and Vercel Sandbox, `container_persistent: true` means Hermes will try to preserve filesystem state across sandbox recreation. It does not promise that the same live sandbox, PID space, or background processes will still be running later.
 
+### Named Execution Targets
+
+A single Hermes process can route terminal, file, and Python execution calls to several configured environments. Recognized backend settings under `terminal` are inherited by every target, and target entries can override backend-scoped values such as `backend`, `cwd`, `timeout`, image/resource fields, Docker options, and SSH connection fields. Keep process-wide policy such as shell initialization, environment-passthrough, approval, and code-execution settings at the top level: arbitrary nested keys are not automatically target-aware.
+
+```yaml
+terminal:
+  timeout: 180
+  container_memory: 5120
+  default_target: local
+  targets:
+    local:
+      backend: local
+      cwd: /workspace/local
+    devbox:
+      backend: ssh
+      ssh_host: devbox.example.com
+      ssh_user: bruno
+      cwd: /home/bruno/project
+```
+
+When `targets` is non-empty, a tool call with no selector uses `default_target`. The default must name an entry; invalid defaults and unknown explicit names fail with an error listing the available names. Target names are arbitrary non-empty strings.
+
+The tools use fixed string parameters so changing config does not change the model tool schema:
+
+```text
+terminal(command="git status", execution_target="devbox")
+read_file(path="README.md", execution_target="local")
+write_file(path="notes.txt", content="...", execution_target="devbox")
+patch(mode="replace", path="app.py", old_string="old", new_string="new", execution_target="devbox")
+execute_code(code="print('hello')", execution_target="devbox")
+search_files(pattern="TODO", target="content", execution_target="devbox")
+```
+
+`search_files` has a separate `target` argument that selects `content` or `files` search mode, while `execution_target` selects the named environment. A target's terminal and file operations share the same environment and per-session working directory. A `cd` on one target does not change another target; an explicit `workdir` on a terminal call still wins.
+
+Background process follow-up actions remain keyed only by `session_id`. Process start, list, poll, log, wait, kill, and checkpoint results expose the selected `target` and `backend`. Local background processes can be recovered from checkpoints after a Hermes restart; remote/container process handles are currently reported as unavailable after restart rather than silently attaching to a newly created environment. Successful terminal/file/code-execution results expose target metadata (and `cwd` when available). The system prompt lists configured names and marks the default without changing tool schemas.
+
+Command and execute-code approval prompts identify the resolved target/backend. Session and UI-created permanent pattern approvals are scoped to the target's profile/name/effective configuration, so approving a command on one host does not silently authorize the same pattern after that target name is repointed. Explicit entries an operator writes in the global `approvals.command_allowlist` remain global by design. An `execute_code` RPC session is bound to its outer target and effective configuration: nested terminal/file calls inherit that target, cannot pivot to another one, and fail closed if the target name is repointed while the script is running.
+
+If `targets` is absent or empty, Hermes preserves the existing flat config and environment-variable behavior exactly. In that legacy mode, omitted `execution_target` and `execution_target="default"` select the existing environment; every other explicit name is an error. Environment variables remain the legacy single-backend interface and do not select named targets. In named mode Hermes mirrors the resolved default target into `TERMINAL_*` for older internal consumers, but explicit model-facing tool selection uses only `execution_target`. Once an entry point reloads or updates its effective configuration, new calls create a replacement environment for any changed target; already-running operations and background sessions remain bound to the environment in which they started. Static `config.yaml` edits still follow each entry point's normal reload/restart behavior. The provider-fragment registry described below is the explicit no-restart path and is checked at each independent dispatch. A persistent named Docker runtime is replaced only when no other logical turn, tool call, or process is using its shared storage; the replacing call's own nested leases do not block it. Retirement is transactional and fail-closed, so a failed container removal retains the prior runtime identity and returns an actionable retry error instead of publishing a replacement. Its separate stable profile/target storage identity keeps persistent home/workspace data across policy, timeout, or image changes.
+
+Target entries are validated strictly before environment creation. Unknown, misspelled, backend-inapplicable, malformed, or missing required settings return an error naming the target and field; documented top-level compatibility and policy fields remain supported.
+
+### Runtime target registry (no gateway restart)
+
+Static targets in `config.yaml` remain the right choice for durable, hand-managed environments. Controllers for ephemeral compute should publish provider-owned runtime targets with the built-in CLI instead:
+
+```bash
+hermes targets register hetzner-mybox \
+  --backend ssh \
+  --host hetzner-dev-mybox \
+  --user dev \
+  --port 443 \
+  --cwd /workspace \
+  --provider hetzner-devbox \
+  --owner-id mybox \
+  --generation "$SERVER_ID" \
+  --json
+
+hermes targets list --all
+hermes targets show hetzner-mybox --provider hetzner-devbox --json
+hermes targets drain hetzner-mybox --provider hetzner-devbox --if-generation "$SERVER_ID"
+hermes targets remove hetzner-mybox --provider hetzner-devbox --if-generation "$SERVER_ID"
+```
+
+Registration is visible to a long-lived gateway on its next independent tool dispatch; the gateway does not need to restart. One restart is still required when you deploy implementation code that adds this feature beneath an already-running gateway. Runtime discovery does not rewrite the cached system prompt or model tool schemas. The prompt's target inventory is only a startup hint, so the exact `execution_target` returned by `register --json` is the discovery event an agent or controller should use on its next tool call.
+
+Static configuration has precedence and reserves its target names. Runtime providers cannot change `default_target`. If two providers claim the same runtime name, that name fails closed while unrelated static and healthy runtime targets continue working. Use `hermes targets list --all` to see collisions, draining records, and secret-safe provider diagnostics. Malformed, unreadable, insecure, or symlinked fragments make only that provider unavailable; Hermes does not route through indefinitely stale last-known-good data or fall back to a lower-policy default.
+
+Each provider owns its complete versioned fragment at:
+
+```text
+$HERMES_HOME/runtime/execution-targets.d/<provider>.json
+```
+
+A provider fragment uses this schema:
+
+```json
+{
+  "version": 1,
+  "provider": "hetzner-devbox",
+  "targets": {
+    "hetzner-build-17": {
+      "config": {
+        "backend": "ssh",
+        "ssh_host": "hetzner-dev-build-17",
+        "ssh_user": "dev",
+        "ssh_port": 443,
+        "cwd": "/workspace"
+      },
+      "owner_id": "build-17",
+      "generation": "provider-server-or-plan-id",
+      "state": "ready"
+    }
+  }
+}
+```
+
+Providers replace their whole fragment; `state` is `ready` or `draining`. Do not edit a fragment incrementally in place.
+
+The path follows the active profile, including multiplexed profile overrides. Provider names are filename-safe and canonicalized to lowercase everywhere (payloads, filenames, filters, and output). Writes use a bounded cross-process lock plus same-directory atomic replacement, and Hermes creates the directory and files with user-only permissions (`0700` and `0600`) where supported. Each state or provider JSON file is limited to 1 MiB, each provider to 1024 targets, and target config size/nesting/complexity is bounded before copying or backend use. A provider that exceeds a limit is isolated like any other malformed fragment while static and unrelated healthy targets continue working. Fragment records include `version`, `provider`, `owner_id`, `generation`, `state`, and the target `config`. Store SSH aliases and private-key paths only, never private-key contents. CLI JSON and human output expose an allowlisted routing summary rather than arbitrary config values.
+
+`generation` is the compare-and-swap token for an external resource. Registration is idempotent when ownership, generation, state, and effective config are unchanged. Repointing an existing alias requires `--replace`; `--if-generation` can additionally require the exact old generation. Drain and remove also accept `--if-generation`, preventing teardown for server A from disabling or deleting replacement server B.
+
+A legacy flat `terminal:` setup is activated without editing `config.yaml`: before the first provider fragment is published, Hermes atomically writes a small versioned activation marker containing no backend configuration or secrets. While static configuration remains flat, Hermes synthesizes the named `default` target in memory from the current effective static/profile configuration and that scope's legacy environment authority on each dispatch. Shared top-level terminal policy remains inherited, and later config-source updates refresh the default's effective spec and keyed identity. Every durable intermediate state is valid, including a crash between marker and fragment publication. The marker remains after the final runtime target is removed, so named mode and the `default` alias remain active.
+
+For a Hetzner devbox, use this control-plane ordering:
+
+```text
+provision -> publish managed SSH alias -> prove SSH/workspace ready -> register ready target
+
+drain target -> reconcile active/background work -> destroy compute -> CAS-remove exact generation
+```
+
+Draining and removed aliases reject new tool calls. Repointing changes the keyed effective-spec identity used by runtimes, cwd state, checkpoints, and scoped approvals, even when an SSH alias string stays the same but its provider generation changes. A dispatch that already started remains pinned to the generation it resolved. Existing background processes retain their immutable producing-runtime handle and can still be listed, polled, waited on, killed, or cleaned up in the same Hermes process after drain/remove. Remote/container handles still cannot be reattached after a Hermes process restart; the existing checkpoint behavior reports them unavailable instead of attaching to replacement compute.
+
 ### Backend Overview
 
 | Backend | Where commands run | Isolation | Best for |
@@ -315,7 +431,7 @@ Parallel subagents spawned via `delegate_task(tasks=[...])` share this one conta
 
 #### Environment variable overrides
 
-Every key under `terminal:` has an env-var override of the form `TERMINAL_<KEY_UPPERCASE>`. The most useful ones for the Docker backend:
+Legacy single-backend terminal settings have `TERMINAL_*` environment-variable overrides. Named `default_target` / `targets` selection is config-only; environment variables do not switch targets. The most useful Docker overrides are:
 
 | Env var | Maps to | Notes |
 |---|---|---|


### PR DESCRIPTION
## What does this PR do?

Adds named and runtime-registerable execution targets so one Hermes session can route work across local, SSH, Docker, and other configured terminal backends without changing its global backend between calls.

The selected target and immutable runtime generation propagate through terminal commands, file operations, background processes, approvals, delegation, and nested `execute_code` RPC calls. Runtime targets can be registered, replaced, drained, and removed through `hermes targets` without restarting an already-activated gateway.

This is the deliberate, cleaned-up replacement for #67076. It contains one feature commit on pinned upstream base `cf64ca20c5ab99ebf7e8ca272c69edc7ea0636ed` and no unrelated fork commits. The mature feature delta was ported from crosslink-ch/hermes-agent#2 and reconciled against the current upstream behavior on that pinned base.

Related to #1855.

Supersedes #67076.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change)
- [x] ✨ New feature
- [x] 🔒 Security hardening
- [x] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill

## Changes Made

- Add `terminal.default_target` and a fixed-schema `terminal.targets` map while preserving legacy single-backend configuration.
- Standardize the model-facing routing selector as `execution_target` across `terminal`, file tools, `execute_code`, and related wrappers. The unpublished `target` routing alias is not accepted.
- Bind the dispatch-time `execution_target` to the value evaluated by hooks, guardrails, and approvals. Execution middleware may still rewrite ordinary arguments, but cannot replace, inject, remove, or mutate the routing selector after authorization.
- Preserve `search_files.target` exclusively as the `content` / `files` search-mode selector; `search_files.execution_target` selects the backend.
- Add a profile-scoped runtime target registry and lifecycle CLI: `hermes targets register`, `list`, `show`, `drain`, and `remove`.
- Make runtime registration visible to an already-running gateway on the next dispatch while keeping tool schemas and cached prompts stable.
- Freeze one target snapshot per dispatch so authorization, approval, checkpoints, backend construction, execution, nested RPC, and result metadata use the same generation.
- Scope cwd, process sessions, approvals, file state, tool-result persistence, and profile-multiplexed state by immutable runtime identity.
- Add provider ownership, generation compare-and-swap, draining, stale teardown protection, collision isolation, bounded registry reads, atomic publication, and secret-safe JSON output.
- Preserve producing-runtime metadata on background-process error paths.

### Configuration example

```yaml
terminal:
  default_target: local
  timeout: 180
  targets:
    local:
      backend: local
      cwd: /home/me/project
    compute:
      backend: ssh
      ssh_host: compute.example.com
      ssh_port: 22
      ssh_user: agent
      ssh_key: ~/.ssh/compute_ed25519
      cwd: ~/project
```

```python
terminal(command="pytest -q", execution_target="compute")
write_file(path="notes.txt", content="remote\n", execution_target="compute")
search_files(pattern="TODO", target="content", execution_target="compute")
execute_code(code="...", execution_target="compute")
```

Runtime registration example:

```bash
hermes targets register compute \
  --backend ssh \
  --host compute.example.com \
  --user agent \
  --cwd /workspace \
  --provider my-controller \
  --owner-id compute-17 \
  --generation server-17 \
  --json
```

## How to Test

Focused regression gate:

```bash
scripts/run_tests.sh \
  tests/tools/test_execution_targets.py \
  tests/tools/test_named_execution_target_routing.py \
  tests/tools/test_code_execution_named_target.py \
  tests/tools/test_process_target_routing.py \
  tests/tools/test_runtime_execution_target_registry.py \
  tests/tools/test_runtime_execution_target_locking.py \
  tests/tools/test_runtime_execution_target_background.py \
  tests/hermes_cli/test_targets_cli.py
```

Manual route check:

1. Configure one local target and one SSH target.
2. Start Hermes and write the same relative path on each target.
3. Read both files back and confirm the target-specific markers differ.
4. Change cwd on one target and confirm the other target's cwd is unchanged.
5. Start and inspect a background process on the SSH target.
6. Run nested tool calls through `execute_code` and confirm they inherit the selected target.
7. Register a new runtime target from another process and confirm the existing process can use it without a restart.
8. Drain/remove the target and confirm new calls fail while existing background work remains cleanable by immutable runtime identity.

## Author Verification

Verification was performed on exact head `f4fc3be5d1049659c86a760026a48a1243461832` against pinned base `cf64ca20c5ab99ebf7e8ca272c69edc7ea0636ed` on a task-owned Hetzner devbox:

- Changed/affected test matrix: `1,155 passed, 0 failed, 11 Windows-only skips across 35 files`.
- Canonical full Python suite: `34,494 passed, 3 failed, 308 skipped; all 3 failures reproduce identically on the pinned upstream base in untouched files, so 0 candidate-only regressions`.
- Ruff lint, compile, lock, diff, and conflict-marker gates: `passed (whole-repository Ruff lint; 66 changed Python files parsed/compiled; lock, diff, conflict-marker, and public-selector audits)`.
- Production documentation build: `passed (`npm ci && npm run build` with CI-required npm 12 from the frozen archive)`.
- Same-process runtime registration/schema-stability probe: `passed (same-process CLI registration became visible without restart; schemas remained byte-stable; removed alias rejected)`.
- Authorization-binding exploit probe: `passed (29 middleware/dispatch tests; post-authorization alpha-to-beta retargeting rejected before registry dispatch)`.
- Real target-routing acceptance: `passed (real loopback SSH terminal and file round-trip, nested execute_code inheritance, drain/removal, and producing-runtime cleanup)`.
- Independent frozen-candidate integration/security review: `PASS; no blocking findings; frozen provenance, 71-path reconciliation, upstream-overlap seams, selector contract, authorization binding, runtime lifecycle, nested RPC confinement, and background-process metadata independently reverified; no files modified`.

The three full-suite failures are two `tests/test_mcp_serve.py` EventBridge timing/mtime assertions and one `tests/test_hermes_state.py` FTS query-trace assertion. Both files are unchanged by this PR, and all three failures reproduce identically on pristine pinned base `cf64ca20c5ab99ebf7e8ca272c69edc7ea0636ed` under the same locked CI environment.

## Interlock with #82243

#82243 proposes making all internal tools available to `execute_code` rather than only the current bridge subset. This PR remains compatible with the current subset-based bridge. If #82243 lands first, resolve the overlap by preserving its full availability model while retaining this PR's immutable `execution_target` and runtime-generation binding for nested RPC dispatch.
