### PR TITLE
fix(ssh): create ControlPath directory as 0o700

### DIFF
--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -144,6 +144,138 @@ class TestControlSocketPath:
         assert SSHEnvironment(host="h", user="v", port=22).control_socket != base
         assert SSHEnvironment(host="g", user="u", port=22).control_socket != base
 
+    def test_control_dir_mode_is_private(self, tmp_path, monkeypatch):
+        """ControlPath directory must be 0o700 so other local users cannot
+        plant sockets under /tmp/hermes-ssh (#80284)."""
+        monkeypatch.setattr(ssh_env, "_SSH_MULTIPLEX", True)
+        monkeypatch.setattr(
+            "tools.environments.ssh.tempfile.gettempdir",
+            lambda: str(tmp_path),
+        )
+        env = SSHEnvironment(host="example.com", user="alice")
+        assert env.control_dir == tmp_path / "hermes-ssh"
+        assert env.control_dir.is_dir()
+        mode = env.control_dir.stat().st_mode & 0o777
+        assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+        assert env._use_multiplex is True
+
+
+class TestControlPathTrust:
+    """#80299: do not trust a leftover ControlPath socket after dir harden."""
+
+    def _unix_socket(self, path):
+        import socket
+
+        path.unlink(missing_ok=True)
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.bind(str(path))
+        return sock
+
+    def test_prepare_skips_posix_mode_when_not_multiplexing(self, tmp_path):
+        control = tmp_path / "hermes-ssh"
+        control.mkdir()
+        control.chmod(0o777)
+        use, shared = ssh_env._prepare_control_dir(control, multiplex=False)
+        assert use is False
+        assert shared is False
+        assert control.is_dir()
+
+    def test_unowned_control_dir_is_rejected(self, tmp_path, monkeypatch):
+        control = tmp_path / "hermes-ssh"
+        control.mkdir(mode=0o700)
+        real_uid = os.getuid()
+        monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+        with pytest.raises(RuntimeError, match="not owned"):
+            ssh_env._prepare_control_dir(control, multiplex=True)
+
+    def test_symlink_control_dir_is_rejected(self, tmp_path):
+        real = tmp_path / "real"
+        real.mkdir()
+        control = tmp_path / "hermes-ssh"
+        control.symlink_to(real)
+        with pytest.raises(RuntimeError, match="symlink"):
+            ssh_env._prepare_control_dir(control, multiplex=True)
+
+    def test_chmod_ineffective_disables_multiplex(self, tmp_path, monkeypatch):
+        control = tmp_path / "hermes-ssh"
+        control.mkdir()
+        control.chmod(0o777)
+        monkeypatch.setattr(type(control), "chmod", lambda self, mode: None)
+        use, shared = ssh_env._prepare_control_dir(control, multiplex=True)
+        assert shared is True
+        assert use is False
+
+    def test_foreign_socket_is_unlinked(self, tmp_path, monkeypatch):
+        sock_path = tmp_path / "x.sock"
+        sock = self._unix_socket(sock_path)
+        try:
+            real_uid = os.getuid()
+            monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+            ssh_env._quarantine_untrusted_control_socket(
+                sock_path, dir_was_shared=False
+            )
+            assert not sock_path.exists()
+        finally:
+            sock.close()
+
+    def test_regular_file_at_socket_path_is_unlinked(self, tmp_path):
+        sock_path = tmp_path / "x.sock"
+        sock_path.write_text("planted", encoding="utf-8")
+        ssh_env._quarantine_untrusted_control_socket(
+            sock_path, dir_was_shared=False
+        )
+        assert not sock_path.exists()
+
+    def test_owned_socket_in_private_dir_is_kept(self, tmp_path):
+        sock_path = tmp_path / "x.sock"
+        sock = self._unix_socket(sock_path)
+        try:
+            ssh_env._quarantine_untrusted_control_socket(
+                sock_path, dir_was_shared=False
+            )
+            assert sock_path.exists()
+        finally:
+            sock.close()
+            sock_path.unlink(missing_ok=True)
+
+    def test_owned_socket_from_shared_dir_is_unlinked(self, tmp_path):
+        sock_path = tmp_path / "x.sock"
+        sock = self._unix_socket(sock_path)
+        try:
+            ssh_env._quarantine_untrusted_control_socket(
+                sock_path, dir_was_shared=True
+            )
+            assert not sock_path.exists()
+        finally:
+            sock.close()
+
+    def test_chmod_ineffective_init_omits_controlpath(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(ssh_env, "_SSH_MULTIPLEX", True)
+        monkeypatch.setattr(
+            "tools.environments.ssh.subprocess.run",
+            lambda *a, **k: __import__("subprocess").CompletedProcess([], 0),
+        )
+        monkeypatch.setattr(
+            "tools.environments.ssh.subprocess.Popen",
+            lambda *a, **k: MagicMock(
+                stdout=iter([]), stderr=iter([]), stdin=MagicMock()
+            ),
+        )
+        monkeypatch.setattr("tools.environments.base.time.sleep", lambda _: None)
+        monkeypatch.setattr(
+            "tools.environments.ssh.tempfile.gettempdir",
+            lambda: str(tmp_path),
+        )
+        control = tmp_path / "hermes-ssh"
+        control.mkdir()
+        control.chmod(0o777)
+        monkeypatch.setattr(type(control), "chmod", lambda self, mode: None)
+        env = SSHEnvironment(host="h", user="u")
+        assert env._use_multiplex is False
+        cmd = " ".join(env._build_ssh_command())
+        assert "ControlPath" not in cmd
+        assert "ControlMaster" not in cmd
+
 
 class TestTerminalToolConfig:
     def test_ssh_persistent_default_true(self, monkeypatch):

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -126,6 +126,21 @@ class TestControlSocketPath:
         assert SSHEnvironment(host="g", user="u", port=22).control_socket != base
 
 
+
+    def test_control_dir_mode_is_private(self, tmp_path, monkeypatch):
+        """ControlPath directory must be 0o700 so other local users cannot
+        plant sockets under /tmp/hermes-ssh (#80284)."""
+        monkeypatch.setattr(
+            "tools.environments.ssh.tempfile.gettempdir",
+            lambda: str(tmp_path),
+        )
+        env = SSHEnvironment(host="example.com", user="alice")
+        assert env.control_dir == tmp_path / "hermes-ssh"
+        assert env.control_dir.is_dir()
+        mode = env.control_dir.stat().st_mode & 0o777
+        assert mode == 0o700, f"expected 0o700, got {oct(mode)}"
+
+
 class TestTerminalToolConfig:
     def test_ssh_persistent_default_true(self, monkeypatch):
         """SSH persistent defaults to True (via TERMINAL_PERSISTENT_SHELL)."""

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -11,6 +11,7 @@ import os
 _SSH_MULTIPLEX = os.name != "nt"
 import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
@@ -43,6 +44,92 @@ def _ensure_ssh_available() -> None:
         )
 
 
+def _prepare_control_dir(control_dir: Path, *, multiplex: bool) -> tuple[bool, bool]:
+    """Create the ControlPath directory.
+
+    Returns ``(use_multiplex, dir_was_shared)``.
+
+    POSIX owner/mode checks run only when multiplexing is on. Windows
+    OpenSSH cannot use ControlMaster (#73927). If chmod does not make
+    the directory private, skip ControlPath rather than failing SSH
+    init — the backend still connects, just without reuse.
+    """
+    if not multiplex:
+        control_dir.mkdir(parents=True, exist_ok=True)
+        return False, False
+
+    control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        st = control_dir.lstat()
+    except FileNotFoundError:
+        return True, False
+
+    if stat.S_ISLNK(st.st_mode):
+        raise RuntimeError(
+            f"SSH control directory {control_dir} is a symlink; refuse to "
+            f"place ControlPath sockets there"
+        )
+
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and st.st_uid != getuid():
+        raise RuntimeError(
+            f"SSH control directory {control_dir} is not owned by the "
+            f"current user (uid={st.st_uid}); refuse to use a potentially "
+            f"planted path"
+        )
+
+    dir_was_shared = bool(stat.S_IMODE(st.st_mode) & 0o077)
+    if dir_was_shared:
+        try:
+            control_dir.chmod(0o700)
+        except OSError:
+            pass
+        try:
+            mode = stat.S_IMODE(control_dir.stat().st_mode)
+        except OSError:
+            mode = stat.S_IMODE(st.st_mode)
+        if mode & 0o077:
+            logger.warning(
+                "SSH control directory %s stays group/world-accessible "
+                "(mode=%s) after chmod; skipping ControlMaster",
+                control_dir,
+                oct(mode),
+            )
+            return False, True
+    return True, dir_was_shared
+
+
+def _quarantine_untrusted_control_socket(
+    socket_path: Path, *, dir_was_shared: bool
+) -> None:
+    """Remove a ControlPath name we must not hand to OpenSSH.
+
+    Directory mode alone is not proof that an existing socket is ours
+    (#80299): a previously-shared dir can hold a planted inode, and
+    chmod on the directory does not replace it.
+    """
+    try:
+        st = socket_path.lstat()
+    except FileNotFoundError:
+        return
+
+    getuid = getattr(os, "getuid", None)
+    trusted = stat.S_ISSOCK(st.st_mode)
+    if getuid is not None and st.st_uid != getuid():
+        trusted = False
+    if dir_was_shared:
+        trusted = False
+    if trusted:
+        return
+    try:
+        socket_path.unlink()
+    except OSError as exc:
+        raise RuntimeError(
+            f"SSH control socket {socket_path} is untrusted and could not "
+            f"be removed: {exc}"
+        ) from exc
+
+
 class SSHEnvironment(BaseEnvironment):
     """Run commands on a remote machine over SSH.
 
@@ -61,7 +148,6 @@ class SSHEnvironment(BaseEnvironment):
         self.key_path = key_path
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
-        self.control_dir.mkdir(parents=True, exist_ok=True)
         # Keep the socket filename short and deterministic so the full path
         # stays under the 104-byte sun_path limit that macOS enforces on
         # Unix domain sockets. A raw ``user@host:port`` — especially with an
@@ -74,6 +160,18 @@ class SSHEnvironment(BaseEnvironment):
             f"{user}@{host}:{port}".encode()
         ).hexdigest()[:16]
         self.control_socket = self.control_dir / f"{_socket_id}.sock"
+        # Mode 0o700: the ControlPath socket is deterministic. A world-writable
+        # /tmp/hermes-ssh lets another local user plant a socket and hijack
+        # the multiplexed connection (#80284). Existing sockets are checked
+        # separately — hardening the directory does not make a planted inode
+        # trusted (#80299).
+        self._use_multiplex, dir_was_shared = _prepare_control_dir(
+            self.control_dir, multiplex=_SSH_MULTIPLEX
+        )
+        if self._use_multiplex:
+            _quarantine_untrusted_control_socket(
+                self.control_socket, dir_was_shared=dir_was_shared
+            )
         _ensure_ssh_available()
         self._establish_connection()
         self._remote_home = self._detect_remote_home()
@@ -92,7 +190,7 @@ class SSHEnvironment(BaseEnvironment):
 
     def _build_ssh_command(self, extra_args: list | None = None) -> list:
         cmd = ["ssh"]
-        if _SSH_MULTIPLEX:
+        if self._use_multiplex:
             cmd.extend(["-o", f"ControlPath={self.control_socket}"])
             cmd.extend(["-o", "ControlMaster=auto"])
             cmd.extend(["-o", "ControlPersist=300"])
@@ -194,7 +292,7 @@ class SSHEnvironment(BaseEnvironment):
         )
 
         scp_cmd = ["scp"]
-        if _SSH_MULTIPLEX:
+        if self._use_multiplex:
             scp_cmd.extend(["-o", f"ControlPath={self.control_socket}"])
         if self.port != 22:
             scp_cmd.extend(["-P", str(self.port)])
@@ -417,7 +515,7 @@ class SSHEnvironment(BaseEnvironment):
             logger.info("SSH: syncing files from sandbox...")
             self._sync_manager.sync_back()
 
-        if self.control_socket.exists():
+        if self._use_multiplex and self.control_socket.exists():
             try:
                 cmd = ["ssh", "-o", f"ControlPath={self.control_socket}",
                        "-O", "exit", f"{self.user}@{self.host}"]

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -64,9 +64,12 @@ class SSHEnvironment(BaseEnvironment):
             pass
         # Reject an existing directory that is not owned by us or is group/
         # world-writable — safer than reusing a pre-planted attacker path.
+        # os.getuid is POSIX-only (AttributeError on Windows); ownership
+        # checks apply where multi-user /tmp planting is real.
         try:
             st = self.control_dir.stat()
-            if st.st_uid != os.getuid():
+            getuid = getattr(os, "getuid", None)
+            if getuid is not None and st.st_uid != getuid():
                 raise RuntimeError(
                     f"SSH control directory {self.control_dir} is not owned by "
                     f"the current user (uid={st.st_uid}); refuse to use a "

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -5,6 +5,7 @@ import logging
 import os
 import shlex
 import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
@@ -51,7 +52,42 @@ class SSHEnvironment(BaseEnvironment):
         self.key_path = key_path
 
         self.control_dir = Path(tempfile.gettempdir()) / "hermes-ssh"
-        self.control_dir.mkdir(parents=True, exist_ok=True)
+        # Mode 0o700: the ControlPath socket is deterministic (sha256 of
+        # user@host:port). A world-writable /tmp/hermes-ssh lets another local
+        # user pre-create the dir or plant a socket and hijack/deny the
+        # multiplexed connection (#80284).
+        self.control_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        try:
+            self.control_dir.chmod(0o700)
+        except OSError:
+            # Best-effort on filesystems that ignore chmod (e.g. some NTFS).
+            pass
+        # Reject an existing directory that is not owned by us or is group/
+        # world-writable — safer than reusing a pre-planted attacker path.
+        try:
+            st = self.control_dir.stat()
+            if st.st_uid != os.getuid():
+                raise RuntimeError(
+                    f"SSH control directory {self.control_dir} is not owned by "
+                    f"the current user (uid={st.st_uid}); refuse to use a "
+                    f"potentially planted path"
+                )
+            mode = stat.S_IMODE(st.st_mode)
+            if mode & 0o077:
+                # Tighten if we can; if still loose after chmod, refuse.
+                try:
+                    self.control_dir.chmod(0o700)
+                except OSError:
+                    pass
+                mode = stat.S_IMODE(self.control_dir.stat().st_mode)
+                if mode & 0o077:
+                    raise RuntimeError(
+                        f"SSH control directory {self.control_dir} is "
+                        f"group/world-accessible (mode={oct(mode)}); refuse "
+                        f"to place ControlPath sockets there"
+                    )
+        except FileNotFoundError:
+            pass
         # Keep the socket filename short and deterministic so the full path
         # stays under the 104-byte sun_path limit that macOS enforces on
         # Unix domain sockets. A raw ``user@host:port`` — especially with an


### PR DESCRIPTION
## Summary
- Create `tempfile/hermes-ssh` with **mode 0o700**, re-chmod after create, and refuse directories that remain group/world-accessible or are not owned by the current user.
- ControlPath socket names are deterministic (sha256 of `user@host:port`); a world-writable parent under `/tmp` lets another local user plant the path (#80284).

Fixes #80284

## Test plan
- [x] `pytest tests/tools/test_ssh_environment.py::TestControlSocketPath` (4 passed)