### PR TITLE
fix(serve): headless backend exits when the desktop parent dies (#80204)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -17338,6 +17338,46 @@ def _read_bound_port(server: "uvicorn.Server", fallback: int) -> int:
     return fallback
 
 
+async def _request_parent_death_shutdown(server: "uvicorn.Server") -> None:
+    """Ask the running uvicorn server to exit (parent-death watchdog)."""
+    server.should_exit = True
+    try:
+        server.exit_event.set()
+    except Exception:
+        pass
+
+
+def _parent_death_watchdog_loop(
+    server: "uvicorn.Server",
+    loop: "asyncio.AbstractEventLoop",
+    parent_pid: int,
+    *,
+    poll_interval: float = 2.0,
+) -> None:
+    """Daemon-thread body: poll getppid() and shut the server down when the
+    spawning parent dies (reparented to 1). Exits when the server already
+    stopped or the loop is closed."""
+    while not server.should_exit:
+        try:
+            if os.getppid() != parent_pid:
+                _log.warning(
+                    "parent (desktop) exited; shutting down headless backend "
+                    "(was pid %s)",
+                    parent_pid,
+                )
+                try:
+                    asyncio.run_coroutine_threadsafe(
+                        _request_parent_death_shutdown(server), loop
+                    )
+                except RuntimeError:
+                    # Loop is closed — nothing left to signal.
+                    pass
+                return
+        except (OSError, RuntimeError):
+            return
+        time.sleep(poll_interval)
+
+
 def _write_dashboard_ready_file(actual_port: int) -> None:
     """Optionally publish the dashboard port through an atomic ready file.
 
@@ -17683,6 +17723,25 @@ def start_server(
             _hb_loop.call_later(
                 _hb_interval, _loop_heartbeat, _hb_loop.time() + _hb_interval
             )
+
+            # ── Parent-death watchdog (headless desktop backend, #80204) ──
+            # The Desktop app normally SIGTERMs its `hermes serve` child on
+            # quit (before-quit → stopBackendChild). But update hand-offs,
+            # crashes, and force-quits skip that path: the backend is
+            # reparented to PID 1 and keeps serving forever — 14 orphaned
+            # backends observed (each holding MCP watchdogs + helper daemons).
+            # When the Electron parent dies, exit on our own: poll getppid()
+            # from a daemon thread and flip uvicorn's should_exit once the
+            # parent is gone (reparented to 1 = no longer the spawner).
+            if headless and os.environ.get("HERMES_DESKTOP") == "1":
+                _parent_pid = os.getppid()
+                _loop = asyncio.get_running_loop()
+                threading.Thread(
+                    target=_parent_death_watchdog_loop,
+                    args=(server, _loop, _parent_pid),
+                    name="serve-parent-watch",
+                    daemon=True,
+                ).start()
 
             await server.main_loop()
             if server.started:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -240,3 +240,94 @@ def test_start_server_keeps_bare_asyncio_run_on_posix(monkeypatch):
     assert runner_called["hit"] is False, (
         "POSIX must not take the Windows loop-factory branch"
     )
+
+
+# ---------------------------------------------------------------------------
+# Parent-death watchdog (#80204)
+# ---------------------------------------------------------------------------
+
+class _FakeWatchServer:
+    def __init__(self):
+        self.should_exit = False
+        self.exit_event = asyncio.Event()
+        self.exit_event.set = lambda: None  # no-op set; flag check below
+        self.signaled = False
+
+    async def shutdown(self):
+        self.signaled = True
+
+
+def test_parent_death_watchdog_shuts_down_when_parent_dies(monkeypatch):
+    """getppid() changing (parent reparented to 1) triggers should_exit."""
+    server = _FakeWatchServer()
+    loop = asyncio.new_event_loop()
+    try:
+        # The thread runs in a real event-loop context via run_coroutine_threadsafe.
+        # Simulate by patching the loop's call to run the coroutine inline.
+        calls = []
+
+        def _fake_threadsafe(coro, _loop):
+            calls.append(coro)
+            asyncio.get_event_loop().run_until_complete(coro)
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server.asyncio.run_coroutine_threadsafe", _fake_threadsafe
+        )
+        monkeypatch.setattr(web_server.os, "getppid", lambda: 1)  # parent gone
+
+        web_server._parent_death_watchdog_loop(
+            server, loop, parent_pid=424242, poll_interval=0.001
+        )
+
+        assert server.should_exit is True
+        assert len(calls) == 1  # exactly one shutdown request
+    finally:
+        loop.close()
+
+
+def test_parent_death_watchdog_noop_while_parent_alive(monkeypatch):
+    """getppid() unchanged → watchdog keeps polling, never signals."""
+    server = _FakeWatchServer()
+    loop = asyncio.new_event_loop()
+    try:
+        signaled = {"hit": False}
+
+        def _fake_threadsafe(coro, _loop):
+            signaled["hit"] = True
+
+        monkeypatch.setattr(
+            "hermes_cli.web_server.asyncio.run_coroutine_threadsafe", _fake_threadsafe
+        )
+        monkeypatch.setattr(web_server.os, "getppid", lambda: 424242)
+
+        # Poll a few times with a tiny interval, then stop via should_exit.
+        import threading
+
+        def _stop():
+            import time
+
+            time.sleep(0.02)
+            server.should_exit = True
+
+        t = threading.Thread(target=_stop)
+        t.start()
+        web_server._parent_death_watchdog_loop(
+            server, loop, parent_pid=424242, poll_interval=0.001
+        )
+        t.join()
+
+        assert signaled["hit"] is False
+        assert server.should_exit is True  # exited via loop condition, not parent
+    finally:
+        loop.close()
+
+
+def test_request_parent_death_shutdown_flags_server(monkeypatch):
+    server = _FakeWatchServer()
+    monkeypatch.setattr(web_server.asyncio, "Event", lambda: type("E", (), {})())
+
+    async def _run():
+        await web_server._request_parent_death_shutdown(server)
+
+    asyncio.get_event_loop().run_until_complete(_run())
+    assert server.should_exit is True


### PR DESCRIPTION
## Summary

Fixes #80204. Desktop-launched `hermes serve` backends survived their Electron parent (update hand-off, crash, force-quit all skip the `before-quit` teardown path), got reparented to PID 1, and kept serving forever — **14 orphaned backends observed**, each holding MCP watchdogs + helper daemons, and every new Desktop launch adding another (32 Hermes Python processes total in the report).

**Fix — parent-death watchdog on the headless desktop backend:**

- `hermes_cli/web_server.py`: when `serve` runs with `HERMES_DESKTOP=1` (desktop-managed), arm a daemon thread that polls `os.getppid()`. Once the spawning Electron parent is gone (reparented to 1), it flips `uvicorn.Server.should_exit` via `run_coroutine_threadsafe`, so the backend — and its MCP watchdog/helper children — exit on their own.
- Deliberately scoped to `headless && HERMES_DESKTOP=1`: standalone `hermes serve` / `hermes dashboard` (real servers, systemd-managed, remote) are untouched — no parent-death coupling where there's no managing parent.

This covers the issue's "managed backend should exit within a bounded grace period" for the abnormal-exit cases the existing `before-quit` SIGTERM never sees. The existing Desktop launch-side cleanup (stale-backend sweep via `_scan_dashboard_processes`) remains the second line of defense.

## Verification

- 3 new tests (`tests/test_web_server.py`): parent-died → exactly one shutdown request + `should_exit`; parent-alive → no signal, keeps polling; `_request_parent_death_shutdown` flags the server
- RED on old code (3 failed), GREEN now: 9/9 in the file
