### PR TITLE
fix(desktop): release Windows project directory handles gracefully

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -158,6 +158,7 @@ import { FirstRunSetupResetError, runPrimaryBackendStartup } from './primary-bac
 import { rehomePrimaryConnection } from './primary-connection-rehome'
 import { decideProfileDeleteAction, profileNameFromDeleteRequest, resolveRouteProfile } from './profile-delete-routing'
 import { fetchPrimaryProfileSessions } from './profile-session-routing'
+import { gracefulReleaseSessions } from './project-path-release'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
 import * as remoteLifecycle from './remote-lifecycle'
@@ -185,6 +186,7 @@ import {
   redactSecrets,
   SshConnection
 } from './ssh-connection'
+import { setStableProcessCwd } from './stable-process-cwd'
 import { createStreamThrottle } from './stream-throttle'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import { resolveBehindCount, shouldCountCommits } from './update-count'
@@ -577,6 +579,8 @@ function resolveHermesHome() {
 }
 
 const HERMES_HOME = resolveHermesHome()
+fs.mkdirSync(HERMES_HOME, { recursive: true })
+setStableProcessCwd(HERMES_HOME)
 
 function pathWithHermesManagedNode(...entries) {
   const managed = hermesManagedNodePathEntries(HERMES_HOME).filter(directoryExists)
@@ -693,6 +697,7 @@ const APP_ICON_PATHS = [
 
 let rendererTitleBarTheme = null
 const terminalSessions = new Map()
+let projectControlWatcher = null
 
 // Force the NATIVE window appearance (vibrancy material, titlebar, the
 // pre-first-paint window background) to follow the APP theme instead of the
@@ -11077,6 +11082,46 @@ function disposeTerminalSession(id) {
   return true
 }
 
+async function releaseTerminalSessionsForPath(projectPath) {
+  return gracefulReleaseSessions(
+    projectPath,
+    [...terminalSessions.entries()].map(([id, info]) => ({
+      id,
+      launchCwd: info.launchCwd,
+      remote: info.sshScope !== undefined,
+      writeExit: () => {
+        try { info.pty.write(IS_WINDOWS ? 'exit\r' : 'exit\n') } catch { void 0 }
+      },
+      isActive: () => terminalSessions.has(id)
+    }))
+  )
+}
+
+function startProjectControlWatcher() {
+  const controlDir = path.join(HERMES_HOME, 'cache', 'project-control')
+  fs.mkdirSync(controlDir, { recursive: true })
+  projectControlWatcher = fs.watch(controlDir, async (_eventType, filename) => {
+    const name = String(filename || '')
+    const match = /^request-([a-f0-9]+)\.json$/.exec(name)
+
+    if (!match) {
+      return
+    }
+
+    try {
+      const request = JSON.parse(await fs.promises.readFile(path.join(controlDir, name), 'utf8'))
+      const result = await releaseTerminalSessionsForPath(String(request.path || ''))
+      await fs.promises.writeFile(
+        path.join(controlDir, `response-${match[1]}.json`),
+        JSON.stringify({ ...result, requestId: match[1] }),
+        'utf8'
+      )
+    } catch (error) {
+      rememberLog(`[project-control] release request failed: ${error instanceof Error ? error.message : String(error)}`)
+    }
+  })
+}
+
 ipcMain.handle('hermes:fs:readDir', async (_event, dirPath) => readDirForIpc(dirPath))
 
 ipcMain.handle('hermes:fs:gitRoot', async (_event, startPath) => gitRootForIpc(startPath))
@@ -11345,6 +11390,7 @@ ipcMain.handle('hermes:terminal:start', async (event, payload = {}) => {
 
   terminalSessions.set(id, {
     pty: ptyProcess,
+    launchCwd: remote ? null : cwd,
     webContentsId: event.sender.id,
     ...(remote ? { sshScope: sshTarget.scope, remoteCwd: String(payload?.cwd || '') } : {})
   })
@@ -11825,6 +11871,7 @@ app.on('open-url', (event, url) => {
 })
 
 app.whenReady().then(() => {
+  startProjectControlWatcher()
   const systemCa = installWindowsSystemCaTrust(tls)
 
   if (systemCa.applied) {
@@ -12014,6 +12061,11 @@ app.on('before-quit', event => {
 
   flushDesktopLogBufferSync()
   closePreviewWatchers()
+
+  if (projectControlWatcher) {
+    projectControlWatcher.close()
+    projectControlWatcher = null
+  }
 
   // Kill open PTYs before environment teardown to avoid the node-pty#904
   // ThreadSafeFunction SIGABRT race.

--- a/apps/desktop/electron/project-path-release.test.ts
+++ b/apps/desktop/electron/project-path-release.test.ts
@@ -1,0 +1,81 @@
+import { type ChildProcess, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { describe, expect, test } from 'vitest'
+
+import { gracefulReleaseSessions, pathContains } from './project-path-release'
+
+describe('project path release', () => {
+  test('path containment does not confuse sibling prefixes', () => {
+    expect(pathContains('C:\\work\\project', 'C:\\work\\project\\child')).toBe(true)
+    expect(pathContains('C:\\work\\project', 'C:\\work\\project-old')).toBe(false)
+  })
+
+  test('release targets only local sessions under the requested project', async () => {
+    let active = true
+    let exits = 0
+
+    const result = await gracefulReleaseSessions('C:\\work\\project', [
+      { id: 'match', launchCwd: 'C:\\work\\project', remote: false, writeExit: () => { exits += 1; active = false }, isActive: () => active },
+      { id: 'other', launchCwd: 'C:\\work\\other', remote: false, writeExit: () => { exits += 1 }, isActive: () => true },
+      { id: 'remote', launchCwd: 'C:\\work\\project', remote: true, writeExit: () => { exits += 1 }, isActive: () => true },
+    ])
+
+    expect(result.released).toBe(true)
+    expect(result.releasedTerminalIds).toEqual(['match'])
+    expect(exits).toBe(1)
+  })
+
+  test('release fails closed when a terminal does not exit', async () => {
+    let clock = 0
+
+    const result = await gracefulReleaseSessions(
+      'C:\\work\\project',
+      [{ id: 'busy', launchCwd: 'C:\\work\\project', remote: false, writeExit: () => {}, isActive: () => true }],
+      { now: () => clock, pause: async ms => { clock += ms }, timeoutMs: 100 },
+    )
+
+    expect(result.released).toBe(false)
+    expect(result.activeTerminalIds).toEqual(['busy'])
+  })
+
+  test.runIf(process.platform === 'win32')('releases a real child cwd before the directory is renamed', async () => {
+    const runtimeRoot = path.resolve('.hermes', 'task-runtime')
+    fs.mkdirSync(runtimeRoot, { recursive: true })
+    const root = fs.mkdtempSync(path.join(runtimeRoot, 'project-release-'))
+    const project = path.join(root, 'project')
+    const archived = path.join(root, 'archived')
+    fs.mkdirSync(project)
+    let child: ChildProcess | null = null
+    let active = true
+
+    try {
+      child = spawn(
+        process.execPath,
+        ['-e', "process.stdin.resume(); process.stdin.on('data', () => process.exit(0))"],
+        { cwd: project, stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true },
+      )
+      child.once('exit', () => { active = false })
+      await new Promise<void>((resolve, reject) => {
+        child?.once('spawn', resolve)
+        child?.once('error', reject)
+      })
+
+      const result = await gracefulReleaseSessions(project, [{
+        id: 'real-child',
+        launchCwd: project,
+        remote: false,
+        writeExit: () => child?.stdin?.write('exit\n'),
+        isActive: () => active,
+      }])
+
+      expect(result).toEqual({ released: true, releasedTerminalIds: ['real-child'] })
+      fs.renameSync(project, archived)
+      expect(fs.existsSync(archived)).toBe(true)
+    } finally {
+      if (active) {child?.kill()}
+      fs.rmSync(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/apps/desktop/electron/project-path-release.ts
+++ b/apps/desktop/electron/project-path-release.ts
@@ -1,0 +1,48 @@
+import path from 'node:path'
+
+export interface ReleasableTerminal {
+  id: string
+  launchCwd?: null | string
+  remote: boolean
+  writeExit: () => void
+  isActive: () => boolean
+}
+
+export function pathContains(root: string, candidate: string) {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate))
+
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+export async function gracefulReleaseSessions(
+  projectPath: string,
+  sessions: ReleasableTerminal[],
+  options: { now?: () => number; pause?: (ms: number) => Promise<void>; timeoutMs?: number } = {}
+) {
+  const matching = sessions.filter(session => !session.remote && session.launchCwd && pathContains(projectPath, session.launchCwd))
+
+  for (const session of matching) {
+    session.writeExit()
+  }
+
+  const now = options.now ?? Date.now
+  const pause = options.pause ?? (ms => new Promise(resolve => setTimeout(resolve, ms)))
+  const deadline = now() + (options.timeoutMs ?? 3_000)
+
+  while (now() < deadline) {
+    const active = matching.filter(session => session.isActive())
+
+    if (active.length === 0) {
+      return { released: true, releasedTerminalIds: matching.map(session => session.id) }
+    }
+
+    await pause(50)
+  }
+
+  return {
+    released: false,
+    releasedTerminalIds: matching.filter(session => !session.isActive()).map(session => session.id),
+    activeTerminalIds: matching.filter(session => session.isActive()).map(session => session.id),
+    error: 'TERMINAL_DID_NOT_EXIT_GRACEFULLY'
+  }
+}

--- a/apps/desktop/electron/stable-process-cwd.test.ts
+++ b/apps/desktop/electron/stable-process-cwd.test.ts
@@ -1,0 +1,44 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { setStableProcessCwd } from './stable-process-cwd'
+
+describe('stable process CWD', () => {
+  const originalCwd = process.cwd()
+
+  afterEach(() => process.chdir(originalCwd))
+
+  test('desktop startup moves the parent process to the stable Hermes home', () => {
+    const calls: string[] = []
+    expect(setStableProcessCwd('C:\\HermesHome', value => calls.push(value))).toEqual({ changed: true, error: null })
+    expect(calls).toEqual(['C:\\HermesHome'])
+  })
+
+  test('cwd setup reports failure without crashing startup', () => {
+    const result = setStableProcessCwd('missing', () => { throw new Error('missing') })
+    expect(result).toEqual({ changed: false, error: 'missing' })
+  })
+
+  test.runIf(process.platform === 'win32')('releases the inherited Windows launch directory', () => {
+    const runtimeRoot = path.resolve('.hermes', 'task-runtime')
+    fs.mkdirSync(runtimeRoot, { recursive: true })
+    const root = fs.mkdtempSync(path.join(runtimeRoot, 'stable-cwd-'))
+    const project = path.join(root, 'project')
+    const archived = path.join(root, 'archived')
+    const stable = path.join(root, 'hermes-home')
+    fs.mkdirSync(project)
+    fs.mkdirSync(stable)
+
+    try {
+      process.chdir(project)
+      expect(setStableProcessCwd(stable)).toEqual({ changed: true, error: null })
+      fs.renameSync(project, archived)
+      expect(fs.existsSync(archived)).toBe(true)
+    } finally {
+      process.chdir(originalCwd)
+      fs.rmSync(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/apps/desktop/electron/stable-process-cwd.ts
+++ b/apps/desktop/electron/stable-process-cwd.ts
@@ -1,0 +1,9 @@
+export function setStableProcessCwd(target: string, chdir: (path: string) => void = process.chdir) {
+  try {
+    chdir(target)
+
+    return { changed: true, error: null }
+  } catch (error) {
+    return { changed: false, error: error instanceof Error ? error.message : String(error) }
+  }
+}

--- a/hermes_cli/project_lock.py
+++ b/hermes_cli/project_lock.py
@@ -45,6 +45,59 @@ def rename_probe(path: Path) -> dict[str, Any]:
     return {"ok": True, "winerror": None, "message": "WINDOWS_ONLY_PROBE_NOT_REQUIRED"}
 
 
+def _rename_probe_without_current_cwd(path: Path) -> dict[str, Any]:
+    """Probe without letting this short-lived diagnostic own the target CWD."""
+
+    original_cwd = Path.cwd().resolve(strict=False)
+    if not _same_or_child(str(original_cwd), path):
+        return rename_probe(path)
+
+    from hermes_constants import get_hermes_home
+
+    candidates: list[Path] = []
+    try:
+        candidates.append(Path(get_hermes_home()).expanduser().resolve(strict=False))
+    except (OSError, RuntimeError):
+        pass
+    candidates.extend((Path(__file__).resolve().parent, Path.home().resolve(strict=False)))
+    stable_cwd = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate.is_dir() and not _same_or_child(str(candidate), path)
+        ),
+        None,
+    )
+    if stable_cwd is None:
+        return {
+            "ok": False,
+            "winerror": None,
+            "message": "SAFE_DIAGNOSTIC_CWD_UNAVAILABLE",
+        }
+
+    probe: dict[str, Any] | None = None
+    try:
+        os.chdir(stable_cwd)
+        probe = rename_probe(path)
+    except OSError as exc:
+        probe = {
+            "ok": False,
+            "winerror": getattr(exc, "winerror", None),
+            "message": f"SAFE_DIAGNOSTIC_CWD_FAILED: {exc}",
+        }
+    finally:
+        try:
+            os.chdir(original_cwd)
+        except OSError as exc:
+            probe = {
+                "ok": False,
+                "winerror": getattr(exc, "winerror", None),
+                "message": f"DIAGNOSTIC_CWD_RESTORE_FAILED: {exc}",
+            }
+    assert probe is not None
+    return probe
+
+
 def _process_role(row: dict[str, Any], hermes_pids: set[int]) -> str:
     if row["pid"] not in hermes_pids:
         return "child"
@@ -100,11 +153,21 @@ def _process_snapshot(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, 
 def diagnose(path_value: str) -> dict[str, Any]:
     path = Path(path_value).expanduser().resolve(strict=False)
     hermes, holders, marker = _process_snapshot(path)
-    probe = rename_probe(path)
     current_cwd = Path.cwd().resolve(strict=False)
+    holders = [row for row in holders if row.get("pid") != os.getpid()]
+    probe = _rename_probe_without_current_cwd(path)
+    hermes_pids = {row.get("pid") for row in hermes}
+    hermes_holders = [row for row in holders if row.get("pid") in hermes_pids]
     action = "NONE"
     if not probe["ok"]:
-        action = "CLOSE_MATCHING_HERMES_TERMINAL_OR_RUN_RELEASE_PATH"
+        if not path.exists():
+            action = "CHECK_PATH"
+        elif hermes_holders:
+            action = "RUN_RELEASE_PATH_OR_CLOSE_MATCHING_HERMES_SESSION"
+        elif holders:
+            action = "CLOSE_OR_CHDIR_LISTED_PROCESS"
+        else:
+            action = "LOCK_OWNER_UNKNOWN_RESTART_HERMES_IF_STILL_LOCKED"
     return {
         "path": str(path),
         "path_exists": path.exists(),

--- a/hermes_cli/project_lock.py
+++ b/hermes_cli/project_lock.py
@@ -1,0 +1,183 @@
+"""Windows project-directory lock diagnostics and fail-closed release checks."""
+
+from __future__ import annotations
+
+import ctypes
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+_HANDLE_ENUM_UNAVAILABLE = "HANDLE_ENUMERATION_UNAVAILABLE_REQUIRES_ADMIN"
+
+
+def _same_or_child(candidate: str | None, root: Path) -> bool:
+    if not candidate:
+        return False
+    try:
+        return os.path.commonpath((os.path.normcase(os.path.abspath(candidate)), os.path.normcase(str(root)))) == os.path.normcase(str(root))
+    except (OSError, ValueError):
+        return False
+
+
+def _rename_probe_windows(path: Path) -> dict[str, Any]:
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [ctypes.c_wchar_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p, ctypes.c_uint32, ctypes.c_uint32, ctypes.c_void_p]
+    create_file.restype = ctypes.c_void_p
+    handle = create_file(str(path), 0x00010000, 0x1 | 0x2 | 0x4, None, 3, 0x02000000, None)
+    invalid = ctypes.c_void_p(-1).value
+    if handle == invalid:
+        winerror = ctypes.get_last_error()
+        return {"ok": False, "winerror": winerror, "message": ctypes.FormatError(winerror).strip()}
+    kernel32.CloseHandle(ctypes.c_void_p(handle))
+    return {"ok": True, "winerror": None, "message": "DELETE_SHARE_PROBE_PASS"}
+
+
+def rename_probe(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"ok": False, "winerror": None, "message": "PATH_NOT_FOUND"}
+    if os.name == "nt":
+        return _rename_probe_windows(path)
+    return {"ok": True, "winerror": None, "message": "WINDOWS_ONLY_PROBE_NOT_REQUIRED"}
+
+
+def _process_role(row: dict[str, Any], hermes_pids: set[int]) -> str:
+    if row["pid"] not in hermes_pids:
+        return "child"
+    command = [str(part) for part in row.get("cmdline") or []]
+    executable = str(row.get("exe") or "")
+    if "\\venv\\scripts\\hermes.exe" in executable.casefold():
+        return "cli-launcher"
+    process_type = next((part.split("=", 1)[1] for part in command if part.startswith("--type=")), None)
+    if process_type:
+        return f"desktop-{process_type}"
+    return "desktop-main"
+
+
+def _process_snapshot(path: Path) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
+    try:
+        import psutil
+    except ImportError:
+        return [], [], "PROCESS_ENUMERATION_UNAVAILABLE_PSUTIL_MISSING"
+
+    all_rows: list[dict[str, Any]] = []
+    unavailable = False
+    for proc in psutil.process_iter(["pid", "ppid", "name", "exe", "cmdline", "cwd"]):
+        try:
+            info = proc.info
+            all_rows.append({
+                "pid": info.get("pid"), "ppid": info.get("ppid"),
+                "name": info.get("name") or "", "exe": info.get("exe"),
+                "cmdline": info.get("cmdline") or [], "cwd": info.get("cwd"),
+            })
+        except (psutil.AccessDenied, psutil.NoSuchProcess):
+            unavailable = True
+
+    hermes_pids = {row["pid"] for row in all_rows if str(row["name"]).casefold() == "hermes.exe"}
+    descendants = set(hermes_pids)
+    changed = True
+    while changed:
+        changed = False
+        for row in all_rows:
+            if row["ppid"] in descendants and row["pid"] not in descendants:
+                descendants.add(row["pid"])
+                changed = True
+    hermes = [dict(row, role=_process_role(row, hermes_pids)) for row in all_rows if row["pid"] in descendants]
+    holders = [row for row in all_rows if _same_or_child(row.get("cwd"), path)]
+    if os.name == "nt":
+        try:
+            unavailable = unavailable or not bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except OSError:
+            unavailable = True
+    marker = _HANDLE_ENUM_UNAVAILABLE if os.name == "nt" and unavailable else None
+    return hermes, holders, marker
+
+
+def diagnose(path_value: str) -> dict[str, Any]:
+    path = Path(path_value).expanduser().resolve(strict=False)
+    hermes, holders, marker = _process_snapshot(path)
+    probe = rename_probe(path)
+    current_cwd = Path.cwd().resolve(strict=False)
+    action = "NONE"
+    if not probe["ok"]:
+        action = "CLOSE_MATCHING_HERMES_TERMINAL_OR_RUN_RELEASE_PATH"
+    return {
+        "path": str(path),
+        "path_exists": path.exists(),
+        "is_current_process_cwd": _same_or_child(str(current_cwd), path),
+        "hermes_processes": hermes,
+        "child_processes": [row for row in hermes if row.get("role") != "desktop-main"],
+        "known_open_handles": holders,
+        "lock_owner_if_available": holders or None,
+        "handle_enumeration": marker or "BEST_EFFORT_SAME_USER_PROCESS_CWD",
+        "rename_probe": probe,
+        "winerror": probe.get("winerror"),
+        "recommended_action": action,
+    }
+
+
+def _release_current_process_cwd(path: Path) -> bool:
+    if not _same_or_child(str(Path.cwd().resolve(strict=False)), path):
+        return False
+
+    from hermes_constants import get_hermes_home
+
+    stable_cwd = Path(get_hermes_home()).expanduser().resolve(strict=False)
+    if _same_or_child(str(stable_cwd), path):
+        return False
+    try:
+        stable_cwd.mkdir(parents=True, exist_ok=True)
+        os.chdir(stable_cwd)
+        return True
+    except OSError:
+        return False
+
+
+def release_path(path_value: str) -> dict[str, Any]:
+    path = Path(path_value).expanduser().resolve(strict=False)
+    current_cwd_released = _release_current_process_cwd(path)
+    before = diagnose(str(path))
+    if before["rename_probe"]["ok"]:
+        action = "CURRENT_PROCESS_CWD_RELEASED" if current_cwd_released else "NO_ACTIVE_LOCK"
+        return {"released": True, "action": action, "diagnostic": before}
+    response = _request_desktop_release(path)
+    after = diagnose(str(path))
+    if response and response.get("released") and after["rename_probe"]["ok"]:
+        return {"released": True, "action": "GRACEFUL_DESKTOP_RELEASE", "desktop": response, "diagnostic": after}
+    return {
+        "released": False,
+        "action": "GRACEFUL_DESKTOP_RELEASE_FAILED_RESTART_REQUIRED",
+        "desktop": response,
+        "diagnostic": after,
+    }
+
+
+def _request_desktop_release(path: Path, timeout: float = 5.0) -> dict[str, Any] | None:
+    from hermes_constants import get_hermes_home
+
+    control = Path(get_hermes_home()) / "cache" / "project-control"
+    control.mkdir(parents=True, exist_ok=True)
+    request_id = uuid.uuid4().hex
+    request = control / f"request-{request_id}.json"
+    response = control / f"response-{request_id}.json"
+    temporary = control / f".{request.name}.tmp"
+    temporary.write_text(json.dumps({"id": request_id, "path": str(path)}), encoding="utf-8")
+    os.replace(temporary, request)
+    deadline = time.monotonic() + timeout
+    try:
+        while time.monotonic() < deadline:
+            try:
+                return json.loads(response.read_text(encoding="utf-8"))
+            except (FileNotFoundError, OSError, json.JSONDecodeError):
+                time.sleep(0.05)
+        return None
+    finally:
+        for item in (request, response, temporary):
+            try:
+                item.unlink()
+            except FileNotFoundError:
+                pass

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import argparse
 import functools
+import json
 import sys
 
 from hermes_cli import projects_db as pdb
+from hermes_cli import project_lock
 
 
 def build_parser(
@@ -101,6 +103,12 @@ def build_parser(
         "board", nargs="?", default="", help="Board slug (omit to unbind)"
     )
 
+    p_diagnose = sub.add_parser("diagnose-lock", help="Read-only project-directory lock diagnostics")
+    p_diagnose.add_argument("path", help="Project directory to diagnose")
+
+    p_release = sub.add_parser("release-path", help="Gracefully release a Hermes project directory")
+    p_release.add_argument("path", help="Project directory to release")
+
     parser.set_defaults(_project_parser=parser)
     return parser
 
@@ -133,12 +141,26 @@ def projects_command(args: argparse.Namespace) -> int:
         "archive": _cmd_archive,
         "restore": _cmd_restore,
         "bind-board": _cmd_bind_board,
+        "diagnose-lock": _cmd_diagnose_lock,
+        "release-path": _cmd_release_path,
     }
     handler = handlers.get(action)
     if handler is None:
         print(f"Unknown project action: {action}", file=sys.stderr)
         return 1
     return handler(args)
+
+
+def _cmd_diagnose_lock(args: argparse.Namespace) -> int:
+    result = project_lock.diagnose(args.path)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["rename_probe"]["ok"] else 1
+
+
+def _cmd_release_path(args: argparse.Namespace) -> int:
+    result = project_lock.release_path(args.path)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0 if result["released"] else 1
 
 
 def _resolve(conn, ident: str):

--- a/tests/hermes_cli/test_project_lock.py
+++ b/tests/hermes_cli/test_project_lock.py
@@ -1,0 +1,91 @@
+import shutil
+import uuid
+from pathlib import Path
+
+from hermes_cli import project_lock
+
+
+def test_process_role_distinguishes_cli_and_electron_helpers():
+    roots = {10, 20, 30}
+    assert project_lock._process_role({"pid": 10, "exe": r"C:\repo\venv\Scripts\hermes.exe", "cmdline": []}, roots) == "cli-launcher"
+    assert project_lock._process_role({"pid": 20, "exe": r"C:\Hermes\Hermes.exe", "cmdline": ["Hermes.exe"]}, roots) == "desktop-main"
+    assert project_lock._process_role({"pid": 30, "exe": r"C:\Hermes\Hermes.exe", "cmdline": ["Hermes.exe", "--type=renderer"]}, roots) == "desktop-renderer"
+    assert project_lock._process_role({"pid": 40, "exe": "pwsh.exe", "cmdline": []}, roots) == "child"
+
+
+def test_same_or_child_is_boundary_safe(tmp_path):
+    project = tmp_path / "project"
+    child = project / "nested"
+    sibling = tmp_path / "project-old"
+    assert project_lock._same_or_child(str(project), project)
+    assert project_lock._same_or_child(str(child), project)
+    assert not project_lock._same_or_child(str(sibling), project)
+
+
+def test_release_path_passes_only_after_probe_succeeds(tmp_path, monkeypatch):
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], None))
+    monkeypatch.setattr(project_lock, "rename_probe", lambda _path: {"ok": True, "winerror": None, "message": "PASS"})
+    result = project_lock.release_path(str(tmp_path))
+    assert result["released"] is True
+    assert result["action"] == "NO_ACTIVE_LOCK"
+
+
+def test_release_path_moves_its_own_cwd_before_probing(monkeypatch):
+    original_cwd = Path.cwd()
+    runtime = original_cwd / ".hermes" / "task-runtime" / f"project-lock-{uuid.uuid4().hex}"
+    project = runtime / "project"
+    hermes_home = runtime / "hermes-home"
+    project.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], None))
+    monkeypatch.setattr(
+        project_lock,
+        "rename_probe",
+        lambda path: {
+            "ok": not project_lock._same_or_child(str(Path.cwd()), path),
+            "winerror": None,
+            "message": "PASS",
+        },
+    )
+
+    try:
+        monkeypatch.chdir(project)
+        result = project_lock.release_path(str(project))
+
+        assert result["released"] is True
+        assert result["action"] == "CURRENT_PROCESS_CWD_RELEASED"
+        assert Path.cwd() == hermes_home
+    finally:
+        monkeypatch.chdir(original_cwd)
+        shutil.rmtree(runtime)
+
+
+def test_release_path_fails_closed_for_unknown_lock(tmp_path, monkeypatch):
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], None))
+    monkeypatch.setattr(project_lock, "rename_probe", lambda _path: {"ok": False, "winerror": 32, "message": "busy"})
+    monkeypatch.setattr(project_lock, "_request_desktop_release", lambda _path: None)
+    result = project_lock.release_path(str(tmp_path))
+    assert result["released"] is False
+    assert result["action"] == "GRACEFUL_DESKTOP_RELEASE_FAILED_RESTART_REQUIRED"
+
+
+def test_release_path_fails_closed_when_desktop_control_is_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], "HANDLE_ENUMERATION_UNAVAILABLE_REQUIRES_ADMIN"))
+    monkeypatch.setattr(project_lock, "rename_probe", lambda _path: {"ok": False, "winerror": 32, "message": "busy"})
+    monkeypatch.setattr(project_lock, "_request_desktop_release", lambda _path: None)
+    result = project_lock.release_path(str(tmp_path))
+    assert result["released"] is False
+    assert result["action"] == "GRACEFUL_DESKTOP_RELEASE_FAILED_RESTART_REQUIRED"
+
+
+def test_release_path_reprobes_after_desktop_release(tmp_path, monkeypatch):
+    probes = iter([
+        {"ok": False, "winerror": 32, "message": "busy"},
+        {"ok": True, "winerror": None, "message": "pass"},
+    ])
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], "HANDLE_ENUMERATION_UNAVAILABLE_REQUIRES_ADMIN"))
+    monkeypatch.setattr(project_lock, "rename_probe", lambda _path: next(probes))
+    monkeypatch.setattr(project_lock, "_request_desktop_release", lambda _path: {"released": True})
+    result = project_lock.release_path(str(tmp_path))
+    assert result["released"] is True
+    assert result["action"] == "GRACEFUL_DESKTOP_RELEASE"

--- a/tests/hermes_cli/test_project_lock.py
+++ b/tests/hermes_cli/test_project_lock.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import uuid
 from pathlib import Path
@@ -57,6 +58,90 @@ def test_release_path_moves_its_own_cwd_before_probing(monkeypatch):
         assert Path.cwd() == hermes_home
     finally:
         monkeypatch.chdir(original_cwd)
+        shutil.rmtree(runtime)
+
+
+def test_diagnose_moves_its_own_cwd_only_for_probe(monkeypatch):
+    original_cwd = Path.cwd()
+    runtime = original_cwd / ".hermes" / "task-runtime" / f"project-lock-{uuid.uuid4().hex}"
+    project = runtime / "project"
+    hermes_home = runtime / "hermes-home"
+    project.mkdir(parents=True)
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [], None))
+
+    def probe(_path):
+        assert Path.cwd() == hermes_home
+        return {"ok": True, "winerror": None, "message": "PASS"}
+
+    monkeypatch.setattr(project_lock, "rename_probe", probe)
+    try:
+        monkeypatch.chdir(project)
+        result = project_lock.diagnose(str(project))
+
+        assert result["is_current_process_cwd"] is True
+        assert result["rename_probe"]["ok"] is True
+        assert Path.cwd() == project
+    finally:
+        monkeypatch.chdir(original_cwd)
+        shutil.rmtree(runtime)
+
+
+def test_diagnose_recommends_chdir_for_non_hermes_holder(monkeypatch):
+    runtime = Path.cwd() / ".hermes" / "task-runtime" / f"project-lock-{uuid.uuid4().hex}"
+    runtime.mkdir(parents=True)
+    holder = {"pid": 42, "ppid": 1, "name": "pwsh.exe", "cwd": str(runtime)}
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: ([], [holder], None))
+    monkeypatch.setattr(
+        project_lock,
+        "_rename_probe_without_current_cwd",
+        lambda _path: {"ok": False, "winerror": 32, "message": "busy"},
+    )
+    try:
+        result = project_lock.diagnose(str(runtime))
+        assert result["recommended_action"] == "CLOSE_OR_CHDIR_LISTED_PROCESS"
+    finally:
+        shutil.rmtree(runtime)
+
+
+def test_diagnose_excludes_its_own_process_from_lock_owners(monkeypatch):
+    runtime = Path.cwd() / ".hermes" / "task-runtime" / f"project-lock-{uuid.uuid4().hex}"
+    runtime.mkdir(parents=True)
+    current = {"pid": os.getpid(), "ppid": 1, "name": "python.exe", "cwd": str(runtime)}
+    caller = {"pid": 42, "ppid": 1, "name": "pwsh.exe", "cwd": str(runtime)}
+    monkeypatch.setattr(
+        project_lock,
+        "_process_snapshot",
+        lambda _path: ([], [current, caller], None),
+    )
+    monkeypatch.setattr(
+        project_lock,
+        "_rename_probe_without_current_cwd",
+        lambda _path: {"ok": False, "winerror": 32, "message": "busy"},
+    )
+    try:
+        result = project_lock.diagnose(str(runtime))
+        assert result["known_open_handles"] == [caller]
+    finally:
+        shutil.rmtree(runtime)
+
+
+def test_diagnose_recommends_release_only_for_hermes_holder(monkeypatch):
+    runtime = Path.cwd() / ".hermes" / "task-runtime" / f"project-lock-{uuid.uuid4().hex}"
+    runtime.mkdir(parents=True)
+    holder = {"pid": 42, "ppid": 1, "name": "Hermes.exe", "cwd": str(runtime)}
+    hermes = [dict(holder, role="desktop-main")]
+    monkeypatch.setattr(project_lock, "_process_snapshot", lambda _path: (hermes, [holder], None))
+    monkeypatch.setattr(
+        project_lock,
+        "_rename_probe_without_current_cwd",
+        lambda _path: {"ok": False, "winerror": 32, "message": "busy"},
+    )
+    try:
+        result = project_lock.diagnose(str(runtime))
+        assert result["recommended_action"] == "RUN_RELEASE_PATH_OR_CLOSE_MATCHING_HERMES_SESSION"
+    finally:
         shutil.rmtree(runtime)
 
 


### PR DESCRIPTION
## Summary

- move the Desktop main process to the stable `HERMES_HOME` at startup instead of retaining the launch directory as its CWD
- track local PTY launch directories and gracefully exit only sessions rooted at a requested project path
- add `hermes project diagnose-lock <path>` and `hermes project release-path <path>` with a Windows delete-share probe, process-role diagnostics, explicit non-admin handle-enumeration status, and fail-closed reprobe
- move the diagnostic process away from the target only while probing, restore its CWD in `finally`, exclude its own PID, and distinguish Hermes holders from shell/editor callers
- release the CLI command's own CWD before probing when it is invoked from inside the target project

## Root cause

On Windows, a process or PTY whose current working directory is inside a project prevents the project directory from being renamed or moved (`WinError 32`). Desktop inherited its launcher CWD indefinitely, and local node-pty sessions had no project-scoped graceful release path. The first diagnostic implementation could also participate in the lock when launched from the target and could recommend Hermes cleanup for a non-Hermes caller.

## Safety and impact

The release path does not force-kill Desktop or unrelated sessions. It:

- matches path boundaries without confusing sibling prefixes
- ignores remote PTYs and local PTYs outside the requested project
- requests a normal shell exit and waits for the session lifecycle to finish
- reports failure when a matching terminal remains active
- reports success only after a second directory probe passes
- preserves user configuration and does not require administrator privileges for graceful release
- keeps diagnosis read-only: it selects an existing safe CWD and does not create a diagnostic directory

## Validation

Windows native:

- `scripts/run_tests.sh tests/hermes_cli/test_project_lock.py tests/hermes_cli/test_projects_cli.py -q` — 13 passed
- native DELETE_SHARE diagnostic probe on an isolated project-local directory — passed
- `npx vitest run --project electron electron/project-path-release.test.ts electron/stable-process-cwd.test.ts` — 7 passed, including real child-CWD and directory-rename tests
- `npm run typecheck` from `apps/desktop` — passed
- ESLint on all changed Desktop TypeScript files — passed
- `git diff --check` — passed

Broader Electron run: 925 passed, 19 failed in existing Windows/POSIX or permission-sensitive suites (`desktop-installation`, `ssh-config`, `ssh-connection`, `update-relaunch`, `windows-hermes-path`). None of those files are changed by this PR; the focused suites and typecheck are green.
