### PR TITLE
fix(title): don't let an unrecognised enabled value silently disable titling

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -54,8 +54,22 @@ def _title_language() -> str:
         return ""
 
 
+# Mirror of utils.TRUTHY_STRINGS for the opposite side. `is_truthy_value`
+# answers "is this truthy?", which collapses "explicitly off" and "not a value
+# I recognise" into the same False — fine for an env var, wrong for a config
+# knob whose default is on (see _auto_title_enabled).
+_FALSY_STRINGS = frozenset({"0", "false", "no", "off"})
+
+
 def _auto_title_enabled() -> bool:
-    """Return whether automatic session title generation is enabled."""
+    """Return whether automatic session title generation is enabled.
+
+    Only a value that actually says "off" disables titling. An unrecognised
+    value keeps the documented default (on) and warns: ``enabled: ture`` is
+    YAML for the string "ture", so a user typo made while trying to *enable*
+    titling would otherwise turn it off silently, for as long as it goes
+    unnoticed.
+    """
     try:
         # Lazy imports, matching _title_language(): title_generator is imported
         # from agent code paths where a module-level hermes_cli import risks
@@ -65,7 +79,19 @@ def _auto_title_enabled() -> bool:
 
         config = load_config_readonly()
         title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
-        return is_truthy_value(title_config.get("enabled"), default=True)
+        raw = title_config.get("enabled")
+        if isinstance(raw, str):
+            token = raw.strip().lower()
+            from utils import TRUTHY_STRINGS
+
+            if token not in TRUTHY_STRINGS and token not in _FALSY_STRINGS:
+                logger.warning(
+                    "Ignoring unrecognised auxiliary.title_generation.enabled=%r; "
+                    "auto-title stays on. Use true or false.",
+                    raw,
+                )
+                return True
+        return is_truthy_value(raw, default=True)
     except Exception:
         logger.debug("Failed to read title_generation.enabled", exc_info=True)
         return True

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -159,8 +159,22 @@ def _title_language() -> str:
         return ""
 
 
+# Mirror of utils.TRUTHY_STRINGS for the opposite side. `is_truthy_value`
+# answers "is this truthy?", which collapses "explicitly off" and "not a value
+# I recognise" into the same False — fine for an env var, wrong for a config
+# knob whose default is on (see _auto_title_enabled).
+_FALSY_STRINGS = frozenset({"0", "false", "no", "off"})
+
+
 def _auto_title_enabled() -> bool:
-    """Return whether automatic session title generation is enabled."""
+    """Return whether automatic session title generation is enabled.
+
+    Only a value that actually says "off" disables titling. An unrecognised
+    value keeps the documented default (on) and warns: ``enabled: ture`` is
+    YAML for the string "ture", so a user typo made while trying to *enable*
+    titling would otherwise turn it off silently, for as long as it goes
+    unnoticed.
+    """
     try:
         # Lazy imports, matching _title_language(): title_generator is imported
         # from agent code paths where a module-level hermes_cli import risks
@@ -170,7 +184,19 @@ def _auto_title_enabled() -> bool:
 
         config = load_config_readonly()
         title_config = (config.get("auxiliary") or {}).get("title_generation") or {}
-        return is_truthy_value(title_config.get("enabled"), default=True)
+        raw = title_config.get("enabled")
+        if isinstance(raw, str):
+            token = raw.strip().lower()
+            from utils import TRUTHY_STRINGS
+
+            if token not in TRUTHY_STRINGS and token not in _FALSY_STRINGS:
+                logger.warning(
+                    "Ignoring unrecognised auxiliary.title_generation.enabled=%r; "
+                    "auto-title stays on. Use true or false.",
+                    raw,
+                )
+                return True
+        return is_truthy_value(raw, default=True)
     except Exception:
         logger.debug("Failed to read title_generation.enabled", exc_info=True)
         return True

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -9,6 +9,7 @@ from agent.title_generator import (
     auto_title_session,
     maybe_auto_title,
     _title_language,
+    _auto_title_enabled,
 )
 from hermes_state import SessionDB
 
@@ -29,6 +30,49 @@ class TestGenerateTitle:
         with patch("hermes_cli.config.load_config", side_effect=RuntimeError("bad config")), \
          patch("hermes_cli.config.load_config_readonly", side_effect=RuntimeError("bad config")):
             assert _title_language() == ""
+
+    @pytest.mark.parametrize("raw", [True, "true", "yes", "on", "1", " True "])
+    def test_recognised_truthy_values_enable_titling(self, raw):
+        cfg = {"auxiliary": {"title_generation": {"enabled": raw}}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _auto_title_enabled() is True
+
+    @pytest.mark.parametrize("raw", [False, "false", "no", "off", "0"])
+    def test_recognised_falsy_values_disable_titling(self, raw):
+        cfg = {"auxiliary": {"title_generation": {"enabled": raw}}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _auto_title_enabled() is False
+
+    @pytest.mark.parametrize("raw", ["ture", "treu", "enabled", "maybe", ""])
+    def test_unrecognised_value_keeps_titling_on_and_warns(self, raw, caplog):
+        """A value the truthy set doesn't recognise is a typo, not consent.
+
+        ``enabled: ture`` is YAML for the string "ture", which is not in
+        ``TRUTHY_STRINGS`` — so a user typing it while trying to *enable*
+        titling silently loses it. Only ``enabled`` values that actually say
+        "off" turn titling off; anything else keeps the documented default and
+        says so in the log.
+        """
+        cfg = {"auxiliary": {"title_generation": {"enabled": raw}}}
+
+        with patch("hermes_cli.config.load_config", return_value=cfg), \
+             patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+            assert _auto_title_enabled() is True
+
+        assert any(
+            "title_generation.enabled" in r.message and raw in r.message
+            for r in caplog.records
+        )
+
+    def test_absent_key_keeps_documented_default(self):
+        for cfg in ({}, {"auxiliary": {}}, {"auxiliary": {"title_generation": {}}}):
+            with patch("hermes_cli.config.load_config", return_value=cfg), \
+                 patch("hermes_cli.config.load_config_readonly", return_value=cfg):
+                assert _auto_title_enabled() is True
 
     def test_default_timeout_delegates_to_auxiliary_config(self):
         captured_kwargs = {}


### PR DESCRIPTION
Follow-up to the `auxiliary.title_generation.enabled` gate that #66049 landed
(salvaging #37349), for the issue it was fixing: #41744.

## The gap

`_auto_title_enabled()` (`agent/title_generator.py:57`) reads the knob with
`is_truthy_value(title_config.get("enabled"), default=True)`. That helper answers
"is this truthy?" — the right question for an env var, the wrong one for a config
key whose documented default is on. `default=True` applies only when the key is
*absent* (`value is None`), so every value the truthy set doesn't recognise is
falsy, and the safe direction ends up being a typo in the **key**, not in the value:

```
enabled: true    -> True      titling on
enabled: ture    -> 'ture'    titling OFF   <- typo meant to enable, disables instead
enbaled: false   -> None      titling on    <- typo in the key falls through to the default
```

`TRUTHY_STRINGS` is `{"1", "true", "yes", "on"}` (`utils.py:19`), and YAML parses
an unquoted `ture` as the string `"ture"`. So a user who mistypes the value while
trying to turn titling **on** silently loses it, with nothing in the log to say
why — the same failure shape #41744 reported, arriving through the fix for it.
`cli-config.yaml.example:634` documents the knob as `enabled: true`, which is
what makes a value typo plausible in the first place.

## The change

Recognise the falsy tokens explicitly and treat anything else as "not a value I
understand": keep the documented default and warn, naming the offending value.
Booleans, the truthy tokens and the falsy tokens all behave exactly as before —
`enabled: false`, `no`, `off`, `0` still disable titling.

## Scope

Deliberately at this call site, not in `utils.is_truthy_value`. The helper is
shared, and `env_var_enabled` passes `default=False`, where collapsing
unrecognised into False is correct — the distinction belongs to callers whose
default is True. Seven call sites pass `default=True` today
(`title_generator.py:68`, `verify_hooks.py:47`, `cli.py:12762`, `voice.py:259`,
`web_routers/tools.py:96`, `delegate_tool.py:654`,
`transcription_tools.py:162`); this PR fixes the one reported in #41744 rather
than assuming the same answer fits the other six. Happy to follow up on the rest
if you'd like it handled centrally.

## Tests

`tests/agent/test_title_generator.py` — parametrised over recognised truthy
values, recognised falsy values, unrecognised values (asserting titling stays on
*and* that the warning names the value), and the absent key. The unrecognised
cases fail on current `main` and pass with the change; the rest pass on both.
`32 passed` for the file.

— 🤖 Claude Opus 5
