### PR TITLE
fix(dashboard): probe last_read_at in read-only session-store staleness check

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11202,6 +11202,7 @@ _session_db_bootstrap_lock = threading.Lock()
 _SESSION_DB_READ_PROBE_SQL = (
     "SELECT (SELECT archived FROM sessions LIMIT 1), "
     "(SELECT pinned FROM sessions LIMIT 1), "
+    "(SELECT last_read_at FROM sessions LIMIT 1), "
     "(SELECT active FROM messages LIMIT 1), "
     "(SELECT compacted FROM messages LIMIT 1)"
 )


### PR DESCRIPTION
## Summary

The read-only session-store staleness probe (`_SESSION_DB_READ_PROBE_SQL` in `hermes_cli/web_server.py`) was not updated when `last_read_at` landed in `ec0c8d9c2` ("feat(state): sessions carry read/unread state").

Read-only opens skip `_reconcile_columns()` (by design), so an older store missing **only** that column passes the probe — `archived` / `pinned` / `active` / `compacted` all exist — and never triggers the heal-once writable open. Every `GET /api/sessions` poll then 500s with `no such column: s.last_read_at` until something opens the store writable (CLI/gateway startup). Profiles used only through the desktop/dashboard backend never get that writable open, so their session lists stay broken indefinitely.

## Reproduction

On a profile whose `state.db` predates `ec0c8d9c2` (sessions table without `last_read_at`):

1. Desktop sidebar polls `GET /api/sessions` → 500 on every poll (once per ~60s)
2. Logs: `hermes_cli.web_server: GET /api/sessions failed` → `sqlite3.OperationalError: no such column: s.last_read_at` (traceback in `list_sessions_rich`, hermes_state.py:6055)
3. The stale-schema heal in `_open_session_db_for_profile` never fires because the probe SQL doesn't reference the missing column, so the store stays read-only forever

Observed on a real install: two profiles (`xuanru`, `money`) created Aug 2 with stores missing `last_read_at`; both session lists 500'd from the moment the update landed until a CLI run opened the store writable.

## Fix

Add `(SELECT last_read_at FROM sessions LIMIT 1)` to the probe. A store missing the column now fails the probe, which triggers the existing one-time writable open; `_init_schema()` → `_reconcile_columns()` then adds the column declaratively (no version-gated migration needed).

## Test Plan

- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/test_web_server_sessiondb_eventloop.py -q` → **142 passed, 0 failed**
- E2E against a real pre-update `state.db` snapshot (missing `last_read_at`):
  - probe now raises `no such column: last_read_at` ✅
  - writable `SessionDB` open adds the column (53 cols) ✅
  - re-probe passes, `list_sessions_rich(limit=3)` returns rows ✅
