### PR TITLE
fix(agent): raise codex stream idle budgets for xAI/Grok reasoning

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -140,6 +140,25 @@ def _is_openai_codex_backend(agent) -> bool:
     )
 
 
+def _is_xai_responses_backend(agent) -> bool:
+    """True when the request targets xAI's Responses API (Grok).
+
+    xAI reuses ``api_mode="codex_responses"`` transport, but its reasoning
+    models legitimately go silent for many minutes between SSE frames while
+    thinking. The hang-recovery watchdogs tuned for chatgpt.com/codex must
+    not apply those aggressive defaults here.
+    """
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    hostname = str(getattr(agent, "_base_url_hostname", "") or "").strip().lower()
+    if not hostname:
+        base_url = str(getattr(agent, "base_url", "") or "").strip().lower()
+        if "://" in base_url:
+            hostname = base_url.split("://", 1)[1].split("/", 1)[0]
+        else:
+            hostname = base_url.split("/", 1)[0]
+    return provider in {"xai", "xai-oauth"} or hostname == "api.x.ai"
+
+
 def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     """Minimum wall-clock stale timeout for openai-codex by estimated context.
 
@@ -829,11 +848,23 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS (0 disables each).
     _codex_watchdog_enabled = agent.api_mode == "codex_responses"
     _openai_codex_backend = _is_openai_codex_backend(agent)
+    _xai_responses_backend = _is_xai_responses_backend(agent)
     _est_tokens_for_codex_watchdog = estimate_request_context_tokens(api_kwargs)
     if _codex_watchdog_enabled and _openai_codex_backend:
         _codex_floor = openai_codex_stale_timeout_floor(_est_tokens_for_codex_watchdog)
         if _codex_floor:
             _stale_timeout = max(_stale_timeout, _codex_floor)
+    elif _codex_watchdog_enabled and _xai_responses_backend:
+        # Grok reasoning regularly spends several minutes in silent prefill /
+        # chain-of-thought before the next SSE frame. Raise the wall-clock
+        # stale floor so the non-stream detector doesn't abort healthy turns
+        # while the event-idle watchdog (below) uses its own xAI budget.
+        if _est_tokens_for_codex_watchdog > 100_000:
+            _stale_timeout = max(_stale_timeout, 1800.0)
+        elif _est_tokens_for_codex_watchdog > 10_000:
+            _stale_timeout = max(_stale_timeout, 1200.0)
+        else:
+            _stale_timeout = max(_stale_timeout, 900.0)
 
     # ── Codex absolute hard ceiling (#64507) ──────────────────────────
     # ``openai_codex_stale_timeout_floor`` *raises* the stale timeout (up to
@@ -850,15 +881,33 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # requests — it is a backstop against unbounded growth, not a tighter
     # limit. Tunable via HERMES_CODEX_HARD_TIMEOUT_SECONDS (set to 0 to
     # disable the ceiling entirely; that restores the pre-fix behavior).
-    _codex_hard_timeout = _env_float("HERMES_CODEX_HARD_TIMEOUT_SECONDS", 1500.0)
+    # xAI documents multi-hour client timeouts for reasoning models; use a
+    # higher default ceiling there so we don't clip long healthy Grok turns.
+    _codex_hard_timeout_default = 3600.0 if _xai_responses_backend else 1500.0
+    _codex_hard_timeout = _env_float(
+        "HERMES_CODEX_HARD_TIMEOUT_SECONDS", _codex_hard_timeout_default
+    )
     if (
         _codex_watchdog_enabled
-        and _openai_codex_backend
+        and (_openai_codex_backend or _xai_responses_backend)
         and _codex_hard_timeout > 0
     ):
         _stale_timeout = min(_stale_timeout, _codex_hard_timeout)
 
-    if _est_tokens_for_codex_watchdog > 100_000:
+    if _xai_responses_backend:
+        # OpenAI-Codex hang defaults (12–180s) false-positive-kill healthy
+        # Grok streams during long silent reasoning after the first SSE
+        # frame — the exact "no SSE events for 120s after first byte" error.
+        # xAI's own SDK examples set client timeout to 3600s for reasoning.
+        if _est_tokens_for_codex_watchdog > 100_000:
+            _codex_idle_timeout_default = 900.0
+        elif _est_tokens_for_codex_watchdog > 50_000:
+            _codex_idle_timeout_default = 720.0
+        elif _est_tokens_for_codex_watchdog > 10_000:
+            _codex_idle_timeout_default = 600.0
+        else:
+            _codex_idle_timeout_default = 300.0
+    elif _est_tokens_for_codex_watchdog > 100_000:
         _codex_idle_timeout_default = 180.0
     elif _est_tokens_for_codex_watchdog > 50_000:
         _codex_idle_timeout_default = 120.0
@@ -874,8 +923,10 @@ def interruptible_api_call(agent, api_kwargs: dict):
     # clear normal backend admission / prompt prefill, short enough to still
     # reconnect promptly when the socket is genuinely wedged. Set
     # HERMES_CODEX_TTFB_TIMEOUT_SECONDS=0 to disable this watchdog entirely.
+    # xAI reasoning prefill is slower; default higher there.
     _ttfb_enabled = _codex_watchdog_enabled
-    _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", 120.0)
+    _ttfb_default = 300.0 if _xai_responses_backend else 120.0
+    _ttfb_timeout = _env_float("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", _ttfb_default)
     if _ttfb_timeout <= 0:
         _ttfb_enabled = False
     elif _openai_codex_backend:
@@ -909,6 +960,11 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 _ttfb_cap,
                 f"{_est_tokens_for_codex_watchdog:,}",
             )
+            _ttfb_timeout = _ttfb_cap
+    elif _xai_responses_backend:
+        # Don't clamp xAI TTFB back down to the openai-codex 120s cap.
+        _ttfb_cap = _env_float("HERMES_CODEX_TTFB_MAX_SECONDS", 600.0)
+        if _ttfb_cap > 0 and _ttfb_timeout > _ttfb_cap:
             _ttfb_timeout = _ttfb_cap
 
     _codex_idle_enabled = _codex_watchdog_enabled

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -347,5 +347,94 @@ def test_large_codex_request_hard_ceiling_reclaims_silent_stall(tmp_path, monkey
         stop["flag"] = True
 
 
+def test_is_xai_responses_backend_detection():
+    from agent import chat_completion_helpers as h
+
+    assert h._is_xai_responses_backend(
+        SimpleNamespace(provider="xai-oauth", _base_url_hostname="api.x.ai", base_url="")
+    )
+    assert h._is_xai_responses_backend(
+        SimpleNamespace(provider="xai", _base_url_hostname="", base_url="https://api.x.ai/v1")
+    )
+    assert not h._is_xai_responses_backend(
+        SimpleNamespace(
+            provider="openai-codex",
+            _base_url_hostname="chatgpt.com",
+            base_url="https://chatgpt.com/backend-api/codex",
+        )
+    )
 
 
+def test_xai_stream_survives_openai_codex_120s_event_idle(tmp_path, monkeypatch):
+    """Grok can go silent for minutes after the first SSE frame while reasoning.
+
+    The OpenAI-Codex event-idle budget (12–180s, often 120s) must not kill
+    healthy xAI streams. Regression for:
+    'Codex stream produced no SSE events for 120s after first byte'.
+    """
+    from agent import chat_completion_helpers as h
+
+    # Ensure code defaults apply (user env overrides would hide the bug/fix).
+    for key in (
+        "HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS",
+        "HERMES_CODEX_TTFB_TIMEOUT_SECONDS",
+        "HERMES_CODEX_TTFB_MAX_SECONDS",
+        "HERMES_CODEX_HARD_TIMEOUT_SECONDS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    agent.provider = "xai-oauth"
+    agent.model = "grok-4.5"
+    agent.base_url = "https://api.x.ai/v1"
+    agent._base_url_hostname = "api.x.ai"
+    agent._base_url_lower = "https://api.x.ai/v1"
+    # Keep wall stale high so only the event-idle path could fire.
+    monkeypatch.setattr(agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 3600.0)
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    real_time = time.time
+    t0 = real_time()
+
+    def accelerated_time():
+        # ~50x realtime so a few wall seconds cover >120s of watchdog clock.
+        return t0 + (real_time() - t0) * 50.0
+
+    monkeypatch.setattr(h.time, "time", accelerated_time)
+
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        # First byte arrives immediately, then silence past the old 120s budget.
+        agent._codex_stream_last_event_ts = h.time.time()
+        if on_first_delta:
+            on_first_delta()
+        deadline = real_time() + 3.2  # ~160s accelerated
+        while real_time() < deadline and not agent._interrupt_requested:
+            time.sleep(0.02)
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    # ~50k+ estimated tokens → old openai-codex idle default was 120s;
+    # xAI path must use a much higher budget and complete successfully.
+    large_input = "x" * 220_000
+    resp = h.interruptible_api_call(
+        agent, {"model": "grok-4.5", "input": large_input}
+    )
+    assert resp is sentinel
+    assert "codex_stream_idle_kill" not in closes
+    assert "codex_ttfb_kill" not in closes


### PR DESCRIPTION
## Summary
- xAI/Grok uses `api_mode=codex_responses`, so OpenAI-Codex hang-recovery watchdogs were applied to Grok streams.
- Those defaults (often **120s event-idle after first byte**) false-positive kill healthy Grok reasoning turns that go silent between SSE frames.
- Detect xAI backends (`xai` / `xai-oauth` / `api.x.ai`) and raise idle / TTFB / hard-timeout budgets; leave OpenAI-Codex budgets unchanged.
- Add regression tests for backend detection and the 120s idle false-kill case.

## Symptom
```
Codex stream produced no SSE events for 120s after first byte (threshold: 120s)
```
Observed on xAI OAuth / Grok during long tool+reasoning turns.

## Test plan
- [x] `pytest tests/agent/test_codex_ttfb_watchdog.py` → 10 passed
- [ ] Manual: long Grok reasoning/tool turn no longer dies at 120s idle after first SSE frame
- [ ] Manual: openai-codex hang recovery still reconnects on truly stalled streams