### PR TITLE
fix(credential-pool): address sweeper feedback on #68832 + error-classifier fix

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1003,6 +1003,7 @@ def recover_with_credential_pool(
                 or "gousagelimit" in context_reason
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
+                or "session usage limit" in context_message
             )
         if not has_retried_429 and not usage_limit_reached:
             return False, True

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -345,6 +345,13 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     min_only_match = re.search(r"resets?\s+in\s+(\d+)\s*min\b", message, re.IGNORECASE)
     if min_only_match:
         return int(min_only_match.group(1)) * 60
+    # Ollama Cloud "session usage limit" — resets every 5 hours, but the
+    # reset window started before we hit the limit, so the actual remaining
+    # time is unknown. Use a short TTL: if the primary is still limited, the
+    # 429 fires again and we rotate back to the fallback — one wasted request.
+    # If the limit has cleared, we reclaim the primary immediately.
+    if "session usage limit" in message.lower():
+        return 30 * 60
     return None
 
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -325,7 +325,7 @@ def _parse_absolute_timestamp(value: Any) -> Optional[float]:
     return None
 
 
-def _extract_retry_delay_seconds(message: str) -> Optional[float]:
+def _extract_retry_delay_seconds(message: str, status_code: Optional[int] = None) -> Optional[float]:
     if not message:
         return None
     delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
@@ -350,12 +350,17 @@ def _extract_retry_delay_seconds(message: str) -> Optional[float]:
     # time is unknown. Use a short TTL: if the primary is still limited, the
     # 429 fires again and we rotate back to the fallback — one wasted request.
     # If the limit has cleared, we reclaim the primary immediately.
-    if "session usage limit" in message.lower():
+    # Gated on status_code == 429 per sweeper review (#68832): the phrase
+    # could appear in a non-429 body where a shorter cooldown is inappropriate.
+    if status_code == 429 and "session usage limit" in message.lower():
         return 30 * 60
     return None
 
 
-def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+def _normalize_error_context(
+    error_context: Optional[Dict[str, Any]],
+    status_code: Optional[int] = None,
+) -> Dict[str, Any]:
     if not isinstance(error_context, dict):
         return {}
     normalized: Dict[str, Any] = {}
@@ -372,7 +377,7 @@ def _normalize_error_context(error_context: Optional[Dict[str, Any]]) -> Dict[st
     )
     parsed_reset_at = _parse_absolute_timestamp(reset_at)
     if parsed_reset_at is None and isinstance(message, str):
-        retry_delay_seconds = _extract_retry_delay_seconds(message)
+        retry_delay_seconds = _extract_retry_delay_seconds(message, status_code=status_code)
         if retry_delay_seconds is not None:
             parsed_reset_at = time.time() + retry_delay_seconds
     if parsed_reset_at is not None:
@@ -660,7 +665,7 @@ class CredentialPool:
         status_code: Optional[int],
         error_context: Optional[Dict[str, Any]] = None,
     ) -> PooledCredential:
-        normalized_error = _normalize_error_context(error_context)
+        normalized_error = _normalize_error_context(error_context, status_code=status_code)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
         # transition to STATUS_DEAD instead of STATUS_EXHAUSTED.  Without this,
         # a revoked credential gets a 1-hour TTL cooldown and then re-enters

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -192,6 +192,9 @@ _USAGE_LIMIT_PATTERNS = [
     "quota",
     "limit exceeded",
     "key limit exceeded",
+    # Ollama Cloud's per-session cap — semipermanent for the session,
+    # not a transient throttle that clears in seconds.
+    "session usage limit",
 ]
 
 # Patterns confirming usage limit is transient (not billing)
@@ -1053,6 +1056,19 @@ def _classify_by_status(
                 should_rotate_credential=False,
                 should_fallback=True,
                 error_context=ctx,
+            )
+        # Ollama Cloud returns HTTP 429 "session usage limit" for a per-session
+        # cap that is semipermanent (not a transient throttle that clears in
+        # seconds).  Classify as billing so the pool rotates immediately and
+        # applies the full billing cooldown, instead of retrying the same key
+        # once and then treating the follow-up 429 as a fresh rate-limit —
+        # which burns both keys within minutes on a multi-credential pool.
+        if "session usage limit" in error_msg:
+            return result_fn(
+                FailoverReason.billing,
+                retryable=False,
+                should_rotate_credential=True,
+                should_fallback=True,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/tests/agent/test_ollama_cloud_session_usage_limit.py
+++ b/tests/agent/test_ollama_cloud_session_usage_limit.py
@@ -1,0 +1,155 @@
+"""Tests for Ollama Cloud "session usage limit" credential pool handling.
+
+Covers two fixes:
+1. ``_extract_retry_delay_seconds`` recognising "session usage limit" and
+   returning a 30-minute TTL instead of falling through to the 1-hour default.
+2. ``recover_with_credential_pool`` treating "session usage limit" as a
+   usage-limit condition so the pool rotates on the first 429 instead of
+   retrying the same credential 3 times.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from agent.credential_pool import PooledCredential
+from agent.error_classifier import FailoverReason
+
+
+# ---------------------------------------------------------------------------
+# Helpers (match conventions from test_credential_pool_interrupt.py)
+# ---------------------------------------------------------------------------
+
+def _make_entry(idx, **overrides):
+    defaults = dict(
+        provider="ollama-cloud",
+        id=f"cred-{idx}",
+        label=f"Credential {idx}",
+        auth_type="api_key",
+        priority=idx,
+        source="manual",
+        access_token=f"key-{idx}",
+    )
+    defaults.update(overrides)
+    return PooledCredential(**defaults)
+
+
+def _make_pool(entries):
+    pool = MagicMock()
+    pool.entries = entries
+    pool.current.return_value = entries[0]
+    # Must be set explicitly — MagicMock.provider returns a truthy
+    # child mock, which would trigger the provider-mismatch guard.
+    pool.provider = ""
+    return pool
+
+
+# ---------------------------------------------------------------------------
+# _extract_retry_delay_seconds
+# ---------------------------------------------------------------------------
+
+def test_session_usage_limit_returns_30_minutes():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "you (user) have reached your session usage limit, upgrade for higher limits"
+    assert _extract_retry_delay_seconds(msg) == 30 * 60
+
+
+def test_session_usage_limit_case_insensitive():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "Session Usage Limit reached"
+    assert _extract_retry_delay_seconds(msg) == 30 * 60
+
+
+def test_session_usage_limit_does_not_shadow_explicit_reset_time():
+    """If the message also contains an explicit 'resets in Nmin', that wins."""
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "session usage limit. Resets in 5min"
+    assert _extract_retry_delay_seconds(msg) == 5 * 60
+
+
+def test_session_usage_limit_does_not_shadow_hr_min_format():
+    """If the message also contains 'resets in Nhr Mmin', that wins."""
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    msg = "session usage limit. Resets in 2hr 15min"
+    assert _extract_retry_delay_seconds(msg) == 2 * 3600 + 15 * 60
+
+
+def test_non_session_usage_limit_returns_none():
+    from agent.credential_pool import _extract_retry_delay_seconds
+
+    assert _extract_retry_delay_seconds("rate limited, try again later") is None
+    assert _extract_retry_delay_seconds("") is None
+
+
+# ---------------------------------------------------------------------------
+# recover_with_credential_pool — usage_limit_reached detection
+# ---------------------------------------------------------------------------
+
+def test_session_usage_limit_triggers_pool_rotation_on_first_429():
+    """On the first 429 with 'session usage limit', the pool should rotate
+    immediately instead of waiting for has_retried_429=True."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+    pool.mark_exhausted_and_rotate.return_value = entries[1]
+
+    from run_agent import AIAgent
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+        agent._swap_credential = MagicMock()
+
+        error_context = {
+            "reason": "",
+            "message": "you (user) have reached your session usage limit, "
+                       "upgrade for higher limits",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is True
+    assert retried is False
+    pool.mark_exhausted_and_rotate.assert_called_once()
+    agent._swap_credential.assert_called_once_with(entries[1])
+
+
+def test_plain_rate_limit_without_usage_limit_waits_for_retry():
+    """A normal 429 without 'session usage limit' should NOT rotate on the
+    first 429 — it should retry first (has_retried_429=False → retried=True)."""
+    entries = [_make_entry(0), _make_entry(1)]
+    pool = _make_pool(entries)
+
+    from run_agent import AIAgent
+    with patch("run_agent.get_tool_definitions", return_value=[]), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI"):
+        agent = MagicMock(spec=AIAgent)
+        agent._credential_pool = pool
+
+        error_context = {
+            "reason": "rate_limit",
+            "message": "Too many requests, try again later",
+        }
+
+        recovered, retried = AIAgent._recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=False,
+            classified_reason=None,
+            error_context=error_context,
+        )
+
+    assert recovered is False
+    assert retried is True
+    pool.mark_exhausted_and_rotate.assert_not_called()

--- a/tests/agent/test_ollama_cloud_session_usage_limit.py
+++ b/tests/agent/test_ollama_cloud_session_usage_limit.py
@@ -1,19 +1,28 @@
 """Tests for Ollama Cloud "session usage limit" credential pool handling.
 
-Covers two fixes:
+Covers three fixes:
 1. ``_extract_retry_delay_seconds`` recognising "session usage limit" and
-   returning a 30-minute TTL instead of falling through to the 1-hour default.
+   returning a 30-minute TTL (gated on status_code == 429) instead of
+   falling through to the 1-hour default.
 2. ``recover_with_credential_pool`` treating "session usage limit" as a
    usage-limit condition so the pool rotates on the first 429 instead of
    retrying the same credential 3 times.
+3. ``classify_api_error`` classifying the 429 as ``billing`` so the pool
+   rotates immediately via the billing recovery branch.
 """
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock, patch
 
-from agent.credential_pool import PooledCredential
-from agent.error_classifier import FailoverReason
+from agent.credential_pool import (
+    PooledCredential,
+    _extract_retry_delay_seconds,
+    _exhausted_until,
+    _normalize_error_context,
+)
+from agent.error_classifier import classify_api_error, FailoverReason
 
 
 # ---------------------------------------------------------------------------
@@ -36,7 +45,7 @@ def _make_entry(idx, **overrides):
 
 def _make_pool(entries):
     pool = MagicMock()
-    pool.entries = entries
+    pool.entries.return_value = entries
     pool.current.return_value = entries[0]
     # Must be set explicitly — MagicMock.provider returns a truthy
     # child mock, which would trigger the provider-mismatch guard.
@@ -49,40 +58,117 @@ def _make_pool(entries):
 # ---------------------------------------------------------------------------
 
 def test_session_usage_limit_returns_30_minutes():
-    from agent.credential_pool import _extract_retry_delay_seconds
-
     msg = "you (user) have reached your session usage limit, upgrade for higher limits"
-    assert _extract_retry_delay_seconds(msg) == 30 * 60
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 30 * 60
 
 
 def test_session_usage_limit_case_insensitive():
-    from agent.credential_pool import _extract_retry_delay_seconds
-
     msg = "Session Usage Limit reached"
-    assert _extract_retry_delay_seconds(msg) == 30 * 60
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 30 * 60
 
 
 def test_session_usage_limit_does_not_shadow_explicit_reset_time():
     """If the message also contains an explicit 'resets in Nmin', that wins."""
-    from agent.credential_pool import _extract_retry_delay_seconds
-
     msg = "session usage limit. Resets in 5min"
-    assert _extract_retry_delay_seconds(msg) == 5 * 60
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 5 * 60
 
 
 def test_session_usage_limit_does_not_shadow_hr_min_format():
     """If the message also contains 'resets in Nhr Mmin', that wins."""
-    from agent.credential_pool import _extract_retry_delay_seconds
-
     msg = "session usage limit. Resets in 2hr 15min"
-    assert _extract_retry_delay_seconds(msg) == 2 * 3600 + 15 * 60
+    assert _extract_retry_delay_seconds(msg, status_code=429) == 2 * 3600 + 15 * 60
+
+
+def test_session_usage_limit_non_429_returns_none():
+    """The 30-min TTL must NOT fire on non-429 errors (sweeper gate on #68832)."""
+    msg = "you (user) have reached your session usage limit"
+    assert _extract_retry_delay_seconds(msg, status_code=403) is None
+    assert _extract_retry_delay_seconds(msg, status_code=None) is None
 
 
 def test_non_session_usage_limit_returns_none():
-    from agent.credential_pool import _extract_retry_delay_seconds
+    assert _extract_retry_delay_seconds("rate limited, try again later", status_code=429) is None
+    assert _extract_retry_delay_seconds("", status_code=429) is None
 
-    assert _extract_retry_delay_seconds("rate limited, try again later") is None
-    assert _extract_retry_delay_seconds("") is None
+
+# ---------------------------------------------------------------------------
+# Persisted cooldown: _normalize_error_context → _exhausted_until
+# ---------------------------------------------------------------------------
+
+def test_persisted_cooldown_is_30min_for_session_usage_limit_429():
+    """End-to-end: the normalized reset_at produces a ~30min cooldown."""
+    ctx = _normalize_error_context(
+        {"message": "you (user) have reached your session usage limit"},
+        status_code=429,
+    )
+    assert "reset_at" in ctx
+    now = time.time()
+    delta = ctx["reset_at"] - now
+    assert 29 * 60 < delta < 31 * 60
+
+
+def test_persisted_cooldown_non_429_uses_default_ttl():
+    """Without status_code, no custom reset_at is set (falls back to default TTL)."""
+    ctx = _normalize_error_context(
+        {"message": "you (user) have reached your session usage limit"},
+        status_code=None,
+    )
+    assert "reset_at" not in ctx
+
+
+def test_exhausted_until_uses_persisted_reset_at():
+    """A pool entry with a persisted reset_at should honor it."""
+    now = time.time()
+    reset = now + 30 * 60
+    entry = _make_entry(0, last_status="exhausted", last_status_at=now)
+    entry.last_error_reset_at = reset
+    result = _exhausted_until(entry)
+    assert result is not None
+    assert abs(result - reset) < 2
+
+
+# ---------------------------------------------------------------------------
+# error_classifier: 429 "session usage limit" → billing
+# ---------------------------------------------------------------------------
+
+class _FakeError(Exception):
+    status_code = 429
+
+    def __init__(self, msg):
+        super().__init__(msg)
+
+
+_OLLAMA_429_MSG = (
+    "Error code: 429 - {'error': {'message': "
+    "'you (seppe) have reached your session usage limit, "
+    "upgrade for higher limits: https://ollama.com/upgrade"
+    " or add extra usage: https://ollama.com/settings"
+    " (ref: 64445a74-57b5-4de8-93ee-965b7b10ef47)', "
+    "'type': 'api_error', 'param': None, 'code': None}}"
+)
+
+
+def test_classify_429_session_usage_limit_as_billing():
+    """The 429 must classify as billing (rotate immediately, non-retryable)."""
+    err = _FakeError(_OLLAMA_429_MSG)
+    c = classify_api_error(err, provider="ollama-cloud", model="glm-5.2")
+    assert c.reason == FailoverReason.billing
+    assert c.should_rotate_credential is True
+    assert c.retryable is False
+
+
+def test_classify_429_plain_rate_limit_still_rate_limit():
+    """A normal 429 without 'session usage limit' stays rate_limit."""
+    err = _FakeError("Error code: 429 - Too many requests")
+    c = classify_api_error(err, provider="openrouter", model="claude-sonnet-4")
+    assert c.reason == FailoverReason.rate_limit
+
+
+def test_classify_429_overloaded_still_overloaded():
+    """Z.AI-style overload 429 still classifies as overloaded."""
+    err = _FakeError("Error code: 429 - The server is overloaded")
+    c = classify_api_error(err, provider="zai", model="glm-5.2")
+    assert c.reason == FailoverReason.overloaded
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Builds on #68832 (by @ioseph-ai) to address the open sweeper review feedback and add the missing error-classifier layer. Closes #68831.

## What this adds on top of #68832

### 1. Error classifier fix (`agent/error_classifier.py`) — **new**
#68832 patches the rate_limit recovery branch (`agent_runtime_helpers.py`) to detect "session usage limit", but the error is still classified as `rate_limit` by `classify_api_error()`. This means the billing recovery branch (which rotates immediately, no retry-same step) is never reached for this error. This PR adds a check in the 429 handler of `_classify_by_status` so that `"session usage limit"` classifies as `FailoverReason.billing`, giving **two layers of defense**: the classifier routes to the billing branch, and the rate_limit branch also skips the retry step as a fallback.

Also added `"session usage limit"` to `_USAGE_LIMIT_PATTERNS` for the message-only classification path.

### 2. 429-gated TTL (`agent/credential_pool.py`) — **sweeper feedback**
The sweeper review on #68832 flagged that the 30-min TTL is status-agnostic: `_extract_retry_delay_seconds()` is called without a status, so the heuristic would apply to any non-429 failure whose message contains this phrase. This PR:
- Adds a `status_code` parameter to `_extract_retry_delay_seconds()`
- Gates the 30-min TTL on `status_code == 429`
- Threads `status_code` through `_normalize_error_context()` → `_mark_exhausted()`

### 3. Additional tests (14 total, up from 7)
- Non-429 boundary case: TTL returns `None` for status 403/None
- Persisted cooldown end-to-end: `_normalize_error_context` → 30min `reset_at`
- Non-429 persisted cooldown: no custom `reset_at` (falls back to default TTL)
- `_exhausted_until` honors persisted `reset_at`
- Error classifier: 429 session-usage-limit → billing; plain 429 → rate_limit; overload 429 → overloaded

## Test plan
- [x] `pytest tests/agent/test_ollama_cloud_session_usage_limit.py` — 14 passed
- [x] `pytest tests/agent/test_credential_pool_routing.py tests/run_agent/test_credential_pool_interrupt.py tests/run_agent/test_fallback_credential_isolation.py` — 21 passed (no regressions)
- [x] Verified with live Ollama Cloud `"session usage limit"` error string from production logs

## Relationship to other PRs
| PR | Error classifier? | TTL 429-gated? | Sweeper feedback addressed? |
|----|-------------------|----------------|---------------------------|
| #68832 | No | No (status-agnostic) | Partially |
| #68921 | No | No (status-agnostic) | No (duplicate) |
| **This PR** | **Yes** | **Yes** | **Yes** |

Supersedes #68832 and #68921.