### PR TITLE
docs: use canonical test runner in platform guide

### DIFF
--- a/gateway/platforms/ADDING_A_PLATFORM.md
+++ b/gateway/platforms/ADDING_A_PLATFORM.md
@@ -394,8 +394,8 @@ Optional but valuable:
 After implementing everything, verify with:
 
 ```bash
-# All tests pass
-python -m pytest tests/ -q
+# All tests pass (uses the canonical wrapper for CI-parity verification)
+scripts/run_tests.sh tests/ -q
 
 # Grep for your platform name to find any missed integration points
 grep -r "telegram\|discord\|whatsapp\|slack" gateway/ tools/ agent/ cron/ hermes_cli/ toolsets.py \


### PR DESCRIPTION
## Summary

Update the platform-adapter guide's Quick Verification section to use the repository's canonical test wrapper:

- Replace `python -m pytest tests/ -q` with `scripts/run_tests.sh tests/ -q`.
- Note that the wrapper provides CI-parity verification.

## Verification

- Sol analysis selected this as a one-file, documentation-only task.
- Claude execution was contract-gated.
- Changed-file scope: exactly `gateway/platforms/ADDING_A_PLATFORM.md`.
- `git diff --check`: passed.
- Content assertions: passed.
- Terra independent review: approved.
- Commit: `0d3e595df8600e081348aab38720d5350903cb9b`.

No production Python behavior or test implementation was changed. The original dirty local checkout was preserved untouched; promotion used an isolated worktree and a fork branch.
