### PR TITLE
fix(coding-context): detect pytest via setup.cfg and tox.ini

### DIFF
--- a/agent/coding_context.py
+++ b/agent/coding_context.py
@@ -150,6 +150,19 @@ _VERIFY_TARGETS = ("test", "tests", "lint", "typecheck", "check", "build", "fmt"
 _MAX_VERIFY_COMMANDS = 8
 _MAX_FACT_FILE_BYTES = 256 * 1024
 
+# Project files that configure pytest, each paired with its pytest section
+# header. Presence of any of these means `pytest` is the project's test runner,
+# even when there is no manifest/script to prove it. `pyproject.toml` owns the
+# `[tool.pytest.ini_options]` block and is matched by its `[tool.pytest` prefix;
+# `setup.cfg` still uses the classic `[tool:pytest]` section. `_read_small`
+# returns "" for missing files, so absent files are simply skipped.
+_PYTEST_CONFIG_SECTIONS = (
+    ("pytest.ini", "[pytest]"),
+    ("pyproject.toml", "[tool.pytest"),
+    ("setup.cfg", "[tool:pytest]"),
+    ("tox.ini", "[pytest]"),
+)
+
 _GIT_TIMEOUT = 2.5
 
 
@@ -777,6 +790,22 @@ class ProjectFacts:
     context_files: list[str]
 
 
+def _has_pytest_config(root: Path) -> bool:
+    """Return True when ``root`` declares pytest in any standard config file.
+
+    Checks every conventional pytest configuration location — ``pytest.ini``,
+    ``pyproject.toml``, ``setup.cfg``, ``tox.ini`` — for its section header, so
+    a project that configures pytest in any of them gets `pytest` surfaced as a
+    verify command instead of falling back to ad-hoc verification scripting.
+    ``_read_small`` never raises and returns ``""`` for absent files, so missing
+    config is simply not matched.
+    """
+    return any(
+        section in _read_small(root / filename)
+        for filename, section in _PYTEST_CONFIG_SECTIONS
+    )
+
+
 def detect_project_facts(root: Path) -> ProjectFacts:
     """Detect manifests, package manager(s), verify commands, and context files.
 
@@ -799,7 +828,7 @@ def detect_project_facts(root: Path) -> ProjectFacts:
             scripts = {}
         js_pm = next((pm for lock, pm in _JS_LOCKFILES if (root / lock).is_file()), "npm")
         verify.extend(f"{js_pm} run {name}" for name in _VERIFY_TARGETS if name in scripts)
-    if (root / "pytest.ini").is_file() or "[tool.pytest" in _read_small(root / "pyproject.toml"):
+    if _has_pytest_config(root):
         verify.append("pytest")
     makefile = _read_small(root / "Makefile")
     if makefile:

--- a/tests/agent/test_coding_context.py
+++ b/tests/agent/test_coding_context.py
@@ -156,6 +156,27 @@ class TestProjectFacts:
         assert facts.verify_commands == ["pnpm run test"]  # dev excluded
         assert facts.context_files == []
 
+    @pytest.mark.parametrize(
+        "filename,content",
+        [
+            ("pytest.ini", "[pytest]\naddopts = -q\n"),
+            ("pyproject.toml", "[tool.pytest.ini_options]\naddopts = -q\n"),
+            ("setup.cfg", "[tool:pytest]\naddopts = -q\n"),
+            ("tox.ini", "[pytest]\naddopts = -q\n"),
+        ],
+    )
+    def test_detect_project_facts_pytest_config(self, tmp_path, filename, content):
+        """Any standard pytest config location surfaces `pytest` as a verify command."""
+        (tmp_path / filename).write_text(content)
+        facts = cc.detect_project_facts(tmp_path)
+        assert "pytest" in facts.verify_commands
+
+    def test_detect_project_facts_no_pytest_without_config(self, tmp_path):
+        """A Python-ish project with no pytest config does not claim a pytest verify command."""
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+        facts = cc.detect_project_facts(tmp_path)
+        assert "pytest" not in facts.verify_commands
+
     def test_project_facts_for_matches_prompt_block(self, tmp_path):
         # Invariant: the structured facts the UI consumes must not drift from the
         # commands the prompt snapshot renders — one detector feeds both.


### PR DESCRIPTION
## What does this PR do?

`detect_project_facts` only recognised pytest when it was configured in
`pytest.ini` or a `[tool.pytest...]` block in `pyproject.toml`. A Python project
that configures its tests in **`setup.cfg`** (`[tool:pytest]`) or **`tox.ini`**
(`[pytest]`) never had `pytest` surfaced as a verify command, so verification
guidance fell back to ad-hoc temp-script scripting instead of the project's real
test runner. This is a reliability gap: the workspace snapshot and verify-on-stop
guidance under-report the correct verification path, and weaker/local models are
the ones most likely to follow the weaker ad-hoc path.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/coding_context.py`
  - New data-driven constant `_PYTEST_CONFIG_SECTIONS` (filename -> pytest
    section header) covering the four conventional pytest config locations.
  - New helper `_has_pytest_config(root)` that scans them via the existing
    `_read_small` (never raises; missing files simply don't match).
  - The verify-command detection now uses the helper instead of the inline
    `pytest.ini`-file / `[tool.pytest` substring check.
- `tests/agent/test_coding_context.py`
  - Parametrised test asserting `pytest` is surfaced for each of the four config
    locations.
  - Negative case: a `[project]`-only `pyproject.toml` does not claim a pytest
    verify command.

## How to Test

```bash
python -m pytest tests/agent/test_coding_context.py -q   # 32 passed
```

New tests: `test_detect_project_facts_pytest_config[*]` (all 4 locations) and
`test_detect_project_facts_no_pytest_without_config`. Reverting to the old
inline check makes the `setup.cfg` and `tox.ini` cases fail (`verify_commands` is
empty) — proving the test captures the gap.

## Checklist

### Code
- [x] Read the Contributing Guide
- [x] Conventional Commit (`fix(coding-context): ...`)
- [x] Searched for existing PRs — none address pytest verify-command detection
      via `setup.cfg`/`tox.ini`
- [x] PR contains only changes related to this fix
- [x] Ran `python -m pytest tests/agent/test_coding_context.py -q` — 32 passed
- [x] Added tests (RED-GREEN proven)
- [x] Tested on macOS (Mac mini M4, Python 3.11); `ruff check` clean

### Documentation and Housekeeping
- [x] Docstrings updated; no config keys or tool schemas touched — N/A for the rest
