### PR TITLE
refactor(state): extract RowID/Role cluster into hermes_state_rowid.py (R4-C5)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -74,6 +74,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _PREVIEW_SCAFFOLDED_SQL,
 )
 from hermes_state_portability import SessionPortabilityMixin
+from hermes_state_rowid import SessionRowIdMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
 
@@ -1887,7 +1888,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             handle.close()
 
 
-class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
+class SessionDB(SessionRowIdMixin, SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
     """
     SQLite-backed session storage with FTS5 search.
 
@@ -6705,66 +6706,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return pending
 
         return self._execute_write(_do) or []
-
-    def latest_message_row_id(
-        self, session_id: str, *, role: str = "user", offset: int = 0, require_text: bool = True
-    ) -> Optional[int]:
-        """Row id of the most recent active message with *role*, or ``None``.
-
-        Two callers, same need — "the message I mean, without an id": the agent
-        defaulting to the turn that triggered it, and the desktop reacting to a
-        live message that hasn't round-tripped through a resume yet.
-        ``offset`` steps to earlier turns (1 = the one before the latest) so a
-        reaction can land retroactively — "two messages ago" is how the caller
-        thinks about it.
-
-        ``require_text`` (default) skips rows with no plain-text content —
-        tool-call-only assistant turns and attachment stubs don't render as
-        bubbles, so "the latest message" as a HUMAN means it must never
-        resolve to one (a reaction landing on an invisible row looks dropped,
-        and its annotation quotes an empty string).
-        """
-        if not session_id or role not in {"user", "assistant"} or offset < 0:
-            return None
-
-        text_filter = (
-            "AND content IS NOT NULL AND TRIM(content) != '' " if require_text else ""
-        )
-
-        with self._lock:
-            row = self._conn.execute(
-                "SELECT id FROM messages WHERE session_id = ? AND role = ? "
-                f"AND active = 1 {text_filter}ORDER BY id DESC LIMIT 1 OFFSET ?",
-                (session_id, role, int(offset)),
-            ).fetchone()
-
-        return row[0] if row else None
-
-    def latest_user_message_row_id(self, session_id: str) -> Optional[int]:
-        """Row id of the most recent active user message, or ``None``.
-
-        The agent's default reaction target: "the message that triggered me",
-        so the model never has to thread row ids through a tool call (mirrors
-        the photon adapter's ``_record_last_inbound``).
-        """
-        return self.latest_message_row_id(session_id, role="user")
-
-    def get_message_role(self, session_id: str, row_id: int) -> Optional[str]:
-        """Role of the active message at *row_id* in *session_id*, or ``None``.
-
-        Lets a reaction event carry the target's role so a renderer can match
-        a live message that doesn't know its durable row id yet.
-        """
-        if not session_id:
-            return None
-
-        with self._lock:
-            row = self._conn.execute(
-                "SELECT role FROM messages WHERE id = ? AND session_id = ? AND active = 1",
-                (int(row_id), session_id),
-            ).fetchone()
-
-        return row[0] if row else None
 
     def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.

--- a/hermes_state_rowid.py
+++ b/hermes_state_rowid.py
@@ -1,0 +1,78 @@
+"""Message row-id / role lookups for SessionDB.
+
+Mixin contract: this is a plain mixin class consumed by
+``hermes_state.SessionDB``. It defines no ``__init__`` and no state of its
+own; methods access the host's attributes (``self._conn``, ``self._lock``)
+established by ``SessionDB.__init__``. It must never import hermes_state
+(cycle) — shared module-level constants live in hermes_state_common.
+"""
+
+import logging
+
+from typing import Optional
+
+# Moved methods logged under the "hermes_state" logger before the split;
+# keep that logger identity so log filtering/capture behavior is unchanged.
+logger = logging.getLogger("hermes_state")
+
+
+class SessionRowIdMixin:
+    def latest_message_row_id(
+        self, session_id: str, *, role: str = "user", offset: int = 0, require_text: bool = True
+    ) -> Optional[int]:
+        """Row id of the most recent active message with *role*, or ``None``.
+
+        Two callers, same need — "the message I mean, without an id": the agent
+        defaulting to the turn that triggered it, and the desktop reacting to a
+        live message that hasn't round-tripped through a resume yet.
+        ``offset`` steps to earlier turns (1 = the one before the latest) so a
+        reaction can land retroactively — "two messages ago" is how the caller
+        thinks about it.
+
+        ``require_text`` (default) skips rows with no plain-text content —
+        tool-call-only assistant turns and attachment stubs don't render as
+        bubbles, so "the latest message" as a HUMAN means it must never
+        resolve to one (a reaction landing on an invisible row looks dropped,
+        and its annotation quotes an empty string).
+        """
+        if not session_id or role not in {"user", "assistant"} or offset < 0:
+            return None
+
+        text_filter = (
+            "AND content IS NOT NULL AND TRIM(content) != '' " if require_text else ""
+        )
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT id FROM messages WHERE session_id = ? AND role = ? "
+                f"AND active = 1 {text_filter}ORDER BY id DESC LIMIT 1 OFFSET ?",
+                (session_id, role, int(offset)),
+            ).fetchone()
+
+        return row[0] if row else None
+
+    def latest_user_message_row_id(self, session_id: str) -> Optional[int]:
+        """Row id of the most recent active user message, or ``None``.
+
+        The agent's default reaction target: "the message that triggered me",
+        so the model never has to thread row ids through a tool call (mirrors
+        the photon adapter's ``_record_last_inbound``).
+        """
+        return self.latest_message_row_id(session_id, role="user")
+
+    def get_message_role(self, session_id: str, row_id: int) -> Optional[str]:
+        """Role of the active message at *row_id* in *session_id*, or ``None``.
+
+        Lets a reaction event carry the target's role so a renderer can match
+        a live message that doesn't know its durable row id yet.
+        """
+        if not session_id:
+            return None
+
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT role FROM messages WHERE id = ? AND session_id = ? AND active = 1",
+                (int(row_id), session_id),
+            ).fetchone()
+
+        return row[0] if row else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,6 +389,7 @@ py-modules = [
   "hermes_state_portability",
   "hermes_state_schema",
   "hermes_state_search",
+  "hermes_state_rowid",
   "hermes_time",
   "hermes_logging",
   "utils",

--- a/tests/hermes_state/test_hermes_state_rowid_seam.py
+++ b/tests/hermes_state/test_hermes_state_rowid_seam.py
@@ -1,0 +1,120 @@
+"""Seam tests for the R4-C5 RowID/Role extraction (hermes_state_rowid.py).
+
+The window bytes (hermes_state.py lines 6709-6767 at pin aaf9688519) moved
+byte-verbatim into ``SessionRowIdMixin``; ``hermes_state.SessionDB`` now
+inherits it. These tests pin the seam: every moved name must resolve
+``is``-identical through the class, and the RowID/Role behavior must work
+through the SessionDB re-export path.
+"""
+
+import pytest
+
+import hermes_state
+import hermes_state_rowid
+from hermes_state import SessionDB
+from hermes_state_rowid import SessionRowIdMixin
+
+#: Moved names: (class attribute, name on the leaf mixin)
+MOVED_NAMES = [
+    "latest_message_row_id",
+    "latest_user_message_row_id",
+    "get_message_role",
+]
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("sess-rowid", source="cli")
+    yield d
+    d.close()
+
+
+def test_leaf_is_mixin_class():
+    """The leaf module exports exactly the mixin class."""
+    assert SessionRowIdMixin.__name__ == "SessionRowIdMixin"
+
+
+def test_moved_names_identity_through_class():
+    """Every moved method is `is`-identical through SessionDB (seam identity).
+
+    The mixin is a real base of SessionDB, so attribute lookup walks the
+    MRO to the same function object the leaf module defines.
+    """
+    for name in MOVED_NAMES:
+        leaf_attr = getattr(SessionRowIdMixin, name)
+        class_attr = getattr(SessionDB, name)
+        assert class_attr is leaf_attr, f"{name}: SessionDB.{name} is not SessionRowIdMixin.{name}"
+        # and it resolves through hermes_state the same way
+        assert getattr(hermes_state.SessionDB, name) is leaf_attr
+
+
+def test_leaf_module_reexports_are_identical():
+    """Module attribute on hermes_state (module-level lookup) matches leaf."""
+    for name in MOVED_NAMES:
+        assert getattr(hermes_state_rowid.SessionRowIdMixin, name) is getattr(
+            hermes_state.SessionDB, name
+        )
+
+
+def test_mixin_declared_as_base():
+    """SessionRowIdMixin is a direct base of SessionDB (MRO sanity)."""
+    assert SessionRowIdMixin in SessionDB.__mro__
+    assert SessionDB.__mro__.index(SessionRowIdMixin) > 0
+
+
+def test_rowid_assignment_and_role_roundtrip(db):
+    """Row ids are durable and monotonic; roles round-trip via get_message_role."""
+    db.append_messages_batch(
+        "sess-rowid",
+        [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "user", "content": "second question"},
+        ],
+    )
+
+    # latest user message is the third row
+    last_user = db.latest_user_message_row_id("sess-rowid")
+    assert last_user is not None
+    assert last_user > 0
+
+    # latest message (default role=user) == latest user message
+    assert db.latest_message_row_id("sess-rowid") == last_user
+
+    # latest assistant message is the second row
+    last_assistant = db.latest_message_row_id("sess-rowid", role="assistant")
+    assert last_assistant is not None
+    assert last_assistant < last_user
+
+    # roles round-trip
+    assert db.get_message_role("sess-rowid", last_user) == "user"
+    assert db.get_message_role("sess-rowid", last_assistant) == "assistant"
+
+    # offset steps back: second-to-latest user message is the first row
+    assert db.latest_message_row_id("sess-rowid", offset=1) == last_user - 2
+
+    # unknown row / empty session guards
+    assert db.get_message_role("sess-rowid", 999999) is None
+    assert db.latest_message_row_id("") is None
+    assert db.latest_message_row_id("sess-rowid", role="system") is None
+    assert db.latest_message_row_id("sess-rowid", offset=-1) is None
+
+
+def test_rowid_skips_empty_content_when_require_text(db):
+    """require_text (default) skips rows with no plain-text content."""
+    db.append_messages_batch(
+        "sess-rowid",
+        [
+            {"role": "user", "content": "visible question"},
+            {"role": "assistant", "content": "", "tool_calls": [{"name": "terminal", "arguments": "{}"}]},
+        ],
+    )
+    # default: latest user message is the visible one
+    assert db.get_message_role("sess-rowid", db.latest_user_message_row_id("sess-rowid")) == "user"
+    # require_text (default) skips the empty assistant row -> None
+    assert db.latest_message_row_id("sess-rowid", role="assistant") is None
+    # require_text=False resolves to the empty assistant row (id 2)
+    latest_any = db.latest_message_row_id("sess-rowid", role="assistant", require_text=False)
+    assert latest_any is not None
+    assert db.get_message_role("sess-rowid", latest_any) == "assistant"


### PR DESCRIPTION
refactor(state): extract RowID/Role cluster into hermes_state_rowid.py (R4-C5)

## Slice

- **God-file:** `hermes_state.py` (9,691 lines) — large-file decomposition tracker #78647, target #78636
- **Window:** 6709–6767 (59 lines, 2,647 B) — RowID/Role cluster (C5)
- **Module:** `hermes_state_rowid.py` — class `SessionRowIdMixin` (house precedent: SessionSearchMixin/SessionSchemaMixin/SessionPortabilityMixin; no re-indent)
- **Golden sha256:** `68d5aba228998b20b227429b6f2ad6f3d0cb7adfdcc11ecfd38f2d1474dc50b4` — verified byte-identical after sanctioned seams (difflib 0; full reconstruction == module file exactly). Window sha also verified at current origin/main `ea0d54db1d` — no drift, merge-relevant.

## Collision gate (live, nothing trusted)

310 open PRs touch hermes_state.py (consensus warning: earlier censuses counted 10). Per-PR merge-base-accurate hunk verification: **0 PRs modify any byte of window 6709–6767** (76 carry it byte-identical; 234 forked before the window existed). No patch-path collisions on the moved names.

## Seam identity

`SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin, SessionRowIdMixin)` — MRO chain verified. All 3 moved names (`latest_message_row_id`, `latest_user_message_row_id`, `get_message_role`) resolve `is`-identical through SessionDB. Out-edges only `self._conn`/`self._lock`/`self.latest_message_row_id` (internal) — instance attrs stay on SessionDB. `hermes_state_rowid.py` imports only `typing` — one-way edge, no circular import (module docstring forbids importing hermes_state).

## Double-blind review (2 reviewers, never 1)

- Pass A: **APPROVED** — golden sha re-derived, difflib 0, reconstruction exact, MRO identity runtime-verified, zero collateral, full affected-set green (217/217: seam 6 + hermes_state 187 + reactions 13 + send_react 2 + finalize 9)
- Pass B (adversarial): **APPROVED** — SPEC COMPLIANCE PASS on all 8 hunt items; one failing test confirmed pre-existing at the pin baseline (SQLite tmp-path env failure, reproduced in sibling worktree at aaf9688519 — unrelated to the slice); file math reconciles exactly

## Zero collateral

`git show --stat`: hermes_state.py diff = import + bases + window deletion ONLY (63 lines changed); pyproject.toml py-modules += hermes_state_rowid (house convention). ruff clean, `git diff --check` clean, LF-only, DCO-signed.

## Interlock

Part of #78647
Part of #78636
Kill lock on #78636. Collision discipline: no overlap with R5-C9 (gated on #71945), R2 (3204–3279), or R3 (5291–5463) windows — in-flight slices, no double-slicing.
