### PR TITLE
fix(gateway): restart_after_turn_timeout default 6h -> 30min (#79133)

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -50,8 +50,11 @@ DEFAULT_CONFIG = {
         # this cap for in-flight agents/cron/api runs to complete naturally
         # so the requesting turn is not amputated by restart_drain_timeout.
         # 0 = legacy behaviour (enter stop()/drain immediately). Default
-        # 6h is a safety valve for wedged agents, not a target latency.
-        "restart_after_turn_timeout": 21600,
+        # 30 min is a safety valve for wedged agents, not a target latency —
+        # an interactive `hermes gateway restart` must never block for hours
+        # on a turn that wedged (#79133). Long unattended turns can raise
+        # this in config.yaml.
+        "restart_after_turn_timeout": 1800,
         # Upper bound (seconds) a submitted prompt waits for the deferred
         # agent build (MCP discovery, model metadata, skills scan) before
         # failing with a visible error (#63078). The gateway's wait is

--- a/tests/gateway/test_restart_after_turn.py
+++ b/tests/gateway/test_restart_after_turn.py
@@ -17,6 +17,22 @@ def test_parse_restart_after_turn_timeout_defaults_and_clamps():
     assert parse_restart_after_turn_timeout("120") == 120.0
 
 
+def test_default_restart_after_turn_timeout_is_human_tolerable():
+    """The shipped default must not make interactive restarts block for hours.
+
+    A wedged turn must not pin `hermes gateway restart` for 6h — the
+    default is a safety valve for hung agents, not a target latency
+    (#79133). 900-1800s protects long autonomous turns while keeping
+    worst-case interactive restart in human-tolerable territory.
+    """
+    assert 900 <= DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT <= 1800
+    # An interactive restart's printed wait budget stays under ~32 min.
+    budget = resolve_restart_exit_wait_budget(
+        60, DEFAULT_GATEWAY_RESTART_AFTER_TURN_TIMEOUT, headroom=15
+    )
+    assert budget <= 1875
+
+
 def test_resolve_restart_exit_wait_budget_covers_both_phases():
     assert resolve_restart_exit_wait_budget(0, 0, headroom=15) == 15.0
     assert resolve_restart_exit_wait_budget(180, 21600, headroom=15) == 180 + 21600 + 15


### PR DESCRIPTION
## Summary

Fixes #79133. The `restart_after_turn_timeout` default of 21600s (6h) — introduced in #77184 — makes an interactive `hermes gateway restart` print `waiting up to 21675s` and block for up to six hours when a turn wedges. That is exactly the scenario the cap exists for, which makes the 6h default a footgun: an operator at a terminal watches the CLI hang for hours on a hung tool call / wedged event loop / stuck provider stream.

**Fix**: lower the shipped default from 21600 → **1800s (30 min)** in `hermes_cli/config_defaults.py`.

- Still protects the overwhelming majority of long autonomous turns — tool calls have their own timeouts well below 30 min.
- Worst-case interactive restart latency is human-tolerable (≤ ~32 min printed budget).
- Users running genuinely long unattended turns can raise it in `config.yaml` — the right place for a 6h opt-in, rather than a default every install inherits.

The resolution chain (`resolve_restart_exit_wait_budget`, config/env overrides) is unchanged; this is the one literal the issue identified.

## Verification

- New contract test `test_default_restart_after_turn_timeout_is_human_tolerable` (asserts default ∈ [900, 1800] and printed budget ≤ 1875s — a range contract, not a change-detector)
- RED on old code (21600 fails the range), GREEN now: 4/4 in `tests/gateway/test_restart_after_turn.py`
