### PR TITLE
fix(cron): add bootout/remove/disable to lifecycle_guard launchctl verb list (#80260)

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -72,7 +72,7 @@ _GATEWAY_LIFECYCLE_PATTERN = re.compile(
     # loop instead (#62891) — same foot-gun, indirect shape. Neutral-label
     # submissions that dodge this text anchor are caught separately by
     # `contains_launchctl_submit_command` (execution-aware, label-independent).
-    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap)\b[^\n]*\bhermes[.\-]?gateway)"
+    r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch C: systemctl ops on a hermes-gateway unit.
     r"|(?:systemctl\s+(?:-\S+\s+)*(?:restart|stop|start)\b[^\n]*\bhermes[.\-]?gateway)"
     # Branch D: pkill / kill targeting the hermes gateway process. Both


### PR DESCRIPTION
## Summary

Adds `bootout`, `remove`, and `disable` to Branch B of `_GATEWAY_LIFECYCLE_PATTERN` in `cron/lifecycle_guard.py`.

## Problem

The guard blocked `bootstrap` (modern `load`) but not `bootout` (modern `unload`), nor the legacy `remove` or `disable` verbs. Since Apple deprecated `load`/`unload` in favour of `bootstrap`/`bootout`, the guard missed the **modern** spelling — the one that documentation and muscle memory steer users toward.

`launchctl bootout gui/$UID/<gateway label>` stops the gateway from inside the gateway process, which is precisely what this guard exists to prevent.

## Fix

One-line change adding three verbs to the alternation:

```diff
-r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap)\b[^\n]*\bhermes[.\-]?gateway)"
+r"|(?:launchctl\s+(?:kickstart|unload|load|stop|restart|submit|bootstrap|bootout|remove|disable)\b[^\n]*\bhermes[.\-]?gateway)"
```

The label requirement (`\bhermes[.\-]?gateway`) is unchanged, so unrelated services such as `launchctl bootout gui/501/ai.hermes.update-checker` remain unaffected.

## Testing

Verified that the regex matches all three new verbs against gateway labels while still allowing unrelated services through.

Fixes #80260