### PR TITLE
fix(credential-pool): rotate on Ollama Cloud "session usage limit" 429

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1120,6 +1120,7 @@ def recover_with_credential_pool(
                 or "gousagelimit" in context_reason
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
+                or "session usage limit" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -372,7 +372,7 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
     return None
 
 
-def _extract_retry_delay_seconds(message: str) -> Optional[float]:
+def _extract_retry_delay_seconds(message: str, status_code: Optional[int] = None) -> Optional[float]:
     if not message:
         return None
     delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
@@ -392,10 +392,23 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
     if min_only_match:
         return int(min_only_match.group(1)) * 60
+    # Ollama Cloud "session usage limit" — the per-session cap resets every
+    # 5 hours, but the reset window started before the limit was hit, so the
+    # actual remaining time is unknown.  A 30-minute TTL is a better default
+    # than the 1-hour 429 cooldown: if the credential is still limited, the
+    # 429 fires again and we rotate back (one wasted request); if it has
+    # cleared, we reclaim the credential sooner.  Gated on status_code == 429
+    # per sweeper review (#68832): the phrase could appear in a non-429 body
+    # where a shorter cooldown is inappropriate.
+    if status_code == 429 and "session usage limit" in message.lower():
+        return 30 * 60
     return None
 
 
-def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_error_context(
+    error_context: Optional[Dict[str, Any]],
+    status_code: Optional[int] = None,
+) -> Dict[str, Any]:
     if not isinstance(error_context, dict):
         return {}
     normalized: Dict[str, Any] = {}
@@ -412,7 +425,7 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     )
     parsed_reset_at = _parse_absolute_timestamp(reset_at)
     if parsed_reset_at is None and isinstance(message, str):
-        retry_delay_seconds = _extract_retry_delay_seconds(message)
+        retry_delay_seconds = _extract_retry_delay_seconds(message, status_code=status_code)
         if retry_delay_seconds is not None:
             parsed_reset_at = time.time() + retry_delay_seconds
     if parsed_reset_at is not None:
@@ -799,7 +812,7 @@ class CredentialPool:
         persist: bool = True,
         failure_reason: Optional[str] = None,
     ) -> PooledCredential:
-        normalized_error = _normalize_error_context(error_context)
+        normalized_error = _normalize_error_context(error_context, status_code=status_code)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
         # a revoked credential gets a 1-hour TTL cooldown and then re-enters

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -200,6 +200,11 @@ _USAGE_LIMIT_PATTERNS = [
     "quota",
     "limit exceeded",
     "key limit exceeded",
+    # Ollama Cloud's per-session cap — semipermanent for the session,
+    # not a transient throttle that clears in seconds.  Matched here so
+    # the recovery flow rotates immediately instead of retrying the same
+    # key and then treating the follow-up 429 as a fresh rate-limit.
+    "session usage limit",
 ]
 
 # Patterns confirming usage limit is transient (not billing)
@@ -1147,6 +1152,19 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        # Ollama Cloud returns HTTP 429 "session usage limit" for a per-session
+        # cap that is semipermanent (not a transient throttle that clears in
+        # seconds).  Classify as billing so the pool rotates immediately and
+        # applies the full billing cooldown, instead of retrying the same key
+        # once and then treating the follow-up 429 as a fresh rate-limit —
+        # which burns both keys within minutes on a multi-credential pool.
+        if "session usage limit" in error_msg:
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/tests/agent/test_ollama_session_usage_limit.py
+++ b/tests/agent/test_ollama_session_usage_limit.py
@@ -1,0 +1,235 @@
+"""Tests for Ollama Cloud "session usage limit" credential pool handling.
+
+Covers three fixes:
+1. ``error_classifier.classify_api_error`` classifying the 429 as ``billing``
+   so the pool rotates immediately instead of retrying the same key.
+2. ``recover_with_credential_pool`` treating "session usage limit" as a
+   usage-limit condition for the rate_limit recovery branch.
+3. ``_extract_retry_delay_seconds`` returning a 30-minute TTL gated on
+   ``status_code == 429``, and the persisted ``_exhausted_until`` cooldown.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from agent.credential_pool import (
+    PooledCredential,
+    _extract_retry_delay_seconds,
+    _exhausted_until,
+    _normalize_error_context,
+    EXHAUSTED_TTL_429_SECONDS,
+)
+from agent.error_classifier import classify_api_error, FailoverReason
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_entry(idx, **overrides):
+    defaults = dict(
+        provider="ollama-cloud",
+        id=f"cred-{idx}",
+        label=f"Credential {idx}",
+        auth_type="api_key",
+        priority=idx,
+        source="manual",
+        access_token=f"key-{idx}",
+    )
+    defaults.update(overrides)
+    return PooledCredential(**defaults)
+
+
+def _make_pool(entries):
+    pool = MagicMock()
+    pool.entries.return_value = entries
+    pool.current.return_value = entries[0]
+    pool.provider = ""
+    pool.mark_exhausted_and_rotate.return_value = entries[1] if len(entries) > 1 else None
+    return pool
+
+
+class _FakeError(Exception):
+    status_code = 429
+
+    def __init__(self, msg):
+        super().__init__(msg)
+
+
+_OLLAMA_429_MSG = (
+    "Error code: 429 - {'error': {'message': "
+    "'you (seppe) have reached your session usage limit, "
+    "upgrade for higher limits: https://ollama.com/upgrade"
+    " or add extra usage: https://ollama.com/settings"
+    " (ref: 64445a74-57b5-4de8-93ee-965b7b10ef47)', "
+    "'type': 'api_error', 'param': None, 'code': None}}"
+)
+
+
+# ---------------------------------------------------------------------------
+# error_classifier: 429 "session usage limit" → billing
+# ---------------------------------------------------------------------------
+
+def test_classify_429_session_usage_limit_as_billing():
+    """The 429 must classify as billing (rotate immediately, non-retryable)."""
+    err = _FakeError(_OLLAMA_429_MSG)
+    c = classify_api_error(err, provider="ollama-cloud", model="glm-5.2")
+    assert c.reason == FailoverReason.billing
+    assert c.should_rotate_credential is True
+    assert c.retryable is False
+
+
+def test_classify_429_plain_rate_limit_still_rate_limit():
+    """A normal 429 without 'session usage limit' stays rate_limit."""
+    err = _FakeError("Error code: 429 - Too many requests")
+    c = classify_api_error(err, provider="openrouter", model="claude-sonnet-4")
+    assert c.reason == FailoverReason.rate_limit
+
+
+def test_classify_429_overloaded_still_overloaded():
+    """Z.AI-style overload 429 still classifies as overloaded."""
+    err = _FakeError("Error code: 429 - The server is overloaded")
+    c = classify_api_error(err, provider="zai", model="glm-5.2")
+    assert c.reason == FailoverReason.overloaded
+
+
+# ---------------------------------------------------------------------------
+# _extract_retry_delay_seconds: status-gated 30-minute TTL
+# ---------------------------------------------------------------------------
+
+def test_retry_delay_session_usage_limit_429_returns_30min():
+    msg = "you (user) have reached your session usage limit"
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 30 * 60
+
+
+def test_retry_delay_session_usage_limit_non_429_returns_none():
+    """The TTL must NOT fire on non-429 errors (sweeper gate)."""
+    msg = "you (user) have reached your session usage limit"
+    assert _extract_retry_delay_seconds(msg, status_code=403) is None
+    assert _extract_retry_delay_seconds(msg, status_code=None) is None
+
+
+def test_retry_delay_session_usage_limit_case_insensitive():
+    assert _extract_retry_delay_seconds(
+        "Session Usage Limit reached", status_code=429
+    ) == 30 * 60
+
+
+def test_retry_delay_explicit_reset_takes_priority():
+    """Explicit 'resets in Nmin' wins over the 30-min heuristic."""
+    msg = "session usage limit. Resets in 5min"
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 5 * 60
+
+
+def test_retry_delay_non_session_returns_none():
+    assert _extract_retry_delay_seconds("rate limited", status_code=429) is None
+    assert _extract_retry_delay_seconds("", status_code=429) is None
+
+
+# ---------------------------------------------------------------------------
+# Persisted cooldown: _normalize_error_context → _exhausted_until
+# ---------------------------------------------------------------------------
+
+def test_persisted_cooldown_is_30min_for_session_usage_limit_429():
+    """End-to-end: the normalized reset_at produces a ~30min cooldown."""
+    ctx = _normalize_error_context(
+        {"message": "you (user) have reached your session usage limit"},
+        status_code=429,
+    )
+    assert "reset_at" in ctx
+    now = time.time()
+    delta = ctx["reset_at"] - now
+    # Allow a few seconds of slack for execution time
+    assert 29 * 60 < delta < 31 * 60
+
+
+def test_persisted_cooldown_non_429_uses_default_429_ttl():
+    """Without status_code, the 1-hour default applies (no 30-min heuristic)."""
+    ctx = _normalize_error_context(
+        {"message": "you (user) have reached your session usage limit"},
+        status_code=None,
+    )
+    # No custom reset_at → falls back to the 429 default TTL in _exhausted_ttl
+    assert "reset_at" not in ctx
+
+
+def test_exhausted_until_uses_persisted_reset_at():
+    """A pool entry with a persisted reset_at should honor it."""
+    now = time.time()
+    reset = now + 30 * 60
+    entry = _make_entry(0, last_status="exhausted", last_status_at=now)
+    entry.last_error_reset_at = reset
+    result = _exhausted_until(entry)
+    assert result is not None
+    assert abs(result - reset) < 2
+
+
+# ---------------------------------------------------------------------------
+# recover_with_credential_pool: first-429 rotation
+# ---------------------------------------------------------------------------
+
+def test_session_usage_limit_triggers_pool_rotation_on_first_429():
+    """On the first 429 with 'session usage limit', the pool rotates
+    immediately instead of retrying the same credential."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+
+    from run_agent import AIAgent
+
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+
+        error_context = {
+            "reason": "",
+            "message": "you (user) have reached your session usage limit",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is True
+    assert retried is False
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    agent._swap_credential.assert_called_once_with(entries[1])
+
+
+def test_plain_rate_limit_without_usage_limit_waits_for_retry():
+    """A normal 429 without 'session usage limit' retries first."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+
+    from run_agent import AIAgent
+
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+
+        error_context = {
+            "reason": "rate_limit",
+            "message": "Too many requests, try again later",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is False
+    assert retried is True
+    pool.mark_exhausted_and_rotate.assert_not_called()


### PR DESCRIPTION
## Problem

When Ollama Cloud returns HTTP 429 with `"you have reached your session usage limit"`, the credential pool does not rotate to the next key. Instead it retries the same credential 3 times (the `rate_limit` recovery path retries once before rotating), then gives up. With a multi-key pool both keys get exhausted within minutes because each retry re-triggers the same semipermanent session cap.

Root cause: the 429 is classified as `FailoverReason.rate_limit` (transient — retry same key first), but Ollama's session usage limit is semipermanent for the session, not a transient throttle.

## Changes

### 1. `agent/error_classifier.py` — classify as billing
In `_classify_by_status`, a 429 whose body contains `"session usage limit"` now classifies as `FailoverReason.billing` instead of `rate_limit`. This triggers **immediate rotation** on the first 429 via the billing recovery branch (no retry-same-credential step). Also added `"session usage limit"` to `_USAGE_LIMIT_PATTERNS` for the message-only classification path.

### 2. `agent/agent_runtime_helpers.py` — usage_limit_reached detection
Added `"session usage limit"` to the `usage_limit_reached` pattern check in `recover_with_credential_pool()`, matching the approach in #68832. This ensures the rate_limit recovery branch also skips the retry-same step, covering the case where the error arrives without classifier metadata.

### 3. `agent/credential_pool.py` — 30-minute TTL (status-gated)
Added a 30-minute TTL for `"session usage limit"` in `_extract_retry_delay_seconds()`, gated on `status_code == 429` per sweeper review on #68832. Shorter than the default 1-hour 429 cooldown: if still limited, the 429 fires again and rotates back (one wasted request); if cleared, the credential reclaims sooner. Explicit reset times (`"resets in Nmin"`) take priority.

The `status_code` parameter is threaded through `_normalize_error_context` → `_mark_exhausted` so the gate has access to the HTTP status.

### 4. Tests — `tests/agent/test_ollama_session_usage_limit.py` (13 tests)
- Error classifier: 429 session-usage-limit → billing; plain 429 → rate_limit; overload 429 → overloaded
- TTL: 30min for 429; `None` for non-429; case-insensitive; explicit-reset priority; negative cases
- Persisted cooldown: end-to-end `_normalize_error_context` → 30min `reset_at`; non-429 falls back to default TTL; `_exhausted_until` honors persisted reset_at
- Pool rotation: first-429 rotation with session-usage-limit; plain rate-limit still retries first

## Relationship to existing PRs

| PR | Approach | Error classifier fix? | TTL fix? | Sweeper feedback addressed? |
|----|----------|----------------------|----------|---------------------------|
| #68832 | `agent_runtime_helpers` + `credential_pool` | No | Yes (status-agnostic) | Partially (no 429 gate) |
| #68921 | Duplicate of #68832 | No | Yes (status-agnostic) | No |
| **This PR** | All three layers | **Yes** | **Yes (429-gated)** | **Yes** |

This PR supersedes #68832 and #68921 by addressing the sweeper feedback (gate TTL on HTTP 429, add persisted cooldown + non-429 boundary tests) and closing the error-classifier gap that #68832 did not cover.

## Test plan

- [x] `pytest tests/agent/test_ollama_session_usage_limit.py` — 13 passed
- [x] `pytest tests/agent/test_credential_pool_routing.py tests/run_agent/test_credential_pool_interrupt.py tests/run_agent/test_fallback_credential_isolation.py` — 27 passed (no regressions)
- [x] Verified with live Ollama Cloud `"session usage limit"` error string from production logs

Closes #68831.