### PR TITLE
fix(anthropic): derive auxiliary is_oauth from the token instead of hardcoding False

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1993,6 +1993,39 @@ def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
     return False
 
 
+def _aux_is_oauth(api_key: Any, base_url: str) -> bool:
+    """Decide the ``is_oauth`` flag for an ``AnthropicAuxiliaryClient``.
+
+    Two conditions must BOTH hold before the Claude Code identity
+    transforms in ``build_anthropic_kwargs`` may fire:
+
+    1. ``api_key`` is an Anthropic OAuth token (``_is_oauth_token``), and
+    2. ``base_url`` is native ``api.anthropic.com``.
+
+    Condition (2) preserves the invariant established in #12846: an OAuth
+    flag must never leak onto a third-party Anthropic-compatible gateway
+    (MiniMax, Zhipu GLM, DashScope, Kimi, LiteLLM proxies), because those
+    endpoints reject the Claude Code identity headers with 401/403.
+    Condition (1) is what the three hardcoded ``is_oauth=False`` call
+    sites were missing: on native Anthropic with a subscription token the
+    aux client was built as if it were an API-key client, so the identity
+    block was never prepended and Anthropic answered 429
+    ``{"type":"rate_limit_error","message":"Error"}`` on Opus-class models.
+
+    ``api_key`` may be a callable (Entra ID token provider) — those are
+    never Anthropic OAuth tokens, so they resolve to False.
+    """
+    if not isinstance(api_key, str) or not api_key:
+        return False
+    if not _is_anthropic_compatible_host(base_url):
+        return False
+    try:
+        from agent.anthropic_adapter import _is_oauth_token
+    except ImportError:
+        return False
+    return bool(_is_oauth_token(api_key))
+
+
 def _maybe_wrap_anthropic(
     client_obj: Any,
     model: str,
@@ -2073,7 +2106,8 @@ def _maybe_wrap_anthropic(
         model, base_url[:60] if base_url else "", api_mode or "auto-detected",
     )
     return AnthropicAuxiliaryClient(
-        real_client, model, api_key, base_url, is_oauth=False,
+        real_client, model, api_key, base_url,
+        is_oauth=_aux_is_oauth(api_key, base_url),
     )
 
 
@@ -3283,7 +3317,10 @@ def _try_custom_endpoint() -> Tuple[Optional[Any], Optional[str]]:
             )
             return _create_openai_client(api_key=custom_key, base_url=_clean_base, **_extra), model
         return (
-            AnthropicAuxiliaryClient(real_client, model, custom_key, custom_base, is_oauth=False),
+            AnthropicAuxiliaryClient(
+                real_client, model, custom_key, custom_base,
+                is_oauth=_aux_is_oauth(custom_key, custom_base),
+            ),
             model,
         )
     # URL-based anthropic detection for custom endpoints that didn't set
@@ -6128,7 +6165,8 @@ def resolve_provider_client(
                         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                                 else (client, final_model))
                     sync_anthropic = AnthropicAuxiliaryClient(
-                        real_client, final_model, custom_key, custom_base, is_oauth=False,
+                        real_client, final_model, custom_key, custom_base,
+                        is_oauth=_aux_is_oauth(custom_key, custom_base),
                     )
                     if async_mode:
                         return AsyncAnthropicAuxiliaryClient(sync_anthropic), final_model

--- a/tests/agent/test_auxiliary_client_oauth_flag.py
+++ b/tests/agent/test_auxiliary_client_oauth_flag.py
@@ -1,0 +1,173 @@
+"""Auxiliary Anthropic clients must derive ``is_oauth`` from the token.
+
+Three ``AnthropicAuxiliaryClient`` construction sites hardcoded
+``is_oauth=False``.  On native ``api.anthropic.com`` with a Claude
+Pro/Max subscription token that silently suppresses the Claude Code
+identity transforms in ``build_anthropic_kwargs``, and Anthropic answers
+HTTP 429 ``{"type":"rate_limit_error","message":"Error"}`` on Opus-class
+models — an opaque failure that looks like a quota but is not one.
+
+The flag must be True only when BOTH hold:
+  1. the token is an Anthropic OAuth token, and
+  2. the endpoint is native ``api.anthropic.com``.
+
+Condition (2) preserves the #12846 invariant: no OAuth leak onto
+third-party Anthropic-compatible gateways (MiniMax, GLM, Kimi, LiteLLM).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+OAUTH_TOKEN = "sk-ant-oat01-" + "x" * 95
+API_KEY = "sk-ant-api03-" + "y" * 95
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in (
+        "OPENAI_API_KEY", "OPENAI_BASE_URL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── _aux_is_oauth truth table ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "token,base_url,expected",
+    [
+        # Native Anthropic + OAuth token → identity transforms must fire.
+        (OAUTH_TOKEN, "https://api.anthropic.com", True),
+        (OAUTH_TOKEN, "https://api.anthropic.com/v1", True),
+        # Native Anthropic + plain API key → not OAuth.
+        (API_KEY, "https://api.anthropic.com", False),
+        # Third-party Anthropic-compatible gateways must NEVER get the
+        # OAuth flag even when the token happens to look like one (#12846).
+        (OAUTH_TOKEN, "https://api.minimaxi.com/anthropic", False),
+        (OAUTH_TOKEN, "https://open.bigmodel.cn/api/anthropic", False),
+        (OAUTH_TOKEN, "https://api.kimi.com/coding", False),
+        (OAUTH_TOKEN, "http://127.0.0.1:8080/anthropic", False),
+        # Degenerate inputs.
+        ("", "https://api.anthropic.com", False),
+        (None, "https://api.anthropic.com", False),
+        (OAUTH_TOKEN, "", False),
+    ],
+)
+def test_aux_is_oauth_truth_table(token, base_url, expected):
+    from agent.auxiliary_client import _aux_is_oauth
+
+    assert _aux_is_oauth(token, base_url) is expected
+
+
+def test_aux_is_oauth_rejects_callable_token_provider():
+    """Entra ID passes a callable bearer provider — never Anthropic OAuth."""
+    from agent.auxiliary_client import _aux_is_oauth
+
+    assert _aux_is_oauth(lambda: OAUTH_TOKEN, "https://api.anthropic.com") is False
+
+
+# ── call site 1: _maybe_wrap_anthropic (the transport chokepoint) ────
+
+
+def _fake_openai_client():
+    client = MagicMock(name="openai_client")
+    # Must not look like an already-wrapped adapter.
+    return client
+
+
+@pytest.mark.parametrize(
+    "token,base_url,expected",
+    [
+        (OAUTH_TOKEN, "https://api.anthropic.com", True),
+        (API_KEY, "https://api.anthropic.com", False),
+        (OAUTH_TOKEN, "https://api.minimaxi.com/anthropic", False),
+    ],
+)
+def test_maybe_wrap_anthropic_propagates_oauth_flag(token, base_url, expected):
+    from agent import auxiliary_client as ac
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=MagicMock(name="anthropic_sdk_client"),
+    ):
+        wrapped = ac._maybe_wrap_anthropic(
+            _fake_openai_client(), "claude-opus-4-5", token, base_url,
+        )
+
+    assert isinstance(wrapped, ac.AnthropicAuxiliaryClient)
+    assert wrapped.chat.completions._is_oauth is expected
+
+
+# ── call site 2: custom endpoint with api_mode=anthropic_messages ────
+
+
+@pytest.mark.parametrize(
+    "token,base_url,expected",
+    [
+        (OAUTH_TOKEN, "https://api.anthropic.com", True),
+        (OAUTH_TOKEN, "https://api.minimaxi.com/anthropic", False),
+        (API_KEY, "https://api.anthropic.com", False),
+    ],
+)
+def test_custom_anthropic_messages_endpoint_propagates_oauth_flag(
+    token, base_url, expected,
+):
+    from agent import auxiliary_client as ac
+
+    with patch(
+        "agent.auxiliary_client._resolve_custom_runtime",
+        return_value=(base_url, token, "anthropic_messages"),
+    ), patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=MagicMock(name="anthropic_sdk_client"),
+    ), patch(
+        "agent.auxiliary_client._read_main_model_for_aux",
+        return_value="claude-opus-4-5",
+    ):
+        client, _model = ac._try_custom_endpoint()
+
+    assert isinstance(client, ac.AnthropicAuxiliaryClient)
+    assert client.chat.completions._is_oauth is expected
+
+
+# ── consistency with the already-correct branch ──────────────────────
+
+
+def test_chokepoint_agrees_with_try_anthropic_on_native_oauth():
+    """The two paths must not disagree for the same token + host.
+
+    ``_try_anthropic`` already derives the flag correctly
+    (``is_oauth=_is_oauth_token(token)``).  The chokepoint used to
+    hardcode False, so identical inputs produced different wire
+    behaviour depending on which branch happened to build the client.
+    """
+    from agent import auxiliary_client as ac
+
+    with patch(
+        "agent.anthropic_adapter.build_anthropic_client",
+        return_value=MagicMock(name="anthropic_sdk_client"),
+    ), patch(
+        "agent.auxiliary_client._select_pool_entry",
+        return_value=(False, None),
+    ), patch(
+        "agent.anthropic_adapter.resolve_anthropic_token",
+        return_value=OAUTH_TOKEN,
+    ), patch(
+        "agent.auxiliary_client._get_aux_model_for_provider",
+        return_value="claude-haiku-4-5",
+    ):
+        via_branch, _ = ac._try_anthropic()
+        via_chokepoint = ac._maybe_wrap_anthropic(
+            _fake_openai_client(), "claude-haiku-4-5",
+            OAUTH_TOKEN, "https://api.anthropic.com",
+        )
+
+    assert (
+        via_chokepoint.chat.completions._is_oauth
+        == via_branch.chat.completions._is_oauth
+        is True
+    )


### PR DESCRIPTION
## Summary

Three `AnthropicAuxiliaryClient` construction sites in `agent/auxiliary_client.py` pass `is_oauth=False` unconditionally. A fourth — `_try_anthropic()` — derives it correctly from the token. The result: **the same OAuth token against the same `api.anthropic.com` host produces different wire behaviour depending on which branch happened to build the client**, and the wrong one fails with an opaque 429 that looks like a quota but isn't.

| Line | Site |
|---|---|
| ~2076 | `_maybe_wrap_anthropic()` — the transport chokepoint every `resolve_provider_client` branch funnels through |
| ~3286 | `_try_custom_endpoint()` — custom endpoint, `api_mode: anthropic_messages` |
| ~6131 | named custom provider branch — same, for `custom_providers` entries |
| ~3540 | `_try_anthropic()` — ✅ already correct: `is_oauth=_is_oauth_token(token)` |

## Why it matters

`is_oauth` is not cosmetic. `agent/anthropic_adapter.py::build_anthropic_kwargs` gates two things on it:

```python
# anthropic_adapter.py:2888
if is_oauth:
    cc_block = {"type": "text", "text": _CLAUDE_CODE_SYSTEM_PREFIX}
    ...
# anthropic_adapter.py:3043
if is_oauth:
    betas.extend(_OAUTH_ONLY_BETAS)
```

With the flag false on native Anthropic, a Claude Pro/Max subscription token goes out without the identity Anthropic expects, and Opus-class models answer:

```
HTTP 429 {"type":"error","error":{"type":"rate_limit_error","message":"Error"}}
```

with **no `anthropic-ratelimit-unified-*` reset headers**. Account utilisation at time of capture was `0.14` (5h) / `0.23` (7d), both `allowed` — this is not a quota, but it is indistinguishable from one at the call site, which makes it expensive to diagnose. It also defeats any retry logic that waits for a reset window: there is no window to wait for.

## Reachability (public API, not internals)

```python
from agent.auxiliary_client import resolve_provider_client

resolve_provider_client("custom", model="claude-opus-5",
    explicit_base_url="https://api.anthropic.com",
    explicit_api_key=<sk-ant-oat01 token>)   # is_oauth=False   <-- bug
resolve_provider_client("anthropic")          # is_oauth=True    <-- correct
```

Observed output:

```
=== PUBLIC API: resolve_provider_client('custom', base=api.anthropic.com) ===
  client : AnthropicAuxiliaryClient
  model  : claude-opus-5
  is_oauth: False

=== PUBLIC API: resolve_provider_client('anthropic') ===
  client : AnthropicAuxiliaryClient
  model  : claude-haiku-4-5-20251001
  is_oauth: True
```

## Live wire confirmation

Same real OAuth token, same host, only the construction path differs:

```
A. client built by _maybe_wrap_anthropic (hardcoded is_oauth=False)
   opus-5     -> RateLimitError 429 {'type':'rate_limit_error','message':'Error'}
B. client built by _try_anthropic (correct _is_oauth_token)
   opus-5     -> 200  'AUXOK'
C. control: same chokepoint client on haiku
   haiku-4-5  -> 200  'AUXOK'
```

Row C is why this hides: **only Opus-class models enforce the identity**, so the defect stays invisible while auxiliary tasks resolve to Haiku (the current default aux model), and surfaces only when someone points an auxiliary task at Opus.

## The fix

A shared helper, `_aux_is_oauth()`, requiring **both** conditions:

1. `_is_oauth_token(api_key)` — the token really is an Anthropic OAuth token; **and**
2. `_is_anthropic_compatible_host(base_url)` — the endpoint is native `api.anthropic.com`.

Condition (2) deliberately preserves the invariant established in #12846: the OAuth flag must never leak onto third-party Anthropic-compatible gateways (MiniMax, Zhipu GLM, DashScope, Kimi, LiteLLM proxies), which reject Claude Code identity headers with 401/403. That is exactly why the original `False` was *safe for those endpoints* and *wrong only for native Anthropic* — this PR narrows the behaviour rather than flipping it. Callable API keys (Entra ID token providers) resolve to `False`.

## Tests

`tests/agent/test_auxiliary_client_oauth_flag.py` — 18 cases:

- `_aux_is_oauth` truth table, including explicit no-leak cases for MiniMax / Zhipu GLM / Kimi `/coding` / a local `/anthropic` proxy, plain `sk-ant-api` keys, and degenerate inputs
- OAuth flag propagation through all three previously-hardcoded call sites
- a cross-check that the chokepoint now agrees with `_try_anthropic()` for identical inputs

Verified in both directions:

```
without the source change:  14 failed, 4 passed   (RED)
with the source change:     18 passed             (GREEN)
```

## Regression

`tests/agent/` on `upstream/main @ aaf968851`:

```
before:  106 failed, 3698 passed, 17 skipped
after:   106 failed, 3716 passed, 17 skipped
```

Failure sets compared line-by-line (`comm`): **zero new failures, zero fixed** — the same 106 pre-existing failures, plus the 18 new tests. Pyright reports one pre-existing `str | None` complaint on `final_model` at the third call site; it is on an argument this PR does not touch.

## Environment

- Hermes Agent @ `aaf968851`
- Provider `anthropic`, endpoint `api.anthropic.com`, Claude **Max** OAuth (`sk-ant-oat01`)
- Models: `claude-opus-5` (fails), `claude-haiku-4-5` (passes on the same broken path)
- Python 3.11.15, Arch/CachyOS
