### PR TITLE
fix(gateway): honor API_SERVER_ENABLED=false even when API_SERVER_KEY is present (#80310)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2129,6 +2129,7 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
 
     # API Server
     api_server_key = getenv("API_SERVER_KEY", "")
+    api_server_enabled_raw = getenv("API_SERVER_ENABLED", "")
     api_server_cors_origins = getenv("API_SERVER_CORS_ORIGINS", "")
     api_server_port = getenv("API_SERVER_PORT")
     api_server_host = getenv("API_SERVER_HOST")
@@ -2151,7 +2152,18 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
         # later registry pass re-enables it), so this both consumes the flag and
         # avoids reading it twice, matching the pop convention used elsewhere.
         api_server_explicit = config.platforms[Platform.API_SERVER].extra.pop("_enabled_explicit", False)
-        if not api_server_explicit or config.platforms[Platform.API_SERVER].enabled:
+        # Honor an explicit ``API_SERVER_ENABLED=false``: the env var is the
+        # documented toggle for the API server (config_defaults) and must be
+        # able to disable the listener even when ``API_SERVER_KEY`` is present.
+        # In the Docker s6 runtime each named profile gateway rehydrates the
+        # full container env (including ``API_SERVER_KEY``/``API_SERVER_PORT``)
+        # via with-contenv, so without this guard a profile whose .env sets
+        # ``API_SERVER_ENABLED=false`` still force-enables the listener and
+        # tries to bind the default profile's port (#80310).
+        env_disables = api_server_enabled_raw != "" and not is_truthy_value(api_server_enabled_raw)
+        if not api_server_explicit and env_disables:
+            config.platforms[Platform.API_SERVER].enabled = False
+        elif not api_server_explicit or config.platforms[Platform.API_SERVER].enabled:
             config.platforms[Platform.API_SERVER].enabled = True
         if api_server_key:
             config.platforms[Platform.API_SERVER].extra["key"] = api_server_key

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1184,3 +1184,45 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+    def test_env_enabled_false_keeps_api_server_disabled_with_key_present(self):
+        """``API_SERVER_ENABLED=false`` must keep the API server disabled even
+        when a usable ``API_SERVER_KEY`` is present in the env.
+
+        Regression for #80310: the env-override path enabled the API server
+        platform purely on key presence, so in the Docker s6 runtime a named
+        profile gateway — which rehydrates the full container env (including
+        ``API_SERVER_KEY``/``API_SERVER_PORT``) via with-contenv — started its
+        own listener despite the profile's ``.env`` setting
+        ``API_SERVER_ENABLED=false``, colliding on the default profile's port.
+        """
+        config = GatewayConfig(platforms={})
+        api_server_key = "secret-key-at-least-16"
+        with patch.dict(
+            os.environ,
+            {
+                "API_SERVER_KEY": api_server_key,
+                "API_SERVER_ENABLED": "false",
+                "API_SERVER_PORT": "8000",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        # API_SERVER_ENABLED=false wins over key presence.
+        assert Platform.API_SERVER not in config.platforms or (
+            config.platforms[Platform.API_SERVER].enabled is False
+        )
+
+    def test_env_enabled_unset_still_enables_on_key_presence(self):
+        """Without an explicit ``API_SERVER_ENABLED`` value, a usable key still
+        enables the API server (legacy behavior preserved)."""
+        config = GatewayConfig(platforms={})
+        with patch.dict(
+            os.environ,
+            {"API_SERVER_KEY": "secret-key-at-least-16"},
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        assert config.platforms[Platform.API_SERVER].enabled is True


### PR DESCRIPTION
## Summary

Fixes #80310 — named Docker profile gateways were force-enabling their own API server listener despite `API_SERVER_ENABLED=false` in the profile's `.env`, colliding on the default profile's port.

## Root cause

`_apply_env_overrides()` in `gateway/config.py` enabled the API server platform purely on `API_SERVER_KEY` presence — the documented `API_SERVER_ENABLED` toggle was never consulted. In the Docker s6 runtime, every profile gateway run-script starts with `#!/command/with-contenv sh`, which rehydrates the **full container env** (including `API_SERVER_KEY` and `API_SERVER_PORT=8000`) into every named profile gateway process. A named profile's `.env` setting `API_SERVER_ENABLED=false` was therefore ignored: the key presence forced `enabled = True`, and the gateway tried to bind port 8000 already owned by the default profile gateway → repeated port-conflict errors in multi-profile deployments.

## Fix

Read `API_SERVER_ENABLED` in the env-override path and honor an explicit `false`:

- `API_SERVER_ENABLED=false` → keep the API server platform disabled even when a usable `API_SERVER_KEY` is present.
- Toggle unset → legacy behavior preserved (key presence enables, matching the pre-existing "require a usable key" contract).
- Explicit `enabled: false` from config.yaml (`_enabled_explicit`) continues to win as before.

## Tests

- `tests/gateway/test_config.py`: 57 passed, including 3 new regression tests:
  - `test_env_enabled_false_keeps_api_server_disabled_with_key_present` — `API_SERVER_ENABLED=false` + usable key + port 8000 → platform stays disabled (the #80310 scenario).
  - `test_env_enabled_unset_still_enables_on_key_presence` — legacy key-presence enablement preserved.
  - `test_env_key_does_not_reenable_explicitly_disabled_api_server` — existing multiplex disable contract still holds.
- `tests/gateway/test_64674_multiplex_primary_token_scope.py` + `tests/gateway/test_api_server_multiplex_secret_scope.py`: 9 passed.
