### PR TITLE
fix: verify NUL bytes before flagging U+FFFD samples as binary (#80308)

### DIFF
--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -903,8 +903,33 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
+            #
+            # HOWEVER: head -c N can cut UTF-8 multibyte sequences (CJK = 3
+            # bytes, emoji = 4 bytes) at the byte boundary, producing false
+            # U+FFFD from perfectly valid text.  A sample decodable only via
+            # errors="replace" is NOT reliable evidence of binary content.
+            #
+            # The reliable binary indicator is NUL (0x00): genuine binary
+            # files almost always contain NUL bytes, while text files
+            # (regardless of encoding) effectively never do.  When U+FFFD is
+            # detected, verify by checking raw bytes for NUL via Python.
+            # See: https://github.com/NousResearch/hermes-agent/issues/80308
             if "\ufffd" in content_sample[:1000]:
-                return True
+                # U+FFFD present -- could be binary OR truncation artifact.
+                # Verify by checking raw bytes for NUL.
+                try:
+                    null_check = self._exec(
+                        "python -c \"import sys;"
+                        " sys.exit(0 if b'\\x00' in"
+                        " open(sys.argv[1],'rb').read(8192) else 1)\""
+                        f" {self._escape_shell_arg(path)}"
+                    )
+                    if null_check.exit_code == 0:
+                        return True  # NUL found -> genuine binary
+                except Exception:
+                    pass
+                # No NUL found despite U+FFFD -> truncation artifact from
+                # head -c splitting a multibyte char.  Treat as text.
             non_printable = sum(1 for c in content_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')
             return non_printable / min(len(content_sample), 1000) > 0.30


### PR DESCRIPTION
## Summary

`read_file` misclassifies valid UTF-8 files containing CJK characters (Chinese, Japanese, Korean, emoji) as binary and refuses to display them. The root cause is in `_is_likely_binary()` in `tools/file_operations.py`.

## Root Cause

The function reads the first 1000 bytes via `head -c 1000` and checks for U+FFFD (replacement character). However, CJK characters are 3 bytes each in UTF-8 (emoji = 4 bytes), so the 1000-byte boundary frequently cuts a character in half. The terminal decoder (using `errors="replace"`) produces U+FFFD from the truncated sequence, which the function incorrectly treats as evidence of binary content.

**Key insight:** `head -c 1000` is a byte-level operation that doesn't respect UTF-8 character boundaries. A file of 1002 CJK bytes will always trigger this false positive.

## Fix

When U+FFFD is detected in the sample, instead of immediately returning `True` (binary), verify by checking the raw file bytes for NUL (0x00) via Python. NUL is the reliable binary indicator:

- Genuine binary files almost always contain NUL bytes
- Text files (regardless of encoding) effectively never contain NUL

If no NUL is found, the U+FFFD is a truncation artifact from `head -c` splitting a multibyte character, and the file should be treated as text.

## Changes

- `tools/file_operations.py`: `_is_likely_binary()` — add NUL byte verification when U+FFFD is detected before flagging as binary

## Test Plan

- [x] Syntax check passes (`ast.parse`)
- [x] CJK file > 1000 bytes: correctly identified as TEXT (not binary)
- [x] Binary file with NUL bytes: correctly identified as BINARY
- [x] ASCII file: correctly identified as TEXT
- [x] Existing test `test_replacement_char_sample_flagged_binary` still passes (non-printable ratio check catches genuine encoding errors)
- [x] Existing test `test_plain_utf8_text_not_flagged` still passes

Fixes #80308
