### PR TITLE
fix(desktop): repair Feishu setup guide link

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7734,7 +7734,7 @@ _PLATFORM_OVERRIDES: dict[str, dict[str, Any]] = {
     "feishu": {
         "name": "Feishu / Lark",
         "description": "Use Hermes inside Feishu / Lark.",
-        "docs_url": "https://open.feishu.cn/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/intro",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/feishu/",
         "env_vars": (
             "FEISHU_APP_ID",
             "FEISHU_APP_SECRET",

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1113,6 +1113,21 @@ class TestWebServerEndpoints:
         assert "GATEWAY_PROXY_URL" in _MESSAGING_KEYS_PAGE_KEYS
 
 
+    def test_feishu_setup_guide_points_to_hermes_docs(self):
+        """Keep the Feishu setup link on the maintained Hermes guide.
+
+        The former Feishu API reference URL was removed upstream and rendered
+        as a 404 from the Desktop Messaging page.
+        """
+        from hermes_cli.web_server import _build_catalog_entry
+
+        feishu = _build_catalog_entry("feishu")
+
+        assert feishu["docs_url"] == (
+            "https://hermes-agent.nousresearch.com/docs/user-guide/messaging/feishu/"
+        )
+
+
 
     def test_model_set_maps_unknown_vendor_to_aggregator(self, monkeypatch):
         """A bare vendor name from analytics rows (no billing_provider) is not


### PR DESCRIPTION
## Summary

- point the Desktop Messaging Feishu / Lark setup guide at Hermes' maintained documentation
- add a regression test for the Feishu catalog URL

The previous Feishu API reference document was removed upstream. Its Markdown endpoint returns `This document is not found`, so the Desktop button rendered a 404 after the Feishu SPA loaded.

## Testing

- `uv run --extra dev pytest tests/hermes_cli/test_web_server.py -q` (136 passed, 4 skipped)
- `python scripts/check-windows-footguns.py --diff origin/main`
- verified the replacement URL responds with HTTP 200