### PR TITLE
fix(moa): raise when preset exists in root config but not in profile scope

### DIFF
--- a/agent/moa_loop.py
+++ b/agent/moa_loop.py
@@ -2371,8 +2371,48 @@ def build_moa_facade(agent, preset_name: Any = None) -> MoAClient:
         moa_cfg = normalize_moa_config(load_config().get("moa") or {})
         presets = moa_cfg.get("presets") or {}
         if resolved_preset not in presets:
+            # Distinguish two cases:
+            # 1. The preset EXISTS in the root config but is invisible in the
+            #    effective (profile-scoped) config — a config-scoping bug
+            #    (kanban workers run with HERMES_HOME=<root>/profiles/<name>,
+            #    so load_config() reads the profile config and misses
+            #    root-authored presets, issue #80318). Fail loudly instead of
+            #    silently running the hardcoded default preset, which uses
+            #    unrelated models the user never selected.
+            # 2. The name exists NOWHERE — a drifted model name during fallback
+            #    restore. Keep the historical silent downgrade to the default
+            #    preset for this case (see
+            #    test_build_moa_facade_ignores_fallback_model_name_when_restoring).
+            try:
+                from hermes_constants import get_default_hermes_root
+                import yaml
+
+                root_cfg_path = get_default_hermes_root() / "config.yaml"
+                if root_cfg_path.is_file():
+                    root_raw = yaml.safe_load(root_cfg_path.read_text(encoding="utf-8")) or {}
+                    root_presets = normalize_moa_config(root_raw.get("moa") or {}).get("presets") or {}
+                else:
+                    root_presets = {}
+            except Exception:
+                root_presets = {}
+
+            if resolved_preset in root_presets:
+                from agent.errors import MoAPresetNotFoundError as _NotFound
+
+                available = ", ".join(presets) or "(none)"
+                raise _NotFound(
+                    f"MoA preset '{resolved_preset}' exists in the root config "
+                    f"but is missing from the effective (profile-scoped) config "
+                    f"of this session. Available in this scope: {available}. "
+                    f"Copy the preset into the profile's config.yaml or run the "
+                    f"session with the root HERMES_HOME."
+                )
             resolved_preset = moa_cfg.get("default_preset") or "default"
-    except Exception:
+    except Exception as _exc:
+        from agent.errors import MoAPresetNotFoundError as _NotFoundType
+
+        if isinstance(_exc, _NotFoundType):
+            raise
         resolved_preset = "default"
 
     return MoAClient(

--- a/tests/run_agent/test_moa_streaming.py
+++ b/tests/run_agent/test_moa_streaming.py
@@ -113,6 +113,82 @@ def test_build_moa_facade_ignores_fallback_model_name_when_restoring(monkeypatch
     assert client.chat.completions.preset_name == "review"
 
 
+def test_build_moa_facade_root_preset_missing_in_profile_scope_raises(monkeypatch, tmp_path):
+    """A preset that exists in the ROOT config but is invisible in the
+    profile-scoped config must raise MoAPresetNotFoundError instead of silently
+    downgrading to the hardcoded default preset (#80318).
+
+    Kanban workers run with HERMES_HOME=<root>/profiles/<name>, so load_config()
+    reads the profile config and misses root-authored presets. Before the fix
+    build_moa_facade() silently fell back to the in-code default preset
+    (openai-codex:gpt-5.5 + openrouter:deepseek-v4-pro + claude-opus-4.8),
+    running unrelated models the user never selected.
+    """
+    root = tmp_path / "root"
+    (root / "profiles" / "reviewer").mkdir(parents=True)
+    (root / "config.yaml").write_text(
+        """\
+moa:
+  default_preset: Speed Quality
+  presets:
+    Speed Quality:
+      reference_models:
+        - provider: opencode-go
+          model: deepseek-v4-flash
+        - provider: opencode-go
+          model: mimo-v2.5
+      aggregator:
+        provider: opencode-go
+        model: deepseek-v4-flash
+""".strip(),
+        encoding="utf-8",
+    )
+    # Profile config without a moa block — the scoping bug.
+    (root / "profiles" / "reviewer" / "config.yaml").write_text(
+        """\
+model:
+  default: Speed Quality
+  provider: moa
+""".strip(),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "reviewer"))
+
+    from agent.errors import MoAPresetNotFoundError
+    from agent.moa_loop import build_moa_facade
+
+    agent = SimpleNamespace(
+        provider="moa",
+        model="Speed Quality",
+        tool_progress_callback=None,
+    )
+
+    with pytest.raises(MoAPresetNotFoundError) as excinfo:
+        build_moa_facade(agent, "Speed Quality")
+    assert "exists in the root config" in str(excinfo.value)
+
+
+def test_build_moa_facade_unknown_name_still_falls_back_to_default(monkeypatch, tmp_path):
+    """A name that exists NOWHERE (drifted model name during fallback restore)
+    must keep the historical silent downgrade to the default preset — not raise.
+    Guards the restore path that previously crashed (#MoA restore path)."""
+    home = tmp_path / ".hermes"
+    _write_cfg(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    from agent.moa_loop import build_moa_facade
+
+    agent = SimpleNamespace(
+        provider="moa",
+        model="totally-unknown-model-name",
+        tool_progress_callback=None,
+    )
+
+    client = build_moa_facade(agent, None)
+
+    assert client.chat.completions.preset_name == "review"
+
+
 def test_create_wraps_completed_aggregator_response_as_delta_chunk(monkeypatch, tmp_path):
     """When an aggregator adapter returns a completed response despite
     stream=True (Codex Responses compatibility shape), MoA must return a


### PR DESCRIPTION
## Summary

Kanban workers are spawned with a profile-scoped `HERMES_HOME` (`<root>/profiles/<name>`, see `hermes_cli/kanban_db.py`), so `load_config()` inside `build_moa_facade` reads the **profile** config — which normally has no `moa:` block. MoA presets are authored in the **root** config via `hermes moa configure`. When a profile sets `model.provider: moa` + `model.default: <preset>`, the worker could not see the preset and **silently downgraded to the hardcoded in-code default preset** (`openai-codex:gpt-5.5` + `openrouter:deepseek/deepseek-v4-pro` + aggregator `openrouter:anthropic/claude-opus-4.8`) — unrelated models the user never selected, often billing the wrong (more expensive) providers (observed: OpenRouter 402 with the configured cheap opencode-go preset).

## Change

`build_moa_facade` now distinguishes the two cases instead of always silently downgrading:

1. **Preset exists in the ROOT config but is missing from the effective (profile-scoped) config** → raise `MoAPresetNotFoundError` with a clear message pointing at the config-scoping problem (and the two remedies: copy the preset into the profile config, or run with root `HERMES_HOME`). This makes the misconfiguration visible instead of running unrelated models.
2. **Name exists nowhere** (drifted model name during fallback restore) → keep the historical silent downgrade to the default preset. This preserves the behavior guarded by `test_build_moa_facade_ignores_fallback_model_name_when_restoring`.

The root-preset check reads `<root>/config.yaml` via `get_default_hermes_root()`, which resolves the pre-profile root even when `HERMES_HOME` points at `profiles/<name>` (handles the standard `~/.hermes` and Docker layouts).

## Tests

- `test_build_moa_facade_root_preset_missing_in_profile_scope_raises` — reproduces #80318: root config has the preset, profile config doesn't → `MoAPresetNotFoundError`.
- `test_build_moa_facade_unknown_name_still_falls_back_to_default` — name exists nowhere → still falls back (guards the restore path).
- Existing restore test (`test_build_moa_facade_ignores_fallback_model_name_when_restoring`) still passes.

Ran: `tests/agent/test_moa_*.py tests/run_agent/test_moa_*.py` (84 passed) + `tests/hermes_cli/test_moa_config.py` (6 passed). Note: `tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py` requires fastapi/uvicorn which isn't installed in this environment (unrelated to this change).

Fixes #80318
