### PR TITLE
fix(profiles): stop Desktop-spawned profile backends before renaming the profile directory

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2021,8 +2021,31 @@ def list_authenticated_providers(
     _current_provider_norm = str(current_provider or "").strip().lower()
     _current_base_url_norm = str(current_base_url or "").strip().rstrip("/").lower()
 
-    def _can_probe_custom_provider(*, row_is_current: bool) -> bool:
-        return bool(probe_custom_providers or (probe_current_custom_provider and row_is_current))
+    def _can_probe_custom_provider(*, row_is_current: bool, url: str = "") -> bool:
+        if probe_custom_providers or (probe_current_custom_provider and row_is_current):
+            return True
+        # Local endpoints (localhost Ollama, LM Studio, llama.cpp, ...) are
+        # always worth probing: they are cheap to hit and their catalog
+        # changes whenever the user pulls/loads a model. A saved allowlist
+        # ``models:`` list would otherwise pin the row to stale entries and
+        # hide every model pulled after the config was written.
+        if url:
+            try:
+                from agent.model_metadata import is_local_endpoint as _ile
+                if _ile(url):
+                    return True
+            except Exception:
+                pass
+        return False
+
+    def _is_local_endpoint_url(url: str) -> bool:
+        if not url:
+            return False
+        try:
+            from agent.model_metadata import is_local_endpoint as _ile
+            return bool(_ile(url))
+        except Exception:
+            return False
 
     # Normalize the excluded-providers list once for fast membership checks.
     # Compared against hermes_id / mdev_id (section 1), pid / hermes_slug
@@ -2690,6 +2713,9 @@ def list_authenticated_providers(
             # - With an api_key: always probe (user opted into the endpoint).
             # - Without an api_key but with an allowlist-shaped ``models:``
             #   (list/string): skip — the user narrowed a public endpoint.
+            #   LOCAL endpoints (localhost Ollama / LM Studio / llama.cpp)
+            #   are exempt: their allowlist pins stale entries, so probe
+            #   live so newly pulled/loaded models stay visible.
             #   A singular ``default_model``/``model`` does NOT count as
             #   narrowing (mirrors section 4 / #40542).
             # - A dict-shaped ``models:`` is per-model metadata
@@ -2720,8 +2746,10 @@ def list_authenticated_providers(
                     and _ep_url_norm == _current_base_url_norm
                 )
             )
-            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current) and bool(api_url) and discover and (
-                bool(api_key) or not has_explicit_models
+            should_probe = _can_probe_custom_provider(row_is_current=_ep_is_current, url=api_url) and bool(api_url) and discover and (
+                bool(api_key)
+                or not has_explicit_models
+                or bool(api_url) and _is_local_endpoint_url(api_url)
             )
             if should_probe:
                 try:
@@ -3009,7 +3037,11 @@ def list_authenticated_providers(
             #   live catalog (Bifrost / aggregator-gateway case).
             # - Without an api_key but with an allowlist-shaped ``models:``
             #   (list/string), the user narrowed a public endpoint (e.g.
-            #   ollama.com). Preserve that list and skip live discovery.
+            #   ollama.com). Preserve that list and skip live discovery —
+            #   unless the endpoint is LOCAL (localhost Ollama / LM Studio /
+            #   llama.cpp): there the allowlist only pins stale entries and
+            #   hides models pulled after the config was written, so probe
+            #   live regardless (cheap, local, fast).
             # - A dict-shaped ``models:`` is per-model metadata written by
             #   ``_save_custom_provider`` for context_length — not an
             #   allowlist. Still probe so Desktop/Telegram match
@@ -3032,9 +3064,13 @@ def list_authenticated_providers(
                 and _current_base_url_group_count == 1
             )
             should_probe = (
-                _can_probe_custom_provider(row_is_current=_grp_is_current)
+                _can_probe_custom_provider(row_is_current=_grp_is_current, url=api_url)
                 and bool(api_url)
-                and (bool(api_key) or not grp.get("has_explicit_models"))
+                and (
+                    bool(api_key)
+                    or not grp.get("has_explicit_models")
+                    or _is_local_endpoint_url(api_url)
+                )
                 and grp.get("discover_models", True)
             )
             if should_probe:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2212,6 +2212,13 @@ def rename_profile(old_name: str, new_name: str) -> Path:
         _cleanup_gateway_service(old_canon, old_dir)
         _stop_gateway_process(old_dir)
 
+    # 1b. Stop any other backends bound to this profile (Desktop-spawned
+    # serve/dashboard processes the gateway.pid file never names). They hold
+    # the profile's SQLite connection open and keep writing files, which makes
+    # the directory rename below fail with PermissionError [WinError 5] (and,
+    # on POSIX, EBUSY/ENOTEMPTY). Mirrors the delete path.
+    _stop_profile_backends(old_canon, old_dir)
+
     # 2. Rename directory
     old_dir.rename(new_dir)
     print(f"✓ Renamed {old_dir.name} → {new_dir.name}")

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -968,3 +968,85 @@ def test_custom_provider_dict_models_pin_requires_discover_false(monkeypatch):
     row = next(p for p in providers if p["name"] == "Local Ollama")
     assert calls == []
     assert row["models"] == ["llama3"]
+
+
+def test_local_custom_provider_allowlist_is_live_probed(monkeypatch):
+    """A local (localhost) custom_providers entry with an allowlist-shaped
+    ``models:`` list and NO api_key must still be live-probed.
+
+    Regression: the allowlist + missing-key gate skipped discovery, so models
+    pulled after config was written (deepseek-r1:14b, deepseek-coder-en:latest,
+    dagbs/deepseek-coder-v2-lite-instruct:Q4_K_M) never appeared in the picker.
+    """
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.model_switch._save_discovered_models_to_config",
+        lambda *a, **k: None,
+    )
+    calls = []
+
+    def fetch(api_key, base_url, **kwargs):
+        calls.append((api_key, base_url))
+        return ["deepseek-r1:14b", "deepseek-coder-en:latest",
+                "dagbs/deepseek-coder-v2-lite-instruct:Q4_K_M",
+                "qwen2.5-coder:7b", "llama3.1:latest", "qwen2.5:14b"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="custom:groq",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "ollama",
+                "base_url": "http://localhost:11434/v1",
+                "models": ["qwen2.5-coder:7b", "llama3.1:latest", "qwen2.5:14b"],
+            }
+        ],
+        # GUI path with the endpoint neither current nor probe-flagged.
+        probe_custom_providers=False,
+        probe_current_custom_provider=False,
+    )
+
+    assert len(calls) == 1
+    assert calls[0] == ("", "http://localhost:11434/v1")
+    row = next(p for p in providers if p["name"] == "ollama")
+    assert row["models"] == [
+        "deepseek-r1:14b", "deepseek-coder-en:latest",
+        "dagbs/deepseek-coder-v2-lite-instruct:Q4_K_M",
+        "qwen2.5-coder:7b", "llama3.1:latest", "qwen2.5:14b",
+    ]
+
+
+def test_remote_custom_provider_allowlist_without_key_is_not_probed(monkeypatch):
+    """A public remote endpoint with an allowlist and no api_key must keep its
+    allowlist — live /models is not probed, so the picker preserves the user's
+    curated narrowing instead of replacing it."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    calls = []
+
+    def fetch(*args, **kwargs):
+        calls.append(args)
+        return ["llama-4-maverick"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fetch)
+
+    providers = list_authenticated_providers(
+        current_provider="openai-codex",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "groq",
+                "base_url": "https://api.groq.com/openai/v1",
+                "models": ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"],
+            }
+        ],
+        probe_custom_providers=False,
+        probe_current_custom_provider=False,
+    )
+
+    assert calls == []
+    row = next(p for p in providers if p["name"] == "groq")
+    assert row["models"] == ["llama-3.3-70b-versatile", "llama-3.1-8b-instant"]


### PR DESCRIPTION
## What\n\nename_profile only stopped the gateway process named by gateway.pid. Profiles managed by the Desktop app run an additional per-profile serve backend that keeps the profile's SQLite connections open and keeps writing files, so renaming the profile directory failed on Windows with PermissionError [WinError 5] (surfaced as HTTP 500 from PATCH /api/profiles/{name}).\n\nThis mirrors the delete path: stop any profile-bound backends before renaming.\n\n## Also included\n\n- d93b656d9 fix: always live-probe local custom provider endpoints\n\n## Verified\n\n- Live rename steve -> noty succeeded with the backend running (2 processes stopped, dir renamed, alias updated).\n- state.db / projects.db integrity checks pass; all files intact.\n- Profile starts and serves under the new name (HERMES_BACKEND_READY); Desktop re-attaches to the renamed profile.