### PR TITLE
fix(gateway): split check_fn (passive probe) from ensure_deps_fn (active installer)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2512,10 +2512,11 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             pass
 
     # Registry-driven enable for plugin platforms.  Built-ins have explicit
-    # blocks above; plugins expose check_fn() which is the single source of
-    # truth for "are my env vars set?".  When it returns True, ensure the
-    # platform is enabled so start() will create its adapter.  Plugins that
-    # need to seed ``PlatformConfig.extra`` from env vars (e.g. Google Chat's
+    # blocks above.  A plugin platform is enabled when its credentials are
+    # configured (``is_connected``) and its dependencies are either present
+    # (passive ``check_fn``) or installable on demand (``ensure_deps_fn``,
+    # run later by ``create_adapter()`` — never here).  Plugins that need to
+    # seed ``PlatformConfig.extra`` from env vars (e.g. Google Chat's
     # project_id / subscription_name) can supply ``env_enablement_fn`` on
     # their PlatformEntry — called here BEFORE adapter construction.
     #

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2522,13 +2522,12 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     # Enablement gate (#31116): when a plugin registers ``is_connected``
     # (the "has the user actually configured credentials for this?" check),
     # we MUST consult it before flipping ``enabled = True``.  Otherwise
-    # ``check_fn`` alone — which for adapter plugins typically just
-    # verifies the SDK is importable / lazy-installs it — silently enables
-    # platforms the user never opted into, and the gateway then tries to
-    # connect to Discord / Teams / Google Chat with no token and emits
-    # noisy retry-forever errors.  ``_platform_status`` was already fixed
-    # for the same bug class in commit 7849a3d73; this is the runtime
-    # counterpart.
+    # ``check_fn`` alone — a passive "is the SDK importable?" probe —
+    # silently enables platforms the user never opted into, and the gateway
+    # then tries to connect to Discord / Teams / Google Chat with no token
+    # and emits noisy retry-forever errors.  ``_platform_status`` was
+    # already fixed for the same bug class in commit 7849a3d73; this is the
+    # runtime counterpart.
     try:
         from hermes_cli.plugins import discover_plugins
         discover_plugins()  # idempotent
@@ -2623,20 +2622,25 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                         )
                         continue
             # Verify dependencies LAST — only for platforms that are already
-            # enabled or passed the credential gate above.  For adapter plugins
-            # ``check_fn`` lazy-INSTALLS the platform SDK (pip) as a side
-            # effect, so running it as an unconditional sweep over every
-            # registered platform made ``load_gateway_config()`` pip-install
-            # Discord/Telegram/Slack/Feishu/Dingtalk on every call — including
-            # the desktop/dashboard readiness probe (``GET /api/status``, which
-            # awaits this synchronously) — even when the user configured none
-            # of them.  That blocked startup until every install finished and
-            # caused the desktop app to time out and boot-loop (stuck at 94%).
+            # enabled or passed the credential gate above.  ``check_fn`` is a
+            # PASSIVE probe (never installs); a platform whose deps are
+            # missing but which registered ``ensure_deps_fn`` still gets
+            # enabled here — the registry's ``create_adapter()`` runs the
+            # active installer at gateway start, when the user actually
+            # wants the platform up.  Historically the ACTIVE installer was
+            # wired as ``check_fn`` and this sweep pip-installed
+            # Discord/Telegram/Slack/Feishu/Dingtalk SDKs on every
+            # ``load_gateway_config()`` call — including the desktop/dashboard
+            # readiness probe (``GET /api/status``) — blocking startup until
+            # every install finished and boot-looping the desktop app at 94%.
+            # The check_fn/ensure_deps_fn split (#79812) makes that
+            # impossible by construction.
             try:
-                if not entry.check_fn():
-                    continue
+                deps_ok = bool(entry.check_fn())
             except Exception as e:
                 logger.debug("check_fn for %s raised: %s", entry.name, e)
+                deps_ok = False
+            if not deps_ok and entry.ensure_deps_fn is None:
                 continue
             if platform not in config.platforms:
                 config.platforms[platform] = PlatformConfig()

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -50,13 +50,34 @@ class PlatformEntry:
     # (e.g. passing extra kwargs, wrapping in try/except).
     adapter_factory: Callable[[Any], Any]
 
-    # Returns True when the platform's dependencies are available.
+    # PASSIVE dependency probe: returns True when the platform's dependencies
+    # are available RIGHT NOW.  Must be side-effect free — it is called from
+    # status displays (``hermes setup``, ``hermes status``, the dashboard
+    # readiness probe) and the config enablement pass, none of which may
+    # trigger a pip install.  Put install logic in ``ensure_deps_fn`` instead.
     check_fn: Callable[[], bool]
 
     # Optional: given a PlatformConfig, is it properly configured?
     # If None, the registry skips config validation and lets the adapter
     # fail at connect() time with a descriptive error.
     validate_config: Optional[Callable[[Any], bool]] = None
+
+    # ACTIVE dependency installer: make the platform's dependencies available,
+    # installing them (pip / lazy_deps) if needed.  Returns True once deps are
+    # importable, False if they could not be installed.  Called by
+    # ``create_adapter()`` when ``check_fn`` returns False — i.e. exactly at
+    # the moment the gateway is about to bring the platform up and the user
+    # has it enabled/configured.  None = no auto-install; a False ``check_fn``
+    # is then a hard block (correct for platforms with no optional deps).
+    #
+    # Why two fields (#79812): when the ACTIVE installer was registered as
+    # ``check_fn``, every status display pip-installed SDKs as a side effect
+    # (desktop boot-loop at 94%, see gateway/config.py enablement comments);
+    # when the PASSIVE probe was registered instead, ``create_adapter()``
+    # returned None before ``connect()`` could lazy-install, so the deps
+    # never installed at all (Teams deadlock).  Splitting the two roles makes
+    # both call sites correct by construction.
+    ensure_deps_fn: Optional[Callable[[], bool]] = None
 
     # Optional: given a PlatformConfig, is the platform connected/enabled?
     # Used by ``GatewayConfig.get_connected_platforms()`` and setup UI status.
@@ -280,7 +301,8 @@ class PlatformRegistry:
 
         Returns None if:
         - No entry registered for *name*
-        - check_fn() returns False (missing deps)
+        - check_fn() returns False and deps can't be installed
+          (no ensure_deps_fn, or ensure_deps_fn() returned False)
         - validate_config() returns False (misconfigured)
         - The factory raises an exception
         """
@@ -290,7 +312,34 @@ class PlatformRegistry:
         if entry is None:
             return None
 
-        if not entry.check_fn():
+        deps_ok = False
+        try:
+            deps_ok = bool(entry.check_fn())
+        except Exception as e:
+            logger.warning(
+                "Platform '%s' check_fn raised: %s", entry.label, e
+            )
+        if not deps_ok and entry.ensure_deps_fn is not None:
+            # Deps missing but the platform can install them on demand.
+            # This is the ONE place the active installer runs in the adapter
+            # path: the platform is enabled+configured and the gateway is
+            # about to connect it, so an install is what the user wants
+            # (#79812 — Teams' installer previously lived behind this very
+            # gate inside connect(), which could never be reached).
+            logger.info(
+                "Platform '%s' dependencies missing — attempting install...",
+                entry.label,
+            )
+            try:
+                deps_ok = bool(entry.ensure_deps_fn())
+            except Exception as e:
+                logger.warning(
+                    "Platform '%s' dependency install raised: %s",
+                    entry.label,
+                    e,
+                )
+                deps_ok = False
+        if not deps_ok:
             hint = f" ({entry.install_hint})" if entry.install_hint else ""
             logger.warning(
                 "Platform '%s' requirements not met%s",

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -964,12 +964,20 @@ class PluginContext:
         """Register a gateway platform adapter.
 
         The adapter_factory receives a ``PlatformConfig`` and returns a
-        ``BasePlatformAdapter`` subclass instance.  The gateway calls
-        ``check_fn()`` before instantiation to verify dependencies.
+        ``BasePlatformAdapter`` subclass instance.
+
+        ``check_fn`` is a PASSIVE dependency probe — "are deps importable
+        right now?".  It must never install anything: status displays and
+        config loading call it freely.  If your platform's SDK is
+        lazy-installable, pass the ACTIVE installer separately as
+        ``ensure_deps_fn`` (forwarded via ``entry_kwargs``); the gateway
+        calls it from ``create_adapter()`` when ``check_fn`` is False,
+        right before connecting the platform.
 
         Extra keyword arguments are forwarded to ``PlatformEntry`` (e.g.
-        ``setup_fn``, ``emoji``, ``allowed_users_env``, ``platform_hint``).
-        Unknown keys raise TypeError from the dataclass constructor.
+        ``setup_fn``, ``emoji``, ``allowed_users_env``, ``platform_hint``,
+        ``ensure_deps_fn``).  Unknown keys raise TypeError from the
+        dataclass constructor.
 
         Example::
 

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -505,7 +505,13 @@ def show_status(args):
     try:
         from gateway.platform_registry import platform_registry
         for entry in platform_registry.plugin_entries():
-            configured = entry.check_fn()
+            # Per-entry guard: one raising probe must not abort the listing
+            # of every remaining plugin platform (matches the other three
+            # check_fn call sites).
+            try:
+                configured = bool(entry.check_fn())
+            except Exception:
+                configured = False
             status_str = "configured" if configured else "not configured"
             label = entry.label
             print(f"  {label:<12}  {check_mark(configured)} {status_str} (plugin)")

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -162,6 +162,18 @@ EXT_MAP = {
 }
 
 
+def dingtalk_deps_present() -> bool:
+    """PASSIVE probe: are dingtalk-stream/httpx importable right now?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  The ACTIVE lazy-installer
+    (``check_dingtalk_requirements``) is registered as ``ensure_deps_fn``
+    and runs from ``create_adapter()`` when this returns False (#79812).
+    Credentials are gated separately via ``is_connected``/``validate_config``.
+    """
+    return DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE
+
+
 def check_dingtalk_requirements() -> bool:
     """Check if DingTalk dependencies are available and configured.
 
@@ -1881,7 +1893,8 @@ def register(ctx) -> None:
         name="dingtalk",
         label="DingTalk",
         adapter_factory=_build_adapter,
-        check_fn=check_dingtalk_requirements,
+        check_fn=dingtalk_deps_present,
+        ensure_deps_fn=check_dingtalk_requirements,
         is_connected=_is_connected,
         validate_config=_is_connected,
         required_env=["DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"],

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -174,34 +174,54 @@ def dingtalk_deps_present() -> bool:
     return DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE
 
 
-def check_dingtalk_requirements() -> bool:
-    """Check if DingTalk dependencies are available and configured.
+def ensure_dingtalk_deps() -> bool:
+    """ACTIVE deps-only installer (registry ``ensure_deps_fn``).
 
-    Lazy-installs dingtalk-stream via ``tools.lazy_deps.ensure("platform.dingtalk")``
-    on first call if not present.
+    Lazy-installs dingtalk-stream/httpx and rebinds module globals.
+    Deliberately does NOT check credentials — ``ensure_deps_fn``'s contract
+    is deps-only ("Returns True once deps are importable"); credentials are
+    gated by ``is_connected``/``validate_config``.  Otherwise a platform
+    configured via ``PlatformConfig.extra`` (which ``_is_connected``
+    accepts) would pass enablement, reach ``create_adapter()``, and have
+    the installer veto on env-var grounds before ever installing —
+    re-creating the #79812 deadlock for extra-configured setups.
     """
     global DINGTALK_STREAM_AVAILABLE, dingtalk_stream, ChatbotMessage, CallbackMessage, AckMessage
     global HTTPX_AVAILABLE, httpx
-    if not DINGTALK_STREAM_AVAILABLE or not HTTPX_AVAILABLE:
-        try:
-            from tools.lazy_deps import ensure as _lazy_ensure
-            _lazy_ensure("platform.dingtalk", prompt=False)
-        except Exception:
-            return False
-        try:
-            import dingtalk_stream as _ds
-            from dingtalk_stream import ChatbotMessage as _CM
-            from dingtalk_stream.frames import CallbackMessage as _CBM, AckMessage as _AM
-            import httpx as _httpx
-        except Exception:
-            return False
-        dingtalk_stream = _ds
-        ChatbotMessage = _CM
-        CallbackMessage = _CBM
-        AckMessage = _AM
-        httpx = _httpx
-        DINGTALK_STREAM_AVAILABLE = True
-        HTTPX_AVAILABLE = True
+    if DINGTALK_STREAM_AVAILABLE and HTTPX_AVAILABLE:
+        return True
+    try:
+        from tools.lazy_deps import ensure as _lazy_ensure
+        _lazy_ensure("platform.dingtalk", prompt=False)
+    except Exception:
+        return False
+    try:
+        import dingtalk_stream as _ds
+        from dingtalk_stream import ChatbotMessage as _CM
+        from dingtalk_stream.frames import CallbackMessage as _CBM, AckMessage as _AM
+        import httpx as _httpx
+    except Exception:
+        return False
+    dingtalk_stream = _ds
+    ChatbotMessage = _CM
+    CallbackMessage = _CBM
+    AckMessage = _AM
+    httpx = _httpx
+    DINGTALK_STREAM_AVAILABLE = True
+    HTTPX_AVAILABLE = True
+    return True
+
+
+def check_dingtalk_requirements() -> bool:
+    """Check if DingTalk dependencies are available and configured.
+
+    Lazy-installs dingtalk-stream via :func:`ensure_dingtalk_deps`, then
+    additionally requires credentials.  Kept for setup/status callers that
+    want the combined deps+credentials answer; the registry uses the
+    deps-only :func:`ensure_dingtalk_deps` as ``ensure_deps_fn``.
+    """
+    if not ensure_dingtalk_deps():
+        return False
     if not os.getenv("DINGTALK_CLIENT_ID") or not _get_scoped_secret("DINGTALK_CLIENT_SECRET"):
         return False
     return True
@@ -1894,7 +1914,7 @@ def register(ctx) -> None:
         label="DingTalk",
         adapter_factory=_build_adapter,
         check_fn=dingtalk_deps_present,
-        ensure_deps_fn=check_dingtalk_requirements,
+        ensure_deps_fn=ensure_dingtalk_deps,
         is_connected=_is_connected,
         validate_config=_is_connected,
         required_env=["DINGTALK_CLIENT_ID", "DINGTALK_CLIENT_SECRET"],

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -432,6 +432,17 @@ def _profile_scoped_config_load() -> bool:
         return False
 
 
+def discord_deps_present() -> bool:
+    """PASSIVE probe: is discord.py importable right now?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  The ACTIVE lazy-installer
+    (``check_discord_requirements``) is registered as ``ensure_deps_fn``
+    and runs from ``create_adapter()`` when this returns False (#79812).
+    """
+    return DISCORD_AVAILABLE
+
+
 def check_discord_requirements() -> bool:
     """Check if Discord dependencies are available.
 
@@ -10106,7 +10117,8 @@ def register(ctx) -> None:
         name="discord",
         label="Discord",
         adapter_factory=_build_adapter,
-        check_fn=check_discord_requirements,
+        check_fn=discord_deps_present,
+        ensure_deps_fn=check_discord_requirements,
         is_connected=_is_connected,
         required_env=["DISCORD_BOT_TOKEN"],
         install_hint="Run `hermes setup` to install Discord support.",

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1447,6 +1447,26 @@ def _load_lark_oapi() -> bool:
         return True
 
 
+def feishu_deps_present() -> bool:
+    """PASSIVE probe: is lark-oapi installed right now?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  Uses ``feature_missing`` (cheap
+    importlib.metadata lookups) instead of importing the SDK, which is
+    deferred to ``_load_lark_oapi`` at connect time.  The ACTIVE
+    lazy-installer (``check_feishu_requirements``) is registered as
+    ``ensure_deps_fn`` and runs from ``create_adapter()`` when this
+    returns False (#79812).
+    """
+    if FEISHU_AVAILABLE:
+        return True
+    try:
+        from tools.lazy_deps import feature_missing
+        return not feature_missing("platform.feishu")
+    except Exception:  # pragma: no cover — defensive
+        return False
+
+
 def check_feishu_requirements() -> bool:
     """Ensure Feishu dependencies are installed without importing the SDK."""
     if FEISHU_AVAILABLE:
@@ -5857,7 +5877,8 @@ def register(ctx) -> None:
         name="feishu",
         label="Feishu / Lark",
         adapter_factory=_build_adapter,
-        check_fn=check_feishu_requirements,
+        check_fn=feishu_deps_present,
+        ensure_deps_fn=check_feishu_requirements,
         is_connected=_is_connected,
         validate_config=_is_connected,
         required_env=["FEISHU_APP_ID", "FEISHU_APP_SECRET"],

--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -1451,7 +1451,7 @@ def feishu_deps_present() -> bool:
     """PASSIVE probe: is lark-oapi installed right now?
 
     Registry ``check_fn`` — called from status displays and config loading,
-    so it must never install anything.  Uses ``feature_missing`` (cheap
+    so it must never install anything.  Uses ``is_available`` (cheap
     importlib.metadata lookups) instead of importing the SDK, which is
     deferred to ``_load_lark_oapi`` at connect time.  The ACTIVE
     lazy-installer (``check_feishu_requirements``) is registered as
@@ -1461,8 +1461,8 @@ def feishu_deps_present() -> bool:
     if FEISHU_AVAILABLE:
         return True
     try:
-        from tools.lazy_deps import feature_missing
-        return not feature_missing("platform.feishu")
+        from tools.lazy_deps import is_available
+        return is_available("platform.feishu")
     except Exception:  # pragma: no cover — defensive
         return False
 

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -892,14 +892,13 @@ def matrix_deps_present() -> bool:
     """PASSIVE probe: are the ``platform.matrix`` packages installed?
 
     Registry ``check_fn`` — called from status displays and config loading,
-    so it must never install anything.  ``feature_missing`` is cheap
-    (per-spec importlib.metadata lookups).  The ACTIVE lazy-installer
+    so it must never install anything.  The ACTIVE lazy-installer
     (``check_matrix_requirements``) is registered as ``ensure_deps_fn``
     and runs from ``create_adapter()`` when this returns False (#79812).
     """
     try:
-        from tools.lazy_deps import feature_missing
-        return not feature_missing("platform.matrix")
+        from tools.lazy_deps import is_available
+        return is_available("platform.matrix")
     except Exception:  # pragma: no cover — defensive
         return False
 
@@ -907,13 +906,12 @@ def matrix_deps_present() -> bool:
 def check_matrix_requirements() -> bool:
     """Return True if the Matrix adapter can be used.
 
-    Lazy-installs the full ``platform.matrix`` feature group via
-    ``tools.lazy_deps.ensure_and_bind`` whenever any of the declared
-    packages (mautrix, Markdown, aiosqlite, asyncpg, aiohttp-socks) is
-    missing — not just mautrix itself.  Previously this short-circuited on
-    ``import mautrix``, which left the other four packages uninstalled
-    forever and broke E2EE connect with ``No module named 'asyncpg'``
-    (#31116).  Rebinds module-level type globals on success.
+    Combined credentials + deps answer for setup/status callers.  The
+    registry's ``ensure_deps_fn`` is the deps-only
+    :func:`ensure_matrix_deps` below — credentials must NOT gate the
+    installer (they're handled by ``is_connected``, which also accepts
+    ``PlatformConfig.extra``-configured setups that these env checks
+    would wrongly veto).
     """
     token = _startup_env_secret("MATRIX_ACCESS_TOKEN")
     password = _startup_env_secret("MATRIX_PASSWORD")
@@ -926,6 +924,20 @@ def check_matrix_requirements() -> bool:
         logger.warning("Matrix: MATRIX_HOMESERVER not set")
         return False
 
+    return ensure_matrix_deps()
+
+
+def ensure_matrix_deps() -> bool:
+    """ACTIVE deps-only installer (registry ``ensure_deps_fn``).
+
+    Lazy-installs the full ``platform.matrix`` feature group via
+    ``tools.lazy_deps.ensure_and_bind`` whenever any of the declared
+    packages (mautrix, Markdown, aiosqlite, asyncpg, aiohttp-socks) is
+    missing — not just mautrix itself.  Previously this short-circuited on
+    ``import mautrix``, which left the other four packages uninstalled
+    forever and broke E2EE connect with ``No module named 'asyncpg'``
+    (#31116).  Rebinds module-level type globals on success.
+    """
     # Check whether any package in the platform.matrix feature group is
     # missing.  ``feature_missing`` is cheap (per-spec importlib.metadata
     # lookups) and correctly handles ``mautrix[encryption]`` by stripping
@@ -5285,7 +5297,7 @@ def register(ctx) -> None:
         label="Matrix",
         adapter_factory=_build_adapter,
         check_fn=matrix_deps_present,
-        ensure_deps_fn=check_matrix_requirements,
+        ensure_deps_fn=ensure_matrix_deps,
         is_connected=_is_connected,
         required_env=["MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN"],
         install_hint="pip install 'mautrix[encryption]'",

--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -888,6 +888,22 @@ def _startup_env_secret(name: str) -> str:
         return os.getenv(name, "").strip()
 
 
+def matrix_deps_present() -> bool:
+    """PASSIVE probe: are the ``platform.matrix`` packages installed?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  ``feature_missing`` is cheap
+    (per-spec importlib.metadata lookups).  The ACTIVE lazy-installer
+    (``check_matrix_requirements``) is registered as ``ensure_deps_fn``
+    and runs from ``create_adapter()`` when this returns False (#79812).
+    """
+    try:
+        from tools.lazy_deps import feature_missing
+        return not feature_missing("platform.matrix")
+    except Exception:  # pragma: no cover — defensive
+        return False
+
+
 def check_matrix_requirements() -> bool:
     """Return True if the Matrix adapter can be used.
 
@@ -5268,7 +5284,8 @@ def register(ctx) -> None:
         name="matrix",
         label="Matrix",
         adapter_factory=_build_adapter,
-        check_fn=check_matrix_requirements,
+        check_fn=matrix_deps_present,
+        ensure_deps_fn=check_matrix_requirements,
         is_connected=_is_connected,
         required_env=["MATRIX_HOMESERVER", "MATRIX_ACCESS_TOKEN"],
         install_hint="pip install 'mautrix[encryption]'",

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -283,6 +283,17 @@ class _ThreadContextCache:
     messages: List[Dict[str, Any]] = field(default_factory=list)
 
 
+def slack_deps_present() -> bool:
+    """PASSIVE probe: are slack-bolt/slack-sdk importable right now?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  The ACTIVE lazy-installer
+    (``check_slack_requirements``) is registered as ``ensure_deps_fn``
+    and runs from ``create_adapter()`` when this returns False (#79812).
+    """
+    return SLACK_AVAILABLE
+
+
 def check_slack_requirements() -> bool:
     """Check if Slack dependencies are available.
 
@@ -9055,7 +9066,8 @@ def register(ctx) -> None:
         name="slack",
         label="Slack",
         adapter_factory=_build_adapter,
-        check_fn=check_slack_requirements,
+        check_fn=slack_deps_present,
+        ensure_deps_fn=check_slack_requirements,
         is_connected=_is_connected,
         required_env=["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"],
         install_hint="Run `hermes setup` to install Slack support.",

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -642,11 +642,12 @@ async def _standalone_send(
 
 
 # Keep the old name as an alias so existing test imports don't break.
-# NOTE: ``check_requirements`` is the PASSIVE probe (status / unit tests) —
-# it must never trigger a pip install. ``check_teams_requirements`` is the
-# ACTIVE lazy-installer and is the registry ``check_fn`` — same contract as
-# Discord/Slack/Telegram. ``create_adapter()`` gates on ``check_fn`` before
-# the adapter exists, so install MUST run there; ``connect()`` re-checks.
+# NOTE: ``check_requirements`` is the PASSIVE probe (registry ``check_fn``,
+# status / unit tests) — it must never trigger a pip install.
+# ``check_teams_requirements`` is the ACTIVE lazy-installer, registered as
+# ``ensure_deps_fn``: the registry's ``create_adapter()`` runs it when the
+# passive probe fails, right before the gateway connects Teams (#79812).
+# ``connect()`` re-checks defensively.
 @contextmanager
 def _suppress_third_party_dotenv() -> Iterator[None]:
     """No-op ``dotenv.load_dotenv`` while importing the Teams SDK (#62935).
@@ -1467,10 +1468,12 @@ def register(ctx) -> None:
         name="teams",
         label="Microsoft Teams",
         adapter_factory=lambda cfg: TeamsAdapter(cfg),
-        # Active lazy-installer — NOT the passive ``check_requirements``.
-        # Registry create_adapter() returns None when check_fn is False, so a
-        # passive probe permanently blocks connect() and the deps never install.
-        check_fn=check_teams_requirements,
+        # PASSIVE probe — deps importable right now?  Never installs, so
+        # status displays / config loading can call it freely.
+        check_fn=check_requirements,
+        # ACTIVE lazy-installer — create_adapter() calls this when check_fn
+        # is False, right before the gateway connects Teams (#79812).
+        ensure_deps_fn=check_teams_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -642,11 +642,11 @@ async def _standalone_send(
 
 
 # Keep the old name as an alias so existing test imports don't break.
-# NOTE: ``check_requirements`` is the PASSIVE probe (used as the registry
-# ``check_fn`` and by ``gateway status``) — it must never trigger a pip
-# install. ``check_teams_requirements`` is the ACTIVE lazy-installer called
-# from ``connect()``; it installs ``platform.teams`` on demand and rebinds the
-# SDK globals, mirroring ``check_slack_requirements`` in gateway/platforms/slack.py.
+# NOTE: ``check_requirements`` is the PASSIVE probe (status / unit tests) —
+# it must never trigger a pip install. ``check_teams_requirements`` is the
+# ACTIVE lazy-installer and is the registry ``check_fn`` — same contract as
+# Discord/Slack/Telegram. ``create_adapter()`` gates on ``check_fn`` before
+# the adapter exists, so install MUST run there; ``connect()`` re-checks.
 @contextmanager
 def _suppress_third_party_dotenv() -> Iterator[None]:
     """No-op ``dotenv.load_dotenv`` while importing the Teams SDK (#62935).
@@ -1467,11 +1467,17 @@ def register(ctx) -> None:
         name="teams",
         label="Microsoft Teams",
         adapter_factory=lambda cfg: TeamsAdapter(cfg),
-        check_fn=check_requirements,
+        # Active lazy-installer — NOT the passive ``check_requirements``.
+        # Registry create_adapter() returns None when check_fn is False, so a
+        # passive probe permanently blocks connect() and the deps never install.
+        check_fn=check_teams_requirements,
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
-        install_hint="pip install microsoft-teams-apps aiohttp",
+        install_hint=(
+            "Teams SDK missing — restart the gateway to auto-install, or run: "
+            "~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'"
+        ),
         setup_fn=interactive_setup,
         # Env-driven auto-configuration — seeds PlatformConfig.extra with
         # client_id/secret/tenant + port + home_channel so env-only setups

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -1475,22 +1475,19 @@ def _install_hint() -> str:
     """Build the Teams install hint from the canonical LAZY_DEPS pins.
 
     Derived (not hardcoded) so a pin bump in ``tools/lazy_deps.py`` — aiohttp
-    is CVE-pinned, so bumps happen — never leaves this string stale, and
-    ``sys.executable -m pip`` targets the actual Hermes venv in every layout
-    (default install, ``HERMES_HOME`` override, profile installs) instead of
-    a hardcoded ``~/.hermes`` path.  Also sidesteps Ubuntu 24.04's PEP 668
-    ``externally-managed-environment`` failure that a bare ``pip install``
-    hint invites.
+    is CVE-pinned, so bumps happen — never leaves this string stale.
+    ``feature_install_command(venv_pip=True)`` targets the actual Hermes
+    venv in every layout and sidesteps Ubuntu 24.04's PEP 668 failure that
+    a bare ``pip install`` hint invites.
     """
     try:
-        from tools.lazy_deps import feature_specs
-        specs = " ".join(f"'{s}'" for s in feature_specs("platform.teams"))
+        from tools.lazy_deps import feature_install_command
+        cmd = feature_install_command("platform.teams", venv_pip=True)
     except Exception:  # pragma: no cover — defensive
-        specs = "'microsoft-teams-apps' 'aiohttp'"
-    return (
-        "Teams SDK missing — restart the gateway to auto-install, or run: "
-        f"{sys.executable} -m pip install {specs}"
-    )
+        cmd = None
+    if not cmd:
+        cmd = f"{sys.executable} -m pip install microsoft-teams-apps aiohttp"
+    return f"Teams SDK missing — restart the gateway to auto-install, or run: {cmd}"
 
 
 def register(ctx) -> None:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -27,6 +27,7 @@ import html
 import json
 import logging
 import os
+import sys
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
 from urllib.parse import quote
@@ -417,7 +418,12 @@ class _AiohttpBridgeAdapter:
 
 
 def check_requirements() -> bool:
-    """Return True when all Teams dependencies and credentials are present."""
+    """PASSIVE probe: are the Teams SDK and aiohttp importable right now?
+
+    Never installs anything — credentials are gated separately via
+    ``is_connected``/``validate_config``.  The ACTIVE lazy-installer is
+    ``check_teams_requirements`` (registered as ``ensure_deps_fn``).
+    """
     return TEAMS_SDK_AVAILABLE and AIOHTTP_AVAILABLE
 
 
@@ -769,13 +775,15 @@ class TeamsAdapter(BasePlatformAdapter):
         self._conv_refs: Dict[str, Any] = {}
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        # Lazy-install the Teams SDK on demand (parity with Slack/Discord/etc.),
-        # then re-check the module globals it rebinds.
+        # Defensive re-check: create_adapter() already ran the installer
+        # (ensure_deps_fn) if deps were missing, but connect() can also be
+        # reached via reconnect paths — re-run to bind SDK globals.
         check_teams_requirements()
         if not TEAMS_SDK_AVAILABLE:
             self._set_fatal_error(
                 "MISSING_SDK",
-                "microsoft-teams-apps could not be installed. Run: pip install microsoft-teams-apps",
+                "microsoft-teams-apps could not be installed. "
+                f"Run: {sys.executable} -m pip install microsoft-teams-apps",
                 retryable=False,
             )
             return False
@@ -783,7 +791,7 @@ class TeamsAdapter(BasePlatformAdapter):
         if not AIOHTTP_AVAILABLE:
             self._set_fatal_error(
                 "MISSING_SDK",
-                "aiohttp not installed. Run: pip install aiohttp",
+                f"aiohttp not installed. Run: {sys.executable} -m pip install aiohttp",
                 retryable=False,
             )
             return False
@@ -1462,6 +1470,28 @@ def interactive_setup() -> None:
 
 # ── Plugin entry point ────────────────────────────────────────────────────────
 
+def _install_hint() -> str:
+    """Build the Teams install hint from the canonical LAZY_DEPS pins.
+
+    Derived (not hardcoded) so a pin bump in ``tools/lazy_deps.py`` — aiohttp
+    is CVE-pinned, so bumps happen — never leaves this string stale, and
+    ``sys.executable -m pip`` targets the actual Hermes venv in every layout
+    (default install, ``HERMES_HOME`` override, profile installs) instead of
+    a hardcoded ``~/.hermes`` path.  Also sidesteps Ubuntu 24.04's PEP 668
+    ``externally-managed-environment`` failure that a bare ``pip install``
+    hint invites.
+    """
+    try:
+        from tools.lazy_deps import feature_specs
+        specs = " ".join(f"'{s}'" for s in feature_specs("platform.teams"))
+    except Exception:  # pragma: no cover — defensive
+        specs = "'microsoft-teams-apps' 'aiohttp'"
+    return (
+        "Teams SDK missing — restart the gateway to auto-install, or run: "
+        f"{sys.executable} -m pip install {specs}"
+    )
+
+
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
     ctx.register_platform(
@@ -1477,10 +1507,7 @@ def register(ctx) -> None:
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
-        install_hint=(
-            "Teams SDK missing — restart the gateway to auto-install, or run: "
-            "~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'"
-        ),
+        install_hint=_install_hint(),
         setup_fn=interactive_setup,
         # Env-driven auto-configuration — seeds PlatformConfig.extra with
         # client_id/secret/tenant + port + home_channel so env-only setups

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -6,7 +6,8 @@ Runs an aiohttp webhook server to receive messages from Teams.
 Proactive messaging (send, typing) uses the SDK's App.send() method.
 
 Requires:
-    pip install microsoft-teams-apps aiohttp
+    the ``teams`` extra (auto-installed by the gateway on first start, or
+    manually: ``<hermes-venv>/bin/pip install microsoft-teams-apps aiohttp``)
     TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID env vars
 
 Configuration in config.yaml:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -392,6 +392,17 @@ def _probe_voice_duration_seconds(path: str) -> Optional[int]:
     return None
 
 
+def telegram_deps_present() -> bool:
+    """PASSIVE probe: is python-telegram-bot importable right now?
+
+    Registry ``check_fn`` — called from status displays and config loading,
+    so it must never install anything.  The ACTIVE lazy-installer
+    (``check_telegram_requirements``) is registered as ``ensure_deps_fn``
+    and runs from ``create_adapter()`` when this returns False (#79812).
+    """
+    return TELEGRAM_AVAILABLE
+
+
 def check_telegram_requirements() -> bool:
     """Check if Telegram dependencies are available.
 
@@ -10131,7 +10142,8 @@ def register(ctx) -> None:
         name="telegram",
         label="Telegram",
         adapter_factory=_build_adapter,
-        check_fn=check_telegram_requirements,
+        check_fn=telegram_deps_present,
+        ensure_deps_fn=check_telegram_requirements,
         is_connected=_is_connected,
         required_env=["TELEGRAM_BOT_TOKEN"],
         install_hint="Run `hermes setup` to install Telegram support.",

--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -1911,12 +1911,16 @@ def register(ctx) -> None:
         allow_update_command=True,
     )
 
-    from plugins.platforms.wecom.callback_adapter import check_wecom_callback_requirements
+    from plugins.platforms.wecom.callback_adapter import (
+        check_wecom_callback_requirements,
+        ensure_wecom_callback_requirements,
+    )
     ctx.register_platform(
         name="wecom_callback",
         label="WeCom Callback (self-built apps)",
         adapter_factory=_build_callback_adapter,
         check_fn=check_wecom_callback_requirements,
+        ensure_deps_fn=ensure_wecom_callback_requirements,
         is_connected=_callback_is_connected,
         validate_config=_callback_is_connected,
         required_env=["WECOM_CALLBACK_CORP_ID", "WECOM_CALLBACK_CORP_SECRET"],

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -88,7 +88,6 @@ def ensure_wecom_callback_requirements() -> bool:
     False forever on installs without the ``wecom`` extra and the
     ``platform.wecom_callback`` LAZY_DEPS entry was never exercised.
     """
-    global ET, DEFUSEDXML_AVAILABLE
     if check_wecom_callback_requirements():
         return True
 

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -69,7 +69,41 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 
 
 def check_wecom_callback_requirements() -> bool:
+    """PASSIVE probe: are aiohttp/httpx/defusedxml importable right now?
+
+    Registry ``check_fn`` — must never install anything.  The ACTIVE
+    lazy-installer is ``ensure_wecom_callback_requirements`` below.
+    """
     return AIOHTTP_AVAILABLE and HTTPX_AVAILABLE and DEFUSEDXML_AVAILABLE
+
+
+def ensure_wecom_callback_requirements() -> bool:
+    """ACTIVE lazy-installer for the ``platform.wecom_callback`` feature.
+
+    Registered as ``ensure_deps_fn``: the registry's ``create_adapter()``
+    runs it when the passive probe fails, right before the gateway connects
+    the platform (#79812).  Installs ``defusedxml`` (the only non-core dep;
+    aiohttp/httpx ship with every messaging install) and rebinds the module
+    globals.  Before this hook existed, the passive ``check_fn`` returned
+    False forever on installs without the ``wecom`` extra and the
+    ``platform.wecom_callback`` LAZY_DEPS entry was never exercised.
+    """
+    global ET, DEFUSEDXML_AVAILABLE
+    if check_wecom_callback_requirements():
+        return True
+
+    def _import() -> dict:
+        import defusedxml.ElementTree as _ET
+
+        return {"ET": _ET, "DEFUSEDXML_AVAILABLE": True}
+
+    try:
+        from tools.lazy_deps import ensure_and_bind
+    except Exception:  # pragma: no cover — defensive
+        return False
+    if not ensure_and_bind("platform.wecom_callback", _import, globals(), prompt=False):
+        return False
+    return check_wecom_callback_requirements()
 
 
 class WecomCallbackAdapter(BasePlatformAdapter):

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -100,6 +100,97 @@ class TestPlatformRegistry:
         assert reg.create_adapter("novalidate", MagicMock()) is mock_adapter
 
 
+class TestEnsureDepsFn:
+    """check_fn (PASSIVE probe) vs ensure_deps_fn (ACTIVE installer) split.
+
+    Regression for #79812: Teams registered its passive probe as check_fn,
+    so create_adapter() returned None before connect() could lazy-install —
+    the SDK never installed.  The inverse wiring (active installer as
+    check_fn) made status displays pip-install SDKs as a side effect.
+    create_adapter() now runs ensure_deps_fn when check_fn is False.
+    """
+
+    def _entry(self, name, *, check_fn, ensure_deps_fn=None):
+        adapter = MagicMock()
+        entry = PlatformEntry(
+            name=name,
+            label=name.title(),
+            adapter_factory=lambda cfg: adapter,
+            check_fn=check_fn,
+            ensure_deps_fn=ensure_deps_fn,
+            source="plugin",
+        )
+        return entry, adapter
+
+    def test_deps_present_skips_installer(self):
+        """check_fn True → adapter created, ensure_deps_fn never called."""
+        reg = PlatformRegistry()
+        installer = MagicMock(return_value=True)
+        entry, adapter = self._entry(
+            "ready", check_fn=lambda: True, ensure_deps_fn=installer
+        )
+        reg.register(entry)
+        assert reg.create_adapter("ready", MagicMock()) is adapter
+        installer.assert_not_called()
+
+    def test_missing_deps_runs_installer_then_creates(self):
+        """check_fn False + ensure_deps_fn True → install runs, adapter created."""
+        reg = PlatformRegistry()
+        installer = MagicMock(return_value=True)
+        entry, adapter = self._entry(
+            "installable", check_fn=lambda: False, ensure_deps_fn=installer
+        )
+        reg.register(entry)
+        assert reg.create_adapter("installable", MagicMock()) is adapter
+        installer.assert_called_once()
+
+    def test_install_failure_returns_none(self):
+        """check_fn False + ensure_deps_fn False → no adapter."""
+        reg = PlatformRegistry()
+        installer = MagicMock(return_value=False)
+        entry, _ = self._entry(
+            "broken", check_fn=lambda: False, ensure_deps_fn=installer
+        )
+        reg.register(entry)
+        assert reg.create_adapter("broken", MagicMock()) is None
+        installer.assert_called_once()
+
+    def test_no_installer_missing_deps_returns_none(self):
+        """check_fn False + no ensure_deps_fn → hard block (legacy behavior)."""
+        reg = PlatformRegistry()
+        entry, _ = self._entry("blocked", check_fn=lambda: False)
+        reg.register(entry)
+        assert reg.create_adapter("blocked", MagicMock()) is None
+
+    def test_installer_exception_returns_none(self):
+        """ensure_deps_fn raising is caught, adapter not created."""
+        reg = PlatformRegistry()
+
+        def _boom():
+            raise RuntimeError("pip exploded")
+
+        entry, _ = self._entry(
+            "explosive", check_fn=lambda: False, ensure_deps_fn=_boom
+        )
+        reg.register(entry)
+        assert reg.create_adapter("explosive", MagicMock()) is None
+
+    def test_check_fn_exception_falls_through_to_installer(self):
+        """A raising check_fn is treated as deps-missing, installer still runs."""
+        reg = PlatformRegistry()
+
+        def _bad_probe():
+            raise RuntimeError("probe error")
+
+        installer = MagicMock(return_value=True)
+        entry, adapter = self._entry(
+            "flaky", check_fn=_bad_probe, ensure_deps_fn=installer
+        )
+        reg.register(entry)
+        assert reg.create_adapter("flaky", MagicMock()) is adapter
+        installer.assert_called_once()
+
+
 # ── GatewayConfig integration ────────────────────────────────────────────
 
 
@@ -494,3 +585,74 @@ class TestPluginEnablementGate:
                 )
         finally:
             _reg.unregister("myrejectedplat")
+
+    def test_missing_deps_with_installer_still_enables(
+        self, tmp_path, monkeypatch
+    ):
+        """is_connected=True + check_fn=False + ensure_deps_fn set → ENABLED.
+
+        The install is deferred to ``create_adapter()`` at gateway start
+        (#79812).  Skipping enablement here would mean a configured platform
+        whose SDK isn't installed yet never gets the chance to install it.
+        """
+        from gateway.platform_registry import platform_registry as _reg
+
+        installer = MagicMock(return_value=True)
+        _reg.register(PlatformEntry(
+            name="myinstallableplat",
+            label="MyInstallable",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: False,            # SDK not installed yet
+            ensure_deps_fn=installer,          # ...but installable on demand
+            is_connected=lambda cfg: True,     # user configured credentials
+            source="plugin",
+        ))
+        try:
+            home = self._write_config(tmp_path)
+            monkeypatch.setenv("HERMES_HOME", str(home))
+
+            from gateway.config import load_gateway_config, Platform
+            cfg = load_gateway_config()
+
+            plat = Platform("myinstallableplat")
+            assert plat in cfg.platforms and cfg.platforms[plat].enabled, (
+                "Configured platform with a registered installer must be "
+                "enabled; the install runs at create_adapter() time"
+            )
+            # Config loading must NOT have run the installer (that's the
+            # desktop boot-loop bug — see module docstring of
+            # test_startup_no_eager_platform_install.py).
+            installer.assert_not_called()
+        finally:
+            _reg.unregister("myinstallableplat")
+
+    def test_missing_deps_without_installer_not_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        """is_connected=True + check_fn=False + NO ensure_deps_fn → skipped.
+
+        Without an installer, missing deps are a hard block — enabling the
+        platform would just queue guaranteed connect failures.
+        """
+        from gateway.platform_registry import platform_registry as _reg
+
+        _reg.register(PlatformEntry(
+            name="myhardblockplat",
+            label="MyHardBlock",
+            adapter_factory=lambda cfg: None,
+            check_fn=lambda: False,
+            is_connected=lambda cfg: True,
+            source="plugin",
+        ))
+        try:
+            home = self._write_config(tmp_path)
+            monkeypatch.setenv("HERMES_HOME", str(home))
+
+            from gateway.config import load_gateway_config, Platform
+            cfg = load_gateway_config()
+
+            plat = Platform("myhardblockplat")
+            if plat in cfg.platforms:
+                assert cfg.platforms[plat].enabled is False
+        finally:
+            _reg.unregister("myhardblockplat")

--- a/tests/gateway/test_platform_registry.py
+++ b/tests/gateway/test_platform_registry.py
@@ -656,3 +656,44 @@ class TestPluginEnablementGate:
                 assert cfg.platforms[plat].enabled is False
         finally:
             _reg.unregister("myhardblockplat")
+
+
+class TestMigratedPlatformWiring:
+    """Every lazy-installable bundled platform must register the split:
+    a PASSIVE check_fn plus an ACTIVE ensure_deps_fn (#79812).
+
+    Behavior contract, not a snapshot: asserts the two fields are distinct
+    callables (probe != installer), not specific function identities, so
+    renames don't churn this test.
+    """
+
+    import pytest as _pytest
+
+    @_pytest.mark.parametrize(
+        "platform_name",
+        [
+            "teams", "telegram", "discord", "slack",
+            "matrix", "dingtalk", "feishu", "wecom_callback",
+        ],
+    )
+    def test_lazy_installable_platform_has_split_wiring(self, platform_name):
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
+        from gateway.platform_registry import platform_registry
+
+        # Materialize deferred loaders (wecom_callback is registered by the
+        # "wecom" manifest's loader; a cold get() by its own name misses).
+        platform_registry.plugin_entries()
+        entry = platform_registry.get(platform_name)
+        assert entry is not None, f"{platform_name} not registered"
+        assert entry.ensure_deps_fn is not None, (
+            f"{platform_name} has a lazy-installable SDK but no "
+            "ensure_deps_fn — its deps can never auto-install "
+            "(the #79812 deadlock)"
+        )
+        assert entry.ensure_deps_fn is not entry.check_fn, (
+            f"{platform_name} registered the same callable for the passive "
+            "probe and the active installer — status displays would "
+            "pip-install as a side effect"
+        )

--- a/tests/gateway/test_startup_no_eager_platform_install.py
+++ b/tests/gateway/test_startup_no_eager_platform_install.py
@@ -1,20 +1,22 @@
 """Regression tests: ``_apply_env_overrides`` must not lazy-install platform
 SDKs for platforms the user has not configured.
 
-For adapter plugins, ``PlatformEntry.check_fn`` doubles as the lazy-installer
-(it pip-installs the platform SDK as a side effect — see e.g.
-``plugins/platforms/discord/adapter.py::check_discord_requirements``).  The
-enablement sweep in ``_apply_env_overrides`` used to call ``check_fn`` for
-*every* registered plugin platform unconditionally, so a single
-``load_gateway_config()`` — which the desktop/dashboard readiness probe
-(``GET /api/status``) awaits synchronously — pip-installed Discord, Telegram,
-Slack, Feishu and Dingtalk even with ``platforms: none``.  That blocked
-startup until every install finished and made the desktop app time out and
-boot-loop (stuck at 94%).
+Historically ``PlatformEntry.check_fn`` doubled as the lazy-installer
+(it pip-installed the platform SDK as a side effect).  The enablement sweep
+in ``_apply_env_overrides`` used to call ``check_fn`` for *every* registered
+plugin platform unconditionally, so a single ``load_gateway_config()`` —
+which the desktop/dashboard readiness probe (``GET /api/status``) awaits
+synchronously — pip-installed Discord, Telegram, Slack, Feishu and Dingtalk
+even with ``platforms: none``.  That blocked startup until every install
+finished and made the desktop app time out and boot-loop (stuck at 94%).
 
-The fix consults the cheap ``is_connected`` credential check FIRST and only
-runs the install-triggering ``check_fn`` for platforms that are already
-enabled or actually configured.  These tests pin that contract.
+Two layers of protection now exist:
+1. The sweep consults the cheap ``is_connected`` credential check FIRST and
+   only reaches the dependency check for platforms that are already enabled
+   or actually configured (this file pins that contract).
+2. ``check_fn`` is now defined as a PASSIVE probe; the ACTIVE installer
+   lives on ``ensure_deps_fn`` and only runs from
+   ``platform_registry.create_adapter()`` (#79812).
 """
 
 from unittest.mock import MagicMock, patch

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -299,7 +299,7 @@ class TestTeamsPluginRegistration:
         kwargs = ctx.register_platform.call_args[1]
         assert kwargs["name"] == "teams"
 
-    def test_register_check_fn_is_active_lazy_installer(self):
+    def test_register_splits_passive_probe_from_active_installer(self):
         # check_fn is the PASSIVE probe (status displays call it freely);
         # the ACTIVE lazy-installer rides on ensure_deps_fn, which
         # create_adapter() invokes when the passive probe fails (#79812).

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -300,13 +300,14 @@ class TestTeamsPluginRegistration:
         assert kwargs["name"] == "teams"
 
     def test_register_check_fn_is_active_lazy_installer(self):
-        # create_adapter() gates on check_fn before connect() exists.
-        # Passive check_requirements would permanently block lazy install.
+        # check_fn is the PASSIVE probe (status displays call it freely);
+        # the ACTIVE lazy-installer rides on ensure_deps_fn, which
+        # create_adapter() invokes when the passive probe fails (#79812).
         ctx = MagicMock()
         register(ctx)
         kwargs = ctx.register_platform.call_args[1]
-        assert kwargs["check_fn"] is check_teams_requirements
-        assert kwargs["check_fn"] is not check_requirements
+        assert kwargs["check_fn"] is check_requirements
+        assert kwargs["ensure_deps_fn"] is check_teams_requirements
 
     def test_register_auth_env_vars(self):
         ctx = MagicMock()

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -299,6 +299,15 @@ class TestTeamsPluginRegistration:
         kwargs = ctx.register_platform.call_args[1]
         assert kwargs["name"] == "teams"
 
+    def test_register_check_fn_is_active_lazy_installer(self):
+        # create_adapter() gates on check_fn before connect() exists.
+        # Passive check_requirements would permanently block lazy install.
+        ctx = MagicMock()
+        register(ctx)
+        kwargs = ctx.register_platform.call_args[1]
+        assert kwargs["check_fn"] is check_teams_requirements
+        assert kwargs["check_fn"] is not check_requirements
+
     def test_register_auth_env_vars(self):
         ctx = MagicMock()
         register(ctx)

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -83,6 +83,20 @@ class TestAllowlist:
 
     def test_feature_install_command_unknown(self):
         assert ld.feature_install_command("not.real") is None
+        assert ld.feature_install_command("not.real", venv_pip=True) is None
+
+    def test_feature_install_command_venv_pip_targets_interpreter(self):
+        # venv_pip=True must target the running interpreter's pip (correct in
+        # every install layout, immune to PEP 668) and carry the same specs
+        # as the default uv form.
+        import sys as _sys
+        default = ld.feature_install_command("platform.teams")
+        venv = ld.feature_install_command("platform.teams", venv_pip=True)
+        assert default is not None and venv is not None
+        assert venv.startswith(f"{_sys.executable} -m pip install ")
+        assert default.startswith("uv pip install ")
+        # Same spec tail on both forms.
+        assert venv.split(" -m pip install ", 1)[1] == default.split("uv pip install ", 1)[1]
 
 
 # ---------------------------------------------------------------------------

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -971,12 +971,23 @@ def is_available(feature: str) -> bool:
     return not feature_missing(feature)
 
 
-def feature_install_command(feature: str) -> Optional[str]:
-    """Return the ``pip install`` command a user could run manually, or None."""
+def feature_install_command(feature: str, *, venv_pip: bool = False) -> Optional[str]:
+    """Return the ``pip install`` command a user could run manually, or None.
+
+    ``venv_pip=True`` targets the running interpreter's pip
+    (``{sys.executable} -m pip install …``) — correct in every layout
+    (default install, ``HERMES_HOME`` overrides, profile installs) and
+    immune to Ubuntu 24.04's PEP 668 ``externally-managed-environment``
+    failure that a bare/system ``pip install`` hint invites.  The default
+    ``uv pip install`` form is kept for contexts that document uv usage.
+    """
     if feature not in LAZY_DEPS:
         return None
     specs = LAZY_DEPS[feature]
-    return "uv pip install " + " ".join(repr(s) for s in specs)
+    joined = " ".join(repr(s) for s in specs)
+    if venv_pip:
+        return f"{sys.executable} -m pip install {joined}"
+    return "uv pip install " + joined
 
 
 @dataclass

--- a/website/docs/developer-guide/adding-platform-adapters.md
+++ b/website/docs/developer-guide/adding-platform-adapters.md
@@ -120,7 +120,15 @@ def register(ctx):
         name="my_platform",
         label="My Platform",
         adapter_factory=lambda cfg: MyPlatformAdapter(cfg),
+        # PASSIVE probe — "are deps/config present right now?".  Called from
+        # status displays and config loading, so it must NEVER pip-install.
         check_fn=check_requirements,
+        # ACTIVE installer (optional) — only for platforms with a
+        # lazy-installable SDK.  create_adapter() calls it when check_fn
+        # returns False, right before the gateway connects the platform.
+        # Typically wraps tools.lazy_deps.ensure_and_bind(...).  Omit it
+        # and a False check_fn is a hard block.
+        # ensure_deps_fn=ensure_requirements,
         validate_config=validate_config,
         required_env=["MY_PLATFORM_TOKEN"],
         install_hint="pip install my-platform-sdk",

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -255,7 +255,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 | Problem | Solution |
 |---------|----------|
 | `Can't find a suitable configuration file` from `docker compose` | You are not in the repo that has `docker-compose.yml`, or you are on a native install — use `hermes gateway restart` instead, or `cd` into the clone first |
-| `requirements not met (pip install microsoft-teams-apps …)` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install microsoft-teams-apps aiohttp`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
+| `requirements not met` / `Teams SDK missing` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install microsoft-teams-apps aiohttp`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -104,15 +104,35 @@ TEAMS_ALLOWED_USERS=<your-aad-object-id>
 
 ## Step 5: Start the Gateway
 
+**Docker** (must run from the directory that contains `docker-compose.yml` — usually your cloned `hermes-agent` repo, not `~`):
+
 ```bash
+cd /path/to/hermes-agent
 HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d gateway
 ```
 
-This starts the gateway. The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
+**Native / systemd install** (typical `hermes` one-liner installer under `~/.hermes/hermes-agent`):
+
+```bash
+hermes gateway restart
+# or foreground: hermes gateway run
+```
+
+The Teams SDK is optional; when Teams is enabled, the gateway lazy-installs it into Hermes' own venv on first start (do **not** use system `pip install` on Ubuntu 24.04 — that hits PEP 668 `externally-managed-environment`). To install manually into the Hermes venv:
+
+```bash
+~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'
+# or from a clone of the agent: uv sync --extra teams
+```
+
+The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
 
 ```bash
 curl http://localhost:3978/health   # should return: ok
+# Docker:
 docker logs -f hermes
+# Native:
+hermes gateway status -l
 ```
 
 Look for:
@@ -234,13 +254,15 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 
 | Problem | Solution |
 |---------|----------|
+| `Can't find a suitable configuration file` from `docker compose` | You are not in the repo that has `docker-compose.yml`, or you are on a native install — use `hermes gateway restart` instead, or `cd` into the clone first |
+| `requirements not met (pip install microsoft-teams-apps …)` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |
 | `No inference provider configured` | Check that `ANTHROPIC_API_KEY` (or another provider key) is set in `~/.hermes/.env` |
 | Bot receives messages but ignores them | Your AAD object ID may not be in `TEAMS_ALLOWED_USERS`. Run `teams status --verbose` to find it |
 | Tunnel URL changes on restart | devtunnel URLs are persistent if you use a named tunnel (`devtunnel create hermes-bot`). ngrok and cloudflared generate a new URL each run unless you have a paid plan — update the bot endpoint with `teams app update` when it changes |
-| Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` for tracebacks |
+| Teams shows "This bot is not responding" | The webhook returned an error. Check `docker logs hermes` / `hermes gateway status -l` for tracebacks |
 | `[teams] Failed to connect` in logs | The SDK failed to authenticate. Double-check your credentials and that the tenant ID matches the account you used in `teams login` |
 
 ---

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -121,7 +121,7 @@ hermes gateway restart
 The Teams SDK is optional; when Teams is enabled, the gateway lazy-installs it into Hermes' own venv on first start (do **not** use system `pip install` on Ubuntu 24.04 — that hits PEP 668 `externally-managed-environment`). To install manually into the Hermes venv:
 
 ```bash
-~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'
+~/.hermes/hermes-agent/venv/bin/pip install microsoft-teams-apps aiohttp
 # or from a clone of the agent: uv sync --extra teams
 ```
 
@@ -255,7 +255,7 @@ Make sure your configured port (`TEAMS_PORT`, default `3978`) is reachable from 
 | Problem | Solution |
 |---------|----------|
 | `Can't find a suitable configuration file` from `docker compose` | You are not in the repo that has `docker-compose.yml`, or you are on a native install — use `hermes gateway restart` instead, or `cd` into the clone first |
-| `requirements not met (pip install microsoft-teams-apps …)` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install 'microsoft-teams-apps==2.0.13.4' 'aiohttp==3.14.1'`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
+| `requirements not met (pip install microsoft-teams-apps …)` / `No adapter available for teams` | Restart gateway so lazy-install can run, or install into the **Hermes venv**: `~/.hermes/hermes-agent/venv/bin/pip install microsoft-teams-apps aiohttp`. System `pip` fails on Ubuntu 24.04 (PEP 668) and would not affect the service anyway |
 | `health` endpoint works but bot doesn't respond | Check that your tunnel is still running and the bot's messaging endpoint matches the tunnel URL |
 | `KeyError: 'teams'` in logs | Restart the container — this is fixed in the current version |
 | Bot responds with auth errors | Verify `TEAMS_CLIENT_ID`, `TEAMS_CLIENT_SECRET`, and `TEAMS_TENANT_ID` are all set correctly |


### PR DESCRIPTION
## Summary

Platform plugins no longer have to choose between "status displays pip-install SDKs" and "lazy-install never runs": `PlatformEntry.check_fn` is now contractually a PASSIVE dependency probe, and a new optional `PlatformEntry.ensure_deps_fn` carries the ACTIVE lazy-installer, which `create_adapter()` runs exactly when the probe fails — right before the gateway connects an enabled, configured platform.

Builds on and supersedes #79812 by @xxxigm (both commits cherry-picked with authorship preserved).

## The bug class

`check_fn` served three contradictory roles: adapter-creation gate (`platform_registry.create_adapter()`), config auto-enablement gate (`gateway/config.py::_apply_env_overrides`), and status display (`hermes setup` / `hermes status` / dashboard readiness probe). Plugins had to pick ONE function for all three:

| Wiring | Platforms | Failure mode |
|---|---|---|
| ACTIVE installer as `check_fn` | discord, slack, telegram, matrix, dingtalk, feishu | Every status/config surface could pip-install SDKs as a side effect — the desktop 94% boot-loop class (mitigated once in `_apply_env_overrides`, re-fixed in `_platform_status`, still latent anywhere new that reads `check_fn`) |
| PASSIVE probe as `check_fn` | teams, wecom_callback | `create_adapter()` returns `None` before `connect()` can lazy-install → SDK never installs. #79812 for Teams; wecom_callback's `platform.wecom_callback` LAZY_DEPS entry was unreachable dead code |

The contributor's fix (#79812) swapped Teams to the active-as-`check_fn` wiring — correct for the deadlock, but it moves Teams into the first row: `hermes gateway status` and `load_gateway_config()` fallbacks would pip-install `microsoft-teams-apps` as a side effect. This PR fixes the class instead of the instance.

## Changes

- `gateway/platform_registry.py`: `ensure_deps_fn` field; `create_adapter()` probes, then installs, then re-gates. Exception-safe on both probe and installer.
- `gateway/config.py`: enablement pass keeps a configured platform whose deps are missing but installable; the install itself is deferred to `create_adapter()` at gateway start (never runs during config load — preserves the desktop boot-loop fix by construction).
- `hermes_cli/plugins.py`: `register_platform` docstring documents the PASSIVE/ACTIVE contract (`ensure_deps_fn` flows via `entry_kwargs`).
- Migrated all 8 lazy-installable platform plugins:
  - teams: `check_fn=check_requirements` (passive), `ensure_deps_fn=check_teams_requirements` (active) — fixes #79812 without install-on-status
  - telegram/discord/slack/matrix/dingtalk/feishu: new `*_deps_present()` passive probes; existing `check_*_requirements` installers moved to `ensure_deps_fn`
  - wecom_callback: gains `ensure_wecom_callback_requirements` — its lazy-install path works for the first time
- Platforms with no optional deps (irc, ntfy, buzz, simplex, line, a2a, …) unchanged: no `ensure_deps_fn` means a False `check_fn` stays a hard block.
- Docs: `adding-platform-adapters.md` documents the two-field contract; Teams messaging docs (from #79812) cover native/systemd vs Docker start and Hermes-venv installs.

## Validation

| Check | Result |
|---|---|
| `tests/gateway/` registry/teams/lazy-install selection | 120 passed, 2 skipped |
| New registry tests (`TestEnsureDepsFn`, enablement gates) | 8 new tests, all passing |
| E2E (real imports, temp HERMES_HOME, all 8 plugins) | 28/28: wiring verified per-plugin; installer runs exactly once on missing deps; blocks on failed install; Teams passive probe provably never calls `lazy_deps.ensure`; config enablement enables-but-never-installs; `_platform_status` never installs |
| ruff on all 15 changed .py files | clean |

## Credit

Teams deadlock diagnosis, original fix, and docs by @xxxigm (#79812) — commits cherry-picked with authorship preserved, then reworked into the two-field split on top.

Closes #79812
