### PR TITLE
fix(delegation): honor delegation.fallback_providers for child agents

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1303,6 +1303,9 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1476,6 +1476,9 @@ delegation:
   #                                           # delegation.model to an inexpensive one — children carry the
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1669,6 +1669,9 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "fallback_providers": None,  # fallback chain for delegated children, same entry
+                           # format as the top-level fallback_providers list. null =
+                           # inherit the parent agent's chain; [] = disable child fallback.
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1825,6 +1825,9 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "fallback_providers": None,  # fallback chain for delegated children, same entry
+                           # format as the top-level fallback_providers list. null =
+                           # inherit the parent agent's chain; [] = disable child fallback.
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -223,6 +223,13 @@ def test_dispatch_rejected_at_capacity():
     assert r3["status"] == "rejected"
     assert "capacity reached" in r3["error"]
     ev.set()
+    # Drain both blockers' completions before returning: they enqueue
+    # asynchronously after ev.set(), and any event that lands after the
+    # fixture's teardown drain leaks into the next test's _drain_one()
+    # (test_crashed_runner_produces_error_completion then reads a stale
+    # "completed" event instead of its own error event).
+    assert _drain_one() is not None
+    assert _drain_one() is not None
 
 
 def test_interrupt_all_signals_running_children():

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -56,6 +56,95 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+class TestDelegationFallbackChain(unittest.TestCase):
+    """delegation.fallback_providers beats parent-chain inheritance (#65038).
+
+    A worker explicitly routed via delegation.* must not silently escalate
+    onto the head agent's fallback models when the delegation section
+    declares its own chain.
+    """
+
+    HEAD = [{"provider": "provider-b", "model": "head-fallback"}]
+    WORKER = [{"provider": "provider-d", "model": "worker-fallback"}]
+
+    def _child_fallback(self, delegation_cfg, parent_chain):
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = parent_chain
+        with patch("tools.delegate_tool._load_config", return_value=delegation_cfg), \
+             patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+        return MockAgent.call_args.kwargs.get("fallback_model")
+
+    def test_delegation_chain_overrides_parent_inheritance(self):
+        got = self._child_fallback({"fallback_providers": list(self.WORKER)}, list(self.HEAD))
+        self.assertEqual(got, self.WORKER)
+
+    def test_absent_key_inherits_parent_chain(self):
+        self.assertEqual(self._child_fallback({}, list(self.HEAD)), self.HEAD)
+
+    def test_null_key_inherits_parent_chain(self):
+        # DEFAULT_CONFIG ships fallback_providers: null — the deep-merged
+        # default must behave exactly like an absent key.
+        self.assertEqual(
+            self._child_fallback({"fallback_providers": None}, list(self.HEAD)), self.HEAD
+        )
+
+    def test_explicit_empty_list_disables_child_fallback(self):
+        self.assertEqual(self._child_fallback({"fallback_providers": []}, list(self.HEAD)), [])
+
+    def test_malformed_entries_inherit_parent_chain(self):
+        got = self._child_fallback(
+            {"fallback_providers": ["not-a-dict", {"provider": "", "model": ""}]},
+            list(self.HEAD),
+        )
+        self.assertEqual(got, self.HEAD)
+
+    def test_fallback_providers_flow_through_real_config_loader(self):
+        """Regression through the REAL config loader — no ``_load_config``
+        patch: the key written to ``$HERMES_HOME/config.yaml`` must survive
+        the profile-aware DEFAULT_CONFIG deep-merge (where the shipped
+        default is ``None``) and reach the child's ``fallback_model``."""
+        import yaml
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"delegation": {"fallback_providers": list(self.WORKER)}}
+            ),
+            encoding="utf-8",
+        )
+
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = list(self.HEAD)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs.get("fallback_model"), self.WORKER)
+
+
 class TestDelegateRequirements(unittest.TestCase):
 
     def test_schema_valid(self):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -57,6 +57,95 @@ def _make_mock_parent(depth=0):
     return parent
 
 
+class TestDelegationFallbackChain(unittest.TestCase):
+    """delegation.fallback_providers beats parent-chain inheritance (#65038).
+
+    A worker explicitly routed via delegation.* must not silently escalate
+    onto the head agent's fallback models when the delegation section
+    declares its own chain.
+    """
+
+    HEAD = [{"provider": "provider-b", "model": "head-fallback"}]
+    WORKER = [{"provider": "provider-d", "model": "worker-fallback"}]
+
+    def _child_fallback(self, delegation_cfg, parent_chain):
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = parent_chain
+        with patch("tools.delegate_tool._load_config", return_value=delegation_cfg), \
+             patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+        return MockAgent.call_args.kwargs.get("fallback_model")
+
+    def test_delegation_chain_overrides_parent_inheritance(self):
+        got = self._child_fallback({"fallback_providers": list(self.WORKER)}, list(self.HEAD))
+        self.assertEqual(got, self.WORKER)
+
+    def test_absent_key_inherits_parent_chain(self):
+        self.assertEqual(self._child_fallback({}, list(self.HEAD)), self.HEAD)
+
+    def test_null_key_inherits_parent_chain(self):
+        # DEFAULT_CONFIG ships fallback_providers: null — the deep-merged
+        # default must behave exactly like an absent key.
+        self.assertEqual(
+            self._child_fallback({"fallback_providers": None}, list(self.HEAD)), self.HEAD
+        )
+
+    def test_explicit_empty_list_disables_child_fallback(self):
+        self.assertEqual(self._child_fallback({"fallback_providers": []}, list(self.HEAD)), [])
+
+    def test_malformed_entries_inherit_parent_chain(self):
+        got = self._child_fallback(
+            {"fallback_providers": ["not-a-dict", {"provider": "", "model": ""}]},
+            list(self.HEAD),
+        )
+        self.assertEqual(got, self.HEAD)
+
+    def test_fallback_providers_flow_through_real_config_loader(self):
+        """Regression through the REAL config loader — no ``_load_config``
+        patch: the key written to ``$HERMES_HOME/config.yaml`` must survive
+        the profile-aware DEFAULT_CONFIG deep-merge (where the shipped
+        default is ``None``) and reach the child's ``fallback_model``."""
+        import yaml
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home()
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"delegation": {"fallback_providers": list(self.WORKER)}}
+            ),
+            encoding="utf-8",
+        )
+
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = list(self.HEAD)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="g",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs.get("fallback_model"), self.WORKER)
+
+
 class TestDelegateRequirements(unittest.TestCase):
 
     def test_schema_valid(self):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1462,11 +1462,36 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
+    # Fallback chain: delegation.fallback_providers > parent inheritance.
+    # By default children inherit the parent's resolved chain so subagents
+    # recover from rate-limits and credential exhaustion exactly like the
+    # top-level agent does (#7481).  But when the delegation section declares
+    # its own chain, use it — a worker explicitly routed via delegation.*
+    # must not silently escalate onto fallback models intended only for the
+    # head agent (#65038; same reasoning as the provider-filter clearing
+    # below).  ``fallback_providers: []`` explicitly disables child fallback;
+    # a malformed value logs and inherits, mirroring reasoning_effort above.
     parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    delegation_fallback_raw = delegation_cfg.get("fallback_providers")
+    if delegation_fallback_raw is None:
+        child_fallback = parent_fallback
+    else:
+        try:
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            child_fallback = get_fallback_chain(
+                {"fallback_providers": delegation_fallback_raw}
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve delegation.fallback_providers: %s", exc)
+            child_fallback = parent_fallback
+        else:
+            if not child_fallback and delegation_fallback_raw:
+                logger.warning(
+                    "delegation.fallback_providers has no valid entries "
+                    "(each needs provider + model); inheriting parent chain"
+                )
+                child_fallback = parent_fallback
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1521,7 +1546,7 @@ def _build_child_agent(
 
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
-            fallback_model=parent_fallback,
+            fallback_model=child_fallback,
             enabled_toolsets=child_toolsets,
             disabled_toolsets=child_disabled_toolsets,
             quiet_mode=True,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1729,23 +1729,54 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
+    # Fallback chain precedence: delegation.fallback_providers (explicit
+    # child config) > parent inheritance subject to the pinned-provider
+    # exception.
     #
-    # EXCEPT when the user pinned delegation.provider: an explicit pin means
-    # "children run on THIS provider".  Inheriting the parent chain would let
-    # a mid-run auth/429 failure silently reroute the quiet-mode child onto
-    # the parent's fallback models with no surfaced signal (#80450) — the
-    # same class of silent-drag the override_provider filter-clearing below
-    # already prevents for OpenRouter routing preferences.  Predictability >
-    # liveness for explicit pins: the pinned child fails loudly instead.
-    parent_fallback = (
-        None
-        if override_provider
-        else (getattr(parent_agent, "_fallback_chain", None) or None)
-    )
+    # When delegation.fallback_providers is declared, it is the child's own
+    # chain — a worker explicitly routed via delegation.* uses exactly those
+    # fallback models, never the head agent's (#65038). ``[]`` explicitly
+    # disables child fallback; a malformed value logs a warning and falls
+    # back to parent inheritance (mirroring reasoning_effort above).
+    #
+    # When it is unset, children inherit the parent's resolved chain so
+    # subagents recover from rate-limits and credential exhaustion exactly
+    # like the top-level agent does (#7481) — EXCEPT when the user pinned
+    # delegation.provider: an explicit pin means "children run on THIS
+    # provider". Inheriting the parent chain would let a mid-run auth/429
+    # failure silently reroute the quiet-mode child onto the parent's
+    # fallback models with no surfaced signal (#80450) — the same class of
+    # silent-drag the override_provider filter-clearing below already
+    # prevents for OpenRouter routing preferences. Predictability > liveness
+    # for explicit pins: the pinned child fails loudly instead.
+    delegation_fallback_raw = delegation_cfg.get("fallback_providers")
+    if delegation_fallback_raw is not None:
+        try:
+            from hermes_cli.fallback_config import get_fallback_chain
+
+            child_fallback = get_fallback_chain(
+                {"fallback_providers": delegation_fallback_raw}
+            )
+        except Exception as exc:
+            logger.debug("Could not resolve delegation.fallback_providers: %s", exc)
+            child_fallback = None
+        else:
+            if not child_fallback and delegation_fallback_raw:
+                logger.warning(
+                    "delegation.fallback_providers has no valid entries "
+                    "(each needs provider + model); inheriting parent chain"
+                )
+                child_fallback = (
+                    None
+                    if override_provider
+                    else (getattr(parent_agent, "_fallback_chain", None) or None)
+                )
+    else:
+        child_fallback = (
+            None
+            if override_provider
+            else (getattr(parent_agent, "_fallback_chain", None) or None)
+        )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1831,10 +1862,9 @@ def _build_child_agent(
                 acp_command=effective_acp_command,
                 acp_args=effective_acp_args,
                 max_iterations=max_iterations,
-
                 reasoning_config=child_reasoning,
                 prefill_messages=getattr(parent_agent, "prefill_messages", None),
-                fallback_model=parent_fallback,
+                fallback_model=child_fallback,
                 enabled_toolsets=child_toolsets,
                 disabled_toolsets=child_disabled_toolsets,
                 quiet_mode=True,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2273,6 +2273,8 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
+**Subagent fallback chain:** By default, delegated children inherit the parent agent's top-level `fallback_providers` chain. Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list) so a failed worker does not silently escalate onto head-agent fallback models. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely. When the key is absent or `null`, parent-chain inheritance is preserved (#65038).
+
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
 **Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2410,6 +2410,8 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
+**Subagent fallback chain:** By default, delegated children inherit the parent agent's top-level `fallback_providers` chain. Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list) so a failed worker does not silently escalate onto head-agent fallback models. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely. When the key is absent or `null`, parent-chain inheritance is preserved (#65038).
+
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
 **Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -173,7 +173,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -174,7 +174,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 


### PR DESCRIPTION
## Summary

Honor a `delegation.fallback_providers` chain for delegated children so a worker explicitly routed via `delegation.*` no longer silently escalates onto fallback models intended only for the head agent (**Fixes #65038**).

## Why this matters to users

**Before:** You set `delegation.provider: xai-oauth` so subagents run on xAI. When the child hit a retryable error, Hermes still walked the *head* agent's `fallback_providers` list — which often put `ollama-cloud` first — and burned through an exhausted Ollama quota while ignoring the provider you pinned.

**After:** You can give workers their own fallback chain under `delegation.fallback_providers`. Set `[]` to disable child fallback entirely. If you leave the key unset/`null`, children keep inheriting the parent chain (backward compatible with #7481).

## Changes

- `tools/delegate_tool.py` — `_build_child_agent()` resolves child chain as `delegation.fallback_providers` > parent inheritance. Key absent/null → inherit parent `_fallback_chain`; `[]` → no child fallback; malformed → warn + inherit (mirrors `reasoning_effort`). Normalization reuses `hermes_cli.fallback_config.get_fallback_chain()`.
- `hermes_cli/config_defaults.py` — `delegation.fallback_providers: None` (null sentinel = inherit; no `_config_version` bump).
- `cli-config.yaml.example` + docs — document the key and the three-way semantic.
- Tests — `TestDelegationFallbackChain` (override / absent / null / empty / malformed / real config loader). Async capacity test drains blocker completions to kill a latent race.

## Credit / prior art

Supersedes/reimplements the approach in open PR #65052 (@ayushnangia) against current `main` with DCO + green local suite. Prior PR had no reported checks; this branch is a clean rebase of that design onto `6e9cae6ac4b`.

## How to test

```bash
scripts/run_tests.sh tests/tools/test_delegate.py tests/tools/test_async_delegation.py
```

Local result: **89 passed, 0 failed**.

Minimal config repro from #65038:

```yaml
delegation:
  provider: xai-oauth
  model: grok-composer-2.5-fast
  fallback_providers:
    - provider: xai-oauth
      model: grok-composer-2.5-fast
```

## Platforms

- Windows (native) + git-bash test runner via `scripts/run_tests.sh`

## Interlock

- **Fixes #65038**
- Related: #65052 (prior open attempt — credit preserved)
- Related: #7481 (parent-chain inheritance, preserved when key absent)

Part of #65038

Part of #80450
