### PR TITLE
fix(compressor): gate MEMORY.md/USER.md notes on flat-file memory

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2497,6 +2497,10 @@ def init_agent(
             proactive_prune_min_result_chars=compression_proactive_prune_min_chars,
             proactive_prune_min_reclaim_tokens=compression_proactive_prune_min_reclaim,
             min_tail_user_messages=compression_min_tail_users,
+            flat_memory_active=bool(
+                getattr(agent, "_memory_enabled", False)
+                or getattr(agent, "_user_profile_enabled", False)
+            ),
         )
     _bind_session_state = getattr(agent.context_compressor, "bind_session_state", None)
     if callable(_bind_session_state):

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -97,6 +97,12 @@ def _is_summary_access_or_quota_error(exc: Exception) -> bool:
 HISTORICAL_TASK_HEADING = "## Historical Task Snapshot"
 
 
+_MEMORY_AUTHORITY_SENTENCE = (
+    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
+    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
+    "memory content due to this compaction note. "
+)
+
 SUMMARY_PREFIX = (
     "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted "
     "into the summary below. This is a handoff from a previous context "
@@ -116,15 +122,25 @@ SUMMARY_PREFIX = (
     "back', 'just verify', 'don't do that anymore', 'never mind', a new "
     "topic) must immediately end any in-flight work described in the "
     "summary; do not re-surface it in later turns. "
-    "IMPORTANT: Your persistent memory (MEMORY.md, USER.md) in the system "
-    "prompt is ALWAYS authoritative and active — never ignore or deprioritize "
-    "memory content due to this compaction note. "
+    f"{_MEMORY_AUTHORITY_SENTENCE}"
     "None of the above restricts HOW you work: your tools remain fully "
     "active — keep calling them normally for the active task (edit files, "
     "run commands, search) instead of merely narrating what you would do. "
     "The current session state (files, config, etc.) may reflect work "
     "described here — avoid repeating it:"
 )
+# SUMMARY_PREFIX without the flat-file memory sentence, used when the built-in
+# MEMORY.md/USER.md store is not loaded (memory_enabled and user_profile_enabled
+# both false — e.g. data-layer / external memory-provider setups) so agents
+# don't go looking for markdown memory files that don't exist.
+_SUMMARY_PREFIX_NO_MEMORY = SUMMARY_PREFIX.replace(_MEMORY_AUTHORITY_SENTENCE, "")
+
+
+def _summary_prefix_for(flat_memory_active: bool) -> str:
+    """Return the live compaction prefix for the given memory configuration."""
+    return SUMMARY_PREFIX if flat_memory_active else _SUMMARY_PREFIX_NO_MEMORY
+
+
 LEGACY_SUMMARY_PREFIX = "[CONTEXT SUMMARY]:"
 
 # Metadata key added to context compression summary messages so that frontends
@@ -2270,8 +2286,14 @@ class ContextCompressor(ContextEngine):
         proactive_prune_min_result_chars: int = 8000,
         proactive_prune_min_reclaim_tokens: int = 4096,
         min_tail_user_messages: int = 1,
+        flat_memory_active: bool = True,
     ):
         self.model = model
+        # Whether the built-in flat-file memory (MEMORY.md/USER.md) is loaded
+        # for this agent. When False (data-layer / external memory-provider
+        # setups), compaction notes omit the markdown-memory sentence so the
+        # model doesn't go looking for files that don't exist.
+        self._flat_memory_active = flat_memory_active
         self.base_url = base_url
         self.api_key = api_key
         self.provider = provider
@@ -3487,7 +3509,7 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         # exactly like the LLM-summary path.
         _pruned_names = _collect_ghosted_skill_names(turns_to_summarize)
         del _pruned_names[_MAX_PRUNED_SKILL_MARKERS:]
-        summary = self._with_summary_prefix(_redact_compaction_text(body.strip()))
+        summary = self._with_summary_prefix(_redact_compaction_text(body.strip()), flat_memory_active=self._flat_memory_active)
         if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
             summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
         # Re-inject AFTER the size cap: the markers live at the end of the
@@ -3969,7 +3991,7 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_error = None
             self._last_summary_auth_failure = False
             self._last_summary_network_failure = False
-            return self._with_summary_prefix(summary)
+            return self._with_summary_prefix(summary, flat_memory_active=self._flat_memory_active)
         except Exception as e:
             # ``call_llm`` raises ``RuntimeError`` for two very different cases:
             #   1. No provider configured ("No LLM provider configured ...") —
@@ -4164,7 +4186,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # summarizer prompt.
         if _MERGED_SUMMARY_DELIMITER in text:
             text = text.split(_MERGED_SUMMARY_DELIMITER, 1)[1].strip()
-        for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX, *_HISTORICAL_SUMMARY_PREFIXES):
+        for prefix in (SUMMARY_PREFIX, LEGACY_SUMMARY_PREFIX, _SUMMARY_PREFIX_NO_MEMORY, *_HISTORICAL_SUMMARY_PREFIXES):
             if text.startswith(prefix):
                 text = text[len(prefix):].lstrip()
                 break
@@ -4180,15 +4202,22 @@ This compaction should PRIORITISE preserving all information related to the focu
         return text
 
     @classmethod
-    def _with_summary_prefix(cls, summary: str) -> str:
-        """Normalize summary text to the current compaction handoff format."""
+    def _with_summary_prefix(cls, summary: str, *, flat_memory_active: bool = True) -> str:
+        """Normalize summary text to the current compaction handoff format.
+
+        ``flat_memory_active=False`` (built-in MEMORY.md/USER.md not loaded)
+        uses the prefix variant that omits the markdown-memory sentence.
+        """
+        prefix = _summary_prefix_for(flat_memory_active)
         text = cls._strip_summary_prefix(summary)
-        return f"{SUMMARY_PREFIX}\n{text}" if text else SUMMARY_PREFIX
+        return f"{prefix}\n{text}" if text else prefix
 
     @staticmethod
     def _starts_with_summary_prefix(text: str) -> bool:
         """Return True if *text* begins with any known handoff prefix."""
         if text.startswith(SUMMARY_PREFIX) or text.startswith(LEGACY_SUMMARY_PREFIX):
+            return True
+        if text.startswith(_SUMMARY_PREFIX_NO_MEMORY):
             return True
         return any(text.startswith(p) for p in _HISTORICAL_SUMMARY_PREFIXES)
 
@@ -5563,7 +5592,7 @@ This compaction should PRIORITISE preserving all information related to the focu
                 and entry.get(COMPRESSED_SUMMARY_METADATA_KEY)
                 and entry.get(MICRO_COMPACT_MARKER_KEY)
             ):
-                entry["content"] = self._render_micro_marker_content(fresh_summary)
+                entry["content"] = self._render_micro_marker_content(fresh_summary, flat_memory_active=self._flat_memory_active)
                 # Content changed after a possible flush — clear the persisted
                 # stamp so the DB sync/flush rewrites the row.
                 entry.pop(_DB_PERSISTED_MARKER, None)
@@ -5916,7 +5945,7 @@ This compaction should PRIORITISE preserving all information related to the focu
 
         summary_msg = {
             "role": "assistant",
-            "content": self._render_micro_marker_content(summary_text),
+            "content": self._render_micro_marker_content(summary_text, flat_memory_active=self._flat_memory_active),
             COMPRESSED_SUMMARY_METADATA_KEY: True,
             # Micro-created marker: eligible for supersede/defrag rewrites.
             # Batch markers never carry this key and are never touched —
@@ -5973,10 +6002,10 @@ This compaction should PRIORITISE preserving all information related to the focu
         return result
 
     @staticmethod
-    def _render_micro_marker_content(summary_text: str) -> str:
+    def _render_micro_marker_content(summary_text: str, *, flat_memory_active: bool = True) -> str:
         """Assemble the marker content wrapper around *summary_text*."""
         return (
-            f"{SUMMARY_PREFIX}\n\n"
+            f"{_summary_prefix_for(flat_memory_active)}\n\n"
             f"{HISTORICAL_TASK_HEADING}\n"
             f"{summary_text.strip()}"
             f"\n\n{_SUMMARY_END_MARKER}"
@@ -6509,7 +6538,14 @@ This compaction should PRIORITISE preserving all information related to the focu
             msg = _fresh_compaction_message_copy(messages[i])
             if i == 0 and msg.get("role") == "system":
                 existing = msg.get("content")
-                _compression_note = "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work. Your persistent memory (MEMORY.md, USER.md) remains fully authoritative regardless of compaction.]"
+                _memory_sentence = (
+                    " Your persistent memory (MEMORY.md, USER.md) remains fully authoritative regardless of compaction."
+                    if self._flat_memory_active else ""
+                )
+                _compression_note = (
+                    "[Note: Some earlier conversation turns have been compacted into a handoff summary to preserve context space. The current session state may still reflect earlier work, so build on that summary and state rather than re-doing work."
+                    f"{_memory_sentence}]"
+                )
                 if _compression_note not in _content_text_for_contains(existing):
                     msg["content"] = _append_text_to_content(
                         existing,

--- a/tests/agent/test_compressor_memory_note_gating.py
+++ b/tests/agent/test_compressor_memory_note_gating.py
@@ -1,0 +1,79 @@
+"""Tests for gating the MEMORY.md/USER.md sentence in compaction notes.
+
+When the built-in flat-file memory store is not loaded (``memory_enabled``
+and ``user_profile_enabled`` both false — data-layer / external memory
+providers), compaction handoffs must not tell the model that its
+persistent memory lives in MEMORY.md/USER.md, or agents go looking for
+markdown memory files that don't exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.context_compressor import (
+    SUMMARY_PREFIX,
+    _MEMORY_AUTHORITY_SENTENCE,
+    _SUMMARY_PREFIX_NO_MEMORY,
+    _summary_prefix_for,
+    ContextCompressor,
+)
+
+
+def test_summary_prefix_still_contains_memory_sentence_by_default():
+    # The refactor must keep the live default prefix byte-identical.
+    assert _MEMORY_AUTHORITY_SENTENCE in SUMMARY_PREFIX
+    assert "MEMORY.md" in SUMMARY_PREFIX
+
+
+def test_summary_prefix_for_false_omits_markdown_memory():
+    no_memory = _summary_prefix_for(False)
+    assert "MEMORY.md" not in no_memory
+    assert "USER.md" not in no_memory
+    # Still a recognizable compaction handoff prefix, sharing the intro with
+    # the full variant (the sentence is removed from the middle).
+    assert no_memory.startswith("[CONTEXT COMPACTION — REFERENCE ONLY]")
+    intro = SUMMARY_PREFIX.split(_MEMORY_AUTHORITY_SENTENCE)[0]
+    assert no_memory.startswith(intro)
+    assert _MEMORY_AUTHORITY_SENTENCE not in no_memory
+
+
+def test_with_summary_prefix_gates_memory_sentence():
+    with_memory = ContextCompressor._with_summary_prefix("body")
+    assert "MEMORY.md" in with_memory
+
+    without_memory = ContextCompressor._with_summary_prefix(
+        "body", flat_memory_active=False
+    )
+    assert "MEMORY.md" not in without_memory
+    assert without_memory.startswith(_SUMMARY_PREFIX_NO_MEMORY)
+
+
+def test_micro_marker_gates_memory_sentence():
+    with_memory = ContextCompressor._render_micro_marker_content("sum")
+    assert "MEMORY.md" in with_memory
+
+    without_memory = ContextCompressor._render_micro_marker_content(
+        "sum", flat_memory_active=False
+    )
+    assert "MEMORY.md" not in without_memory
+
+
+def test_no_memory_variant_still_recognized_and_stripped():
+    # Rehydration must recognize + strip handoffs generated with the
+    # no-memory prefix, otherwise they leak on re-compaction.
+    assert ContextCompressor._starts_with_summary_prefix(_SUMMARY_PREFIX_NO_MEMORY)
+    stripped = ContextCompressor._strip_summary_prefix(
+        _SUMMARY_PREFIX_NO_MEMORY + "\nbody"
+    )
+    assert stripped == "body"
+
+
+def test_compressor_instance_flag_drives_prefix():
+    c = ContextCompressor(model="test", quiet_mode=True, flat_memory_active=False)
+    out = c._with_summary_prefix("body", flat_memory_active=c._flat_memory_active)
+    assert "MEMORY.md" not in out
+
+    c2 = ContextCompressor(model="test", quiet_mode=True)
+    out2 = c2._with_summary_prefix("body", flat_memory_active=c2._flat_memory_active)
+    assert "MEMORY.md" in out2


### PR DESCRIPTION
## Summary

Compaction handoffs unconditionally told the model its persistent memory lives in `MEMORY.md`/`USER.md` — even when the built-in flat-file store is **not loaded** (`memory_enabled: false` / `user_profile_enabled: false`, i.e. data-layer or external memory-provider setups). Agents read that directive and go looking for markdown memory files that don't exist (or try to write to them), when their real memory lives in the configured provider.

## Root cause

- `SUMMARY_PREFIX` (the live compaction handoff prefix) hardcodes: *"Your persistent memory (MEMORY.md, USER.md) in the system prompt is ALWAYS authoritative and active…"*
- The in-place compression note (`compress()`, "Some earlier conversation turns have been compacted…") hardcodes the same claim.
- Neither is gated on whether the flat-file store was actually loaded for this agent.

## Fix

- `ContextCompressor` gains `flat_memory_active: bool = True` (default preserves behavior for all existing callers); `agent_init.py` passes `memory_enabled or user_profile_enabled`.
- The sentence is extracted into `_MEMORY_AUTHORITY_SENTENCE` and `SUMMARY_PREFIX` is rebuilt from it byte-identically (verified by test), so the frozen `_HISTORICAL_SUMMARY_PREFIXES` copies stay consistent.
- `_summary_prefix_for(flat_memory_active)` returns a no-memory variant when flat-file memory is off; used by `_with_summary_prefix` and `_render_micro_marker_content`.
- The in-place compression note drops the sentence when flat-file memory is off.
- The no-memory variant is registered in `_strip_summary_prefix` / `_starts_with_summary_prefix` so handoffs generated with it are still recognized and stripped on re-compaction (no leak).

## Test plan

- New: `tests/agent/test_compressor_memory_note_gating.py` (6 tests)
- Existing: `tests/agent/test_context_compressor.py` (108 tests) — green
- Ran via `scripts/run_tests.sh`: `test_compressor_memory_note_gating.py`, `test_context_compressor.py`, `test_update_node_health.py`, `test_update_venv_health.py`, `test_cmd_update.py` → **148 passed, 0 failed**

## Notes

The related update-flow gap ("`hermes update` doesn't re-sync Node deps on an already-current checkout", issue #77211) is intentionally **not** included here — PRs #77231, #77546, and #76467 already cover it. This PR is only the memory-note gating.