### PR TITLE
fix(browser): fall back to the native dialog when the bridge can't be intercepted

### DIFF
--- a/tests/tools/test_browser_supervisor.py
+++ b/tests/tools/test_browser_supervisor.py
@@ -309,6 +309,65 @@ def test_browser_dialog_tool_end_to_end(chrome_cdp, supervisor_registry):
     assert "PYTEST-TOOL-END2END" in r["dialog"]["message"]
 
 
+def _disable_fetch_on_supervisor_session(supervisor) -> None:
+    """Turn Fetch interception off underneath the already-installed bridge.
+
+    Models any backend that accepts ``Fetch.enable`` but never delivers
+    ``Fetch.requestPaused`` for the bridge's XHR — a CDP proxy that owns the
+    Fetch domain itself, or a request the browser refuses before it reaches
+    the network stack.
+    """
+    from agent.async_utils import safe_schedule_threadsafe
+
+    future = safe_schedule_threadsafe(
+        supervisor._cdp("Fetch.disable", session_id=supervisor._page_session_id),
+        supervisor._loop,
+    )
+    assert future is not None, "supervisor loop unavailable"
+    future.result(timeout=10)
+
+
+def test_dialog_falls_back_to_native_when_bridge_cannot_intercept(
+    chrome_cdp, supervisor_registry
+):
+    """An uninterceptable bridge XHR must not answer the dialog for the page.
+
+    The bridge replaces window.confirm, so if its XHR can't be intercepted
+    and it returns early, the page gets ``false`` and no dialog is ever
+    surfaced to the agent. The native call has to run instead.
+    """
+    cdp_url, _port = chrome_cdp
+    supervisor = supervisor_registry.get_or_start(
+        task_id="pytest-bridge-fallback", cdp_url=cdp_url
+    )
+    _disable_fetch_on_supervisor_session(supervisor)
+
+    _fire_on_page(
+        cdp_url,
+        "setTimeout(() => { window.__confirmResult = confirm('PYTEST-FALLBACK'); }, 50)",
+    )
+
+    dialogs = _wait_for_dialog(supervisor)
+    assert dialogs, "confirm() surfaced no dialog — the bridge swallowed it"
+    d = dialogs[0]
+    assert d.type == "confirm"
+    assert "PYTEST-FALLBACK" in d.message
+    # Nothing intercepted the XHR, so this must be the native dialog.
+    assert d.bridge_request_id is None
+
+    assert supervisor.respond_to_dialog("accept")["ok"] is True
+
+    # The page must observe our answer, not a synthesized cancel.
+    deadline = time.monotonic() + 5.0
+    out = {}
+    while time.monotonic() < deadline:
+        out = supervisor.evaluate_runtime("window.__confirmResult")
+        if out.get("ok") and out.get("result") is not None:
+            break
+        time.sleep(0.1)
+    assert out.get("result") is True, f"page saw {out!r}, expected confirm() === true"
+
+
 def test_browser_cdp_frame_id_real_oopif_smoke_documented():
     """Document that real-OOPIF E2E was manually verified — see PR #14540.
 

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -100,11 +100,19 @@ DIALOG_BRIDGE_URL_PATTERN = f"http://{DIALOG_BRIDGE_HOST}/*"
 # intercept via Fetch.requestPaused. Works on Browserbase (whose CDP proxy
 # auto-dismisses REAL native dialogs) because the native dialogs never fire
 # in the first place — the overrides take precedence.
+#
+# When the XHR cannot be intercepted, each override calls the native dialog it
+# replaced instead of answering on the page's behalf. Suppressing the native
+# dialog is only safe while the bridge can actually answer it.
 _DIALOG_BRIDGE_SCRIPT = r"""
 (() => {
   if (window.__hermesDialogBridgeInstalled) return;
   window.__hermesDialogBridgeInstalled = true;
   const ENDPOINT = "http://hermes-dialog-bridge.invalid/";
+  // Distinguishes "the bridge could not answer" from "the agent answered
+  // cancel". Collapsing the two is what made an uninterceptable XHR look
+  // like a dismissed dialog to the page.
+  const UNAVAILABLE = {};
   function ask(kind, message, defaultPrompt) {
     try {
       const xhr = new XMLHttpRequest();
@@ -117,33 +125,41 @@ _DIALOG_BRIDGE_SCRIPT = r"""
       });
       xhr.open("GET", ENDPOINT + "?" + params.toString(), false);  // sync
       xhr.send(null);
-      if (xhr.status !== 200) return null;
+      if (xhr.status !== 200) return UNAVAILABLE;
       const body = xhr.responseText || "";
       let parsed;
-      try { parsed = JSON.parse(body); } catch (e) { return null; }
+      try { parsed = JSON.parse(body); } catch (e) { return UNAVAILABLE; }
       if (kind === "alert") return undefined;
       if (kind === "confirm") return Boolean(parsed && parsed.accept);
       if (kind === "prompt") {
         if (!parsed || !parsed.accept) return null;
         return parsed.prompt_text == null ? "" : String(parsed.prompt_text);
       }
-      return null;
+      return UNAVAILABLE;
     } catch (e) {
-      // If the bridge is unreachable, fall back to the native call so the
-      // page still sees *some* behavior (the backend will auto-dismiss).
-      return null;
+      // Fetch.requestPaused never fired for this request — no supervisor
+      // attached, the backend owns the Fetch domain, or the browser refused
+      // the request before it reached the network stack. Fall through to the
+      // native dialog so the supervisor can still capture it via
+      // Page.javascriptDialogOpening.
+      return UNAVAILABLE;
     }
   }
   const realAlert   = window.alert;
   const realConfirm = window.confirm;
   const realPrompt  = window.prompt;
-  window.alert   = function(message) { ask("alert",   message, ""); };
+  window.alert   = function(message) {
+    if (ask("alert", message, "") === UNAVAILABLE) realAlert.call(window, message);
+  };
   window.confirm = function(message) {
     const r = ask("confirm", message, "");
+    if (r === UNAVAILABLE) return realConfirm.call(window, message);
     return r === null ? false : Boolean(r);
   };
   window.prompt  = function(message, def) {
-    const r = ask("prompt", message, def == null ? "" : def);
+    const d = def == null ? "" : def;
+    const r = ask("prompt", message, d);
+    if (r === UNAVAILABLE) return realPrompt.call(window, message, d);
     return r === null ? null : String(r);
   };
   // onbeforeunload — we can't really synchronously prompt the user from this

--- a/website/docs/developer-guide/browser-supervisor.md
+++ b/website/docs/developer-guide/browser-supervisor.md
@@ -39,6 +39,11 @@ they touch the network — the dialog becomes a `Fetch.requestPaused` event the
 supervisor captures, and `respond_to_dialog` fulfills via
 `Fetch.fulfillRequest` with a JSON body the injected script decodes.
 
+If that XHR can't be intercepted — no `Fetch.requestPaused` arrives for it —
+each override calls the native dialog it replaced, so the dialog still reaches
+the supervisor through `Page.javascriptDialogOpening`. The overrides only
+suppress the native dialog while the bridge can actually answer it.
+
 From the page's perspective, `prompt()` still returns the agent-supplied
 string. From the agent's perspective, it's the same `browser_dialog(action=...)`
 API either way.
@@ -133,8 +138,8 @@ is attached:
 ```
 
 - **`pending_dialogs`** — dialogs currently blocking the page's JS thread.
-  The agent must call `browser_dialog(action=...)` to respond. Empty on
-  Browserbase because their CDP proxy auto-dismisses within ~10ms.
+  The agent must call `browser_dialog(action=...)` to respond. Bridge-captured
+  and native dialogs both land here; the agent responds to them the same way.
 
 - **`recent_dialogs`** — ring buffer of up to 20 recently-closed dialogs with
   a `closed_by` tag: `"agent"` (we responded), `"auto_policy"` (local

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -581,7 +581,7 @@ Responds to a native JS dialog (`alert` / `confirm` / `prompt` / `beforeunload`)
 | Browserbase | ✓ | ✓ full workflow (via injected XHR bridge) |
 | Camofox / default local agent-browser | ✗ | ✗ (no CDP endpoint) |
 
-**How it works on Browserbase.** Browserbase's CDP proxy auto-dismisses real native dialogs server-side within ~10ms, so we can't use `Page.handleJavaScriptDialog`. The supervisor injects a small script via `Page.addScriptToEvaluateOnNewDocument` that overrides `window.alert`/`confirm`/`prompt` with a synchronous XHR. We intercept those XHRs via `Fetch.enable` — the page's JS thread stays blocked on the XHR until we call `Fetch.fulfillRequest` with the agent's response. `prompt()` return values round-trip back into page JS unchanged.
+**How it works on Browserbase.** Browserbase's CDP proxy auto-dismisses real native dialogs server-side within ~10ms, so we can't use `Page.handleJavaScriptDialog`. The supervisor injects a small script via `Page.addScriptToEvaluateOnNewDocument` that overrides `window.alert`/`confirm`/`prompt` with a synchronous XHR. We intercept those XHRs via `Fetch.enable` — the page's JS thread stays blocked on the XHR until we call `Fetch.fulfillRequest` with the agent's response. `prompt()` return values round-trip back into page JS unchanged. If that XHR can't be intercepted, the override calls the real dialog instead, so it still surfaces to the agent rather than being silently answered as cancelled.
 
 **Dialog policy** is configured in `config.yaml` under `browser.dialog_policy`:
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/browser-supervisor.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/developer-guide/browser-supervisor.md
@@ -25,6 +25,8 @@
 
 **Browserbase 响应的工作原理。** Browserbase 的 CDP 代理在内部使用 Playwright，并在约 10ms 内自动关闭原生对话框，因此 `Page.handleJavaScriptDialog` 无法跟上。为解决此问题，supervisor 通过 `Page.addScriptToEvaluateOnNewDocument` 注入一个 bridge 脚本，将 `window.alert`/`confirm`/`prompt` 覆盖为向魔法主机（`hermes-dialog-bridge.invalid`）发起的同步 XHR。`Fetch.enable` 在这些 XHR 触达网络之前将其拦截——对话框变成 supervisor 捕获的 `Fetch.requestPaused` 事件，`respond_to_dialog` 通过 `Fetch.fulfillRequest` 以 JSON 响应体完成请求，注入的脚本对其进行解码。
 
+如果该 XHR 无法被拦截（没有为它到达的 `Fetch.requestPaused`），每个覆盖函数都会调用它所替换的原生对话框，因此对话框仍会通过 `Page.javascriptDialogOpening` 到达 supervisor。只有在 bridge 确实能够作出响应时，这些覆盖函数才会抑制原生对话框。
+
 最终效果：从页面角度看，`prompt()` 仍然返回 agent 提供的字符串。从 agent 角度看，无论哪种方式，都是同一套 `browser_dialog(action=...)` API。已针对真实 Browserbase 会话进行端到端测试——4/4（alert/prompt/confirm-accept/confirm-dismiss）全部通过，包括值回传到页面 JS 的验证。
 
 Camofox 在本 PR 中暂不支持；计划在 `jo-inc/camofox-browser` 提交上游 issue，请求添加对话框轮询端点。
@@ -101,7 +103,7 @@ browser_dialog(action, prompt_text=None, dialog_id=None)
 }
 ```
 
-- **`pending_dialogs`**：当前阻塞页面 JS 线程的对话框。Agent 必须调用 `browser_dialog(action=...)` 进行响应。在 Browserbase 上为空，因为其 CDP 代理会在约 10ms 内自动关闭对话框。
+- **`pending_dialogs`**：当前阻塞页面 JS 线程的对话框。Agent 必须调用 `browser_dialog(action=...)` 进行响应。由 bridge 捕获的对话框与原生对话框都会出现在这里，agent 的响应方式完全相同。
 
 - **`recent_dialogs`**：最近关闭的最多 20 个对话框的环形缓冲区，带有 `closed_by` 标签——`"agent"`（我们响应了）、`"auto_policy"`（本地 auto_dismiss/auto_accept）、`"watchdog"`（must_respond 超时触发）或 `"remote"`（浏览器/后端主动关闭，例如 Browserbase）。这是 Browserbase 上的 agent 仍能了解发生了什么的方式。
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/browser.md
@@ -547,7 +547,7 @@ browser_cdp(
 | Browserbase | ✓ | ✓ 完整工作流（通过注入的 XHR 桥接） |
 | Camofox / 默认本地 agent-browser | ✗ | ✗（无 CDP 端点） |
 
-**在 Browserbase 上的工作原理。** Browserbase 的 CDP 代理会在约 10ms 内在服务端自动关闭真实的原生对话框，因此无法使用 `Page.handleJavaScriptDialog`。监督器通过 `Page.addScriptToEvaluateOnNewDocument` 注入一段小脚本，将 `window.alert`/`confirm`/`prompt` 替换为同步 XHR。我们通过 `Fetch.enable` 拦截这些 XHR — 页面 JS 线程在 XHR 上保持阻塞，直到我们用 Agent 的响应调用 `Fetch.fulfillRequest`。`prompt()` 的返回值原样传回页面 JS。
+**在 Browserbase 上的工作原理。** Browserbase 的 CDP 代理会在约 10ms 内在服务端自动关闭真实的原生对话框，因此无法使用 `Page.handleJavaScriptDialog`。监督器通过 `Page.addScriptToEvaluateOnNewDocument` 注入一段小脚本，将 `window.alert`/`confirm`/`prompt` 替换为同步 XHR。我们通过 `Fetch.enable` 拦截这些 XHR — 页面 JS 线程在 XHR 上保持阻塞，直到我们用 Agent 的响应调用 `Fetch.fulfillRequest`。`prompt()` 的返回值原样传回页面 JS。如果该 XHR 无法被拦截，覆盖函数会转而调用真实的对话框，因此它仍会呈现给 Agent，而不是被静默地当作“取消”处理。
 
 **对话框策略**在 `config.yaml` 的 `browser.dialog_policy` 下配置：
 


### PR DESCRIPTION
## What & Why

The dialog bridge (`_DIALOG_BRIDGE_SCRIPT` in `tools/browser_supervisor.py`) replaces `window.alert`/`confirm`/`prompt` with a synchronous XHR to `hermes-dialog-bridge.invalid`, which the supervisor answers from `Fetch.requestPaused`. Suppressing the native dialog is only safe while the bridge can actually answer it — and when it can't, the bridge answered on the page's behalf instead:

- `ask()` returned `null` when `xhr.send()` threw, when the status wasn't 200, and when the body didn't parse.
- The wrappers turned `null` into `confirm() === false` and `prompt() === null`.

So a page that calls `confirm()` gets a cancel nobody chose, **and** the agent never finds out a dialog fired: `pending_dialogs` stays empty because the native dialog was suppressed and no `Fetch` event arrived to replace it. `browser_dialog` has nothing to respond to. The `realAlert` / `realConfirm` / `realPrompt` references the script captures were dead code, and the comment on the `catch` block described a fallback that was never wired up.

This is silent by construction: the dialog simply vanishes.

## Fix

`ask()` returns a distinct `UNAVAILABLE` sentinel on every "the bridge could not answer" path, and each override calls the native dialog it replaced. The un-answerable case then flows through `Page.javascriptDialogOpening`, which the supervisor already captures and `browser_dialog` already responds to — no new surface.

A dialog the agent genuinely dismissed still returns cancel; only "the bridge could not answer" falls through. The path where the bridge does work is byte-for-byte unchanged in behavior.

## Testing

Verified against a real local Chrome with `Fetch.disable` applied underneath the installed bridge, modelling a backend that accepts `Fetch.enable` but never delivers `Fetch.requestPaused` for the bridge's XHR:

| scenario | dialog captured | path | page saw `confirm()` |
|---|---|---|---|
| bridge intercepts (before & after) | yes | bridge | `true` |
| bridge un-intercepted, **before** | **no** | — | **`false`** |
| bridge un-intercepted, **after** | yes | native | `true` |

- New: `tests/tools/test_browser_supervisor.py::test_dialog_falls_back_to_native_when_bridge_cannot_intercept`. It fails on `main` with `AssertionError: confirm() surfaced no dialog — the bridge swallowed it`, and passes with this change.
- Whole file green against real Chrome: `HERMES_E2E_BROWSER=1 scripts/run_tests.sh -m integration tests/tools/test_browser_supervisor.py` → 7 passed, 1 skipped (the pre-existing documented OOPIF skip). The other dialog tests confirm the bridge and native paths both still work.
- `scripts/run_tests.sh tests/tools/test_browser_supervisor_healthcheck.py tests/tools/test_browser_eval_supervisor_path.py tests/tools/test_browser_cdp_tool.py tests/tools/test_managed_browserbase_and_modal.py tests/website/` → 51 passed.
- `scripts/check-windows-footguns.py` on the changed files → clean.

## Relationship to #30414

[#30414](https://github.com/NousResearch/hermes-agent/pull/30414) proposed the same `catch`-block fallback and was closed by its author on the reasoning that the block was unreachable because `Fetch.enable` is always called on the session. Enabling the Fetch domain is not the same thing as the interception firing for a given request — a proxy that owns the Fetch domain itself, or a request the browser refuses before it reaches the network stack, both leave `Fetch.requestPaused` silent while `Fetch.enable` succeeded. That is exactly the state this change covers, and the test above reaches the block on real Chrome. This PR also covers the two non-throwing failure paths (`status !== 200`, unparseable body) that #30414 left returning `null`.

## Checklist

- [x] Tests added (integration, real Chrome, opt-in via `HERMES_E2E_BROWSER=1` per the file's existing gate)
- [x] Docs updated — `browser-supervisor.md` and `browser.md`, EN + zh-Hans
- [x] No new tool schema surface, no new config keys, no new env vars
- [x] Prompt caching unaffected
