### PR TITLE
fix(gateway): channel_overrides scope model banner + reasoning effort (#79468)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -543,7 +543,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and reasoning effort.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -552,6 +552,9 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+
+    _KNOWN_KEYS = {"model", "provider", "system_prompt", "reasoning_effort"}
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -561,16 +564,30 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.reasoning_effort is not None:
+            out["reasoning_effort"] = self.reasoning_effort
         return out
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChannelOverride":
         if not data:
             return cls()
+        # Silent discard of unknown keys cost real debugging time (#79468) —
+        # warn so typos in model/system_prompt/reasoning_effort surface
+        # immediately instead of being swallowed.
+        unknown = set(data) - cls._KNOWN_KEYS
+        if unknown:
+            import logging
+            logging.getLogger(__name__).warning(
+                "channel_overrides entry has unknown key(s) %s — ignored. "
+                "Known keys: model, provider, system_prompt, reasoning_effort",
+                sorted(unknown),
+            )
         return cls(
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            reasoning_effort=data.get("reasoning_effort"),
         )
 
 

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -596,7 +596,7 @@ class SessionResetPolicy:
 @dataclass
 class ChannelOverride:
     """
-    Per-channel override for model, provider, and system prompt.
+    Per-channel override for model, provider, system prompt, and reasoning effort.
 
     Used in config under platforms.<name>.channel_overrides[channel_id].
     Enables different channels (e.g. Discord #daily vs #dev) to use different
@@ -605,6 +605,9 @@ class ChannelOverride:
     model: Optional[str] = None
     provider: Optional[str] = None
     system_prompt: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+
+    _KNOWN_KEYS = {"model", "provider", "system_prompt", "reasoning_effort"}
 
     def to_dict(self) -> Dict[str, Any]:
         out: Dict[str, Any] = {}
@@ -614,16 +617,30 @@ class ChannelOverride:
             out["provider"] = self.provider
         if self.system_prompt is not None:
             out["system_prompt"] = self.system_prompt
+        if self.reasoning_effort is not None:
+            out["reasoning_effort"] = self.reasoning_effort
         return out
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "ChannelOverride":
         if not data:
             return cls()
+        # Silent discard of unknown keys cost real debugging time (#79468) —
+        # warn so typos in model/system_prompt/reasoning_effort surface
+        # immediately instead of being swallowed.
+        unknown = set(data) - cls._KNOWN_KEYS
+        if unknown:
+            import logging
+            logging.getLogger(__name__).warning(
+                "channel_overrides entry has unknown key(s) %s — ignored. "
+                "Known keys: model, provider, system_prompt, reasoning_effort",
+                sorted(unknown),
+            )
         return cls(
             model=data.get("model"),
             provider=data.get("provider"),
             system_prompt=data.get("system_prompt"),
+            reasoning_effort=data.get("reasoning_effort"),
         )
 
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8163,6 +8163,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Resolve reasoning effort for a session, honoring session overrides.
 
         Priority: session-scoped ``/reasoning --session`` override >
+        channel override (``channel_overrides.reasoning_effort``) >
         per-model override (``agent.reasoning_overrides``) > global
         ``agent.reasoning_effort``. ``model`` should be the session's
         *effective* model (session ``/model`` override included) so
@@ -8180,6 +8181,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
+
+        # Channel-scoped reasoning effort — the channel is a first-class
+        # config scope (model/provider/system_prompt already are), so a
+        # listing channel and a strategy channel can have different
+        # thinking budgets without a global setting (#79468).
+        if source is not None:
+            try:
+                override = _get_channel_override(
+                    self.config,
+                    source.platform,
+                    source.chat_id,
+                    thread_id=getattr(source, "thread_id", None),
+                    parent_id=getattr(source, "parent_chat_id", None),
+                )
+                if override is not None and override.reasoning_effort:
+                    from hermes_constants import parse_reasoning_effort
+
+                    parsed = parse_reasoning_effort(override.reasoning_effort)
+                    if parsed is not None:
+                        return parsed
+            except Exception:
+                pass
+
         return self._load_reasoning_config(model)
 
     def _set_session_reasoning_override(
@@ -18309,19 +18333,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When ``source`` is given, the model resolves through the channel
+        override chain (channel_overrides > global default) so the banner
+        advertises the model the session will actually run on (#79468).
         """
         from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
 
-        model = _resolve_gateway_model()
+        if source is not None:
+            try:
+                model = self._resolve_model_for_channel(
+                    source.platform,
+                    source.chat_id,
+                    thread_id=getattr(source, "thread_id", None),
+                    parent_id=getattr(source, "parent_chat_id", None),
+                ) or _resolve_gateway_model()
+            except Exception:
+                model = _resolve_gateway_model()
+        else:
+            model = _resolve_gateway_model()
         config_context_length = None
         provider = None
         base_url = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9726,6 +9726,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Resolve reasoning effort for a session, honoring session overrides.
 
         Priority: session-scoped ``/reasoning --session`` override >
+        channel override (``channel_overrides.reasoning_effort``) >
         per-model override (``agent.reasoning_overrides``) > global
         ``agent.reasoning_effort``. ``model`` should be the session's
         *effective* model (session ``/model`` override included) so
@@ -9743,6 +9744,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _r_state = self._peek_session_state(resolved_session_key)
             if _r_state is not None and _r_state.conversation.reasoning_override is not None:
                 return _r_state.conversation.reasoning_override
+
+        # Channel-scoped reasoning effort — the channel is a first-class
+        # config scope (model/provider/system_prompt already are), so a
+        # listing channel and a strategy channel can have different
+        # thinking budgets without a global setting (#79468).
+        if source is not None:
+            try:
+                override = _get_channel_override(
+                    self.config,
+                    source.platform,
+                    source.chat_id,
+                    thread_id=getattr(source, "thread_id", None),
+                    parent_id=getattr(source, "parent_chat_id", None),
+                )
+                if override is not None and override.reasoning_effort:
+                    from hermes_constants import parse_reasoning_effort
+
+                    parsed = parse_reasoning_effort(override.reasoning_effort)
+                    if parsed is not None:
+                        return parsed
+            except Exception:
+                pass
+
         return self._load_reasoning_config(model)
 
     def _set_session_reasoning_override(
@@ -21897,17 +21921,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(source)
+        return self._format_session_info(source)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, source: Optional[SessionSource] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
+
+        When ``source`` is given, the model resolves through the channel
+        override chain (channel_overrides > global default) so the banner
+        advertises the model the session will actually run on (#79468).
         """
-        resolved = _resolve_gateway_model_context()
+        # Channel-override scoping (#79468): the banner must advertise the
+        # model the session actually runs on, so when a source is given we
+        # resolve the model through the channel override chain
+        # (channel_overrides > global default) and feed it to the shared
+        # gateway model/context helper, which stays the single authority for
+        # provider/base_url/context_length.
+        channel_model = None
+        if source is not None:
+            try:
+                channel_model = self._resolve_model_for_channel(
+                    source.platform,
+                    source.chat_id,
+                    thread_id=getattr(source, "thread_id", None),
+                    parent_id=getattr(source, "parent_chat_id", None),
+                ) or _resolve_gateway_model()
+            except Exception:
+                channel_model = _resolve_gateway_model()
+        resolved = _resolve_gateway_model_context(model=channel_model)
         model = resolved.model
         provider = resolved.provider
         base_url = resolved.base_url

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2964,7 +2964,10 @@ class _GatewayModelContext:
     context_source: str
 
 
-def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModelContext:
+def _resolve_gateway_model_context(
+    model: Optional[str] = None,
+    runtime_kwargs: Optional[dict] = None,
+) -> _GatewayModelContext:
     """Resolve the configured gateway route and its effective context window.
 
     This is the shared non-resident authority for status/session banners and
@@ -3009,7 +3012,11 @@ def _resolve_gateway_model_context(model: Optional[str] = None) -> _GatewayModel
         pass
 
     try:
-        runtime = _resolve_runtime_agent_kwargs()
+        runtime = (
+            runtime_kwargs
+            if runtime_kwargs is not None
+            else _resolve_runtime_agent_kwargs()
+        )
         provider = runtime.get("provider") or provider
         base_url = runtime.get("base_url") or base_url
         api_key = runtime.get("api_key")
@@ -21931,28 +21938,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
 
-        When ``source`` is given, the model resolves through the channel
-        override chain (channel_overrides > global default) so the banner
-        advertises the model the session will actually run on (#79468).
+        When a session source is available, resolve the model and runtime as
+        one effective route. This keeps provider, endpoint, and context
+        metadata aligned with channel/thread model routing instead of mixing a
+        channel model with the global provider route (#79468).
         """
-        # Channel-override scoping (#79468): the banner must advertise the
-        # model the session actually runs on, so when a source is given we
-        # resolve the model through the channel override chain
-        # (channel_overrides > global default) and feed it to the shared
-        # gateway model/context helper, which stays the single authority for
-        # provider/base_url/context_length.
-        channel_model = None
+        model = None
+        runtime_kwargs = None
         if source is not None:
-            try:
-                channel_model = self._resolve_model_for_channel(
-                    source.platform,
-                    source.chat_id,
-                    thread_id=getattr(source, "thread_id", None),
-                    parent_id=getattr(source, "parent_chat_id", None),
-                ) or _resolve_gateway_model()
-            except Exception:
-                channel_model = _resolve_gateway_model()
-        resolved = _resolve_gateway_model_context(model=channel_model)
+            user_config = _load_gateway_runtime_config()
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                user_config=user_config,
+            )
+        resolved = _resolve_gateway_model_context(
+            model=model,
+            runtime_kwargs=runtime_kwargs,
+        )
         model = resolved.model
         provider = resolved.provider
         base_url = resolved.base_url

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -12,6 +12,7 @@ from gateway.config import (
 )
 from gateway.run import _get_channel_override, GatewayRunner
 from gateway.session import SessionSource
+from types import SimpleNamespace
 
 
 class TestGetChannelOverride:
@@ -152,5 +153,129 @@ class TestResolveSessionAgentRuntimePriority:
             )
         assert model == "channel/model"
         assert runtime["provider"] == "openrouter"
+
+
+class TestChannelOverrideReasoningEffort:
+    """ChannelOverride carries reasoning_effort and warns on unknown keys (#79468)."""
+
+    def test_parses_reasoning_effort(self):
+        ov = ChannelOverride.from_dict(
+            {"model": "m", "provider": "p", "reasoning_effort": "high"}
+        )
+        assert ov.reasoning_effort == "high"
+        assert ov.to_dict()["reasoning_effort"] == "high"
+
+    def test_from_dict_warns_on_unknown_key(self, caplog):
+        import logging
+        with caplog.at_level(logging.WARNING, logger="gateway.config"):
+            ov = ChannelOverride.from_dict(
+                {"model": "m", "reasoning_effort": "low", "typo_key": 1}
+            )
+        assert ov.reasoning_effort == "low"
+        assert ov.model == "m"
+        assert "typo_key" in caplog.text
+
+    def test_channel_override_used_when_session_has_no_reasoning_override(self):
+        """channel_overrides.reasoning_effort wins over global config (#79468)."""
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(reasoning_effort="xhigh"),
+                    },
+                ),
+            },
+        )
+        runner._peek_session_state = lambda key: SimpleNamespace(
+            conversation=SimpleNamespace(reasoning_override=None)
+        )
+        runner._session_key_for_source = lambda source: "discord:chan_1"
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="chan_1", user_id="u1"
+        )
+        with patch.object(GatewayRunner, "_load_reasoning_config", return_value=None) as mock_load:
+            result = runner._resolve_session_reasoning_config(source=source)
+        assert result == {"enabled": True, "effort": "xhigh"}
+        mock_load.assert_not_called()
+
+    def test_session_reasoning_override_still_wins_over_channel(self):
+        """Session-scoped /reasoning --session remains the top priority (#79468)."""
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(reasoning_effort="high"),
+                    },
+                ),
+            },
+        )
+        runner._peek_session_state = lambda key: SimpleNamespace(
+            conversation=SimpleNamespace(
+                reasoning_override={"enabled": False}
+            )
+        )
+        runner._session_key_for_source = lambda source: "discord:chan_1"
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="chan_1", user_id="u1"
+        )
+        with patch.object(GatewayRunner, "_load_reasoning_config", return_value=None):
+            result = runner._resolve_session_reasoning_config(source=source)
+        assert result == {"enabled": False}
+
+
+class TestFormatSessionInfoChannelModel:
+    """_format_session_info advertises the channel-override model (#79468)."""
+
+    def test_banner_uses_channel_override_model(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        "chan_1": ChannelOverride(model="channel/model"),
+                    },
+                ),
+            },
+        )
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="chan_1", user_id="u1"
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs",
+                 return_value={
+                     "provider": "anthropic",
+                     "api_key": "k",
+                     "base_url": "https://api.anthropic.com",
+                 },
+             ), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info(source)
+        assert "channel/model" in info
+        assert "global/model" not in info
+
+    def test_banner_falls_back_to_global_without_override(self):
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(platforms={})
+        source = SessionSource(
+            platform=Platform.DISCORD, chat_id="chan_1", user_id="u1"
+        )
+        with patch("gateway.run._resolve_gateway_model", return_value="global/model"), \
+             patch(
+                 "gateway.run._resolve_runtime_agent_kwargs",
+                 return_value={
+                     "provider": "anthropic",
+                     "api_key": "k",
+                     "base_url": "https://api.anthropic.com",
+                 },
+             ), \
+             patch("agent.model_metadata.get_model_context_length", return_value=128000):
+            info = runner._format_session_info(source)
+        assert "global/model" in info
 
 

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -3,7 +3,9 @@
 import pytest
 from unittest.mock import patch
 
+from gateway.config import ChannelOverride, GatewayConfig, Platform, PlatformConfig
 from gateway.run import GatewayRunner
+from gateway.session import SessionSource
 
 
 @pytest.fixture()
@@ -154,3 +156,94 @@ class TestResetNoticeSessionInfo:
         assert "anthropic" in info
         assert "base-model" not in info
 
+    @pytest.mark.parametrize(
+        ("source", "override_key"),
+        [
+            (
+                SessionSource(
+                    platform=Platform.DISCORD,
+                    chat_id="thread-1",
+                    thread_id="thread-1",
+                    parent_chat_id="parent-1",
+                    user_id="u1",
+                ),
+                "thread-1",
+            ),
+            (
+                SessionSource(
+                    platform=Platform.DISCORD,
+                    chat_id="thread-1",
+                    thread_id="thread-1",
+                    parent_chat_id="parent-1",
+                    user_id="u1",
+                ),
+                "parent-1",
+            ),
+        ],
+        ids=("exact-thread-route", "parent-route-inheritance"),
+    )
+    def test_reset_notice_uses_one_effective_thread_route(
+        self, runner, tmp_path, source, override_key
+    ):
+        """Every banner field must come from the inherited channel/thread route."""
+        tmp_path.joinpath("config.yaml").write_text(
+            "model:\n"
+            "  default: global-model\n"
+            "  provider: anthropic\n"
+            "  base_url: https://api.anthropic.com\n"
+            "  context_length: 12345\n"
+        )
+        runner.config = GatewayConfig(
+            platforms={
+                Platform.DISCORD: PlatformConfig(
+                    enabled=True,
+                    channel_overrides={
+                        override_key: ChannelOverride(
+                            model="thread-model",
+                            provider="thread-provider",
+                        )
+                    },
+                )
+            }
+        )
+        runner._session_key_for_source = lambda _source: None
+        route_runtime = {
+            "provider": "thread-provider",
+            "requested_provider": "thread-provider",
+            "base_url": "http://localhost:9000/v1",
+            "api_key": "route-key",
+            "api_mode": "chat_completions",
+        }
+
+        with (
+            patch("gateway.run._hermes_home", tmp_path),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs",
+                return_value={
+                    "provider": "anthropic",
+                    "base_url": "https://api.anthropic.com",
+                    "api_key": "global-key",
+                },
+            ),
+            patch(
+                "gateway.run._resolve_runtime_agent_kwargs_for_provider",
+                return_value=route_runtime,
+            ),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                side_effect=lambda *args, **kwargs: (
+                    65536
+                    if kwargs.get("provider") == "thread-provider"
+                    and kwargs.get("base_url") == "http://localhost:9000/v1"
+                    else 12345
+                ),
+            ),
+        ):
+            info = runner._reset_notice_session_info(source)
+
+        assert "thread-model" in info
+        assert "thread-provider" in info
+        assert "65K" in info
+        assert "http://localhost:9000/v1" in info
+        assert "global-model" not in info
+        assert "anthropic" not in info


### PR DESCRIPTION
## Summary

Fixes #79468. Two related gaps in the `channel_overrides` mechanism plus the secondary ask:

**1. `/new` reset banner reported the wrong model.** `_format_session_info()` (channel-blind `_resolve_gateway_model()`) now accepts the `SessionSource` and resolves through `_resolve_model_for_channel()` — the same resolver the actual turn path uses — so the banner advertises the model the session will actually run on. Mirrors the #59003 profile fix; falls back to the global model when resolution fails.

**2. `reasoning_effort` could not be scoped per channel.** Added `reasoning_effort: Optional[str]` to `ChannelOverride` (parsed via the existing `parse_reasoning_effort()`), and `_resolve_session_reasoning_config()` now consults the channel override between the session override and the global config. Precedence is now: *session `/reasoning` → channel override → per-model override → global*.

**3. Unknown keys now warn.** `ChannelOverride.from_dict()` emits a `logger.warning` for unrecognised keys instead of silently discarding them — typos in `model`/`system_prompt`/`reasoning_effort` surface immediately.

## Verification

- 6 new tests in `tests/gateway/test_channel_overrides.py` (banner uses override model; banner falls back; channel reasoning wins over global; session override still wins over channel; `from_dict` parses + warns)
- RED on old code (6 failed), GREEN now: 12/12
