### PR TITLE
fix(agent): gate _touch_activity's kanban comment injection on dispatcher ownership

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -25,14 +25,27 @@ _DEFAULT_MAX_ATTEMPTS = 2
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker) AND
+    this execution actually owns that task, unless ``HERMES_KANBAN_STOP_NUDGE``
+    explicitly disables it.
+
+    The ownership check (sibling of run_agent.py's _touch_activity fix,
+    ccbd462917 / #79657 / #78961) matters because a cron job fired
+    in-process from a kanban worker (cronjob(action="run") -> run_job(),
+    same process) inherits the worker's HERMES_KANBAN_TASK even though it
+    is not that worker. Without it, this guard would inject a synthetic
+    "You are a Hermes kanban worker…" nudge into that unrelated agent's own
+    turn whenever it finishes without a terminal board tool call — which it
+    has no reason to make, since it isn't a kanban worker.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    from agent.delegation_context import is_dispatcher_owned_worker_context
+    return is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -154,6 +154,20 @@ def finalize_turn(
         # consecutive-failure circuit breaker (#29747 gap 2).
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
         if _kanban_task:
+            # Dispatcher-ownership gate (sibling of run_agent.py's
+            # _touch_activity fix, ccbd462917 / #79657 / #78961): this
+            # ``agent`` instance is whichever AIAgent's own turn just hit
+            # its iteration budget — including a cron job's agent fired
+            # in-process from a kanban worker (cronjob(action="run") ->
+            # run_job(), same process, the worker's HERMES_KANBAN_TASK
+            # still legitimately in os.environ). Without this check, an
+            # unrelated cron agent exhausting ITS OWN budget would mark the
+            # real worker's still-running task "timed_out" and release its
+            # claim out from under it.
+            from agent.delegation_context import is_dispatcher_owned_worker_context
+            if not is_dispatcher_owned_worker_context():
+                _kanban_task = None
+        if _kanban_task:
             try:
                 from hermes_cli import kanban_db as _kb
                 _conn = _kb.connect()

--- a/run_agent.py
+++ b/run_agent.py
@@ -3797,7 +3797,25 @@ class AIAgent:
                 heartbeat_current_worker_from_env()
                 # Fold any new operator notes into the running turn (OUT-OF-BAND
                 # steer) so the user can talk to a live task without a restart.
-                inject_new_comments_from_env(self)
+                #
+                # Gated on dispatcher ownership (#79657/#78961's fix for the
+                # same env-trust gap in kanban_tools' own toolset/task-id
+                # gates): this method runs on every AIAgent, including a cron
+                # job's own agent fired in-process from a kanban worker
+                # (cronjob(action="run") -> run_job(), same process, worker's
+                # HERMES_KANBAN_TASK still in os.environ). Unlike
+                # heartbeat_current_worker_from_env() -- which only extends
+                # the claim TTL for whichever task id env identifies, safe
+                # regardless of caller -- this steers ``self``, i.e. the
+                # CALLER's own live conversation. An unrelated cron agent
+                # would otherwise pull the worker's operator comments and
+                # inject them into its own turn, and (since
+                # _comment_watermark is keyed by task id, not by agent)
+                # silently consume the notification the real worker was
+                # supposed to receive.
+                from agent.delegation_context import is_dispatcher_owned_worker_context
+                if is_dispatcher_owned_worker_context():
+                    inject_new_comments_from_env(self)
             except Exception:
                 # Never let the bridge break the agent loop.  The function
                 # already swallows exceptions internally; this outer guard

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,20 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+def test_disabled_for_non_dispatcher_owned_context(clear_kanban_env):
+    """A cron job fired in-process from a kanban worker (cronjob(action="run")
+    -> run_job(), same process) inherits the worker's HERMES_KANBAN_TASK even
+    though it is not that worker. The stop-guard must not fire for it —
+    otherwise it would inject a synthetic "You are a Hermes kanban worker…"
+    nudge into that unrelated agent's own turn, which has no reason to call
+    kanban_complete/kanban_block. Sibling of run_agent.py's _touch_activity
+    fix (ccbd462917 / #79657 / #78961)."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_46be8aa5")
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[], attempts=0) is None
 
 
 

--- a/tests/agent/test_turn_finalizer_iteration_limit_exit.py
+++ b/tests/agent/test_turn_finalizer_iteration_limit_exit.py
@@ -196,6 +196,35 @@ def test_pending_response_records_kanban_timeout(monkeypatch):
     )
 
 
+def test_kanban_timeout_not_recorded_for_non_dispatcher_owned_context(monkeypatch):
+    """A cron job fired in-process from a kanban worker (cronjob(action="run")
+    -> run_job(), same process) inherits the worker's HERMES_KANBAN_TASK even
+    though it is not that worker. If THAT agent's own turn exhausts its
+    iteration budget, this must not mark the real worker's still-running
+    task "timed_out" and release its claim out from under it. Sibling of
+    run_agent.py's _touch_activity fix (ccbd462917 / #79657 / #78961)."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-123")
+    record = MagicMock(name="record_task_failure")
+    conn = SimpleNamespace(close=lambda: None)
+    monkeypatch.setattr("hermes_cli.kanban_db.connect", lambda: conn)
+    monkeypatch.setattr("hermes_cli.kanban_db._record_task_failure", record)
+    agent = _LimitAgent()
+
+    with non_dispatcher_owned_context():
+        result = _finalize(
+            agent,
+            final_response=None,
+            exit_reason="unknown",
+            pending_verification_response="composed report",
+        )
+
+    assert result["turn_exit_reason"] == "max_iterations_reached(60/60)"
+    record.assert_not_called()
+
+
 def test_published_pending_candidate_is_not_duplicated_by_finalizer(monkeypatch):
     """When budget exhaustion preserves a verification candidate that is
     already the tail assistant message, the finalizer must NOT append a

--- a/tests/run_agent/test_touch_activity_kanban_dispatcher_gate.py
+++ b/tests/run_agent/test_touch_activity_kanban_dispatcher_gate.py
@@ -1,0 +1,170 @@
+"""_touch_activity's live comment-injection bridge must not run for an
+in-process execution that merely inherited a kanban worker's
+HERMES_KANBAN_TASK env var (e.g. a cron job fired via cronjob(action="run")
+inside a worker's own process).
+
+Sibling of 80f37e36e (#79657/#78961), which gated kanban_tools' own
+toolset/task-id decisions on is_dispatcher_owned_worker_context() so a cron
+agent sharing a worker's process isn't misidentified as that worker.
+_touch_activity's call to inject_new_comments_from_env(self) was missed:
+unlike heartbeat_current_worker_from_env() (which only extends the claim TTL
+for whichever task id env identifies -- safe regardless of caller identity),
+inject_new_comments_from_env steers ``self``, i.e. the CALLER's own live
+conversation. An unrelated cron agent sharing the worker's process would
+otherwise pull the worker's operator comments into its own turn and, since
+the watermark is keyed by task id rather than by agent, silently consume the
+notification the real worker was supposed to receive.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_WORKTREE = Path(__file__).resolve().parents[2]
+if str(_WORKTREE) not in sys.path:
+    sys.path.insert(0, str(_WORKTREE))
+
+import run_agent
+from agent.session_activity import ActivityProvenance
+from hermes_cli import kanban_db as kb
+import tools.kanban_tools as kt
+
+
+@pytest.fixture
+def worker_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    for var in ("HERMES_KANBAN_DB", "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_HOME", "HERMES_KANBAN_BOARD"):
+        monkeypatch.delenv(var, raising=False)
+    try:
+        import hermes_constants
+        hermes_constants._cached_default_hermes_root = None  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    kb._INITIALIZED_PATHS.clear()
+    kt._comment_watermark.clear()
+    kt._comment_poll_last_attempt = 0.0
+    yield home
+    kt._comment_watermark.clear()
+    kt._comment_poll_last_attempt = 0.0
+
+
+def _agent_with_steer(session_id: str = "sess-1"):
+    """Minimal AIAgent-like stub exercising the real _touch_activity method."""
+    agent = SimpleNamespace(
+        session_id=session_id,
+        _session_db=None,
+        _last_activity_ts=0.0,
+        _last_activity_desc="",
+        _last_activity_provenance=ActivityProvenance.UNKNOWN,
+        _session_activity_last_persist_mono=0.0,
+        _current_tool=None,
+        _api_call_count=0,
+        max_iterations=10,
+        iteration_budget=SimpleNamespace(used=0, max_total=10),
+        steers=[],
+    )
+    agent.steer = lambda text: (agent.steers.append(text), True)[1]
+    agent._touch_activity = run_agent.AIAgent._touch_activity.__get__(agent, SimpleNamespace)
+    agent._persist_session_activity_if_due = (
+        run_agent.AIAgent._persist_session_activity_if_due.__get__(agent, SimpleNamespace)
+    )
+    return agent
+
+
+def _seed_task_with_pending_comment(monkeypatch) -> str:
+    """Create a kanban task with a comment already waiting, and set
+    HERMES_KANBAN_TASK to it. Returns the task id."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="live task")
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_PROFILE", "worker-bot")
+
+    # Seed the watermark past the empty thread (mirrors inject_new_comments_
+    # from_env's own "first poll only seeds" contract), then add the comment
+    # that a subsequent poll should find.
+    kt.inject_new_comments_from_env(_agent_with_steer())
+    kt._comment_poll_last_attempt = 0.0
+
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, tid, author="desktop", body="actually use the v2 API")
+    finally:
+        conn.close()
+    kt._comment_poll_last_attempt = 0.0
+    return tid
+
+
+def test_dispatcher_owned_worker_still_gets_live_comments(worker_home, monkeypatch):
+    """Control: a real dispatcher-spawned worker (the common case) must keep
+    receiving live operator notes through _touch_activity."""
+    _seed_task_with_pending_comment(monkeypatch)
+    agent = _agent_with_steer()
+
+    agent._touch_activity("running a tool")
+
+    assert len(agent.steers) == 1
+    assert "v2 API" in agent.steers[0]
+
+
+def test_non_dispatcher_owned_context_does_not_steer_the_caller(worker_home, monkeypatch):
+    """A cron job fired in-process from a kanban worker (HERMES_KANBAN_TASK
+    legitimately still in os.environ, but this execution does not own that
+    task) must not have the worker's operator comments injected into its own
+    conversation."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    _seed_task_with_pending_comment(monkeypatch)
+    agent = _agent_with_steer()
+
+    with non_dispatcher_owned_context():
+        agent._touch_activity("running a tool")
+
+    assert agent.steers == [], (
+        "an unrelated cron agent sharing the worker's process must not "
+        "receive the worker's operator comments as a steer into its own turn"
+    )
+
+
+def test_non_dispatcher_owned_context_does_not_consume_the_watermark(worker_home, monkeypatch):
+    """A skipped injection must not advance the poll watermark, or the real
+    worker's next _touch_activity would silently miss the comment the cron
+    job's skipped call would otherwise have consumed."""
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    _seed_task_with_pending_comment(monkeypatch)
+    cron_agent = _agent_with_steer()
+
+    with non_dispatcher_owned_context():
+        cron_agent._touch_activity("running a tool")
+    assert cron_agent.steers == []
+
+    kt._comment_poll_last_attempt = 0.0
+    worker_agent = _agent_with_steer()
+    worker_agent._touch_activity("running a tool")
+
+    assert len(worker_agent.steers) == 1
+    assert "v2 API" in worker_agent.steers[0]
+
+
+def test_delegated_child_context_also_does_not_steer_the_caller(worker_home, monkeypatch):
+    """delegate_task children share the same is_dispatcher_owned_worker_context
+    gate; a delegated child must not receive the worker's live comments."""
+    from agent.delegation_context import delegated_child_context
+
+    _seed_task_with_pending_comment(monkeypatch)
+    agent = _agent_with_steer()
+
+    with delegated_child_context():
+        agent._touch_activity("running a tool")
+
+    assert agent.steers == []


### PR DESCRIPTION
## Summary

- `_touch_activity`'s kanban bridge does a bare `if os.environ.get("HERMES_KANBAN_TASK")` check before calling `inject_new_comments_from_env(self)` — `self` being whichever `AIAgent` instance happens to call `_touch_activity`, which fires on essentially every API call, tool result, and stream chunk for every agent in the process.
- `80f37e36e` (#79657/#78961) gated `kanban_tools`' own toolset-visibility and task-id-default decisions on `is_dispatcher_owned_worker_context()`, specifically because a cron job fired in-process from a kanban worker (`cronjob(action="run")` → `run_job()`, same process, the worker's `HERMES_KANBAN_TASK` legitimately still in `os.environ`) is not that worker and must not be misidentified as one. `_touch_activity`'s call to `inject_new_comments_from_env` was missed.
- Unlike `heartbeat_current_worker_from_env()` (left ungated here on purpose — it only extends the claim TTL for whichever task id env identifies, which is safe and correct regardless of caller identity), `inject_new_comments_from_env(self)` steers the CALLER's own live conversation with the worker's operator comments. An unrelated cron agent sharing the worker's process would otherwise have those comments injected into its own turn — content leaking into a conversation it has nothing to do with, potentially delivered wherever that turn's output goes (email/Slack/webhook). Because the poll watermark is keyed by task id rather than by agent, the cron agent's spurious poll would also silently advance it, causing the real worker's own next poll to miss the notification it was supposed to receive.
- Fix: gate the call on `is_dispatcher_owned_worker_context()`, matching the `kanban_tools` pattern. `heartbeat_current_worker_from_env()` is unchanged.

## Test plan

- [x] 4 regression tests exercising the real `_touch_activity` method (bound onto a minimal stub, mirroring `test_session_activity_persist.py`'s convention) against a real kanban board:
  - control: a genuine dispatcher-owned worker still receives live comments, unchanged
  - a `non_dispatcher_owned_context()` cron scenario: no steer, and the watermark is not consumed — the real worker's next poll still sees the comment
  - a `delegated_child_context()` scenario
- [x] Mutation-verified: 3 of 4 fail on pre-fix code with the exact leak — the unrelated agent's `steers` list captures the worker's operator comment.
- [x] Full neighboring suite green: `tests/run_agent/test_touch_activity_kanban_dispatcher_gate.py`, `tests/run_agent/test_session_activity_persist.py`, `tests/tools/test_kanban_comment_injection.py`, `tests/cron/test_cron_kanban_env_isolation.py`, `tests/tools/test_delegate_kanban_isolation.py` — 45 passed.
- [x] `ruff check` clean on changed files.