### PR TITLE
fix(agent): clamp reasoning effort ultra/max to high for non-gpt-5.6 providers

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -80,12 +80,18 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
     """Return the model's wire-compatible reasoning config."""
     if not isinstance(reasoning_config, dict):
         return reasoning_config
-    if (
-        "gpt-5.6" in (model or "").lower()
-        and str(reasoning_config.get("effort") or "").strip().lower() == "ultra"
-    ):
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    if "gpt-5.6" in (model or "").lower():
+        # gpt-5.6 accepts ``max`` as its strongest effort level.
+        if effort == "ultra":
+            normalized = dict(reasoning_config)
+            normalized["effort"] = "max"
+            return normalized
+    elif effort in {"ultra", "max"}:
+        # Custom OpenAI-compatible providers only accept low/medium/high;
+        # clamp unsupported levels so the request is not rejected (HTTP 422).
         normalized = dict(reasoning_config)
-        normalized["effort"] = "max"
+        normalized["effort"] = "high"
         return normalized
     return reasoning_config
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -39,6 +39,27 @@ class TestChatCompletionsBasic:
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
 
 
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("ultra", "high"),
+            ("max", "high"),
+        ],
+    )
+    def test_custom_provider_ultra_clamped_to_high(self, effort, expected):
+        """Custom OpenAI-compatible providers that only accept low/medium/high
+        reject ``ultra``/``max`` with HTTP 422 'unknown variant'; clamp them to
+        ``high`` while preserving the rest of the config (#80242)."""
+        from agent.transports.chat_completions import _reasoning_config_for_model
+
+        original = {"enabled": True, "effort": effort}
+        result = _reasoning_config_for_model("agnes-2.5-flash", original)
+        assert result == {"enabled": True, "effort": expected}
+        assert result is not original
+        # Input dict is never mutated.
+        assert original["effort"] == effort
+
+
     def test_convert_messages_no_codex_leaks(self, transport):
         msgs = [{"role": "user", "content": "hi"}]
         result = transport.convert_messages(msgs)


### PR DESCRIPTION
## Summary

Fixes #80242 — custom OpenAI-compatible providers that only accept `low`/`medium`/`high` reasoning efforts crash with HTTP 422 (`reasoning_effort: unknown variant 'ultra'`) when `reasoning_effort` is set to `ultra` (e.g. via `/reasoning ultra`).

## Root Cause

`_reasoning_config_for_model` in `agent/transports/chat_completions.py` only normalized the effort for `gpt-5.6` models (ultra → max). For every other model it passed the effort value through verbatim, so unsupported levels like `ultra` leaked to providers that reject them.

## Change

- `agent/transports/chat_completions.py`: for non-gpt-5.6 models, clamp `ultra`/`max` effort to `high` (the strongest level those providers accept). The gpt-5.6 behavior (ultra → max) is preserved unchanged, and the original reasoning config dict is never mutated (a copy is returned only when normalization applies).
- `tests/agent/transports/test_chat_completions.py`: added parametrized test `test_custom_provider_ultra_clamped_to_high` covering ultra → high and max → high for a non-gpt-5.6 model, including a no-mutation check. The existing `test_gpt56_ultra_uses_max_wire_effort` regression test still passes.

## Verification

```
$ python -m pytest tests/agent/transports/test_chat_completions.py -q
47 passed in 1.74s
```

Self-check from the issue also passes:

```python
from agent.transports.chat_completions import _reasoning_config_for_model

# Custom provider: ultra → high
r = _reasoning_config_for_model("agnes-2.5-flash", {"effort": "ultra"})
assert r["effort"] == "high"

# gpt-5.6: ultra still → max
r = _reasoning_config_for_model("gpt-5.6", {"effort": "ultra"})
assert r["effort"] == "max"
```

## Closes

Closes #80242
