### PR TITLE
feat: retain local delivery timing samples

### DIFF
--- a/hermes_cli/observability/relay_shared_metrics.py
+++ b/hermes_cli/observability/relay_shared_metrics.py
@@ -74,6 +74,7 @@ class _ModelCall:
     handle: Any
     task_id: str
     fields: dict[str, str]
+    started_ns: int
     retry_ordinal: int | None = None
 
 
@@ -355,6 +356,7 @@ class _Runtime:
                 handle=handle,
                 task_id=str(event.get("task_id") or ""),
                 fields=fields,
+                started_ns=monotonic_ns(),
                 retry_ordinal=retry_ordinal,
             )
 
@@ -941,6 +943,12 @@ class _Runtime:
         if model_call is None:
             return
         try:
+            self.subscriber.store.record_latency_sample(
+                "model_call", max(0, (monotonic_ns() - model_call.started_ns) // 1_000_000)
+            )
+        except Exception:
+            logger.warning("Hermes local model timing write failed", exc_info=True)
+        try:
             task = session.tasks.get(model_call.task_id)
             if task is not None:
                 self._run_in_task(
@@ -1016,13 +1024,18 @@ class _Runtime:
             return False
         self._end_pending_tool_calls(session, task, event)
         self._end_pending_model_calls(session, {**event, "task_id": task_id})
+        duration_ms = max(0, (monotonic_ns() - task.started_ns) // 1_000_000)
         fields = task_terminal_fields(
             {**task.start_fields, **event},
-            duration_ms=max(0, (monotonic_ns() - task.started_ns) // 1_000_000),
+            duration_ms=duration_ms,
             model_call_count=len(task.model_call_ids),
             tool_call_count=len(task.tool_call_ids) + task.unidentified_tool_calls,
             retry_count=task.retry_count,
         )
+        try:
+            self.subscriber.store.record_latency_sample("task", duration_ms)
+        except Exception:
+            logger.warning("Hermes local task timing write failed", exc_info=True)
         try:
             self._run_in_task(
                 task,

--- a/hermes_cli/observability/shared_metrics.py
+++ b/hermes_cli/observability/shared_metrics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import sqlite3
 import uuid
 from collections.abc import Iterator
@@ -116,6 +117,41 @@ class SharedMetricsStore:
                     (_ACTIVE_INSTALL_STATE_KEY, _isoformat(now)),
                 )
         return True
+
+    def record_latency_sample(self, metric_name: str, duration_ms: int) -> None:
+        """Persist one local-only, content-free timing sample."""
+        if metric_name not in {"task", "model_call"}:
+            raise ValueError(f"Unsupported latency metric: {metric_name}")
+        if isinstance(duration_ms, bool) or not isinstance(duration_ms, int) or duration_ms < 0:
+            raise ValueError("Latency duration must be a non-negative integer")
+        with self._connection() as connection:
+            connection.execute(
+                """
+                INSERT INTO local_latency_samples(metric_name, recorded_at, duration_ms)
+                VALUES (?, ?, ?)
+                """,
+                (metric_name, _isoformat(_utc_now()), duration_ms),
+            )
+
+    def latency_summary(self, metric_name: str) -> dict[str, int]:
+        """Return local count/p50/p90 for one content-free timing metric."""
+        if metric_name not in {"task", "model_call"}:
+            raise ValueError(f"Unsupported latency metric: {metric_name}")
+        with self._connection() as connection:
+            rows = connection.execute(
+                """
+                SELECT duration_ms FROM local_latency_samples
+                WHERE metric_name = ? ORDER BY duration_ms
+                """,
+                (metric_name,),
+            ).fetchall()
+        values = [int(row["duration_ms"]) for row in rows]
+        if not values:
+            return {"count": 0, "p50_ms": 0, "p90_ms": 0}
+        def percentile(fraction: float) -> int:
+            index = max(0, -1 + math.ceil(len(values) * fraction))
+            return values[index]
+        return {"count": len(values), "p50_ms": percentile(0.5), "p90_ms": percentile(0.9)}
 
     def record_counter(
         self,
@@ -335,6 +371,21 @@ class SharedMetricsStore:
                 created_at TEXT NOT NULL,
                 exported_at TEXT
             )
+            """
+        )
+        connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS local_latency_samples (
+                metric_name TEXT NOT NULL,
+                recorded_at TEXT NOT NULL,
+                duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0)
+            )
+            """
+        )
+        connection.execute(
+            """
+            CREATE INDEX IF NOT EXISTS local_latency_samples_metric_duration
+            ON local_latency_samples(metric_name, duration_ms)
             """
         )
         connection.execute(
@@ -701,6 +752,10 @@ class SharedMetricsStore:
                         """,
                         (package_id, cutoff_timestamp),
                     )
+                connection.execute(
+                    "DELETE FROM local_latency_samples WHERE recorded_at < ?",
+                    (cutoff_timestamp,),
+                )
                 connection.execute(
                     """
                     DELETE FROM counter_aggregates

--- a/tests/hermes_cli/test_relay_shared_metrics.py
+++ b/tests/hermes_cli/test_relay_shared_metrics.py
@@ -168,6 +168,35 @@ def _record_client_active_in_process(
     store.record_client_active(_resource())
 
 
+def test_local_latency_summary_is_private_and_reports_nearest_rank_percentiles(tmp_path):
+    store = SharedMetricsStore(tmp_path / "metrics.sqlite3", tmp_path / "outbox")
+    assert store.latency_summary("task") == {"count": 0, "p50_ms": 0, "p90_ms": 0}
+    for value in [10, 20, 30, 40, 50]:
+        store.record_latency_sample("task", value)
+    assert store.latency_summary("task") == {"count": 5, "p50_ms": 30, "p90_ms": 50}
+    with pytest.raises(ValueError):
+        store.record_latency_sample("tool", 1)
+    with pytest.raises(ValueError):
+        store.record_latency_sample("task", -1)
+
+
+def test_local_latency_samples_prune_and_use_metric_duration_index(tmp_path):
+    database_path = tmp_path / "metrics.sqlite3"
+    store = SharedMetricsStore(database_path, tmp_path / "outbox")
+    store.record_latency_sample("task", 10)
+    store.record_latency_sample("task", 20)
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "UPDATE local_latency_samples SET recorded_at = '2026-01-01T00:00:00Z' WHERE duration_ms = 10"
+        )
+        plan = connection.execute(
+            "EXPLAIN QUERY PLAN SELECT duration_ms FROM local_latency_samples WHERE metric_name = 'task' ORDER BY duration_ms"
+        ).fetchall()
+    assert any("local_latency_samples_metric_duration" in row[-1] for row in plan)
+    store._prune_expired_history(now=datetime(2026, 7, 23, tzinfo=timezone.utc))
+    assert store.latency_summary("task") == {"count": 1, "p50_ms": 20, "p90_ms": 20}
+
+
 def test_model_call_counter_survives_restart_and_exports_only_new_deltas(tmp_path):
     database_path = tmp_path / "metrics.sqlite3"
     outbox_directory = tmp_path / "outbox"


### PR DESCRIPTION
## Summary
- retain exact local-only task and model-call timing samples in the existing private metrics store
- expose local count/p50/p90 summaries
- prune timing samples under the existing 30-day retention policy
- index percentile reads by metric and duration

## Privacy and safety
- no prompts, responses, source code, raw IDs, tool arguments/results, or credentials are stored
- shared/exported metric payloads are unchanged
- timing-store errors are caught so task/model completion remains fail-open
- this does not enable telemetry or restart any gateway

## Proof
- `uv run --extra dev pytest -q tests/hermes_cli/test_relay_shared_metrics.py tests/hermes_cli/test_relay_shared_metrics_runtime.py`
- 153 passed
- `git diff --check`
- fresh privacy/correctness review; retention/index finding reconciled with regression coverage