### PR TITLE
fix(tools): stop search_files failing on absolute Windows paths under Git Bash

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -326,6 +326,47 @@ class TestShellFileOpsHelpers:
         assert "'C:/workspace/tools'" in commands[0]
         assert "'/c/workspace/tools'" not in commands[0]
 
+    def test_search_files_rg_passes_win32_safe_path(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        ops._command_cache["rg"] = True
+        ops._search_files_rg("*.py", r"C:\workspace\tools", 10, 0)
+
+        assert commands, "expected rg --files invocation"
+        assert "'C:/workspace/tools'" in commands[0]
+        assert "'/c/workspace/tools'" not in commands[0]
+
+    def test_zero_match_probe_passes_win32_safe_path(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            return {"output": "", "returncode": 1}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        ops._command_cache["rg"] = True
+        ops._zero_match_probe("NoSuchTokenXYZ", r"C:\workspace\tools", None)
+
+        assert commands, "expected zero-match probe rg invocation"
+        for cmd in commands:
+            assert "'C:/workspace/tools'" in cmd
+            assert "'/c/workspace/tools'" not in cmd
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -295,6 +295,37 @@ class TestShellFileOpsHelpers:
             "C:/Users/alice/notes.txt"
         ) == "'/c/Users/alice/notes.txt'"
 
+    def test_escape_native_tool_arg_keeps_win32_drive_paths(self, monkeypatch, file_ops):
+        import tools.environments.local as local_mod
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert file_ops._escape_native_tool_arg(
+            "/c/Users/alice/notes.txt"
+        ) == "'C:/Users/alice/notes.txt'"
+        assert file_ops._escape_native_tool_arg(
+            r"C:\Users\alice\notes.txt"
+        ) == "'C:/Users/alice/notes.txt'"
+
+    def test_search_with_rg_passes_win32_safe_path(self, mock_env, monkeypatch):
+        import tools.environments.local as local_mod
+        from tools.file_operations import ShellFileOperations
+
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        commands = []
+
+        def side_effect(command, **kwargs):
+            commands.append(command)
+            return {"output": "", "returncode": 1}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        ops._command_cache["rg"] = True
+        ops._search_with_rg("ShellFileOperations", r"C:\workspace\tools", None, 10, 0, "content", 0)
+
+        assert commands, "expected rg invocation"
+        assert "'C:/workspace/tools'" in commands[0]
+        assert "'/c/workspace/tools'" not in commands[0]
+
     @pytest.mark.windows_only
     def test_read_file_uses_bash_safe_windows_paths(self, mock_env):
         """Windows-only: proves read_file's shell commands carry the MSYS path

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -46,6 +46,7 @@ from tools.environments.local import (
     _quote_bash_path,
     _resolve_safe_cwd,
     _sanitize_subprocess_env,
+    _win32_tool_path,
     _windows_to_msys_path,
     hermes_subprocess_env,
 )
@@ -103,6 +104,26 @@ class TestBashSafePath:
         )
         assert "/c/Users/Alexander/AppData/Local/Temp/hermes-snap-abc.sh" in quoted
         assert "\\" not in quoted
+
+
+class TestWin32ToolPath:
+    def test_msys_drive_becomes_forward_slash_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _win32_tool_path("/c/workspace/hermes-agent/tools") == (
+            "C:/workspace/hermes-agent/tools"
+        )
+
+    def test_native_backslash_becomes_forward_slash(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _win32_tool_path(r"C:\workspace\tools") == "C:/workspace/tools"
+
+    def test_relative_path_unchanged(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _win32_tool_path("tools") == "tools"
+
+    def test_noop_off_windows(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", False)
+        assert _win32_tool_path("/c/workspace/tools") == "/c/workspace/tools"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_local_env_windows_msys.py
+++ b/tests/tools/test_local_env_windows_msys.py
@@ -113,6 +113,11 @@ class TestWin32ToolPath:
             "C:/workspace/hermes-agent/tools"
         )
 
+    def test_cygdrive_and_mnt_drive_forms(self, monkeypatch):
+        monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
+        assert _win32_tool_path("/cygdrive/c/Users/x") == "C:/Users/x"
+        assert _win32_tool_path("/mnt/c/Users/x") == "C:/Users/x"
+
     def test_native_backslash_becomes_forward_slash(self, monkeypatch):
         monkeypatch.setattr(local_mod, "_IS_WINDOWS", True)
         assert _win32_tool_path(r"C:\workspace\tools") == "C:/workspace/tools"

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -121,6 +121,12 @@ def _bash_safe_path(path: str) -> str:
     Python compatibility; those still need the ``/c/...`` rewrite —
     MSYS argument conversion treats ``C:/...`` as a Windows path and
     can corrupt the login-shell ``drivers\\etc`` lookup.
+
+    For Win32-native tools invoked from Git Bash under
+    ``MSYS_NO_PATHCONV`` (e.g. Win32 ``rg.exe``), use
+    :func:`_win32_tool_path` instead — those binaries speak CreateFile,
+    not MSYS mounts, and quoted ``/c/...`` argv is passed through
+    unchanged.
     """
     if not _IS_WINDOWS or not path:
         return path
@@ -128,6 +134,33 @@ def _bash_safe_path(path: str) -> str:
     if "\\" in path:
         path = path.replace("\\", "/")
     return path
+
+
+def _win32_tool_path(path: str) -> str:
+    """Return *path* in a form Win32 CreateFile APIs accept from Git Bash.
+
+    Hermes sets ``MSYS_NO_PATHCONV=1`` / ``MSYS2_ARG_CONV_EXCL=*`` so bash
+    does not rewrite argv for native Windows children. Combined with
+    single-quoted ``/c/...`` paths (see :func:`_bash_safe_path`), Win32
+    ``rg.exe`` then fails with ``IO error ... (os error 3)`` because
+    CreateFile does not understand MSYS drive mounts.
+
+    Normalize drive paths to forward-slash ``C:/Users/x`` (also accepts
+    ``/c/...``, ``/cygdrive/c/...``, ``/mnt/c/...``). Relative and plain
+    POSIX paths are left alone aside from backslash → slash so bash
+    single-quoting cannot eat escapes. No-op off Windows.
+    """
+    if not _IS_WINDOWS or not path:
+        return path
+    native = _msys_to_windows_path(path)
+    m = re.match(r'^([a-zA-Z]):[\\/]*(.*)$', native)
+    if m:
+        drive = m.group(1).upper()
+        tail = (m.group(2) or "").replace("\\", "/")
+        return f"{drive}:/{tail}" if tail else f"{drive}:/"
+    if "\\" in native:
+        return native.replace("\\", "/")
+    return native
 
 
 def _quote_bash_path(path: str) -> str:

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1137,11 +1137,27 @@ class ShellFileOperations(FileOperations):
         ``Directory \\drivers\\etc does not exist`` failure class. Reuses
         the env-layer translator so shell file ops and the terminal ``cd``
         agree on the path form. No-op off Windows and for plain POSIX paths.
+
+        Do not use this for paths passed to Win32-native tools (``rg.exe``);
+        use :meth:`_escape_native_tool_arg` instead.
         """
         from tools.environments.local import _bash_safe_path
 
         arg = _bash_safe_path(arg)
         # Use single quotes and escape any single quotes in the string
+        return "'" + arg.replace("'", "'\"'\"'") + "'"
+
+    def _escape_native_tool_arg(self, arg: str) -> str:
+        """Escape a path for Win32-native tools spawned via Git Bash.
+
+        Under ``MSYS_NO_PATHCONV``, quoted ``/c/...`` argv reaches
+        CreateFile unchanged and Win32 ``rg`` fails. Keep drive paths as
+        ``C:/...`` so search_files works with native Win32 ripgrep while
+        bash builtins continue to use :meth:`_escape_shell_arg`.
+        """
+        from tools.environments.local import _win32_tool_path
+
+        arg = _win32_tool_path(arg)
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
     def _atomic_write(self, path: str, content: str) -> "ExecuteResult":
@@ -2696,9 +2712,11 @@ class ShellFileOperations(FileOperations):
         if not self._has_command('rg'):
             return None
         glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        # Path uses Win32-safe form: rg.exe under MSYS_NO_PATHCONV rejects /c/...
+        q_path = self._escape_native_tool_arg(path)
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {q_path} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2720,7 +2738,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_arg(pattern)} {q_path} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2740,7 +2758,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_arg(pattern)} {q_path} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2859,10 +2877,11 @@ class ShellFileOperations(FileOperations):
             glob_pattern = pattern
 
         fetch_limit = limit + offset
+        q_path = self._escape_native_tool_arg(path)
         # Try mtime-sorted first (rg 13+); fall back to unsorted if not supported.
         cmd_sorted = (
             f"rg --files --sortr=modified -g {self._escape_shell_arg(glob_pattern)} "
-            f"{self._escape_shell_arg(path)} 2>/dev/null "
+            f"{q_path} 2>/dev/null "
             f"| head -n {fetch_limit}"
         )
         result = self._exec(cmd_sorted, timeout=60)
@@ -2873,7 +2892,7 @@ class ShellFileOperations(FileOperations):
             # --sortr may have failed on older rg; retry without it.
             cmd_plain = (
                 f"rg --files -g {self._escape_shell_arg(glob_pattern)} "
-                f"{self._escape_shell_arg(path)} 2>/dev/null "
+                f"{q_path} 2>/dev/null "
                 f"| head -n {fetch_limit}"
             )
             result = self._exec(cmd_plain, timeout=60)
@@ -2955,9 +2974,10 @@ class ShellFileOperations(FileOperations):
         elif output_mode == "count":
             cmd_parts.append("-c")  # Count per file
         
-        # Add pattern and path
+        # Add pattern and path. Path must be Win32-safe (C:/...), not /c/... —
+        # native Win32 rg.exe uses CreateFile under MSYS_NO_PATHCONV.
         cmd_parts.append(self._escape_shell_arg(pattern))
-        cmd_parts.append(self._escape_shell_arg(path))
+        cmd_parts.append(self._escape_native_tool_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
         # For context mode, rg emits separator lines ("--") between groups,


### PR DESCRIPTION
## What does this PR do?

On native Windows with Git Bash, `search_files` failed when given absolute drive paths (`C:\...` or `/c/...`). The tool rewrote those paths to MSYS form for bash, then passed the quoted `/c/...` argv to Win32 `rg.exe`. With Hermes' default `MSYS_NO_PATHCONV`, CreateFile does not understand MSYS mounts, so searches returned IO errors even though `cd /c/...` worked in the same shell.

### Bug Cause

`_escape_shell_arg` rewrites drive paths to `/c/...` so bash builtins (`sed`, `test`, `find`, GNU `grep`) resolve correctly. That form is wrong for Win32 ripgrep under `MSYS_NO_PATHCONV=1` / `MSYS2_ARG_CONV_EXCL=*`: quoted `/c/...` is passed through unchanged and CreateFile fails with os error 3. Relative paths still worked because they never triggered the drive rewrite.

### Fix

Add `_win32_tool_path` / `_escape_native_tool_arg` and use them for every `rg` search-root path (`_search_with_rg`, `_search_files_rg`, `_zero_match_probe`). Bash builtins keep `_escape_shell_arg` (`/c/...`). Off-Windows behavior is unchanged.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/local.py` - add `_win32_tool_path` to normalize MSYS/Cygwin/WSL drive paths to forward-slash `C:/...` for Win32 tools
- `tools/file_operations.py` - add `_escape_native_tool_arg`; pass Win32-safe paths to all `rg` invocations; leave bash/find/grep on `/c/...`
- `tests/tools/test_local_env_windows_msys.py` - cover `_win32_tool_path` including `/cygdrive` and `/mnt` forms
- `tests/tools/test_file_operations.py` - assert content search, file search, and zero-match probes quote `C:/...` not `/c/...`

## How to Test

1. On Windows with Git Bash + a Win32 `rg` on PATH, from a Hermes checkout:
   - Call `search_files` with `path=/c/<drive>/.../<repo>/tools` and a known pattern -> matches (not `IO error ... os error 3`)
   - Same with `path=C:\...\tools` -> matches
   - Relative `path=tools` -> still matches
2. Automated (already run locally):

```bash
scripts/run_tests.sh tests/tools/test_local_env_windows_msys.py tests/tools/test_file_operations.py -q
# focused Win32 path nodes also: pytest -k "Win32Tool or win32_safe" -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (Git Bash + Win32 ripgrep)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
