### PR TITLE
fix(gateway): skip the transformed-response edit on a multi-message split

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25970,8 +25970,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             elif not _is_empty_sentinel and _transformed and _sc is not None:
                 # Plugin hooks transformed the response after streaming — edit the
                 # existing streamed message instead of sending a duplicate.
+                #
+                # Not valid for a multi-message split delivery: there
+                # ``message_id`` is only the LAST chunk, so editing it with the
+                # complete (transformed) response would repeat every sealed head
+                # chunk's text inside the tail message — the same reasoning as
+                # the stale-finalize branch above (#78541). Fall through to the
+                # normal final send instead, which already knows how to deliver
+                # a complete response across a split turn.
                 _sc_msg_id = _sc.message_id
-                if _sc_msg_id:
+                if getattr(_sc, "_turn_split_delivery", False):
+                    logger.info(
+                        "Plugin-transformed response for session %s is on a multi-message split; skipping the in-place edit and delivering the complete response via normal final send (#78541).",
+                        session_key or "?",
+                    )
+                elif _sc_msg_id:
                     try:
                         await _sc.adapter.edit_message(
                             chat_id=source.chat_id,

--- a/tests/gateway/test_stale_finalize_suppression.py
+++ b/tests/gateway/test_stale_finalize_suppression.py
@@ -351,6 +351,132 @@ async def test_payload_less_split_does_not_suppress_complete_response(
     )
 
 
+class TransformedAgent:
+    """Streams a prefix; the completed response is plugin-transformed.
+
+    Models a transform_llm_output hook rewriting the response after
+    streaming finished (e.g. translation, citation-adding) — the
+    ``response_transformed`` flag this sets is read verbatim from the
+    agent's returned dict (gateway/run.py forwards ``result.get(
+    "response_transformed", False)``), so no real plugin is needed to
+    exercise the gateway-boundary branch that reacts to it.
+    """
+
+    def __init__(self, **kwargs):
+        self.stream_delta_callback = kwargs.get("stream_delta_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        if self.stream_delta_callback:
+            self.stream_delta_callback(STREAMED_PREFIX)
+        return {
+            "final_response": FULL_RESPONSE,
+            "response_previewed": False,
+            "response_transformed": True,
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class _TransformedSplitConsumer(GatewayStreamConsumer):
+    """Force the split-delivery shape onto an otherwise normal stream.
+
+    Sibling of ``_PayloadLessSplitConsumer`` above, but exercising the
+    ``_transformed`` branch (plugin-transformed response) rather than the
+    stale-finalize branch: both read the streamed message's
+    ``_turn_split_delivery`` flag before deciding whether an in-place edit
+    is safe.
+    """
+
+    async def run(self):
+        await super().run()
+        self._turn_split_delivery = True
+
+
+@pytest.mark.asyncio
+async def test_transformed_response_on_split_delivery_does_not_repeat_head_chunks(
+    monkeypatch, tmp_path
+):
+    """The _transformed branch must skip its edit on a multi-message split,
+    exactly like the sibling stale-finalize branch already does (#78541).
+
+    Editing ``_sc.message_id`` (only the LAST chunk on a split turn) with the
+    complete transformed text would repeat every sealed head chunk's content
+    inside the tail message. The complete response must instead reach the
+    platform through the normal final send (or, if the gateway does choose to
+    edit, the edited content must not re-embed the streamed prefix that was
+    already sealed into an earlier chunk)."""
+    import yaml
+
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "display": {"tool_progress": "off", "interim_assistant_messages": False},
+                "streaming": {
+                    "enabled": True,
+                    "edit_interval": 0.01,
+                    "buffer_threshold": 1,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = TransformedAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    stream_consumer_mod = importlib.import_module("gateway.stream_consumer")
+    monkeypatch.setattr(
+        stream_consumer_mod, "GatewayStreamConsumer", _TransformedSplitConsumer
+    )
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"}
+    )
+
+    adapter = FinalizeCaptureAdapter()
+    runner = _make_runner(adapter)
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1005",
+        chat_type="group",
+    )
+    result = await runner._run_agent(
+        message="describe this photo",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-transformed-split",
+        session_key="agent:main:telegram:group:-1005",
+    )
+
+    assert result["final_response"] == FULL_RESPONSE
+    # The bug: the pre-fix branch unconditionally edits _sc.message_id with
+    # the complete text and claims already_sent, regardless of split state.
+    # On a split turn that message is only the tail — sent as a SEPARATE
+    # platform message from the already-sealed head chunk(s) — so an edit
+    # carrying the complete (head+tail) text duplicates the head's content
+    # once the two messages are read together, even though the edit's own
+    # content string only contains the prefix once. The fix must skip that
+    # edit and leave delivery to the normal final send instead, exactly like
+    # the sibling stale-finalize branch already does for this flag.
+    full_text_edits = [e for e in adapter.edits if e["content"] == FULL_RESPONSE]
+    assert full_text_edits == [], (
+        "the transformed-response branch must not edit a split-delivery tail "
+        f"message with the complete text: {full_text_edits!r}"
+    )
+    assert not result.get("already_sent"), (
+        "must not claim delivery on a split turn — declining lets the "
+        "caller's normal final send deliver the complete response instead"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Consumer unit coverage: delivered_final_matches tri-state
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `392e3a8c5` (merged today) taught the stale-finalize reconciliation branch in `_run_agent`'s final-delivery block to refuse an in-place edit of `_sc.message_id` when `_sc._turn_split_delivery` is true, because on a split turn `message_id` is only the LAST chunk — editing it with the complete text repeats every sealed head chunk's content once the messages are read together (#78541).
- The very next branch in the same `if`/`elif` chain does the exact same kind of edit for a different trigger (a `transform_llm_output` plugin hook rewrote the response after streaming) but had no `_turn_split_delivery` check at all: a long reply that overflow-splits into a sealed head message plus a tail message, combined with a transform hook that fires per-turn independent of delivery shape, edits the tail with the complete transformed text and reproduces the same defect `392e3a8c5` just fixed one branch above.
- Fix: add the same check, falling through to the normal final send (which already knows how to deliver a complete response across a split turn) instead of editing — mirroring the sibling's log message and reasoning.

## Test plan

- [x] New regression test forcing the split-delivery shape onto a plugin-transformed response (sibling of the existing payload-less-split test for the stale-finalize branch) — asserts no edit call carries the complete response text, and that `already_sent` is left unset so the caller's normal final send delivers it.
- [x] Mutation-verified: fails on pre-fix code with the exact edit the bug produces captured in the assertion failure (`content` == the complete response, `message_id` == the tail chunk).
- [x] Full neighboring suite green: `tests/gateway/test_stale_finalize_suppression.py`, `tests/gateway/test_run_progress_topics.py` — 36 passed.
- [x] `ruff check` clean on changed files.

## Heads up: adjacent PRs in the same branch

Two open PRs touch the same `elif` branch for different, orthogonal bugs: #31900 (checking `SendResult.success` before setting `already_sent`) and #67145 (preserving thread/routing metadata via the consumer's edit helper on a reconnect). Neither adds a `_turn_split_delivery` check; no logical overlap, but a rebase may be needed depending on merge order.