### PR TITLE
fix(desktop): sudo password dialog shows the command being approved (#79874)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -954,9 +954,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // Sudo password capture (tools/terminal_tool.py). Blocked on
         // sudo.respond {request_id, password}.
         const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+        // #79874: the gateway now includes the command being approved so the
+        // dialog can show what the password authorizes.
+        const command = typeof payload?.command === 'string' ? payload.command : ''
 
         if (requestId) {
-          setSudoRequest({ requestId, sessionId: sessionId ?? null })
+          setSudoRequest({ requestId, command, sessionId: sessionId ?? null })
 
           if (sessionId) {
             updateSessionState(sessionId, state => ({ ...state, needsInput: true }))

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -271,9 +271,12 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
     // Sudo password capture (tools/terminal_tool.py). Blocked on
     // sudo.respond {request_id, password}.
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
+    // #79874: the gateway now includes the command being approved so the
+    // dialog can show what the password authorizes.
+    const command = typeof payload?.command === 'string' ? payload.command : ''
 
     if (requestId) {
-      setSudoRequest({ requestId, sessionId: sessionId ?? null })
+      setSudoRequest({ requestId, command, sessionId: sessionId ?? null })
 
       if (sessionId) {
         updateSessionState(sessionId, state => ({ ...state, needsInput: true }))

--- a/apps/desktop/src/components/prompt-overlays.tsx
+++ b/apps/desktop/src/components/prompt-overlays.tsx
@@ -112,7 +112,18 @@ function SudoDialog({ sessionId }: { sessionId: string | null }) {
       <DialogContent showCloseButton={false}>
         <DialogHeader>
           <DialogTitle icon={Lock}>{copy.sudoTitle}</DialogTitle>
-          <DialogDescription>{copy.sudoDesc}</DialogDescription>
+          <DialogDescription>
+            {request.command ? (
+              <>
+                {copy.sudoDescCommand}
+                <code className="mt-1 block rounded-md bg-muted px-2 py-1 font-mono text-xs text-foreground">
+                  {request.command}
+                </code>
+              </>
+            ) : (
+              copy.sudoDesc
+            )}
+          </DialogDescription>
         </DialogHeader>
 
         <form className="grid gap-3" onSubmit={onSubmit}>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2509,6 +2509,7 @@ export const ar = defineLocale({
     secretSendFailed: 'فشل إرسال السر',
     sudoTitle: 'مطلوب sudo',
     sudoDesc: 'أدخل كلمة المرور لمتابعة الأمر.',
+    sudoDescCommand: 'يحتاج Hermes إلى كلمة مرور sudo لتشغيل:',
     sudoPlaceholder: 'كلمة المرور',
     secretTitle: 'مطلوب سر',
     secretDesc: 'أدخل القيمة المطلوبة لمتابعة المهمة.',

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2754,6 +2754,7 @@ export const ar = defineLocale({
     secretSendFailed: 'فشل إرسال السر',
     sudoTitle: 'مطلوب sudo',
     sudoDesc: 'أدخل كلمة المرور لمتابعة الأمر.',
+    sudoDescCommand: 'يحتاج Hermes إلى كلمة مرور sudo لتشغيل:',
     sudoPlaceholder: 'كلمة المرور',
     secretTitle: 'مطلوب سر',
     secretDesc: 'أدخل القيمة المطلوبة لمتابعة المهمة.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2878,6 +2878,7 @@ export const en: Translations = {
     secretSendFailed: 'Could not send secret',
     sudoTitle: 'Administrator password',
     sudoDesc: 'Hermes needs your sudo password to run a privileged command. It is sent only to your local agent.',
+    sudoDescCommand: 'Hermes needs your sudo password to run:',
     sudoPlaceholder: 'sudo password',
     secretTitle: 'Secret required',
     secretDesc: 'Hermes needs a credential to continue.',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3381,6 +3381,7 @@ export const en: Translations = {
     secretSendFailed: 'Could not send secret',
     sudoTitle: 'Administrator password',
     sudoDesc: 'Hermes needs your sudo password to run a privileged command. It is sent only to your local agent.',
+    sudoDescCommand: 'Hermes needs your sudo password to run:',
     sudoPlaceholder: 'sudo password',
     secretTitle: 'Secret required',
     secretDesc: 'Hermes needs a credential to continue.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2717,6 +2717,7 @@ export const ja = defineLocale({
     sudoTitle: '管理者パスワード',
     sudoDesc:
       'Hermes は特権コマンドを実行するために sudo パスワードが必要です。ローカルエージェントにのみ送信されます。',
+    sudoDescCommand: 'Hermes は sudo パスワードが必要です。実行するコマンド:',
     sudoPlaceholder: 'sudo パスワード',
     secretTitle: 'シークレットが必要です',
     secretDesc: 'Hermes は続行するための認証情報が必要です。',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -3003,6 +3003,7 @@ export const ja = defineLocale({
     sudoTitle: '管理者パスワード',
     sudoDesc:
       'Hermes は特権コマンドを実行するために sudo パスワードが必要です。ローカルエージェントにのみ送信されます。',
+    sudoDescCommand: 'Hermes は sudo パスワードが必要です。実行するコマンド:',
     sudoPlaceholder: 'sudo パスワード',
     secretTitle: 'シークレットが必要です',
     secretDesc: 'Hermes は続行するための認証情報が必要です。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2433,6 +2433,7 @@ export interface Translations {
     secretSendFailed: string
     sudoTitle: string
     sudoDesc: string
+    sudoDescCommand: string
     sudoPlaceholder: string
     secretTitle: string
     secretDesc: string

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2903,6 +2903,7 @@ export interface Translations {
     secretSendFailed: string
     sudoTitle: string
     sudoDesc: string
+    sudoDescCommand: string
     sudoPlaceholder: string
     secretTitle: string
     secretDesc: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2606,6 +2606,7 @@ export const zhHant = defineLocale({
     secretSendFailed: '無法傳送密鑰',
     sudoTitle: '管理員密碼',
     sudoDesc: 'Hermes 需要您的 sudo 密碼來執行特權指令。它只會傳送給您的本機代理。',
+    sudoDescCommand: 'Hermes 需要您的 sudo 密碼來執行：',
     sudoPlaceholder: 'sudo 密碼',
     secretTitle: '需要密鑰',
     secretDesc: 'Hermes 需要一個憑證才能繼續。',

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2878,6 +2878,7 @@ export const zhHant = defineLocale({
     secretSendFailed: '無法傳送密鑰',
     sudoTitle: '管理員密碼',
     sudoDesc: 'Hermes 需要您的 sudo 密碼來執行特權指令。它只會傳送給您的本機代理。',
+    sudoDescCommand: 'Hermes 需要您的 sudo 密碼來執行：',
     sudoPlaceholder: 'sudo 密碼',
     secretTitle: '需要密鑰',
     secretDesc: 'Hermes 需要一個憑證才能繼續。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3041,6 +3041,7 @@ export const zh: Translations = {
     secretSendFailed: '无法发送密钥',
     sudoTitle: '管理员密码',
     sudoDesc: 'Hermes 需要你的 sudo 密码来运行特权命令。它只会发送给你的本地 agent。',
+    sudoDescCommand: 'Hermes 需要你的 sudo 密码来运行：',
     sudoPlaceholder: 'sudo 密码',
     secretTitle: '需要密钥',
     secretDesc: 'Hermes 需要一个凭据才能继续。',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3526,6 +3526,7 @@ export const zh: Translations = {
     secretSendFailed: '无法发送密钥',
     sudoTitle: '管理员密码',
     sudoDesc: 'Hermes 需要你的 sudo 密码来运行特权命令。它只会发送给你的本地 agent。',
+    sudoDescCommand: 'Hermes 需要你的 sudo 密码来运行：',
     sudoPlaceholder: 'sudo 密码',
     secretTitle: '需要密钥',
     secretDesc: 'Hermes 需要一个凭据才能继续。',

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -81,6 +81,8 @@ export interface ApprovalRequest extends KeyedPrompt {
 
 export interface SudoRequest extends KeyedPrompt {
   requestId: string
+  /** The privileged command the password will authorize (#79874). */
+  command?: string
 }
 
 export interface SecretRequest extends KeyedPrompt {

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -95,6 +95,8 @@ interface PendingApprovalPayload {
 
 export interface SudoRequest extends KeyedPrompt {
   requestId: string
+  /** The privileged command the password will authorize (#79874). */
+  command?: string
 }
 
 export interface SecretRequest extends KeyedPrompt {

--- a/tests/tools/test_subagent_sudo_prompt.py
+++ b/tests/tools/test_subagent_sudo_prompt.py
@@ -68,7 +68,7 @@ class TestDelegatedChildNeverPrompts:
         monkeypatch.setattr(
             tt,
             "_prompt_for_sudo_password",
-            lambda timeout_seconds=45: calls.append(1) or "hunter2",
+            lambda timeout_seconds=45, command=None: calls.append(1) or "hunter2",
         )
 
         transformed, sudo_stdin = _transform_in_child("sudo apt-get update")
@@ -101,7 +101,8 @@ class TestDelegatedChildNeverPrompts:
         """The fix must not break interactive prompting outside children."""
         monkeypatch.setenv("HERMES_INTERACTIVE", "1")
         monkeypatch.setattr(
-            tt, "_prompt_for_sudo_password", lambda timeout_seconds=45: "hunter2"
+            tt, "_prompt_for_sudo_password",
+            lambda timeout_seconds=45, command=None: "hunter2",
         )
 
         transformed, sudo_stdin = tt._transform_sudo_command("sudo whoami")

--- a/tests/tools/test_terminal_tool.py
+++ b/tests/tools/test_terminal_tool.py
@@ -77,6 +77,47 @@ def test_explicit_empty_sudo_password_tries_empty_without_prompt(monkeypatch):
     assert sudo_stdin == "\n"
 
 
+def test_sudo_prompt_callback_receives_command(monkeypatch):
+    """A command-aware sudo callback gets the command to show in the UI (#79874)."""
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    seen = {}
+
+    def _cb(command=None):
+        seen["command"] = command
+        return "pw"
+
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: _cb)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo pacman -S task")
+
+    assert seen.get("command") == "sudo pacman -S task"
+    assert transformed == "sudo -S -p '' pacman -S task"
+    assert sudo_stdin == "pw\n"
+
+
+def test_sudo_prompt_zero_arg_callback_still_works(monkeypatch):
+    """Legacy zero-arg callbacks (CLI prompt_toolkit) keep working (#79874)."""
+    monkeypatch.delenv("SUDO_PASSWORD", raising=False)
+    monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+
+    calls = []
+
+    def _cb():
+        calls.append(1)
+        return "pw"
+
+    monkeypatch.setattr(terminal_tool, "_get_sudo_password_callback", lambda: _cb)
+    monkeypatch.setattr(terminal_tool, "_sudo_nopasswd_works", lambda: False)
+
+    transformed, sudo_stdin = terminal_tool._transform_sudo_command("sudo apt update")
+
+    assert calls == [1]
+    assert sudo_stdin == "pw\n"
+
+
 def test_validate_workdir_blocks_shell_metacharacters_in_windows_paths():
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project; rm -rf /")
     assert terminal_tool._validate_workdir(r"C:\Users\Alice\project$(whoami)")

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -476,7 +476,7 @@ def _invalidate_cached_sudo_on_auth_failure(
     return True
 
 
-def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
+def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = None) -> str:
     """
     Prompt user for sudo password with timeout.
     
@@ -492,11 +492,17 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     """
     import sys
     
-    # Use the registered callback when available (prompt_toolkit-compatible)
+    # Use the registered callback when available (prompt_toolkit-compatible).
+    # Callbacks that accept a command argument (the gateway/desktop sudo
+    # dialogs) get it so the approval UI can show WHAT is being approved;
+    # zero-arg callbacks (legacy CLI) are called bare (#79874).
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
         try:
-            return _sudo_cb() or ""
+            try:
+                return _sudo_cb(command) or ""
+            except TypeError:
+                return _sudo_cb() or ""
         except Exception:
             return ""
 
@@ -1041,7 +1047,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         env_var_enabled("HERMES_INTERACTIVE") or has_sudo_prompt_callback
     )
     if not has_configured_password and not sudo_password and should_prompt_for_sudo:
-        sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
+        sudo_password = _prompt_for_sudo_password(timeout_seconds=45, command=command)
         if sudo_password:
             _set_cached_sudo_password(sudo_password)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+import inspect
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -489,6 +490,12 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = N
     If a _sudo_password_callback is registered (by the CLI), delegates to it
     so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
     directly from /dev/tty with echo disabled.
+
+    ``command`` is the sudo command being authorized; the registered callback
+    receives it when it accepts an argument (the gateway's sudo dialog shows
+    what the password is for, #79874).  Callbacks that take no arguments
+    (the legacy CLI prompt) are probed once via inspect.signature and called
+    without the argument.
     """
     import sys
     
@@ -499,10 +506,19 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = N
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
         try:
-            try:
-                return _sudo_cb(command) or ""
-            except TypeError:
-                return _sudo_cb() or ""
+            if command is not None:
+                try:
+                    _sig = inspect.signature(_sudo_cb)
+                except (TypeError, ValueError):
+                    _sig = None
+                _accepts_arg = _sig is not None and any(
+                    p.kind
+                    in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                    for p in _sig.parameters.values()
+                )
+                if _accepts_arg:
+                    return _sudo_cb(command) or ""
+            return _sudo_cb() or ""
         except Exception:
             return ""
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -522,7 +522,7 @@ def _invalidate_cached_sudo_on_auth_failure(
     return True
 
 
-def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
+def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = None) -> str:
     """
     Prompt user for sudo password with timeout.
     
@@ -538,7 +538,10 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
     """
     import sys
     
-    # Use the registered callback when available (prompt_toolkit-compatible)
+    # Use the registered callback when available (prompt_toolkit-compatible).
+    # Callbacks that accept a command argument (the gateway/desktop sudo
+    # dialogs) get it so the approval UI can show WHAT is being approved;
+    # zero-arg callbacks (legacy CLI) are called bare (#79874).
     _sudo_cb = _get_sudo_password_callback()
     if _sudo_cb is not None:
         try:
@@ -547,7 +550,10 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45) -> str:
             # surprises; tools.terminal_tool already imports tools.approval.
             from tools.approval import human_wait_window
             with human_wait_window():
-                return _sudo_cb() or ""
+                try:
+                    return _sudo_cb(command) or ""
+                except TypeError:
+                    return _sudo_cb() or ""
         except Exception:
             return ""
 
@@ -1104,7 +1110,7 @@ def _transform_sudo_command(command: str | None) -> tuple[str | None, str | None
         env_var_enabled("HERMES_INTERACTIVE") or has_sudo_prompt_callback
     ) and not _in_delegated_child_context()
     if not has_configured_password and not sudo_password and should_prompt_for_sudo:
-        sudo_password = _prompt_for_sudo_password(timeout_seconds=45)
+        sudo_password = _prompt_for_sudo_password(timeout_seconds=45, command=command)
         if sudo_password:
             _set_cached_sudo_password(sudo_password)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -46,6 +46,7 @@ import threading
 import atexit
 import shutil
 import subprocess
+import inspect
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
@@ -535,6 +536,12 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = N
     If a _sudo_password_callback is registered (by the CLI), delegates to it
     so the prompt integrates with prompt_toolkit's UI.  Otherwise reads
     directly from /dev/tty with echo disabled.
+
+    ``command`` is the sudo command being authorized; the registered callback
+    receives it when it accepts an argument (the gateway's sudo dialog shows
+    what the password is for, #79874).  Callbacks that take no arguments
+    (the legacy CLI prompt) are probed once via inspect.signature and called
+    without the argument.
     """
     import sys
     
@@ -550,10 +557,19 @@ def _prompt_for_sudo_password(timeout_seconds: int = 45, command: str | None = N
             # surprises; tools.terminal_tool already imports tools.approval.
             from tools.approval import human_wait_window
             with human_wait_window():
-                try:
-                    return _sudo_cb(command) or ""
-                except TypeError:
-                    return _sudo_cb() or ""
+                if command is not None:
+                    try:
+                        _sig = inspect.signature(_sudo_cb)
+                    except (TypeError, ValueError):
+                        _sig = None
+                    _accepts_arg = _sig is not None and any(
+                        p.kind
+                        in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                        for p in _sig.parameters.values()
+                    )
+                    if _accepts_arg:
+                        return _sudo_cb(command) or ""
+                return _sudo_cb() or ""
         except Exception:
             return ""
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5770,7 +5770,14 @@ def _wire_callbacks(sid: str):
     from tools.skills_tool import set_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback
 
-    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+    set_sudo_password_callback(
+        lambda command=None: _block(
+            "sudo.request",
+            sid,
+            {"command": command or ""},
+            timeout=120,
+        )
+    )
     set_project_workspace_callback(_apply_project_workspace)
 
     def secret_cb(env_var, prompt, metadata=None):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -8109,7 +8109,14 @@ def _wire_callbacks(sid: str):
     from tools.skills_tool import set_secret_capture_callback
     from tools.project_tools import set_project_workspace_callback
 
-    set_sudo_password_callback(lambda: _block("sudo.request", sid, {}, timeout=120))
+    set_sudo_password_callback(
+        lambda command=None: _block(
+            "sudo.request",
+            sid,
+            {"command": command or ""},
+            timeout=120,
+        )
+    )
     set_project_workspace_callback(_apply_project_workspace)
 
     def secret_cb(env_var, prompt, metadata=None):


### PR DESCRIPTION
## Summary

Fixes #79874: the desktop sudo approval dialog showed no command context. The gaussian-blur backdrop made the terminal content underneath unreadable, so a user was asked to type a sudo password without being able to see what command they were approving.

**Fix**: thread the privileged command through the whole chain so the dialog shows exactly what will run.

- `tools/terminal_tool.py`: `_prompt_for_sudo_password` now accepts the command and hands it to the registered sudo-password callback. Command-aware callbacks (gateway/desktop) receive it; legacy zero-arg callbacks (CLI prompt_toolkit) are called bare via a `TypeError` fallback — no behavior change for existing surfaces.
- `tui_gateway/server.py`: the `sudo.request` payload now carries the `command` field.
- Desktop: `SudoRequest.command` is rendered in the dialog as a monospace block under a new `sudoDescCommand` string (added to en / zh / zh-hant / ja / ar).

## Verification

- New regression test asserts the command reaches a command-aware callback (RED on old code, GREEN now); zero-arg callback compat test guards the legacy path.
- `scripts/run_tests.sh tests/tools/test_terminal_tool.py`: 12/12 pass.
- `tsc --noEmit` in apps/desktop: clean.
