### PR TITLE
fix(desktop): pinned sessions stay in their project group in grouped sidebar (#80013)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -701,16 +701,18 @@ export function ChatSidebar({
 
     // The live-session overlay (creates/evictions) is applied per-repo in
     // RepoFlatSection, AFTER the visual git-worktree lanes are merged in (so
-    // out-of-tree worktrees can be placed). Here we just order the snapshot and
-    // drop pinned rows — the hydrated lanes come straight from the backend, so
-    // they haven't been through projectModel's filter.
+    // out-of-tree worktrees can be placed). Here we just order the snapshot —
+    // the hydrated lanes come straight from the backend, so they haven't been
+    // through projectModel's filter. Pinned sessions stay in their project
+    // group (#80013): pinning adds a Pinned-section accelerator, it does not
+    // remove the session from the project tree.
     // The label comes from the overview node either way — that's the model's
     // presentation copy (Home is translated there), not the raw payload's.
     return excludeProjectSessions(
       { ...hydrated, label: overviewEnteredProject.label, repos: orderRepos(hydrated.repos) },
-      isPinnedSession
+      () => false
     )
-  }, [overviewEnteredProject, enteredProjectTree, orderRepos, isPinnedSession])
+  }, [overviewEnteredProject, enteredProjectTree, orderRepos])
 
   // Overlay live `$sessions` onto the entered project so a just-created session
   // (which the backend snapshot hasn't folded in yet) counts as content and

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -115,6 +115,7 @@ import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
+  KEEP_ALL_PROJECT_SESSIONS,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -621,7 +622,10 @@ export function ChatSidebar({
             label: project.isNoProject ? s.projects.home : project.label,
             repos: orderRepos(project.repos)
           },
-          isPinnedSession
+          // Pinned sessions stay in their project group (#80013): pinning
+          // adds a Pinned-section accelerator, it does not remove the
+          // session from the project tree. Same contract as the drill-in.
+          KEEP_ALL_PROJECT_SESSIONS
         )
       ),
       activeProjectId
@@ -638,7 +642,6 @@ export function ChatSidebar({
     orderRepos,
     activeProjectId,
     projectOrderIds,
-    isPinnedSession,
     s
   ])
 
@@ -710,7 +713,7 @@ export function ChatSidebar({
     // presentation copy (Home is translated there), not the raw payload's.
     return excludeProjectSessions(
       { ...hydrated, label: overviewEnteredProject.label, repos: orderRepos(hydrated.repos) },
-      () => false
+      KEEP_ALL_PROJECT_SESSIONS
     )
   }, [overviewEnteredProject, enteredProjectTree, orderRepos])
 

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -12,6 +12,7 @@ export { ProjectMenu } from './project-menu'
 export { SidebarWorkspaceGroup } from './workspace-group'
 export {
   excludeProjectSessions,
+  KEEP_ALL_PROJECT_SESSIONS,
   overlayLiveLanes,
   overlayLivePreviews,
   sessionRecency,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -964,4 +964,33 @@ describe('excludeProjectSessions', () => {
 
     expect(overlaid.repos[0].groups.map(g => g.id)).toEqual(['wt'])
   })
+
+  it('a never-matching filter keeps pinned sessions in their project group (#80013)', () => {
+    // The sidebar no longer passes isPinnedSession to the project-tree filter:
+    // pinning ADDS a Pinned-section accelerator, it does not remove the
+    // session from its project group. The flat recents list keeps its own
+    // pinned exclusion.
+    const pinnedRow = makeSession('/www/app', { id: 'pinned', pinned: true } as never)
+
+    const project = projectNode({
+      id: '/www/app',
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [lane({ id: 'main', isMain: true, label: 'main', path: '/www/app', sessions: [pinnedRow] })]
+        }
+      ],
+      sessionCount: 1
+    })
+
+    // The project-tree call sites pass () => false (no pinned exclusion).
+    const filtered = excludeProjectSessions(project, () => false)
+
+    expect(filtered.repos[0].groups[0].sessions.map(s => s.id)).toEqual(['pinned'])
+    expect(filtered.repos[0].sessionCount).toBe(1)
+    expect(filtered.sessionCount).toBe(1)
+  })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -6,6 +6,7 @@ import type { ProjectInfo, SessionInfo } from '@/types/hermes'
 import {
   baseName,
   excludeProjectSessions,
+  KEEP_ALL_PROJECT_SESSIONS,
   kanbanWorktreeDir,
   liveSessionProjectId,
   mergeRepoWorktreeGroups,
@@ -937,7 +938,32 @@ describe('excludeProjectSessions', () => {
       sessionCount: 1
     })
 
-    expect(excludeProjectSessions(project, () => false)).toBe(project)
+    expect(excludeProjectSessions(project, KEEP_ALL_PROJECT_SESSIONS)).toBe(project)
+  })
+
+  it('KEEP_ALL_PROJECT_SESSIONS keeps pinned sessions in the project tree', () => {
+    // #80013 contract: both the overview and drill-in pass this predicate so
+    // a pinned session stays in its project group (pinning adds a Pinned
+    // accelerator, it never removes the session from the project tree).
+    const pinnedRow = makeSession('/www/app', { id: 'pinned' })
+
+    const project = projectNode({
+      id: '/www/app',
+      previewSessions: [pinnedRow],
+      repos: [
+        {
+          id: '/www/app',
+          label: 'app',
+          path: '/www/app',
+          sessionCount: 1,
+          groups: [lane({ id: 'main', isMain: true, label: 'main', sessions: [pinnedRow] })]
+        }
+      ],
+      sessionCount: 1
+    })
+
+    expect(excludeProjectSessions(project, KEEP_ALL_PROJECT_SESSIONS)).toBe(project)
+    expect(excludeProjectSessions(project, KEEP_ALL_PROJECT_SESSIONS).repos[0].groups[0].sessions.map(s => s.id)).toEqual(['pinned'])
   })
 
   it('survives the live overlay: a lane left empty by the filter is not pruned', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -627,6 +627,15 @@ function overlayHomeLane(
  * that never had a session. Only the rows move. Memo-stable: returns the same
  * ref when nothing matched.
  */
+
+/**
+ * Pinned sessions stay in their project group (#80013): pinning adds a
+ * Pinned-section accelerator, it does not remove the session from the
+ * project tree. Both the overview and the drill-in pass this predicate so
+ * the two call sites can never diverge.
+ */
+export const KEEP_ALL_PROJECT_SESSIONS = (): boolean => false
+
 export function excludeProjectSessions(
   project: SidebarProjectTree,
   isExcluded: (session: SessionInfo) => boolean


### PR DESCRIPTION
## Summary

Fixes #80013: in the desktop app's grouped (worktree) sidebar view, pinning a session removed it from its project group.

**Root cause**: the sidebar filtered pinned rows out of *every* other list — including the project tree (overview + drill-in both passed `isPinnedSession` to `excludeProjectSessions`). A pinned session only appeared under the global Pinned section, visibly "leaving" its project.

**Fix**: the two project-tree call sites no longer pass `isPinnedSession` — pinning now *adds* a Pinned-section accelerator while the session stays visible in its project group. The flat recents list keeps its exclusion, so a pinned session isn't duplicated between Recents and Pinned. `excludeProjectSessions` itself is unchanged (still used for other predicates).

## Verification

- New unit test pins the no-op contract: a never-matching filter keeps pinned rows and counts in the project subtree
- 56 workspace-groups tests + 108 sidebar tests green; `tsc --noEmit` clean
