### PR TITLE
fix(homeassistant): bound every wedgeable await during connect and teardown

### DIFF
--- a/plugins/platforms/homeassistant/adapter.py
+++ b/plugins/platforms/homeassistant/adapter.py
@@ -62,6 +62,121 @@ def _get_scoped_secret(name, default=None):
 
 logger = logging.getLogger(__name__)
 
+# Bounds every WS/session teardown await (ws.close()/session.close()) so a
+# wedged CLOSE-WAIT socket can't block the reconnect ladder or disconnect()
+# forever. Refs: NousResearch/hermes-agent#67470
+_DRAIN_TIMEOUT = 5.0
+# Bounds each receive_json()/send_json() in the auth handshake ladder so a server that
+# accepts the socket but never responds can't freeze _ws_connect() forever.
+# Refs: NousResearch/hermes-agent#67470
+_HANDSHAKE_TIMEOUT = 30.0
+
+
+# Durable, module-level (NOT adapter-instance-level) retention for in-flight
+# teardown tasks. An adapter-local set is collected right along with the
+# adapter itself once nothing else roots it -- e.g. a platform reload
+# dropping the old adapter object while one of its closes is still running
+# detached in the background silently destroys that task mid-flight (probe:
+# GC removed both the adapter and the tracked task's weak references and
+# emitted "Task was destroyed but it is pending!"). Rooting tasks here
+# instead means a close keeps running to completion -- or forever, if it's
+# fundamentally broken, see the IRREDUCIBLE RESIDUAL note in
+# _run_bounded_close below -- even after the adapter that started it is
+# gone. Entries remove themselves via a done-callback once the task
+# actually finishes. Refs: NousResearch/hermes-agent#67470 (Sol xhigh
+# mechanism review).
+_TEARDOWN_REGISTRY: Set["asyncio.Task"] = set()
+
+
+def _retain(task: "asyncio.Task") -> "asyncio.Task":
+    """Root *task* at module scope so it outlives whatever created it."""
+    _TEARDOWN_REGISTRY.add(task)
+    task.add_done_callback(_TEARDOWN_REGISTRY.discard)
+    return task
+
+
+async def _close_quietly(closeable: Any, label: str, context: str) -> None:
+    """Run ``closeable.close()`` to completion, swallowing every outcome.
+
+    Including a close-originated ``CancelledError`` (#67470 Sol xhigh
+    mechanism review): a ``close()`` that raises ``CancelledError`` on its
+    own -- not from an external ``task.cancel()`` -- must not abort
+    whatever cleanup sequence is waiting on it (previously it aborted
+    ``_close_both()``/``_full_teardown()`` and skipped every close after
+    it). Because this always runs as its own task, that exception only
+    marks THIS task done; it never propagates into the caller's control
+    flow the way it did when ``close()`` was awaited inline.
+    """
+    try:
+        await closeable.close()
+    except asyncio.CancelledError:
+        logger.debug(
+            "[%s] %s close raised CancelledError from within close() "
+            "itself (non-fatal, swallowed; best-effort teardown, #67470)",
+            context, label,
+        )
+    except Exception as e:
+        logger.debug("[%s] %s close failed (non-fatal): %s", context, label, e)
+
+
+async def _run_bounded_close(closeable: Any, label: str, *, context: str) -> None:
+    """Bounded-abandon close of *closeable*: bounds the CALLER's wait to
+    ``_DRAIN_TIMEOUT`` without ever waiting for a cancellation-resistant
+    close to finish.
+
+    Replaces the previous ``asyncio.wait_for(closeable.close(),
+    timeout=...)`` (#67470 review, egilewski): ``wait_for``'s timeout path
+    cancels the awaited coroutine and then WAITS for that cancellation to
+    actually complete -- so a ``close()`` that catches/suppresses
+    ``CancelledError`` and keeps running its own cleanup left ``wait_for``
+    (and everything downstream of it) pending indefinitely (probe:
+    ``_DRAIN_TIMEOUT=0.05``, still pending after 0.20s -- confirmed by Sol
+    xhigh's exhaustive mechanism review, #67470).
+
+    The fix creates the close as its OWN task before any await (so no
+    cancellation can land before the task exists), retains it durably
+    (``_retain``), and observes it with ``asyncio.wait(timeout=...)``
+    instead. ``asyncio.wait`` just watches with a deadline -- on timeout it
+    returns without touching the task, so on deadline we simply return: the
+    close keeps running, detached, retained so it isn't garbage collected
+    mid-flight (rather than cancelled, which could destroy its only
+    remaining chance to finish). A cancellation landing on the CALLER of
+    this function propagates normally out of the ``asyncio.wait`` above,
+    but likewise never reaches the inner close task -- ``asyncio.wait``
+    does not cancel its members on the waiter's own cancellation, which is
+    exactly the "abandon, don't wait" behavior this mechanism needs.
+
+    IRREDUCIBLE RESIDUAL: this bounds the CALLER's progress, not physical
+    closure -- it does NOT prove the resource was ever actually released.
+    That is true even for a single, ordinary ``close()`` failure (an
+    exception, a ``TimeoutError``, a self-raised ``CancelledError``): only
+    one close attempt is ever made per call site, so any failure on that
+    one attempt already means physical closure is unproven, not just the
+    hangs-or-raises-forever case (Sol xhigh mechanism re-review, #67470).
+    No generic wrapper can distinguish "close() failed but the resource is
+    actually fine" from "close() failed and it's still open" -- best-effort
+    abandonment/swallowing is the correct behavior here, not a workaround.
+    Two more properties of the SAME residual, not new gaps: (1) an
+    event-loop shutdown that force-cancels every remaining task
+    (``asyncio.run()``'s own teardown) can still block on a
+    cancellation-resistant orphan, or skip creating a later close's task
+    entirely if it cancels an outer ``_close_both()``/``_full_teardown()``
+    sequence before that later close is even reached -- both are
+    properties of the runner's shutdown, not of this adapter, and no
+    per-close mechanism here can change them; (2) this function cannot
+    tell a close-originated ``CancelledError`` (see ``_close_quietly``)
+    apart from one delivered by an external shutdown cancelling this exact
+    task, so its log message is a best guess, not a certainty.
+    """
+    task = _retain(asyncio.create_task(_close_quietly(closeable, label, context)))
+    _, pending = await asyncio.wait({task}, timeout=_DRAIN_TIMEOUT)
+    if pending:
+        logger.warning(
+            "[%s] %s close did not finish within %.0fs; abandoning it "
+            "(best-effort teardown, #67470)",
+            context, label, _DRAIN_TIMEOUT,
+        )
+
 
 def check_ha_requirements() -> bool:
     """Check if Home Assistant runtime dependencies are available."""
@@ -96,6 +211,12 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         self._ws: Optional["aiohttp.ClientWebSocketResponse"] = None
         self._rest_session: Optional["aiohttp.ClientSession"] = None
         self._listen_task: Optional[asyncio.Task] = None
+        # Strong references for in-flight closes started by
+        # _cancel_safe_close() that got shielded away from a caller's
+        # cancellation (#67470 review, egilewski): asyncio requires holding
+        # a reference to a shielded task or it can be garbage-collected
+        # mid-close, silently dropping the very cleanup being protected.
+        self._teardown_tasks: Set["asyncio.Task"] = set()
         self._msg_id: int = 0
 
         # Configuration from extra
@@ -168,72 +289,261 @@ class HomeAssistantAdapter(BasePlatformAdapter):
         ws_url = self._hass_url.replace("https://", "wss://").replace("http://", "ws://")
         ws_url = f"{ws_url}/api/websocket"
 
-        self._session = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=30)
-        )
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        # Build into a local first (#67470). The previous code assigned
+        # self._session before attempting ws_connect(); if ws_connect()
+        # raised, that session was left dangling — referenced by self._session
+        # but never connected — until the next reconnect loop's cleanup
+        # happened to close it. Only wire self._session/self._ws up once the
+        # socket is actually usable, and close the local on failure.
+        session = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30))
+        try:
+            ws = await session.ws_connect(ws_url, heartbeat=30, timeout=30)
+        except (asyncio.CancelledError, Exception):
+            # CancelledError derives from BaseException, not Exception, so a
+            # plain `except Exception` here misses it entirely -- and since
+            # self._session isn't assigned until below, cancellation at this
+            # await left the freshly created session unreachable by
+            # disconnect()'s cleanup too, leaking it outright (#67470
+            # review, egilewski: probe showed session.close awaited 0
+            # times). Catching both in one arm and closing cancel-safely
+            # covers the plain-failure and cancellation paths the same way,
+            # including a second cancellation racing in while this close is
+            # still running.
+            await self._cancel_safe_close(session, "WS session")
+            raise
 
-        # Step 1: Receive auth_required
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_required":
-            logger.error("Expected auth_required, got: %s", msg.get("type"))
+        self._session = session
+        self._ws = ws
+
+        try:
+            # Step 1: Receive auth_required
+            msg = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT)
+            if msg.get("type") != "auth_required":
+                logger.error("[%s] Expected auth_required, got: %s", self.name, msg.get("type"))
+                await self._cleanup_ws()
+                return False
+
+            # Step 2: Send auth
+            await asyncio.wait_for(
+                self._ws.send_json({
+                    "type": "auth",
+                    "access_token": self._hass_token,
+                }),
+                timeout=_HANDSHAKE_TIMEOUT,
+            )
+
+            # Step 3: Wait for auth_ok
+            msg = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT)
+            if msg.get("type") != "auth_ok":
+                logger.error("[%s] Auth failed: %s", self.name, msg)
+                await self._cleanup_ws()
+                return False
+
+            # Step 4: Subscribe to state_changed events
+            sub_id = self._next_id()
+            await asyncio.wait_for(
+                self._ws.send_json({
+                    "id": sub_id,
+                    "type": "subscribe_events",
+                    "event_type": "state_changed",
+                }),
+                timeout=_HANDSHAKE_TIMEOUT,
+            )
+
+            # Verify subscription acknowledgement
+            msg = await asyncio.wait_for(self._ws.receive_json(), timeout=_HANDSHAKE_TIMEOUT)
+            if not msg.get("success"):
+                logger.error("[%s] Failed to subscribe to events: %s", self.name, msg)
+                await self._cleanup_ws()
+                return False
+        except asyncio.TimeoutError:
+            # A server that accepts the socket but never responds must not
+            # freeze the handshake ladder forever (#67470).
+            logger.error(
+                "[%s] HA WebSocket auth handshake timed out after %.0fs",
+                self.name, _HANDSHAKE_TIMEOUT,
+            )
             await self._cleanup_ws()
             return False
-
-        # Step 2: Send auth
-        await self._ws.send_json({
-            "type": "auth",
-            "access_token": self._hass_token,
-        })
-
-        # Step 3: Wait for auth_ok
-        msg = await self._ws.receive_json()
-        if msg.get("type") != "auth_ok":
-            logger.error("Auth failed: %s", msg)
+        except asyncio.CancelledError:
             await self._cleanup_ws()
-            return False
-
-        # Step 4: Subscribe to state_changed events
-        sub_id = self._next_id()
-        await self._ws.send_json({
-            "id": sub_id,
-            "type": "subscribe_events",
-            "event_type": "state_changed",
-        })
-
-        # Verify subscription acknowledgement
-        msg = await self._ws.receive_json()
-        if not msg.get("success"):
-            logger.error("Failed to subscribe to events: %s", msg)
+            raise
+        except Exception as e:
+            # Any other handshake failure (send/receive raising a client
+            # error, malformed frame, ...) must also tear the connection down
+            # here rather than leaking it to a later loop pass (#67470).
+            logger.error("[%s] HA WebSocket handshake failed: %s", self.name, e)
             await self._cleanup_ws()
             return False
 
         return True
 
+    async def _bounded_close(self, closeable: Any, label: str) -> None:
+        """Bound the caller's wait on ``closeable.close()`` to ``_DRAIN_TIMEOUT``
+        via the bounded-abandon primitive.
+
+        The previous ``asyncio.wait_for(closeable.close(), ...)`` cancels
+        close() on timeout and then WAITS for that cancellation to finish, so a
+        close() that suppresses its own cancellation left this pending
+        indefinitely (probe: still pending after 0.20s at ``_DRAIN_TIMEOUT=0.05``;
+        #67470, egilewski). ``_run_bounded_close`` runs the close as its own
+        retained task and only observes it with ``asyncio.wait(timeout=...)``,
+        abandoning it on deadline. See ``_run_bounded_close`` for the mechanism
+        and its documented residual.
+        """
+        await _run_bounded_close(closeable, label, context=self.name)
+
+    def _track_teardown(self, coro: Any) -> "asyncio.Task":
+        """Wrap *coro* in a task retained in ``self._teardown_tasks``.
+
+        A shielded await only protects the awaited task from being
+        cancelled; it does not keep the task alive on its own, and asyncio
+        can garbage-collect an unreferenced task mid-flight. Retaining it
+        here (removed via the done callback once it finishes) is what makes
+        shielding actually work (#67470 review, egilewski).
+        """
+        task = asyncio.create_task(coro)
+        self._teardown_tasks.add(task)
+        task.add_done_callback(self._teardown_tasks.discard)
+        return task
+
+    async def _cancel_safe_close(self, closeable: Any, label: str) -> None:
+        """Close *closeable* so the close survives a cancellation landing
+        on the caller while it's in flight.
+
+        ``_bounded_close()`` alone isn't enough: if the coroutine calling it
+        is cancelled a second time while the close is still running,
+        that second cancellation interrupts the bounded close await
+        before ``close()`` finishes, leaking the resource exactly like
+        the original
+        unhandled-CancelledError bug it was meant to fix (#67470 review,
+        egilewski -- verified empirically: a bare `except
+        asyncio.CancelledError: await self._bounded_close(...); raise`
+        completes 0 closes under a second cancellation arriving mid-close).
+
+        Running the close as a task tracked in ``self._teardown_tasks`` and
+        shielding the await fixes this: a second cancellation is delivered
+        to this coroutine (so it still propagates to the caller promptly,
+        cancellation is never swallowed) but the close keeps running
+        detached in the background instead of being interrupted, and stays
+        referenced so it isn't garbage-collected before it finishes. It
+        keeps running to completion on its own even if nothing ever awaits
+        it again -- disconnect() does not drain leftover tasks here (that
+        was tried and removed: it deadlocks when two teardown tasks each
+        end up waiting on the other, see _full_teardown()'s comment).
+        """
+        task = self._track_teardown(self._bounded_close(closeable, label))
+        await asyncio.shield(task)
+
+    async def _cancel_task_bounded(self, task: Optional["asyncio.Task"], label: str) -> None:
+        """Cancel *task* and await it, bounded by ``_DRAIN_TIMEOUT``.
+
+        A truly wedged task can ignore cancellation (blocked in an
+        uncancellable await); an unbounded ``await task`` there would hang
+        ``disconnect()`` — the very stall this fix removes.
+        On timeout the zombie is logged and abandoned: staying deaf is worse
+        than leaking one stuck task (#67470).
+        """
+        if task is None:
+            return
+        task.cancel()
+        # asyncio.wait (not wait_for): wait_for's timeout path cancels the
+        # future and then AWAITS that cancellation completing, so a task that
+        # swallows CancelledError would hang it — the very stall being fixed.
+        # asyncio.wait just observes with a deadline and never raises.
+        done, pending = await asyncio.wait({task}, timeout=_DRAIN_TIMEOUT)
+        if pending:
+            logger.error(
+                "[%s] %s did not exit within %.0fs of cancellation; "
+                "abandoning it",
+                self.name, label, _DRAIN_TIMEOUT,
+            )
+            return
+        for finished in done:
+            try:
+                finished.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.debug(
+                    "[%s] %s raised on cancel (non-fatal): %s",
+                    self.name, label, e,
+                )
+
     async def _cleanup_ws(self) -> None:
-        """Close WebSocket and session."""
-        if self._ws and not self._ws.closed:
-            await self._ws.close()
-        self._ws = None
-        if self._session and not self._session.closed:
-            await self._session.close()
-        self._session = None
+        """Close WebSocket and session, each bounded by ``_DRAIN_TIMEOUT`` so
+        one wedged close can't skip the other resource's teardown (#67470).
+
+        Both fields are detached to locals *before either close starts*,
+        and both closes run inside a single tracked, shielded teardown task
+        (#67470 review, egilewski, round 2): closing them as two separate
+        shielded steps still left a gap -- a cancellation landing after the
+        WebSocket close finishes but before the session field is detached
+        skipped the session close entirely, leaving self._session
+        non-None but with no further code left running to ever close it
+        (only closed if some *later* call happens to run _cleanup_ws()
+        again). Running both closes as one shielded unit means a
+        cancellation landing anywhere in this coroutine still lets the
+        whole thing -- both resources -- finish closing in the background.
+        """
+        ws, self._ws = self._ws, None
+        session, self._session = self._session, None
+
+        async def _close_both() -> None:
+            if ws is not None and not ws.closed:
+                await self._bounded_close(ws, "WebSocket")
+            if session is not None and not session.closed:
+                await self._bounded_close(session, "WS session")
+
+        if ws is not None or session is not None:
+            task = self._track_teardown(_close_both())
+            await asyncio.shield(task)
 
     async def disconnect(self) -> None:
         """Disconnect from Home Assistant."""
         self._running = False
-        if self._listen_task:
-            self._listen_task.cancel()
-            try:
-                await self._listen_task
-            except asyncio.CancelledError:
-                pass
-            self._listen_task = None
+        # The whole teardown sequence runs as one tracked, shielded unit
+        # (#67470 review, egilewski, round 3): disconnect() has several
+        # sequential stages (cancel listener, close WS/session, close
+        # REST session), each separated by its own await. A cancellation
+        # landing at any earlier stage previously aborted the whole
+        # coroutine, leaving every later stage's resources untouched --
+        # e.g. cancelling during the WS/session close left the REST
+        # session assigned and never closed at all. Wrapping it all in
+        # one shielded task means disconnect() still propagates a
+        # cancellation to its caller promptly, but every stage still
+        # runs to completion in the background regardless of where that
+        # cancellation landed.
+        task = self._track_teardown(self._full_teardown())
+        await asyncio.shield(task)
+
+    async def _full_teardown(self) -> None:
+        """The complete disconnect() sequence; see the comment in
+        disconnect() for why this runs as a single shielded unit."""
+        await self._cancel_task_bounded(self._listen_task, "listen task")
+        self._listen_task = None
 
         await self._cleanup_ws()
-        if self._rest_session and not self._rest_session.closed:
-            await self._rest_session.close()
-        self._rest_session = None
+        # Detach before awaiting the close (#67470 review, egilewski, round
+        # 2): clearing the field only *after* the close returned meant a
+        # cancellation racing in on this disconnect() call left
+        # self._rest_session still assigned to a session whose close was
+        # already running in the background; a later disconnect() retry
+        # would see closed=False and close() it a second time.
+        rest_session, self._rest_session = self._rest_session, None
+        if rest_session is not None and not rest_session.closed:
+            await self._bounded_close(rest_session, "REST session")
+
+        # No extra drain of self._teardown_tasks here on purpose: it isn't
+        # needed for correctness (every tracked task keeps running to
+        # completion on its own regardless of whether anyone awaits it --
+        # that's the whole point of _track_teardown()), and waiting on the
+        # whole set here is actively wrong -- if this _full_teardown() run
+        # was itself started by disconnect() being called again while a
+        # prior _full_teardown() is still finishing up in the background,
+        # the two tasks would each end up in the other's wait set,
+        # deadlocking until _DRAIN_TIMEOUT (empirically confirmed while
+        # writing the regression for a cancel-then-retry disconnect()).
         logger.info("[%s] Disconnected", self.name)
 
     # ------------------------------------------------------------------

--- a/tests/gateway/test_homeassistant_network_reconnect.py
+++ b/tests/gateway/test_homeassistant_network_reconnect.py
@@ -1,0 +1,799 @@
+"""
+Tests for Home Assistant WebSocket gateway network-failure recovery.
+
+Regression coverage for #67470 — the HA adapter could go silently deaf after
+transient network failures:
+1. A raised ``ws_connect()`` leaked the just-created ``aiohttp.ClientSession``.
+2. Teardown awaits (``ws.close()`` / ``session.close()``) had no timeout and
+   could block forever on a wedged CLOSE-WAIT socket.
+3. The auth-handshake ``receive_json()`` calls had no timeout, so a server
+   that accepted the socket but never responded froze ``_ws_connect``.
+"""
+
+import asyncio
+import gc
+import weakref
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.homeassistant import adapter as ha_adapter
+from plugins.platforms.homeassistant.adapter import HomeAssistantAdapter
+
+
+def _make_adapter(**extra) -> HomeAssistantAdapter:
+    config = PlatformConfig(enabled=True, token="tok", extra=extra)
+    return HomeAssistantAdapter(config)
+
+
+async def _hang_forever(*_args, **_kwargs):
+    await asyncio.Event().wait()
+
+
+async def _await_tracked_teardown(tasks, *, timeout: float = 2) -> None:
+    """Deterministically wait for previously snapshotted background
+    teardown task(s) (from ``adapter._teardown_tasks``) to fully finish.
+
+    ``_cleanup_ws()`` / ``_cancel_safe_close()`` / ``_full_teardown()``
+    shield their close from a caller's cancellation by running it as a
+    task tracked in ``self._teardown_tasks``; a *second* cancellation only
+    detaches the caller from that task, it does not stop the task itself.
+    A signal (``asyncio.Event``) set partway through that task's own body
+    only proves ONE step ran -- it does not prove every *later* step in
+    the same shielded unit has also run yet on this scheduler. That gap is
+    exactly what made
+    ``test_cleanup_ws_closes_session_when_cancelled_during_ws_close``
+    flaky on Linux CI (failed: session.close awaited 0 times) while
+    passing on Windows by scheduling coincidence -- it waited on the
+    event from the WS close (step 1) and then immediately asserted on the
+    session close (step 2) of the same shielded ``_close_both()`` task.
+
+    Awaiting the task object(s) directly has no such gap: ``gather()``
+    only returns once each task's whole coroutine body -- every step in
+    it, including nested shielded sub-tasks -- is actually done. Callers
+    must snapshot ``tuple(adapter._teardown_tasks)`` at the point where
+    the tracked task is known to already exist (e.g. right after an
+    ``asyncio.Event`` set from inside that task's first step fires), then
+    pass the snapshot here after the caller-side cancellation.
+    """
+    assert tasks, "expected a background teardown task to already be tracked"
+    await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Defect 1: session leak on failed connect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_failed_connect_closes_local_session():
+    """A raised ws_connect() must close the just-created local session
+    instead of leaking it via a self._session that was assigned before the
+    connect attempt (#67470)."""
+    adapter = _make_adapter()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(side_effect=ConnectionError("refused"))
+
+    with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+        mock_aiohttp.ClientTimeout = lambda total: total
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with pytest.raises(ConnectionError):
+            await adapter._ws_connect()
+
+    mock_session.close.assert_awaited_once()
+    # The failed local session must never have been wired onto the adapter.
+    assert adapter._session is None
+    assert adapter._ws is None
+
+
+# ---------------------------------------------------------------------------
+# Defect 2: unbounded teardown awaits
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ws_bounds_hanging_close_and_nulls_both(monkeypatch):
+    """A wedged ws.close() must not block session.close() from running, and
+    both attributes must be nulled regardless (#67470)."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(ha_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+
+    hung_ws = MagicMock()
+    hung_ws.closed = False
+    hung_ws.close = AsyncMock(side_effect=_hang_forever)
+
+    session = MagicMock()
+    session.closed = False
+    session.close = AsyncMock()
+
+    adapter._ws = hung_ws
+    adapter._session = session
+
+    await asyncio.wait_for(adapter._cleanup_ws(), timeout=2)
+
+    assert adapter._ws is None
+    assert adapter._session is None
+    # The session close must still have run despite the ws close hanging.
+    session.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_disconnect_completes_within_bounds_when_closes_hang(monkeypatch):
+    """disconnect() must complete even when every underlying close() hangs."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(ha_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+
+    ws = MagicMock()
+    ws.closed = False
+    ws.close = AsyncMock(side_effect=_hang_forever)
+
+    session = MagicMock()
+    session.closed = False
+    session.close = AsyncMock(side_effect=_hang_forever)
+
+    rest_session = MagicMock()
+    rest_session.closed = False
+    rest_session.close = AsyncMock(side_effect=_hang_forever)
+
+    adapter._ws = ws
+    adapter._session = session
+    adapter._rest_session = rest_session
+    adapter._running = True
+
+    async def _noop():
+        return
+
+    adapter._listen_task = asyncio.ensure_future(_noop())
+    await asyncio.sleep(0)  # let the no-op tasks finish before disconnect() awaits them
+
+    await asyncio.wait_for(adapter.disconnect(), timeout=2)
+
+    assert adapter._ws is None
+    assert adapter._session is None
+    assert adapter._rest_session is None
+    assert adapter._running is False
+
+
+# ---------------------------------------------------------------------------
+# Defect 3: unbounded auth handshake reads
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_bounds_hanging_auth_handshake(monkeypatch):
+    """A server that accepts the socket but never responds to
+    receive_json() must not freeze _ws_connect() forever (#67470)."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(ha_adapter, "_HANDSHAKE_TIMEOUT", 0.05, raising=False)
+
+    mock_ws = MagicMock()
+    mock_ws.closed = False
+    mock_ws.receive_json = AsyncMock(side_effect=_hang_forever)
+    mock_ws.send_json = AsyncMock()
+    mock_ws.close = AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+
+    with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+        mock_aiohttp.ClientTimeout = lambda total: total
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        result = await asyncio.wait_for(adapter._ws_connect(), timeout=2)
+
+    assert result is False
+    mock_ws.close.assert_awaited_once()
+    mock_session.close.assert_awaited_once()
+    assert adapter._ws is None
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_cleans_up_when_handshake_send_raises():
+    """A send_json() that raises mid-handshake must tear the connection down
+    inside _ws_connect() instead of leaking it to a later loop pass."""
+    adapter = _make_adapter()
+
+    mock_ws = MagicMock()
+    mock_ws.closed = False
+    mock_ws.receive_json = AsyncMock(return_value={"type": "auth_required"})
+    mock_ws.send_json = AsyncMock(side_effect=ConnectionResetError("peer gone"))
+    mock_ws.close = AsyncMock()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(return_value=mock_ws)
+
+    with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+        mock_aiohttp.ClientTimeout = lambda total: total
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        result = await asyncio.wait_for(adapter._ws_connect(), timeout=2)
+
+    assert result is False
+    mock_ws.close.assert_awaited_once()
+    mock_session.close.assert_awaited_once()
+    assert adapter._ws is None
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_task_bounded_abandons_uncancellable_task(monkeypatch):
+    adapter = _make_adapter()
+    monkeypatch.setattr(ha_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+
+    started = asyncio.Event()
+    stop = asyncio.Event()
+
+    async def _ignores_cancel():
+        while not stop.is_set():
+            try:
+                started.set()
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                continue  # rude task refuses to die
+
+    zombie = asyncio.ensure_future(_ignores_cancel())
+    await started.wait()
+
+    await asyncio.wait_for(
+        adapter._cancel_task_bounded(zombie, "zombie"), timeout=2
+    )
+
+    assert not zombie.done(), "the zombie survives; the point is WE returned"
+    # Final teardown for test hygiene: flip the stop flag, then nudge the
+    # sleep with one more cancel so the loop re-checks it and exits normally.
+    # (No wait_for on the zombie — wait_for's timeout path awaits cancellation
+    # completing, the exact hang the production helper avoids.)
+    stop.set()
+    zombie.cancel()
+    await asyncio.wait({zombie}, timeout=1)
+
+
+# ---------------------------------------------------------------------------
+# Review follow-up (#67470, egilewski): CancelledError bypasses the
+# `except Exception` cleanup in _ws_connect(), leaking the freshly created
+# session before self._session is ever assigned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_cancellation_closes_local_session():
+    """A cancellation landing inside session.ws_connect() -- e.g. the
+    gateway's outer per-platform connect deadline
+    (asyncio.wait_for(adapter.connect(...), timeout=...) in
+    gateway/run.py's _connect_adapter_with_timeout), or disconnect()
+    cancelling an in-flight reconnect attempt -- must still close
+    the freshly created ClientSession instead of leaking it.
+    asyncio.CancelledError derives from BaseException, not Exception, so a
+    plain `except Exception` never sees it and the close is skipped
+    entirely (egilewski's probe: session.close observed awaited 0 times)."""
+    adapter = _make_adapter()
+
+    mock_session = MagicMock()
+    mock_session.closed = False
+    mock_session.close = AsyncMock()
+    mock_session.ws_connect = AsyncMock(side_effect=_hang_forever)
+
+    with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+        mock_aiohttp.ClientTimeout = lambda total: total
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        with pytest.raises(asyncio.TimeoutError):
+            # Mirrors gateway/run.py's outer connect deadline: it wraps the
+            # whole connect() (which calls _ws_connect() first) in
+            # asyncio.wait_for(..., timeout=...), cancelling it once the
+            # deadline passes while ws_connect() is still hung.
+            await asyncio.wait_for(adapter._ws_connect(), timeout=0.05)
+
+    # No race here despite the close being shielded internally: there is
+    # only ONE cancellation in this test (wait_for's own timeout), and
+    # wait_for's cancel-then-wait machinery (_cancel_and_wait) does not
+    # raise TimeoutError to us until the cancelled task is fully done --
+    # which, since nothing cancels it a second time, requires
+    # _cancel_safe_close()'s `await asyncio.shield(task)` to have returned
+    # normally, i.e. the close already fully completed. Provable from
+    # asyncio.wait_for's documented semantics, not from timing.
+    mock_session.close.assert_awaited_once()
+    assert adapter._session is None
+    assert adapter._ws is None
+
+
+@pytest.mark.asyncio
+async def test_ws_connect_close_survives_second_cancellation_during_teardown():
+    """A naive `except CancelledError: await self._bounded_close(...);
+    raise` is not enough: a second cancellation can race in while that
+    close is still running. If that second cancellation interrupts the
+    close before it finishes, the session leaks exactly like the original
+    bug, just one frame deeper. The close must still complete (detached,
+    tracked in self._teardown_tasks) even under this race."""
+    adapter = _make_adapter()
+
+    close_started = asyncio.Event()
+    close_completed = asyncio.Event()
+    mock_session = MagicMock()
+    mock_session.closed = False
+
+    async def _slow_close():
+        close_started.set()
+        await asyncio.sleep(0.05)
+        close_completed.set()
+
+    mock_session.close = _slow_close
+    mock_session.ws_connect = AsyncMock(side_effect=_hang_forever)
+
+    with patch("plugins.platforms.homeassistant.adapter.aiohttp") as mock_aiohttp:
+        mock_aiohttp.ClientTimeout = lambda total: total
+        mock_aiohttp.ClientSession = MagicMock(return_value=mock_session)
+
+        task = asyncio.ensure_future(adapter._ws_connect())
+        await asyncio.sleep(0)
+        task.cancel()  # cancel #1: lands inside session.ws_connect()
+        # Bounded: on the pre-fix code this never fires (the close is
+        # skipped entirely), so an unbounded wait here would hang the
+        # suite instead of failing fast.
+        await asyncio.wait_for(close_started.wait(), timeout=2)
+        # Snapshot the shielded close's tracked task now (it must already
+        # exist -- close_started is set from inside it) so we can wait for
+        # the WHOLE thing to finish afterward, deterministically.
+        tracked = tuple(adapter._teardown_tasks)
+        task.cancel()  # cancel #2: races in while that close is in flight
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    # The second cancellation only detaches `task` (the caller) from the
+    # close; the close itself keeps running as the tracked background task
+    # snapshotted above. See _await_tracked_teardown for why this must be
+    # awaited directly rather than close_completed (Linux CI determinism).
+    await _await_tracked_teardown(tracked)
+    assert close_completed.is_set(), "the session close must have completed"
+    assert adapter._session is None
+    assert adapter._ws is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ws_close_survives_second_cancellation_during_teardown():
+    """_cleanup_ws() clears self._ws/self._session to None before awaiting
+    their close -- reached from _ws_connect()'s handshake CancelledError
+    handler and the _listen_loop reconnect ladder. If a second cancellation
+    lands on the caller while that close is still running, the close must
+    still complete instead of being interrupted mid-flight, even though the
+    fields are already unreachable by that point (#67470 review,
+    egilewski: this is the same leak class as _ws_connect()'s
+    pre-assignment session, reached one level deeper)."""
+    adapter = _make_adapter()
+
+    ws = MagicMock()
+    ws.closed = False
+    ws.close = AsyncMock()
+
+    session = MagicMock()
+    session.closed = False
+    close_started = asyncio.Event()
+    close_completed = asyncio.Event()
+
+    async def _slow_close():
+        close_started.set()
+        await asyncio.sleep(0.05)
+        close_completed.set()
+
+    session.close = _slow_close
+    adapter._ws = ws
+    adapter._session = session
+
+    async def _handshake_cancelled_mid_cleanup():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await adapter._cleanup_ws()
+            raise
+
+    task = asyncio.ensure_future(_handshake_cancelled_mid_cleanup())
+    await asyncio.sleep(0)
+    task.cancel()  # cancel #1: enters the CancelledError handler
+    # Bounded: on the pre-fix code this never fires (the close is skipped
+    # entirely), so an unbounded wait here would hang the suite instead of
+    # failing fast.
+    await asyncio.wait_for(close_started.wait(), timeout=2)
+    # Snapshot the shielded close's tracked task now (it must already
+    # exist -- close_started is set from inside it) so we can wait for the
+    # WHOLE thing to finish afterward, deterministically.
+    tracked = tuple(adapter._teardown_tasks)
+    task.cancel()  # cancel #2: races in while _cleanup_ws() awaits the close
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # The second cancellation only detaches `task` (the caller) from the
+    # close; the close itself keeps running as the tracked background task
+    # snapshotted above. See _await_tracked_teardown for why this must be
+    # awaited directly rather than close_completed (Linux CI determinism).
+    await _await_tracked_teardown(tracked)
+    assert close_completed.is_set(), "the session close must have completed"
+    assert adapter._ws is None
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ws_closes_session_when_cancelled_during_ws_close():
+    """A cancellation racing in while _cleanup_ws()'s WebSocket close is
+    still running must not skip the session close entirely (#67470 review
+    round 2, egilewski). Running the WS close and session close as two
+    separately shielded steps meant that second cancellation propagated out
+    of the WS close's shielded await, so _cleanup_ws() returned before ever
+    reaching the code that even attempts the session close -- leaving
+    self._session non-None with nothing left running to close it. Both
+    closes must run as one shielded unit so the whole thing keeps going."""
+    adapter = _make_adapter()
+
+    ws = MagicMock()
+    ws.closed = False
+    ws_close_started = asyncio.Event()
+    ws_close_completed = asyncio.Event()
+
+    async def _slow_ws_close():
+        ws_close_started.set()
+        await asyncio.sleep(0.05)
+        ws_close_completed.set()
+
+    ws.close = _slow_ws_close
+
+    session = MagicMock()
+    session.closed = False
+    session.close = AsyncMock()
+
+    adapter._ws = ws
+    adapter._session = session
+
+    async def _handshake_cancelled_mid_cleanup():
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await adapter._cleanup_ws()
+            raise
+
+    task = asyncio.ensure_future(_handshake_cancelled_mid_cleanup())
+    await asyncio.sleep(0)
+    task.cancel()  # cancel #1: enters the CancelledError handler
+    await asyncio.wait_for(ws_close_started.wait(), timeout=2)
+    # Snapshot the shielded _close_both() task now (it must already exist
+    # -- ws_close_started is set from inside it) so we can wait for the
+    # WHOLE unit -- both the WS close AND the session close after it -- to
+    # finish, deterministically, instead of guessing from timing.
+    tracked = tuple(adapter._teardown_tasks)
+    task.cancel()  # cancel #2: races in while the WS close is still running
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # _close_both() runs the WS close THEN the session close as one
+    # shielded background unit. ws_close_started/ws_close_completed only
+    # signal the FIRST step; they do NOT guarantee the scheduler has
+    # already run the second step (the session close) by the time control
+    # resumes here on every event loop implementation. Waiting on that
+    # partial-progress signal and then immediately asserting on the
+    # session close is exactly what made this test flaky on Linux CI
+    # (observed: session.close awaited 0 times) while passing on Windows
+    # by scheduling coincidence. Awaiting the tracked task itself has no
+    # such gap -- see _await_tracked_teardown.
+    await _await_tracked_teardown(tracked)
+    assert ws_close_completed.is_set(), "the WS close must have completed"
+    session.close.assert_awaited_once()
+    assert adapter._ws is None
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_rest_session_not_double_closed_on_cancellation():
+    """disconnect() must detach self._rest_session before awaiting its
+    close (#67470 review round 2, egilewski): clearing the field only
+    *after* the close returned meant a cancellation racing in on
+    disconnect() left the field still assigned to a session whose close was
+    already running in the background -- a later disconnect() retry would
+    see closed=False and call close() on it a second time."""
+    adapter = _make_adapter()
+    adapter._running = True
+
+    rest_session = MagicMock()
+    rest_session.closed = False
+    close_started = asyncio.Event()
+    close_completed = asyncio.Event()
+    close_calls = 0
+
+    async def _slow_close():
+        nonlocal close_calls
+        close_calls += 1
+        close_started.set()
+        await asyncio.sleep(0.05)
+        rest_session.closed = True
+        close_completed.set()
+
+    rest_session.close = _slow_close
+    adapter._rest_session = rest_session
+
+    async def _noop():
+        return
+
+    adapter._listen_task = asyncio.ensure_future(_noop())
+    await asyncio.sleep(0)
+
+    task = asyncio.ensure_future(adapter.disconnect())
+    await asyncio.wait_for(close_started.wait(), timeout=2)
+    # Snapshot the shielded _full_teardown() task now (it must already
+    # exist -- close_started is set from inside it, via the REST close it
+    # runs directly) so we can wait for it to fully finish at the end,
+    # deterministically. Deliberately NOT drained here yet -- the whole
+    # point of this test is to retry disconnect() while this first close
+    # may still be in flight in the background.
+    tracked = tuple(adapter._teardown_tasks)
+    task.cancel()  # races in while the REST session close is still running
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # A retried disconnect() (or any other caller) must see the field
+    # already cleared, not call close() on the same session a second time.
+    # Safe to assert immediately, no race: _full_teardown() clears
+    # self._rest_session synchronously before the close is even entered --
+    # close_started already firing above proves that already happened.
+    assert adapter._rest_session is None
+
+    # Simulate a caller retrying disconnect() right away, before the
+    # backgrounded close has even finished.
+    adapter._running = True
+    adapter._listen_task = asyncio.ensure_future(_noop())
+    await asyncio.sleep(0)
+    await asyncio.wait_for(adapter.disconnect(), timeout=2)
+
+    # Deterministically wait for the FIRST close (still possibly running in
+    # the background from the cancelled call above) to finish before the
+    # final assert. See _await_tracked_teardown (Linux CI determinism).
+    await _await_tracked_teardown(tracked)
+    assert close_completed.is_set(), "the REST session close must have completed"
+    assert close_calls == 1, "REST session close() must not run twice"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_closes_rest_session_when_cancelled_during_ws_close():
+    """disconnect() has several sequential stages (cancel
+    listener, close WS/session, close REST session). A cancellation landing
+    at an EARLIER stage must not leave a LATER stage's resources untouched
+    (#67470 review round 3, egilewski): previously, cancelling disconnect()
+    while _cleanup_ws() was still closing the WebSocket aborted the whole
+    coroutine before the REST session close was ever attempted, leaving
+    self._rest_session assigned and open. The full teardown must run as one
+    protected unit so every stage still completes in the background."""
+    adapter = _make_adapter()
+    adapter._running = True
+
+    ws = MagicMock()
+    ws.closed = False
+    ws_close_started = asyncio.Event()
+
+    async def _slow_ws_close():
+        ws_close_started.set()
+        await asyncio.sleep(0.05)
+
+    ws.close = _slow_ws_close
+    adapter._ws = ws
+    adapter._session = None
+
+    rest_session = MagicMock()
+    rest_session.closed = False
+    rest_close_completed = asyncio.Event()
+
+    async def _rest_close():
+        await asyncio.sleep(0.02)
+        rest_close_completed.set()
+
+    rest_session.close = _rest_close
+    adapter._rest_session = rest_session
+
+    async def _noop():
+        return
+
+    adapter._listen_task = asyncio.ensure_future(_noop())
+    await asyncio.sleep(0)
+
+    task = asyncio.ensure_future(adapter.disconnect())
+    await asyncio.wait_for(ws_close_started.wait(), timeout=2)
+    # Snapshot the shielded task(s) now: disconnect()'s own _full_teardown()
+    # task, plus _cleanup_ws()'s nested _close_both() task (both already
+    # exist -- ws_close_started fires from inside the innermost one). Wait
+    # for ALL of them so we know the whole nested teardown -- WS close,
+    # session close, and the REST close after it -- has actually finished,
+    # not just that the WS close's own event fired.
+    tracked = tuple(adapter._teardown_tasks)
+    task.cancel()  # races in while the WS close (an earlier stage) is running
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # rest_close_completed alone would still be a correct (if slower to
+    # fail) bound here -- if the REST close never ran, this would legitimately
+    # time out rather than pass early -- but await the tracked tasks
+    # directly for the same reason as the other hardened tests: no reliance
+    # on scheduling order between nested shielded steps.
+    await _await_tracked_teardown(tracked)
+    assert rest_close_completed.is_set(), "the REST session close must have completed"
+    assert adapter._rest_session is None
+
+
+@pytest.mark.asyncio
+async def test_bounded_close_abandons_cancellation_suppressing_close(monkeypatch):
+    """A close() that catches its own cancellation and keeps polling a stop
+    signal (rather than actually finishing) must not be AWAITED to
+    completion by _bounded_close.
+
+    Pre-fix, `asyncio.wait_for(closeable.close(), timeout=_DRAIN_TIMEOUT)`
+    cancels close() on timeout and then WAITS for that cancellation to
+    actually finish -- so a close() that swallows the cancellation and
+    keeps running left `_bounded_close` pending until close() eventually
+    decides to stop on its own, which is exactly the boundedness violation
+    the bounded-abandon mechanism removes (#67470 Sol xhigh mechanism
+    review, gap 1)."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(ha_adapter, "_DRAIN_TIMEOUT", 0.05, raising=False)
+
+    stop = asyncio.Event()
+    close_truly_finished = asyncio.Event()
+
+    async def _suppresses_cancellation_until_stopped():
+        while not stop.is_set():
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=0.05)
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                continue  # rude close(): swallows cancellation, keeps going
+        close_truly_finished.set()
+
+    closeable = MagicMock()
+    closeable.close = AsyncMock(side_effect=_suppresses_cancellation_until_stopped)
+
+    # Run _bounded_close as its OWN task (mirrors the bounded-abandon
+    # mechanism itself) and observe it with asyncio.wait(timeout=...)
+    # rather than wrapping the bare coroutine in another wait_for.
+    # asyncio.wait_for cancels the CURRENT task on timeout, not a separate
+    # one, for a bare coroutine argument -- nesting it around another
+    # wait_for(bare coroutine) that itself swallows cancellation forever
+    # (the exact defect under test) would make the outer wait_for's own
+    # cancellation land in that same swallow loop too and never escape,
+    # hanging the TEST instead of failing it. asyncio.wait() on an actual
+    # Task has no such trap: it only observes, never cancels.
+    bounded_close_task = asyncio.ensure_future(
+        adapter._bounded_close(closeable, "suppressing")
+    )
+    try:
+        done, pending = await asyncio.wait({bounded_close_task}, timeout=1)
+
+        assert not pending, (
+            "_bounded_close must return on its own within a bounded window "
+            "instead of hanging behind a cancellation-suppressing close "
+            "(pre-fix: asyncio.wait_for waits for the close's actual "
+            "completion after cancelling it, which a suppressing close "
+            "never delivers)"
+        )
+        assert not close_truly_finished.is_set(), (
+            "_bounded_close must abandon a cancellation-suppressing close "
+            "after _DRAIN_TIMEOUT instead of waiting for it to actually "
+            "finish"
+        )
+
+        # Corroborate durable retention alongside boundedness (Sol xhigh
+        # mechanism re-review: the first version of this test "does not
+        # prove module-level retention because it never forces GC after
+        # abandonment"; the second version kept a strong local reference
+        # to the task throughout, so surviving gc.collect() proved
+        # nothing about the registry -- it would have survived from the
+        # local alone). Find the abandoned inner close task (separate
+        # from bounded_close_task, the outer _bounded_close() call, which
+        # already completed above) in the module registry, take only a
+        # WEAK reference, drop every strong local including the list
+        # itself, force a collection, and confirm the weakref is still
+        # alive. NOTE (Sol xhigh follow-up, negative-control probe): this
+        # is corroborating evidence, not an isolated proof that
+        # _TEARDOWN_REGISTRY specifically is what kept it alive -- a task
+        # that is still actively scheduled (a live callback pending on
+        # its current await) can also survive collection via asyncio's
+        # own internal bookkeeping, independent of any registry. The
+        # direct `in _TEARDOWN_REGISTRY` membership check below is the
+        # evidence that the module registry is what roots the task.
+        abandoned = [t for t in ha_adapter._TEARDOWN_REGISTRY if not t.done()]
+        assert abandoned, "the abandoned close task must be rooted in the module registry"
+        abandoned_ref = weakref.ref(abandoned[0])
+        del abandoned
+        gc.collect()
+        still_alive = abandoned_ref()
+        assert still_alive is not None, (
+            "a forced gc.collect() destroyed the abandoned close task after "
+            "every local strong reference was dropped"
+        )
+        assert not still_alive.done(), (
+            "a forced gc.collect() must not destroy an abandoned close "
+            "that is still rooted in _TEARDOWN_REGISTRY"
+        )
+    finally:
+        # Test hygiene: let the abandoned close actually finish instead of
+        # leaving a zombie task behind -- unconditionally, even if an
+        # assertion above failed (on pre-fix code the close is genuinely
+        # still running at that point; without this in `finally`, the
+        # loop's own teardown would gather it, and it never finishes on
+        # its own since `stop` was never set, hanging the WHOLE suite
+        # instead of just failing this one test).
+        stop.set()
+        await asyncio.wait_for(close_truly_finished.wait(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_ws_session_close_runs_when_ws_close_raises_cancellederror():
+    """A close() that raises CancelledError ON ITS OWN -- not from an
+    external task.cancel() -- must not abort the surrounding cleanup
+    sequence: the session close must still run after it (#67470 Sol xhigh
+    mechanism review, gap 3). Pre-fix, `_bounded_close` awaited
+    `closeable.close()` inline inside `_close_both()`; a self-raised
+    CancelledError propagated straight out of `_close_both()`, skipping
+    the session close entirely."""
+    adapter = _make_adapter()
+
+    ws = MagicMock()
+    ws.closed = False
+
+    async def _raises_cancelled_from_close():
+        raise asyncio.CancelledError("close() itself raises, not externally cancelled")
+
+    ws.close = AsyncMock(side_effect=_raises_cancelled_from_close)
+
+    session = MagicMock()
+    session.closed = False
+    session.close = AsyncMock()
+
+    adapter._ws = ws
+    adapter._session = session
+
+    await asyncio.wait_for(adapter._cleanup_ws(), timeout=2)
+
+    session.close.assert_awaited_once()
+    assert adapter._ws is None
+    assert adapter._session is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_rest_close_runs_when_ws_close_raises_cancellederror():
+    """The same close-originated-CancelledError protection must hold across
+    the whole disconnect() sequence, not just _cleanup_ws()'s own two
+    closes: the REST session close must still run after a WS close that
+    raises CancelledError on its own (#67470 Sol xhigh mechanism review,
+    gap 3)."""
+    adapter = _make_adapter()
+    adapter._running = True
+
+    ws = MagicMock()
+    ws.closed = False
+
+    async def _raises_cancelled_from_close():
+        raise asyncio.CancelledError("close() itself raises, not externally cancelled")
+
+    ws.close = AsyncMock(side_effect=_raises_cancelled_from_close)
+    adapter._ws = ws
+    adapter._session = None
+
+    rest_session = MagicMock()
+    rest_session.closed = False
+    rest_session.close = AsyncMock()
+    adapter._rest_session = rest_session
+
+    async def _noop():
+        return
+
+    adapter._listen_task = asyncio.ensure_future(_noop())
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(adapter.disconnect(), timeout=2)
+
+    rest_session.close.assert_awaited_once()
+    assert adapter._rest_session is None


### PR DESCRIPTION
This is the first half of the split I promised in #68540: the bounded-await hardening alone, without the watchdog machinery.

The problem (#67470): the HA adapter could go silently deaf. Several awaits in the connect/teardown path had no bound, so a wedged WebSocket close or a hung auth handshake left the adapter stuck forever while the gateway still reported "running".

What this PR does:

- `_ws_connect()` now builds the session into a local first and closes it on failure or cancellation (the session leak egilewski probed in #68540), and bounds all three auth handshake steps with `_HANDSHAKE_TIMEOUT`
- in teardown (`disconnect()` / `_full_teardown()` / `_cleanup_ws()`), every close and cancel is bounded by `_DRAIN_TIMEOUT`, and a close survives a second cancellation racing in while it is still running (the close detaches and is tracked in `_teardown_tasks`)
- a module-level `_run_bounded_close()` primitive plus a `_cancel_task_bounded()` adapter method, which the follow-up PR reuses

This PR does not add the watchdog or stall detection. That is the second half (watchdog plus stale-generation guard). It builds on these primitives and comes as a separate PR once this one lands.

Verification:

- 15 tests, all carried over from the #68540 suite (13 bounded-await, 2 primitive tests)
- mutation check: removing the cancel-safe close in `_ws_connect` makes 3 tests fail, restoring it goes green
- every line traces back to the reviewed #68540 head (f862558) or current main. I wrote no new implementation for this split
- rebased on current main, so it includes the HASS_TOKEN scoped-secret read

#68540 stays open for reference. Happy to close it once both halves are in, or however you prefer to handle it.
