### PR TITLE
fix(acp): honor model on session init

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -840,6 +840,15 @@ class HermesACPAgent(acp.Agent):
         return target_provider, new_model
 
     @staticmethod
+    def _requested_session_model(kwargs: dict[str, Any]) -> str | None:
+        """Return the optional ACP session model parameter across client spellings."""
+        for key in ("model_id", "modelId", "model"):
+            raw_model = kwargs.get(key)
+            if isinstance(raw_model, str) and raw_model.strip():
+                return raw_model.strip()
+        return None
+
+    @staticmethod
     def _build_usage_update(state: SessionState) -> UsageUpdate | None:
         """Build ACP native context-usage data for clients like Zed.
 
@@ -1438,7 +1447,19 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> NewSessionResponse:
-        state = self.session_manager.create_session(cwd=cwd)
+        requested_provider = None
+        resolved_model = None
+        requested_model = self._requested_session_model(kwargs)
+        if requested_model:
+            requested_provider, resolved_model = self._resolve_model_selection(
+                requested_model,
+                detect_provider() or "openrouter",
+            )
+        state = self.session_manager.create_session(
+            cwd=cwd,
+            model=resolved_model,
+            requested_provider=requested_provider,
+        )
         await self._register_session_mcp_servers(state, mcp_servers)
         self._schedule_mcp_late_refresh(state)
         logger.info("New session %s (cwd=%s)", state.session_id, cwd)
@@ -1460,7 +1481,36 @@ class HermesACPAgent(acp.Agent):
         mcp_servers: list | None = None,
         **kwargs: Any,
     ) -> LoadSessionResponse | None:
-        state = self.session_manager.update_cwd(session_id, cwd)
+        requested_provider = None
+        resolved_model = None
+        current_base_url = None
+        current_api_mode = None
+        requested_model = self._requested_session_model(kwargs)
+        if requested_model:
+            current_state = self.session_manager.get_session(session_id)
+            current_provider = (
+                getattr(current_state.agent, "provider", None)
+                if current_state is not None
+                else None
+            )
+            requested_provider, resolved_model = self._resolve_model_selection(
+                requested_model,
+                current_provider or detect_provider() or "openrouter",
+            )
+            provider_changed = bool(
+                current_provider and requested_provider != current_provider
+            )
+            if current_state is not None and not provider_changed:
+                current_base_url = getattr(current_state.agent, "base_url", None)
+                current_api_mode = getattr(current_state.agent, "api_mode", None)
+        state = self.session_manager.update_cwd(
+            session_id,
+            cwd,
+            model=resolved_model,
+            requested_provider=requested_provider,
+            base_url=current_base_url,
+            api_mode=current_api_mode,
+        )
         if state is None:
             logger.warning("load_session: session %s not found", session_id)
             return None

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -196,13 +196,23 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
+    def create_session(
+        self,
+        cwd: str = ".",
+        model: str | None = None,
+        requested_provider: str | None = None,
+    ) -> SessionState:
         """Create a new session with a unique ID and a fresh AIAgent."""
         import threading
 
         cwd = _translate_acp_cwd(cwd)
         session_id = str(uuid.uuid4())
-        agent = self._make_agent(session_id=session_id, cwd=cwd)
+        agent = self._make_agent(
+            session_id=session_id,
+            cwd=cwd,
+            model=model,
+            requested_provider=requested_provider,
+        )
         state = SessionState(
             session_id=session_id,
             agent=agent,
@@ -343,13 +353,31 @@ class SessionManager:
         results.sort(key=lambda item: _updated_at_sort_key(item.get("updated_at")), reverse=True)
         return results
 
-    def update_cwd(self, session_id: str, cwd: str) -> Optional[SessionState]:
+    def update_cwd(
+        self,
+        session_id: str,
+        cwd: str,
+        model: str | None = None,
+        requested_provider: str | None = None,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+    ) -> Optional[SessionState]:
         """Update the working directory for a session and its tool overrides."""
         cwd = _translate_acp_cwd(cwd)
         state = self.get_session(session_id)  # checks DB too
         if state is None:
             return None
         state.cwd = cwd
+        if model is not None:
+            state.agent = self._make_agent(
+                session_id=session_id,
+                cwd=cwd,
+                model=model,
+                requested_provider=requested_provider,
+                base_url=base_url,
+                api_mode=api_mode,
+            )
+            state.model = getattr(state.agent, "model", model) or model
         _register_task_cwd(session_id, cwd)
         self._persist(state)
         return state

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -368,6 +368,10 @@ class TestListAndFork:
 
 
 class TestSessionConfiguration:
+    def test_session_model_param_accepts_acp_spellings(self):
+        assert HermesACPAgent._requested_session_model({"modelId": "gpt-5.4"}) == "gpt-5.4"
+        assert HermesACPAgent._requested_session_model({"model_id": "gpt-5.4"}) == "gpt-5.4"
+        assert HermesACPAgent._requested_session_model({"model": "gpt-5.4"}) == "gpt-5.4"
 
     @pytest.mark.asyncio
     async def test_router_accepts_stable_session_config_methods(self, agent):
@@ -391,6 +395,104 @@ class TestSessionConfiguration:
 
         assert mode_result == {}
         assert config_result["configOptions"] == []
+
+    @pytest.mark.asyncio
+    async def test_new_session_applies_requested_model_id(self, tmp_path, monkeypatch):
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            resp = await acp_agent.new_session(
+                cwd="/tmp",
+                modelId="anthropic:claude-sonnet-4-6",
+            )
+
+        state = acp_agent.session_manager.get_session(resp.session_id)
+        assert state.model == "claude-sonnet-4-6"
+        assert state.agent.provider == "anthropic"
+        assert state.agent.base_url == "https://anthropic.example/v1"
+        assert resp.models.current_model_id == "anthropic:claude-sonnet-4-6"
+        assert runtime_calls[-1] == "anthropic"
+
+    @pytest.mark.asyncio
+    async def test_load_session_applies_requested_model_id(self, tmp_path, monkeypatch):
+        runtime_calls = []
+
+        def fake_resolve_runtime_provider(requested=None, **kwargs):
+            runtime_calls.append(requested)
+            provider = requested or "openrouter"
+            return {
+                "provider": provider,
+                "api_mode": "anthropic_messages" if provider == "anthropic" else "chat_completions",
+                "base_url": f"https://{provider}.example/v1",
+                "api_key": f"{provider}-key",
+                "command": None,
+                "args": [],
+            }
+
+        def fake_agent(**kwargs):
+            return SimpleNamespace(
+                model=kwargs.get("model"),
+                provider=kwargs.get("provider"),
+                base_url=kwargs.get("base_url"),
+                api_mode=kwargs.get("api_mode"),
+            )
+
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+            "model": {"provider": "openrouter", "default": "openrouter/gpt-5"}
+        })
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            fake_resolve_runtime_provider,
+        )
+        manager = SessionManager(db=SessionDB(tmp_path / "state.db"))
+
+        with patch("run_agent.AIAgent", side_effect=fake_agent):
+            acp_agent = HermesACPAgent(session_manager=manager)
+            new_resp = await acp_agent.new_session(cwd="/tmp")
+            load_resp = await acp_agent.load_session(
+                cwd="/workspace",
+                session_id=new_resp.session_id,
+                modelId="anthropic:claude-sonnet-4-6",
+            )
+
+        state = acp_agent.session_manager.get_session(new_resp.session_id)
+        assert isinstance(load_resp, LoadSessionResponse)
+        assert state.cwd == "/workspace"
+        assert state.model == "claude-sonnet-4-6"
+        assert state.agent.provider == "anthropic"
+        assert state.agent.base_url == "https://anthropic.example/v1"
+        assert load_resp.models.current_model_id == "anthropic:claude-sonnet-4-6"
+        assert runtime_calls[-1] == "anthropic"
 
 
 


### PR DESCRIPTION
Fixes NousResearch#80150

ACP session/new and session/load accepted a model parameter from clients, but the value was not applied when the session agent was created or loaded. Clients had to send a separate session/set_model request after every session initialization.

This change reads the requested model from the ACP session params, supporting modelId, model_id, and model spellings, resolves provider-prefixed selections through the same model selection path used by session/set_model, and passes the resolved model/provider into the session manager.

For session/load, the selected model is applied while preserving the cwd update and retaining the existing base_url/api_mode when the provider does not change.

Regression coverage includes:

session/new applying a provider-prefixed modelId immediately
session/load applying a provider-prefixed modelId immediately
accepted ACP model parameter spellings

Validation:
scripts/run_tests.sh tests/acp/test_server.py tests/acp_adapter -q

Result:
47 passed