### PR TITLE
fix(mcp): cold-start identical-error parking for deterministically broken servers (#79141)

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -611,9 +611,17 @@ class GatewayKanbanWatchersMixin:
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
+                            # Name the actual failure class, not a generic
+                            # "spawn failures" — iteration exhaustion and
+                            # crashes are different failure modes (#79399).
+                            trigger = ""
+                            if ev.payload and ev.payload.get("trigger_outcome"):
+                                trigger = (
+                                    f" ({ev.payload['trigger_outcome']})"
+                                )
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                                f"after repeated failures{trigger}{err}"
                             )
                         elif kind == "crashed":
                             msg = (
@@ -621,13 +629,38 @@ class GatewayKanbanWatchersMixin:
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
-                            )
+                            limit = None
+                            if ev.payload:
+                                # Iteration-budget exhaustion carries the
+                                # budget (budget_used/budget_max), not a
+                                # wall-clock limit — render it as such and
+                                # never invent max_runtime=0s (#79399).
+                                budget_used = ev.payload.get("budget_used")
+                                budget_max = ev.payload.get("budget_max")
+                                if budget_used is not None and budget_max is not None:
+                                    msg = (
+                                        f"⏱ {board_tag}{tag}Kanban {sub['task_id']} "
+                                        f"iteration budget exhausted "
+                                        f"({budget_used}/{budget_max}); will retry"
+                                    )
+                                else:
+                                    if ev.payload.get("limit_seconds"):
+                                        limit = int(ev.payload["limit_seconds"])
+                            if limit is None and "iteration budget" not in msg:
+                                # Legacy events / metadata-less payloads:
+                                # fall back to the task's configured runtime,
+                                # never an invented zero.
+                                limit = sub.get("max_runtime_seconds")
+                            if limit is not None:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime={limit}s); will retry"
+                                )
+                            elif "iteration budget" not in msg:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime=?s); will retry"
+                                )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -630,6 +630,7 @@ class GatewayKanbanWatchersMixin:
                             )
                         elif kind == "timed_out":
                             limit = None
+                            budget_rendered = False
                             if ev.payload:
                                 # Iteration-budget exhaustion carries the
                                 # budget (budget_used/budget_max), not a
@@ -643,24 +644,28 @@ class GatewayKanbanWatchersMixin:
                                         f"iteration budget exhausted "
                                         f"({budget_used}/{budget_max}); will retry"
                                     )
-                                else:
-                                    if ev.payload.get("limit_seconds"):
+                                    budget_rendered = True
+                                elif ev.payload.get("limit_seconds"):
+                                    try:
                                         limit = int(ev.payload["limit_seconds"])
-                            if limit is None and "iteration budget" not in msg:
+                                    except (TypeError, ValueError):
+                                        limit = None
+                            if limit is None and not budget_rendered:
                                 # Legacy events / metadata-less payloads:
                                 # fall back to the task's configured runtime,
                                 # never an invented zero.
                                 limit = sub.get("max_runtime_seconds")
-                            if limit is not None:
-                                msg = (
-                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                    f"(max_runtime={limit}s); will retry"
-                                )
-                            elif "iteration budget" not in msg:
-                                msg = (
-                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                    f"(max_runtime=?s); will retry"
-                                )
+                            if not budget_rendered:
+                                if limit is not None:
+                                    msg = (
+                                        f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                        f"(max_runtime={limit}s); will retry"
+                                    )
+                                else:
+                                    msg = (
+                                        f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                        f"(max_runtime=?s); will retry"
+                                    )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -464,9 +464,17 @@ class GatewayKanbanWatchersMixin:
                             err = ""
                             if ev.payload and ev.payload.get("error"):
                                 err = f"\n{str(ev.payload['error'])[:200]}"
+                            # Name the actual failure class, not a generic
+                            # "spawn failures" — iteration exhaustion and
+                            # crashes are different failure modes (#79399).
+                            trigger = ""
+                            if ev.payload and ev.payload.get("trigger_outcome"):
+                                trigger = (
+                                    f" ({ev.payload['trigger_outcome']})"
+                                )
                             msg = (
                                 f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                                f"after repeated failures{trigger}{err}"
                             )
                         elif kind == "crashed":
                             msg = (
@@ -474,13 +482,38 @@ class GatewayKanbanWatchersMixin:
                                 f"(pid gone); dispatcher will retry"
                             )
                         elif kind == "timed_out":
-                            limit = 0
-                            if ev.payload and ev.payload.get("limit_seconds"):
-                                limit = int(ev.payload["limit_seconds"])
-                            msg = (
-                                f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
-                                f"(max_runtime={limit}s); will retry"
-                            )
+                            limit = None
+                            if ev.payload:
+                                # Iteration-budget exhaustion carries the
+                                # budget (budget_used/budget_max), not a
+                                # wall-clock limit — render it as such and
+                                # never invent max_runtime=0s (#79399).
+                                budget_used = ev.payload.get("budget_used")
+                                budget_max = ev.payload.get("budget_max")
+                                if budget_used is not None and budget_max is not None:
+                                    msg = (
+                                        f"⏱ {board_tag}{tag}Kanban {sub['task_id']} "
+                                        f"iteration budget exhausted "
+                                        f"({budget_used}/{budget_max}); will retry"
+                                    )
+                                else:
+                                    if ev.payload.get("limit_seconds"):
+                                        limit = int(ev.payload["limit_seconds"])
+                            if limit is None and "iteration budget" not in msg:
+                                # Legacy events / metadata-less payloads:
+                                # fall back to the task's configured runtime,
+                                # never an invented zero.
+                                limit = sub.get("max_runtime_seconds")
+                            if limit is not None:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime={limit}s); will retry"
+                                )
+                            elif "iteration budget" not in msg:
+                                msg = (
+                                    f"⏱ {board_tag}{tag}Kanban {sub['task_id']} timed out "
+                                    f"(max_runtime=?s); will retry"
+                                )
                         elif kind == "status":
                             new_status = ""
                             if ev.payload and ev.payload.get("status"):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9198,7 +9198,10 @@ def _record_task_failure(
 
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
-    context (e.g. pid on crash, elapsed on timeout).
+    context (e.g. pid on crash, elapsed on timeout). It is also merged
+    into the below-threshold ``timed_out`` run metadata + event payload
+    so budget/elapsed metadata survives for notification rendering
+    (#79399).
 
     Resolution order for the effective threshold:
       1. per-task ``max_retries`` if set (nothing else overrides)
@@ -9224,6 +9227,12 @@ def _record_task_failure(
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
+            return False
+        # Late finalizers: a worker that already ended its task via
+        # kanban_block / kanban_complete must not emit a bogus failure
+        # on top of the handoff. Only a still-running (or still-claimable
+        # ready/review) task may be failed (#79399).
+        if row["status"] not in ("running", "ready", "review"):
             return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
@@ -9314,22 +9323,25 @@ def _record_task_failure(
                 )
             if end_run:
                 # Spawn path: close the open run with outcome.
+                run_meta = {"failures": failures, "retry_status": retry_status}
+                if event_payload_extra:
+                    run_meta.update(event_payload_extra)
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_meta,
                 )
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if event_payload_extra:
+                    event_payload.update(event_payload_extra)
                 _append_event(
                     conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8785,7 +8785,10 @@ def _record_task_failure(
 
     ``event_payload_extra`` merges into the ``gave_up`` event payload
     when the breaker trips, so callers can include outcome-specific
-    context (e.g. pid on crash, elapsed on timeout).
+    context (e.g. pid on crash, elapsed on timeout). It is also merged
+    into the below-threshold ``timed_out`` run metadata + event payload
+    so budget/elapsed metadata survives for notification rendering
+    (#79399).
 
     Resolution order for the effective threshold:
       1. per-task ``max_retries`` if set (nothing else overrides)
@@ -8811,6 +8814,12 @@ def _record_task_failure(
             "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if row is None:
+            return False
+        # Late finalizers: a worker that already ended its task via
+        # kanban_block / kanban_complete must not emit a bogus failure
+        # on top of the handoff. Only a still-running (or still-claimable
+        # ready/review) task may be failed (#79399).
+        if row["status"] not in ("running", "ready", "review"):
             return False
         retry_status = (
             _retry_status_for_run(conn, task_id, row["current_run_id"])
@@ -8901,22 +8910,25 @@ def _record_task_failure(
                 )
             if end_run:
                 # Spawn path: close the open run with outcome.
+                run_meta = {"failures": failures, "retry_status": retry_status}
+                if event_payload_extra:
+                    run_meta.update(event_payload_extra)
                 run_id = _end_run(
                     conn, task_id,
                     outcome=outcome, status=outcome,
                     error=error[:500],
-                    metadata={
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    metadata=run_meta,
                 )
+                event_payload = {
+                    "error": error[:500],
+                    "failures": failures,
+                    "retry_status": retry_status,
+                }
+                if event_payload_extra:
+                    event_payload.update(event_payload_extra)
                 _append_event(
                     conn, task_id, outcome,
-                    {
-                        "error": error[:500],
-                        "failures": failures,
-                        "retry_status": retry_status,
-                    },
+                    event_payload,
                     run_id=run_id,
                 )
             # Timeout/crash path's caller already emitted its own event.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import json
 import os
 import sqlite3
 import subprocess
@@ -508,6 +509,110 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 # Respawn guard (check_respawn_guard + dispatch_once integration)
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# _record_task_failure metadata + late-finalizer guard (#79399)
+# ---------------------------------------------------------------------------
+
+
+def test_record_task_failure_below_threshold_preserves_budget_metadata(kanban_home):
+    """Iteration-budget exhaustion keeps budget_used/budget_max in run metadata (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="budget task")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+        assert kb.get_task(conn, tid).status == "running"
+
+        # Below the breaker threshold (failure_limit=5, this is failure 1).
+        blocked = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert blocked is False
+        # Task dropped back to ready for respawn.
+        assert kb.get_task(conn, tid).status == "ready"
+
+        run = conn.execute(
+            "SELECT metadata FROM task_runs WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert run is not None
+        meta = json.loads(run["metadata"] or "{}")
+        assert meta.get("budget_used") == 20
+        assert meta.get("budget_max") == 20
+
+        ev = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? "
+            "AND kind = 'timed_out' ORDER BY id DESC LIMIT 1",
+            (tid,),
+        ).fetchone()
+        assert ev is not None
+        payload = json.loads(ev["payload"] or "{}")
+        assert payload.get("budget_used") == 20
+        assert payload.get("budget_max") == 20
+
+
+def test_record_task_failure_noop_after_blocked_handoff(kanban_home):
+    """A late iteration finalizer must not fail a task already blocked (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="blocked handoff")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+
+        # Worker spends its final iteration on kanban_block → task blocked.
+        assert kb.block_task(conn, tid, reason="needs human input") is True
+        assert kb.get_task(conn, tid).status == "blocked"
+
+        # Late finalizer fires after the handoff: must be a no-op.
+        result = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert result is False
+        assert kb.get_task(conn, tid).status == "blocked"
+        # No timed_out event appended on top of the handoff.
+        kinds = [
+            r["kind"]
+            for r in conn.execute(
+                "SELECT kind FROM task_events WHERE task_id = ?", (tid,)
+            ).fetchall()
+        ]
+        assert "timed_out" not in kinds
+
+
+def test_record_task_failure_noop_after_completed_handoff(kanban_home):
+    """A late iteration finalizer must not fail a task already done (#79399)."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="completed handoff")
+        claimed = kb.claim_task(conn, tid, claimer="test:1")
+        assert claimed is not None
+
+        assert kb.complete_task(conn, tid, result="done") is True
+        assert kb.get_task(conn, tid).status == "done"
+
+        result = kb._record_task_failure(
+            conn, tid,
+            error="Iteration budget exhausted (20/20)",
+            outcome="timed_out",
+            failure_limit=5,
+            release_claim=True,
+            end_run=True,
+            event_payload_extra={"budget_used": 20, "budget_max": 20},
+        )
+        assert result is False
+        assert kb.get_task(conn, tid).status == "done"
 
 
 

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -544,6 +544,53 @@ class TestFailureFingerprint:
 class TestColdStartParking:
     """5 identical failures park cold; a different error resets the streak."""
 
+    def _make_task(self, name):
+        from tools.mcp_tool import MCPServerTask
+
+        return MCPServerTask(name)
+
+    def test_permanent_failure_never_advances_identical_streak(self):
+        """A permanent initial failure parks on attempt 1 (no retry ladder)
+        and must NOT advance the identical-error streak — the 5th permanent
+        revival would otherwise cold-park with a misleading message."""
+        from tools.mcp_tool import MCPServerTask, _PARKED_RETRY_INTERVAL
+
+        async def _run():
+            server = self._make_task("test-perm")
+            attempts = {"n": 0}
+            waits: list = []
+
+            async def fake_run_stdio(self_inner, config):
+                attempts["n"] += 1
+                # ENOENT-class permanent failure (classifies permanent)
+                raise FileNotFoundError("No such file or directory: /nope/mcp.js")
+
+            async def fake_wait(self_inner, timeout=None):
+                waits.append(timeout)
+                # Give the main coroutine a chance to run (the real wait
+                # blocks on events; a zero-delay fake would CPU-spin).
+                await asyncio.sleep(0.01)
+                return "shutdown" if self_inner._shutdown_event.is_set() else "reconnect"
+
+            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio), \
+                 patch.object(MCPServerTask, '_wait_for_reconnect_or_shutdown', fake_wait), \
+                 patch('tools.mcp_tool._jittered', lambda s: 0.001):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await server._ready.wait()
+                # Let several permanent revivals run, then stop.
+                await asyncio.sleep(0.2)
+                server._shutdown_event.set()
+                await task
+
+            # Permanent error parks on EVERY attempt (attempt 1 immediately,
+            # then every revival) — never burns a retry ladder, and the
+            # identical streak never reaches 5 (no cold park / no None wait).
+            assert attempts["n"] >= 4
+            assert server._identical_failures < 5
+            assert all(t == _PARKED_RETRY_INTERVAL for t in waits)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
     def test_identical_failures_park_without_self_probe(self):
         from tools.mcp_tool import MCPServerTask, _COLD_START_IDENTICAL_FAILURES
 

--- a/tests/tools/test_mcp_stability.py
+++ b/tests/tools/test_mcp_stability.py
@@ -517,6 +517,113 @@ class TestMCPInitialConnectionRetry:
 
 
 # ---------------------------------------------------------------------------
+# Cold-start identical-error parking (#79141)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureFingerprint:
+    def test_same_error_fingerprints_identically(self):
+        from tools.mcp_tool import _failure_fingerprint
+        a = _failure_fingerprint(RuntimeError("Cannot find module /x/scoped-entry.js"))
+        b = _failure_fingerprint(RuntimeError("Cannot find module /x/scoped-entry.js"))
+        assert a == b
+
+    def test_different_error_types_fingerprint_distinctly(self):
+        from tools.mcp_tool import _failure_fingerprint
+        a = _failure_fingerprint(RuntimeError("Cannot find module /x/scoped-entry.js"))
+        b = _failure_fingerprint(ConnectionError("Cannot find module /x/scoped-entry.js"))
+        assert a != b
+
+    def test_error_message_controls_fingerprint(self):
+        from tools.mcp_tool import _failure_fingerprint
+        a = _failure_fingerprint(RuntimeError("Cannot find module /x/scoped-entry.js"))
+        b = _failure_fingerprint(RuntimeError("Cannot find module /y/other.js"))
+        assert a != b
+
+
+class TestColdStartParking:
+    """5 identical failures park cold; a different error resets the streak."""
+
+    def test_identical_failures_park_without_self_probe(self):
+        from tools.mcp_tool import MCPServerTask, _COLD_START_IDENTICAL_FAILURES
+
+        async def _run():
+            server = MCPServerTask("test-cold")
+            attempts = {"n": 0}
+            waits: list = []
+
+            async def fake_run_stdio(self_inner, config):
+                attempts["n"] += 1
+                raise RuntimeError("Cannot find module /x/scoped-entry.js")
+
+            async def fake_wait(self_inner, timeout=None):
+                # Record whether a self-probe timeout was used (5-min park)
+                waits.append(timeout)
+                if self_inner._shutdown_event.is_set():
+                    return "shutdown"
+                return "reconnect"  # external revive
+
+            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio), \
+                 patch.object(MCPServerTask, '_wait_for_reconnect_or_shutdown', fake_wait), \
+                 patch('tools.mcp_tool._jittered', lambda s: 0.001):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await server._ready.wait()
+                # Let the loop reach the cold-start park (5 identical), then stop.
+                await asyncio.sleep(0.2)
+                server._shutdown_event.set()
+                await task
+
+            # Cold-start reached: after the initial budget park (300s), the
+            # 5-identical streak trips and parks cold (None = no self-probe).
+            assert attempts["n"] >= 2 * _COLD_START_IDENTICAL_FAILURES
+            assert 300 in waits  # initial-connect budget park happened
+            assert None in waits  # cold-start park happened (no self-probe)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_different_error_resets_streak(self):
+        from tools.mcp_tool import (
+            MCPServerTask,
+            _COLD_START_IDENTICAL_FAILURES,
+            _MAX_INITIAL_CONNECT_RETRIES,
+        )
+
+        async def _run():
+            server = MCPServerTask("test-reset")
+            attempts = {"n": 0}
+            waits: list = []
+
+            async def fake_run_stdio(self_inner, config):
+                attempts["n"] += 1
+                if attempts["n"] % 2 == 0:
+                    # Different error resets the identical streak
+                    raise ConnectionError("network blip")
+                raise RuntimeError("Cannot find module /x/scoped-entry.js")
+
+            async def fake_wait(self_inner, timeout=None):
+                waits.append(timeout)
+                if self_inner._shutdown_event.is_set():
+                    return "shutdown"
+                return "reconnect"
+
+            with patch.object(MCPServerTask, '_run_stdio', fake_run_stdio), \
+                 patch.object(MCPServerTask, '_wait_for_reconnect_or_shutdown', fake_wait), \
+                 patch('tools.mcp_tool._jittered', lambda s: 0.001):
+                task = asyncio.ensure_future(server.run({"command": "fake"}))
+                await server._ready.wait()
+                await asyncio.sleep(0.2)
+                server._shutdown_event.set()
+                await task
+
+            # Alternating errors never accumulate 5 identical in a row: every
+            # park is a TIMED self-probe (300s), never a cold park (None).
+            assert attempts["n"] >= 2 * _MAX_INITIAL_CONNECT_RETRIES
+            assert attempts["n"] < 5 * _COLD_START_IDENTICAL_FAILURES
+            assert waits and all(t == 300 for t in waits)
+            assert None not in waits
+
+
+# ---------------------------------------------------------------------------
 # Fix: drain pending tasks before closing the MCP loop
 # ---------------------------------------------------------------------------
 

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -262,6 +262,38 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_timed_out_budget_exhaustion_renders_budget_not_runtime(self):
+        """Iteration-budget exhaustion is not a wall-clock timeout (#79399)."""
+        ev = SimpleNamespace(
+            kind="timed_out",
+            payload={"budget_used": 20, "budget_max": 20},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "iteration budget exhausted" in text
+        assert "20/20" in text
+        assert "max_runtime" not in text
+
+    def test_timed_out_falls_back_to_task_max_runtime(self):
+        """Legacy metadata-less payloads fall back to configured runtime (#79399)."""
+        ev = SimpleNamespace(kind="timed_out", payload={})
+        task = SimpleNamespace(
+            title="build the thing", assignee="worker",
+            result=None, max_runtime_seconds=1800,
+        )
+        text = _format_kanban_event_text(self.SUB, task, ev, "")
+        assert "max_runtime=1800s" in text
+        assert "max_runtime=0s" not in text
+
+    def test_gave_up_names_trigger_outcome(self):
+        """gave_up names the actual failure class, not generic spawn failures (#79399)."""
+        ev = SimpleNamespace(
+            kind="gave_up",
+            payload={"trigger_outcome": "timed_out", "error": "Iteration budget exhausted"},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "repeated failures (timed_out)" in text
+        assert "spawn failures" not in text
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -222,6 +222,38 @@ class TestFormatKanbanEventText:
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
         assert "timed out" in text
 
+    def test_timed_out_budget_exhaustion_renders_budget_not_runtime(self):
+        """Iteration-budget exhaustion is not a wall-clock timeout (#79399)."""
+        ev = SimpleNamespace(
+            kind="timed_out",
+            payload={"budget_used": 20, "budget_max": 20},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "iteration budget exhausted" in text
+        assert "20/20" in text
+        assert "max_runtime" not in text
+
+    def test_timed_out_falls_back_to_task_max_runtime(self):
+        """Legacy metadata-less payloads fall back to configured runtime (#79399)."""
+        ev = SimpleNamespace(kind="timed_out", payload={})
+        task = SimpleNamespace(
+            title="build the thing", assignee="worker",
+            result=None, max_runtime_seconds=1800,
+        )
+        text = _format_kanban_event_text(self.SUB, task, ev, "")
+        assert "max_runtime=1800s" in text
+        assert "max_runtime=0s" not in text
+
+    def test_gave_up_names_trigger_outcome(self):
+        """gave_up names the actual failure class, not generic spawn failures (#79399)."""
+        ev = SimpleNamespace(
+            kind="gave_up",
+            payload={"trigger_outcome": "timed_out", "error": "Iteration budget exhausted"},
+        )
+        text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert "repeated failures (timed_out)" in text
+        assert "spawn failures" not in text
+
 
 class TestNotificationPollerLoopKanbanWiring:
     """Drive a real TUI subscription through ``_notification_poller_loop``.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -430,6 +430,11 @@ _MAX_BACKOFF_SECONDS = 60
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+# Cold-start mode: a deterministically-broken server (same error every
+# attempt — missing module, revoked creds) must not self-probe forever.
+# After N consecutive identical failures, park WITHOUT a self-probe and
+# only revive on an external trigger (tool call / manual /mcp refresh).
+_COLD_START_IDENTICAL_FAILURES = 5
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
@@ -441,6 +446,23 @@ def _jittered(seconds: float) -> float:
     """Return ``seconds`` with +/-20% uniform jitter, floored at 0."""
     return max(0.0, seconds * random.uniform(1.0 - _BACKOFF_JITTER,
                                              1.0 + _BACKOFF_JITTER))
+
+
+def _failure_fingerprint(exc: BaseException) -> str:
+    """Stable string key for a failure, for identical-error detection.
+
+    Root-causes the exception (unwrapping anyio TaskGroup wrappers) and
+    keys on the exception type + primary message so the same
+    deterministically-broken server (missing module, revoked token)
+    fingerprints identically across attempts, while genuinely different
+    failures (network blip vs auth vs EOF) stay distinct.
+    """
+    root = _unwrap_exception_group(exc)
+    msg = str(root).strip() or type(root).__name__
+    # Truncate to the first line so stack traces / multi-line payloads
+    # don't defeat the match.
+    first_line = msg.splitlines()[0] if msg.splitlines() else msg
+    return f"{type(root).__name__}:{first_line[:200]}"
 
 # Keepalive cadence for HTTP/SSE sessions. The MCP spec lets a server expire
 # idle sessions on any TTL it chooses (Streamable HTTP "Session Management"),
@@ -2077,6 +2099,7 @@ class MCPServerTask:
         "_idle_timeout_seconds", "_max_lifetime_seconds", "_recycled_reason",
         "initialize_result", "_ping_unsupported",
         "_reconnect_retries", "_session_proven", "_was_parked",
+        "_identical_failures", "_last_failure_fingerprint",
     )
 
     def __init__(self, name: str):
@@ -2099,6 +2122,12 @@ class MCPServerTask:
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
         self._reconnect_retries: int = 0
+        # Identical-error streak (#79141): consecutive failures whose
+        # fingerprint matches the previous failure. Once >= 5, the server is
+        # deterministically broken (missing module, revoked creds) and parks
+        # cold — no self-probe, revive only on external trigger.
+        self._identical_failures: int = 0
+        self._last_failure_fingerprint: Optional[str] = None
         # Rapid-drop budget (#62212): a freshly (re)established session is
         # UNPROVEN until it demonstrates real health — it survived at least
         # one full keepalive interval (keepalive success path) or served at
@@ -2777,6 +2806,10 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    # Identical-error streak is moot once the server is up
+                    # again (#79141).
+                    self._identical_failures = 0
+                    self._last_failure_fingerprint = None
                     # A completed handshake alone is NOT proof of health: a
                     # flapping transport can handshake fine and drop moments
                     # later, forever (#62212). The session must prove itself
@@ -3577,6 +3610,51 @@ class MCPServerTask:
                         self._ready.clear()
                         continue
 
+                    # Track identical-error streak AFTER the permanent
+                    # classification: a deterministically-broken server
+                    # (missing module) fingerprints the same every attempt,
+                    # but a permanent error (auth/ENOENT) parks immediately on
+                    # attempt 1 and must NOT advance the streak — otherwise the
+                    # 5th permanent revival would cold-park with a misleading
+                    # "deterministically broken" message and burn the ladder
+                    # it already avoided (#79141).
+                    fp = _failure_fingerprint(root)
+                    if fp == self._last_failure_fingerprint:
+                        self._identical_failures += 1
+                    else:
+                        self._identical_failures = 1
+                        self._last_failure_fingerprint = fp
+                    if self._identical_failures >= _COLD_START_IDENTICAL_FAILURES:
+                        logger.warning(
+                            "MCP server '%s' failed %d consecutive attempts with "
+                            "the same error, entering cold-start mode; will only "
+                            "revive on an explicit reconnect request (state: "
+                            "connecting → parked): %s: %s",
+                            self.name, self._identical_failures,
+                            type(root).__name__, root,
+                        )
+                        self._error = exc
+                        self._ready.set()
+                        self._was_parked = True
+                        self._deregister_tools()
+                        self._reconnect_event.clear()
+                        parked = await self._wait_for_reconnect_or_shutdown()
+                        if parked == "shutdown":
+                            return
+                        logger.debug(
+                            "MCP server '%s': cold-start revival requested "
+                            "(explicit reconnect); rebuilding transport.",
+                            self.name,
+                        )
+                        self._identical_failures = 0
+                        self._last_failure_fingerprint = None
+                        initial_retries = 0
+                        self._reconnect_retries = 0
+                        backoff = 1.0
+                        self._error = None
+                        self._ready.clear()
+                        continue
+
                     initial_retries += 1
                     if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
                         logger.warning(
@@ -3665,6 +3743,42 @@ class MCPServerTask:
                     continue
 
                 self._reconnect_retries += 1
+                # Identical-error streak for a server that WAS working: the
+                # first N failures after a healthy session may be a genuine
+                # outage, but the same error 5x in a row is deterministic —
+                # park cold (no self-probe) instead of probing forever.
+                fp = _failure_fingerprint(root)
+                if fp == self._last_failure_fingerprint:
+                    self._identical_failures += 1
+                else:
+                    self._identical_failures = 1
+                    self._last_failure_fingerprint = fp
+                if self._identical_failures >= _COLD_START_IDENTICAL_FAILURES:
+                    logger.warning(
+                        "MCP server '%s' failed %d consecutive reconnects with "
+                        "the same error, entering cold-start mode; will only "
+                        "revive on an explicit reconnect request (state: "
+                        "degraded → parked): %s: %s",
+                        self.name, self._identical_failures,
+                        type(root).__name__, root,
+                    )
+                    self._was_parked = True
+                    self._deregister_tools()
+                    self._reconnect_event.clear()
+                    parked = await self._wait_for_reconnect_or_shutdown()
+                    if parked == "shutdown":
+                        return
+                    logger.debug(
+                        "MCP server '%s': cold-start revival requested "
+                        "(explicit reconnect); rebuilding transport.",
+                        self.name,
+                    )
+                    self._identical_failures = 0
+                    self._last_failure_fingerprint = None
+                    self._reconnect_retries = _MAX_RECONNECT_RETRIES
+                    backoff = 1.0
+                    continue
+
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -587,6 +587,11 @@ _MAX_BACKOFF_SECONDS = 60
 # server is unrevivable: its tools are out of the registry, so no tool call
 # can ever reach the circuit-breaker half-open probe or _signal_reconnect.
 _PARKED_RETRY_INTERVAL = 300     # seconds between parked self-probes
+# Cold-start mode: a deterministically-broken server (same error every
+# attempt — missing module, revoked creds) must not self-probe forever.
+# After N consecutive identical failures, park WITHOUT a self-probe and
+# only revive on an external trigger (tool call / manual /mcp refresh).
+_COLD_START_IDENTICAL_FAILURES = 5
 _RECYCLED_RECONNECT_TIMEOUT = 15.0
 # Jitter applied to reconnect backoff sleeps. Without it, every server that
 # lost the same backend retries in lockstep (thundering herd) and log lines
@@ -598,6 +603,23 @@ def _jittered(seconds: float) -> float:
     """Return ``seconds`` with +/-20% uniform jitter, floored at 0."""
     return max(0.0, seconds * random.uniform(1.0 - _BACKOFF_JITTER,
                                              1.0 + _BACKOFF_JITTER))
+
+
+def _failure_fingerprint(exc: BaseException) -> str:
+    """Stable string key for a failure, for identical-error detection.
+
+    Root-causes the exception (unwrapping anyio TaskGroup wrappers) and
+    keys on the exception type + primary message so the same
+    deterministically-broken server (missing module, revoked token)
+    fingerprints identically across attempts, while genuinely different
+    failures (network blip vs auth vs EOF) stay distinct.
+    """
+    root = _unwrap_exception_group(exc)
+    msg = str(root).strip() or type(root).__name__
+    # Truncate to the first line so stack traces / multi-line payloads
+    # don't defeat the match.
+    first_line = msg.splitlines()[0] if msg.splitlines() else msg
+    return f"{type(root).__name__}:{first_line[:200]}"
 
 # Keepalive cadence for HTTP/SSE sessions. The MCP spec lets a server expire
 # idle sessions on any TTL it chooses (Streamable HTTP "Session Management"),
@@ -2397,6 +2419,7 @@ class MCPServerTask:
         "_inflight_tasks", "_reconnecting", "_suspect_reason",
         "_teardown_race", "_permanent_grace_used", "_stdio_child_pids",
         "_ever_connected",
+        "_identical_failures", "_last_failure_fingerprint",
     )
 
     def __init__(self, name: str):
@@ -2419,6 +2442,12 @@ class MCPServerTask:
         self._elicitation: Optional[ElicitationHandler] = None
         self._registered_tool_names: list[str] = []
         self._reconnect_retries: int = 0
+        # Identical-error streak (#79141): consecutive failures whose
+        # fingerprint matches the previous failure. Once >= 5, the server is
+        # deterministically broken (missing module, revoked creds) and parks
+        # cold — no self-probe, revive only on external trigger.
+        self._identical_failures: int = 0
+        self._last_failure_fingerprint: Optional[str] = None
         # Rapid-drop budget (#62212): a freshly (re)established session is
         # UNPROVEN until it demonstrates real health — it survived at least
         # one full keepalive interval (keepalive success path) or served at
@@ -3368,6 +3397,10 @@ class MCPServerTask:
                     # prior outage so the first call after recovery isn't
                     # gated on a stale consecutive-failure count (#16788).
                     _reset_server_error(self.name)
+                    # Identical-error streak is moot once the server is up
+                    # again (#79141).
+                    self._identical_failures = 0
+                    self._last_failure_fingerprint = None
                     # A completed handshake alone is NOT proof of health: a
                     # flapping transport can handshake fine and drop moments
                     # later, forever (#62212). The session must prove itself
@@ -4210,6 +4243,51 @@ class MCPServerTask:
                         self._ready.clear()
                         continue
 
+                    # Track identical-error streak AFTER the permanent
+                    # classification: a deterministically-broken server
+                    # (missing module) fingerprints the same every attempt,
+                    # but a permanent error (auth/ENOENT) parks immediately on
+                    # attempt 1 and must NOT advance the streak — otherwise the
+                    # 5th permanent revival would cold-park with a misleading
+                    # "deterministically broken" message and burn the ladder
+                    # it already avoided (#79141).
+                    fp = _failure_fingerprint(root)
+                    if fp == self._last_failure_fingerprint:
+                        self._identical_failures += 1
+                    else:
+                        self._identical_failures = 1
+                        self._last_failure_fingerprint = fp
+                    if self._identical_failures >= _COLD_START_IDENTICAL_FAILURES:
+                        logger.warning(
+                            "MCP server '%s' failed %d consecutive attempts with "
+                            "the same error, entering cold-start mode; will only "
+                            "revive on an explicit reconnect request (state: "
+                            "connecting → parked): %s: %s",
+                            self.name, self._identical_failures,
+                            type(root).__name__, root,
+                        )
+                        self._error = exc
+                        self._ready.set()
+                        self._was_parked = True
+                        self._deregister_tools()
+                        self._reconnect_event.clear()
+                        parked = await self._wait_for_reconnect_or_shutdown()
+                        if parked == "shutdown":
+                            return
+                        logger.debug(
+                            "MCP server '%s': cold-start revival requested "
+                            "(explicit reconnect); rebuilding transport.",
+                            self.name,
+                        )
+                        self._identical_failures = 0
+                        self._last_failure_fingerprint = None
+                        initial_retries = 0
+                        self._reconnect_retries = 0
+                        backoff = 1.0
+                        self._error = None
+                        self._ready.clear()
+                        continue
+
                     initial_retries += 1
                     if initial_retries > _MAX_INITIAL_CONNECT_RETRIES:
                         logger.warning(
@@ -4328,6 +4406,42 @@ class MCPServerTask:
                     continue
 
                 self._reconnect_retries += 1
+                # Identical-error streak for a server that WAS working: the
+                # first N failures after a healthy session may be a genuine
+                # outage, but the same error 5x in a row is deterministic —
+                # park cold (no self-probe) instead of probing forever.
+                fp = _failure_fingerprint(root)
+                if fp == self._last_failure_fingerprint:
+                    self._identical_failures += 1
+                else:
+                    self._identical_failures = 1
+                    self._last_failure_fingerprint = fp
+                if self._identical_failures >= _COLD_START_IDENTICAL_FAILURES:
+                    logger.warning(
+                        "MCP server '%s' failed %d consecutive reconnects with "
+                        "the same error, entering cold-start mode; will only "
+                        "revive on an explicit reconnect request (state: "
+                        "degraded → parked): %s: %s",
+                        self.name, self._identical_failures,
+                        type(root).__name__, root,
+                    )
+                    self._was_parked = True
+                    self._deregister_tools()
+                    self._reconnect_event.clear()
+                    parked = await self._wait_for_reconnect_or_shutdown()
+                    if parked == "shutdown":
+                        return
+                    logger.debug(
+                        "MCP server '%s': cold-start revival requested "
+                        "(explicit reconnect); rebuilding transport.",
+                        self.name,
+                    )
+                    self._identical_failures = 0
+                    self._last_failure_fingerprint = None
+                    self._reconnect_retries = _MAX_RECONNECT_RETRIES
+                    backoff = 1.0
+                    continue
+
                 if self._reconnect_retries > _MAX_RECONNECT_RETRIES:
                     logger.warning(
                         "MCP server '%s' failed after %d reconnection attempts, "

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9106,16 +9106,35 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
-        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
+        trigger = f" ({payload['trigger_outcome']})" if payload.get("trigger_outcome") else ""
+        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated failures{trigger}{err}"
     if kind == "crashed":
         return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
     if kind == "timed_out":
-        limit = 0
+        # Iteration-budget exhaustion carries budget_used/budget_max, not a
+        # wall-clock limit — render it as such and never invent
+        # max_runtime=0s (#79399).
+        budget_used = payload.get("budget_used")
+        budget_max = payload.get("budget_max")
+        if budget_used is not None and budget_max is not None:
+            return (
+                f"⏱ {board_tag}{tag}Kanban {task_id} iteration budget exhausted "
+                f"({budget_used}/{budget_max}); will retry"
+            )
+        limit = None
         try:
-            limit = int(payload.get("limit_seconds") or 0)
+            if payload.get("limit_seconds"):
+                limit = int(payload["limit_seconds"])
         except (TypeError, ValueError):
             pass
-        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+        if limit is None and getattr(task, "max_runtime_seconds", None):
+            # Legacy events / metadata-less payloads: fall back to the
+            # task's configured runtime, never an invented zero.
+            limit = int(task.max_runtime_seconds)
+        return (
+            f"⏱ {board_tag}{tag}Kanban {task_id} timed out "
+            f"(max_runtime={limit if limit is not None else '?'}s); will retry"
+        )
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
     return None

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11702,16 +11702,35 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
-        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
+        trigger = f" ({payload['trigger_outcome']})" if payload.get("trigger_outcome") else ""
+        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated failures{trigger}{err}"
     if kind == "crashed":
         return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
     if kind == "timed_out":
-        limit = 0
+        # Iteration-budget exhaustion carries budget_used/budget_max, not a
+        # wall-clock limit — render it as such and never invent
+        # max_runtime=0s (#79399).
+        budget_used = payload.get("budget_used")
+        budget_max = payload.get("budget_max")
+        if budget_used is not None and budget_max is not None:
+            return (
+                f"⏱ {board_tag}{tag}Kanban {task_id} iteration budget exhausted "
+                f"({budget_used}/{budget_max}); will retry"
+            )
+        limit = None
         try:
-            limit = int(payload.get("limit_seconds") or 0)
+            if payload.get("limit_seconds"):
+                limit = int(payload["limit_seconds"])
         except (TypeError, ValueError):
             pass
-        return f"⏱ {board_tag}{tag}Kanban {task_id} timed out (max_runtime={limit}s); will retry"
+        if limit is None and getattr(task, "max_runtime_seconds", None):
+            # Legacy events / metadata-less payloads: fall back to the
+            # task's configured runtime, never an invented zero.
+            limit = int(task.max_runtime_seconds)
+        return (
+            f"⏱ {board_tag}{tag}Kanban {task_id} timed out "
+            f"(max_runtime={limit if limit is not None else '?'}s); will retry"
+        )
     if kind == "status":
         return f"🔄 {board_tag}{tag}Kanban {task_id} → {payload.get('status') or ''}"
     return None


### PR DESCRIPTION
## Summary

Fixes #79141. A stdio MCP server that fails with the **same** error on every attempt (missing module, revoked token) is classified `transient`, burns the initial-connect retry ladder, parks with a 5-minute self-probe, and repeats that forever. Observed: **213 respawns in 4 days, 96% the same "Cannot find module" error** — resource waste, stderr log spam, and a masked root cause.

**Fix — cold-start identical-error parking:**

1. **`_failure_fingerprint(exc)`** (`tools/mcp_tool.py`) — stable key for identical-error detection: root-causes the exception (unwrapping anyio TaskGroup wrappers) and keys on `exception type + first-line message`, so the same deterministic failure fingerprints identically while genuinely different failures (network blip vs auth vs EOF) stay distinct.
2. **`_COLD_START_IDENTICAL_FAILURES = 5`** — after 5 consecutive *identical* failures, the server parks **cold**: no self-probe, revive only on an explicit reconnect request (tool call via `_signal_reconnect` / manual `/mcp` refresh / OAuth recovery).
3. **Both `run()` exception paths** (initial-connect + post-ready reconnect) track the streak; a different error resets it, so real outages still self-heal via the timed self-probe; a successful connect resets it too.

This directly implements the issue's suggested policy (same-error N times → cold-start mode, only external trigger revives) without the heavier full `WatchdogPolicy` class — the existing retry ladder already provides the 1s→60s exponential backoff; the missing piece was the identical-error cold park.

## Verification

- 5 new tests (`tests/tools/test_mcp_stability.py`): fingerprint identity/type/message sensitivity, cold park (no self-probe timeout) after 5 identical, timed self-probe preserved for alternating errors
- RED on old code (5 failed), GREEN now: 21/21 in the file
