### PR TITLE
feat(tui): add Claude Code-style logical-line navigation

### DIFF
--- a/ui-tui/src/__tests__/textInputLineNav.test.ts
+++ b/ui-tui/src/__tests__/textInputLineNav.test.ts
@@ -1,6 +1,148 @@
 import { describe, expect, it } from 'vitest'
 
-import { lineNav } from '../components/textInput.js'
+import {
+  homeEndTarget,
+  lineNav,
+  logicalLineEnd,
+  logicalLineStart,
+  smartEndTarget,
+  smartHomeTarget
+} from '../components/textInput.js'
+
+describe('logicalLineStart', () => {
+  it('returns the buffer start for single-line input', () => {
+    expect(logicalLineStart('hello world', 6)).toBe(0)
+  })
+
+  it('returns the start of the current logical line', () => {
+    expect(logicalLineStart('one\ntwo\nthree', 7)).toBe(4)
+  })
+
+  it('keeps a cursor already at a line start on that line', () => {
+    expect(logicalLineStart('one\ntwo', 4)).toBe(4)
+  })
+
+  it('treats a cursor on a newline as the end of the preceding line', () => {
+    expect(logicalLineStart('one\ntwo', 3)).toBe(0)
+  })
+
+  it('keeps the start of an empty first line at zero', () => {
+    expect(logicalLineStart('\nnext', 0)).toBe(0)
+  })
+
+  it('handles empty lines and Unicode text', () => {
+    expect(logicalLineStart('one\n\nthree', 4)).toBe(4)
+    expect(logicalLineStart('🙂a\nβγ', 6)).toBe(4)
+  })
+})
+
+describe('logicalLineEnd', () => {
+  it('returns the buffer end for single-line input', () => {
+    expect(logicalLineEnd('hello world', 6)).toBe(11)
+  })
+
+  it('returns the end of the current logical line', () => {
+    expect(logicalLineEnd('one\ntwo\nthree', 5)).toBe(7)
+  })
+
+  it('keeps a cursor already at a line end before the newline', () => {
+    expect(logicalLineEnd('one\ntwo', 3)).toBe(3)
+  })
+
+  it('keeps the end of an empty first line at zero', () => {
+    expect(logicalLineEnd('\nnext', 0)).toBe(0)
+  })
+
+  it('handles empty lines and Unicode text', () => {
+    expect(logicalLineEnd('one\n\nthree', 4)).toBe(4)
+    expect(logicalLineEnd('🙂a\nβγ', 4)).toBe(6)
+  })
+
+  it('returns the final empty line boundary', () => {
+    expect(logicalLineEnd('one\n', 4)).toBe(4)
+  })
+})
+
+describe('smartHomeTarget', () => {
+  it('moves to the current line start before crossing a line boundary', () => {
+    expect(smartHomeTarget('one\ntwo\nthree', 11)).toBe(8)
+  })
+
+  it('moves to the previous line start when already at a line start', () => {
+    expect(smartHomeTarget('one\ntwo\nthree', 8)).toBe(4)
+  })
+
+  it('walks backward across logical lines on repeated calls', () => {
+    const value = 'one\ntwo\nthree'
+    let cursor = 11
+
+    cursor = smartHomeTarget(value, cursor)
+    expect(cursor).toBe(8)
+    cursor = smartHomeTarget(value, cursor)
+    expect(cursor).toBe(4)
+    cursor = smartHomeTarget(value, cursor)
+    expect(cursor).toBe(0)
+    expect(smartHomeTarget(value, cursor)).toBe(0)
+  })
+
+  it('stops at an intervening empty line', () => {
+    expect(smartHomeTarget('one\n\nthree', 5)).toBe(4)
+  })
+})
+
+describe('smartEndTarget', () => {
+  it('moves to the current line end before crossing a line boundary', () => {
+    expect(smartEndTarget('one\ntwo\nthree', 1)).toBe(3)
+  })
+
+  it('moves to the next line end when already at a line end', () => {
+    expect(smartEndTarget('one\ntwo\nthree', 3)).toBe(7)
+  })
+
+  it('walks forward across logical lines on repeated calls', () => {
+    const value = 'one\ntwo\nthree'
+    let cursor = 1
+
+    cursor = smartEndTarget(value, cursor)
+    expect(cursor).toBe(3)
+    cursor = smartEndTarget(value, cursor)
+    expect(cursor).toBe(7)
+    cursor = smartEndTarget(value, cursor)
+    expect(cursor).toBe(value.length)
+    expect(smartEndTarget(value, cursor)).toBe(value.length)
+  })
+
+  it('stops at an intervening empty line', () => {
+    expect(smartEndTarget('one\n\nthree', 3)).toBe(4)
+  })
+})
+
+describe('homeEndTarget', () => {
+  const key = (overrides: Partial<{ ctrl: boolean; end: boolean; home: boolean }>) => ({
+    ctrl: false,
+    end: false,
+    home: false,
+    ...overrides
+  })
+
+  it('moves Ctrl+Home and Ctrl+End across the whole buffer', () => {
+    const value = 'one\ntwo\nthree'
+
+    expect(homeEndTarget(value, 6, key({ ctrl: true, home: true }))).toBe(0)
+    expect(homeEndTarget(value, 6, key({ ctrl: true, end: true }))).toBe(value.length)
+  })
+
+  it('keeps unmodified Home and End on smart logical-line navigation', () => {
+    const value = 'one\ntwo\nthree'
+
+    expect(homeEndTarget(value, 6, key({ home: true }))).toBe(4)
+    expect(homeEndTarget(value, 6, key({ end: true }))).toBe(7)
+  })
+
+  it('ignores unrelated keys', () => {
+    expect(homeEndTarget('one\ntwo', 5, key({ ctrl: true }))).toBeNull()
+  })
+})
 
 describe('lineNav', () => {
   it('returns null for single-line input (up)', () => {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -321,6 +321,73 @@ export function resolveCursorLayout(display: string, cur: number, curRefCurrent:
   return cursorLayout(display, curRefCurrent, columns)
 }
 
+/** Readline `beginning-of-line`: move to the current logical line start. */
+export function logicalLineStart(value: string, cursor: number): number {
+  if (cursor <= 0) {
+    return 0
+  }
+
+  return value.lastIndexOf('\n', cursor - 1) + 1
+}
+
+/** Readline `end-of-line`: move to the current logical line end. */
+export function logicalLineEnd(value: string, cursor: number): number {
+  const newline = value.indexOf('\n', cursor)
+
+  return newline < 0 ? value.length : newline
+}
+
+/**
+ * Home first moves to the current logical line start. Repeating it at that
+ * boundary walks to the previous logical line start, matching Claude Code's
+ * multiline composer navigation without changing readline Ctrl+A semantics.
+ */
+export function smartHomeTarget(value: string, cursor: number): number {
+  const currentStart = logicalLineStart(value, cursor)
+
+  if (cursor !== currentStart || currentStart === 0) {
+    return currentStart
+  }
+
+  return logicalLineStart(value, currentStart - 1)
+}
+
+/** Home's forward counterpart: repeat at a line end to reach the next one. */
+export function smartEndTarget(value: string, cursor: number): number {
+  const currentEnd = logicalLineEnd(value, cursor)
+
+  if (cursor !== currentEnd || currentEnd === value.length) {
+    return currentEnd
+  }
+
+  return logicalLineEnd(value, currentEnd + 1)
+}
+
+/** Resolve physical Home/End, preserving Ctrl variants as whole-buffer navigation. */
+export function homeEndTarget(
+  value: string,
+  cursor: number,
+  key: Pick<Key, 'ctrl' | 'end' | 'home'>
+): number | null {
+  if (key.ctrl && key.home) {
+    return 0
+  }
+
+  if (key.ctrl && key.end) {
+    return value.length
+  }
+
+  if (key.home) {
+    return smartHomeTarget(value, cursor)
+  }
+
+  if (key.end) {
+    return smartEndTarget(value, cursor)
+  }
+
+  return null
+}
+
 /**
  * Readline `unix-line-discard` (Ctrl+U / Cmd+Backspace): kill backward to
  * the start of the *current logical line*, not to the start of the whole
@@ -1176,8 +1243,8 @@ export function TextInput({
       let v = vRef.current
       const mod = isActionMod(k)
       const wordMod = mod || k.meta
-      const actionHome = k.home || (!isMac && mod && inp === 'a') || isMacActionFallback(k, inp, 'a')
-      const actionEnd = k.end || (mod && inp === 'e') || isMacActionFallback(k, inp, 'e')
+      const actionHome = (!isMac && mod && inp === 'a') || isMacActionFallback(k, inp, 'a')
+      const actionEnd = (mod && inp === 'e') || isMacActionFallback(k, inp, 'e')
       const actionDeleteToStart = (mod && inp === 'u') || isMacActionFallback(k, inp, 'u')
       const actionKillToEnd = (mod && inp === 'k') || isMacActionFallback(k, inp, 'k')
       const actionDeleteWord = (mod && inp === 'w') || isMacActionFallback(k, inp, 'w')
@@ -1203,13 +1270,15 @@ export function TextInput({
         return selectAll()
       }
 
-      if (actionHome) {
-        c = 0
+      const physicalHomeEndTarget = homeEndTarget(v, c, k)
+
+      if (physicalHomeEndTarget !== null || actionHome) {
+        c = physicalHomeEndTarget ?? logicalLineStart(v, c)
         moveCursor(c, k.shift)
 
         return
       } else if (actionEnd) {
-        c = v.length
+        c = logicalLineEnd(v, c)
         moveCursor(c, k.shift)
 
         return


### PR DESCRIPTION
## Summary

- add Claude Code-style logical-line navigation to the multiline TUI composer
- keep readline-style `Ctrl+A` / `Ctrl+E` within the current newline-delimited logical line
- preserve macOS `Cmd+A` select-all, `Ctrl+Home` / `Ctrl+End` whole-buffer navigation, Shift selection, and single-line behavior
- make physical Home / End stop at the current logical-line boundary first, then walk to the adjacent logical-line boundary on repeated presses
- add behavior-focused coverage for multiline, empty-line, Unicode, modifier, and repeated-navigation cases

## Motivation

The composer currently uses the same whole-buffer targets for readline `Ctrl+A` / `Ctrl+E` and physical Home / End. That is functional, but it makes navigation cumbersome once a prompt contains hard newlines.

Claude Code's multiline composer provides a more useful interaction: readline beginning/end-of-line stays within the current logical line, while repeated physical Home / End can traverse adjacent logical-line boundaries. This PR adds that behavior while keeping the existing selection and platform-specific routing intact.

## Related work

This builds on the readline parity established in #13594. It is intentionally separate from soft-wrap visual-row Up/Down work in #15850 and the broader visual-row proposal in #22197: this PR only defines navigation across hard-newline logical lines.

## Tests

- `npm test --workspace ui-tui -- src/__tests__/textInputLineNav.test.ts` — 33 passed
- `npm run typecheck --workspace ui-tui` — passed
- `npm run lint --workspace ui-tui` — passed with one pre-existing warning in `useSessionLifecycle.ts`
- `git diff --check upstream/main...HEAD` — passed

`npm run check --workspace ui-tui` reaches the passing navigation tests but is currently blocked by 21 unrelated failures in `subscriptionOverlay`, `appChromeBlockedTimers`, and `ink-backpressure`; the same failures reproduce on a detached `upstream/main` worktree.
