### PR TITLE
fix(desktop): sticky user bubble no longer covers 'show earlier' (#80141)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -9,6 +9,7 @@ import {
   LIVE_TAIL_PARTS,
   liveTailStart,
   type MessageGroup,
+  resolveStickyHumanTop,
   resolveThreadScrollTarget
 } from './list'
 
@@ -256,5 +257,21 @@ describe('liveTailStart', () => {
 
       expect(rendered(liveTailStart(groups))).toBeLessThanOrEqual(rendered(oldStart))
     }
+  })
+})
+
+describe('resolveStickyHumanTop', () => {
+  it('parks the sticky bubble below the "show earlier" control (#80141)', () => {
+    const style = resolveStickyHumanTop(true, false, 'calc(var(--titlebar-height) + 0.75rem)')
+    expect(style?.['--sticky-human-top']).toContain('var(--show-earlier-clearance')
+  })
+
+  it('leaves the default park when no "show earlier" control and main window', () => {
+    expect(resolveStickyHumanTop(false, false, 'calc(var(--titlebar-height) + 0.75rem)')).toBeUndefined()
+  })
+
+  it('reserves the titlebar gap for secondary windows', () => {
+    const style = resolveStickyHumanTop(false, true, 'calc(var(--titlebar-height) + 0.75rem)')
+    expect(style?.['--sticky-human-top']).toBe('calc(var(--titlebar-height) + 0.75rem)')
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -377,6 +377,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
+  // The "show earlier" button sits at the top of the transcript. When it's
+  // present, the sticky user bubble must park BELOW it — otherwise the
+  // sticky bubble (top: var(--sticky-human-top), z-40) covers the control
+  // and the user can't click through to older context (#80141). Reserve a
+  // clearance equal to the control's height (pill + turn gap).
+  const showEarlierVisible = hiddenCount > 0 || olderAvailable
+
   useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
   useEffect(() => () => resetThreadScroll(), [])
 
@@ -568,7 +575,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       style={
         {
           height: clampToComposer ? 'var(--thread-viewport-height)' : '100%',
-          ...(secondaryWindow ? { '--sticky-human-top': secondaryTitlebarGap } : {})
+          ...resolveStickyHumanTop(showEarlierVisible, secondaryWindow, secondaryTitlebarGap)
         } as CSSProperties
       }
     >
@@ -626,6 +633,25 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       </div>
     </div>
   )
+}
+
+export function resolveStickyHumanTop(
+  showEarlierVisible: boolean,
+  secondaryWindow: boolean,
+  secondaryTitlebarGap: string
+): Record<string, string> | undefined {
+  // #80141: when the "show earlier" control is visible, bump the sticky
+  // bubble's park position below it. calc() needs the spaces.
+  if (showEarlierVisible && !secondaryWindow) {
+    return {
+      '--sticky-human-top':
+        'calc(var(--sticky-human-top) + var(--show-earlier-clearance, 2.25rem))'
+    }
+  }
+  if (secondaryWindow) {
+    return { '--sticky-human-top': secondaryTitlebarGap }
+  }
+  return undefined
 }
 
 export const ThreadMessageList = memo(ThreadMessageListInner)

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -442,6 +442,9 @@
        freely. */
     --paragraph-gap: 0.7rem;
     --sticky-human-top: 0.23rem;
+    /* Height reserved for the "show earlier" control when present (#80141):
+       the sticky user bubble parks below it instead of covering it. */
+    --show-earlier-clearance: 2.25rem;
     --file-tree-row-height: 1.375rem;
 
     --composer-width: 48.75rem;


### PR DESCRIPTION
## Summary

Fixes #80141. In long sessions the render budget collapses older turns behind a "show earlier" button at the top of the transcript. The sticky pinned user bubble (`position: sticky; top: var(--sticky-human-top)`, `z-40`) parked at the viewport top **on top of that button**, making it impossible to click through to older context.

**Fix** (`apps/desktop/src/components/assistant-ui/thread/list.tsx` + `styles.css`):

- When the "show earlier" control is visible (`hiddenCount > 0 || olderAvailable`), bump the sticky bubble's park position by `--show-earlier-clearance` (2.25rem — the control's pill height + turn gap), so the bubble settles **below** the control instead of covering it.
- Secondary windows (which hide the control and already reserve the titlebar gap) are untouched — no behavior change there.
- Extracted `resolveStickyHumanTop()` as a pure helper so the style merge is unit-testable (the `ThreadMessageList` component is a god-component; direct render-mocking of the wiring is out of scope, same honest limitation as #80013).

## Verification

- 3 new contract tests in `list.test.ts` (parks below control when visible / default park unchanged / secondary-window titlebar gap preserved) — 24/24 in the file
- `npx tsc --noEmit` clean
