### PR TITLE
feat(api): surface agent context-window occupancy to thin clients

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 from typing import Any, Callable, Dict, List
 
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
+from agent.context_breakdown import context_window_usage
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +84,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                     billing_base_url=agent.base_url,
                     billing_mode="subscription_included",
                     api_call_count=1,
+                    **context_window_usage(agent),
                 )
             except Exception as exc:
                 logger.debug(
@@ -174,6 +176,7 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 if cost_result.status == "included" else None,
                 model=agent.model,
                 api_call_count=1,
+                **context_window_usage(agent),
             )
         except Exception as exc:
             logger.debug(

--- a/agent/context_breakdown.py
+++ b/agent/context_breakdown.py
@@ -358,3 +358,37 @@ def render_context_breakdown_lines(
         lines.append("")
         lines.append("Use /context all for per-skill and per-toolset costs.")
     return lines
+
+
+def context_window_usage(agent: Any) -> Dict[str, int]:
+    """Resolve the live context-window occupancy for an agent.
+
+    Returns ``{"context_window": int, "context_used": int}`` suitable for
+    persisting onto the session row. This mirrors the sentinel logic in
+    ``tui_gateway.server._get_usage`` so thin clients (Uplink) present the
+    *same* numbers the desktop shows, computed the same way:
+
+    - ``context_window`` is the resolved window from the compressor.
+    - ``context_used`` is the current-window occupancy
+      (``last_prompt_tokens``), the *measured* last-prompt size -- NOT the
+      cumulative lifetime total (which would fabricate impossible readings
+      like 1.9m/120k, see issue #50421).
+    - The ``-1`` "compression just ran, awaiting real usage" sentinel is
+      clamped to 0 so the transitional turn reads as unknown.
+    - When either value is missing/falsy, both are returned as ``0`` so the
+      caller can treat ``0`` as "unknown" and avoid clobbering a prior
+      good reading.
+
+    Returns ``{"context_window": 0, "context_used": 0}`` for an agent with no
+    compressor (e.g. before the first turn runs).
+    """
+    comp = getattr(agent, "context_compressor", None)
+    if not comp:
+        return {"context_window": 0, "context_used": 0}
+    ctx_max = int(getattr(comp, "context_length", 0) or 0)
+    last_prompt = int(getattr(comp, "last_prompt_tokens", 0) or 0)
+    if last_prompt < 0:
+        last_prompt = 0
+    if not (ctx_max and last_prompt):
+        return {"context_window": 0, "context_used": 0}
+    return {"context_window": ctx_max, "context_used": last_prompt}

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -36,6 +36,7 @@ from agent.conversation_compression import (
     conversation_history_after_compression,
 )
 from agent.context_engine import automatic_compaction_status_message
+from agent.context_breakdown import context_window_usage
 from agent.display import KawaiiSpinner
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.turn_context import (
@@ -3421,6 +3422,7 @@ def run_conversation(
                                 if cost_result.status == "included" else None,
                                 model=agent.model,
                                 api_call_count=1,
+                                **context_window_usage(agent),
                             )
                         except Exception as e:
                             # Log token persistence failures so they're

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -3196,8 +3196,7 @@ class APIServerAdapter(BasePlatformAdapter):
             return default
         return min(parsed, maximum)
 
-    @staticmethod
-    def _session_response(session: Dict[str, Any]) -> Dict[str, Any]:
+    def _session_response(self, session: Dict[str, Any]) -> Dict[str, Any]:
         """Return a stable, client-safe session representation."""
         safe_keys = (
             "id", "source", "user_id", "model", "title", "started_at", "ended_at",
@@ -3212,6 +3211,12 @@ class APIServerAdapter(BasePlatformAdapter):
         # callers only need to know whether those snapshots exist.
         payload["has_system_prompt"] = bool(session.get("system_prompt"))
         payload["has_model_config"] = bool(session.get("model_config"))
+        # Live context-window occupancy, persisted per session by the agent's
+        # own loop (context_window_usage / update_token_counts) from the same
+        # source the desktop uses (agent.context_compressor). 0 means "unknown"
+        # (no measured occupancy yet) — never a fabricated reading.
+        payload["context_window"] = int(session.get("context_window") or 0)
+        payload["context_used"] = int(session.get("context_used") or 0)
         return payload
 
     @staticmethod

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4855,6 +4855,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         billing_mode: Optional[str] = None,
         api_call_count: int = 0,
         absolute: bool = False,
+        context_window: int = 0,
+        context_used: int = 0,
     ) -> None:
         """Update token counters and backfill model if not already set.
 
@@ -4889,7 +4891,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
-                   api_call_count = ?
+                   api_call_count = ?,
+                   context_window = COALESCE(?, context_window),
+                   context_used = COALESCE(?, context_used)
                    WHERE id = ?"""
         else:
             sql = """UPDATE sessions SET
@@ -4910,7 +4914,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    billing_base_url = COALESCE(billing_base_url, ?),
                    billing_mode = COALESCE(billing_mode, ?),
                    model = COALESCE(model, ?),
-                   api_call_count = COALESCE(api_call_count, 0) + ?
+                   api_call_count = COALESCE(api_call_count, 0) + ?,
+                   context_window = COALESCE(?, context_window),
+                   context_used = COALESCE(?, context_used)
                    WHERE id = ?"""
         has_accounted_usage = bool(
             input_tokens or output_tokens or cache_read_tokens
@@ -4934,6 +4940,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             billing_mode if has_accounted_usage else None,
             model if has_accounted_usage else None,
             api_call_count,
+            context_window if context_window else None,
+            context_used if context_used else None,
             session_id,
         )
         # Per-model usage attribution.  ``update_token_counts`` is the single

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -230,6 +230,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     cache_read_tokens INTEGER DEFAULT 0,
     cache_write_tokens INTEGER DEFAULT 0,
     reasoning_tokens INTEGER DEFAULT 0,
+    context_window INTEGER NOT NULL DEFAULT 0,
+    context_used INTEGER NOT NULL DEFAULT 0,
     cwd TEXT,
     git_branch TEXT,
     git_repo_root TEXT,

--- a/tests/agent/test_context_breakdown.py
+++ b/tests/agent/test_context_breakdown.py
@@ -2,7 +2,10 @@
 
 from unittest.mock import MagicMock, patch
 
-from agent.context_breakdown import compute_session_context_breakdown
+from agent.context_breakdown import (
+    compute_session_context_breakdown,
+    context_window_usage,
+)
 
 
 def _make_agent(
@@ -49,6 +52,54 @@ def test_breakdown_includes_major_categories():
     assert data["context_max"] == 200_000
     assert data["estimated_total"] > 0
 
+
+# ── context_window_usage ────────────────────────────────────────────────────
+
+
+def _agent_with_compressor(context_length=128_000, last_prompt_tokens=45_000):
+    """Build a mock agent whose compressor reports the given values."""
+    agent = MagicMock()
+    agent.context_compressor = MagicMock(
+        context_length=context_length,
+        last_prompt_tokens=last_prompt_tokens,
+    )
+    return agent
+
+
+def test_context_window_usage_returns_both_fields():
+    result = context_window_usage(_agent_with_compressor())
+    assert result == {"context_window": 128_000, "context_used": 45_000}
+
+
+def test_context_window_usage_clamps_negative_sentinel():
+    """The -1 "compression just ran" sentinel yields unknown (0,0)."""
+    result = context_window_usage(_agent_with_compressor(
+        context_length=128_000, last_prompt_tokens=-1,
+    ))
+    assert result == {"context_window": 0, "context_used": 0}
+
+
+def test_context_window_usage_no_compressor():
+    agent = MagicMock(spec=[])
+    result = context_window_usage(agent)
+    assert result == {"context_window": 0, "context_used": 0}
+
+
+def test_context_window_usage_compressor_missing_values():
+    agent = MagicMock()
+    agent.context_compressor = MagicMock(
+        context_length=0, last_prompt_tokens=0,
+    )
+    result = context_window_usage(agent)
+    assert result == {"context_window": 0, "context_used": 0}
+
+
+def test_context_window_usage_zero_window_yields_unknown():
+    """A context_length of 0 means 'not configured' -> both are 0."""
+    result = context_window_usage(_agent_with_compressor(
+        context_length=0, last_prompt_tokens=50_000,
+    ))
+    assert result == {"context_window": 0, "context_used": 0}
 
 
 # ── /context renderers (pure functions over the payload) ────────────────────

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -396,6 +396,69 @@ class TestSessionLifecycle:
             db.close()
 
 
+class TestContextWindowPersistence:
+    """context_window / context_used columns in update_token_counts."""
+
+    def test_absolute_update_persists_both_fields(self, db):
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1,
+            absolute=True,
+            context_window=128_000, context_used=45_000,
+        )
+        row = db.get_session("s1")
+        assert row["context_window"] == 128_000
+        assert row["context_used"] == 45_000
+
+    def test_incremental_update_persists_context(self, db):
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1,
+            context_window=128_000, context_used=45_000,
+        )
+        row = db.get_session("s1")
+        assert row["context_window"] == 128_000
+        assert row["context_used"] == 45_000
+
+    def test_subsequent_update_without_context_does_not_clobber(self, db):
+        """COALESCE no-clobber: an update without context values preserves
+        the previous reading."""
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1,
+            context_window=128_000, context_used=45_000,
+        )
+        # Second update with no context_window / context_used
+        db.update_token_counts(
+            "s1", input_tokens=50, output_tokens=25, api_call_count=1,
+        )
+        row = db.get_session("s1")
+        assert row["context_window"] == 128_000
+        assert row["context_used"] == 45_000
+
+    def test_context_defaults_to_zero_fresh_session(self, db):
+        """A newly created session should have context_window=0, context_used=0."""
+        db.create_session("s1", source="cli")
+        row = db.get_session("s1")
+        assert row["context_window"] == 0
+        assert row["context_used"] == 0
+
+    def test_incremental_context_overwrites_prior_values(self, db):
+        """A later incremental update WITH context values should overwrite."""
+        db.create_session("s1", source="cli")
+        db.update_token_counts(
+            "s1", input_tokens=100, output_tokens=50, api_call_count=1,
+            context_window=128_000, context_used=45_000,
+        )
+        db.update_token_counts(
+            "s1", input_tokens=200, output_tokens=100, api_call_count=1,
+            context_window=256_000, context_used=120_000,
+        )
+        row = db.get_session("s1")
+        assert row["context_window"] == 256_000
+        assert row["context_used"] == 120_000
+
+
 # =========================================================================
 # Message storage
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Surface the agent's live context-window occupancy as persisted session fields, so thin clients can display meaningful context usage without computing it from token sums or probing `model_config`.

Currently the API server's session response exposes cumulative lifetime counters (`input_tokens` through `reasoning_tokens`) but nothing that tells a client "how full is the agent's context window right now." Thin clients that want a context ring either sum the cumulative counters (fabricating readings like 1.9M/128K, see issue #50421) or attempt to parse `model_config` (not exposed by the server for security). This PR closes that gap by having the agent persist its compressor's measured occupancy onto the session row at each token-count update, and exposing it in the session detail endpoint.

This is purely additive — existing callers and code paths are untouched. The two new columns default to `0` (meaning "unknown"), and `COALESCE` semantics prevent stale readings from being clobbered when a later update carries no context info.

## Changes Made

1. **`hermes_state_common.py`**: Added `context_window`/`context_used` columns to `sessions` table schema (`INTEGER NOT NULL DEFAULT 0`). Auto-added to existing DBs by `_reconcile_columns()`.

2. **`hermes_state.py`** (`update_token_counts`): Both absolute and incremental SQL branches persist context with `COALESCE` no-clobber semantics.

3. **`agent/context_breakdown.py`**: New `context_window_usage(agent)` helper — reads the agent's compressor state, mirrors the desktop TUI's sentinel logic.

4. **`agent/codex_runtime.py`**, **`agent/conversation_loop.py`**: Both token-count update paths now pass `**context_window_usage(agent)`.

5. **`gateway/platforms/api_server.py`**: Exposes `context_window`/`context_used` in the session detail payload.

6. **Tests**: 10 new tests across `tests/agent/test_context_breakdown.py` (5) and `tests/test_hermes_state.py` (5).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## How to Test

```bash
# Run the new tests
pytest tests/agent/test_context_breakdown.py -k "context_window_usage"
pytest tests/test_hermes_state.py::TestContextWindowPersistence


Or manually:
1. Start a session
2. `GET /api/sessions/{id}` → verify `context_window` and `context_used` are present (nonzero after one turn)
3. Send a follow-up message → verify fields update

## Checklist

- [x] My commit message follows Conventional Commits
- [x] My PR contains only changes related to this feature
- [x] Tests pass: 10/10
- [x] Tested on: Windows 11
- [x] No new config keys, env vars, or core tools
- [x] Cross-platform impact: none (no OS-specific code)

---

**Commit summary:** 8 files, +173/-5 on current `origin/main` (HEAD `069551d19`). Single atomic commit with feature + tests. Ready to PR.