### PR TITLE
fix(cli): scrub lone surrogates before oneshot stdout write

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -277,6 +277,15 @@ def run_oneshot(
 
     _write_usage_file(usage_file, result)
 
+    # Model text can contain lone UTF-16 surrogates (invalid in UTF-8). Writing
+    # those to a real stdout TextIO raises UnicodeEncodeError and aborts with
+    # exit 1 after the turn already completed — scrub to U+FFFD first.
+    # See #80366.
+    if response:
+        from agent.message_sanitization import _sanitize_surrogates
+
+        response = _sanitize_surrogates(response)
+
     if response:
         real_stdout.write(response)
         if not response.endswith("\n"):

--- a/tests/hermes_cli/test_oneshot_surrogate.py
+++ b/tests/hermes_cli/test_oneshot_surrogate.py
@@ -1,0 +1,39 @@
+"""Oneshot stdout must survive lone UTF-16 surrogates in model text (#80366)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+
+def test_oneshot_replaces_lone_surrogate_and_exits_zero():
+    """hermes -z must print U+FFFD and exit 0 when the model returns U+D800."""
+    program = textwrap.dedent(
+        """
+        import hermes_cli.oneshot as oneshot
+
+        dirty = "answer \\ud800 here"
+        oneshot._run_agent = lambda *args, **kwargs: (
+            dirty,
+            {"final_response": dirty, "failed": False, "partial": False, "completed": True},
+        )
+        raise SystemExit(oneshot.run_oneshot("hello"))
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    # U+FFFD as UTF-8; no raw surrogate bytes
+    assert "\ufffd".encode("utf-8") in result.stdout
+    assert b"answer " in result.stdout
+    assert b" here\n" in result.stdout
+    assert b"Traceback" not in result.stderr


### PR DESCRIPTION
## What does this PR do?

`hermes --oneshot` / `hermes -z` crashed with `UnicodeEncodeError` when assistant text contained a lone UTF-16 surrogate (e.g. U+D800). The turn could already be complete, but writing the raw string to a UTF-8 stdout TextIO failed and the process exited 1 with no answer.

Sanitize the response with the existing `_sanitize_surrogates` helper before writing so lone surrogates become U+FFFD, the answer prints, and the process exits 0.

## Related Issue

Fixes #80366

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/oneshot.py` — call `_sanitize_surrogates` on `response` before `real_stdout.write`
- `tests/hermes_cli/test_oneshot_surrogate.py` — subprocess regression: mocked `_run_agent` returns `\ud800`; assert exit 0 and U+FFFD in stdout

## How to Test

1. Call `run_oneshot` with `_run_agent` returning `"answer \ud800 here"` and a real UTF-8 stdout stream — pre-fix raises `UnicodeEncodeError` at `real_stdout.write(response)`.
2. After the fix, same path prints `answer � here` and returns exit code 0.
3. Run: `scripts/run_tests.sh tests/hermes_cli/test_oneshot_surrogate.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25.5.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Pre-fix:
```
File "hermes_cli/oneshot.py", line 281, in run_oneshot
    real_stdout.write(response)
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' ...
```

Post-fix: exit 0, stdout `answer � here\n`