### PR TITLE
fix(gateway): place auto-TTS output under HERMES_HOME write-safe tree

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12569,9 +12569,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
 
             # Use MP3 output for CLI playback (afplay doesn't handle OGG well).
             # The TTS tool may auto-convert MP3->OGG, but the original MP3 remains.
-            os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
+            # Base dir must pass HERMES_WRITE_SAFE_ROOT (same as gateway auto-TTS).
+            from gateway.platforms.base import _auto_tts_base_dir
+
+            voice_dir = _auto_tts_base_dir()
+            os.makedirs(voice_dir, exist_ok=True)
             mp3_path = os.path.join(
-                tempfile.gettempdir(), "hermes_voice",
+                voice_dir,
                 f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
             )
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -161,6 +161,39 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
     return True
 
 
+def _auto_tts_base_dir() -> str:
+    """Directory for gateway auto-TTS files that passes the write-safety guard.
+
+    Official Docker images set ``HERMES_HOME=/opt/data`` and
+    ``HERMES_WRITE_SAFE_ROOT=/opt/data``. Placing auto-TTS under the system
+    temp dir (typically ``/tmp``) is rejected by ``is_write_denied`` before
+    synthesis runs (#80386). Prefer ``$HERMES_HOME/tmp/hermes_voice``; if that
+    is also outside the safe root (unusual multi-root layouts), try the first
+    write-safe root; only then fall back to the system temp dir.
+    """
+    from pathlib import Path
+
+    from agent.file_safety import get_safe_write_roots, is_write_denied
+    from hermes_constants import get_hermes_home
+
+    candidates: list[Path] = [get_hermes_home() / "tmp" / "hermes_voice"]
+    for root in sorted(get_safe_write_roots()):
+        candidates.append(Path(root) / "tmp" / "hermes_voice")
+    candidates.append(Path(tempfile.gettempdir()) / "hermes_voice")
+
+    seen: set[str] = set()
+    for base in candidates:
+        key = str(base)
+        if key in seen:
+            continue
+        seen.add(key)
+        # Probe a child path so the safe-root prefix check matches the file
+        # the TTS tool will actually open.
+        if not is_write_denied(str(base / "tts_probe")):
+            return str(base)
+    return str(Path(tempfile.gettempdir()) / "hermes_voice")
+
+
 def build_auto_tts_output_path(platform) -> str:
     """Return a unique temp output path for gateway auto-TTS synthesis.
 
@@ -174,13 +207,15 @@ def build_auto_tts_output_path(platform) -> str:
     (``_repair_ogg_container``) then guarantees real Ogg/Opus bytes for every
     provider, including MP3-only backends like Edge TTS. Everything else
     keeps the MP3 default.
+
+    The base directory is chosen so the path is allowed by
+    ``HERMES_WRITE_SAFE_ROOT`` when that sandbox is enabled (Docker default).
     """
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
     audio_path = os.path.join(
-        tempfile.gettempdir(),
-        "hermes_voice",
+        _auto_tts_base_dir(),
         f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
     )
     os.makedirs(os.path.dirname(audio_path), exist_ok=True)

--- a/hermes_cli/voice.py
+++ b/hermes_cli/voice.py
@@ -932,7 +932,6 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
         return
 
     import re
-    import tempfile
     import time
 
     # Cancel any live capture before we open the speakers — otherwise the
@@ -999,10 +998,14 @@ def speak_text(text: str, stop_event: Optional[threading.Event] = None) -> None:
         # MP3 output path, pre-chosen so we can play the MP3 directly even
         # when text_to_speech_tool auto-converts to OGG for messaging
         # platforms.  afplay's OGG support is flaky, MP3 always works.
-        os.makedirs(os.path.join(tempfile.gettempdir(), "hermes_voice"), exist_ok=True)
+        # Use the write-safe hermes_voice base (not bare /tmp) under Docker
+        # HERMES_WRITE_SAFE_ROOT — same helper as gateway auto-TTS (#80386).
+        from gateway.platforms.base import _auto_tts_base_dir
+
+        voice_dir = _auto_tts_base_dir()
+        os.makedirs(voice_dir, exist_ok=True)
         mp3_path = os.path.join(
-            tempfile.gettempdir(),
-            "hermes_voice",
+            voice_dir,
             f"tts_{time.strftime('%Y%m%d_%H%M%S')}.mp3",
         )
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -154,6 +154,7 @@ from gateway.platforms.base import (
     MessageType,
     ProcessingOutcome,
     SendResult,
+    _auto_tts_base_dir,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -4092,9 +4093,10 @@ class DiscordAdapter(BasePlatformAdapter):
             phrase = random.choice(phrases)
 
         # Synthesise the ack via the configured TTS provider, then layer it.
+        # Use the same write-safe base as gateway auto-TTS (#80386 / #80398).
         import uuid as _uuid
         audio_path = os.path.join(
-            tempfile.gettempdir(), "hermes_voice",
+            _auto_tts_base_dir(),
             f"ack_{_uuid.uuid4().hex[:12]}.mp3",
         )
         os.makedirs(os.path.dirname(audio_path), exist_ok=True)

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -11,6 +11,7 @@ voice bubble). The fix passes an explicit output path from
 """
 
 import asyncio
+import os
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -141,3 +142,61 @@ async def test_base_auto_tts_skips_playback_when_tool_reports_failure():
     adapter.play_tts.assert_not_awaited()
     # Text reply still goes out.
     assert adapter.sent and adapter.sent[0]["content"] == "reply text"
+
+
+# ---------------------------------------------------------------------------
+# #80386: Docker HERMES_WRITE_SAFE_ROOT must not reject auto-TTS paths
+# ---------------------------------------------------------------------------
+
+
+def test_output_path_respects_write_safe_root(tmp_path, monkeypatch):
+    """Docker defaults HERMES_HOME and WRITE_SAFE_ROOT to the same tree.
+
+    Auto-TTS must land under that tree, not /tmp (which is write-denied).
+    """
+    from agent.file_safety import is_write_denied
+
+    safe = tmp_path / "opt" / "data"
+    safe.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(safe))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe))
+    # Clear any profile override context if present
+    monkeypatch.delenv("HERMES_HOME_PROFILE", raising=False)
+
+    path = build_auto_tts_output_path(Platform.DISCORD)
+    assert path.startswith(str(safe / "tmp" / "hermes_voice")), path
+    assert path.endswith(".mp3")
+    assert not is_write_denied(path), path
+    import tempfile
+    system_voice = os.path.join(tempfile.gettempdir(), "hermes_voice")
+    assert not path.startswith(system_voice + os.sep), path
+
+
+def test_output_path_falls_back_to_safe_root_when_home_outside(tmp_path, monkeypatch):
+    """If HERMES_HOME is outside WRITE_SAFE_ROOT, use the safe root."""
+    from agent.file_safety import is_write_denied
+    import tempfile
+
+    home = tmp_path / "home"
+    safe = tmp_path / "safe"
+    home.mkdir()
+    safe.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe))
+
+    path = build_auto_tts_output_path(Platform.DISCORD)
+    assert path.startswith(str(safe / "tmp" / "hermes_voice")), path
+    assert not is_write_denied(path), path
+    system_voice = os.path.join(tempfile.gettempdir(), "hermes_voice")
+    assert not path.startswith(system_voice + os.sep), path
+
+
+def test_output_path_uses_system_temp_without_safe_root(tmp_path, monkeypatch):
+    """Without WRITE_SAFE_ROOT, HERMES_HOME/tmp is still preferred and allowed."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_WRITE_SAFE_ROOT", raising=False)
+
+    path = build_auto_tts_output_path(Platform.DISCORD)
+    assert path.startswith(str(home / "tmp" / "hermes_voice")), path

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -200,3 +200,40 @@ def test_output_path_uses_system_temp_without_safe_root(tmp_path, monkeypatch):
 
     path = build_auto_tts_output_path(Platform.DISCORD)
     assert path.startswith(str(home / "tmp" / "hermes_voice")), path
+
+
+def test_auto_tts_base_dir_shared_with_cli_and_discord_siblings(tmp_path, monkeypatch):
+    """CLI voice and Discord ack paths must use the same write-safe base (#80398).
+
+    Triage: cli.py and discord play_ack_in_voice used bare /tmp/hermes_voice
+    and hit is_write_denied under Docker HERMES_WRITE_SAFE_ROOT.
+    """
+    from agent.file_safety import is_write_denied
+    from gateway.platforms.base import _auto_tts_base_dir
+    import tempfile
+
+    safe = tmp_path / "opt" / "data"
+    safe.mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(safe))
+    monkeypatch.setenv("HERMES_WRITE_SAFE_ROOT", str(safe))
+    monkeypatch.delenv("HERMES_HOME_PROFILE", raising=False)
+
+    base = _auto_tts_base_dir()
+    assert base == str(safe / "tmp" / "hermes_voice")
+    probe = os.path.join(base, "tts_cli.mp3")
+    assert not is_write_denied(probe), probe
+    system_voice = os.path.join(tempfile.gettempdir(), "hermes_voice")
+    assert base != system_voice
+
+    # Source-level: sibling call sites route through _auto_tts_base_dir.
+    # Read files directly — importing cli patches hermes_cli.voice.speak_text.
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2]
+    for name, rel, needle in (
+        ("cli.py voice path", "cli.py", "from gateway.platforms.base import _auto_tts_base_dir"),
+        ("hermes_cli/voice.py speak_text", "hermes_cli/voice.py", "from gateway.platforms.base import _auto_tts_base_dir"),
+        ("discord play_ack_in_voice", "plugins/platforms/discord/adapter.py", "_auto_tts_base_dir()"),
+    ):
+        source = (root / rel).read_text(encoding="utf-8")
+        assert needle in source, f"{name} should use _auto_tts_base_dir"


### PR DESCRIPTION
## Summary
- Gateway auto-TTS wrote under `tempfile.gettempdir()/hermes_voice` (typically `/tmp`).
- Official Docker sets `HERMES_WRITE_SAFE_ROOT=/opt/data` (and `HERMES_HOME=/opt/data`), so `text_to_speech_tool` rejected the path with *outside HERMES_WRITE_SAFE_ROOT* before calling the provider.
- Choose a base dir that passes the write guard: `$HERMES_HOME/tmp/hermes_voice`, else first safe root, else system temp.

Fixes #80386

## Test plan
- [x] `pytest tests/gateway/test_base_auto_tts_output_format.py` (8 passed)
- [ ] Docker: `HERMES_WRITE_SAFE_ROOT=/opt/data`, `voice.auto_tts: true`, Discord message → audio delivers