### PR TITLE
feat(tui): add cross-platform configurable copy on select

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1388,6 +1388,11 @@ DEFAULT_CONFIG = {
         # Mirrors `hermes -c` muscle memory.  Default off so existing
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
+        # Copy a stable TUI mouse selection as soon as the drag ends while
+        # keeping the highlight visible. None preserves the platform default
+        # (enabled on macOS for Terminal.app compatibility, disabled elsewhere);
+        # true/false explicitly override it on every platform.
+        "tui_copy_on_select": None,
         # When true (default), `hermes --tui` drops a one-time hint
         # ("subagents working · /agents to watch live") the first time a turn
         # starts delegating, nudging the user toward the live spawn-tree

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1102,6 +1102,11 @@ DEFAULT_CONFIG = {
         # Mirrors `hermes -c` muscle memory.  Default off so existing
         # users aren't surprised.  HERMES_TUI_RESUME=<id> always wins.
         "tui_auto_resume_recent": False,
+        # Copy a stable TUI mouse selection as soon as the drag ends while
+        # keeping the highlight visible. None preserves the platform default
+        # (enabled on macOS for Terminal.app compatibility, disabled elsewhere);
+        # true/false explicitly override it on every platform.
+        "tui_copy_on_select": None,
         # When true (default), `hermes --tui` drops a one-time hint
         # ("subagents working · /agents to watch live") the first time a turn
         # starts delegating, nudging the user toward the live spawn-tree

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1635,6 +1635,46 @@ def test_config_set_battery_explicit_off(monkeypatch):
     assert writes == {"display.battery": False}
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("on", True), ("off", False), ("auto", None)],
+)
+def test_config_set_copy_on_select_persists_tri_state(monkeypatch, value, expected):
+    writes: dict[str, object] = {}
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "copy-on-select",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": value},
+        }
+    )
+
+    assert resp is not None
+    assert resp["result"] == {"key": "copy-on-select", "value": value}
+    assert writes == {"display.tui_copy_on_select": expected}
+
+
+def test_config_set_copy_on_select_rejects_unknown_mode(monkeypatch):
+    write = Mock()
+    monkeypatch.setattr(server, "_write_config_key", write)
+
+    resp = server.dispatch(
+        {
+            "id": "copy-on-select",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": "maybe"},
+        }
+    )
+
+    assert resp is not None
+    assert resp["error"]["code"] == 4002
+    write.assert_not_called()
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -8409,6 +8449,27 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
+def test_config_set_copy_on_select_auto_persists_null(tmp_path, monkeypatch):
+    import yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"display": {"tui_copy_on_select": True}}))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": "auto"},
+        }
+    )
+
+    assert resp is not None
+    assert resp["result"] == {"key": "copy-on-select", "value": "auto"}
+    saved = yaml.safe_load(cfg_path.read_text())
+    assert saved["display"]["tui_copy_on_select"] is None
+
+
 def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
     import yaml
 
@@ -8757,6 +8818,17 @@ def test_complete_slash_includes_tui_mouse_command():
     )
 
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
+
+
+def test_complete_slash_includes_tui_copy_on_select_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/copy-on"}}
+    )
+
+    assert resp is not None
+    assert any(
+        item["text"] == "/copy-on-select" for item in resp["result"]["items"]
+    )
 
 
 def test_complete_slash_details_args():
@@ -10654,7 +10726,7 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
     )
 
 
-def test_commands_catalog_includes_tui_mouse_command():
+def test_commands_catalog_includes_tui_local_commands():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}
     )
@@ -10665,6 +10737,8 @@ def test_commands_catalog_includes_tui_mouse_command():
 
     assert "/mouse" in pairs
     assert "/mouse" in tui_pairs
+    assert "/copy-on-select" in pairs
+    assert "/copy-on-select" in tui_pairs
 
 
 def test_commands_catalog_has_no_duplicate_or_alias_colliding_names():

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1174,6 +1174,46 @@ def test_config_set_battery_explicit_off(monkeypatch):
     assert writes == {"display.battery": False}
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("on", True), ("off", False), ("auto", None)],
+)
+def test_config_set_copy_on_select_persists_tri_state(monkeypatch, value, expected):
+    writes: dict[str, object] = {}
+    monkeypatch.setattr(
+        server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
+    )
+
+    resp = server.dispatch(
+        {
+            "id": "copy-on-select",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": value},
+        }
+    )
+
+    assert resp is not None
+    assert resp["result"] == {"key": "copy-on-select", "value": value}
+    assert writes == {"display.tui_copy_on_select": expected}
+
+
+def test_config_set_copy_on_select_rejects_unknown_mode(monkeypatch):
+    write = Mock()
+    monkeypatch.setattr(server, "_write_config_key", write)
+
+    resp = server.dispatch(
+        {
+            "id": "copy-on-select",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": "maybe"},
+        }
+    )
+
+    assert resp is not None
+    assert resp["error"]["code"] == 4002
+    write.assert_not_called()
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -5962,6 +6002,27 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     assert saved["display"]["tui_statusbar"] == "bottom"
 
 
+def test_config_set_copy_on_select_auto_persists_null(tmp_path, monkeypatch):
+    import yaml
+
+    cfg_path = tmp_path / "config.yaml"
+    cfg_path.write_text(yaml.safe_dump({"display": {"tui_copy_on_select": True}}))
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "copy-on-select", "value": "auto"},
+        }
+    )
+
+    assert resp is not None
+    assert resp["result"] == {"key": "copy-on-select", "value": "auto"}
+    saved = yaml.safe_load(cfg_path.read_text())
+    assert saved["display"]["tui_copy_on_select"] is None
+
+
 def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
     import yaml
 
@@ -6310,6 +6371,17 @@ def test_complete_slash_includes_tui_mouse_command():
     )
 
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
+
+
+def test_complete_slash_includes_tui_copy_on_select_command():
+    resp = server.handle_request(
+        {"id": "1", "method": "complete.slash", "params": {"text": "/copy-on"}}
+    )
+
+    assert resp is not None
+    assert any(
+        item["text"] == "/copy-on-select" for item in resp["result"]["items"]
+    )
 
 
 def test_complete_slash_details_args():
@@ -8181,7 +8253,7 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
     )
 
 
-def test_commands_catalog_includes_tui_mouse_command():
+def test_commands_catalog_includes_tui_local_commands():
     resp = server.handle_request(
         {"id": "1", "method": "commands.catalog", "params": {}}
     )
@@ -8192,6 +8264,8 @@ def test_commands_catalog_includes_tui_mouse_command():
 
     assert "/mouse" in pairs
     assert "/mouse" in tui_pairs
+    assert "/copy-on-select" in pairs
+    assert "/copy-on-select" in tui_pairs
 
 
 def test_commands_catalog_has_no_duplicate_or_alias_colliding_names():

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -418,6 +418,12 @@ def _(rid, params: dict) -> dict:
         text_lower = text.lower()
         extras = [
             {
+                "text": "/copy-on-select",
+                "display": "/copy-on-select",
+                "meta": "Set copy on select [on|off|auto|status]",
+                "kind": "command",
+            },
+            {
                 "text": "/density",
                 "display": "/density",
                 "meta": "Toggle compact display mode",

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -276,6 +276,12 @@ def _(rid, params: dict) -> dict:
         text_lower = text.lower()
         extras = [
             {
+                "text": "/copy-on-select",
+                "display": "/copy-on-select",
+                "meta": "Set copy on select [on|off|auto|status]",
+                "kind": "command",
+            },
+            {
                 "text": "/density",
                 "display": "/density",
                 "meta": "Toggle compact display mode",

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13536,6 +13536,19 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.battery", nv_b)
         return _ok(rid, {"key": key, "value": "on" if nv_b else "off"})
 
+    if key == "copy-on-select":
+        raw = str(value or "").strip().lower()
+        if raw == "on":
+            nv = True
+        elif raw == "off":
+            nv = False
+        elif raw == "auto":
+            nv = None
+        else:
+            return _err(rid, 4002, f"unknown copy-on-select value: {value}")
+        _write_config_key("display.tui_copy_on_select", nv)
+        return _ok(rid, {"key": key, "value": raw})
+
     if key == "theme":
         # TUI light/dark mode pin: 'light'/'dark' beat background
         # auto-detection (xterm.js hosts misreport OSC 11); 'auto' trusts it.
@@ -14351,6 +14364,11 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
 )
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
+    (
+        "/copy-on-select",
+        "Set copy on select [on|off|auto|status]",
+        "TUI",
+    ),
     ("/density", "Toggle compact display mode", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
     (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -11056,6 +11056,19 @@ def _(rid, params: dict) -> dict:
         _write_config_key("display.battery", nv_b)
         return _ok(rid, {"key": key, "value": "on" if nv_b else "off"})
 
+    if key == "copy-on-select":
+        raw = str(value or "").strip().lower()
+        if raw == "on":
+            nv = True
+        elif raw == "off":
+            nv = False
+        elif raw == "auto":
+            nv = None
+        else:
+            return _err(rid, 4002, f"unknown copy-on-select value: {value}")
+        _write_config_key("display.tui_copy_on_select", nv)
+        return _ok(rid, {"key": key, "value": raw})
+
     if key == "theme":
         # TUI light/dark mode pin: 'light'/'dark' beat background
         # auto-detection (xterm.js hosts misreport OSC 11); 'auto' trusts it.
@@ -11746,6 +11759,11 @@ _TUI_HIDDEN: frozenset[str] = frozenset(
 )
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
+    (
+        "/copy-on-select",
+        "Set copy on select [on|off|auto|status]",
+        "TUI",
+    ),
     ("/density", "Toggle compact display mode", "TUI"),
     ("/logs", "Show recent gateway log lines", "TUI"),
     (

--- a/ui-tui/packages/hermes-ink/src/entry-exports.ts
+++ b/ui-tui/packages/hermes-ink/src/entry-exports.ts
@@ -36,6 +36,7 @@ export {
   terminalForegroundHex
 } from './ink/terminal.js'
 export type { MouseTrackingMode } from './ink/termio/dec.js'
+export { type ClipboardPath, type ClipboardResult, setTerminalClipboard } from './ink/termio/osc.js'
 export { wrapAnsi } from './ink/wrapAnsi.js'
 
 // NOTE: Do not re-export from 'ink-text-input' here.

--- a/ui-tui/packages/hermes-ink/src/entry-exports.ts
+++ b/ui-tui/packages/hermes-ink/src/entry-exports.ts
@@ -37,6 +37,7 @@ export {
   terminalForegroundHex
 } from './ink/terminal.js'
 export type { MouseTrackingMode } from './ink/termio/dec.js'
+export { type ClipboardPath, type ClipboardResult, setTerminalClipboard } from './ink/termio/osc.js'
 export { wrapAnsi } from './ink/wrapAnsi.js'
 
 // NOTE: Do not re-export from 'ink-text-input' here.

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.test.ts
@@ -1,8 +1,33 @@
-import { describe, expect, it } from 'vitest'
+import { Buffer } from 'buffer'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { env, supportsOsc52Clipboard } from '../../utils/env.js'
 
-import { shouldEmitClipboardSequence, shouldUseNativeClipboard } from './osc.js'
+import { setTerminalClipboard, shouldEmitClipboardSequence, shouldUseNativeClipboard } from './osc.js'
+
+afterEach(() => vi.unstubAllEnvs())
+
+describe('setTerminalClipboard', () => {
+  it('returns the OSC 52 path and sequence when terminal emission is enabled', async () => {
+    vi.stubEnv('HERMES_TUI_FORCE_OSC52', '1')
+    vi.stubEnv('TMUX', '')
+    vi.stubEnv('STY', '')
+
+    const result = await setTerminalClipboard('A日本🎉')
+
+    expect(result).toMatchObject({ path: 'osc52', success: true })
+    expect(result.sequence).toContain(Buffer.from('A日本🎉', 'utf8').toString('base64'))
+  })
+
+  it('reports no path when terminal emission is disabled and no multiplexer is present', async () => {
+    vi.stubEnv('HERMES_TUI_FORCE_OSC52', '0')
+    vi.stubEnv('TMUX', '')
+    vi.stubEnv('STY', '')
+
+    await expect(setTerminalClipboard('text')).resolves.toEqual({ path: null, sequence: '', success: false })
+  })
+})
 
 describe('shouldEmitClipboardSequence', () => {
   it('suppresses local multiplexer clipboard OSC by default', () => {

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
@@ -238,7 +238,9 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
  * utilities (pbcopy/wl-copy/xclip/xsel/clip.exe) always work locally. Over
  * SSH these would write to the remote clipboard — OSC 52 is the right path there.
  *
- * Returns { sequence, success }:
+ * Returns { path, sequence, success }:
+ *   - `path` identifies the primary transport that was attempted. `null`
+ *     means no clipboard path was available.
  *   - `sequence` is the bytes to write to stdout (raw OSC 52 outside tmux,
  *     DCS-wrapped inside; empty string when we shouldn't emit).
  *   - `success` is true when we believe SOME path reached the clipboard:
@@ -250,14 +252,31 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
  *     callers distinguish "nothing attempted" from "attempted".
  */
 export type ClipboardResult = {
+  path: ClipboardPath | null
   sequence: string
   success: boolean
 }
 
-export async function setClipboard(text: string): Promise<ClipboardResult> {
+/**
+ * Copy through terminal-owned transports only: tmux's paste buffer and OSC 52.
+ * The returned sequence is written by the caller that owns the active stdout.
+ */
+export async function setTerminalClipboard(text: string): Promise<ClipboardResult> {
   const b64 = Buffer.from(text, 'utf8').toString('base64')
   const raw = osc(OSC.CLIPBOARD, 'c', b64)
   const emitSequence = shouldEmitClipboardSequence(process.env)
+
+  const tmuxBufferLoaded = await tmuxLoadBuffer(text)
+
+  // Inner OSC uses BEL directly (not osc()) — ST's ESC would need doubling
+  // too, and BEL works everywhere for OSC 52.
+  const sequence = emitSequence ? (tmuxBufferLoaded ? tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`) : raw) : ''
+  const path: ClipboardPath | null = tmuxBufferLoaded ? 'tmux-buffer' : sequence ? 'osc52' : null
+
+  return { path, sequence, success: path !== null }
+}
+
+export async function setClipboard(text: string): Promise<ClipboardResult> {
 
   // Native safety net — fire FIRST, before the tmux await, so a quick
   // focus-switch after selecting doesn't race pbcopy. Previously this ran
@@ -286,11 +305,7 @@ export async function setClipboard(text: string): Promise<ClipboardResult> {
   // whether ANY native path will be tried.
   const nativeAttempted = shouldUseNativeClipboard(process.env, envModule.terminal) && copyNative(text)
 
-  const tmuxBufferLoaded = await tmuxLoadBuffer(text)
-
-  // Inner OSC uses BEL directly (not osc()) — ST's ESC would need doubling
-  // too, and BEL works everywhere for OSC 52.
-  const sequence = emitSequence ? (tmuxBufferLoaded ? tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`) : raw) : ''
+  const terminal = await setTerminalClipboard(text)
 
   // Success if any path was taken. Native and tmux are fire-and-forget,
   // so we can't truly confirm the clipboard was written — but if native
@@ -298,9 +313,11 @@ export async function setClipboard(text: string): Promise<ClipboardResult> {
   // paste is likely to work. The only false case is "we did literally
   // nothing" (e.g. local-in-tmux with osc52 suppressed and tmux buffer
   // load failed), in which case reporting failure to the user is honest.
-  const success = nativeAttempted || tmuxBufferLoaded || sequence.length > 0
-
-  return { sequence, success }
+  return {
+    ...terminal,
+    path: nativeAttempted ? 'native' : terminal.path,
+    success: nativeAttempted || terminal.success
+  }
 }
 
 // Linux clipboard tool: undefined = not yet probed, null = none available.

--- a/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/termio/osc.ts
@@ -241,7 +241,9 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
  * utilities (pbcopy/wl-copy/xclip/xsel/clip.exe) always work locally. Over
  * SSH these would write to the remote clipboard — OSC 52 is the right path there.
  *
- * Returns { sequence, success }:
+ * Returns { path, sequence, success }:
+ *   - `path` identifies the primary transport that was attempted. `null`
+ *     means no clipboard path was available.
  *   - `sequence` is the bytes to write to stdout (raw OSC 52 outside tmux,
  *     DCS-wrapped inside; empty string when we shouldn't emit).
  *   - `success` is true when we believe SOME path reached the clipboard:
@@ -253,14 +255,31 @@ export async function tmuxLoadBuffer(text: string): Promise<boolean> {
  *     callers distinguish "nothing attempted" from "attempted".
  */
 export type ClipboardResult = {
+  path: ClipboardPath | null
   sequence: string
   success: boolean
 }
 
-export async function setClipboard(text: string): Promise<ClipboardResult> {
+/**
+ * Copy through terminal-owned transports only: tmux's paste buffer and OSC 52.
+ * The returned sequence is written by the caller that owns the active stdout.
+ */
+export async function setTerminalClipboard(text: string): Promise<ClipboardResult> {
   const b64 = Buffer.from(text, 'utf8').toString('base64')
   const raw = osc(OSC.CLIPBOARD, 'c', b64)
   const emitSequence = shouldEmitClipboardSequence(process.env)
+
+  const tmuxBufferLoaded = await tmuxLoadBuffer(text)
+
+  // Inner OSC uses BEL directly (not osc()) — ST's ESC would need doubling
+  // too, and BEL works everywhere for OSC 52.
+  const sequence = emitSequence ? (tmuxBufferLoaded ? tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`) : raw) : ''
+  const path: ClipboardPath | null = tmuxBufferLoaded ? 'tmux-buffer' : sequence ? 'osc52' : null
+
+  return { path, sequence, success: path !== null }
+}
+
+export async function setClipboard(text: string): Promise<ClipboardResult> {
 
   // Native safety net — fire FIRST, before the tmux await, so a quick
   // focus-switch after selecting doesn't race pbcopy. Previously this ran
@@ -289,11 +308,7 @@ export async function setClipboard(text: string): Promise<ClipboardResult> {
   // whether ANY native path will be tried.
   const nativeAttempted = shouldUseNativeClipboard(process.env, envModule.terminal) && copyNative(text)
 
-  const tmuxBufferLoaded = await tmuxLoadBuffer(text)
-
-  // Inner OSC uses BEL directly (not osc()) — ST's ESC would need doubling
-  // too, and BEL works everywhere for OSC 52.
-  const sequence = emitSequence ? (tmuxBufferLoaded ? tmuxPassthrough(`${ESC}]52;c;${b64}${BEL}`) : raw) : ''
+  const terminal = await setTerminalClipboard(text)
 
   // Success if any path was taken. Native and tmux are fire-and-forget,
   // so we can't truly confirm the clipboard was written — but if native
@@ -301,9 +316,11 @@ export async function setClipboard(text: string): Promise<ClipboardResult> {
   // paste is likely to work. The only false case is "we did literally
   // nothing" (e.g. local-in-tmux with osc52 suppressed and tmux buffer
   // load failed), in which case reporting failure to the user is honest.
-  const success = nativeAttempted || tmuxBufferLoaded || sequence.length > 0
-
-  return { sequence, success }
+  return {
+    ...terminal,
+    path: nativeAttempted ? 'native' : terminal.path,
+    success: nativeAttempted || terminal.success
+  }
 }
 
 // Linux clipboard tool: undefined = not yet probed, null = none available.

--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { copyTextToClipboard, isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 
 describe('readClipboardText', () => {
   it('reads text from pbpaste on macOS', async () => {
@@ -389,5 +389,68 @@ describe('writeClipboardText', () => {
     const script = calledArgs[commandIdx + 1]
     expect(script).toContain(Buffer.from(cjkText, 'utf8').toString('base64'))
     expect(script).toContain('UTF8.GetString')
+  })
+})
+
+describe('copyTextToClipboard', () => {
+  it('uses the confirmed native path locally without invoking terminal fallback', async () => {
+    const writeNative = vi.fn().mockResolvedValue(true)
+    const writeTerminal = vi.fn()
+
+    await expect(
+      copyTextToClipboard('local text', {
+        env: {},
+        writeNative,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'native', success: true })
+    expect(writeNative).toHaveBeenCalledWith('local text')
+    expect(writeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('skips native clipboard commands remotely and writes the OSC 52 fallback sequence', async () => {
+    const writeNative = vi.fn()
+    const writeSequence = vi.fn()
+    const writeTerminal = vi.fn().mockResolvedValue({ path: 'osc52', sequence: '<osc52>', success: true })
+
+    await expect(
+      copyTextToClipboard('remote text', {
+        env: { SSH_CONNECTION: '1' },
+        writeNative,
+        writeSequence,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'osc52', success: true })
+    expect(writeNative).not.toHaveBeenCalled()
+    expect(writeTerminal).toHaveBeenCalledWith('remote text')
+    expect(writeSequence).toHaveBeenCalledWith('<osc52>')
+  })
+
+  it('falls back to the tmux buffer after a local native failure', async () => {
+    const writeNative = vi.fn().mockResolvedValue(false)
+    const writeSequence = vi.fn()
+    const writeTerminal = vi.fn().mockResolvedValue({ path: 'tmux-buffer', sequence: '', success: true })
+
+    await expect(
+      copyTextToClipboard('tmux text', {
+        env: { TMUX: '/tmp/tmux/default,1,0' },
+        writeNative,
+        writeSequence,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'tmux-buffer', success: true })
+    expect(writeNative).toHaveBeenCalledWith('tmux text')
+    expect(writeTerminal).toHaveBeenCalledWith('tmux text')
+    expect(writeSequence).not.toHaveBeenCalled()
+  })
+
+  it('returns a failed result when neither native nor terminal transport succeeds', async () => {
+    const writeNative = vi.fn().mockResolvedValue(false)
+    const writeTerminal = vi.fn().mockResolvedValue({ path: null, sequence: '', success: false })
+
+    await expect(copyTextToClipboard('lost text', { env: {}, writeNative, writeTerminal })).resolves.toEqual({
+      path: null,
+      success: false
+    })
   })
 })

--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { copyTextToClipboard, isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 
 describe('readClipboardText', () => {
   it('reads text from pbpaste on macOS', async () => {
@@ -357,5 +357,68 @@ describe('writeClipboardText', () => {
     const script = calledArgs[commandIdx + 1]
     expect(script).toContain(Buffer.from(cjkText, 'utf8').toString('base64'))
     expect(script).toContain('UTF8.GetString')
+  })
+})
+
+describe('copyTextToClipboard', () => {
+  it('uses the confirmed native path locally without invoking terminal fallback', async () => {
+    const writeNative = vi.fn().mockResolvedValue(true)
+    const writeTerminal = vi.fn()
+
+    await expect(
+      copyTextToClipboard('local text', {
+        env: {},
+        writeNative,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'native', success: true })
+    expect(writeNative).toHaveBeenCalledWith('local text')
+    expect(writeTerminal).not.toHaveBeenCalled()
+  })
+
+  it('skips native clipboard commands remotely and writes the OSC 52 fallback sequence', async () => {
+    const writeNative = vi.fn()
+    const writeSequence = vi.fn()
+    const writeTerminal = vi.fn().mockResolvedValue({ path: 'osc52', sequence: '<osc52>', success: true })
+
+    await expect(
+      copyTextToClipboard('remote text', {
+        env: { SSH_CONNECTION: '1' },
+        writeNative,
+        writeSequence,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'osc52', success: true })
+    expect(writeNative).not.toHaveBeenCalled()
+    expect(writeTerminal).toHaveBeenCalledWith('remote text')
+    expect(writeSequence).toHaveBeenCalledWith('<osc52>')
+  })
+
+  it('falls back to the tmux buffer after a local native failure', async () => {
+    const writeNative = vi.fn().mockResolvedValue(false)
+    const writeSequence = vi.fn()
+    const writeTerminal = vi.fn().mockResolvedValue({ path: 'tmux-buffer', sequence: '', success: true })
+
+    await expect(
+      copyTextToClipboard('tmux text', {
+        env: { TMUX: '/tmp/tmux/default,1,0' },
+        writeNative,
+        writeSequence,
+        writeTerminal
+      })
+    ).resolves.toEqual({ path: 'tmux-buffer', success: true })
+    expect(writeNative).toHaveBeenCalledWith('tmux text')
+    expect(writeTerminal).toHaveBeenCalledWith('tmux text')
+    expect(writeSequence).not.toHaveBeenCalled()
+  })
+
+  it('returns a failed result when neither native nor terminal transport succeeds', async () => {
+    const writeNative = vi.fn().mockResolvedValue(false)
+    const writeTerminal = vi.fn().mockResolvedValue({ path: null, sequence: '', success: false })
+
+    await expect(copyTextToClipboard('lost text', { env: {}, writeNative, writeTerminal })).resolves.toEqual({
+      path: null,
+      success: false
+    })
   })
 })

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -7,6 +7,7 @@ import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import type * as EnvModule from '../config/env.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import * as ClipboardModule from '../lib/clipboard.js'
+import { resolveCopyOnSelect } from '../lib/platform.js'
 
 // DASHBOARD_TUI_MODE resolves once at module load from HERMES_TUI_DASHBOARD,
 // so toggling process.env in a test body can't move it. Mock just that one
@@ -116,7 +117,7 @@ describe('createSlashHandler', () => {
 
     expect(createSlashHandler(ctx)('/copy-on-select status')).toBe(true)
     expect(ctx.transcript.sys).toHaveBeenCalledWith(
-      `copy on select: auto (currently ${process.platform === 'darwin' ? 'on' : 'off'})`
+      `copy on select: auto (currently ${resolveCopyOnSelect(null) ? 'on' : 'off'})`
     )
     expect(ctx.gateway.rpc).not.toHaveBeenCalled()
   })

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -97,6 +97,38 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('ui redrawn')
   })
 
+  it.each([
+    [true, '/copy-on-select on', 'on'],
+    [false, '/copy-on-select off', 'off'],
+    [null, '/copy-on-select auto', 'auto']
+  ] as const)('applies and persists copy-on-select mode %s', (expected, command, value) => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)(command)).toBe(true)
+    expect(getUiState().copyOnSelect).toBe(expected)
+    expect(ctx.gateway.rpc).toHaveBeenCalledWith('config.set', { key: 'copy-on-select', value })
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
+  it('reports copy-on-select status without persisting it', () => {
+    patchUiState({ copyOnSelect: null })
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/copy-on-select status')).toBe(true)
+    expect(ctx.transcript.sys).toHaveBeenCalledWith(
+      `copy on select: auto (currently ${process.platform === 'darwin' ? 'on' : 'off'})`
+    )
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid copy-on-select mode', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/copy-on-select maybe')).toBe(true)
+    expect(ctx.transcript.sys).toHaveBeenCalledWith('usage: /copy-on-select [on|off|auto|status]')
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
   it('opens the editor locally for /prompt without slash worker fallback', () => {
     const ctx = buildCtx()
 

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -7,8 +7,6 @@ import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
 import type * as EnvModule from '../config/env.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import * as ClipboardModule from '../lib/clipboard.js'
-import * as Osc52Module from '../lib/osc52.js'
-import * as TerminalSetupModule from '../lib/terminalSetup.js'
 
 // DASHBOARD_TUI_MODE resolves once at module load from HERMES_TUI_DASHBOARD,
 // so toggling process.env in a test body can't move it. Mock just that one
@@ -247,49 +245,30 @@ describe('createSlashHandler', () => {
     })
   })
 
-  it('prefers OSC52 copy for remote sessions', async () => {
-    const writeClipboardText = vi.spyOn(ClipboardModule, 'writeClipboardText').mockResolvedValue(true)
-    const writeOsc52Clipboard = vi.spyOn(Osc52Module, 'writeOsc52Clipboard').mockReturnValue(true)
-    vi.spyOn(TerminalSetupModule, 'isRemoteShellSession').mockReturnValue(true)
+  it.each([
+    ['native', { path: 'native', success: true }, 'copied to clipboard'],
+    ['tmux', { path: 'tmux-buffer', success: true }, 'copied to tmux buffer'],
+    ['OSC52', { path: 'osc52', success: true }, 'sent OSC52 copy sequence (terminal support required)'],
+    [
+      'failure',
+      { path: null, success: false },
+      'clipboard copy failed — try HERMES_TUI_FORCE_OSC52=1 to force the escape sequence'
+    ]
+  ] as const)('reports %s results from the shared clipboard policy', async (_label, result, message) => {
+    const copyTextToClipboard = vi.spyOn(ClipboardModule, 'copyTextToClipboard').mockResolvedValue(result)
 
     const ctx = buildCtx({
       local: {
         ...buildLocal(),
-        getHistoryItems: vi.fn(() => [{ role: 'assistant', text: 'remote answer' }])
+        getHistoryItems: vi.fn(() => [{ role: 'assistant', text: 'answer' }])
       }
     })
 
     expect(createSlashHandler(ctx)('/copy')).toBe(true)
     await vi.waitFor(() => {
-      expect(writeOsc52Clipboard).toHaveBeenCalledWith('remote answer')
+      expect(copyTextToClipboard).toHaveBeenCalledWith('answer')
+      expect(ctx.transcript.sys).toHaveBeenCalledWith(message)
     })
-    expect(writeClipboardText).not.toHaveBeenCalled()
-    expect(ctx.transcript.sys).toHaveBeenCalledWith('sent OSC52 copy sequence (terminal support required)')
-  })
-
-  it('keeps native-first copy in local tmux sessions', async () => {
-    const tmuxBackup = process.env.TMUX
-    process.env.TMUX = '/tmp/tmux-123/default,1,0'
-
-    const writeClipboardText = vi.spyOn(ClipboardModule, 'writeClipboardText').mockResolvedValue(true)
-    const writeOsc52Clipboard = vi.spyOn(Osc52Module, 'writeOsc52Clipboard').mockReturnValue(true)
-    vi.spyOn(TerminalSetupModule, 'isRemoteShellSession').mockReturnValue(false)
-
-    const ctx = buildCtx({
-      local: {
-        ...buildLocal(),
-        getHistoryItems: vi.fn(() => [{ role: 'assistant', text: 'local answer' }])
-      }
-    })
-
-    expect(createSlashHandler(ctx)('/copy')).toBe(true)
-    await vi.waitFor(() => {
-      expect(writeClipboardText).toHaveBeenCalledWith('local answer')
-    })
-    expect(writeOsc52Clipboard).not.toHaveBeenCalled()
-    expect(ctx.transcript.sys).toHaveBeenCalledWith('copied to clipboard')
-
-    process.env.TMUX = tmuxBackup
   })
 
   it('applies /reasoning hide to the thinking section immediately', async () => {

--- a/ui-tui/src/__tests__/platform.test.ts
+++ b/ui-tui/src/__tests__/platform.test.ts
@@ -31,6 +31,17 @@ describe('platform action modifier', () => {
   })
 })
 
+describe('resolveCopyOnSelect', () => {
+  it('uses the platform default only when the config is unset', async () => {
+    const { resolveCopyOnSelect } = await importPlatform('linux')
+
+    expect(resolveCopyOnSelect(undefined, false)).toBe(false)
+    expect(resolveCopyOnSelect(null, true)).toBe(true)
+    expect(resolveCopyOnSelect(true, false)).toBe(true)
+    expect(resolveCopyOnSelect(false, true)).toBe(false)
+  })
+})
+
 describe('isCopyShortcut', () => {
   it('keeps Ctrl+C as the local non-macOS copy chord', async () => {
     const { isCopyShortcut } = await importPlatform('linux')

--- a/ui-tui/src/__tests__/textInputRightClick.test.ts
+++ b/ui-tui/src/__tests__/textInputRightClick.test.ts
@@ -34,6 +34,10 @@ describe('decideRightClickAction', () => {
     })
   })
 
+  it('ignores a selected masked value instead of copying or pasting', () => {
+    expect(decideRightClickAction('secret', { end: 6, start: 0 }, false)).toEqual({ action: 'ignore' })
+  })
+
   it('copies a middle slice', () => {
     expect(decideRightClickAction('hello world', { end: 11, start: 6 })).toEqual({
       action: 'copy',

--- a/ui-tui/src/__tests__/textInputRightClick.test.ts
+++ b/ui-tui/src/__tests__/textInputRightClick.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, it } from 'vitest'
 
-import { decideRightClickAction } from '../components/textInput.js'
+import { decideRightClickAction, shouldCopyMouseSelection } from '../components/textInput.js'
+
+describe('shouldCopyMouseSelection', () => {
+  it('honors explicit overrides and the platform fallback', () => {
+    expect(shouldCopyMouseSelection(undefined, undefined, false)).toBe(false)
+    expect(shouldCopyMouseSelection(null, undefined, true)).toBe(true)
+    expect(shouldCopyMouseSelection(true, undefined, false)).toBe(true)
+    expect(shouldCopyMouseSelection(false, undefined, true)).toBe(false)
+  })
+
+  it('never auto-copies masked input contents', () => {
+    expect(shouldCopyMouseSelection(true, '*', false)).toBe(false)
+    expect(shouldCopyMouseSelection(null, '*', true)).toBe(false)
+  })
+})
 
 describe('decideRightClickAction', () => {
   it('returns paste when there is no selection', () => {

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -30,6 +30,7 @@ describe('applyDisplay', () => {
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
+            tui_copy_on_select: true,
             tui_statusbar: false
           }
         }
@@ -40,6 +41,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(true)
     expect(s.compact).toBe(true)
+    expect(s.copyOnSelect).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
     expect(s.showReasoning).toBe(true)
@@ -64,11 +66,22 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.copyOnSelect).toBeNull()
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
+  })
+
+  it('preserves explicit copy-on-select overrides', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tui_copy_on_select: false } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(false)
+
+    applyDisplay({ config: { display: { tui_copy_on_select: true } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(true)
   })
 
   it('uses documented mouse_tracking with legacy tui_mouse fallback', () => {

--- a/ui-tui/src/__tests__/useConfigSync.test.ts
+++ b/ui-tui/src/__tests__/useConfigSync.test.ts
@@ -30,6 +30,7 @@ describe('applyDisplay', () => {
             show_reasoning: true,
             streaming: false,
             tui_compact: true,
+            tui_copy_on_select: true,
             tui_statusbar: false
           }
         }
@@ -40,6 +41,7 @@ describe('applyDisplay', () => {
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(true)
     expect(s.compact).toBe(true)
+    expect(s.copyOnSelect).toBe(true)
     expect(s.detailsMode).toBe('expanded')
     expect(s.inlineDiffs).toBe(false)
     expect(s.showReasoning).toBe(true)
@@ -112,11 +114,22 @@ describe('applyDisplay', () => {
 
     const s = $uiState.get()
     expect(setBell).toHaveBeenCalledWith(false)
+    expect(s.copyOnSelect).toBeNull()
     expect(s.inlineDiffs).toBe(true)
     expect(s.showReasoning).toBe(false)
     expect(s.statusBar).toBe('top')
     expect(s.streaming).toBe(true)
     expect(s.sections).toEqual({})
+  })
+
+  it('preserves explicit copy-on-select overrides', () => {
+    const setBell = vi.fn()
+
+    applyDisplay({ config: { display: { tui_copy_on_select: false } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(false)
+
+    applyDisplay({ config: { display: { tui_copy_on_select: true } } }, setBell)
+    expect($uiState.get().copyOnSelect).toBe(true)
   })
 
   it('uses documented mouse_tracking with legacy tui_mouse fallback', () => {

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import {
   applyVoiceRecordResponse,
+  copyInputSelection,
   dismissSensitivePrompt,
   handleIdleHotkeyExit,
   shouldAllowIdleHotkeyExit,
@@ -18,6 +19,40 @@ const baseKey = {
   wheelDown: false,
   wheelUp: false
 }
+
+describe('copyInputSelection', () => {
+  it('copies the selected composer text before clearing the selection', () => {
+    const copyText = vi.fn().mockResolvedValue({ path: 'native', success: true })
+    const clear = vi.fn()
+
+    expect(
+      copyInputSelection(
+        {
+          clear,
+          collapseToEnd: vi.fn(),
+          end: 5,
+          start: 1,
+          value: 'a日本🎉z'
+        },
+        copyText
+      )
+    ).toBe(true)
+    expect(copyText).toHaveBeenCalledWith('日本🎉')
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves collapsed or missing selections alone', () => {
+    const copyText = vi.fn()
+    const clear = vi.fn()
+
+    expect(copyInputSelection(null, copyText)).toBe(false)
+    expect(
+      copyInputSelection({ clear, collapseToEnd: vi.fn(), end: 2, start: 2, value: 'text' }, copyText)
+    ).toBe(false)
+    expect(copyText).not.toHaveBeenCalled()
+    expect(clear).not.toHaveBeenCalled()
+  })
+})
 
 describe('shouldFallThroughForScroll — keep transcript scrolling alive during prompt overlays', () => {
   it('falls through for wheel scrolls', () => {

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  copyOnSelect: boolean | null
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean
   // Focus view (/focus) — display-only reduced-output mode. Drives the

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -322,6 +322,7 @@ export interface UiState {
   busy: boolean
   busyInputMode: BusyInputMode
   compact: boolean
+  copyOnSelect: boolean | null
   destructiveSlashConfirm: boolean
   detailsMode: DetailsMode
   detailsModeCommandOverride: boolean

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -15,6 +15,7 @@ import type {
   SystemBatteryResponse
 } from '../../../gatewayTypes.js'
 import { copyTextToClipboard } from '../../../lib/clipboard.js'
+import { resolveCopyOnSelect } from '../../../lib/platform.js'
 import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
 import type { Msg, PanelSection } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
@@ -186,7 +187,7 @@ export const coreCommands: SlashCommand[] = [
 
       if (!mode || mode === 'status') {
         const status =
-          current === null ? `auto (currently ${process.platform === 'darwin' ? 'on' : 'off'})` : current ? 'on' : 'off'
+          current === null ? `auto (currently ${resolveCopyOnSelect(current) ? 'on' : 'off'})` : current ? 'on' : 'off'
 
         return ctx.transcript.sys(`copy on select: ${status}`)
       }

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -178,6 +178,35 @@ export const coreCommands: SlashCommand[] = [
   },
 
   {
+    help: 'set copy on select [on|off|auto|status]',
+    name: 'copy-on-select',
+    run: (arg, ctx) => {
+      const mode = arg.trim().toLowerCase()
+      const current = ctx.ui.copyOnSelect
+
+      if (!mode || mode === 'status') {
+        const status =
+          current === null ? `auto (currently ${process.platform === 'darwin' ? 'on' : 'off'})` : current ? 'on' : 'off'
+
+        return ctx.transcript.sys(`copy on select: ${status}`)
+      }
+
+      const next = mode === 'on' ? true : mode === 'off' ? false : mode === 'auto' ? null : undefined
+
+      if (next === undefined) {
+        return ctx.transcript.sys('usage: /copy-on-select [on|off|auto|status]')
+      }
+
+      patchUiState({ copyOnSelect: next })
+      ctx.gateway
+        .rpc<ConfigSetResponse>('config.set', { key: 'copy-on-select', value: mode })
+        .catch(() => {})
+
+      queueMicrotask(() => ctx.transcript.sys(`copy on select: ${mode}`))
+    }
+  },
+
+  {
     aliases: ['new'],
     help: 'start a new session',
     name: 'clear',

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -14,13 +14,8 @@ import type {
   SessionUndoResponse,
   SystemBatteryResponse
 } from '../../../gatewayTypes.js'
-import { writeClipboardText } from '../../../lib/clipboard.js'
-import { writeOsc52Clipboard } from '../../../lib/osc52.js'
-import {
-  configureDetectedTerminalKeybindings,
-  configureTerminalKeybindings,
-  isRemoteShellSession
-} from '../../../lib/terminalSetup.js'
+import { copyTextToClipboard } from '../../../lib/clipboard.js'
+import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
 import type { Msg, PanelSection } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -408,32 +403,25 @@ export const coreCommands: SlashCommand[] = [
         return sys('nothing to copy — start a conversation first')
       }
 
-      const shouldUseTerminalClipboard = isRemoteShellSession(process.env)
+      const result = await copyTextToClipboard(target.text)
 
-      if (shouldUseTerminalClipboard) {
-        writeOsc52Clipboard(target.text)
-
-        return sys('sent OSC52 copy sequence (terminal support required)')
+      if (ctx.stale()) {
+        return
       }
 
-      void writeClipboardText(target.text)
-        .then(nativeOk => {
-          if (ctx.stale()) {
-            return
-          }
+      if (!result.success) {
+        return sys('clipboard copy failed — try HERMES_TUI_FORCE_OSC52=1 to force the escape sequence')
+      }
 
-          if (nativeOk) {
-            sys('copied to clipboard')
-          } else {
-            writeOsc52Clipboard(target.text)
-            sys('sent OSC52 copy sequence (terminal support required)')
-          }
-        })
-        .catch(error => {
-          if (!ctx.stale()) {
-            sys(`copy failed: ${String(error)}`)
-          }
-        })
+      if (result.path === 'native') {
+        return sys('copied to clipboard')
+      }
+
+      if (result.path === 'tmux-buffer') {
+        return sys('copied to tmux buffer')
+      }
+
+      return sys('sent OSC52 copy sequence (terminal support required)')
     }
   },
 

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -14,13 +14,8 @@ import type {
   SessionUndoResponse,
   SystemBatteryResponse
 } from '../../../gatewayTypes.js'
-import { writeClipboardText } from '../../../lib/clipboard.js'
-import { writeOsc52Clipboard } from '../../../lib/osc52.js'
-import {
-  configureDetectedTerminalKeybindings,
-  configureTerminalKeybindings,
-  isRemoteShellSession
-} from '../../../lib/terminalSetup.js'
+import { copyTextToClipboard } from '../../../lib/clipboard.js'
+import { configureDetectedTerminalKeybindings, configureTerminalKeybindings } from '../../../lib/terminalSetup.js'
 import type { Msg, PanelSection } from '../../../types.js'
 import type { StatusBarMode } from '../../interfaces.js'
 import { patchOverlayState } from '../../overlayStore.js'
@@ -407,32 +402,25 @@ export const coreCommands: SlashCommand[] = [
         return sys('nothing to copy — start a conversation first')
       }
 
-      const shouldUseTerminalClipboard = isRemoteShellSession(process.env)
+      const result = await copyTextToClipboard(target.text)
 
-      if (shouldUseTerminalClipboard) {
-        writeOsc52Clipboard(target.text)
-
-        return sys('sent OSC52 copy sequence (terminal support required)')
+      if (ctx.stale()) {
+        return
       }
 
-      void writeClipboardText(target.text)
-        .then(nativeOk => {
-          if (ctx.stale()) {
-            return
-          }
+      if (!result.success) {
+        return sys('clipboard copy failed — try HERMES_TUI_FORCE_OSC52=1 to force the escape sequence')
+      }
 
-          if (nativeOk) {
-            sys('copied to clipboard')
-          } else {
-            writeOsc52Clipboard(target.text)
-            sys('sent OSC52 copy sequence (terminal support required)')
-          }
-        })
-        .catch(error => {
-          if (!ctx.stale()) {
-            sys(`copy failed: ${String(error)}`)
-          }
-        })
+      if (result.path === 'native') {
+        return sys('copied to clipboard')
+      }
+
+      if (result.path === 'tmux-buffer') {
+        return sys('copied to tmux buffer')
+      }
+
+      return sys('sent OSC52 copy sequence (terminal support required)')
     }
   },
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  copyOnSelect: null,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
   focusView: false,
@@ -40,6 +41,7 @@ const buildUiState = (): UiState => ({
 
 export const $uiState = atom<UiState>(buildUiState())
 
+export const $uiCopyOnSelect = computed($uiState, state => state.copyOnSelect)
 export const $uiTheme = computed($uiState, state => state.theme)
 export const $uiSessionId = computed($uiState, state => state.sid)
 

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -14,6 +14,7 @@ const buildUiState = (): UiState => ({
   busy: false,
   busyInputMode: 'queue',
   compact: false,
+  copyOnSelect: null,
   destructiveSlashConfirm: true,
   detailsMode: 'collapsed',
   detailsModeCommandOverride: false,
@@ -42,6 +43,7 @@ const buildUiState = (): UiState => ({
 
 export const $uiState = atom<UiState>(buildUiState())
 
+export const $uiCopyOnSelect = computed($uiState, state => state.copyOnSelect)
 export const $uiTheme = computed($uiState, state => state.theme)
 export const $uiSessionId = computed($uiState, state => state.sid)
 

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -273,6 +273,7 @@ export const applyDisplay = (
     battery: !!d.battery,
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    copyOnSelect: typeof d.tui_copy_on_select === 'boolean' ? d.tui_copy_on_select : null,
     detailsMode: resolveDetailsMode(d),
     detailsModeCommandOverride: false,
     focusView: !!d.focus_view,

--- a/ui-tui/src/app/useConfigSync.ts
+++ b/ui-tui/src/app/useConfigSync.ts
@@ -274,6 +274,7 @@ export const applyDisplay = (
     battery: !!d.battery,
     busyInputMode: normalizeBusyInputMode(d.busy_input_mode),
     compact: !!d.tui_compact,
+    copyOnSelect: typeof d.tui_copy_on_select === 'boolean' ? d.tui_copy_on_select : null,
     // Fail safe: only YAML boolean false disables the prompt. A transient
     // config RPC failure (cfg=null) preserves the last known policy instead
     // of silently changing approval behavior until the next successful poll.

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -12,12 +12,13 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
+import { copyTextToClipboard } from '../lib/clipboard.js'
 import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
 import { closeWidget, dispatchWidgetInput } from '../sdk/host.js'
 
-import { getInputSelection } from './inputSelectionStore.js'
+import { getInputSelection, type InputSelection } from './inputSelectionStore.js'
 import {
   type GatewayRpc,
   type InputHandlerActions,
@@ -32,6 +33,20 @@ import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
+
+export function copyInputSelection(
+  selection: InputSelection | null,
+  copyText: (text: string) => Promise<unknown> = copyTextToClipboard
+): boolean {
+  if (!selection || selection.end <= selection.start) {
+    return false
+  }
+
+  void copyText(selection.value.slice(selection.start, selection.end))
+  selection.clear()
+
+  return true
+}
 
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
@@ -560,11 +575,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
         return copySelection()
       }
 
-      const inputSel = getInputSelection()
-
-      if (inputSel && inputSel.end > inputSel.start) {
-        inputSel.clear()
-
+      if (copyInputSelection(getInputSelection())) {
         return
       }
 

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -31,7 +31,7 @@ import { useGitBranch } from '../hooks/useGitBranch.js'
 import { pruneVirtualHeightCache, useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
-import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, resolveCopyOnSelect } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
@@ -254,16 +254,15 @@ export function useMainApp(gw: GatewayClient) {
     setDimFallbackColor(ui.theme.color.muted)
   }, [ui.theme.color.muted])
 
-  // macOS Terminal.app does not forward Cmd+C to fullscreen TUIs that enable
-  // mouse tracking, so the only reliable native-feeling path is iTerm-style
-  // copy-on-select: once a drag creates a stable TUI selection, write it to
-  // the system clipboard while keeping the highlight visible.
+  // macOS defaults this on because Terminal.app does not forward Cmd+C to a
+  // fullscreen TUI with mouse tracking. Other platforms can opt into the same
+  // iTerm/Claude-style behavior with display.tui_copy_on_select.
   //
   // Subscribe directly via the ink selection bus (not useSyncExternalStore)
   // so React doesn't re-render MainApp on every drag-move tick. The version
   // ref de-dupes against re-entrant notifications.
   useEffect(() => {
-    if (!isMac) {
+    if (!resolveCopyOnSelect(ui.copyOnSelect)) {
       return
     }
 
@@ -287,7 +286,7 @@ export function useMainApp(gw: GatewayClient) {
       lastCopiedVersionRef.current = version
       void selection.copySelectionNoClear()
     })
-  }, [selection])
+  }, [selection, ui.copyOnSelect])
 
   const clearSelection = useCallback(() => {
     selection.clearSelection()

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -31,7 +31,7 @@ import { useGitBranch } from '../hooks/useGitBranch.js'
 import { pruneVirtualHeightCache, useVirtualHistory } from '../hooks/useVirtualHistory.js'
 import { composerPromptWidth } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage, capTranscriptHistory } from '../lib/messages.js'
-import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
+import { DEFAULT_VOICE_RECORD_KEY, type ParsedVoiceRecordKey, resolveCopyOnSelect } from '../lib/platform.js'
 import { createResizeCoalescer } from '../lib/resizeCoalescer.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
@@ -260,16 +260,15 @@ export function useMainApp(gw: GatewayClient) {
     setDimFallbackColor(ui.theme.color.muted)
   }, [ui.theme.color.muted])
 
-  // macOS Terminal.app does not forward Cmd+C to fullscreen TUIs that enable
-  // mouse tracking, so the only reliable native-feeling path is iTerm-style
-  // copy-on-select: once a drag creates a stable TUI selection, write it to
-  // the system clipboard while keeping the highlight visible.
+  // macOS defaults this on because Terminal.app does not forward Cmd+C to a
+  // fullscreen TUI with mouse tracking. Other platforms can opt into the same
+  // iTerm/Claude-style behavior with display.tui_copy_on_select.
   //
   // Subscribe directly via the ink selection bus (not useSyncExternalStore)
   // so React doesn't re-render MainApp on every drag-move tick. The version
   // ref de-dupes against re-entrant notifications.
   useEffect(() => {
-    if (!isMac) {
+    if (!resolveCopyOnSelect(ui.copyOnSelect)) {
       return
     }
 
@@ -293,7 +292,7 @@ export function useMainApp(gw: GatewayClient) {
       lastCopiedVersionRef.current = version
       void selection.copySelectionNoClear()
     })
-  }, [selection])
+  }, [selection, ui.copyOnSelect])
 
   const clearSelection = useCallback(() => {
     selection.clearSelection()

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,8 +1,10 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
+import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
+import { $uiCopyOnSelect } from '../app/uiStore.js'
 import { highlightMask, highlightsStable } from '../domain/composerHighlights.js'
 import { copyTextToClipboard, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
@@ -12,7 +14,8 @@ import {
   isMac,
   isMacActionFallback,
   isVoiceToggleKey,
-  type ParsedVoiceRecordKey
+  type ParsedVoiceRecordKey,
+  resolveCopyOnSelect
 } from '../lib/platform.js'
 import { isTermuxTuiMode } from '../lib/termux.js'
 
@@ -774,6 +777,12 @@ const isPasteResultPromise = (
   value: PasteResult | Promise<PasteResult> | null | undefined
 ): value is Promise<PasteResult> => !!value && typeof (value as PromiseLike<PasteResult>).then === 'function'
 
+export const shouldCopyMouseSelection = (
+  configured: boolean | null | undefined,
+  mask: string | undefined,
+  platformIsMac = isMac
+): boolean => !mask && resolveCopyOnSelect(configured, platformIsMac)
+
 export function TextInput({
   columns = 80,
   value,
@@ -791,6 +800,7 @@ export function TextInput({
 }: TextInputProps) {
   const [cur, setCur] = useState(value.length)
   const [sel, setSel] = useState<null | { end: number; start: number }>(null)
+  const copyOnSelect = useStore($uiCopyOnSelect)
   const fwdDel = useFwdDelete(focus)
   const termFocus = useTerminalFocus()
   const { stdout } = useStdout()
@@ -1317,7 +1327,7 @@ export function TextInput({
 
     const normalized = selRange()
 
-    if (isMac && normalized) {
+    if (shouldCopyMouseSelection(copyOnSelect, mask) && normalized) {
       void copyTextToClipboard(vRef.current.slice(normalized.start, normalized.end))
     }
   }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,7 +4,7 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { highlightMask, highlightsStable } from '../domain/composerHighlights.js'
-import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { copyTextToClipboard, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
@@ -961,7 +961,7 @@ export function TextInput({
         const range = selRange()
 
         if (range) {
-          void writeClipboardText(vRef.current.slice(range.start, range.end))
+          void copyTextToClipboard(vRef.current.slice(range.start, range.end))
         }
       },
       cut: () => {
@@ -1318,7 +1318,7 @@ export function TextInput({
     const normalized = selRange()
 
     if (isMac && normalized) {
-      void writeClipboardText(vRef.current.slice(normalized.start, normalized.end))
+      void copyTextToClipboard(vRef.current.slice(normalized.start, normalized.end))
     }
   }
 
@@ -1706,7 +1706,7 @@ export function TextInput({
           const decision = decideRightClickAction(vRef.current, selRange())
 
           if (decision.action === 'copy') {
-            void writeClipboardText(decision.text)
+            void copyTextToClipboard(decision.text)
 
             return
           }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1713,7 +1713,7 @@ export function TextInput({
         // Right-click → copy active selection if any, otherwise paste.
         if (e.button === 2) {
           e.stopImmediatePropagation?.()
-          const decision = decideRightClickAction(vRef.current, selRange())
+          const decision = decideRightClickAction(vRef.current, selRange(), !mask)
 
           if (decision.action === 'copy') {
             void copyTextToClipboard(decision.text)
@@ -1721,7 +1721,9 @@ export function TextInput({
             return
           }
 
-          emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+          if (decision.action === 'paste') {
+            emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+          }
 
           return
         }
@@ -1805,11 +1807,12 @@ interface TextInputProps {
   voiceRecordKey?: ParsedVoiceRecordKey
 }
 
-export type RightClickDecision = { action: 'copy'; text: string } | { action: 'paste' }
+export type RightClickDecision = { action: 'copy'; text: string } | { action: 'ignore' } | { action: 'paste' }
 
 /**
  * Decide what right-click should do on the composer:
  *   - non-empty selection → copy that text to the clipboard
+ *   - non-empty masked selection → ignore it so plaintext cannot leave the input
  *   - no selection (or empty/collapsed range) → fall through to paste
  *
  * Mirrors terminal-native behavior (xterm, iTerm, gnome-terminal) where
@@ -1820,9 +1823,14 @@ export type RightClickDecision = { action: 'copy'; text: string } | { action: 'p
  */
 export function decideRightClickAction(
   value: string,
-  range: { end: number; start: number } | null
+  range: { end: number; start: number } | null,
+  copyable = true
 ): RightClickDecision {
   if (range && range.end > range.start) {
+    if (!copyable) {
+      return { action: 'ignore' }
+    }
+
     const text = value.slice(range.start, range.end)
 
     if (text) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1,8 +1,10 @@
 import type { InputEvent, Key } from '@hermes/ink'
 import * as Ink from '@hermes/ink'
+import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
+import { $uiCopyOnSelect } from '../app/uiStore.js'
 import { copyTextToClipboard, readClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
@@ -11,7 +13,8 @@ import {
   isMac,
   isMacActionFallback,
   isVoiceToggleKey,
-  type ParsedVoiceRecordKey
+  type ParsedVoiceRecordKey,
+  resolveCopyOnSelect
 } from '../lib/platform.js'
 import { isTermuxTuiMode } from '../lib/termux.js'
 
@@ -609,6 +612,12 @@ const isPasteResultPromise = (
   value: PasteResult | Promise<PasteResult> | null | undefined
 ): value is Promise<PasteResult> => !!value && typeof (value as PromiseLike<PasteResult>).then === 'function'
 
+export const shouldCopyMouseSelection = (
+  configured: boolean | null | undefined,
+  mask: string | undefined,
+  platformIsMac = isMac
+): boolean => !mask && resolveCopyOnSelect(configured, platformIsMac)
+
 export function TextInput({
   columns = 80,
   value,
@@ -625,6 +634,7 @@ export function TextInput({
 }: TextInputProps) {
   const [cur, setCur] = useState(value.length)
   const [sel, setSel] = useState<null | { end: number; start: number }>(null)
+  const copyOnSelect = useStore($uiCopyOnSelect)
   const fwdDel = useFwdDelete(focus)
   const termFocus = useTerminalFocus()
   const { stdout } = useStdout()
@@ -1067,7 +1077,7 @@ export function TextInput({
 
     const normalized = selRange()
 
-    if (isMac && normalized) {
+    if (shouldCopyMouseSelection(copyOnSelect, mask) && normalized) {
       void copyTextToClipboard(vRef.current.slice(normalized.start, normalized.end))
     }
   }

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1417,7 +1417,7 @@ export function TextInput({
         // Right-click → copy active selection if any, otherwise paste.
         if (e.button === 2) {
           e.stopImmediatePropagation?.()
-          const decision = decideRightClickAction(vRef.current, selRange())
+          const decision = decideRightClickAction(vRef.current, selRange(), !mask)
 
           if (decision.action === 'copy') {
             void copyTextToClipboard(decision.text)
@@ -1425,7 +1425,9 @@ export function TextInput({
             return
           }
 
-          emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+          if (decision.action === 'paste') {
+            emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+          }
 
           return
         }
@@ -1507,11 +1509,12 @@ interface TextInputProps {
   voiceRecordKey?: ParsedVoiceRecordKey
 }
 
-export type RightClickDecision = { action: 'copy'; text: string } | { action: 'paste' }
+export type RightClickDecision = { action: 'copy'; text: string } | { action: 'ignore' } | { action: 'paste' }
 
 /**
  * Decide what right-click should do on the composer:
  *   - non-empty selection → copy that text to the clipboard
+ *   - non-empty masked selection → ignore it so plaintext cannot leave the input
  *   - no selection (or empty/collapsed range) → fall through to paste
  *
  * Mirrors terminal-native behavior (xterm, iTerm, gnome-terminal) where
@@ -1522,9 +1525,14 @@ export type RightClickDecision = { action: 'copy'; text: string } | { action: 'p
  */
 export function decideRightClickAction(
   value: string,
-  range: { end: number; start: number } | null
+  range: { end: number; start: number } | null,
+  copyable = true
 ): RightClickDecision {
   if (range && range.end > range.start) {
+    if (!copyable) {
+      return { action: 'ignore' }
+    }
+
     const text = value.slice(range.start, range.end)
 
     if (text) {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -3,7 +3,7 @@ import * as Ink from '@hermes/ink'
 import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
-import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { copyTextToClipboard, readClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
@@ -1068,7 +1068,7 @@ export function TextInput({
     const normalized = selRange()
 
     if (isMac && normalized) {
-      void writeClipboardText(vRef.current.slice(normalized.start, normalized.end))
+      void copyTextToClipboard(vRef.current.slice(normalized.start, normalized.end))
     }
   }
 
@@ -1131,14 +1131,6 @@ export function TextInput({
 
       if (isMac && isActionMod(k) && inp.toLowerCase() === 'c') {
         flushKeyBurst()
-
-        const range = selRange()
-
-        if (range) {
-          const text = vRef.current.slice(range.start, range.end)
-
-          void writeClipboardText(text)
-        }
 
         return
       }
@@ -1418,7 +1410,7 @@ export function TextInput({
           const decision = decideRightClickAction(vRef.current, selRange())
 
           if (decision.action === 'copy') {
-            void writeClipboardText(decision.text)
+            void copyTextToClipboard(decision.text)
 
             return
           }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -98,6 +98,7 @@ export interface ConfigDisplayConfig {
   tui_agents_nudge?: boolean
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
+  tui_copy_on_select?: boolean | null
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -101,6 +101,7 @@ export interface ConfigDisplayConfig {
   tui_agents_nudge?: boolean
   tui_auto_resume_recent?: boolean
   tui_compact?: boolean
+  tui_copy_on_select?: boolean | null
   /** Legacy alias for display.mouse_tracking. */
   tui_mouse?: boolean | null | number | string
   // Forward-compat: backend may send styles this client doesn't know yet —

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -1,6 +1,10 @@
 import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 
+import { type ClipboardResult, setTerminalClipboard } from '@hermes/ink'
+
+import { isRemoteShell } from './platform.js'
+
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
 
@@ -199,4 +203,50 @@ export async function writeClipboardText(
   }
 
   return false
+}
+
+interface CopyTextDependencies {
+  env?: NodeJS.ProcessEnv
+  writeNative?: (text: string) => Promise<boolean>
+  writeSequence?: (sequence: string) => unknown
+  writeTerminal?: (text: string) => Promise<ClipboardResult>
+}
+
+type CopyTextResult = Pick<ClipboardResult, 'path' | 'success'>
+
+/**
+ * Copy text through the TUI's single clipboard policy. Local sessions prefer
+ * the confirmed native writer; remote sessions and native failures reuse
+ * Ink's tmux/OSC 52 terminal transports.
+ */
+export async function copyTextToClipboard(
+  text: string,
+  dependencies: CopyTextDependencies = {}
+): Promise<CopyTextResult> {
+  const env = dependencies.env ?? process.env
+  const writeNative = dependencies.writeNative ?? (value => writeClipboardText(value, process.platform, spawn, env))
+  const writeSequence = dependencies.writeSequence ?? (sequence => process.stdout.write(sequence))
+  const writeTerminal = dependencies.writeTerminal ?? setTerminalClipboard
+
+  if (!isRemoteShell(env)) {
+    try {
+      if (await writeNative(text)) {
+        return { path: 'native', success: true }
+      }
+    } catch {
+      // Fall through to terminal-owned transports.
+    }
+  }
+
+  try {
+    const result = await writeTerminal(text)
+
+    if (result.sequence) {
+      writeSequence(result.sequence)
+    }
+
+    return { path: result.path, success: result.success }
+  } catch {
+    return { path: null, success: false }
+  }
 }

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -1,6 +1,10 @@
 import { execFile, spawn } from 'node:child_process'
 import { promisify } from 'node:util'
 
+import { type ClipboardResult, setTerminalClipboard } from '@hermes/ink'
+
+import { isRemoteShell } from './platform.js'
+
 const execFileAsync = promisify(execFile)
 const CLIPBOARD_MAX_BUFFER = 4 * 1024 * 1024
 const POWERSHELL_ARGS = ['-NoProfile', '-NonInteractive', '-Command', 'Get-Clipboard -Raw'] as const
@@ -185,4 +189,50 @@ export async function writeClipboardText(
   }
 
   return false
+}
+
+interface CopyTextDependencies {
+  env?: NodeJS.ProcessEnv
+  writeNative?: (text: string) => Promise<boolean>
+  writeSequence?: (sequence: string) => unknown
+  writeTerminal?: (text: string) => Promise<ClipboardResult>
+}
+
+type CopyTextResult = Pick<ClipboardResult, 'path' | 'success'>
+
+/**
+ * Copy text through the TUI's single clipboard policy. Local sessions prefer
+ * the confirmed native writer; remote sessions and native failures reuse
+ * Ink's tmux/OSC 52 terminal transports.
+ */
+export async function copyTextToClipboard(
+  text: string,
+  dependencies: CopyTextDependencies = {}
+): Promise<CopyTextResult> {
+  const env = dependencies.env ?? process.env
+  const writeNative = dependencies.writeNative ?? (value => writeClipboardText(value, process.platform, spawn, env))
+  const writeSequence = dependencies.writeSequence ?? (sequence => process.stdout.write(sequence))
+  const writeTerminal = dependencies.writeTerminal ?? setTerminalClipboard
+
+  if (!isRemoteShell(env)) {
+    try {
+      if (await writeNative(text)) {
+        return { path: 'native', success: true }
+      }
+    } catch {
+      // Fall through to terminal-owned transports.
+    }
+  }
+
+  try {
+    const result = await writeTerminal(text)
+
+    if (result.sequence) {
+      writeSequence(result.sequence)
+    }
+
+    return { path: result.path, success: result.success }
+  } catch {
+    return { path: null, success: false }
+  }
 }

--- a/ui-tui/src/lib/platform.ts
+++ b/ui-tui/src/lib/platform.ts
@@ -11,6 +11,10 @@
 
 export const isMac = process.platform === 'darwin'
 
+/** Resolve select-to-copy's tri-state config while preserving macOS's legacy default. */
+export const resolveCopyOnSelect = (configured: boolean | null | undefined, platformIsMac = isMac): boolean =>
+  configured ?? platformIsMac
+
 /** True when the platform action-modifier is pressed (Cmd on macOS, Ctrl elsewhere). */
 export const isActionMod = (key: { ctrl: boolean; meta: boolean; super?: boolean }): boolean =>
   isMac ? key.meta || key.super === true : key.ctrl

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -132,6 +132,12 @@ declare module '@hermes/ink' {
   export const scrollFastPathStats: ScrollFastPathStats
 
   export type EvictLevel = 'all' | 'half'
+  export type ClipboardPath = 'native' | 'tmux-buffer' | 'osc52'
+  export interface ClipboardResult {
+    readonly path: ClipboardPath | null
+    readonly sequence: string
+    readonly success: boolean
+  }
   export type InkCacheSizes = {
     readonly lineWidth: number
     readonly slice: number
@@ -142,6 +148,7 @@ declare module '@hermes/ink' {
 
   export function forceRedraw(stdout?: NodeJS.WriteStream): boolean
   export function render(node: React.ReactNode, options?: NodeJS.WriteStream | RenderOptions): Instance
+  export function setTerminalClipboard(text: string): Promise<ClipboardResult>
 
   export function useApp(): { readonly exit: (error?: Error) => void }
   export type RunExternalProcess = () => Promise<void>

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -133,6 +133,12 @@ declare module '@hermes/ink' {
   export const scrollFastPathStats: ScrollFastPathStats
 
   export type EvictLevel = 'all' | 'half'
+  export type ClipboardPath = 'native' | 'tmux-buffer' | 'osc52'
+  export interface ClipboardResult {
+    readonly path: ClipboardPath | null
+    readonly sequence: string
+    readonly success: boolean
+  }
   export type InkCacheSizes = {
     readonly lineWidth: number
     readonly slice: number
@@ -143,6 +149,7 @@ declare module '@hermes/ink' {
 
   export function forceRedraw(stdout?: NodeJS.WriteStream): boolean
   export function render(node: React.ReactNode, options?: NodeJS.WriteStream | RenderOptions): Instance
+  export function setTerminalClipboard(text: string): Promise<ClipboardResult>
 
   export function useApp(): { readonly exit: (error?: Error) => void }
   export type RunExternalProcess = () => Promise<void>

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -241,7 +241,14 @@ display:
                              #   buttons — adds 1002 for terminal-side drag selection
                              #   all     — adds 1003 for hover (scrollbar paginate-on-hover,
                              #             link mouseenter, etc.)
+  tui_copy_on_select: null   # true: copy when a mouse selection ends; false: disable.
+                             # null/unset: enabled on macOS, disabled elsewhere.
 ```
+
+`tui_copy_on_select` applies to transcript and composer selections, copies only
+after the drag has stabilized, and keeps the highlight visible. Mouse drag
+events must reach the TUI; inside tmux, keep `display.mouse_tracking` set to
+`buttons` or `all` and forward the relevant mouse events with `send-keys -M`.
 
 Runtime toggles:
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -252,6 +252,8 @@ events must reach the TUI; inside tmux, keep `display.mouse_tracking` set to
 
 Runtime toggles:
 
+- `/copy-on-select [on|off|auto|status]` — override copy-on-select or restore
+  the platform default with `auto`
 - `/details [hidden|collapsed|expanded|cycle]` — set the global mode
 - `/details <section> [hidden|collapsed|expanded|reset]` — override one section
   (sections: `thinking`, `tools`, `subagents`, `activity`)

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -235,7 +235,14 @@ display:
                              #   buttons — adds 1002 for terminal-side drag selection
                              #   all     — adds 1003 for hover (scrollbar paginate-on-hover,
                              #             link mouseenter, etc.)
+  tui_copy_on_select: null   # true: copy when a mouse selection ends; false: disable.
+                             # null/unset: enabled on macOS, disabled elsewhere.
 ```
+
+`tui_copy_on_select` applies to transcript and composer selections, copies only
+after the drag has stabilized, and keeps the highlight visible. Mouse drag
+events must reach the TUI; inside tmux, keep `display.mouse_tracking` set to
+`buttons` or `all` and forward the relevant mouse events with `send-keys -M`.
 
 Runtime toggles:
 

--- a/website/docs/user-guide/tui.md
+++ b/website/docs/user-guide/tui.md
@@ -246,6 +246,8 @@ events must reach the TUI; inside tmux, keep `display.mouse_tracking` set to
 
 Runtime toggles:
 
+- `/copy-on-select [on|off|auto|status]` — override copy-on-select or restore
+  the platform default with `auto`
 - `/details [hidden|collapsed|expanded|cycle]` — set the global mode
 - `/details <section> [hidden|collapsed|expanded|reset]` — override one section
   (sections: `thinking`, `tools`, `subagents`, `activity`)


### PR DESCRIPTION
## Summary

- centralize TUI clipboard writes behind one native → tmux buffer → OSC 52 policy and reuse it for `/copy`, composer keyboard copy, and right-click copy
- add tri-state `display.tui_copy_on_select`: unset preserves the existing macOS default, non-macOS defaults off, and explicit `true`/`false` overrides either platform default
- add the TUI-local `/copy-on-select [on|off|auto|status]` command so the setting can be inspected and persisted without editing `config.yaml`
- apply copy-on-select to transcript and composer selections, keep highlights visible, and prevent masked selections from reaching automatic or right-click clipboard transports
- document copy-on-select behavior and tmux mouse forwarding requirements

## Related work

- Related to #46467 and #46491. #46491 provides an on/off guard for the existing macOS-only path; this PR additionally supports explicit opt-in on Linux/Windows and unifies the native, tmux, and OSC 52 fallback paths used by every TUI copy surface.
- Related to #24585, whose current diff is stacked on an older toast implementation and includes broader CLI/RPC/CI changes. This PR includes a focused TUI-only command backed by the existing config RPC while keeping the patch on current TUI clipboard behavior.

## Test plan

- `npm test --workspace ui-tui -- packages/hermes-ink/src/ink/termio/osc.test.ts src/__tests__/clipboard.test.ts src/__tests__/createSlashHandler.test.ts src/__tests__/platform.test.ts src/__tests__/slashParity.test.ts src/__tests__/textInputRightClick.test.ts src/__tests__/useConfigSync.test.ts src/__tests__/useInputHandlers.test.ts` — 259 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py -q` — 523 passed
- `scripts/run_tests.sh tests/hermes_cli/test_config.py -q` — 74 passed
- `npm run typecheck --workspace ui-tui` — passed
- `npm run build --workspace ui-tui` — passed
- `npm run lint --workspace ui-tui` — 0 errors; one pre-existing warning in `useSessionLifecycle.ts`
- `git diff --check upstream/main...HEAD` — passed
- manual dogfooding completed without observed regressions

`npm run check --workspace ui-tui` is not used as the acceptance gate because 21 tests in three unrelated files (`subscriptionOverlay`, `appChromeBlockedTimers`, and `ink-backpressure`) fail unchanged on detached `upstream/main`; the focused tests, typecheck, lint, and production build above pass.