### PR TITLE
fix(gateway): stop multiplex second auth gate from leaking allowlists…

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -28,33 +28,18 @@ from gateway.whatsapp_identity import (
 )
 
 
-def _auth_env(name: str, default: str = "") -> str:
-    """Read allowlist/auth env; prefer profile secret_scope under multiplex."""
-    if not name:
-        return default
-    try:
-        from agent.secret_scope import get_secret
-
-        val = get_secret(name)
-        if val is not None and str(val).strip():
-            return str(val).strip()
-    except Exception:
-        pass
-    return (os.getenv(name) or default).strip()
-
-
 def _platform_gate_env(name: str, default: str = "") -> str:
     """Read a platform allow/deny gate env var with per-profile isolation.
 
-    Like ``_auth_env`` but authoritative under multiplex: when a profile
-    secret scope is installed AND multiplexing is active, a key absent from
-    the scope returns ``default`` instead of falling through to
-    ``os.environ``. Under multiplex the process env may hold ANOTHER
-    profile's first-writer-bridged value (the YAML→env bridges in the
-    Discord/Telegram adapters' ``_apply_yaml_config`` are first-writer-wins),
-    so falling through would leak profile A's allowlist into profile B
-    (issue #72348). Single-profile deployments — no scope installed, or
-    multiplex off — behave exactly like the legacy ``os.getenv`` read.
+    Authoritative under multiplex: when a profile secret scope is installed
+    AND multiplexing is active, a key absent from the scope returns
+    ``default`` instead of falling through to ``os.environ``. Under multiplex
+    the process env may hold ANOTHER profile's first-writer-bridged value
+    (the YAML→env bridges in the Discord/Telegram adapters'
+    ``_apply_yaml_config`` are first-writer-wins), so falling through would
+    leak profile A's allowlist into profile B (issues #72348 / #80026).
+    Single-profile deployments — no scope installed, or multiplex off —
+    behave exactly like the legacy ``os.getenv`` read.
     """
     if not name:
         return default
@@ -567,7 +552,7 @@ class GatewayAuthorizationMixin:
 
         # Per-platform allow-all flag (e.g., DISCORD_ALLOW_ALL_USERS=true)
         platform_allow_all_var = platform_allow_all_map.get(source.platform, "")
-        if platform_allow_all_var and _auth_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
+        if platform_allow_all_var and _platform_gate_env(platform_allow_all_var).lower() in {"true", "1", "yes"}:
             return True
 
         # Adapter-verified role auth: the Discord adapter already confirmed the
@@ -597,14 +582,17 @@ class GatewayAuthorizationMixin:
         if pairing_store is not None and pairing_store.is_approved(platform_name, user_id):
             return True
 
-        # Check platform-specific and global allowlists
-        platform_allowlist = _auth_env(platform_env_map.get(source.platform, ""))
+        # Check platform-specific and global allowlists.
+        # Use _platform_gate_env (not a process-env fallback on scoped miss) so
+        # multiplexed profile B cannot inherit profile A's bridged allowlist
+        # and skip its own adapter-local YAML policy (#80026).
+        platform_allowlist = _platform_gate_env(platform_env_map.get(source.platform, ""))
         group_user_allowlist = ""
         group_chat_allowlist = ""
         if source.chat_type in {"group", "forum"}:
-            group_user_allowlist = _auth_env(platform_group_user_env_map.get(source.platform, ""))
-            group_chat_allowlist = _auth_env(platform_group_chat_env_map.get(source.platform, ""))
-        global_allowlist = _auth_env("GATEWAY_ALLOWED_USERS")
+            group_user_allowlist = _platform_gate_env(platform_group_user_env_map.get(source.platform, ""))
+            group_chat_allowlist = _platform_gate_env(platform_group_chat_env_map.get(source.platform, ""))
+        global_allowlist = _platform_gate_env("GATEWAY_ALLOWED_USERS")
 
         if not platform_allowlist and not group_user_allowlist and not group_chat_allowlist and not global_allowlist:
             # No env allowlist configured. Adapters that own their own
@@ -688,7 +676,7 @@ class GatewayAuthorizationMixin:
                     if user_id in allowed or "*" in allowed:
                         return True
             # No allowlists configured -- check global allow-all flag
-            return _auth_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
+            return _platform_gate_env("GATEWAY_ALLOW_ALL_USERS").lower() in {"true", "1", "yes"}
 
         # Telegram can optionally authorize group traffic by chat ID.
         # Keep this separate from TELEGRAM_GROUP_ALLOWED_USERS, which gates

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8739,13 +8739,34 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return text
         return (enriched_text or text).strip()
 
+    def _is_user_authorized_scoped(self, source: SessionSource) -> bool:
+        """Authorize under the routed profile's secret scope when multiplexed.
+
+        Cold-path message handlers already enter ``_profile_runtime_scope``
+        before calling ``_is_user_authorized``. Busy-session handling, startup
+        resume validation, and adapter authorization callbacks can run *before*
+        that scope is installed. Without this wrapper a scoped miss falls
+        through to process-global allowlists and a foreign profile's value can
+        authorize the wrong profile (issues #72348 / #80026 residual bypass).
+        """
+        if not getattr(getattr(self, "config", None), "multiplex_profiles", False):
+            return self._is_user_authorized(source)
+        try:
+            profile_home = self._resolve_profile_home_for_source(source)
+        except Exception:
+            return self._is_user_authorized(source)
+        with _profile_runtime_scope(profile_home):
+            return self._is_user_authorized(source)
+
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
         # The cold path (_handle_message) checks _is_user_authorized before
         # creating a session.  The busy path must enforce the same check;
         # otherwise unauthorized users in shared threads (Slack/Telegram/Discord)
         # can inject messages into an active session they don't own.
-        if not self._is_user_authorized(event.source):
+        # Under multiplex the shared busy callback is not installed inside a
+        # profile message-handler scope, so use the scoped auth helper.
+        if not self._is_user_authorized_scoped(event.source):
             logger.warning(
                 "Dropping message from unauthorized user in active session: "
                 "user=%s (%s), platform=%s, session=%s",
@@ -10535,8 +10556,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # before the owner was removed from it, must not silently
             # receive a full agent response on gateway restart just
             # because it has a resume-pending marker (issue #23778).
+            # Under multiplex this check runs before the scoped message
+            # handler, so use the profile-scoped helper — otherwise a
+            # foreign process allowlist can resume a revoked owner.
             try:
-                if not self._is_user_authorized(source):
+                if not self._is_user_authorized_scoped(source):
                     logger.warning(
                         "Skipping auto-resume for %s: session owner is no "
                         "longer authorized under the current allowlist",
@@ -11093,7 +11117,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             adapter.set_message_handler(self._primary_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
-            adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+            adapter.set_busy_session_handler(self._primary_busy_session_handler())
             _set_reaction = getattr(adapter, "set_reaction_handler", None)
             if callable(_set_reaction):
                 _set_reaction(self._handle_reaction_event)
@@ -12465,7 +12489,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     adapter.set_message_handler(self._primary_message_handler())
                     adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
                     adapter.set_session_store(self.session_store)
-                    adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+                    adapter.set_busy_session_handler(self._primary_busy_session_handler())
                     _set_reaction = getattr(adapter, "set_reaction_handler", None)
                     if callable(_set_reaction):
                         _set_reaction(self._handle_reaction_event)
@@ -13407,7 +13431,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._make_profile_fatal_error_handler(profile_name, platform)
         )
         adapter.set_session_store(self.session_store)
-        adapter.set_busy_session_handler(self._handle_active_session_busy_message)
+        adapter.set_busy_session_handler(
+            self._make_profile_busy_session_handler(profile_name)
+        )
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
             _set_reaction(self._handle_reaction_event)
@@ -13612,6 +13638,36 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return _handler
 
+    def _make_profile_busy_session_handler(self, profile_name: str):
+        """Return a busy-session handler bound to a secondary profile.
+
+        The shared busy callback is installed on adapters outside the cold-path
+        message-handler wrapper. Stamp ``source.profile`` and enter the
+        profile's runtime scope so authorization reads that profile's allowlist
+        rather than a foreign process-global value.
+        """
+        from hermes_cli.profiles import get_profile_dir
+
+        try:
+            profile_home = get_profile_dir(profile_name)
+        except Exception:
+            profile_home = None
+
+        async def _handler(event, session_key: str):
+            try:
+                if getattr(event, "source", None) is not None and not event.source.profile:
+                    event.source.profile = profile_name
+            except Exception:
+                pass
+            if profile_home is not None:
+                with _profile_runtime_scope(profile_home):
+                    return await self._handle_active_session_busy_message(
+                        event, session_key
+                    )
+            return await self._handle_active_session_busy_message(event, session_key)
+
+        return _handler
+
     def _make_default_profile_message_handler(self):
         """Scope a multiplexed default-profile message from ingress onward."""
         profile_home = Path(get_hermes_home())
@@ -13622,11 +13678,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return _handler
 
+    def _make_default_profile_busy_session_handler(self):
+        """Scope a multiplexed default-profile busy-session callback."""
+        profile_home = Path(get_hermes_home())
+
+        async def _handler(event, session_key: str):
+            with _profile_runtime_scope(profile_home):
+                return await self._handle_active_session_busy_message(
+                    event, session_key
+                )
+
+        return _handler
+
     def _primary_message_handler(self):
         """Return the correctly scoped handler for a primary adapter."""
         if getattr(self.config, "multiplex_profiles", False):
             return self._make_default_profile_message_handler()
         return self._handle_message
+
+    def _primary_busy_session_handler(self):
+        """Return the correctly scoped busy-session handler for a primary adapter."""
+        if getattr(self.config, "multiplex_profiles", False):
+            return self._make_default_profile_busy_session_handler()
+        return self._handle_active_session_busy_message
 
     @staticmethod
     def _adapter_credential_claim(
@@ -13853,9 +13927,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         senders as unverified in LLM context, mitigating indirect prompt
         injection from third parties in shared threads/channels.
 
-        The returned callback delegates to :meth:`_is_user_authorized` so the
-        full auth chain — platform allowlists, group allowlists, pairing
-        store, allow-all flags — stays the single source of truth.
+        The returned callback delegates to :meth:`_is_user_authorized_scoped`
+        so the full auth chain — platform allowlists, group allowlists, pairing
+        store, allow-all flags — stays the single source of truth *and* runs
+        under the bound profile's secret scope under multiplex.
 
         ``profile_name`` binds the callback to the secondary adapter's own
         multiplex profile, so its ``SessionSource`` resolves that profile's
@@ -13875,7 +13950,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 user_id=user_id,
                 profile=profile_name,
             )
-            return self._is_user_authorized(source)
+            return self._is_user_authorized_scoped(source)
         return check
 
 

--- a/tests/gateway/test_discord_multiplex_second_auth_gate.py
+++ b/tests/gateway/test_discord_multiplex_second_auth_gate.py
@@ -1,0 +1,113 @@
+"""Regression for #80026: gateway second auth gate must not leak allowlists.
+
+PR #75970 isolated Discord/Telegram adapter admission. The gateway's second
+authorization gate still used a reader that fell through to process-global
+``os.environ`` on a profile-scoped miss, so profile A's bridged
+``DISCORD_ALLOWED_USERS`` could authorize (or block) traffic for profile B
+and prevent B's adapter-local ``config.extra.allow_from`` from being
+evaluated.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope_state(monkeypatch):
+    for key in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _make_discord_runner(*, allow_from=None, profile="profile-b"):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    extra = {}
+    if allow_from is not None:
+        extra["allow_from"] = allow_from
+    adapter = SimpleNamespace(
+        send=AsyncMock(),
+        config=SimpleNamespace(extra=extra),
+        enforces_own_access_policy=False,
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {profile: {Platform.DISCORD: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    return runner, adapter
+
+
+def _discord_dm(user_id: str, *, profile="profile-b") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id=user_id,
+        chat_id="test-dm",
+        user_name=user_id,
+        chat_type="dm",
+        profile=profile,
+    )
+
+
+class TestDiscordMultiplexSecondAuthGate:
+    def test_foreign_process_allowlist_does_not_authorize_secondary(
+        self, monkeypatch
+    ):
+        # Profile A left DISCORD_ALLOWED_USERS=111 in process env. Profile B
+        # has no env allowlist and only YAML allow_from=222.
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _make_discord_runner(allow_from="222")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})  # profile B .env has no Discord keys
+        try:
+            assert runner._is_user_authorized(_discord_dm("111")) is False
+            assert runner._is_user_authorized(_discord_dm("222")) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_foreign_allow_all_does_not_open_secondary(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+        runner, _adapter = _make_discord_runner(allow_from="222")
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            assert runner._is_user_authorized(_discord_dm("111")) is False
+            assert runner._is_user_authorized(_discord_dm("222")) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_scoped_allowlist_still_authorizes(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _make_discord_runner(allow_from=None)
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({"DISCORD_ALLOWED_USERS": "222"})
+        try:
+            assert runner._is_user_authorized(_discord_dm("111")) is False
+            assert runner._is_user_authorized(_discord_dm("222")) is True
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_single_profile_environ_unchanged(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _make_discord_runner(allow_from="222")
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        ss.set_multiplex_active(False)
+        assert runner._is_user_authorized(_discord_dm("111", profile=None)) is True
+        # Process env allowlist is authoritative; adapter allow_from is only
+        # consulted when env-derived allowlists are empty.
+        assert runner._is_user_authorized(_discord_dm("222", profile=None)) is False

--- a/tests/gateway/test_multiplex_auth_scope_bypass.py
+++ b/tests/gateway/test_multiplex_auth_scope_bypass.py
@@ -1,0 +1,296 @@
+"""Regression: multiplex authorization must not run outside profile secret scope.
+
+Residual P1 bypass after #80026: cold-path message handlers enter
+``_profile_runtime_scope``, but busy-session handling, startup-resume owner
+validation, and adapter authorization callbacks could authorize against the
+process-global allowlist. A foreign profile's env value must not authorize
+another profile's busy action or resume a revoked session owner.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agent import secret_scope as ss
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionEntry, SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _reset_scope_state(monkeypatch):
+    for key in (
+        "DISCORD_ALLOWED_USERS",
+        "DISCORD_ALLOW_ALL_USERS",
+        "TELEGRAM_ALLOWED_USERS",
+        "GATEWAY_ALLOWED_USERS",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    ss.set_multiplex_active(False)
+    yield
+    ss.set_multiplex_active(False)
+
+
+def _discord_runner(*, profile="profile-b", allow_from=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig(multiplex_profiles=True)
+    extra = {}
+    if allow_from is not None:
+        extra["allow_from"] = allow_from
+    adapter = SimpleNamespace(
+        send=AsyncMock(),
+        config=SimpleNamespace(extra=extra),
+        enforces_own_access_policy=False,
+    )
+    runner.adapters = {Platform.DISCORD: adapter}
+    runner._profile_adapters = {profile: {Platform.DISCORD: adapter}}
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = False
+    runner.pairing_stores = {}
+    return runner, adapter
+
+
+def _discord_dm(user_id: str, *, profile="profile-b") -> SessionSource:
+    return SessionSource(
+        platform=Platform.DISCORD,
+        user_id=user_id,
+        chat_id="test-dm",
+        user_name=user_id,
+        chat_type="dm",
+        profile=profile,
+    )
+
+
+def _bind_empty_profile_home(runner, monkeypatch, tmp_path, *, env_body: str = ""):
+    """Point scoped auth at an isolated profile home with optional .env body."""
+    profile_home = tmp_path / "profile-b"
+    profile_home.mkdir(exist_ok=True)
+    (profile_home / ".env").write_text(env_body, encoding="utf-8")
+    monkeypatch.setattr(
+        runner,
+        "_resolve_profile_home_for_source",
+        lambda source: profile_home,
+    )
+    return profile_home
+
+
+class TestIsUserAuthorizedScoped:
+    def test_foreign_process_allowlist_rejected_under_empty_scope(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _discord_runner(allow_from="222")
+        _bind_empty_profile_home(runner, monkeypatch, tmp_path)
+        ss.set_multiplex_active(True)
+
+        assert runner._is_user_authorized_scoped(_discord_dm("111")) is False
+        assert runner._is_user_authorized_scoped(_discord_dm("222")) is True
+
+    def test_scoped_allowlist_authorizes_only_own_profile(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _discord_runner(allow_from=None)
+        _bind_empty_profile_home(
+            runner,
+            monkeypatch,
+            tmp_path,
+            env_body="DISCORD_ALLOWED_USERS=222\n",
+        )
+        ss.set_multiplex_active(True)
+
+        assert runner._is_user_authorized_scoped(_discord_dm("111")) is False
+        assert runner._is_user_authorized_scoped(_discord_dm("222")) is True
+
+    def test_single_profile_mode_uses_process_environ(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _discord_runner(allow_from="222")
+        runner.config = GatewayConfig(multiplex_profiles=False)
+        ss.set_multiplex_active(False)
+        assert runner._is_user_authorized_scoped(
+            _discord_dm("111", profile=None)
+        ) is True
+        assert runner._is_user_authorized_scoped(
+            _discord_dm("222", profile=None)
+        ) is False
+
+
+class TestAdapterAuthCheckScope:
+    def test_adapter_callback_rejects_foreign_process_allowlist(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _discord_runner(allow_from="222", profile="coder")
+        _bind_empty_profile_home(runner, monkeypatch, tmp_path)
+        ss.set_multiplex_active(True)
+
+        check = runner._make_adapter_auth_check(Platform.DISCORD, profile_name="coder")
+        assert check("111", "dm", "test-dm") is False
+        assert check("222", "dm", "test-dm") is True
+
+    def test_adapter_callback_stamps_profile_and_uses_scoped_auth(self):
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        captured: dict = {}
+
+        def fake_scoped(source):
+            captured["profile"] = source.profile
+            return source.user_id == "ok"
+
+        runner._is_user_authorized_scoped = fake_scoped
+        check = runner._make_adapter_auth_check(Platform.WECOM, profile_name="coder")
+        assert check("ok", "dm", "c1") is True
+        assert captured["profile"] == "coder"
+        assert check("nope", "dm", "c1") is False
+
+
+class TestBusySessionAuthScope:
+    @pytest.mark.asyncio
+    async def test_busy_path_rejects_foreign_process_allowlist(
+        self, monkeypatch, tmp_path
+    ):
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.run import GatewayRunner
+
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "111")
+        runner, _adapter = _discord_runner(allow_from="222", profile="profile-b")
+        _bind_empty_profile_home(runner, monkeypatch, tmp_path)
+        ss.set_multiplex_active(True)
+
+        runner._draining = False
+        runner._running_agents = {}
+        runner._pending_messages = {}
+        runner._busy_ack_ts = {}
+
+        foreign = MessageEvent(
+            text="inject",
+            message_type=MessageType.TEXT,
+            source=_discord_dm("111", profile="profile-b"),
+            message_id="m1",
+        )
+        handled = await GatewayRunner._handle_active_session_busy_message(
+            runner, foreign, "agent:main:discord:dm:test-dm"
+        )
+        assert handled is True  # silently dropped as unauthorized
+
+    @pytest.mark.asyncio
+    async def test_profile_busy_handler_stamps_profile(self, monkeypatch, tmp_path):
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig(multiplex_profiles=True)
+        captured: dict = {}
+
+        async def fake_busy(event, session_key):
+            captured["profile"] = getattr(event.source, "profile", None)
+            return True
+
+        runner._handle_active_session_busy_message = fake_busy
+        profile_home = tmp_path / "coder"
+        profile_home.mkdir()
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_profile_dir",
+            lambda name: profile_home if name == "coder" else tmp_path / name,
+        )
+
+        handler = GatewayRunner._make_profile_busy_session_handler(runner, "coder")
+        source = SessionSource(
+            platform=Platform.DISCORD,
+            user_id="u1",
+            chat_id="c1",
+            chat_type="dm",
+            profile=None,
+        )
+        event = MessageEvent(
+            text="hi",
+            message_type=MessageType.TEXT,
+            source=source,
+            message_id="1",
+        )
+        assert await handler(event, "sk") is True
+        assert captured["profile"] == "coder"
+        assert source.profile == "coder"
+
+
+class TestStartupResumeAuthScope:
+    def test_resume_skips_owner_authorized_only_by_foreign_allowlist(
+        self, monkeypatch, tmp_path
+    ):
+        """Revoked owner: foreign process allowlist must not resume the session."""
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "revoked-user")
+        runner, adapter = _discord_runner(allow_from=None, profile="profile-b")
+        _bind_empty_profile_home(runner, monkeypatch, tmp_path)
+        ss.set_multiplex_active(True)
+
+        runner._running_agents = {}
+        runner._running_agents_ts = {}
+        runner._background_tasks = set()
+        runner._persist_active_agents = MagicMock()
+        runner._AUTO_RESUME_REASONS = frozenset(
+            {"restart_timeout", "shutdown_timeout", "restart_interrupted"}
+        )
+        runner._is_session_running = lambda _key: False
+        runner._session_state = lambda key: SimpleNamespace(
+            turn=SimpleNamespace(agent=None, started_ts=None)
+        )
+        runner._adapter_for_source = lambda source: adapter
+        adapter.handle_message = AsyncMock()
+
+        entry = SessionEntry(
+            session_key="agent:main:discord:dm:test-dm",
+            session_id="sid",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+            origin=_discord_dm("revoked-user", profile="profile-b"),
+            platform=Platform.DISCORD,
+            chat_type="dm",
+            resume_pending=True,
+            resume_reason="restart_timeout",
+            last_resume_marked_at=datetime.now(),
+        )
+        store = MagicMock()
+        store._lock = MagicMock()
+        store._lock.__enter__ = MagicMock(return_value=None)
+        store._lock.__exit__ = MagicMock(return_value=False)
+        store._ensure_loaded_locked = MagicMock()
+        store._entries = {entry.session_key: entry}
+        runner.session_store = store
+
+        monkeypatch.setattr(
+            "gateway.restart_loop_guard.check_and_record",
+            lambda *_a, **_k: False,
+        )
+        runner._restart_loop_guard_config = lambda: (5, 600)
+
+        from gateway.run import GatewayRunner
+
+        scheduled = GatewayRunner._schedule_resume_pending_sessions(runner)
+        assert scheduled == 0
+        adapter.handle_message.assert_not_called()
+        runner._persist_active_agents.assert_not_called()
+
+    def test_resume_allows_owner_on_profile_scoped_allowlist(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("DISCORD_ALLOWED_USERS", "foreign-only")
+        runner, _adapter = _discord_runner(allow_from=None, profile="profile-b")
+        _bind_empty_profile_home(
+            runner,
+            monkeypatch,
+            tmp_path,
+            env_body="DISCORD_ALLOWED_USERS=owner-user\n",
+        )
+        ss.set_multiplex_active(True)
+
+        source = _discord_dm("owner-user", profile="profile-b")
+        assert runner._is_user_authorized_scoped(source) is True
+        assert runner._is_user_authorized_scoped(
+            _discord_dm("foreign-only", profile="profile-b")
+        ) is False

--- a/tests/gateway/test_qqbot_scope_paths.py
+++ b/tests/gateway/test_qqbot_scope_paths.py
@@ -97,16 +97,6 @@ class TestAuthzAllowAllScope:
         finally:
             ss.reset_secret_scope(tok)
 
-    @pytest.mark.xfail(
-        reason=(
-            "gateway/authz_mixin.py still reads the platform allow-all flag via "
-            "_auth_env, which falls through to os.environ on a scoped miss; the "
-            "scope-authoritative gate (_platform_gate_env semantics) for the "
-            "remaining authz_mixin reads lands in a separate PR. Flips green "
-            "when that PR converts the allow-all read."
-        ),
-        strict=True,
-    )
     def test_scope_does_not_inherit_environ_opt_in(self, monkeypatch):
         # The PRIMARY profile opted in via os.environ; the secondary profile's
         # scope has no opt-in. The secondary must NOT inherit the primary's
@@ -152,6 +142,18 @@ class TestAuthzAllowlistScope:
         # Secondary scope lists only user-9 → user-1 must NOT inherit the
         # primary's environ allowlist.
         tok = ss.set_secret_scope({"QQ_ALLOWED_USERS": "user-9"})
+        try:
+            assert runner._is_user_authorized(_qq_dm_source()) is False
+        finally:
+            ss.reset_secret_scope(tok)
+
+    def test_empty_scope_does_not_inherit_environ_allowlist(self, monkeypatch):
+        # Scoped miss (key absent from secondary .env) must not fall through
+        # to the primary profile's process-global allowlist.
+        monkeypatch.setenv("QQ_ALLOWED_USERS", "user-1")
+        runner = _make_qq_runner()
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
         try:
             assert runner._is_user_authorized(_qq_dm_source()) is False
         finally:


### PR DESCRIPTION
… (#80026)

Route _is_user_authorized allowlist/allow-all reads through _platform_gate_env so a profile-scoped miss does not fall back to process-global os.environ under multiplex. Remove the redundant _auth_env helper and add Discord/QQ regression coverage.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->
Fixes the gateway's second authorization gate under `multiplex_profiles`: a
profile-scoped miss no longer falls through to process-global `os.environ`,
so profile B cannot inherit profile A's bridged allowlist
(`DISCORD_ALLOWED_USERS`, `*_ALLOW_ALL_USERS`, `GATEWAY_*`, etc.).

Approach: route all `_is_user_authorized` allowlist/allow-all reads through
the existing multiplex-authoritative `_platform_gate_env()` and remove the
redundant `_auth_env()` helper (which fell back to `os.getenv` on a scoped
miss). Single-profile deployments keep legacy env behavior.

Related open PR #80238 fixes the same hole by inlining the isolation guard
into `_auth_env`. This PR consolidates onto one reader and adds regression
tests (Discord + QQ). Happy to close in favor of #80238 if maintainers
prefer the smaller call-site-preserving diff — please keep the tests.



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #80026

Also closes residual gateway-gate gap left after #75970 (adapter-level fix
for #72348). Broader transport/provenance work remains in #76166.


## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->
- `gateway/authz_mixin.py`: remove `_auth_env`; use `_platform_gate_env` for
  platform allow-all, platform/group allowlists, `GATEWAY_ALLOWED_USERS`,
  and `GATEWAY_ALLOW_ALL_USERS` in `_is_user_authorized`
- `tests/gateway/test_discord_multiplex_second_auth_gate.py`: new regression
  for #80026 (foreign allowlist / allow-all must not authorize secondary;
  scoped allowlist still works; single-profile env unchanged)
- `tests/gateway/test_qqbot_scope_paths.py`: remove xfail on
  `test_scope_does_not_inherit_environ_opt_in`; add empty-scope allowlist
  non-inheritance case

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Focused regression:
   ```bash
   scripts/run_tests.sh \
     tests/gateway/test_discord_multiplex_second_auth_gate.py \
     tests/gateway/test_qqbot_scope_paths.py \
     tests/gateway/test_multiplex_profile_authz.py \
     tests/gateway/test_config_driven_access_policy.py \
     tests/gateway/test_unauthorized_dm_behavior.py -q
2. Expect all green, including former xfail
TestAuthzAllowAllScope::test_scope_does_not_inherit_environ_opt_in.
3. Manual multiplex (optional): two Discord/QQ profiles with distinct
allowlists — profile A's user must be denied on profile B; profile B's
configured user must still authorize.
Observed locally (Windows, Python 3.11): 56 passed on the focused set above.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

