### PR TITLE
feat(tui): guard idle exits and support Ctrl+D delete-char

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1388,6 +1388,11 @@ DEFAULT_CONFIG = {
         # Mirrors `hermes -c` muscle memory.  Default off so existing
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
+        # Require a second idle-exit hotkey press within two seconds before the
+        # TUI follows its existing exit handling. Busy Ctrl+C still interrupts
+        # immediately, and Ctrl+C with a draft still clears it immediately. Opt
+        # in with true; omitted or false preserves the legacy single-press behavior.
+        "tui_confirm_idle_exit": False,
         # When true (default), `hermes --tui` drops a one-time hint
         # ("subagents working · /agents to watch live") the first time a turn
         # starts delegating, nudging the user toward the live spawn-tree

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1102,6 +1102,11 @@ DEFAULT_CONFIG = {
         # Mirrors `hermes -c` muscle memory.  Default off so existing
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
+        # Require a second idle-exit hotkey press within two seconds before the
+        # TUI follows its existing exit handling. Busy Ctrl+C still interrupts
+        # immediately, and Ctrl+C with a draft still clears it immediately. Opt
+        # in with true; omitted or false preserves the legacy single-press behavior.
+        "tui_confirm_idle_exit": False,
         # When true (default), `hermes --tui` drops a one-time hint
         # ("subagents working · /agents to watch live") the first time a turn
         # starts delegating, nudging the user toward the live spawn-tree

--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -133,7 +133,7 @@ Current input behavior is split across `app.tsx`, `components/textInput.tsx`, an
 | `Shift+Enter` / `Alt+Enter`     | Insert a newline in the current draft                                                                                                                   |
 | `\` + `Enter`                   | Append the line to the multiline buffer (fallback for terminals without modifier support)                                                               |
 | `Ctrl+C`                        | Interrupt active run, or clear the current draft, or exit if nothing is pending                                                                         |
-| `Ctrl+D`                        | Exit                                                                                                                                                    |
+| `Ctrl+D`                        | Delete the character under the cursor; an empty draft falls through to the existing idle-exit handling                                                  |
 | `Cmd/Ctrl+G` / `Alt+G`          | Open `$EDITOR` with the current draft (use `Alt+G` in VSCode/Cursor — they bind the primary keystroke to Find Next)                                     |
 | `Ctrl+L`                        | New session (same as `/clear`)                                                                                                                          |
 | `Ctrl+V` / `Alt+V`              | Paste text first, then fall back to image/path attachment when applicable                                                                               |

--- a/ui-tui/src/__tests__/textInputCtrlD.test.ts
+++ b/ui-tui/src/__tests__/textInputCtrlD.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyCtrlDDelete } from '../components/textInput.js'
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ ctrl: false, meta: false, ...overrides }) as any
+
+const ctrl = key({ ctrl: true })
+
+describe('applyCtrlDDelete', () => {
+  it('deletes one grapheme under the cursor', () => {
+    expect(applyCtrlDDelete('d', ctrl, { cursor: 1, selection: null, value: 'a🙂b' })).toEqual({
+      cursor: 1,
+      value: 'ab'
+    })
+  })
+
+  it('deletes the active selection', () => {
+    expect(applyCtrlDDelete('d', ctrl, { cursor: 3, selection: { end: 3, start: 1 }, value: 'abcd' })).toEqual({
+      cursor: 1,
+      value: 'ad'
+    })
+  })
+
+  it('consumes Ctrl+D at end of input without inserting a literal d', () => {
+    expect(applyCtrlDDelete('d', ctrl, { cursor: 3, selection: null, value: 'abc' })).toEqual({
+      cursor: 3,
+      value: 'abc'
+    })
+  })
+
+  it('leaves empty input for the existing global hotkey handling', () => {
+    expect(applyCtrlDDelete('d', ctrl, { cursor: 0, selection: null, value: '' })).toBeNull()
+  })
+
+  it('accepts only bare Ctrl+D', () => {
+    const state = { cursor: 0, selection: null, value: 'abc' }
+
+    expect(applyCtrlDDelete('D', ctrl, state)).toEqual({ cursor: 0, value: 'bc' })
+    expect(applyCtrlDDelete('d', key({ ctrl: true, shift: true }), state)).toBeNull()
+    expect(applyCtrlDDelete('d', key({ ctrl: true, alt: true }), state)).toBeNull()
+    expect(applyCtrlDDelete('d', key({ ctrl: true, super: true }), state)).toBeNull()
+    expect(applyCtrlDDelete('x', ctrl, state)).toBeNull()
+  })
+})

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldPassThroughToGlobalHandler, shouldPreserveCtrlJNewline } from '../components/textInput.js'
+import {
+  isIdleExitHotkey,
+  shouldPassThroughToGlobalHandler,
+  shouldPreserveCtrlJNewline
+} from '../components/textInput.js'
 import { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } from '../lib/platform.js'
 
 const key = (overrides: Record<string, unknown> = {}) => ({ ctrl: false, meta: false, ...overrides }) as any
@@ -45,9 +49,20 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('c', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('x', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('o', key({ ctrl: true }))).toBe(true)
+    expect(shouldPassThroughToGlobalHandler('d', key({ ctrl: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ escape: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
+  })
+})
+
+describe('isIdleExitHotkey', () => {
+  it('recognizes Ctrl+D as an idle exit hotkey', () => {
+    expect(isIdleExitHotkey('d', key({ ctrl: true }))).toBe(true)
+  })
+
+  it('does not treat plain d as an idle exit hotkey', () => {
+    expect(isIdleExitHotkey('d', key())).toBe(false)
   })
 })

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -30,6 +30,7 @@ describe('applyDisplay', () => {
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
+            tui_confirm_idle_exit: true,
             tui_statusbar: false
           }
         }
@@ -40,6 +41,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(true)
     expect(s.compact).toBe(true)
+    expect(s.confirmIdleExit).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
     expect(s.showReasoning).toBe(true)
@@ -112,6 +114,7 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.confirmIdleExit).toBe(false)
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -30,6 +30,7 @@ describe('applyDisplay', () => {
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
+            tui_confirm_idle_exit: true,
             tui_statusbar: false
           }
         }
@@ -40,6 +41,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(true)
     expect(s.compact).toBe(true)
+    expect(s.confirmIdleExit).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
     expect(s.showReasoning).toBe(true)
@@ -64,6 +66,7 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.confirmIdleExit).toBe(false)
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  idleHotkeyExitConfirmation,
   resolveCtrlCComposerAction,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
@@ -92,6 +93,47 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.sys).not.toHaveBeenCalled()
   })
 
+  it('requires a second confirmed idle exit hotkey press in normal terminals', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 0 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 1000,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(1000)
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 2500,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms confirmed idle exit hotkeys after the confirmation window expires', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 1000 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 4001,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(4001)
+  })
+
   it('asks the dashboard for a fresh chat instead of leaving a ghost session', () => {
     const actions = { die: vi.fn(), sys: vi.fn() }
     const requestDashboardNewSession = vi.fn()
@@ -101,6 +143,18 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.die).not.toHaveBeenCalled()
     expect(requestDashboardNewSession).toHaveBeenCalledTimes(1)
     expect(actions.sys).toHaveBeenCalledWith('starting a fresh dashboard chat...')
+  })
+})
+
+describe('idleHotkeyExitConfirmation', () => {
+  it.each(['Ctrl+C', 'Ctrl+D'])('requires confirmation for idle %s by default', hotkeyLabel => {
+    const lastPressedAt = { current: 0 }
+
+    expect(idleHotkeyExitConfirmation(true, hotkeyLabel, lastPressedAt)).toEqual({ hotkeyLabel, lastPressedAt })
+  })
+
+  it('disables confirmation when display.tui_confirm_idle_exit is false', () => {
+    expect(idleHotkeyExitConfirmation(false, 'Ctrl+C', { current: 0 })).toBeUndefined()
   })
 })
 

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -5,6 +5,7 @@ import {
   applyVoiceRecordResponse,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
+  idleHotkeyExitConfirmation,
   shouldAllowIdleHotkeyExit,
   shouldFallThroughForScroll
 } from '../app/useInputHandlers.js'
@@ -69,6 +70,47 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.sys).not.toHaveBeenCalled()
   })
 
+  it('requires a second confirmed idle exit hotkey press in normal terminals', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 0 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 1000,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(1000)
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 2500,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms confirmed idle exit hotkeys after the confirmation window expires', () => {
+    const actions = { die: vi.fn(), sys: vi.fn() }
+    const lastPressedAt = { current: 1000 }
+
+    handleIdleHotkeyExit(actions, false, undefined, {
+      hotkeyLabel: 'Ctrl+D',
+      lastPressedAt,
+      now: () => 4001,
+      timeoutMs: 2000
+    })
+
+    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.sys).toHaveBeenCalledWith('press Ctrl+D again to exit')
+    expect(lastPressedAt.current).toBe(4001)
+  })
+
   it('asks the dashboard for a fresh chat instead of leaving a ghost session', () => {
     const actions = { die: vi.fn(), sys: vi.fn() }
     const requestDashboardNewSession = vi.fn()
@@ -78,6 +120,18 @@ describe('handleIdleHotkeyExit', () => {
     expect(actions.die).not.toHaveBeenCalled()
     expect(requestDashboardNewSession).toHaveBeenCalledTimes(1)
     expect(actions.sys).toHaveBeenCalledWith('starting a fresh dashboard chat...')
+  })
+})
+
+describe('idleHotkeyExitConfirmation', () => {
+  it.each(['Ctrl+C', 'Ctrl+D'])('requires confirmation for idle %s by default', hotkeyLabel => {
+    const lastPressedAt = { current: 0 }
+
+    expect(idleHotkeyExitConfirmation(true, hotkeyLabel, lastPressedAt)).toEqual({ hotkeyLabel, lastPressedAt })
+  })
+
+  it('disables confirmation when display.tui_confirm_idle_exit is false', () => {
+    expect(idleHotkeyExitConfirmation(false, 'Ctrl+C', { current: 0 })).toBeUndefined()
   })
 })
 

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -323,6 +323,7 @@ export interface UiState {
   busyInputMode: BusyInputMode
   compact: boolean
   destructiveSlashConfirm: boolean
+  confirmIdleExit: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  confirmIdleExit: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -15,6 +15,7 @@ const buildUiState = (): UiState => ({
   busyInputMode: 'queue',
   compact: false,
   destructiveSlashConfirm: true,
+  confirmIdleExit: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  confirmIdleExit: false,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -278,6 +278,7 @@ export const applyDisplay = (
     // config RPC failure (cfg=null) preserves the last known policy instead
     // of silently changing approval behavior until the next successful poll.
     ...(cfg ? { destructiveSlashConfirm: approvals?.destructive_slash_confirm !== false } : {}),
+    confirmIdleExit: d.tui_confirm_idle_exit === true,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -273,6 +273,7 @@ export const applyDisplay = (
     battery: !!d.battery,
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    confirmIdleExit: d.tui_confirm_idle_exit === true,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -32,6 +32,20 @@ import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
+const IDLE_EXIT_CONFIRM_MS = 2000
+
+interface IdleHotkeyExitConfirmation {
+  hotkeyLabel?: string
+  lastPressedAt: { current: number }
+  now?: () => number
+  timeoutMs?: number
+}
+
+export const idleHotkeyExitConfirmation = (
+  enabled: boolean,
+  hotkeyLabel: string,
+  lastPressedAt: { current: number }
+): IdleHotkeyExitConfirmation | undefined => (enabled ? { hotkeyLabel, lastPressedAt } : undefined)
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
@@ -51,12 +65,24 @@ export function handleInputSelectionClipboard(
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
-  requestDashboardNewSession?: () => void
+  requestDashboardNewSession?: () => void,
+  confirmation?: IdleHotkeyExitConfirmation
 ) {
   if (!shouldAllowIdleHotkeyExit(dashboardTuiMode)) {
     requestDashboardNewSession?.()
 
     return actions.sys(DASHBOARD_NEW_SESSION_MESSAGE)
+  }
+
+  if (confirmation) {
+    const now = confirmation.now?.() ?? Date.now()
+    const timeoutMs = confirmation.timeoutMs ?? IDLE_EXIT_CONFIRM_MS
+
+    if (!confirmation.lastPressedAt.current || now - confirmation.lastPressedAt.current > timeoutMs) {
+      confirmation.lastPressedAt.current = now
+
+      return actions.sys(`press ${confirmation.hotkeyLabel ?? 'the exit hotkey'} again to exit`)
+    }
   }
 
   return actions.die()
@@ -175,6 +201,8 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const isBlocked = useStore($isBlocked)
   const pagerPageSize = Math.max(5, (terminal.stdout?.rows ?? 24) - 6)
   const scrollIdleTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const idleCtrlCConfirmAtRef = useRef(0)
+  const idleCtrlDConfirmAtRef = useRef(0)
 
   // Wheel accel ported from claude-code: inter-event timing drives step size,
   // direction flips reset. wheelStep (WHEEL_SCROLL_STEP) is the base; final
@@ -651,23 +679,37 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         })
       }
 
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      return handleIdleHotkeyExit(
+        actions,
+        DASHBOARD_TUI_MODE,
+        () => {
+          gateway.gw.publishLocalEvent({
+            payload: { reason: 'idle_exit_hotkey' },
+            session_id: live.sid ?? undefined,
+            type: 'dashboard.new_session_requested'
+          })
+        },
+        idleHotkeyExitConfirmation(live.confirmIdleExit, 'Ctrl+C', idleCtrlCConfirmAtRef)
+      )
     }
 
     if (isAction(key, ch, 'd')) {
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      if (cState.input || cState.inputBuf.length) {
+        return
+      }
+
+      return handleIdleHotkeyExit(
+        actions,
+        DASHBOARD_TUI_MODE,
+        () => {
+          gateway.gw.publishLocalEvent({
+            payload: { reason: 'idle_exit_hotkey' },
+            session_id: live.sid ?? undefined,
+            type: 'dashboard.new_session_requested'
+          })
+        },
+        idleHotkeyExitConfirmation(live.confirmIdleExit, isMac ? 'Cmd+D' : 'Ctrl+D', idleCtrlDConfirmAtRef)
+      )
     }
 
     if (isAction(key, ch, 'l')) {

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -32,18 +32,44 @@ import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
+const IDLE_EXIT_CONFIRM_MS = 2000
+
+interface IdleHotkeyExitConfirmation {
+  hotkeyLabel?: string
+  lastPressedAt: { current: number }
+  now?: () => number
+  timeoutMs?: number
+}
+
+export const idleHotkeyExitConfirmation = (
+  enabled: boolean,
+  hotkeyLabel: string,
+  lastPressedAt: { current: number }
+): IdleHotkeyExitConfirmation | undefined => (enabled ? { hotkeyLabel, lastPressedAt } : undefined)
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
 export function handleIdleHotkeyExit(
   actions: Pick<InputHandlerActions, 'die' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
-  requestDashboardNewSession?: () => void
+  requestDashboardNewSession?: () => void,
+  confirmation?: IdleHotkeyExitConfirmation
 ) {
   if (!shouldAllowIdleHotkeyExit(dashboardTuiMode)) {
     requestDashboardNewSession?.()
 
     return actions.sys(DASHBOARD_NEW_SESSION_MESSAGE)
+  }
+
+  if (confirmation) {
+    const now = confirmation.now?.() ?? Date.now()
+    const timeoutMs = confirmation.timeoutMs ?? IDLE_EXIT_CONFIRM_MS
+
+    if (!confirmation.lastPressedAt.current || now - confirmation.lastPressedAt.current > timeoutMs) {
+      confirmation.lastPressedAt.current = now
+
+      return actions.sys(`press ${confirmation.hotkeyLabel ?? 'the exit hotkey'} again to exit`)
+    }
   }
 
   return actions.die()
@@ -139,6 +165,8 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
   const isBlocked = useStore($isBlocked)
   const pagerPageSize = Math.max(5, (terminal.stdout?.rows ?? 24) - 6)
   const scrollIdleTimer = useRef<null | ReturnType<typeof setTimeout>>(null)
+  const idleCtrlCConfirmAtRef = useRef(0)
+  const idleCtrlDConfirmAtRef = useRef(0)
 
   // Wheel accel ported from claude-code: inter-event timing drives step size,
   // direction flips reset. wheelStep (WHEEL_SCROLL_STEP) is the base; final
@@ -608,23 +636,37 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         return cActions.clearIn()
       }
 
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      return handleIdleHotkeyExit(
+        actions,
+        DASHBOARD_TUI_MODE,
+        () => {
+          gateway.gw.publishLocalEvent({
+            payload: { reason: 'idle_exit_hotkey' },
+            session_id: live.sid ?? undefined,
+            type: 'dashboard.new_session_requested'
+          })
+        },
+        idleHotkeyExitConfirmation(live.confirmIdleExit, 'Ctrl+C', idleCtrlCConfirmAtRef)
+      )
     }
 
     if (isAction(key, ch, 'd')) {
-      return handleIdleHotkeyExit(actions, DASHBOARD_TUI_MODE, () => {
-        gateway.gw.publishLocalEvent({
-          payload: { reason: 'idle_exit_hotkey' },
-          session_id: live.sid ?? undefined,
-          type: 'dashboard.new_session_requested'
-        })
-      })
+      if (cState.input || cState.inputBuf.length) {
+        return
+      }
+
+      return handleIdleHotkeyExit(
+        actions,
+        DASHBOARD_TUI_MODE,
+        () => {
+          gateway.gw.publishLocalEvent({
+            payload: { reason: 'idle_exit_hotkey' },
+            session_id: live.sid ?? undefined,
+            type: 'dashboard.new_session_requested'
+          })
+        },
+        idleHotkeyExitConfirmation(live.confirmIdleExit, isMac ? 'Cmd+D' : 'Ctrl+D', idleCtrlDConfirmAtRef)
+      )
     }
 
     if (isAction(key, ch, 'l')) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -331,6 +331,52 @@ function nextPos(s: string, p: number) {
   return s.length
 }
 
+interface CtrlDDeleteState {
+  cursor: number
+  selection: { end: number; start: number } | null
+  value: string
+}
+
+/**
+ * Readline-style bare Ctrl+D: delete the selection or the grapheme under the
+ * cursor. Empty input returns null so the existing global hotkey handling keeps
+ * ownership; an end-of-input no-op is returned as handled so a literal `d`
+ * cannot fall through to insertion.
+ */
+export function applyCtrlDDelete(
+  input: string,
+  key: Pick<Key, 'alt' | 'ctrl' | 'meta' | 'shift' | 'super'>,
+  { cursor, selection, value }: CtrlDDeleteState
+): TextInsertResult | null {
+  const bareCtrlD =
+    input.toLowerCase() === 'd' &&
+    key.ctrl &&
+    !key.alt &&
+    !key.meta &&
+    key.super !== true &&
+    !key.shift
+
+  if (!bareCtrlD || value.length === 0) {
+    return null
+  }
+
+  if (selection) {
+    return {
+      cursor: selection.start,
+      value: value.slice(0, selection.start) + value.slice(selection.end)
+    }
+  }
+
+  if (cursor >= value.length) {
+    return { cursor, value }
+  }
+
+  return {
+    cursor,
+    value: value.slice(0, cursor) + value.slice(nextPos(value, cursor))
+  }
+}
+
 function wordLeft(s: string, p: number) {
   let i = snapPos(s, p) - 1
 
@@ -1350,6 +1396,25 @@ export function TextInput({
       // actually get voice toggled instead of a paste (Copilot round-7
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
+      const ctrlDDelete = isVoiceToggleKey(k, inp, voiceRecordKey)
+        ? null
+        : applyCtrlDDelete(inp, k, {
+            cursor: curRef.current,
+            selection: selRange(),
+            value: vRef.current
+          })
+
+      if (ctrlDDelete) {
+        flushKeyBurst()
+        event.stopImmediatePropagation()
+
+        if (ctrlDDelete.value !== vRef.current || ctrlDDelete.cursor !== curRef.current) {
+          commit(ctrlDDelete.value, ctrlDDelete.cursor)
+        }
+
+        return
+      }
+
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
         flushKeyBurst()
 
@@ -1831,12 +1896,16 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') ||
+  isIdleExitHotkey(input, key) ||
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||
   key.pageDown ||
   key.escape ||
   isVoiceToggleKey(key, input, voiceRecordKey)
+
+export const isIdleExitHotkey = (input: string, key: Key): boolean =>
+  input.toLowerCase() === 'd' && ((key.ctrl && !key.meta && key.super !== true) || isActionMod(key))
 
 export interface TextInputMouseApi {
   dragAt: (row: number, col: number) => void

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -208,6 +208,52 @@ function nextPos(s: string, p: number) {
   return s.length
 }
 
+interface CtrlDDeleteState {
+  cursor: number
+  selection: { end: number; start: number } | null
+  value: string
+}
+
+/**
+ * Readline-style bare Ctrl+D: delete the selection or the grapheme under the
+ * cursor. Empty input returns null so the existing global hotkey handling keeps
+ * ownership; an end-of-input no-op is returned as handled so a literal `d`
+ * cannot fall through to insertion.
+ */
+export function applyCtrlDDelete(
+  input: string,
+  key: Pick<Key, 'alt' | 'ctrl' | 'meta' | 'shift' | 'super'>,
+  { cursor, selection, value }: CtrlDDeleteState
+): TextInsertResult | null {
+  const bareCtrlD =
+    input.toLowerCase() === 'd' &&
+    key.ctrl &&
+    !key.alt &&
+    !key.meta &&
+    key.super !== true &&
+    !key.shift
+
+  if (!bareCtrlD || value.length === 0) {
+    return null
+  }
+
+  if (selection) {
+    return {
+      cursor: selection.start,
+      value: value.slice(0, selection.start) + value.slice(selection.end)
+    }
+  }
+
+  if (cursor >= value.length) {
+    return { cursor, value }
+  }
+
+  return {
+    cursor,
+    value: value.slice(0, cursor) + value.slice(nextPos(value, cursor))
+  }
+}
+
 function wordLeft(s: string, p: number) {
   let i = snapPos(s, p) - 1
 
@@ -1100,6 +1146,25 @@ export function TextInput({
       // actually get voice toggled instead of a paste (Copilot round-7
       // follow-up on #19835). The pass-through predicate is a no-op for
       // ordinary typing and plain paste when voice is unbound to 'v'.
+      const ctrlDDelete = isVoiceToggleKey(k, inp, voiceRecordKey)
+        ? null
+        : applyCtrlDDelete(inp, k, {
+            cursor: curRef.current,
+            selection: selRange(),
+            value: vRef.current
+          })
+
+      if (ctrlDDelete) {
+        flushKeyBurst()
+        event.stopImmediatePropagation()
+
+        if (ctrlDDelete.value !== vRef.current || ctrlDDelete.cursor !== curRef.current) {
+          commit(ctrlDDelete.value, ctrlDDelete.cursor)
+        }
+
+        return
+      }
+
       if (shouldPassThroughToGlobalHandler(inp, k, voiceRecordKey)) {
         flushKeyBurst()
 
@@ -1541,12 +1606,16 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') ||
+  isIdleExitHotkey(input, key) ||
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||
   key.pageDown ||
   key.escape ||
   isVoiceToggleKey(key, input, voiceRecordKey)
+
+export const isIdleExitHotkey = (input: string, key: Key): boolean =>
+  input.toLowerCase() === 'd' && ((key.ctrl && !key.meta && key.super !== true) || isActionMod(key))
 
 export interface TextInputMouseApi {
   dragAt: (row: number, col: number) => void

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -101,6 +101,7 @@ export interface ConfigDisplayConfig {
   tui_agents_nudge?: boolean
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
+  tui_confirm_idle_exit?: boolean
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -98,6 +98,7 @@ export interface ConfigDisplayConfig {
   tui_agents_nudge?: boolean
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
+  tui_confirm_idle_exit?: boolean
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -29,6 +29,7 @@ declare module '@hermes/ink' {
     readonly input: string
     readonly key: Key
     readonly keypress: { readonly isPasted?: boolean; readonly raw?: string }
+    readonly stopImmediatePropagation: () => void
   }
 
   export type InputHandler = (input: string, key: Key, event: InputEvent) => void

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -173,7 +173,7 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 | `Ctrl+X Ctrl+E` | Emacs-style alternate binding for the external editor (same behavior as `Ctrl+G`). |
 | `Ctrl+S` | **Stash the prompt.** Parks the current draft and clears the composer so you can send something else first. Press `Ctrl+S` again on an empty composer to bring the draft back (cursor at the end, attached images restored). Repeated presses build a stack rather than overwriting, so an earlier draft is never silently lost — with two or more stashed, `Ctrl+S` opens a browse panel (`↑`/`↓` to navigate, `Enter` to restore, `D` to discard, `Esc` or `Ctrl+S` to close). A `📌 N` badge in the status bar shows how many drafts are parked. Multi-line drafts round-trip exactly, including blank lines. The stash lives in memory for the session only — nothing is written to disk, since drafts often contain secrets. |
 | `Ctrl+C` | Interrupt agent (double-press within 2s to force exit) |
-| `Ctrl+D` | Exit |
+| `Ctrl+D` | Delete the character under the cursor; an empty buffer falls through to the existing idle-exit handling |
 | `Ctrl+Z` | Suspend Hermes to background (Unix only). Run `fg` in the shell to resume. |
 | `Tab` | Accept auto-suggestion (ghost text) or autocomplete slash commands |
 | `!<command>` | **Shell mode** — run a shell command yourself without spending a model turn (e.g. `!git status`, `!pytest -x`). See below. |
@@ -345,6 +345,14 @@ While the agent is working, you can send a correction without starting a new tur
 - **`Ctrl+C`** — interrupt the current operation (press twice within 2s to force exit)
 - Completed tool work and reasoning already shown stay in context
 - A running tool reaches its safe boundary before the correction is applied
+
+By default, the TUI's existing idle-exit hotkeys retain their legacy
+single-press behavior. To require a second press within two seconds:
+
+```yaml
+display:
+  tui_confirm_idle_exit: true
+```
 
 ### Busy Input Mode
 

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -109,7 +109,7 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 | `Ctrl+X Ctrl+E` | Emacs-style alternate binding for the external editor (same behavior as `Ctrl+G`). |
 | `Ctrl+S` | **Stash the prompt.** Parks the current draft and clears the composer so you can send something else first. Press `Ctrl+S` again on an empty composer to bring the draft back (cursor at the end, attached images restored). Repeated presses build a stack rather than overwriting, so an earlier draft is never silently lost — with two or more stashed, `Ctrl+S` opens a browse panel (`↑`/`↓` to navigate, `Enter` to restore, `D` to discard, `Esc` or `Ctrl+S` to close). A `📌 N` badge in the status bar shows how many drafts are parked. Multi-line drafts round-trip exactly, including blank lines. The stash lives in memory for the session only — nothing is written to disk, since drafts often contain secrets. |
 | `Ctrl+C` | Interrupt agent (double-press within 2s to force exit) |
-| `Ctrl+D` | Exit |
+| `Ctrl+D` | Delete the character under the cursor; an empty buffer falls through to the existing idle-exit handling |
 | `Ctrl+Z` | Suspend Hermes to background (Unix only). Run `fg` in the shell to resume. |
 | `Tab` | Accept auto-suggestion (ghost text) or autocomplete slash commands |
 | `!<command>` | **Shell mode** — run a shell command yourself without spending a model turn (e.g. `!git status`, `!pytest -x`). See below. |
@@ -273,6 +273,14 @@ While the agent is working, you can send a correction without starting a new tur
 - **`Ctrl+C`** — interrupt the current operation (press twice within 2s to force exit)
 - Completed tool work and reasoning already shown stay in context
 - A running tool reaches its safe boundary before the correction is applied
+
+By default, the TUI's existing idle-exit hotkeys retain their legacy
+single-press behavior. To require a second press within two seconds:
+
+```yaml
+display:
+  tui_confirm_idle_exit: true
+```
 
 ### Busy Input Mode
 


### PR DESCRIPTION
## Summary

- add an opt-in `display.tui_confirm_idle_exit` setting that requires a second idle Ctrl+C/Ctrl+D press within two seconds before the standalone TUI exits
- preserve immediate busy-turn interrupts, draft clearing, dashboard new-session behavior, and the legacy single-press default
- give the focused composer readline-style Ctrl+D behavior: delete the selection or grapheme under the cursor, consume end-of-input as a no-op, and leave an empty buffer to idle-exit handling
- document the new setting and Ctrl+D behavior

This adapts the Ctrl+D portion of #21684 by Harish Kukreja (@counterposition), narrowed to composer deletion and integrated with the idle-exit confirmation option. It also addresses the accidental-exit UX discussed in #8478.

## Verification

- `npm test -- src/__tests__/textInputCtrlD.test.ts src/__tests__/textInputPassThrough.test.ts src/__tests__/useConfigSync.test.ts src/__tests__/useInputHandlers.test.ts` — 73 passed
- `npm run typecheck` — passed
- `npm run lint` — passed with one pre-existing warning in `src/app/useSessionLifecycle.ts`
- `git diff --check upstream/main...HEAD` — passed

`npm run check` reaches the full Vitest suite but currently reports 21 unrelated failures in `subscriptionOverlay.test.tsx`, `appChromeBlockedTimers.test.tsx`, and `ink-backpressure.test.ts`. Running those same three files on a detached `upstream/main` reproduces the same 21 failures.