### PR TITLE
fix(webhook): accept X-Hindsight-Signature

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -1054,13 +1054,15 @@ class WebhookAdapter(BasePlatformAdapter):
                 signature_header=svix_signature,
             )
 
-        # GitHub: X-Hub-Signature-256 = sha256=<hex>
+        # GitHub / Hindsight: sha256=<hex> of raw body bytes
         gh_sig = request.headers.get("X-Hub-Signature-256", "")
-        if gh_sig:
+        hindsight_sig = request.headers.get("X-Hindsight-Signature", "")
+        if gh_sig or hindsight_sig:
+            provided_sig = gh_sig or hindsight_sig
             expected = "sha256=" + hmac.new(
                 secret.encode(), body, hashlib.sha256
             ).hexdigest()
-            return _hmac_str_equal(gh_sig, expected)
+            return _hmac_str_equal(provided_sig, expected)
 
         # GitLab: X-Gitlab-Token = <plain secret>
         gl_token = request.headers.get("X-Gitlab-Token", "")


### PR DESCRIPTION
## Summary
- accept `X-Hindsight-Signature` in the generic webhook adapter
- treat it as the same raw-body `sha256=<hex>` contract already accepted for `X-Hub-Signature-256`
- preserve existing GitHub-style behavior unchanged

## Validation
- before patch: `X-Hub-Signature-256` returned `200`; `X-Hindsight-Signature` returned `401` for the same signed payload
- after patch + restart: both headers returned `200`

Closes #80327

## Alternative considered
A possible alternative is to make Hindsight emit `X-Hub-Signature-256` directly, or allow selecting that header name in Hindsight webhook delivery config. Related Hindsight discussion: https://github.com/vectorize-io/hindsight/issues/3071
