### PR TITLE
feat(models): add Meta Muse Spark 1.2 to OpenRouter curated picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -88,6 +88,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("stepfun/step-3.7-flash",                 ""),
     # NVIDIA
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
+    # Meta
+    ("meta/muse-spark-1.2",                    ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-03T22:03:15Z",
+  "updated_at": "2026-08-06T14:48:19Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -135,6 +135,10 @@
         },
         {
           "id": "nvidia/nemotron-3-super-120b-a12b",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.2",
           "description": ""
         },
         {


### PR DESCRIPTION
## Summary

Adds `meta/muse-spark-1.2` to Hermes' curated OpenRouter model list so it appears in the model selector (CLI `hermes model`, desktop picker, gateway `/model` options).

Hermes deliberately shows a curated agentic shortlist for OpenRouter rather than the full live `/models` dump. Muse Spark 1.2 is live on OpenRouter (tool-capable, multimodal, 1M context) but was missing from that shortlist, so users could not select it from the picker UI even with a valid OpenRouter key.

## Changes

- `hermes_cli/models.py`: add `meta/muse-spark-1.2` under a Meta section in `OPENROUTER_MODELS`
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py` so the hosted catalog (and fallback snapshot) stay in sync

## Related / prior art

- No open PR currently adds **1.2** specifically (searched for `muse-spark`, `muse spark`, `muse-spark-1.2`)
- #76273 refreshes the Aug 2026 catalogs and includes `meta/muse-spark-1.1`, but not 1.2
- #61548 (closed, not planned) was a separate Meta Model API native provider plugin, not the OpenRouter curated-list path

## Test plan

- [x] `uv run --with pytest pytest tests/hermes_cli/test_models.py tests/hermes_cli/test_model_catalog.py -q` (49 passed)
- [x] Confirmed `meta/muse-spark-1.2` is present on live OpenRouter `GET /api/v1/models`
- [x] Confirmed regenerated catalog includes the new id (40 OpenRouter entries)
- [ ] After merge + docs deploy: desktop/CLI OpenRouter picker shows Muse Spark 1.2; `/model meta/muse-spark-1.2 --provider openrouter` still works as today

## References

- https://openrouter.ai/meta/muse-spark-1.2
- https://hermes-agent.nousresearch.com/docs/reference/model-catalog
