### PR TITLE
fix(cli): replace lone surrogates before writing to stdout in one-shot mode (#80366)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -278,6 +278,10 @@ def run_oneshot(
     _write_usage_file(usage_file, result)
 
     if response:
+        # Replace lone surrogates (e.g. U+D800 from a malformed provider
+        # response) with U+FFFD so stdout.write() does not crash.
+        # See #80366.
+        response = response.encode("utf-8", "surrogatepass").decode("utf-8", "replace")
         real_stdout.write(response)
         if not response.endswith("\n"):
             real_stdout.write("\n")


### PR DESCRIPTION
## Problem

`hermes --oneshot` crashes with `UnicodeEncodeError` when an OpenAI-compatible provider returns a lone Unicode surrogate (e.g. `\ud800`) in assistant text:

```
File "hermes_cli/oneshot.py", line 281, in run_oneshot
    real_stdout.write(response)
UnicodeEncodeError: utf-8 codec can't encode character '\ud800' in position 8: surrogates not allowed
```

The model response is recorded as completed but nothing is printed and the command exits with code 1.

## Fix

Encode the response with `surrogatepass` (which preserves surrogates in the byte stream) then decode with `replace` (which converts any surrogates to U+FFFD, the Unicode replacement character). This happens before `real_stdout.write()`, so the crash is avoided and the user sees `�` where the malformed character was — exactly the expected behavior described in the issue.

```python
response = response.encode("utf-8", "surrogatepass").decode("utf-8", "replace")
```

This is a minimal 4-line addition with no effect on well-formed responses.

Fixes #80366