### PR TITLE
fix(agent): bypass relay for all internal-streaming MoA aggregators

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10015,12 +10015,13 @@ def _call_llm_impl(
         kwargs["stream"] = True
         if stream_options:
             kwargs["stream_options"] = stream_options
-        if task == "moa_aggregator" and isinstance(client, CodexAuxiliaryClient):
-            # CodexAuxiliaryClient (openai-codex, xai-oauth, and any other
-            # Responses-shim provider) consumes the provider stream internally
-            # and returns a completed response object. Routing that nested
+        if task == "moa_aggregator" and _client_streams_internally(client):
+            # Internal-streaming shims (Codex Responses, Anthropic Messages,
+            # Bedrock Converse) consume the provider stream inside create()
+            # and return a completed response object. Routing that nested
             # MoA stream through Relay's generic managed stream makes the
-            # manager iterate the completed SimpleNamespace itself (#55933).
+            # manager iterate the completed SimpleNamespace itself (#55933;
+            # observed in production with kimi-coding as the aggregator).
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8810,12 +8810,13 @@ def _call_llm_impl(
         kwargs["stream"] = True
         if stream_options:
             kwargs["stream_options"] = stream_options
-        if task == "moa_aggregator" and isinstance(client, CodexAuxiliaryClient):
-            # CodexAuxiliaryClient (openai-codex, xai-oauth, and any other
-            # Responses-shim provider) consumes the provider stream internally
-            # and returns a completed response object. Routing that nested
+        if task == "moa_aggregator" and _client_streams_internally(client):
+            # Internal-streaming shims (Codex Responses, Anthropic Messages,
+            # Bedrock Converse) consume the provider stream inside create()
+            # and return a completed response object. Routing that nested
             # MoA stream through Relay's generic managed stream makes the
-            # manager iterate the completed SimpleNamespace itself (#55933).
+            # manager iterate the completed SimpleNamespace itself (#55933;
+            # observed in production with kimi-coding as the aggregator).
             # Return the provider call directly; the MoA facade converts a
             # completed response into a one-chunk delta iterator at its
             # boundary.

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4344,6 +4344,65 @@ class TestMoaAggregatorStreamingBypass:
         direct_create.assert_called_once()
         relay_stream.assert_not_called()
 
+    @pytest.mark.parametrize("client_kind", ["anthropic", "bedrock"])
+    def test_moa_aggregator_stream_bypasses_relay_for_other_internal_streaming_clients(
+        self, monkeypatch, client_kind
+    ):
+        """Anthropic Messages (kimi-coding, anthropic) and Bedrock Converse
+        shims consume the provider stream inside create() and return a
+        completed response object — the same contract as the Codex Responses
+        shim above. The MoA facade already converts ANY completed response
+        into a one-chunk iterator at its boundary, so call_llm must return
+        the direct create() result for every _client_streams_internally
+        client, not route it through Relay's managed stream (which iterates
+        the completed SimpleNamespace and dies with TypeError — observed in
+        production with kimi-coding as the MoA aggregator).
+        """
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            BedrockAuxiliaryClient,
+        )
+
+        completed = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        if client_kind == "anthropic":
+            client = AnthropicAuxiliaryClient(
+                SimpleNamespace(close=lambda: None),
+                "k3",
+                api_key="test-key",
+                base_url="https://api.kimi.com/coding/v1",
+            )
+            provider, model = "kimi-coding", "k3"
+        else:
+            client = BedrockAuxiliaryClient(
+                "us-east-1", "anthropic.claude-3-sonnet-20240229-v1:0"
+            )
+            provider, model = "bedrock", "anthropic.claude-3-sonnet-20240229-v1:0"
+
+        direct_create = MagicMock(return_value=completed)
+        monkeypatch.setattr(client.chat.completions, "create", direct_create)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (client, model),
+        )
+        relay_stream = MagicMock(side_effect=AssertionError("_relay_sync_stream must not be used"))
+        monkeypatch.setattr("agent.auxiliary_client._relay_sync_stream", relay_stream)
+
+        result = call_llm(
+            task="moa_aggregator",
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "只回答 OK"}],
+            stream=True,
+        )
+
+        assert result is completed
+        direct_create.assert_called_once()
+        relay_stream.assert_not_called()
+
 
 class TestSynchronousFallbackCachePlans:
     @staticmethod

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -4271,6 +4271,65 @@ class TestMoaAggregatorStreamingBypass:
         direct_create.assert_called_once()
         relay_stream.assert_not_called()
 
+    @pytest.mark.parametrize("client_kind", ["anthropic", "bedrock"])
+    def test_moa_aggregator_stream_bypasses_relay_for_other_internal_streaming_clients(
+        self, monkeypatch, client_kind
+    ):
+        """Anthropic Messages (kimi-coding, anthropic) and Bedrock Converse
+        shims consume the provider stream inside create() and return a
+        completed response object — the same contract as the Codex Responses
+        shim above. The MoA facade already converts ANY completed response
+        into a one-chunk iterator at its boundary, so call_llm must return
+        the direct create() result for every _client_streams_internally
+        client, not route it through Relay's managed stream (which iterates
+        the completed SimpleNamespace and dies with TypeError — observed in
+        production with kimi-coding as the MoA aggregator).
+        """
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            BedrockAuxiliaryClient,
+        )
+
+        completed = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+        )
+
+        if client_kind == "anthropic":
+            client = AnthropicAuxiliaryClient(
+                SimpleNamespace(close=lambda: None),
+                "k3",
+                api_key="test-key",
+                base_url="https://api.kimi.com/coding/v1",
+            )
+            provider, model = "kimi-coding", "k3"
+        else:
+            client = BedrockAuxiliaryClient(
+                "us-east-1", "anthropic.claude-3-sonnet-20240229-v1:0"
+            )
+            provider, model = "bedrock", "anthropic.claude-3-sonnet-20240229-v1:0"
+
+        direct_create = MagicMock(return_value=completed)
+        monkeypatch.setattr(client.chat.completions, "create", direct_create)
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._get_cached_client",
+            lambda *args, **kwargs: (client, model),
+        )
+        relay_stream = MagicMock(side_effect=AssertionError("_relay_sync_stream must not be used"))
+        monkeypatch.setattr("agent.auxiliary_client._relay_sync_stream", relay_stream)
+
+        result = call_llm(
+            task="moa_aggregator",
+            provider=provider,
+            model=model,
+            messages=[{"role": "user", "content": "只回答 OK"}],
+            stream=True,
+        )
+
+        assert result is completed
+        direct_create.assert_called_once()
+        relay_stream.assert_not_called()
+
 
 class TestSynchronousFallbackCachePlans:
     @staticmethod


### PR DESCRIPTION
## Summary

Follow-up to the #55933 / #74903 fix. That fix routed MoA aggregator streaming around Relay's managed stream for `CodexAuxiliaryClient` only. The same crash — `TypeError: 'types.SimpleNamespace' object is not iterable` — still hits the **Anthropic Messages** (`kimi-coding`, `anthropic`) and **Bedrock Converse** shims when they serve as the MoA aggregator, because all three consume the provider stream inside `create()` and return a completed response object.

Observed in production with `kimi-coding` as the MoA aggregator:

```
agent/relay_llm.py: raw_iterator = iter(raw_stream)
TypeError: 'types.SimpleNamespace' object is not iterable
```

## Fix

One-condition change in `agent/auxiliary_client.py`: the `moa_aggregator` stream bypass now uses the existing `_client_streams_internally(client)` predicate (Codex + Anthropic + Bedrock) instead of `isinstance(client, CodexAuxiliaryClient)`. The MoA facade already converts any completed response into a one-chunk delta iterator at its boundary (`agent/moa_loop.py`), so no consumer changes are needed.

## Test plan

- New parametrized regression test in `TestMoaAggregatorStreamingBypass` covering the Anthropic and Bedrock shims — verified RED on current main (both fail, routing through the relay), GREEN after the fix.
- CI-parity runner, retries disabled: `tests/agent/test_auxiliary_client.py` → 173/173; full MoA scope (18 files: all `test_moa_*` + relay + aux client) → 255/255, first attempt.

No behavior change for chunk-streaming providers; no config or API surface changes.