### PR TITLE
feat(memory): raise default memory_char_limit and user_char_limit (refs #5320)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -689,8 +689,8 @@ memory:
   user_profile_enabled: true
   
   # Character limits (~2.75 chars per token, model-independent)
-  memory_char_limit: 2200   # ~800 tokens
-  user_char_limit: 1375     # ~500 tokens
+  memory_char_limit: 8800   # ~3200 tokens
+  user_char_limit: 5500     # ~2000 tokens
 
   # Periodic memory nudge: remind the agent to consider saving memories
   # every N user turns. Set to 0 to disable. Only active when memory is enabled.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1653,8 +1653,8 @@ DEFAULT_CONFIG = {
         #                     /memory reject <id>.
         # To disable memory entirely, use memory_enabled: false instead.
         "write_approval": False,
-        "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
-        "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
+        "memory_char_limit": 8800,   # ~3200 tokens at 2.75 chars/token
+        "user_char_limit": 5500,     # ~2000 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
         # Set to a provider name to activate: "openviking", "mem0",
         # "hindsight", "holographic", "retaindb", "byterover".

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -165,7 +165,7 @@ TIPS = [
     # --- Memory ---
     "Memory is a frozen snapshot — changes appear in the system prompt only at next session start.",
     "Memory entries are automatically scanned for prompt injection and exfiltration patterns.",
-    "The agent has two memory stores: personal notes (~2200 chars) and user profile (~1375 chars).",
+    "The agent has two memory stores: personal notes (~8800 chars) and user profile (~5500 chars).",
     "Corrections you give the agent (\"no, do it this way\") are often auto-saved to memory.",
 
     # --- Skills ---

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -131,8 +131,8 @@ def test_load_on_disk_store_honors_configured_char_limits(hermes_home, monkeypat
 
     monkeypatch.setattr("hermes_cli.config.load_config", _boom)
     fallback = load_on_disk_store()
-    assert fallback.memory_char_limit == 2200
-    assert fallback.user_char_limit == 1375
+    assert fallback.memory_char_limit == 8800
+    assert fallback.user_char_limit == 5500
 
 
 # ---------------------------------------------------------------------------

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -162,7 +162,7 @@ class MemoryStore:
     # turn to budget exhaustion and suppress the user's reply (issue #42405).
     _MAX_CONSOLIDATION_FAILURES_PER_TURN = 3
 
-    def __init__(self, memory_char_limit: int = 2200, user_char_limit: int = 1375):
+    def __init__(self, memory_char_limit: int = 8800, user_char_limit: int = 5500):
         self.memory_entries: List[str] = []
         self.user_entries: List[str] = []
         self.memory_char_limit = memory_char_limit
@@ -889,8 +889,8 @@ def load_on_disk_store() -> "MemoryStore":
     Falls back to the built-in defaults if config can't be loaded, so this can
     never raise on a missing/unreadable config.
     """
-    memory_char_limit = 2200
-    user_char_limit = 1375
+    memory_char_limit = 8800
+    user_char_limit = 5500
     try:
         from hermes_cli.config import load_config
 


### PR DESCRIPTION
Supersedes #5323 — fresh branch addressing all review feedback from teknium1 and GottZ triage.

## Problem
Default memory limits (2200/1375 chars) were sized for 8k-context models. Current models routinely have 125k+ context, causing MemoryStore.add() to reject writes quickly on long-running sessions.

## Change
Raise defaults to 4x current values across **all runtime fallback paths**:
- `memory_char_limit`: 2200 → 8800 (~3200 tokens)
- `user_char_limit`: 1375 → 5500 (~2000 tokens)

## Files updated
- `hermes_cli/config_defaults.py` — canonical defaults
- `tools/memory_tool.py` — `__init__` constructor + no-agent fallback
- `cli-config.yaml.example` — sample config + token comments
- `hermes_cli/tips.py` — user-facing tip text

This addresses the remaining review concerns from #5323: all built-in fallbacks, sample config, and tip text are now aligned.

Refs #5320