### PR TITLE
feat(telegram): copy-to-clipboard button on split legacy replies

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -719,6 +719,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # as plain text, which is worse than degraded table/task-list rendering
         # for command snippets and mobile handoffs.
         self._rich_messages_enabled: bool = self._coerce_bool_extra("rich_messages", False)
+        # Optional operator override: route every eligible final response
+        # through sendRichMessage, not only messages containing rich-only
+        # constructs. Keep this separate from rich_messages so the existing
+        # opt-in behavior remains reversible and backwards-compatible.
+        self._rich_messages_all: bool = self._coerce_bool_extra("rich_messages_all", False)
         # Rich draft previews use a separate opt-in. Telegram macOS / Desktop
         # can leave Bot API 10.1 rich draft frames visually overlaid until the
         # chat is redrawn, while final rich messages remain useful.
@@ -1662,6 +1667,8 @@ class TelegramAdapter(BasePlatformAdapter):
         """
         if not content:
             return False
+        if getattr(self, "_rich_messages_all", False):
+            return True
         if any(_TABLE_SEPARATOR_RE.match(line) for line in content.splitlines()):
             return True
         if re.search(r"(?m)^\s*[-*]\s+\[[ xX]\]\s+", content):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -640,6 +640,11 @@ class TelegramAdapter(BasePlatformAdapter):
     _SPLIT_THRESHOLD = 4000
     MEDIA_GROUP_WAIT_SECONDS = 0.8
     _GENERAL_TOPIC_THREAD_ID = "1"
+    # "Copy to clipboard" button state (see _register_clipboard_copy):
+    # short-lived, bounded so an unattended bot can't accumulate entries
+    # holding full response text indefinitely.
+    _CLIPBOARD_COPY_TTL_SECONDS = 600
+    _CLIPBOARD_COPY_MAX_PENDING = 50
 
     # Telegram's edit_message applies MarkdownV2 formatting only on the
     # finalize=True path.  Without this flag, stream_consumer._send_or_edit
@@ -865,6 +870,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # Clarify button state: clarify_id → session_key (for the clarify tool's
         # multiple-choice prompts; see GatewayRunner clarify_callback wiring).
         self._clarify_state: Dict[str, str] = {}
+        # Clipboard-copy button state: token → {text, chat_id, thread_id,
+        # created}. Holds the complete unsplit response for the "copy to
+        # Hermes clipboard" button attached to the final message of a split
+        # reply. Never put into callback_data — see _register_clipboard_copy.
+        self._clipboard_copy_state: Dict[str, dict] = {}
         # Notification mode for message sends.
         # "important" — only final responses, approvals, and slash confirmations
         #               trigger notifications; tool progress, streaming, status
@@ -4498,7 +4508,20 @@ class TelegramAdapter(BasePlatformAdapter):
             thread_id = self._metadata_thread_id(metadata)
             requested_thread_id = self._message_thread_id_for_send(thread_id)
             used_thread_fallback = False
-            
+
+            # Split legacy replies get a "copy full response" button on the
+            # FINAL chunk only, and only for the final user-visible reply
+            # (metadata["notify"]) — not intermediate/progress sends. The
+            # button targets the pre-split, pre-escape `content`, never the
+            # formatted/chunked text (req: never leak full text via
+            # callback_data — see _register_clipboard_copy).
+            clipboard_copy_keyboard = None
+            if len(chunks) > 1 and (metadata or {}).get("notify"):
+                clipboard_copy_token = self._register_clipboard_copy(
+                    content, chat_id=str(chat_id), thread_id=thread_id,
+                )
+                clipboard_copy_keyboard = self._clipboard_copy_keyboard(clipboard_copy_token)
+
             try:
                 from telegram.error import NetworkError as _NetErr
             except ImportError:
@@ -4558,6 +4581,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
                 msg = None
+                # Attach the clipboard-copy keyboard as reply_markup (not
+                # message text) so it never counts against the 4096-char
+                # chunk budget — only the final chunk gets it.
+                chunk_reply_markup_kwargs = (
+                    {"reply_markup": clipboard_copy_keyboard}
+                    if clipboard_copy_keyboard is not None and i == len(chunks) - 1
+                    else {}
+                )
                 for _send_attempt in range(3):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
@@ -4570,6 +4601,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **chunk_reply_markup_kwargs,
                             )
                         except Exception as md_error:
                             # Markdown parsing failed, try plain text
@@ -4584,6 +4616,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
+                                    **chunk_reply_markup_kwargs,
                                 )
                             else:
                                 raise
@@ -5050,6 +5083,17 @@ class TelegramAdapter(BasePlatformAdapter):
             # if truncate_message returned a single chunk just edit normally.
             chunks = [content]
 
+        # A real split (len(chunks) > 1) on the final edit gets a "copy full
+        # response" button on the last continuation message — same contract
+        # as send()'s legacy split path. The button targets the pre-split
+        # `content`, never a formatted/chunked continuation.
+        clipboard_copy_keyboard = None
+        if finalize and len(chunks) > 1:
+            clipboard_copy_token = self._register_clipboard_copy(
+                content, chat_id=str(chat_id), thread_id=self._metadata_thread_id(metadata),
+            )
+            clipboard_copy_keyboard = self._clipboard_copy_keyboard(clipboard_copy_token)
+
         # Step 1 — edit the existing message with the first chunk.
         first_chunk = chunks[0]
         try:
@@ -5107,7 +5151,8 @@ class TelegramAdapter(BasePlatformAdapter):
         delivered_chunks = [first_chunk]
         prev_id = message_id
         thread_id = self._metadata_thread_id(metadata)
-        for chunk in chunks[1:]:
+        last_chunk_index = len(chunks) - 1
+        for chunk_index, chunk in enumerate(chunks[1:], start=1):
             sent_msg = None
             reply_to_id = int(prev_id) if prev_id else None
             thread_kwargs = self._thread_kwargs_for_send(
@@ -5115,6 +5160,13 @@ class TelegramAdapter(BasePlatformAdapter):
                 thread_id,
                 metadata,
                 reply_to_message_id=reply_to_id,
+            )
+            # Only the final continuation carries the clipboard-copy button
+            # (reply_markup, not message text — never inflates the chunk).
+            chunk_reply_markup_kwargs = (
+                {"reply_markup": clipboard_copy_keyboard}
+                if clipboard_copy_keyboard is not None and chunk_index == last_chunk_index
+                else {}
             )
             for use_markdown in (True, False) if finalize else (False,):
                 try:
@@ -5136,6 +5188,7 @@ class TelegramAdapter(BasePlatformAdapter):
                         **thread_kwargs,
                         **self._link_preview_kwargs(),
                         **self._notification_kwargs(metadata),
+                        **chunk_reply_markup_kwargs,
                     )
                     break
                 except Exception as send_err:
@@ -5157,6 +5210,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 **retry_thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
+                                **chunk_reply_markup_kwargs,
                             )
                             break
                         except Exception as _retry_err:
@@ -5435,6 +5489,60 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[%s] send_update_prompt failed: %s", self.name, _redact_telegram_error_text(e))
             return SendResult(success=False, error=_redact_telegram_error_text(e))
+
+    def _clipboard_copy_button_label(self) -> str:
+        """Platform-appropriate label for the clipboard-copy button."""
+        if sys.platform == "darwin":
+            return "🍎📋 Copy to Mac Clipboard"
+        return "📋 Copy to Hermes Clipboard"
+
+    def _prune_clipboard_copy_state(self) -> None:
+        """Drop expired entries, then trim to the max-pending bound (oldest first)."""
+        now = time.time()
+        expired = [
+            token for token, entry in self._clipboard_copy_state.items()
+            if now - entry["created"] > self._CLIPBOARD_COPY_TTL_SECONDS
+        ]
+        for token in expired:
+            self._clipboard_copy_state.pop(token, None)
+
+        overflow = len(self._clipboard_copy_state) - self._CLIPBOARD_COPY_MAX_PENDING
+        if overflow > 0:
+            # Dicts preserve insertion order — oldest entries come first.
+            for token in list(self._clipboard_copy_state.keys())[:overflow]:
+                self._clipboard_copy_state.pop(token, None)
+
+    def _register_clipboard_copy(
+        self, text: str, *, chat_id: str, thread_id: Optional[str],
+    ) -> str:
+        """Store the full unsplit response and return a short opaque token.
+
+        The token (never the response text) goes into callback_data. Bounded
+        + TTL'd per _CLIPBOARD_COPY_MAX_PENDING / _CLIPBOARD_COPY_TTL_SECONDS
+        so an unattended bot can't accumulate full response text indefinitely.
+        """
+        import secrets
+
+        token = secrets.token_urlsafe(9)
+        self._clipboard_copy_state[token] = {
+            "text": text,
+            "chat_id": str(chat_id),
+            "thread_id": str(thread_id) if thread_id is not None else None,
+            "created": time.time(),
+        }
+        # Prune AFTER inserting so the max-pending bound accounts for the
+        # entry we just added (pruning first would only trim to MAX-1 before
+        # the insert, letting the dict grow to MAX+1).
+        self._prune_clipboard_copy_state()
+        return token
+
+    def _clipboard_copy_keyboard(self, token: str) -> "InlineKeyboardMarkup":
+        return InlineKeyboardMarkup([[
+            InlineKeyboardButton(
+                self._clipboard_copy_button_label(),
+                callback_data=f"cc:{token}",
+            )
+        ]])
 
     # Template attrs for the shared _format_exec_approval core (HTML mode).
     _EA_HEADER = "⚠️ <b>Command Approval Required</b>\n\n"
@@ -6654,6 +6762,74 @@ class TelegramAdapter(BasePlatformAdapter):
                         "Telegram clarify button: resolve_gateway_clarify returned False (id=%s)",
                         clarify_id,
                     )
+            return
+
+        # --- Clipboard-copy callbacks (cc:token) ---
+        if data.startswith("cc:"):
+            token = data.split(":", 1)[1]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to copy this response.")
+                return
+
+            self._prune_clipboard_copy_state()
+            entry = self._clipboard_copy_state.get(token)
+            if entry is None:
+                await query.answer(text="⌛ This copy link has expired or was already used.")
+                return
+
+            query_thread_str = str(query_thread_id) if query_thread_id is not None else None
+            entry_thread = entry.get("thread_id")
+            thread_mismatch = (
+                entry_thread is not None
+                and query_thread_str is not None
+                and entry_thread != query_thread_str
+            )
+            if str(entry["chat_id"]) != str(query_chat_id) or thread_mismatch:
+                await query.answer(text="⛔ This button isn't valid in this chat.")
+                return
+
+            # Consume before writing — a slow/failed clipboard write must not
+            # leave the token clickable again (single-use, mirrors the
+            # approval/slash-confirm/clarify state dicts above).
+            self._clipboard_copy_state.pop(token, None)
+            text = entry["text"]
+
+            try:
+                from hermes_cli.clipboard import write_clipboard_text
+                wrote = write_clipboard_text(text)
+            except Exception as exc:
+                # Never fatal — the Telegram response was already delivered;
+                # only the clipboard convenience action failed.
+                logger.warning(
+                    "[%s] clipboard copy callback raised (token=%s, chat=%s, size=%d): %s",
+                    self.name, token, query_chat_id, len(text), exc,
+                )
+                wrote = False
+
+            # Log token/size/status only — never the copied text (#9).
+            if wrote:
+                logger.info(
+                    "[%s] clipboard copy callback succeeded (token=%s, chat=%s, size=%d)",
+                    self.name, token, query_chat_id, len(text),
+                )
+                success_text = (
+                    "🍎📋 Copied to Mac clipboard." if sys.platform == "darwin"
+                    else "📋 Copied to Hermes clipboard."
+                )
+                await query.answer(text=success_text)
+            else:
+                logger.warning(
+                    "[%s] clipboard copy callback: backend unavailable (token=%s, chat=%s, size=%d)",
+                    self.name, token, query_chat_id, len(text),
+                )
+                await query.answer(text="⚠️ Clipboard unavailable on the Hermes host.")
             return
 
         # --- Update prompt callbacks ---

--- a/tests/gateway/test_telegram_clipboard_copy_button.py
+++ b/tests/gateway/test_telegram_clipboard_copy_button.py
@@ -1,0 +1,419 @@
+"""Tests for the Telegram "copy full response to Hermes clipboard" button.
+
+Covers both places a legacy text reply can be split into multiple Telegram
+messages: the normal send() chunking path and the edit/streaming-completion
+overflow path (_edit_overflow_split).
+"""
+
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the repo root is importable
+# ---------------------------------------------------------------------------
+_repo = str(Path(__file__).resolve().parents[2])
+if _repo not in sys.path:
+    sys.path.insert(0, _repo)
+
+
+# ---------------------------------------------------------------------------
+# Minimal Telegram mock so TelegramAdapter can be imported
+# ---------------------------------------------------------------------------
+def _ensure_telegram_mock():
+    """Wire up the minimal mocks required to import TelegramAdapter."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN = "Markdown"
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ParseMode.HTML = "HTML"
+    mod.constants.ChatType.PRIVATE = "private"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.error.NetworkError = type("NetworkError", (OSError,), {})
+    mod.error.TimedOut = type("TimedOut", (OSError,), {})
+    mod.error.BadRequest = type("BadRequest", (Exception,), {})
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+    sys.modules.setdefault("telegram.error", mod.error)
+
+
+_ensure_telegram_mock()
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+from gateway.config import PlatformConfig
+
+
+def _make_adapter(extra=None, *, max_message_length=None):
+    config = PlatformConfig(enabled=True, token="test-token", extra=extra or {})
+    adapter = TelegramAdapter(config)
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    if max_message_length is not None:
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", max_message_length)
+    return adapter
+
+
+def _message(message_id):
+    return SimpleNamespace(message_id=message_id)
+
+
+def _query(data, *, chat_id=12345, thread_id=None, user_id="111"):
+    query = AsyncMock()
+    query.data = data
+    query.message = MagicMock()
+    query.message.chat_id = chat_id
+    query.message.chat = MagicMock()
+    query.message.chat.type = "private"
+    query.message.message_thread_id = thread_id
+    query.from_user = MagicMock()
+    query.from_user.id = user_id
+    query.from_user.first_name = "Tester"
+    query.answer = AsyncMock()
+    query.edit_message_text = AsyncMock()
+    return query
+
+
+def _update_for(query):
+    update = MagicMock()
+    update.callback_query = query
+    return update
+
+
+ALLOW_ALL = {"TELEGRAM_ALLOWED_USERS": "*"}
+
+
+# ===========================================================================
+# send() — legacy split path
+# ===========================================================================
+
+class TestSendClipboardButtonAttachment:
+    @pytest.mark.asyncio
+    async def test_single_message_reply_has_no_button_and_no_state(self):
+        adapter = _make_adapter()
+        adapter._bot.send_message = AsyncMock(return_value=_message(1))
+
+        result = await adapter.send("12345", "short reply", metadata={"notify": True})
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args[1]
+        assert "reply_markup" not in kwargs
+        assert adapter._clipboard_copy_state == {}
+
+    @pytest.mark.asyncio
+    async def test_split_reply_attaches_button_only_to_final_message(self):
+        adapter = _make_adapter(max_message_length=None)
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 120)
+        sent = []
+
+        async def fake_send_message(**kwargs):
+            msg = _message(len(sent) + 1)
+            sent.append(kwargs)
+            return msg
+
+        adapter._bot.send_message = AsyncMock(side_effect=fake_send_message)
+
+        original = "word " * 80  # forces multiple chunks at MAX_MESSAGE_LENGTH=120
+        result = await adapter.send("12345", original, metadata={"notify": True})
+
+        assert result.success is True
+        assert len(sent) > 1
+        for kwargs in sent[:-1]:
+            assert "reply_markup" not in kwargs or kwargs["reply_markup"] is None
+        assert sent[-1]["reply_markup"] is not None
+        assert len(adapter._clipboard_copy_state) == 1
+        token, entry = next(iter(adapter._clipboard_copy_state.items()))
+        assert entry["text"] == original
+        assert entry["chat_id"] == "12345"
+
+    @pytest.mark.asyncio
+    async def test_intermediate_non_final_send_gets_no_button_even_if_split(self):
+        """metadata without notify=True is a progress/status send, not the final reply."""
+        adapter = _make_adapter()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 120)
+        adapter._bot.send_message = AsyncMock(side_effect=lambda **k: _message(1))
+
+        result = await adapter.send("12345", "word " * 80, metadata={})
+
+        assert result.success is True
+        assert adapter._clipboard_copy_state == {}
+
+    @pytest.mark.asyncio
+    async def test_callback_data_is_short_opaque_token_not_report_text(self, monkeypatch):
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardButton",
+            lambda text, callback_data: SimpleNamespace(text=text, callback_data=callback_data),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.InlineKeyboardMarkup",
+            lambda rows: SimpleNamespace(inline_keyboard=rows),
+        )
+        adapter = _make_adapter()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 120)
+        sent = []
+
+        async def fake_send_message(**kwargs):
+            sent.append(kwargs)
+            return _message(len(sent))
+
+        adapter._bot.send_message = AsyncMock(side_effect=fake_send_message)
+        original = "secret-report-body " * 20
+        await adapter.send("12345", original, metadata={"notify": True})
+
+        markup = sent[-1]["reply_markup"]
+        button = markup.inline_keyboard[0][0]
+        assert button.callback_data.startswith("cc:")
+        token = button.callback_data.split(":", 1)[1]
+        assert len(button.callback_data.encode("utf-8")) <= 64
+        assert "secret-report-body" not in button.callback_data
+        assert token in adapter._clipboard_copy_state
+
+
+# ===========================================================================
+# _edit_overflow_split — edit/streaming-completion overflow path
+# ===========================================================================
+
+class TestEditOverflowClipboardButtonAttachment:
+    @pytest.mark.asyncio
+    async def test_finalize_split_attaches_button_to_last_continuation_only(self):
+        adapter = _make_adapter()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 160)
+        adapter._bot.edit_message_text = AsyncMock(return_value=True)
+        sent = []
+
+        async def fake_send_message(**kwargs):
+            sent.append(kwargs)
+            return _message(100 + len(sent))
+
+        adapter._bot.send_message = AsyncMock(side_effect=fake_send_message)
+
+        original = "word " * 120
+        result = await adapter._edit_overflow_split(
+            "12345", "1", original, finalize=True, metadata={"thread_id": "77"},
+        )
+
+        assert result.success is True
+        assert len(sent) >= 1
+        for kwargs in sent[:-1]:
+            assert not kwargs.get("reply_markup")
+        assert sent[-1]["reply_markup"] is not None
+        assert len(adapter._clipboard_copy_state) == 1
+        entry = next(iter(adapter._clipboard_copy_state.values()))
+        assert entry["text"] == original
+
+    @pytest.mark.asyncio
+    async def test_non_finalize_overflow_gets_no_button(self):
+        """Mid-stream (finalize=False) previews never attach the button."""
+        adapter = _make_adapter()
+        object.__setattr__(adapter, "MAX_MESSAGE_LENGTH", 160)
+        adapter._bot.edit_message_text = AsyncMock(return_value=True)
+        adapter._bot.send_message = AsyncMock(side_effect=lambda **k: _message(1))
+
+        result = await adapter._edit_overflow_split(
+            "12345", "1", "word " * 120, finalize=False, metadata={"thread_id": "77"},
+        )
+
+        assert result.success is True
+        assert adapter._clipboard_copy_state == {}
+
+
+# ===========================================================================
+# _handle_callback_query — cc: callback
+# ===========================================================================
+
+class TestClipboardCopyCallback:
+    @pytest.mark.asyncio
+    async def test_authorized_callback_writes_exact_original_text_and_consumes_token(self):
+        adapter = _make_adapter()
+        original = "The *complete* unsplit\nresponse text (1/2) [not escaped]"
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": original, "chat_id": "12345", "thread_id": None, "created": __import__("time").time(),
+        }
+        query = _query("cc:tok1")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_called_once_with(original)
+        assert "tok1" not in adapter._clipboard_copy_state
+        query.answer.assert_called_once()
+        assert "copied" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_user_rejected_and_clipboard_not_written(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": None, "created": 0.0,
+        }
+        query = _query("cc:tok1")
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "999"}, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text") as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_not_called()
+        assert "tok1" in adapter._clipboard_copy_state  # untouched, still pending
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_wrong_chat_is_rejected(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "99999", "thread_id": None, "created": __import__("time").time(),
+        }
+        query = _query("cc:tok1", chat_id=12345)
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text") as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_not_called()
+        assert "tok1" in adapter._clipboard_copy_state
+
+    @pytest.mark.asyncio
+    async def test_wrong_thread_is_rejected(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": "555", "created": __import__("time").time(),
+        }
+        query = _query("cc:tok1", chat_id=12345, thread_id=999)
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text") as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_token_handled_cleanly(self):
+        adapter = _make_adapter()
+        query = _query("cc:does-not-exist")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text") as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_not_called()
+        assert "expired" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_expired_token_is_pruned_and_rejected(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": None,
+            "created": 0.0,  # far in the past -> expired under any real TTL
+        }
+        query = _query("cc:tok1")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text") as write_mock:
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        write_mock.assert_not_called()
+        assert "tok1" not in adapter._clipboard_copy_state
+
+    @pytest.mark.asyncio
+    async def test_already_consumed_token_rejected_on_second_click(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": None, "created": __import__("time").time(),
+        }
+        query1 = _query("cc:tok1")
+        query2 = _query("cc:tok1")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text", return_value=True) as write_mock:
+            await adapter._handle_callback_query(_update_for(query1), MagicMock())
+            await adapter._handle_callback_query(_update_for(query2), MagicMock())
+
+        assert write_mock.call_count == 1
+        assert "expired" in query2.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_clipboard_backend_failure_answers_failure_without_raising(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": None, "created": __import__("time").time(),
+        }
+        query = _query("cc:tok1")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text", return_value=False):
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        assert "tok1" not in adapter._clipboard_copy_state  # still consumed
+        assert "unavailable" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_clipboard_backend_raises_is_non_fatal(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["tok1"] = {
+            "text": "secret", "chat_id": "12345", "thread_id": None, "created": __import__("time").time(),
+        }
+        query = _query("cc:tok1")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("hermes_cli.clipboard.write_clipboard_text", side_effect=RuntimeError("boom")):
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        assert "unavailable" in query.answer.call_args[1]["text"].lower()
+
+
+# ===========================================================================
+# Bounded state
+# ===========================================================================
+
+class TestClipboardCopyStateBounds:
+    def test_state_is_bounded_by_max_pending(self):
+        adapter = _make_adapter()
+        for i in range(adapter._CLIPBOARD_COPY_MAX_PENDING + 10):
+            adapter._register_clipboard_copy(f"text-{i}", chat_id="1", thread_id=None)
+        assert len(adapter._clipboard_copy_state) <= adapter._CLIPBOARD_COPY_MAX_PENDING
+
+    def test_expired_entries_are_pruned_on_register(self):
+        adapter = _make_adapter()
+        adapter._clipboard_copy_state["old"] = {
+            "text": "x", "chat_id": "1", "thread_id": None, "created": 0.0,
+        }
+        adapter._register_clipboard_copy("new text", chat_id="1", thread_id=None)
+        assert "old" not in adapter._clipboard_copy_state
+
+
+# ===========================================================================
+# Existing callbacks unaffected by the new cc: branch
+# ===========================================================================
+
+class TestOtherCallbacksUnaffected:
+    @pytest.mark.asyncio
+    async def test_approval_callback_still_dispatches_normally(self):
+        adapter = _make_adapter()
+        adapter._approval_state[5] = "agent:main:telegram:group:12345:99"
+        query = _query("ea:once:5")
+
+        with patch.dict(os.environ, ALLOW_ALL, clear=False), \
+             patch("tools.approval.resolve_gateway_approval", return_value=1):
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        assert 5 not in adapter._approval_state
+        query.answer.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_prompt_callback_still_dispatches_normally(self, tmp_path):
+        adapter = _make_adapter()
+        query = _query("update_prompt:y")
+
+        with patch("hermes_constants.get_hermes_home", return_value=tmp_path), \
+             patch.dict(os.environ, ALLOW_ALL, clear=False):
+            await adapter._handle_callback_query(_update_for(query), MagicMock())
+
+        assert (tmp_path / ".update_response").read_text() == "y"

--- a/tests/gateway/test_telegram_rich_messages.py
+++ b/tests/gateway/test_telegram_rich_messages.py
@@ -139,6 +139,30 @@ async def test_plain_markdown_stays_on_legacy_path():
 
 
 @pytest.mark.asyncio
+async def test_rich_messages_all_routes_plain_markdown_through_rich_path():
+    """Operator opt-in can use the 32K rich path for ordinary final replies."""
+    adapter = _make_adapter({"rich_messages_all": True})
+
+    result = await adapter.send("12345", "Hello **there**\n\nA normal reply.")
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rich_messages_all_keeps_plain_response_under_rich_limit_in_one_send():
+    """Plain content over 4K but under 32K is not legacy-chunked."""
+    adapter = _make_adapter({"rich_messages_all": True})
+
+    result = await adapter.send("12345", "a" * 10000)
+
+    assert result.success is True
+    adapter._bot.do_api_request.assert_awaited_once()
+    adapter._bot.send_message.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_expect_edits_metadata_keeps_preview_on_legacy_path():
     adapter = _make_adapter()
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -844,6 +844,43 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     else:
         chunks = [message]
 
+    # --- Telegram: use the native adapter for rich final delivery when the
+    # operator enabled rich_messages_all. The standalone sender historically
+    # bypassed TelegramAdapter and therefore reintroduced the 4096-char limit
+    # for hermes send/cron deliveries. Media keeps the legacy path because
+    # captions and attachment ordering have separate handling.
+    if (
+        platform == Platform.TELEGRAM
+        and not media_files
+        and not force_document
+        and _telegram_available
+        and bool(getattr(pconfig, "extra", {}).get("rich_messages_all"))
+    ):
+        bot = None
+        try:
+            from plugins.platforms.telegram.adapter import TelegramAdapter as _RichTelegramAdapter
+            adapter = _RichTelegramAdapter(pconfig)
+            from telegram import Bot
+            bot = Bot(pconfig.token)
+            await bot.initialize()
+            adapter._bot = bot
+            result = await adapter.send(
+                chat_id,
+                message,
+                metadata={"thread_id": thread_id, "notify": True},
+            )
+            if result.success:
+                return {"success": True, "message_id": result.message_id}
+            return {"success": False, "error": result.error or "Telegram rich delivery failed"}
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+        finally:
+            if bot is not None:
+                try:
+                    await bot.shutdown()
+                except Exception:
+                    pass
+
     # --- Telegram: special handling for media attachments ---
     # _send_telegram now owns text chunking internally — it formats the full
     # message (MarkdownV2/HTML) and then splits the *formatted* text on UTF-16

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -977,7 +977,18 @@ gateway:
         rich_drafts: false
 ```
 
-This setting is for client-rendering/copy compatibility; Hermes already falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
+If you prefer the 32,768-character rich-message path for **all final replies**, including ordinary prose, enable the separate operator override:
+
+```yaml
+gateway:
+  platforms:
+    telegram:
+      extra:
+        rich_messages: true
+        rich_messages_all: true
+```
+
+`rich_messages_all` affects final delivery only; streaming previews retain their existing edit/draft behavior. It remains separately reversible: remove it or set it to `false` to return to selective rich rendering. Hermes still falls back automatically when Telegram rejects the rich API call. `rich_drafts` controls the experimental rich draft preview path during Telegram DM streaming and stays off by default because Telegram Desktop/macOS can visually overlay rich draft frames until the chat redraws. If you only want the legacy "always code-block" table behavior while keeping rich messages enabled, disable table normalization by setting `telegram.pretty_tables: false` in `config.yaml` (default: `true`).
 
 **Link previews.** Telegram auto-generates link previews for URLs in bot messages. If you'd rather suppress those (long `/tools` output, agent reply that mentions ten links, etc.):
 


### PR DESCRIPTION
## Summary

When a Telegram reply from Hermes is legacy-split into more than one
message (because it exceeds Telegram's ordinary message limit), attach an
inline "copy full response" button to the **final** message only:

- macOS: "🍎📋 Copy to Mac Clipboard"
- other platforms: "📋 Copy to Hermes Clipboard"

Tapping the button copies the **complete original, unsplit** response to
the clipboard of the machine running Hermes, via the existing
`hermes_cli.clipboard.write_clipboard_text` abstraction (pbcopy /
PowerShell `Set-Clipboard` / wl-copy / xclip / xsel).

- Single-message replies get no button and create no clipboard state.
- The full response text is never put into `callback_data` — only a short
  opaque token (`cc:<token>`, well under Telegram's 64-byte limit) that maps
  to bounded, TTL'd in-memory state (10 min TTL, max 50 pending entries,
  pruned on every register/click).
- On callback: reuses the adapter's existing callback authorization policy
  (`_is_callback_user_authorized`, same helper as approval/slash-confirm/
  clarify buttons), cross-checks originating chat/thread, rejects missing/
  expired/already-consumed tokens, consumes the token before writing (so a
  slow/failed write can't leave it re-clickable), and never re-sends the
  report into the chat.
- Both the normal send-and-split path (`send()`'s legacy chunk loop) and the
  edit/streaming-completion overflow path (`_edit_overflow_split`,
  `finalize=True`) are covered, each attaching the button only to their
  respective final message.
- Clipboard backend failure is non-fatal — the Telegram reply is already
  delivered regardless, the callback just answers with a failure notice.
- Logging is limited to token id / chat id / size / success-or-failure —
  never the response text.
- Does not use Telegram Rich Messages (still disabled for all final
  replies).

## Not yet verified

**Live on-device Telegram/macOS behavior (an actual button tap triggering
`pbcopy`) has not been verified yet.** This PR has only been verified via
unit tests with mocked Telegram objects and a mocked
`write_clipboard_text`. Please do not treat this as confirmed working end
to end until that manual check happens.

## Test plan

- [x] New focused test file `tests/gateway/test_telegram_clipboard_copy_button.py`
      (19 tests): one-message-no-button, split-attaches-once-to-final,
      intermediate-chunk-no-button, opaque-token-not-report-text,
      edit-overflow-split coverage, exact-original-text-on-callback,
      unauthorized-rejected, wrong-chat-rejected, wrong-thread-rejected,
      missing/expired/already-consumed token handling, clipboard-failure
      non-fatal (both a `False` return and a raised exception), bounded
      max-pending state, TTL pruning, existing approval/update-prompt
      callbacks unaffected.
- [x] `pytest tests/gateway/test_telegram_*.py` — 528/528 passed (full
      existing Telegram suite, confirms no regression to approval,
      slash-confirm, clarify, model-picker, or update-prompt callbacks).
- [x] `pytest tests/hermes_cli/test_clipboard_text_write.py` — existing
      clipboard backend tests remain green.
- [x] `ruff check` (blocking CI lint gate) — clean.
- [ ] Live Telegram/macOS on-device verification — **not done, see above.**

🤖 Generated with orchestrated Claude Code sub-agents (implementation +
independent verification pass).