### PR TITLE
fix(skills): search result window keeps per-source diversity (#80176)

### DIFF
--- a/tests/hermes_cli/test_skills_search_diversity.py
+++ b/tests/hermes_cli/test_skills_search_diversity.py
@@ -1,0 +1,110 @@
+"""Regression tests for #80176: skills search must not let one bulk source
+monopolize the visible window.
+
+`hermes skills search <query>` failed to surface results from smaller
+sources (GitHub, LobeHub) whenever a common keyword was used: the
+centralized index is ~76% ClawHub, and the old score-then-truncate
+returned the global top-N, so ClawHub's many matches consumed the whole
+window and other sources' hits never appeared.
+
+The fix: unified_search passes per-source limits (hermes-index gets a
+large limit like browse already does) and round-robin interleaves the
+deduplicated candidates by source before the final limit cut.
+"""
+
+from __future__ import annotations
+
+from tools.skills_hub import SkillMeta, unified_search
+
+
+def _meta(name: str, source: str) -> SkillMeta:
+    return SkillMeta(
+        name=name,
+        description=f"{name} desc",
+        source=source,
+        identifier=f"{source}/{name}",
+        trust_level="community",
+    )
+
+
+class _FakeSource:
+    """Minimal SkillSource stand-in; source_id() is all parallel_search uses."""
+
+    def __init__(self, sid: str, results: list):
+        self._sid = sid
+        self._results = results
+
+    def source_id(self) -> str:
+        return self._sid
+
+    def search(self, query: str, limit: int = 10):
+        return self._results[:limit]
+
+
+def test_bulk_source_does_not_push_small_source_out_of_window():
+    """A bulk source must NOT consume all 10 visible slots.
+
+    Old code: global score-then-truncate gives clawhub 10/10 (it has 30
+    matches, github has 3). New code: round-robin interleaves, so
+    github's top hit appears early and clawhub gets at most ceil(10/2)=5.
+    """
+    clawhub = _FakeSource(
+        "clawhub",
+        [_meta(f"claw-{i}", "clawhub") for i in range(30)],
+    )
+    github = _FakeSource(
+        "github",
+        [_meta(f"gh-{i}", "github") for i in range(3)],
+    )
+
+    results = unified_search(
+        "git",
+        [clawhub, github],
+        source_filter="all",
+        limit=10,
+    )
+
+    sources_in_window = {r.source for r in results}
+    assert "github" in sources_in_window, (
+        "github hits must appear even though clawhub has 10x more matches"
+    )
+    # Round-robin: clawhub gets at most half the window (interleaved 1:1
+    # until github runs out, then clawhub fills the rest).
+    clawhub_count = sum(1 for r in results if r.source == "clawhub")
+    github_count = sum(1 for r in results if r.source == "github")
+    assert clawhub_count <= 8, (
+        "clawhub must not consume nearly all 10 slots; got "
+        f"{clawhub_count}/{clawhub_count + github_count}"
+    )
+    assert github_count >= 2, (
+        "github must get at least 2 slots in a 10-window with 3 hits "
+        f"vs clawhub 30 hits; got {github_count}"
+    )
+    # Round-robin places github's first hit in the first 2 positions.
+    first_github_pos = next(
+        i for i, r in enumerate(results) if r.source == "github"
+    )
+    assert first_github_pos <= 1, (
+        f"github first hit at position {first_github_pos}; round-robin "
+        "must place it in the first 2"
+    )
+
+
+def test_three_sources_all_get_window_representation():
+    """Every source with a match must appear in a 12-slot window."""
+    sources = [
+        _FakeSource("clawhub", [_meta(f"c{i}", "clawhub") for i in range(50)]),
+        _FakeSource("github", [_meta(f"g{i}", "github") for i in range(50)]),
+        _FakeSource("lobehub", [_meta(f"l{i}", "lobehub") for i in range(50)]),
+    ]
+    results = unified_search("x", sources, source_filter="all", limit=12)
+    assert {r.source for r in results} == {"clawhub", "github", "lobehub"}, (
+        "all 3 sources must appear in a 12-slot window"
+    )
+
+
+def test_single_source_still_capped_at_limit():
+    """Single-source case still respects the limit."""
+    clawhub = _FakeSource("clawhub", [_meta(f"c{i}", "clawhub") for i in range(20)])
+    results = unified_search("x", [clawhub], source_filter="all", limit=5)
+    assert len(results) == 5

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -4402,11 +4402,28 @@ def parallel_search_sources(
 
 def unified_search(query: str, sources: List[SkillSource],
                    source_filter: str = "all", limit: int = 10) -> List[SkillMeta]:
-    """Search all sources (in parallel) and merge results."""
+    """Search all sources (in parallel) and merge results.
+
+    Per-source quota: the hermes-index source carries a large per-source
+    limit (browse already does this), and the merged result set is
+    round-robin interleaved by source before the final ``limit`` cut — so
+    a bulk source (ClawHub makes up ~76% of the index) can never starve
+    smaller sources (GitHub, LobeHub) out of the visible window (#80176).
+    """
+    # Large index limit so the score-ranked index search can return enough
+    # candidates for the per-source interleave below; the external-source
+    # limits only matter when the index is unavailable (offline).
+    _PER_SOURCE_LIMIT = {
+        "hermes-index": 1000000,
+        "official": 200, "skills-sh": 200, "well-known": 50,
+        "github": 200, "clawhub": 500,
+        "lobehub": 500, "browse-sh": 500,
+    }
     all_results, _, _ = parallel_search_sources(
         sources,
         query=query,
         source_filter=source_filter,
+        per_source_limits=_PER_SOURCE_LIMIT,
         overall_timeout=30,
     )
 
@@ -4429,4 +4446,22 @@ def unified_search(query: str, sources: List[SkillSource],
             seen[r.identifier] = r
     deduped = list(seen.values())
 
-    return deduped[:limit]
+    # Round-robin by source so no single source monopolizes the visible
+    # window. Keep the overall score ordering within each source (the index
+    # already score-ranked its candidates), but alternate sources on each
+    # pick so a small source's top hit is never pushed out by a bulk
+    # source's 20th-best match.
+    by_source: Dict[str, List[SkillMeta]] = {}
+    for r in deduped:
+        by_source.setdefault(r.source, []).append(r)
+    interleaved: List[SkillMeta] = []
+    while by_source:
+        for sid in list(by_source.keys()):
+            bucket = by_source[sid]
+            if not bucket:
+                del by_source[sid]
+                continue
+            interleaved.append(bucket.pop(0))
+            if not bucket:
+                del by_source[sid]
+    return interleaved[:limit]


### PR DESCRIPTION
## Summary

Fixes #80176: `hermes skills search <query>` failed to surface results from smaller sources (GitHub, LobeHub) for common keywords.

**Root cause**: `unified_search` called `parallel_search_sources` without `per_source_limits` (default 50 per source), and the centralized index (~76% ClawHub) score-ranked and truncated to the global top-N. ClawHub's many matches consumed the whole visible window; GitHub/LobeHub hits were silently dropped. Search diverged from browse, which already raises the index limit (PR #37143).

**Fix**:
1. `unified_search` passes `per_source_limits` (hermes-index gets 1,000,000 like browse; external sources 50-500) so the score-ranked index search returns enough candidates.
2. After dedup, results are **round-robin interleaved by source** before the final `limit` cut — every source with matches gets visible representation, and a bulk source can no longer monopolize the window.

## Verification

- **RED**: 2/3 regression tests fail on pre-fix code (small source starved out of window, 3-source diversity lost)
- **GREEN**: 3/3 pass with the fix
- Ordering within each source is preserved (the index already score-ranks); only the interleave changes which source's hit appears where
