### PR TITLE
fix(acp): honor platform_toolsets.acp and agent.disabled_toolsets (#79516)

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -604,6 +604,7 @@ class SessionManager:
         from run_agent import AIAgent
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_cli.tools_config import _get_platform_tools
 
         config = load_config()
         model_cfg = config.get("model")
@@ -621,12 +622,22 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        # Resolve the ACP toolset through the canonical platform resolver so
+        # platform_toolsets.acp and agent.disabled_toolsets are honored the
+        # same way they are for cli/telegram/etc. (#79516). The resolver
+        # falls back to the hermes-acp composite when acp is unconfigured and
+        # includes enabled MCP server toolsets (mcp-<name>).
+        enabled_toolsets = sorted(_get_platform_tools(config, "acp"))
+        agent_cfg = config.get("agent") or {}
+        disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                enabled_toolsets,
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": disabled_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -603,6 +603,7 @@ class SessionManager:
         from run_agent import AIAgent
         from hermes_cli.config import load_config
         from hermes_cli.runtime_provider import resolve_runtime_provider
+        from hermes_cli.tools_config import _get_platform_tools
 
         config = load_config()
         model_cfg = config.get("model")
@@ -620,12 +621,22 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        # Resolve the ACP toolset through the canonical platform resolver so
+        # platform_toolsets.acp and agent.disabled_toolsets are honored the
+        # same way they are for cli/telegram/etc. (#79516). The resolver
+        # falls back to the hermes-acp composite when acp is unconfigured and
+        # includes enabled MCP server toolsets (mcp-<name>).
+        enabled_toolsets = sorted(_get_platform_tools(config, "acp"))
+        agent_cfg = config.get("agent") or {}
+        disabled_toolsets = agent_cfg.get("disabled_toolsets") or None
+
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
-                ["hermes-acp"],
+                enabled_toolsets,
                 mcp_server_names=configured_mcp_servers,
             ),
+            "disabled_toolsets": disabled_toolsets,
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -110,6 +110,72 @@ class TestCreateSession:
 
         assert state.agent.session_cwd == "/tmp/project"
 
+    def test_make_agent_honors_platform_toolsets_acp(self, monkeypatch):
+        """platform_toolsets.acp scopes the ACP agent's enabled toolsets (#79516)."""
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        base_cfg = {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "mcp_servers": {},
+            "platform_toolsets": {"acp": ["web", "file", "memory"]},
+        }
+        monkeypatch.setattr("acp_adapter.session.load_config", lambda: base_cfg, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: base_cfg)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {"provider": "fake", "api_mode": "chat_completions"},
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        enabled = captured["kwargs"]["enabled_toolsets"]
+        # The explicit acp list wins: no terminal/execute_code, no hermes-acp.
+        assert "hermes-acp" not in enabled
+        assert "terminal" not in enabled
+        assert "web" in enabled
+        assert "file" in enabled
+
+    def test_make_agent_honors_agent_disabled_toolsets(self, monkeypatch):
+        """agent.disabled_toolsets strips toolsets for ACP sessions too (#79516)."""
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["kwargs"] = kwargs
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        base_cfg = {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "mcp_servers": {},
+            "agent": {"disabled_toolsets": ["terminal", "process", "execute_code"]},
+        }
+        monkeypatch.setattr("acp_adapter.session.load_config", lambda: base_cfg, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: base_cfg)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {"provider": "fake", "api_mode": "chat_completions"},
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        kwargs = captured["kwargs"]
+        assert kwargs["disabled_toolsets"] == ["terminal", "process", "execute_code"]
+        # Default ACP toolset is still hermes-acp (unconfigured platform).
+        assert "hermes-acp" in kwargs["enabled_toolsets"]
+
 
 
 

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -93,7 +93,14 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m", "provider": "p"}},
+            cfg_get=lambda _cfg, *_keys, default=None: default,
+            save_config=lambda *_a, **_k: None,
+            get_env_value=lambda *_a, **_k: None,
+            save_env_value=lambda *_a, **_k: None,
+        ),
     )
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## Summary

Fixes #79516: ACP sessions (Buzz.app, Zed, VS Code, JetBrains) ignored all config-file toolset restrictions. `_make_agent()` in `acp_adapter/session.py` hardcoded `["hermes-acp"]` as the enabled toolset, so `terminal`, `process`, and `execute_code` were always available regardless of profile config.

**Fix**: resolve the enabled toolset through the canonical platform resolver — `_get_platform_tools(config, "acp")` — which honors `platform_toolsets.acp` (falling back to the `hermes-acp` composite when unconfigured, matching prior behavior) and passes `agent.disabled_toolsets` through to `AIAgent`. This is the same pattern the gateway uses for every other platform (`gateway/run.py:19520-19523`).

Both documented restriction mechanisms now work for ACP:
1. `platform_toolsets.acp` — an explicit list scopes the ACP agent's tools
2. `agent.disabled_toolsets` — the global cross-platform denylist is now applied

## Verification

- New regression tests: explicit `platform_toolsets.acp` list excludes `hermes-acp`/`terminal`; `agent.disabled_toolsets` is passed through and default `hermes-acp` is preserved when unconfigured
- RED on old code (2 failed), GREEN now: 17/17 in `tests/acp/test_session.py`
