### PR TITLE
fix(search): stop the Windows path translator from rewriting search regexes

### DIFF
--- a/tests/tools/test_search_pattern_not_path_translated.py
+++ b/tests/tools/test_search_pattern_not_path_translated.py
@@ -1,0 +1,98 @@
+"""A search regex is not a path — the Windows path translator must not touch it.
+
+``_escape_shell_arg`` rewrites every backslash to ``/`` on Windows
+(``_bash_safe_path``), which is what ``C:\\Users\\x`` needs. The content-search
+builders used it for the regex and the glob too, so on Windows ``\\d+`` reached
+the engine as ``/d+`` and ``\\bword\\b`` as ``/bword/b`` — a silent zero-match
+result for any pattern using a regex escape.
+
+The translator is monkeypatched here so the Windows behaviour is exercised on
+every platform; off Windows the real one is a no-op.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+
+@pytest.fixture()
+def windows_translator(monkeypatch):
+    """Force the Windows backslash rewrite regardless of the host platform."""
+    import tools.environments.local as local_env
+
+    monkeypatch.setattr(
+        local_env, "_bash_safe_path", lambda p: p.replace("\\", "/") if p else p,
+    )
+
+
+def _fops_capturing(commands):
+    env = MagicMock()
+    env.cwd = "/work"
+
+    def _execute(cmd, *args, **kwargs):
+        commands.append(cmd if isinstance(cmd, str) else " ".join(map(str, cmd)))
+        return {"output": "", "returncode": 1}
+
+    env.execute = _execute
+    return ShellFileOperations(env)
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [r"\d+", r"\bword\b", r"foo\.bar", r"\s+end", r"a\\b"],
+)
+def test_regex_reaches_the_engine_unmodified(windows_translator, pattern):
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content(pattern, "/work", None, 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds, f"no grep command was issued (commands={commands!r})"
+    assert f"'{pattern}'" in search_cmds[0], (
+        f"the regex was rewritten before reaching grep: {search_cmds[0]!r}"
+    )
+
+
+def test_glob_filter_keeps_its_backslashes(windows_translator):
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content("needle", "/work", r"src\*.py", 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds
+    assert r"'src\*.py'" in search_cmds[0], (
+        f"the glob was rewritten before reaching grep: {search_cmds[0]!r}"
+    )
+
+
+def test_the_path_argument_is_still_translated(windows_translator):
+    """The rewrite must keep working where it belongs — the search root."""
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "grep"
+
+    fops._search_content("needle", r"C:\work\src", None, 20, 0, "content", 0)
+
+    search_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert search_cmds
+    assert "'C:/work/src'" in search_cmds[0], (
+        f"the search root lost its path translation: {search_cmds[0]!r}"
+    )
+
+
+def test_escape_helpers_split_path_from_literal(windows_translator):
+    """The two quoters differ exactly in whether they translate separators."""
+    fops = _fops_capturing([])
+
+    assert fops._escape_shell_literal(r"\d+") == r"'\d+'"
+    assert fops._escape_shell_arg(r"C:\work") == "'C:/work'"
+    # Single-quote escaping is unchanged on both.
+    assert fops._escape_shell_literal("it's") == "'it'\"'\"'s'"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -992,7 +992,18 @@ class ShellFileOperations(FileOperations):
         """
         from tools.environments.local import _bash_safe_path
 
-        arg = _bash_safe_path(arg)
+        return self._escape_shell_literal(_bash_safe_path(arg))
+
+    @staticmethod
+    def _escape_shell_literal(arg: str) -> str:
+        """Quote *arg* for the shell WITHOUT any path translation.
+
+        For arguments that are not paths — a search regex, a glob filter —
+        where a backslash is syntax rather than a separator.
+        ``_escape_shell_arg`` rewrites every backslash to ``/`` on Windows
+        via ``_bash_safe_path``, which is what ``C:\\Users\\x`` needs and
+        what turns ``\\d+`` into ``/d+``.
+        """
         # Use single quotes and escape any single quotes in the string
         return "'" + arg.replace("'", "'\"'\"'") + "'"
 
@@ -2308,10 +2319,10 @@ class ShellFileOperations(FileOperations):
         """
         if not self._has_command('rg'):
             return None
-        glob_expr = f" --glob {self._escape_shell_arg(file_glob)}" if file_glob else ""
+        glob_expr = f" --glob {self._escape_shell_literal(file_glob)}" if file_glob else ""
         probe = self._exec(
             f"rg -i --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._escape_shell_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2333,7 +2344,7 @@ class ShellFileOperations(FileOperations):
         # missing from results).
         hidden = self._exec(
             f"rg --hidden --no-ignore --count-matches{glob_expr} "
-            f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+            f"{self._escape_shell_literal(pattern)} {self._escape_shell_arg(path)} "
             f"2>/dev/null | head -50",
             timeout=30,
         )
@@ -2353,7 +2364,7 @@ class ShellFileOperations(FileOperations):
         if re.search(r"[.\[\](){}?*+^$\\|]", pattern):
             fixed = self._exec(
                 f"rg -F --count-matches{glob_expr} "
-                f"{self._escape_shell_arg(pattern)} {self._escape_shell_arg(path)} "
+                f"{self._escape_shell_literal(pattern)} {self._escape_shell_arg(path)} "
                 f"2>/dev/null | head -50",
                 timeout=30,
             )
@@ -2560,7 +2571,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file glob filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--glob", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--glob", self._escape_shell_literal(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -2569,7 +2580,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")  # Count per file
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_literal(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch extra rows so we can report the true total before slicing.
@@ -2696,7 +2707,7 @@ class ShellFileOperations(FileOperations):
         
         # Add file pattern filter (must be quoted to prevent shell expansion)
         if file_glob:
-            cmd_parts.extend(["--include", self._escape_shell_arg(file_glob)])
+            cmd_parts.extend(["--include", self._escape_shell_literal(file_glob)])
         
         # Output mode handling
         if output_mode == "files_only":
@@ -2705,7 +2716,7 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_literal(pattern))
         cmd_parts.append(self._escape_shell_arg(path))
         
         # Fetch generously so we can compute total before slicing


### PR DESCRIPTION
## What

`_escape_shell_arg` runs `_bash_safe_path` on whatever it is handed. On Windows that rewrites every backslash to `/`. For a path that is exactly right — bash eats backslashes and MSYS mangles `C:\Users\x` into the `Directory \drivers\etc does not exist` failure class — and it is what the docstring describes.

The content-search builders hand it the regex and the `--glob`/`--include` filter as well:

```python
cmd_parts.append(self._escape_shell_arg(pattern))
cmd_parts.append(self._escape_shell_arg(path))
```

So on Windows the pattern gets the path treatment. Capturing what actually reaches the shell:

```
grep -rnHE --exclude-dir='.*' '/d+' '/c/Users/.../project' | head -n 20
```

`\d+` arrives as `/d+`, `\bword\b` as `/bword/b`, `foo\.bar` as `foo/.bar`. Nothing matches `/d+`, so the search returns zero results and no error — the agent reads a clean "no matches" and moves on, which is worse than a failure it could react to. Every regex escape is affected, on both engines, in `search`, one of the most-used tools in the loop.

## Root cause

f2fcf89c1 ("fix(windows): bash-safe snapshot paths after #63113") swapped the helper's translator:

```diff
-        from tools.environments.local import _windows_to_msys_path
-        arg = _windows_to_msys_path(arg)
+        from tools.environments.local import _bash_safe_path
+        arg = _bash_safe_path(arg)
```

`_windows_to_msys_path` only rewrites drive-qualified paths, so a bare `\d+` passed through untouched. `_bash_safe_path` adds an unconditional `if "\\" in path: path = path.replace("\\", "/")` for mixed MSYS leftovers — correct for its stated job, but it made the helper act on any string containing a backslash, and the helper was already being used for arguments that are not paths. Both commits that built this helper describe it purely in terms of paths (d1ad9a0f5, f2fcf89c1); nothing intended it to reach a regex.

## The fix

Separate the quoting from the translation. `_escape_shell_literal` quotes for the shell without touching separators; the pattern and glob arguments use it. `_escape_shell_arg` keeps its behaviour and is now a thin wrapper — path arguments are unchanged, including the search root:

```
grep -rnHE --exclude-dir='.*' '\d+' '/c/Users/.../project'
```

## Tests and results

New file `tests/tools/test_search_pattern_not_path_translated.py`. It monkeypatches `_bash_safe_path` to the Windows rewrite so the behaviour is exercised on every platform — off Windows the real translator is a no-op, and a test that only ran on Windows would not defend this on CI.

- five regexes (`\d+`, `\bword\b`, `foo\.bar`, `\s+end`, `a\\b`) must reach grep verbatim
- a glob filter (`src\*.py`) must keep its backslashes
- the search root `C:\work\src` must still become `C:/work/src` — the translation has to keep working where it belongs
- the two quoters differ only in separator translation, and single-quote escaping is unchanged in both

All eight fail on `main` with the corrupted command in the message (`'/d+'`, `'/bword/b'`, `'foo/.bar'`, `'/s+end'`) and pass with the fix.

For regressions I ran the file-operations and search suites (`test_file_operations.py`, `test_file_operations_edge_cases.py`, `test_file_ops_cwd_tracking.py`, `test_search_auto_multiline.py`, `test_search_budget_truncation.py`, `test_search_error_guard.py`, `test_search_hidden_dirs.py`, `test_search_zero_match_and_multipath.py`, `test_session_search.py`) before and after and diffed the failure lists: 29 failures, byte-identical both ways, all pre-existing on `main`.