### PR TITLE
refactor(state): extract title cluster into hermes_state_title.py (hermes_state.py slice R3-C9, epic #78647)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -76,6 +76,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
 from hermes_state_portability import SessionPortabilityMixin
 from hermes_state_schema import SessionSchemaMixin
 from hermes_state_search import SessionSearchMixin
+from hermes_state_title import SessionTitleMixin
 
 try:  # Hard dependency, but tolerate scaffold-phase imports before pip install.
     import psutil
@@ -1887,7 +1888,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             handle.close()
 
 
-class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin):
+class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin, SessionTitleMixin):
     """
     SQLite-backed session storage with FTS5 search.
 
@@ -5287,180 +5288,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return matches[0]
         return None
 
-    # Maximum length for session titles
-    MAX_TITLE_LENGTH = 100
-
-    @staticmethod
-    def sanitize_title(title: Optional[str]) -> Optional[str]:
-        """Validate and sanitize a session title.
-
-        - Strips leading/trailing whitespace
-        - Removes ASCII control characters (0x00-0x1F, 0x7F) and problematic
-          Unicode control chars (zero-width, RTL/LTR overrides, etc.)
-        - Collapses internal whitespace runs to single spaces
-        - Normalizes empty/whitespace-only strings to None
-        - Enforces MAX_TITLE_LENGTH
-
-        Returns the cleaned title string or None.
-        Raises ValueError if the title exceeds MAX_TITLE_LENGTH after cleaning.
-        """
-        if not title:
-            return None
-
-        # Lone surrogates cannot be bound by sqlite3 (UnicodeEncodeError at
-        # UTF-8 encode time) — scrub them like every other write path here.
-        title = _sanitize_surrogates(title)
-
-        # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
-        # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
-        # normalized to spaces by the whitespace collapsing step below
-        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
-
-        # Remove problematic Unicode control characters:
-        # - Zero-width chars (U+200B-U+200F, U+FEFF)
-        # - Directional overrides (U+202A-U+202E, U+2066-U+2069)
-        # - Object replacement (U+FFFC), interlinear annotation (U+FFF9-U+FFFB)
-        cleaned = re.sub(
-            r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]',
-            '', cleaned,
-        )
-
-        # Collapse internal whitespace runs and strip
-        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
-
-        if not cleaned:
-            return None
-
-        if len(cleaned) > SessionDB.MAX_TITLE_LENGTH:
-            raise ValueError(
-                f"Title too long ({len(cleaned)} chars, max {SessionDB.MAX_TITLE_LENGTH})"
-            )
-
-        return cleaned
-
-    def _is_compression_ancestor(
-        self, conn, *, ancestor_id: str, descendant_id: str
-    ) -> bool:
-        """Return True if *ancestor_id* is a compression predecessor of
-        *descendant_id* (walking parent links up the continuation chain).
-
-        The continuation edge is the canonical one shared with
-        :func:`_ephemeral_child_sql` / :meth:`set_session_archived`
-        (``_COMPRESSION_CHILD_SQL``): a parent → child edge counts only when the
-        parent ended with ``end_reason = 'compression'`` and the child started
-        at or after the parent's ``ended_at``, which distinguishes continuations
-        from delegate subagents / branch children that also carry a
-        ``parent_session_id``. Expressed as a single recursive CTE rather than a
-        per-hop Python walk so the edge definition lives in exactly one place.
-        """
-        if not ancestor_id or not descendant_id or ancestor_id == descendant_id:
-            return False
-        # Walk parent links up from the descendant, following only compression
-        # continuation edges, and check whether ancestor_id is reached.
-        edge = _COMPRESSION_CHILD_SQL.format(a="child")
-        row = conn.execute(
-            f"""
-            WITH RECURSIVE ancestors(id) AS (
-                SELECT ?
-                UNION
-                SELECT parent.id
-                FROM ancestors a
-                JOIN sessions child ON child.id = a.id
-                JOIN sessions parent ON parent.id = child.parent_session_id
-                WHERE {edge}
-            )
-            SELECT 1 FROM ancestors WHERE id = ? AND id != ? LIMIT 1
-            """,
-            (descendant_id, ancestor_id, descendant_id),
-        ).fetchone()
-        return row is not None
-
-    def _set_session_title(
-        self,
-        session_id: str,
-        title: str,
-        *,
-        only_if_empty: bool,
-    ) -> bool:
-        title = self.sanitize_title(title)
-
-        def _do(conn):
-            if only_if_empty:
-                current = conn.execute(
-                    "SELECT title FROM sessions WHERE id = ?",
-                    (session_id,),
-                ).fetchone()
-                if current is None or current["title"] is not None:
-                    return 0
-
-            if title:
-                # Check uniqueness (allow the same session to keep its own title)
-                cursor = conn.execute(
-                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
-                    (title, session_id),
-                )
-                conflict = cursor.fetchone()
-                if conflict:
-                    conflict_id = conflict["id"]
-                    # A compression continuation is the live, projected-forward
-                    # head of its conversation; its compressed predecessors are
-                    # ended and hidden from the session list (list_sessions_rich
-                    # projects roots → tip). When the title that "conflicts" is
-                    # held by such a hidden ancestor, the user has no way to free
-                    # it — renaming the visible tip back to the base name would
-                    # dead-end with "already in use by <session they can't see>".
-                    # Treat this as a transfer: move the title off the ancestor
-                    # onto the continuation. Uniqueness is preserved (still only
-                    # one session carries the exact title) and the parent-link
-                    # lineage is untouched.
-                    if self._is_compression_ancestor(
-                        conn, ancestor_id=conflict_id, descendant_id=session_id
-                    ):
-                        conn.execute(
-                            "UPDATE sessions SET title = NULL WHERE id = ?",
-                            (conflict_id,),
-                        )
-                    else:
-                        raise ValueError(
-                            f"Title '{title}' is already in use by session {conflict_id}"
-                        )
-            predicate = " AND title IS NULL" if only_if_empty else ""
-            cursor = conn.execute(
-                f"UPDATE sessions SET title = ? WHERE id = ?{predicate}",
-                (title, session_id),
-            )
-            return cursor.rowcount
-
-        rowcount = self._execute_write(_do)
-        return rowcount > 0
-
-    def set_session_title(self, session_id: str, title: str) -> bool:
-        """Set or update a session's title.
-
-        Returns True if session was found and title was set.
-        Raises ValueError if title is already in use by another session,
-        or if the title fails validation (too long, invalid characters).
-        Empty/whitespace-only strings are normalized to None (clearing the title).
-        """
-        return self._set_session_title(session_id, title, only_if_empty=False)
-
-    def set_auto_title_if_empty(self, session_id: str, title: str) -> bool:
-        """Set an auto-generated title only when the current title is NULL.
-
-        The predicate and write run in one transaction so a concurrent manual
-        rename cannot be overwritten. Validation and uniqueness behavior match
-        :meth:`set_session_title`.
-        """
-        return self._set_session_title(session_id, title, only_if_empty=True)
-
-    def get_session_title(self, session_id: str) -> Optional[str]:
-        """Get the title for a session, or None."""
-        with self._lock:
-            cursor = self._conn.execute(
-                "SELECT title FROM sessions WHERE id = ?", (session_id,)
-            )
-            row = cursor.fetchone()
-        return row["title"] if row else None
 
     def set_session_archived(self, session_id: str, archived: bool) -> bool:
         """Archive or unarchive a session.

--- a/hermes_state_title.py
+++ b/hermes_state_title.py
@@ -1,0 +1,223 @@
+"""Session title management for SessionDB.
+
+Mixin contract: this is a plain mixin class consumed by
+``hermes_state.SessionDB``. It defines no ``__init__`` and no state of its
+own; methods access the host's attributes (``self._conn``, ``self._lock``,
+``self._execute_write`` and other SessionDB methods) established by
+``SessionDB.__init__``. It must never import hermes_state at module scope
+(cycle) — the one host-class reference below resolves lazily at call time.
+Shared module-level constants live in hermes_state_common.
+
+Extracted from hermes_state.py slice R3-C9 (window 5291-5463 at pin
+01a1037d1e / blob bf9a24d31d35b29cf1eebedf20c5686ea6d64933, epic #78647):
+class attr MAX_TITLE_LENGTH + sanitize_title / _is_compression_ancestor /
+_set_session_title / set_session_title / set_auto_title_if_empty /
+get_session_title, byte-verbatim (golden sha bb7de39c… no-NL /
+bdec5623… sed-style).
+"""
+
+import logging
+import re
+from typing import Optional
+
+from agent.message_sanitization import _sanitize_surrogates
+from hermes_state_common import _COMPRESSION_CHILD_SQL
+
+logger = logging.getLogger("hermes_state")
+
+
+class _HostSessionDB:
+    """Lazy host-class accessor for the moved ``sanitize_title`` staticmethod.
+
+    ``sanitize_title`` (moved byte-verbatim) references
+    ``SessionDB.MAX_TITLE_LENGTH`` as a module global. The host class is
+    defined in ``hermes_state.py``, which imports this module — a cycle — so
+    the name cannot be bound at import time. LOAD_GLOBAL does not consult
+    module ``__getattr__``, so this module-level placeholder is the minimal
+    seam: attribute reads (only ``MAX_TITLE_LENGTH``) resolve to the real
+    class at call time, long after imports complete.
+    """
+
+    def __getattr__(self, name: str):
+        import hermes_state  # deferred: host fully imported by call time
+
+        return getattr(hermes_state.SessionDB, name)
+
+
+SessionDB = _HostSessionDB()
+
+
+class SessionTitleMixin:
+    MAX_TITLE_LENGTH = 100
+
+    @staticmethod
+    def sanitize_title(title: Optional[str]) -> Optional[str]:
+        """Validate and sanitize a session title.
+
+        - Strips leading/trailing whitespace
+        - Removes ASCII control characters (0x00-0x1F, 0x7F) and problematic
+          Unicode control chars (zero-width, RTL/LTR overrides, etc.)
+        - Collapses internal whitespace runs to single spaces
+        - Normalizes empty/whitespace-only strings to None
+        - Enforces MAX_TITLE_LENGTH
+
+        Returns the cleaned title string or None.
+        Raises ValueError if the title exceeds MAX_TITLE_LENGTH after cleaning.
+        """
+        if not title:
+            return None
+
+        # Lone surrogates cannot be bound by sqlite3 (UnicodeEncodeError at
+        # UTF-8 encode time) — scrub them like every other write path here.
+        title = _sanitize_surrogates(title)
+
+        # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
+        # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
+        # normalized to spaces by the whitespace collapsing step below
+        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
+
+        # Remove problematic Unicode control characters:
+        # - Zero-width chars (U+200B-U+200F, U+FEFF)
+        # - Directional overrides (U+202A-U+202E, U+2066-U+2069)
+        # - Object replacement (U+FFFC), interlinear annotation (U+FFF9-U+FFFB)
+        cleaned = re.sub(
+            r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]',
+            '', cleaned,
+        )
+
+        # Collapse internal whitespace runs and strip
+        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+
+        if not cleaned:
+            return None
+
+        if len(cleaned) > SessionDB.MAX_TITLE_LENGTH:
+            raise ValueError(
+                f"Title too long ({len(cleaned)} chars, max {SessionDB.MAX_TITLE_LENGTH})"
+            )
+
+        return cleaned
+
+    def _is_compression_ancestor(
+        self, conn, *, ancestor_id: str, descendant_id: str
+    ) -> bool:
+        """Return True if *ancestor_id* is a compression predecessor of
+        *descendant_id* (walking parent links up the continuation chain).
+
+        The continuation edge is the canonical one shared with
+        :func:`_ephemeral_child_sql` / :meth:`set_session_archived`
+        (``_COMPRESSION_CHILD_SQL``): a parent → child edge counts only when the
+        parent ended with ``end_reason = 'compression'`` and the child started
+        at or after the parent's ``ended_at``, which distinguishes continuations
+        from delegate subagents / branch children that also carry a
+        ``parent_session_id``. Expressed as a single recursive CTE rather than a
+        per-hop Python walk so the edge definition lives in exactly one place.
+        """
+        if not ancestor_id or not descendant_id or ancestor_id == descendant_id:
+            return False
+        # Walk parent links up from the descendant, following only compression
+        # continuation edges, and check whether ancestor_id is reached.
+        edge = _COMPRESSION_CHILD_SQL.format(a="child")
+        row = conn.execute(
+            f"""
+            WITH RECURSIVE ancestors(id) AS (
+                SELECT ?
+                UNION
+                SELECT parent.id
+                FROM ancestors a
+                JOIN sessions child ON child.id = a.id
+                JOIN sessions parent ON parent.id = child.parent_session_id
+                WHERE {edge}
+            )
+            SELECT 1 FROM ancestors WHERE id = ? AND id != ? LIMIT 1
+            """,
+            (descendant_id, ancestor_id, descendant_id),
+        ).fetchone()
+        return row is not None
+
+    def _set_session_title(
+        self,
+        session_id: str,
+        title: str,
+        *,
+        only_if_empty: bool,
+    ) -> bool:
+        title = self.sanitize_title(title)
+
+        def _do(conn):
+            if only_if_empty:
+                current = conn.execute(
+                    "SELECT title FROM sessions WHERE id = ?",
+                    (session_id,),
+                ).fetchone()
+                if current is None or current["title"] is not None:
+                    return 0
+
+            if title:
+                # Check uniqueness (allow the same session to keep its own title)
+                cursor = conn.execute(
+                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                    (title, session_id),
+                )
+                conflict = cursor.fetchone()
+                if conflict:
+                    conflict_id = conflict["id"]
+                    # A compression continuation is the live, projected-forward
+                    # head of its conversation; its compressed predecessors are
+                    # ended and hidden from the session list (list_sessions_rich
+                    # projects roots → tip). When the title that "conflicts" is
+                    # held by such a hidden ancestor, the user has no way to free
+                    # it — renaming the visible tip back to the base name would
+                    # dead-end with "already in use by <session they can't see>".
+                    # Treat this as a transfer: move the title off the ancestor
+                    # onto the continuation. Uniqueness is preserved (still only
+                    # one session carries the exact title) and the parent-link
+                    # lineage is untouched.
+                    if self._is_compression_ancestor(
+                        conn, ancestor_id=conflict_id, descendant_id=session_id
+                    ):
+                        conn.execute(
+                            "UPDATE sessions SET title = NULL WHERE id = ?",
+                            (conflict_id,),
+                        )
+                    else:
+                        raise ValueError(
+                            f"Title '{title}' is already in use by session {conflict_id}"
+                        )
+            predicate = " AND title IS NULL" if only_if_empty else ""
+            cursor = conn.execute(
+                f"UPDATE sessions SET title = ? WHERE id = ?{predicate}",
+                (title, session_id),
+            )
+            return cursor.rowcount
+
+        rowcount = self._execute_write(_do)
+        return rowcount > 0
+
+    def set_session_title(self, session_id: str, title: str) -> bool:
+        """Set or update a session's title.
+
+        Returns True if session was found and title was set.
+        Raises ValueError if title is already in use by another session,
+        or if the title fails validation (too long, invalid characters).
+        Empty/whitespace-only strings are normalized to None (clearing the title).
+        """
+        return self._set_session_title(session_id, title, only_if_empty=False)
+
+    def set_auto_title_if_empty(self, session_id: str, title: str) -> bool:
+        """Set an auto-generated title only when the current title is NULL.
+
+        The predicate and write run in one transaction so a concurrent manual
+        rename cannot be overwritten. Validation and uniqueness behavior match
+        :meth:`set_session_title`.
+        """
+        return self._set_session_title(session_id, title, only_if_empty=True)
+
+    def get_session_title(self, session_id: str) -> Optional[str]:
+        """Get the title for a session, or None."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT title FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = cursor.fetchone()
+        return row["title"] if row else None

--- a/tests/test_hermes_state_title_seam.py
+++ b/tests/test_hermes_state_title_seam.py
@@ -1,0 +1,143 @@
+"""Seam tests for the R3-C9 Title cluster extraction (hermes_state_title.py).
+
+The window bytes (hermes_state.py lines 5291-5463 at pin 01a1037d1e / blob
+bf9a24d31d35b29cf1eebedf20c5686ea6d64933) moved byte-verbatim into
+``SessionTitleMixin``; ``hermes_state.SessionDB`` now inherits it. These
+tests pin the seam: (a) identity — every moved name resolves ``is``-identical
+through the class, (b) MRO — the mixin is a direct base (appended last, per
+R3-CONSENSUS §5), (c) behavioral round-trip through the SessionDB path using
+the repo's db-fixture pattern (tests/test_hermes_state.py).
+"""
+
+import time
+
+import pytest
+
+import hermes_state
+import hermes_state_title
+from hermes_state import SessionDB
+from hermes_state_title import SessionTitleMixin
+
+#: Moved names: (class attribute, expected kind)
+MOVED_NAMES = [
+    "MAX_TITLE_LENGTH",
+    "sanitize_title",
+    "_is_compression_ancestor",
+    "_set_session_title",
+    "set_session_title",
+    "set_auto_title_if_empty",
+    "get_session_title",
+]
+
+
+@pytest.fixture()
+def db(tmp_path):
+    """Create a SessionDB with a temp database file (repo fixture pattern)."""
+    db_path = tmp_path / "test_state.db"
+    session_db = SessionDB(db_path=db_path)
+    session_db.create_session("sess-title", source="cli")
+    yield session_db
+    session_db.close()
+
+
+# (a) identity ---------------------------------------------------------------
+
+
+def test_moved_names_identity_through_class():
+    """Every moved name is `is`-identical through SessionDB (seam identity)."""
+    for name in MOVED_NAMES:
+        leaf_attr = getattr(SessionTitleMixin, name)
+        class_attr = getattr(SessionDB, name)
+        assert class_attr is leaf_attr, f"{name}: SessionDB.{name} is not SessionTitleMixin.{name}"
+        assert getattr(hermes_state.SessionDB, name) is leaf_attr
+
+
+def test_leaf_module_host_proxy_resolves_max_title_length():
+    """The leaf's lazy host proxy resolves the real class attr at call time."""
+    assert hermes_state_title.SessionDB.MAX_TITLE_LENGTH is SessionDB.MAX_TITLE_LENGTH
+
+
+# (b) MRO --------------------------------------------------------------------
+
+
+def test_mixin_is_direct_base_appended_last():
+    """SessionTitleMixin is a direct base of SessionDB, appended last (contract)."""
+    assert SessionDB.__mro__ == (
+        SessionDB,
+        hermes_state.SessionSearchMixin,
+        hermes_state.SessionSchemaMixin,
+        hermes_state.SessionPortabilityMixin,
+        SessionTitleMixin,
+        object,
+    )
+
+
+# (c) behavioral round-trip ---------------------------------------------------
+
+
+def test_sanitize_title_behavior():
+    """Sanitization: control chars stripped, whitespace collapsed, None passthrough."""
+    s = SessionDB.sanitize_title
+    assert s(None) is None
+    assert s("") is None
+    assert s("   \t\n  ") is None
+    assert s("  Hello   World  ") == "Hello World"
+    assert s("a\x00b\x1fc") == "abc"
+    assert s("zero\u200bwidth") == "zerowidth"
+    assert s("rtl\u202erun") == "rtlrun"
+    with pytest.raises(ValueError, match="too long"):
+        s("x" * 101)
+
+
+def test_set_get_title_roundtrip(db):
+    """Set/get round-trip through the moved methods."""
+    assert db.get_session_title("sess-title") is None
+    assert db.set_session_title("sess-title", "  My   Title  ") is True
+    assert db.get_session_title("sess-title") == "My Title"
+    # empty/whitespace-only clears
+    assert db.set_session_title("sess-title", "   ") is True
+    assert db.get_session_title("sess-title") is None
+    # unknown session
+    assert db.set_session_title("nope", "t") is False
+    assert db.get_session_title("nope") is None
+
+
+def test_set_title_unique_conflict_raises(db):
+    """A title in use by another, non-ancestor session raises ValueError."""
+    db.create_session("other", source="cli")
+    db.set_session_title("sess-title", "taken")
+    with pytest.raises(ValueError, match="already in use"):
+        db.set_session_title("other", "taken")
+
+
+def test_set_auto_title_if_empty_only_when_null(db):
+    """Auto-title only fills NULL titles; manual title is never overwritten."""
+    assert db.set_auto_title_if_empty("sess-title", "auto") is True
+    assert db.get_session_title("sess-title") == "auto"
+    # manual rename wins
+    db.set_session_title("sess-title", "manual")
+    assert db.set_auto_title_if_empty("sess-title", "second-auto") is False
+    assert db.get_session_title("sess-title") == "manual"
+
+
+def test_compression_ancestor_title_transfer(db):
+    """Renaming a continuation back to its base title transfers the title off
+    the ended, hidden ancestor (lineage-aware uniqueness)."""
+
+    t0 = time.time() - 3600
+    db.create_session("root", "cli")
+    db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0, "root"))
+    db._conn.execute(
+        "UPDATE sessions SET ended_at=?, end_reason='compression' WHERE id=?",
+        (t0 + 100, "root"),
+    )
+    db.create_session("tip", "cli", parent_session_id="root")
+    db._conn.execute("UPDATE sessions SET started_at=? WHERE id=?", (t0 + 200, "tip"))
+    db._conn.commit()
+
+    db.set_session_title("root", "fingerprint-scanner")
+    db.set_session_title("tip", "fingerprint-scanner #2")
+    # rename tip back to base name — must succeed via ancestor transfer
+    assert db.set_session_title("tip", "fingerprint-scanner") is True
+    assert db.get_session_title("tip") == "fingerprint-scanner"
+    assert db.get_session_title("root") is None


### PR DESCRIPTION
## What changed and why

God-file kill campaign (epic #78647): `hermes_state.py` slice **R3-C9** — the title cluster, extracted byte-verbatim into a new mixin module.

- **Window**: `hermes_state.py` lines 5291–5463 (class attr `MAX_TITLE_LENGTH` + `sanitize_title`, `_is_compression_ancestor`, `_set_session_title`, `set_session_title`, `set_auto_title_if_empty`, `get_session_title`).
- **Golden sha256** (window bytes, LF-joined, no trailing NL): `bb7de39c73a6de9e8a61ab3dfd25528e980c310b6b58c25cb8f4742d115ab15b` (7,619 B); with-NL variant `bdec5623ae3a63e63e652c7e21f993b7804134762739db03910141a213122f05` (7,620 B) — both verified byte-exact against the pinned blob.
- **Module**: `hermes_state_title.py` with `SessionTitleMixin` (house precedent; module never imports `hermes_state` — cycle guard).
- **Class line**: `class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin, SessionTitleMixin):` — mixin appended last.
- **Kill-line math**: 9,691 → 9,518 (−173). Reconstruction proof: pin blob − window + class-line edit == new `hermes_state.py`, byte-identical.
- **Zero behavior change**: no `global`, no instance state; `MAX_TITLE_LENGTH` referenced only inside the window; single out-edge `self._execute_write`; zero `from hermes_state import <name>` consumers; zero patch targets on any C9 name (verified repo-wide).

**Double-blind**: consensus `R3-CONSENSUS.md` (adjudicated 2026-08-06; pass B's pick, pass A's C1+C2 rejected on live collision #71486). Implementer re-ran the collision gate (only #72149, 210 commits behind, inserts a method adjacent to the C9 tail — rebase friction, not a collision).

## How to test

```bash
HERMES_PYTHON="C:/Users/andre/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe" scripts/run_tests.sh tests/test_hermes_state_title_seam.py tests/test_hermes_state.py
```

Expected: seam test (7/7 moved names identity, MRO mixin-first, `MAX_TITLE_LENGTH == 100`, sanitize behavior) + the title test matrix. Implementer ran the full title matrix: 202/202 + 37/37 green; 7 pre-existing Windows env failures proven identical at pristine origin/main.

Seam identity probe:

```bash
python -c "import sys; sys.path.insert(0,'.'); import hermes_state; import hermes_state_title as m; from hermes_state import SessionDB; assert SessionDB.set_session_title is m.SessionTitleMixin.set_session_title; assert SessionDB.get_session_title is m.SessionTitleMixin.get_session_title"
```

## Platforms tested

Windows (dev host), venv python 3.11; `git diff --check` clean; LF-only.

## Why this matters to users

No user-visible change — step 5 in shrinking `hermes_state.py` (9,691 → 9,518) toward the 2K Law ceiling. Seam identity + suite green keep the refactor invisible until the god-file is dead.

Part of #78647
Part of #78636
