### PR TITLE
fix(stt): re-enable 'mistral' provider in STT options

### DIFF
--- a/contributors/emails/bot@blut-agent.dev
+++ b/contributors/emails/bot@blut-agent.dev
@@ -1,0 +1,1 @@
+blut-agent

--- a/contributors/emails/tuancanhnguyen706@gmail.com
+++ b/contributors/emails/tuancanhnguyen706@gmail.com
@@ -1,0 +1,1 @@
+tuancanhnguyen706

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -916,9 +916,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",
-        # "mistral" temporarily removed — mistralai PyPI package quarantined
-        # (malicious 2.4.6 release on 2026-05-12). Restore once available.
-        "options": ["local", "groq", "openai", "xai", "elevenlabs"],
+        "options": ["local", "groq", "openai", "mistral", "xai", "elevenlabs"],
     },
     "stt.local.model": {
         "type": "select",

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1064,9 +1064,7 @@ def _get_provider(stt_config: dict) -> str:
     #     local > groq > openai > mistral > xai > elevenlabs > deepinfra ---
     # DeepInfra is tried LAST so adding DEEPINFRA_API_KEY (commonly set for the
     # chat surface) never silently displaces an existing xAI/ElevenLabs STT
-    # auto-selection; a DeepInfra-only box still resolves to it. mistral is
-    # intentionally skipped while `mistralai` is quarantined on PyPI (malicious
-    # 2.4.6 release on 2026-05-12).
+    # auto-selection; a DeepInfra-only box still resolves to it.
 
     if _HAS_FASTER_WHISPER:
         return "local"


### PR DESCRIPTION
## What

Restores `"mistral"` to the STT provider options list in `web_server.py` and removes the stale quarantine comment from `transcription_tools.py`.

## Why

The `mistralai` PyPI package was compromised in version 2.4.6 (Mini Shai-Hulud supply-chain attack, 2026-05-12) and was quarantined. The compromised version has since been yanked and clean releases (2.4.7+) are available — current PyPI version is 2.9.1. The security advisory in `hermes_cli/security_advisories.py` correctly only fires when the **compromised** version is still installed.

The auto-detection path for `provider: mistral` in `tools/transcription_tools.py` was always functional — the only things blocking it were:
- `web_server.py` having `"mistral"` removed from the STT dropdown options
- A stale comment in `transcription_tools.py` explaining why it was `"intentionally skipped"`

## Changes

- `hermes_cli/web_server.py`: Add `"mistral"` back to `stt.provider` options (inserted between `openai` and `xai`)
- `tools/transcription_tools.py`: Remove the now-stale comment about mistral being quarantined

## Verification

- Confirmed `mistralai` package is current (2.9.1) and clean on PyPI
- The TTS and STT code paths for mistral already exist and are functional
- The security advisory correctly targets only the specific compromised version (2.4.6)