### PR TITLE
refactor(state): extract AsyncSessionDB facade into hermes_state_async.py (hermes_state.py slice R5-C9, tracker #78647)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9672,20 +9672,4 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (error[:500], session_id),
             )
         self._execute_write(_do)
-
-
-class AsyncSessionDB:
-    """Async door onto SessionDB: offloads each call via asyncio.to_thread so a blocking SQLite call never freezes the event loop. Generic forwarder — the audit confirms no method returns a live cursor/generator."""
-
-    def __init__(self, db: "SessionDB") -> None:
-        self._db = db
-
-    def __getattr__(self, name: str):
-        attr = getattr(self._db, name)
-        if not callable(attr):
-            return attr
-
-        async def _offloaded(*args, **kwargs):
-            return await asyncio.to_thread(attr, *args, **kwargs)
-
-        return _offloaded
+from hermes_state_async import AsyncSessionDB  # noqa: F401  (re-exported for back-compat)

--- a/hermes_state_async.py
+++ b/hermes_state_async.py
@@ -1,0 +1,29 @@
+"""AsyncSessionDB offload facade for SessionDB.
+
+Extracted verbatim from hermes_state.py (slice R5-C9, epic #78647) so the
+async door onto SessionDB can live without importing hermes_state (which
+would be a cycle). hermes_state re-imports AsyncSessionDB from here for
+backward compatibility.
+
+Contract: every method call is offloaded via asyncio.to_thread so a
+blocking SQLite call never freezes the event loop. Generic forwarder —
+the audit confirms no method returns a live cursor/generator.
+"""
+
+import asyncio
+
+class AsyncSessionDB:
+    """Async door onto SessionDB: offloads each call via asyncio.to_thread so a blocking SQLite call never freezes the event loop. Generic forwarder — the audit confirms no method returns a live cursor/generator."""
+
+    def __init__(self, db: "SessionDB") -> None:
+        self._db = db
+
+    def __getattr__(self, name: str):
+        attr = getattr(self._db, name)
+        if not callable(attr):
+            return attr
+
+        async def _offloaded(*args, **kwargs):
+            return await asyncio.to_thread(attr, *args, **kwargs)
+
+        return _offloaded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -389,6 +389,7 @@ py-modules = [
   "hermes_state_portability",
   "hermes_state_schema",
   "hermes_state_search",
+  "hermes_state_async",
   "hermes_time",
   "hermes_logging",
   "utils",

--- a/tests/gateway/test_hermes_state_async_seam.py
+++ b/tests/gateway/test_hermes_state_async_seam.py
@@ -1,0 +1,99 @@
+"""Re-export seam: hermes_state.AsyncSessionDB is hermes_state_async.AsyncSessionDB.
+
+Slice R5-C9 (epic #78647) moved the AsyncSessionDB facade verbatim from
+hermes_state.py into hermes_state_async.py. hermes_state re-exports the
+name so ``from hermes_state import AsyncSessionDB, SessionDB`` (gateway,
+cli, 16 test files) keeps working with zero consumer edits.
+
+These tests pin the seam: the re-export must resolve to the SAME object,
+and the facade must still forward calls off the event loop.
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+import hermes_state
+import hermes_state_async
+from hermes_state import AsyncSessionDB
+from hermes_state_async import AsyncSessionDB as AsyncSessionDBAsync
+
+
+class _SpyDB:
+    """SessionDB stand-in recording the thread each call ran on."""
+
+    def __init__(self):
+        self.calls = []
+        self.attr = "plain-value"
+
+    def _ran_on(self, name):
+        self.calls.append((name, threading.get_ident()))
+
+    def returns_none(self):
+        self._ran_on("returns_none")
+        return None
+
+    def returns_str(self):
+        self._ran_on("returns_str")
+        return "title"
+
+
+def test_reexport_is_same_object():
+    """hermes_state.AsyncSessionDB must BE hermes_state_async.AsyncSessionDB."""
+    assert AsyncSessionDB is AsyncSessionDBAsync
+    assert AsyncSessionDB is hermes_state.AsyncSessionDB
+    assert hermes_state.AsyncSessionDB is hermes_state_async.AsyncSessionDB
+
+
+def test_module_has_no_hermes_state_import():
+    """hermes_state_async must not import hermes_state (no cycle)."""
+    src = open(hermes_state_async.__file__, "r", encoding="utf-8").read()
+    imports = [
+        line.strip()
+        for line in src.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+    assert imports == ["import asyncio"], imports
+
+
+@pytest.mark.asyncio
+async def test_facade_still_forwards_off_thread():
+    """The re-exported facade must still offload calls via asyncio.to_thread."""
+    db = _SpyDB()
+    facade = AsyncSessionDB(db)
+    caller_ident = threading.get_ident()
+
+    result = await facade.returns_str()
+
+    assert result == "title"
+    ran_idents = [ident for _name, ident in db.calls]
+    assert ran_idents and all(i != caller_ident for i in ran_idents)
+
+
+@pytest.mark.asyncio
+async def test_facade_routes_through_to_thread(monkeypatch):
+    """The offload must route through asyncio.to_thread (where the facade lives)."""
+    db = _SpyDB()
+    facade = AsyncSessionDB(db)
+
+    seen = []
+    real = asyncio.to_thread
+
+    async def _spy(func, *args, **kwargs):
+        seen.append(getattr(func, "__name__", repr(func)))
+        return await real(func, *args, **kwargs)
+
+    monkeypatch.setattr(hermes_state_async.asyncio, "to_thread", _spy)
+    await facade.returns_str()
+    assert "returns_str" in seen
+
+
+@pytest.mark.asyncio
+async def test_non_callable_attributes_pass_through():
+    """Plain (non-callable) attributes must pass through unchanged, not wrapped."""
+    db = _SpyDB()
+    facade = AsyncSessionDB(db)
+
+    assert facade.attr == "plain-value"
+    assert not callable(facade.attr)


### PR DESCRIPTION
## What changed and why

Large-file decomposition feature package (tracker #78647): `hermes_state.py` slice **R5-C9** — the `AsyncSessionDB` facade, extracted byte-verbatim into a new module with a re-export seam.

- **Window**: `hermes_state.py` lines 9677–9691 (class `AsyncSessionDB`, 586 B). Golden sha256 (with trailing \n): `c5417b709389b4b30d66e1f0b5b77c6071347e8f5b4235be64e9162bd39924c1`; extraction unit 9675–9691: `dc913787868c0c2414f5ebedbb5563420c02958af5b871b03052992cd5b0a59c` — both verified byte-exact.
- **Module**: `hermes_state_async.py`, class moved as-is; re-export seam `from hermes_state_async import AsyncSessionDB` in `hermes_state.py` (back-compat; `AsyncSessionDB` is a public name tests import as `hermes_state.AsyncSessionDB`). New module added to `py-modules` in `pyproject.toml` (house convention — all sibling mixin modules are listed).
- **Kill-line math**: 9,691 → 9,675 (−16). Reconstruction proof: pin blob − window + re-export == new `hermes_state.py`, byte-identical.
- **Zero behavior change**: no-import guard (module never imports `hermes_state`); orphan gate clean; `AsyncSessionDB.__getattr__` keeps the async door transparent.

**Double-blind**: consensus `R5-CONSENSUS.md` (adjudicated 2026-08-06). Blind witness re-review of the committed slice (independent, adversarial, mutation-positive-control): **VERIFIED** — 10/10 checks (fidelity, identity, LF, collision freshness; only stale #71945, CONFLICTING base 2026-07-26, touches `AsyncSessionDB`).

## How to test

```bash
HERMES_PYTHON="C:/Users/andre/AppData/Local/hermes/hermes-agent/venv/Scripts/python.exe" scripts/run_tests.sh tests/gateway/test_hermes_state_async_seam.py
```

Expected: 5/5 seam tests (a-is-b identity, no-import guard, off-thread, to_thread routing, non-callable passthrough) + `-k 'async'` subset of the hermes_state suites.

Identity probe:

```bash
python -c "import sys; sys.path.insert(0,'.'); import hermes_state; import hermes_state_async; assert hermes_state.AsyncSessionDB is hermes_state_async.AsyncSessionDB"
```

## Platforms tested

Windows (dev host), venv python 3.11: seam suite 5/5 + async subset 3/3; `git diff --check` clean; LF-only.

## Why this matters to users

No user-visible change — the tail slice of `hermes_state.py` (9,691 → 9,675 and counting) toward the 2K Law ceiling.

Part of #78647
Part of #78636
