### PR TITLE
fix: auto-recover orphaned compression sessions (#80337)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6279,6 +6279,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             and session["ended_at"] is not None
             and session["end_reason"] == "compression"
         ):
+            # Orphan recovery: if the compression handoff was interrupted
+            # before a continuation session was persisted, the parent is
+            # permanently stuck.  Detect this by checking for a live child
+            # and, when none exists, reopen the session so writes can
+            # proceed.  (#80337)
+            child = conn.execute(
+                "SELECT 1 FROM sessions "
+                "WHERE parent_session_id = ? AND ended_at IS NULL "
+                "LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if child is None:
+                logger.warning(
+                    "Compression-closed session %s has no live continuation; "
+                    "auto-recovering orphan (clearing end_reason/ended_at)",
+                    session_id,
+                )
+                conn.execute(
+                    "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
+                    "WHERE id = ?",
+                    (session_id,),
+                )
+                return
             raise CompressionSessionClosedError(session_id)
 
     @staticmethod
@@ -6902,7 +6925,27 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 and session["ended_at"] is not None
                 and session["end_reason"] == "compression"
             ):
-                raise CompressionSessionClosedError(session_id)
+                # Orphan recovery — same logic as _check_transcript_write_guards.
+                child = conn.execute(
+                    "SELECT 1 FROM sessions "
+                    "WHERE parent_session_id = ? AND ended_at IS NULL "
+                    "LIMIT 1",
+                    (session_id,),
+                ).fetchone()
+                if child is None:
+                    logger.warning(
+                        "Compression-closed session %s has no live "
+                        "continuation; auto-recovering orphan "
+                        "(clearing end_reason/ended_at)",
+                        session_id,
+                    )
+                    conn.execute(
+                        "UPDATE sessions SET ended_at = NULL, "
+                        "end_reason = NULL WHERE id = ?",
+                        (session_id,),
+                    )
+                else:
+                    raise CompressionSessionClosedError(session_id)
             conn.execute(
                 f"DELETE FROM messages WHERE session_id = ?{active_clause}",
                 (session_id,),

--- a/tests/hermes_state/test_append_messages_batch.py
+++ b/tests/hermes_state/test_append_messages_batch.py
@@ -156,14 +156,38 @@ class TestAppendMessagesBatch:
         assert row["tool_call_count"] == 0
 
     def test_compression_closed_session_rejected(self, db):
+        """A compression-closed session with a live child still raises."""
+        db._conn.execute(
+            "UPDATE sessions SET ended_at = 1.0, end_reason = 'compression' "
+            "WHERE id = ?",
+            ("sess-batch",),
+        )
+        # Create a live continuation so the error is still raised.
+        db.create_session("sess-batch-child", source="cli")
+        db._conn.execute(
+            "UPDATE sessions SET parent_session_id = ? WHERE id = ?",
+            ("sess-batch", "sess-batch-child"),
+        )
+        db._conn.commit()
+        with pytest.raises(CompressionSessionClosedError):
+            db.append_messages_batch("sess-batch", _turn_messages())
+
+    def test_compression_orphan_auto_recovery(self, db):
+        """A compression-closed session with no live child is auto-recovered."""
         db._conn.execute(
             "UPDATE sessions SET ended_at = 1.0, end_reason = 'compression' "
             "WHERE id = ?",
             ("sess-batch",),
         )
         db._conn.commit()
-        with pytest.raises(CompressionSessionClosedError):
-            db.append_messages_batch("sess-batch", _turn_messages())
+        # No child session exists — should auto-recover and succeed.
+        db.append_messages_batch("sess-batch", _turn_messages())
+        row = db._conn.execute(
+            "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+            ("sess-batch",),
+        ).fetchone()
+        assert row["ended_at"] is None
+        assert row["end_reason"] is None
 
     def test_multimodal_content_encoded(self, db):
         msgs = [


### PR DESCRIPTION
## Summary

When context compression closes a session (`end_reason='compression'`) but the handoff is interrupted before a continuation session is persisted, the parent session becomes permanently stuck — every write raises `CompressionSessionClosedError` with no recovery path.

The user sees `session_persistence_failed` on every turn. The only workaround is manual SQL surgery on `state.db` (`UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ...`), which a normal user cannot be expected to do.

## Root Cause

The guard in `hermes_state.py` (`_check_transcript_write_guards` and `replace_all_active_messages`) unconditionally raises `CompressionSessionClosedError` when `end_reason='compression'`, assuming a live continuation always exists. But the compression handoff that creates the continuation is not atomic with closing the parent — if interrupted (model switch, process kill, crash), the parent stays closed and no child exists.

## Fix

In both transcript-write guards, check whether a live continuation session exists before raising. When none exists (orphaned compression session), log a warning and auto-recover by clearing `ended_at` and `end_reason`, allowing writes to proceed normally.

The recovery happens transparently on the first write attempt — no user action needed.

## Changes

- `hermes_state.py`: Add orphan detection in `_check_transcript_write_guards` and `replace_all_active_messages` — query for a live child, and when absent, clear the compression state instead of raising
- `tests/hermes_state/test_append_messages_batch.py`: Update `test_compression_closed_session_rejected` to create a live child (so the error still fires), add `test_compression_orphan_auto_recovery` covering the new recovery path

## Test Plan

- [x] All existing compression tests pass (`test_append_messages_batch.py`: 10/10, `test_lazy_session_regressions.py`: 7/7, `test_hermes_state.py` compress tests: 9/9, `gateway/test_session.py` compress tests: 2/2)
- [x] New test `test_compression_orphan_auto_recovery` verifies recovery
- [x] Updated test `test_compression_closed_session_rejected` verifies error still fires when child exists

Fixes NousResearch/hermes-agent#80337