### PR TITLE
fix(agent): stop verify loop on committed paths

### DIFF
--- a/agent/verification_stop.py
+++ b/agent/verification_stop.py
@@ -8,6 +8,7 @@ finish immediately after editing code without fresh evidence.
 from __future__ import annotations
 
 import os
+import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Iterable
@@ -70,6 +71,49 @@ def _is_non_code_path(raw: str) -> bool:
 def _filter_verifiable_paths(paths: Iterable[str]) -> list[str]:
     """Drop documentation/prose paths; keep paths that could have verifiable behavior."""
     return [p for p in paths if p and not _is_non_code_path(p)]
+
+
+def _git_dirty_path(path: str) -> bool:
+    """Return whether ``path`` has uncommitted Git state.
+
+    Verify-on-stop receives the turn's mutation set, which can outlive a later
+    commit in the same session. In Git workspaces, committed clean paths should
+    not keep the stale-verification loop alive. If Git cannot classify the path,
+    keep the conservative old behavior and treat it as dirty.
+    """
+    try:
+        raw_path = Path(path).expanduser()
+        probe_dir = raw_path if raw_path.is_dir() else raw_path.parent
+        if not probe_dir:
+            return True
+        root = subprocess.run(
+            ["git", "-C", str(probe_dir), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if root.returncode != 0:
+            return True
+        repo_root = Path(root.stdout.strip())
+        target = raw_path if raw_path.is_absolute() else probe_dir / raw_path
+        rel = os.path.relpath(str(target), str(repo_root))
+        status = subprocess.run(
+            ["git", "-C", str(repo_root), "status", "--porcelain=v1", "--", rel],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if status.returncode != 0:
+            return True
+        return bool(status.stdout.strip())
+    except Exception:
+        return True
+
+
+def _filter_uncommitted_paths(paths: Iterable[str]) -> list[str]:
+    return [path for path in paths if _git_dirty_path(path)]
 
 
 def _session_is_messaging_surface() -> bool:
@@ -213,7 +257,10 @@ def build_verify_on_stop_nudge(
     # Drop documentation/prose paths (markdown, skills, README, LICENSE, ...) —
     # they carry no verifiable behavior, so a turn that touched only those has
     # nothing to verify and must not nudge.
-    paths = sorted({str(p) for p in _filter_verifiable_paths(changed_paths)})
+    paths = sorted({
+        str(p)
+        for p in _filter_uncommitted_paths(_filter_verifiable_paths(changed_paths))
+    })
     if not paths or attempts >= max_attempts:
         return None
 

--- a/tests/agent/test_verification_stop.py
+++ b/tests/agent/test_verification_stop.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -25,6 +26,32 @@ def _node_project(root: Path) -> None:
 def _make_project(root: Path) -> None:
     root.mkdir()
     _node_project(root)
+
+
+def _init_git_project(root: Path) -> None:
+    subprocess.run(["git", "init"], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
+
+
+def _commit_all(root: Path, message: str) -> None:
+    subprocess.run(["git", "add", "."], cwd=root, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "commit", "-m", message],
+        cwd=root,
+        check=True,
+        capture_output=True,
+    )
 
 
 @pytest.fixture
@@ -199,6 +226,61 @@ def test_nudge_attempts_are_bounded(tmp_path, monkeypatch):
         attempts=2,
         max_attempts=2,
     ) is None
+
+
+def test_committed_paths_do_not_keep_stale_verification_loop_alive(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    project = tmp_path / "project"
+    _make_project(project)
+    src = project / "src"
+    src.mkdir()
+    changed = src / "app.ts"
+    changed.write_text("export const value = 1;\n", encoding="utf-8")
+
+    _init_git_project(project)
+    _commit_all(project, "initial")
+
+    record_terminal_result(
+        command="pnpm test",
+        cwd=project,
+        session_id="s1",
+        exit_code=0,
+        output="old green output",
+    )
+    changed.write_text("export const value = 2;\n", encoding="utf-8")
+    mark_workspace_edited(session_id="s1", cwd=project, paths=[str(changed)])
+    _commit_all(project, "change value")
+
+    assert build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[str(changed)],
+    ) is None
+
+
+def test_uncommitted_paths_still_require_fresh_verification(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    project = tmp_path / "project"
+    _make_project(project)
+    src = project / "src"
+    src.mkdir()
+    changed = src / "app.ts"
+    changed.write_text("export const value = 1;\n", encoding="utf-8")
+
+    _init_git_project(project)
+    _commit_all(project, "initial")
+
+    changed.write_text("export const value = 2;\n", encoding="utf-8")
+    mark_workspace_edited(session_id="s1", cwd=project, paths=[str(changed)])
+
+    nudge = build_verify_on_stop_nudge(
+        session_id="s1",
+        changed_paths=[str(changed)],
+    )
+
+    assert nudge is not None
+    assert str(changed) in nudge
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #80274

Verify-on-stop could keep nudging the agent even after the edited files had already been committed.

The turn-level mutation set can outlive a later commit in the same session. When that happened, the verification guard still treated those old paths as active unverified edits, so it could keep asking for fresh verification even though git status was clean.

This patch filters verify-on-stop paths through Git status before building the nudge:

- clean committed paths no longer keep the stale-verification loop alive
- dirty, staged, and untracked paths still require fresh verification
- non-Git paths, or paths Git cannot classify, keep the previous conservative behavior

Regression coverage includes both sides of the contract: committed clean paths stop the loop, while uncommitted edits still trigger verification.

Validation:

uv run --extra dev pytest tests/agent/test_verification_stop.py tests/agent/test_verification_evidence.py tests/run_agent/test_verification_continuation_budget.py -q

Result: 28 passed

uv run ruff