### PR TITLE
fix(environments): prevent delegated child marker snapshot leak

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -357,6 +357,69 @@ def test_wrapped_exec_scopes_explicit_forward_env_across_profiles(monkeypatch, t
         ss.set_multiplex_active(False)
 
 
+def test_delegated_marker_is_runtime_only_for_docker(monkeypatch, tmp_path):
+    """Daemon-less docker-exec semantics keep the child marker per-command."""
+    from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER, delegated_child_context
+
+    marker = DELEGATED_CHILD_ENV_MARKER
+    env = _make_execute_only_env()
+    env.cwd = str(tmp_path)
+    env._snapshot_path = str(tmp_path / "snapshot.sh")
+    env._cwd_file = str(tmp_path / "cwd.txt")
+    env._snapshot_passthrough_names = set()
+    (tmp_path / "snapshot.sh").write_text("", encoding="utf-8")
+    # Keep profile forwarding out of this proof: the delegated marker must be
+    # injected by Docker's shell-exec boundary itself.
+    env._build_runtime_env_args_with_unsets = lambda: ([], ())
+    captured = []
+    container_env = {
+        "HOME": str(tmp_path),
+        "LANG": "C.UTF-8",
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        marker: "parent-marker",
+    }
+
+    def _run_fake_docker_exec(cmd, stdin_data=None):
+        """Run docker exec argv locally with its per-command -e semantics."""
+        captured.append(list(cmd))
+        container_index = cmd.index(env._container_id)
+        child_env = container_env.copy()
+        index = 2
+        while index < container_index:
+            if cmd[index] == "-i":
+                index += 1
+                continue
+            assert cmd[index] == "-e", cmd
+            key, value = cmd[index + 1].split("=", 1)
+            child_env[key] = value
+            index += 2
+        return subprocess.Popen(
+            cmd[container_index + 1 :],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=child_env,
+        )
+
+    monkeypatch.setattr(docker_env, "_popen_bash", _run_fake_docker_exec)
+    command = f'printf "[%s]" "${{{marker}:-absent}}"'
+
+    with delegated_child_context():
+        child = env.execute(command)
+    ordinary = env.execute(command)
+
+    assert child["returncode"] == 0
+    assert child["output"] == "[1]"
+    assert ordinary["returncode"] == 0
+    assert ordinary["output"] == "[parent-marker]"
+    assert f"{marker}=1" in captured[0]
+    assert f"{marker}=1" not in captured[1]
+    assert marker not in (tmp_path / "snapshot.sh").read_text(encoding="utf-8")
+
+
 # ── docker_env tests ──────────────────────────────────────────────
 
 

--- a/tests/tools/test_snapshot_session_id_leak.py
+++ b/tests/tools/test_snapshot_session_id_leak.py
@@ -106,3 +106,55 @@ def test_shared_snapshot_no_cross_session_leak(tmp_path):
                 assert "HERMES_SESSION_ID" not in f.read()
     finally:
         env.cleanup()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX bash snapshot path")
+def test_delegated_marker_survives_snapshot_helper_collision(tmp_path, monkeypatch):
+    """Snapshot bookkeeping cannot override a delegated-child marker."""
+    from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER, delegated_child_context
+    from tools.environments.local import LocalEnvironment
+
+    marker = DELEGATED_CHILD_ENV_MARKER
+    present = f"_HERMES_RUNTIME_PASSTHROUGH_{marker}_PRESENT"
+    value = f"_HERMES_RUNTIME_PASSTHROUGH_{marker}_VALUE"
+    marker_command = f'printf "[%s]" "${{{marker}:-absent}}"'
+    monkeypatch.delenv(marker, raising=False)
+
+    def run_case(name, *, delegated=False, parent_value=None):
+        cwd = tmp_path / name
+        cwd.mkdir()
+        kwargs = {"cwd": str(cwd), "timeout": 30}
+        if parent_value is not None:
+            kwargs["env"] = {marker: parent_value}
+        env = LocalEnvironment(**kwargs)
+        env.init_session()
+        try:
+            seeded = env.execute(
+                f"export {present}=x; export {value}=forged-from-snapshot-helper; printf '[seeded]'"
+            )
+            assert seeded["returncode"] == 0
+            if delegated:
+                with delegated_child_context():
+                    result = env.execute(marker_command)
+            else:
+                result = env.execute(marker_command)
+            with open(env._snapshot_path, encoding="utf-8") as stream:
+                snapshot = stream.read()
+            return result, snapshot
+        finally:
+            env.cleanup()
+
+    child, child_snapshot = run_case("child", delegated=True)
+    ordinary, ordinary_snapshot = run_case("ordinary")
+    parent, parent_snapshot = run_case("parent", parent_value="parent-marker")
+
+    assert child["returncode"] == 0
+    assert child["output"].strip() == "[1]"
+    assert ordinary["returncode"] == 0
+    assert ordinary["output"].strip() == "[absent]"
+    assert parent["returncode"] == 0
+    assert parent["output"].strip() == "[parent-marker]"
+    for snapshot in (child_snapshot, ordinary_snapshot, parent_snapshot):
+        assert marker not in snapshot
+        assert present not in snapshot
+        assert value not in snapshot

--- a/tests/tools/test_ssh_environment.py
+++ b/tests/tools/test_ssh_environment.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 import subprocess
 from unittest.mock import MagicMock
 
@@ -170,6 +171,65 @@ class TestSSHPreflight:
         assert called["count"] == 1
         assert env.host == "example.com"
         assert env.user == "alice"
+
+
+def test_delegated_marker_reaches_clean_remote_shell(monkeypatch, tmp_path):
+    """SSH must carry delegated-child lineage into a clean remote shell."""
+    from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER, delegated_child_context
+
+    marker = DELEGATED_CHILD_ENV_MARKER
+    env = SSHEnvironment.__new__(SSHEnvironment)
+    env.cwd = str(tmp_path)
+    env.timeout = 30
+    env._profile_scoped_passthrough = False
+    env._snapshot_passthrough_names = set()
+    env._snapshot_path = str(tmp_path / "snapshot.sh")
+    env._cwd_file = str(tmp_path / "cwd.txt")
+    env._cwd_marker = "__HERMES_CWD_ssh_marker__"
+    env._snapshot_ready = True
+    env._build_ssh_command = lambda extra_args=None: ["ssh", "fake-remote"]
+    (tmp_path / "snapshot.sh").write_text("", encoding="utf-8")
+    captured: list[list[str]] = []
+
+    def _run_clean_remote(cmd: list[str], stdin_data=None):
+        captured.append(list(cmd))
+        remote_script = shlex.split(cmd[-1])[0]
+        return subprocess.Popen(
+            ["bash", "-c", remote_script],
+            stdin=subprocess.PIPE if stdin_data is not None else subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env={
+                "HOME": str(tmp_path),
+                "LANG": "C.UTF-8",
+                "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            },
+        )
+
+    monkeypatch.setattr(ssh_env, "_popen_bash", _run_clean_remote)
+    command = f'printf "[%s]" "${{{marker}:-absent}}"'
+
+    with delegated_child_context():
+        child_wrapped = env._wrap_command(command, str(tmp_path))
+        child_proc = env._run_bash(child_wrapped)
+        child_stdout, _ = child_proc.communicate(timeout=30)
+    ordinary_wrapped = env._wrap_command(command, str(tmp_path))
+    ordinary_proc = env._run_bash(ordinary_wrapped)
+    ordinary_stdout, _ = ordinary_proc.communicate(timeout=30)
+
+    child_output = child_stdout.split(env._cwd_marker, 1)[0].strip()
+    ordinary_output = ordinary_stdout.split(env._cwd_marker, 1)[0].strip()
+    assert child_proc.returncode == 0
+    assert child_output == "[1]"
+    assert f"export {marker}=1" in child_wrapped
+    assert ordinary_proc.returncode == 0
+    assert ordinary_output == "[absent]"
+    assert f"export {marker}=1" not in ordinary_wrapped
+    assert marker not in (tmp_path / "snapshot.sh").read_text(encoding="utf-8")
+    assert len(captured) == 2
 
 
 def _setup_ssh_env(monkeypatch, persistent: bool):

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -631,6 +631,30 @@ class BaseEnvironment(ABC):
             )
         return tuple(sorted(self._snapshot_passthrough_names))
 
+    @staticmethod
+    def _snapshot_saved_passthrough_state_names(name: str) -> tuple[str, str]:
+        """Return the shell-private names used to restore *name* after source()."""
+        marker = f"_HERMES_RUNTIME_PASSTHROUGH_{name}"
+        return f"{marker}_PRESENT", f"{marker}_VALUE"
+
+    def _snapshot_runtime_passthrough_names(self) -> tuple[str, ...]:
+        """Return values restored after sourcing a shared command snapshot."""
+        # Keep this import lazy: environment backends are imported before most
+        # agent runtime setup, while this state is only needed at command time.
+        from agent.delegation_context import DELEGATED_CHILD_ENV_MARKER
+
+        return tuple(sorted({
+            *self._snapshot_excluded_passthrough_names(),
+            DELEGATED_CHILD_ENV_MARKER,
+        }))
+
+    def _snapshot_dump_excluded_names(self, passthrough_names: Iterable[str]) -> tuple[str, ...]:
+        """Return transient names that must never be serialized into a snapshot."""
+        excluded_names = set(passthrough_names)
+        for name in passthrough_names:
+            excluded_names.update(self._snapshot_saved_passthrough_state_names(name))
+        return tuple(sorted(excluded_names))
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
@@ -677,7 +701,9 @@ class BaseEnvironment(ABC):
         # every later expansion is consistent.
         _snap_tmp_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXXXXXX")
         _snap_tmp = '"$__hermes_snap_tmp"'
-        snapshot_excluded = self._snapshot_excluded_passthrough_names()
+        snapshot_excluded = self._snapshot_dump_excluded_names(
+            self._snapshot_runtime_passthrough_names()
+        )
         bootstrap = (
             f"umask 077\n"
             f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) || exit 1\n"
@@ -798,7 +824,18 @@ class BaseEnvironment(ABC):
         _snap_tmp = '"$__hermes_snap_tmp"'
 
         parts = []
-        passthrough_names = self._snapshot_excluded_passthrough_names()
+        # SSH and other remote backends begin each command in a fresh shell,
+        # so a ContextVar alone cannot cross that process boundary. Install the
+        # delegated-child marker before saving and restoring snapshot values;
+        # the existing runtime exclusion keeps it out of the persisted snapshot.
+        from agent.delegation_context import (
+            DELEGATED_CHILD_ENV_MARKER,
+            is_delegated_child_process_context,
+        )
+        if is_delegated_child_process_context():
+            parts.append(f"export {DELEGATED_CHILD_ENV_MARKER}=1")
+        passthrough_names = self._snapshot_runtime_passthrough_names()
+        snapshot_excluded = self._snapshot_dump_excluded_names(passthrough_names)
 
         # A shared snapshot may contain the previous profile's value. Save
         # the current process environment before sourcing it, then restore the
@@ -807,12 +844,15 @@ class BaseEnvironment(ABC):
         # string, so secrets are not exposed through process arguments/logs.
         saved_names: list[tuple[str, str, str]] = []
         for name in passthrough_names:
-            marker = f"_HERMES_RUNTIME_PASSTHROUGH_{name}"
-            present = f"{marker}_PRESENT"
-            value = f"{marker}_VALUE"
+            present, value = self._snapshot_saved_passthrough_state_names(name)
             saved_names.append((name, present, value))
-            parts.append(f"{present}=${{{name}+x}}")
-            parts.append(f"{value}=${{{name}-}}")
+            # The snapshot is executable shell code and may contain stale
+            # declarations for our fixed bookkeeping names.  Readonly shell
+            # variables retain the current process state across source(), so
+            # a legacy or hostile snapshot cannot replace restoration data.
+            # They are deliberately unexported and excluded from every dump.
+            parts.append(f"readonly {present}=${{{name}+x}}")
+            parts.append(f"readonly {value}=${{{name}-}}")
 
         # Source snapshot (env vars from previous commands).
         # Redirect stdout to /dev/null: on macOS (bash 3.2 and certain
@@ -830,7 +870,6 @@ class BaseEnvironment(ABC):
                 f'if [ "${present}" = x ]; then export {name}="${value}"; '
                 f'else unset {name}; fi'
             )
-            parts.append(f"unset {present} {value}")
 
         # Preserve bare ``~`` expansion, but rewrite ``~/...`` through
         # ``$HOME`` so suffixes with spaces remain a single shell word.
@@ -856,7 +895,7 @@ class BaseEnvironment(ABC):
         if self._snapshot_ready:
             parts.append(
                 f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) && "
-                f"{{ {_export_dump_excluding_session_vars(_snap_tmp, passthrough_names)} "
+                f"{{ {_export_dump_excluding_session_vars(_snap_tmp, snapshot_excluded)} "
                 f"&& mv -f {_snap_tmp} {_quoted_snap}; }} "
                 f"2>/dev/null || rm -f {_snap_tmp} 2>/dev/null || true"
             )

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -1595,6 +1595,21 @@ class DockerEnvironment(BaseEnvironment):
             runtime_args, unset_names = self._build_runtime_env_args_with_unsets()
             cmd.extend(runtime_args)
 
+        if not login:
+            # ContextVars do not cross the docker-exec process boundary.
+            # Inject this transient marker at the shell-exec boundary itself
+            # so it remains effective even when profile forwarding is absent.
+            from agent.delegation_context import (
+                DELEGATED_CHILD_ENV_MARKER,
+                is_delegated_child_process_context,
+            )
+
+            if is_delegated_child_process_context():
+                cmd.extend(["-e", f"{DELEGATED_CHILD_ENV_MARKER}=1"])
+                unset_names = tuple(
+                    name for name in unset_names if name != DELEGATED_CHILD_ENV_MARKER
+                )
+
         if login:
             unset_names = getattr(self, "_init_unset_passthrough_names", ())
         if unset_names:


### PR DESCRIPTION
## Summary

Prevents `HERMES_DELEGATED_CHILD_CONTEXT=1` from leaking into persisted environment snapshots used by delegated child tasks.

### Fix
- `tools/environments/base.py`: snapshot save/restore excludes the delegated-child marker and its helper bookkeeping (`_HERMES_RUNTIME_PASSTHROUGH_*`); the marker is propagated generically into wrapped shells so SSH/remote backends carry it too.
- `tools/environments/docker.py`: delegated exec receives the marker via `-e` override; ordinary execution is unchanged.
- Regression tests: `tests/tools/test_snapshot_session_id_leak.py`, `tests/tools/test_docker_environment.py`, `tests/tools/test_ssh_environment.py`.

### Verification (L2 adversarial review chain)
- Terra produced + controller independent verification: 7-file suite 111 tests passed, py_compile pass, diff --check clean.
- Sol (independent reviewer) round-1 `needs_changes` (4 findings) → scoped repair → round-3 `approve` (findings: []). Probe evidence: helper-collision probe, Docker marker probe, SSH clean-shell marker probe all green.
- Evidence archive: `~/.hermes/knowledge/curation-runs/l2-delegated-child-snapshot-current-base-v2/`

### Known gaps (non-blocking for this bounded repair)
- SSH validated with clean-shell emulation, not a live authenticated SSH daemon.
- Docker validated daemon-less (argv/env emulation), not a live daemon.
- No Windows runtime, full repository suite, CI, push, merge, deploy, or promotion exercised in this review.