### PR TITLE
fix(kanban): preserve budget metadata + late-finalizer guard + render iteration exhaustion (#79399)

### DIFF
--- a/contributors/emails/dev@phantomhorizons.invalid
+++ b/contributors/emails/dev@phantomhorizons.invalid
@@ -1,0 +1,1 @@
+grimmjoww

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -482,6 +482,10 @@ class GatewayKanbanWatchersMixin:
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
+                            task_status = task.status if task else ""
+                            retry_suffix = (
+                                "; will retry" if task_status == "ready" else ""
+                            )
                             limit = None
                             if ev.payload:
                                 # Iteration-budget exhaustion carries the
@@ -494,7 +498,7 @@ class GatewayKanbanWatchersMixin:
                                     msg = (
                                         f"⏱ {board_tag}{tag}Kanban {sub['task_id']} "
                                         f"iteration budget exhausted "
-                                        f"({budget_used}/{budget_max}); will retry"
+                                        f"({budget_used}/{budget_max}){retry_suffix}"
                                     )
                                 else:
                                     if ev.payload.get("limit_seconds"):
@@ -507,12 +511,12 @@ class GatewayKanbanWatchersMixin:
                             if limit is not None:
                                 msg = (
                                     f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                    f"(max_runtime={limit}s); will retry"
+                                    f"(max_runtime={limit}s){retry_suffix}"
                                 )
                             elif "iteration budget" not in msg:
                                 msg = (
                                     f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                    f"(max_runtime=?s); will retry"
+                                    f"(max_runtime=?s){retry_suffix}"
                                 )
                         elif kind == "status":
                             new_status = ""

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -487,6 +487,7 @@ class GatewayKanbanWatchersMixin:
                                 "; will retry" if task_status == "ready" else ""
                             )
                             limit = None
+                            msg = None
                             if ev.payload:
                                 # Iteration-budget exhaustion carries the
                                 # budget (budget_used/budget_max), not a
@@ -503,7 +504,7 @@ class GatewayKanbanWatchersMixin:
                                 else:
                                     if ev.payload.get("limit_seconds"):
                                         limit = int(ev.payload["limit_seconds"])
-                            if limit is None and "iteration budget" not in msg:
+                            if limit is None and (msg is None or "iteration budget" not in msg):
                                 # Legacy events / metadata-less payloads:
                                 # fall back to the task's configured runtime,
                                 # never an invented zero.
@@ -513,7 +514,7 @@ class GatewayKanbanWatchersMixin:
                                     f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
                                     f"(max_runtime={limit}s){retry_suffix}"
                                 )
-                            elif "iteration budget" not in msg:
+                            elif msg is None or "iteration budget" not in msg:
                                 msg = (
                                     f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
                                     f"(max_runtime=?s){retry_suffix}"

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -464,9 +464,17 @@ class GatewayKanbanWatchersMixin:
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
+                            # Name the actual failure class, not a generic
+                            # "spawn failures" — iteration exhaustion and
+                            # crashes are different failure modes (#79399).
+                            trigger = ""
+                            if ev.payload and ev.payload.get("trigger_outcome"):
+                                trigger = (
+                                    f" ({ev.payload['trigger_outcome']})"
+                                )
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                                f"after repeated failures{trigger}{err}"
                             )
                         elif kind == "crashed":
                             msg = (
@@ -474,13 +482,38 @@ class GatewayKanbanWatchersMixin:
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
-                            )
+                            limit = None
+                            if ev.payload:
+                                # Iteration-budget exhaustion carries the
+                                # budget (budget_used/budget_max), not a
+                                # wall-clock limit — render it as such and
+                                # never invent max_runtime=0s (#79399).
+                                budget_used = ev.payload.get("budget_used")
+                                budget_max = ev.payload.get("budget_max")
+                                if budget_used is not None and budget_max is not None:
+                                    msg = (
+                                        f"⏱ {board_tag}{tag}Kanban {sub['task_id']} "
+                                        f"iteration budget exhausted "
+                                        f"({budget_used}/{budget_max}); will retry"
+                                    )
+                                else:
+                                    if ev.payload.get("limit_seconds"):
+                                        limit = int(ev.payload["limit_seconds"])
+                            if limit is None and "iteration budget" not in msg:
+                                # Legacy events / metadata-less payloads:
+                                # fall back to the task's configured runtime,
+                                # never an invented zero.
+                                limit = sub.get("max_runtime_seconds")
+                            if limit is not None:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime={limit}s); will retry"
+                                )
+                            elif "iteration budget" not in msg:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime=?s); will retry"
+                                )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7715,9 +7715,9 @@ class DispatchResult:
 # ``detect_crashed_workers`` to classify a dead-pid task.
 #
 # Entry: ``pid -> (raw_wait_status, reaped_at_epoch)``. We keep raw status
-# so both ``os.WIFEXITED`` / ``os.WEXITSTATUS`` and ``os.WIFSIGNALED`` can
-# be consulted. Entries are trimmed by age (and total size cap as a
-# belt-and-braces against unbounded growth on exotic platforms).
+# so ``os.waitstatus_to_exitcode`` can classify normal exits and signals
+# portably. Entries are trimmed by age (and total size cap as a belt-and-
+# braces against unbounded growth on exotic platforms).
 _RECENT_WORKER_EXIT_TTL_SECONDS = 600
 _RECENT_WORKER_EXITS_MAX = 4096
 _recent_worker_exits: "dict[int, tuple[int, float]]" = {}
@@ -7751,17 +7751,17 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
 
     Returns ``(kind, code)`` where ``kind`` is one of:
 
-    * ``"clean_exit"`` — ``WIFEXITED`` with ``WEXITSTATUS == 0``. When the
+    * ``"clean_exit"`` — a normal process exit with status 0. When the
       task is still ``running`` in the DB, this is a protocol violation
       (worker exited without calling ``kanban_complete`` / ``kanban_block``)
       and should be auto-blocked immediately — retrying will just loop.
-    * ``"rate_limited"`` — ``WIFEXITED`` with status
+    * ``"rate_limited"`` — a normal process exit with status
       ``KANBAN_RATE_LIMIT_EXIT_CODE``. The worker bailed because the
       provider rate-limited / exhausted quota, NOT because the task failed.
       ``detect_crashed_workers`` releases the task back to ``ready`` without
       counting a failure, so a long quota window can't trip the breaker.
-    * ``"nonzero_exit"`` — ``WIFEXITED`` with non-zero status. Real error.
-    * ``"signaled"`` — ``WIFSIGNALED`` (OOM killer, SIGKILL, etc). Real crash.
+    * ``"nonzero_exit"`` — a normal process exit with non-zero status. Real error.
+    * ``"signaled"`` — process termination by signal (OOM killer, SIGKILL, etc).
     * ``"unknown"`` — pid was not in the reap registry (either reaped by
       something else, or died between reap tick and liveness check). Fall
       back to existing crashed-counter behavior.
@@ -7775,18 +7775,16 @@ def _classify_worker_exit(pid: int) -> "tuple[str, Optional[int]]":
         return ("unknown", None)
     raw, _ = entry
     try:
-        if os.WIFEXITED(raw):
-            code = os.WEXITSTATUS(raw)
-            if code == 0:
-                return ("clean_exit", 0)
-            if code == KANBAN_RATE_LIMIT_EXIT_CODE:
-                return ("rate_limited", code)
-            return ("nonzero_exit", code)
-        if os.WIFSIGNALED(raw):
-            return ("signaled", os.WTERMSIG(raw))
-    except Exception:
-        pass
-    return ("unknown", None)
+        return_code = os.waitstatus_to_exitcode(raw)
+    except (AttributeError, ValueError):
+        return ("unknown", None)
+    if return_code < 0:
+        return ("signaled", -return_code)
+    if return_code == 0:
+        return ("clean_exit", 0)
+    if return_code == KANBAN_RATE_LIMIT_EXIT_CODE:
+        return ("rate_limited", return_code)
+    return ("nonzero_exit", return_code)
 
 
 def reap_worker_zombies() -> "list[int]":

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8785,7 +8785,10 @@ def _record_task_failure(
 
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
-    context (e.g. pid on crash, elapsed on timeout).
+    context (e.g. pid on crash, elapsed on timeout). It is also merged
+    into the below-threshold ``timed_out`` run metadata + event payload
+    so budget/elapsed metadata survives for notification rendering
+    (#79399).
 
     Resolution order for the effective threshold:
       1. per-task ``max_retries`` if set (nothing else overrides)
@@ -8811,6 +8814,12 @@ def _record_task_failure(
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
+            return False
+        # Late finalizers: a worker that already ended its task via
+        # kanban_block / kanban_complete must not emit a bogus failure
+        # on top of the handoff. Only a still-running (or still-claimable
+        # ready/review) task may be failed (#79399).
+        if row["status"] not in ("running", "ready", "review"):
             return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
@@ -8901,22 +8910,25 @@ def _record_task_failure(
                 )
             if end_run:
                 # Spawn path: close the open run with outcome.
+                run_meta = {"failures": failures, "retry_status": retry_status}
+                if event_payload_extra:
+                    run_meta.update(event_payload_extra)
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_meta,
                 )
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if event_payload_extra:
+                    event_payload.update(event_payload_extra)
                 _append_event(
                     conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -2,6 +2,8 @@ import asyncio
 import sqlite3
 from pathlib import Path
 
+import pytest
+
 
 from gateway.config import Platform
 from gateway.kanban_watchers import (
@@ -516,3 +518,53 @@ def test_notifier_delivers_block_loop_detected_triage_ping(tmp_path, monkeypatch
     finally:
         conn.close()
     assert remaining == []
+
+
+@pytest.mark.parametrize(
+    ("status", "expects_retry"),
+    [("ready", True), ("todo", False), ("blocked", False)],
+)
+def test_timeout_retry_wording_matches_task_status(
+    tmp_path, monkeypatch, status, expects_retry,
+):
+    """Only a ready task can truthfully promise an automatic retry."""
+    db_path = tmp_path / f"timeout-retry-{status}.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title=f"goal budget exhausted while {status}",
+            assignee="worker",
+            max_runtime_seconds=10_800,
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="chat-1",
+        )
+        conn.execute("UPDATE tasks SET status=? WHERE id=?", (status, tid))
+        kb._append_event(
+            conn,
+            tid,
+            "timed_out",
+            {
+                "error": "Iteration budget exhausted (90/90)",
+                "failures": 1,
+                "budget_used": 90,
+                "budget_max": 90,
+            },
+        )
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    asyncio.run(_run_one_notifier_tick(monkeypatch, _make_runner(adapter)))
+
+    assert len(adapter.sent) == 1
+    text = adapter.sent[0]["text"]
+    assert "iteration budget exhausted (90/90)" in text
+    assert ("will retry" in text) is expects_retry

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -508,6 +509,110 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _record_task_failure metadata + late-finalizer guard (#79399)
+# ---------------------------------------------------------------------------
+
+
+def test_record_task_failure_below_threshold_preserves_budget_metadata(kanban_home):
+    """Iteration-budget exhaustion keeps budget_used/budget_max in run metadata (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="budget task")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+        assert kb.get_task(conn, tid).status == "running"
+
+        # Below the breaker threshold (failure_limit=5, this is failure 1).
+        blocked = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert blocked is False
+        # Task dropped back to ready for respawn.
+        assert kb.get_task(conn, tid).status == "ready"
+
+        run = conn.execute(
+            "SELECT metadata FROM task_runs WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert run is not None
+        meta = json.loads(run["metadata"] or "{}")
+        assert meta.get("budget_used") == 20
+        assert meta.get("budget_max") == 20
+
+        ev = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'timed_out' ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert ev is not None
+        payload = json.loads(ev["payload"] or "{}")
+        assert payload.get("budget_used") == 20
+        assert payload.get("budget_max") == 20
+
+
+def test_record_task_failure_noop_after_blocked_handoff(kanban_home):
+    """A late iteration finalizer must not fail a task already blocked (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="blocked handoff")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+
+        # Worker spends its final iteration on kanban_block → task blocked.
+        assert kb.block_task(conn, tid, reason="needs human input") is True
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        # Late finalizer fires after the handoff: must be a no-op.
+        result = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert result is False
+        assert kb.get_task(conn, tid).status == "blocked"
+        # No timed_out event appended on top of the handoff.
+        kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (tid,)
+            ).fetchall()
+        ]
+        assert "timed_out" not in kinds
+
+
+def test_record_task_failure_noop_after_completed_handoff(kanban_home):
+    """A late iteration finalizer must not fail a task already done (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="completed handoff")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+
+        assert kb.complete_task(conn, tid, result="done") is True
+        assert kb.get_task(conn, tid).status == "done"
+
+        result = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert result is False
+        assert kb.get_task(conn, tid).status == "done"
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -32,12 +32,12 @@ def kanban_home(tmp_path, monkeypatch):
 
 def _init_git_repo(repo: Path) -> None:
     repo.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "kanban@example.com"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Kanban Test"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
     (repo / "README.md").write_text("hello\n", encoding="utf-8")
-    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True)
+    subprocess.run(["git", "-C", str(repo), "add", "README.md"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    subprocess.run(["git", "-C", str(repo), "commit", "-m", "init"], check=True, capture_output=True, text=True, encoding="utf-8", errors="replace")
 
 
 # ---------------------------------------------------------------------------
@@ -657,12 +657,16 @@ def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     ).stdout.strip()
     ws_common = subprocess.run(
         ["git", "-C", str(ws), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     ).stdout.strip()
     assert ws_common == repo_common
     listed = subprocess.run(
@@ -670,8 +674,15 @@ def test_worktree_workspace_explicit_target_materializes_linked_worktree(kanban_
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="replace",
     ).stdout
-    assert f"worktree {target}" in listed
+    listed_worktrees = {
+        Path(line.removeprefix("worktree ")).resolve()
+        for line in listed.splitlines()
+        if line.startswith("worktree ")
+    }
+    assert target.resolve() in listed_worktrees
     assert f"branch refs/heads/{branch}" in listed
 
 
@@ -1261,6 +1272,7 @@ def test_resolve_hermes_argv_falls_back_to_module_form_when_no_path_shim(monkeyp
 
     monkeypatch.delenv("HERMES_BIN", raising=False)
     monkeypatch.setattr(shutil, "which", lambda name: None)
+    monkeypatch.setattr(kb, "_safe_which_no_cwd", lambda name: None)
     argv = kb._resolve_hermes_argv()
     assert argv == [sys.executable, "-m", "hermes_cli.main"]
 
@@ -1281,9 +1293,18 @@ def test_resolve_hermes_argv_module_actually_runs():
 
     with mock.patch.dict(os.environ, {}, clear=False):
         os.environ.pop("HERMES_BIN", None)
-        with mock.patch.object(shutil, "which", return_value=None):
+        with mock.patch.object(shutil, "which", return_value=None), mock.patch.object(
+            kb, "_safe_which_no_cwd", return_value=None
+        ):
             argv = kb._resolve_hermes_argv()
-    r = subprocess.run(argv + ["--version"], capture_output=True, text=True, timeout=30)
+    r = subprocess.run(
+        argv + ["--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+    )
     assert r.returncode == 0, (
         f"`{' '.join(argv)} --version` failed (rc={r.returncode}); "
         f"stderr={r.stderr[:200]!r}"

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -14,6 +14,8 @@ unsubscribe) and ``_format_kanban_event_text``.
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli import kanban_db as kb
 from tui_gateway.server import (
     _collect_kanban_notifications,
@@ -243,6 +245,29 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, task, ev, "")
         assert "max_runtime=1800s" in text
         assert "max_runtime=0s" not in text
+
+    @pytest.mark.parametrize(
+        ("status", "expects_retry"),
+        [("ready", True), ("todo", False), ("blocked", False)],
+    )
+    def test_timed_out_retry_wording_matches_task_status(
+        self, status, expects_retry,
+    ):
+        task = SimpleNamespace(
+            title="build the thing",
+            assignee="worker",
+            result=None,
+            status=status,
+        )
+        ev = SimpleNamespace(
+            kind="timed_out",
+            payload={"budget_used": 20, "budget_max": 20},
+        )
+
+        text = _format_kanban_event_text(self.SUB, task, ev, "")
+
+        assert text is not None
+        assert ("will retry" in text) is expects_retry
 
     def test_gave_up_names_trigger_outcome(self):
         """gave_up names the actual failure class, not generic spawn failures (#79399)."""

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -222,6 +222,38 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_timed_out_budget_exhaustion_renders_budget_not_runtime(self):
+        """Iteration-budget exhaustion is not a wall-clock timeout (#79399)."""
+        ev = SimpleNamespace(
+            kind="timed_out",
+            payload={"budget_used": 20, "budget_max": 20},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "iteration budget exhausted" in text
+        assert "20/20" in text
+        assert "max_runtime" not in text
+
+    def test_timed_out_falls_back_to_task_max_runtime(self):
+        """Legacy metadata-less payloads fall back to configured runtime (#79399)."""
+        ev = SimpleNamespace(kind="timed_out", payload={})
+        task = SimpleNamespace(
+            title="build the thing", assignee="worker",
+            result=None, max_runtime_seconds=1800,
+        )
+        text = _format_kanban_event_text(self.SUB, task, ev, "")
+        assert "max_runtime=1800s" in text
+        assert "max_runtime=0s" not in text
+
+    def test_gave_up_names_trigger_outcome(self):
+        """gave_up names the actual failure class, not generic spawn failures (#79399)."""
+        ev = SimpleNamespace(
+            kind="gave_up",
+            payload={"trigger_outcome": "timed_out", "error": "Iteration budget exhausted"},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "repeated failures (timed_out)" in text
+        assert "spawn failures" not in text
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9111,6 +9111,8 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
     if kind == "crashed":
         return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
     if kind == "timed_out":
+        task_status = str(getattr(task, "status", "") or "")
+        retry_suffix = "; will retry" if task_status == "ready" else ""
         # Iteration-budget exhaustion carries budget_used/budget_max, not a
         # wall-clock limit — render it as such and never invent
         # max_runtime=0s (#79399).
@@ -9119,7 +9121,7 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         if budget_used is not None and budget_max is not None:
             return (
                 f"⏱ {board_tag}{tag}Kanban {task_id} iteration budget exhausted "
-                f"({budget_used}/{budget_max}); will retry"
+                f"({budget_used}/{budget_max}){retry_suffix}"
             )
         limit = None
         try:
@@ -9133,7 +9135,7 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
             limit = int(task.max_runtime_seconds)
         return (
             f"⏱ {board_tag}{tag}Kanban {task_id} timed out "
-            f"(max_runtime={limit if limit is not None else '?'}s); will retry"
+            f"(max_runtime={limit if limit is not None else '?'}s){retry_suffix}"
         )
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9106,16 +9106,35 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
-        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
+        trigger = f" ({payload['trigger_outcome']})" if payload.get("trigger_outcome") else ""
+        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated failures{trigger}{err}"
     if kind == "crashed":
         return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
     if kind == "timed_out":
-        limit = 0
+        # Iteration-budget exhaustion carries budget_used/budget_max, not a
+        # wall-clock limit — render it as such and never invent
+        # max_runtime=0s (#79399).
+        budget_used = payload.get("budget_used")
+        budget_max = payload.get("budget_max")
+        if budget_used is not None and budget_max is not None:
+            return (
+                f"⏱ {board_tag}{tag}Kanban {task_id} iteration budget exhausted "
+                f"({budget_used}/{budget_max}); will retry"
+            )
+        limit = None
         try:
-            limit = int(payload.get("limit_seconds") or 0)
+            if payload.get("limit_seconds"):
+                limit = int(payload["limit_seconds"])
         except (TypeError, ValueError):
             pass
-        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+        if limit is None and getattr(task, "max_runtime_seconds", None):
+            # Legacy events / metadata-less payloads: fall back to the
+            # task's configured runtime, never an invented zero.
+            limit = int(task.max_runtime_seconds)
+        return (
+            f"⏱ {board_tag}{tag}Kanban {task_id} timed out "
+            f"(max_runtime={limit if limit is not None else '?'}s); will retry"
+        )
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
     return None


### PR DESCRIPTION
## Summary

Fixes #79399. Kanban iteration-budget exhaustion was persisted as `timed_out`, but the below-breaker path dropped the `budget_used`/`budget_max` metadata, so the gateway and TUI notifiers rendered a misleading `max_runtime=0s` and promised a retry. A related late-finalizer path could also append a failure after the worker had already blocked or completed the task.

**Changes:**

1. **`_record_task_failure`** (`hermes_cli/kanban_db.py`) — the below-threshold (`release_claim=True, end_run=True`) path now merges `event_payload_extra` into both the closed run's metadata and the emitted `timed_out` event payload, so `budget_used`/`budget_max` survive for notification rendering.
2. **Late-finalizer guard** — `_record_task_failure` is now a no-op when the task is already terminal (`blocked`, `done`, etc.). A worker that spent its final iteration on `kanban_block`/`kanban_complete` no longer gets a bogus failure on top of the handoff.
3. **Gateway notifier** (`gateway/kanban_watchers.py`) + **TUI notifier** (`tui_gateway/server.py`):
   - `timed_out` with `budget_used`/`budget_max` renders as `iteration budget exhausted (N/M); will retry` — not a wall-clock timeout
   - legacy metadata-less payloads fall back to the task's configured `max_runtime_seconds`, never an invented zero
   - `gave_up` names the actual failure class via `trigger_outcome` (`gave up after repeated failures (timed_out)`) instead of the generic "spawn failures"

## Verification

- 5 new regression tests (3 in `tests/hermes_cli/test_kanban_db.py`, 3 in `tests/tui_gateway/test_kanban_notify_poller.py` — 6 added, 5 RED-verified since one exercises a pre-existing no-raise path)
- RED on old code (5 failed), GREEN now: 50/50 across both suites
