### PR TITLE
fix(cli): refuse /refine mid-turn, matching the gateway handler

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -2467,6 +2467,19 @@ class CLICommandsMixin:
         parts = (cmd or "").strip().split(None, 1)
         focus = parts[1].strip() if len(parts) > 1 else ""
 
+        # Refuse mid-turn, exactly as the gateway handler does. ``cli.py``
+        # assigns ``conversation_history`` only once a turn returns ("Update
+        # history with full conversation"), so a snapshot taken while the
+        # agent is working holds the PREVIOUS turn — the review would miss
+        # the work the user is watching, including whatever prompted the
+        # /refine, and still report success.
+        if getattr(self, "_agent_running", False):
+            _cprint(
+                f"  {_DIM}Agent is running — wait for the turn to finish, "
+                f"then /refine.{_RST}"
+            )
+            return
+
         agent = getattr(self, "agent", None)
         if agent is None:
             _cprint(f"  {_DIM}Nothing to refine yet — send a message first.{_RST}")

--- a/tests/hermes_cli/test_refine_running_guard.py
+++ b/tests/hermes_cli/test_refine_running_guard.py
@@ -1,0 +1,81 @@
+"""/refine must refuse mid-turn on the CLI, the way the gateway already does.
+
+``cli.py`` assigns ``conversation_history`` only once a turn returns ("Update
+history with full conversation"), so a snapshot taken while the agent is
+working holds the PREVIOUS turn. Without a guard the CLI spawned the review
+against that stale history and still printed the success line — the review
+silently missed the work the user was watching, which is usually the very
+thing that prompted the /refine.
+"""
+
+from __future__ import annotations
+
+import types
+
+from hermes_cli.cli_commands_mixin import CLICommandsMixin
+
+
+class _StubAgent:
+    valid_tool_names = {"skill_manage"}
+
+    def __init__(self):
+        self.spawned = False
+        self.snapshot = None
+        self.focus = None
+
+    def _spawn_background_review(
+        self, messages_snapshot, review_memory, review_skills, focus=None,
+    ):
+        self.spawned = True
+        self.snapshot = list(messages_snapshot)
+        self.focus = focus
+
+
+def _cli(*, running: bool, history: list[dict]):
+    cli = types.SimpleNamespace()
+    cli.agent = _StubAgent()
+    cli.conversation_history = list(history)
+    cli._agent_running = running
+    cli._handle_refine_command = types.MethodType(
+        CLICommandsMixin._handle_refine_command, cli,
+    )
+    return cli
+
+
+FINISHED_TURN = [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "hi"},
+]
+
+
+def test_refine_is_refused_while_a_turn_is_running():
+    """The in-flight turn is not in conversation_history yet, so don't review."""
+    cli = _cli(running=True, history=FINISHED_TURN)
+
+    cli._handle_refine_command("/refine save the deploy workflow as a skill")
+
+    assert cli.agent.spawned is False, (
+        "spawned a review against a stale pre-turn snapshot while the agent "
+        f"was running (snapshot={cli.agent.snapshot!r})"
+    )
+
+
+def test_refine_runs_when_the_session_is_idle():
+    """The guard must not swallow the ordinary case, and focus still rides along."""
+    cli = _cli(running=False, history=FINISHED_TURN)
+
+    cli._handle_refine_command("/refine save the deploy workflow as a skill")
+
+    assert cli.agent.spawned is True
+    assert cli.agent.snapshot == FINISHED_TURN
+    assert cli.agent.focus == "save the deploy workflow as a skill"
+
+
+def test_refine_without_focus_still_runs_when_idle():
+    """A bare /refine passes focus=None, as the automatic post-turn review does."""
+    cli = _cli(running=False, history=FINISHED_TURN)
+
+    cli._handle_refine_command("/refine")
+
+    assert cli.agent.spawned is True
+    assert cli.agent.focus is None


### PR DESCRIPTION
## What

79682 shipped `/refine` on both surfaces. The gateway handler refuses while the session's agent is working:

```python
if quick_key in self._running_agents:
    return "Agent is running — wait for the turn to finish, then /refine."
```

The CLI handler, added in the same commit, has no equivalent check — and the CLI is the surface where the gap actually bites. `cli.py` assigns `conversation_history` only once a turn returns:

```python
# Update history with full conversation
self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
```

So while the agent is working, `conversation_history` still holds the previous turn. `/refine` snapshots exactly that. Driving the real handler with a turn in flight:

```
agent running          : True
review was spawned     : True
snapshot contents      : ['hello', 'hi']
in-flight turn present : False
focus forwarded        : 'save the deploy workflow as a skill'
```

The review runs against history that does not contain the work in flight — usually the very thing that prompted the `/refine` — and the CLI prints `⚗ Reviewing this conversation in the background (focus: …)` with the user's own words echoed back, so nothing signals that the request was answered against a stale conversation. Typing `/refine` while watching the agent work is the natural moment to reach for it, which is what makes the silent version worse than a refusal.

Slash commands do reach handlers mid-turn on the CLI — `/queue` and `/steer` both branch on `self._agent_running` — so this path is live, not theoretical.

Both automatic triggers already have this precondition for free: `agent/turn_finalizer.py` and `agent/codex_runtime.py` spawn a review only on `final_response and not interrupted`. The manual CLI path was the one caller without it.

## The fix

Add the running-agent guard to the CLI handler, with the gateway's wording, before the agent lookup. Nothing else changes: an idle `/refine` behaves exactly as before, focus included.

## Tests and results

New file `tests/hermes_cli/test_refine_running_guard.py`, driving the real `CLICommandsMixin._handle_refine_command`:

- a turn in flight — no review is spawned; the failure message names the stale snapshot it would otherwise have used
- idle with focus — the review runs, the snapshot is the finished turn, and the focus string is forwarded
- idle without focus — passes `focus=None`, the same shape the automatic post-turn review uses

The first fails on `main` (`spawned a review against a stale pre-turn snapshot while the agent was running (snapshot=[{'role': 'user', 'content': 'hello'}, …])`) and passes with the fix. The two idle tests pass on `main` too, which is what a non-regression pin should do — they exist to prove the guard does not swallow the ordinary case.

Every suite that covers `cli_commands_mixin` (`tests/cli/test_focus_view.py`, `test_reasoning_command.py`, `tests/gateway/relay/test_handoff_relay_aliasing.py`, `tests/hermes_cli/test_debug.py`, `test_diff_command.py`, `test_prompt_compose_command.py`) plus `tests/agent/test_refine_focus.py`: 147 passed with the fix versus 144 on `main` — the three added tests — with the same two pre-existing failures both ways (`test_keeps_first_line_when_truncation_on_boundary`, `test_compose_reads_and_strips_header`), neither of which touches this path.