### PR TITLE
fix(gateway): respect explicit qqbot disable over env credentials

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -2415,10 +2415,14 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     qq_app_id = getenv("QQ_APP_ID")
     qq_client_secret = getenv("QQ_CLIENT_SECRET")
     if qq_app_id or qq_client_secret:
-        if Platform.QQBOT not in config.platforms:
-            config.platforms[Platform.QQBOT] = PlatformConfig()
-        config.platforms[Platform.QQBOT].enabled = True
-        extra = config.platforms[Platform.QQBOT].extra
+        # Respect an explicit ``platforms.qqbot.enabled: false`` instead of
+        # unconditionally re-enabling whenever env credentials are present.
+        # Same ``_enabled_explicit`` guard as Telegram/Slack (#41112); the
+        # Desktop/dashboard toggle writes the explicit disable to config.yaml
+        # and must survive a gateway restart with QQ_APP_ID/QQ_CLIENT_SECRET
+        # still set in .env. #80333.
+        qq_config = _enable_from_env(Platform.QQBOT)
+        extra = qq_config.extra
         if qq_app_id:
             extra["app_id"] = qq_app_id
         if qq_client_secret:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -1184,3 +1184,64 @@ class TestApiServerEnvOverride:
         assert config.platforms[Platform.API_SERVER].enabled is False
         # The key is still wired through for the shared listener.
         assert config.platforms[Platform.API_SERVER].extra.get("key") == api_server_key
+
+
+class TestQQBotEnvOverride:
+    def test_env_credentials_do_not_reenable_explicitly_disabled_qqbot(self):
+        """An explicit ``platforms.qqbot.enabled: false`` must survive
+        _apply_env_overrides() even when QQ_APP_ID / QQ_CLIENT_SECRET are
+        present in the env.
+
+        Regression: the QQBot block unconditionally set ``enabled = True``
+        whenever env credentials existed, so the Desktop/dashboard toggle
+        (which writes ``platforms.qqbot.enabled: false`` to config.yaml)
+        flipped back to ON after a gateway restart and QQBot reconnected.
+
+        The fix routes QQBot through the same ``_enabled_explicit`` guard
+        used by Telegram/Slack (#41112): when ``enabled`` was explicitly
+        written to config, env credentials must not re-enable it — but they
+        are still wired into ``extra`` so skills can use them.
+        """
+        config = GatewayConfig(
+            platforms={
+                Platform.QQBOT: PlatformConfig(
+                    enabled=False,
+                    extra={"_enabled_explicit": True},
+                ),
+            },
+        )
+
+        with patch.dict(
+            os.environ,
+            {
+                "QQ_APP_ID": "env-app-id",
+                "QQ_CLIENT_SECRET": "env-client-secret",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        # Explicit disable wins over the env-credential presence.
+        assert config.platforms[Platform.QQBOT].enabled is False
+        # Credentials are still wired through for skills / manual use.
+        assert config.platforms[Platform.QQBOT].extra.get("app_id") == "env-app-id"
+        assert config.platforms[Platform.QQBOT].extra.get("client_secret") == "env-client-secret"
+        # The marker is cleaned up after the pass.
+        assert "_enabled_explicit" not in config.platforms[Platform.QQBOT].extra
+
+    def test_env_credentials_enable_qqbot_when_not_configured(self):
+        """Env-only setup (no config.yaml block) still arms QQBot."""
+        config = GatewayConfig(platforms={})
+
+        with patch.dict(
+            os.environ,
+            {
+                "QQ_APP_ID": "env-app-id",
+                "QQ_CLIENT_SECRET": "env-client-secret",
+            },
+            clear=True,
+        ):
+            _apply_env_overrides(config)
+
+        assert config.platforms[Platform.QQBOT].enabled is True
+        assert config.platforms[Platform.QQBOT].extra.get("app_id") == "env-app-id"


### PR DESCRIPTION
## Summary
`platforms.qqbot.enabled: false` in config.yaml was overridden by env credentials: `QQ_APP_ID`/`QQ_CLIENT_SECRET` present in `~/.hermes/.env` re-enabled QQBot unconditionally, so the Desktop/dashboard toggle flipped back to ON after a gateway restart.

## Root Cause
The QQ block of `_apply_env_overrides()` in `gateway/config.py` (L2417-2420) set `enabled = True` unconditionally whenever env credentials existed — ignoring an explicit `enabled: false` written to the YAML.

## Change
- `gateway/config.py`: the QQBot block now uses the canonical `_enable_from_env(Platform.QQBOT)` helper with the same `_enabled_explicit` guard already used by Telegram/Discord/Signal/Mattermost/Matrix/Relay and the inline guards used by Slack/API_SERVER:
  - Explicit `enabled: false` (Desktop/dashboard sets `_enabled_explicit` via `_merge_platform_map`) → env does **not** re-enable.
  - Env-only setups still arm as before (`enabled=True`); credentials still wire through to `extra`; the marker is cleared in final cleanup.
  - Fail-closed: the user's explicit decision always wins.
- `tests/gateway/test_config.py`: new `TestQQBotEnvOverride` — (1) regression: `enabled=False` + `_enabled_explicit` + env creds → stays `False`, creds still in `extra`, marker cleared; (2) env-only setup still arms.

## Note for maintainer
Same unconditional-`enabled=True` pattern remains in `_apply_env_overrides()` for: HOMEASSISTANT, EMAIL, SMS, WEBHOOK, MSGRAPH_WEBHOOK, DINGTALK, FEISHU, WECOM, WECOM_CALLBACK, WEIXIN, BLUEBUBBLES, YUANBAO, WHATSAPP (partial), WHATSAPP_CLOUD — candidates for the same class fix if desired.

## Verification
- `tests/gateway/test_config.py`: **57 passed**.

Closes #80333