### PR TITLE
fix(acp): resume compression continuations

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -502,10 +502,20 @@ class SessionManager:
         if db is None:
             return None
 
+        storage_session_id = session_id
         try:
-            row = db.get_session(session_id)
+            storage_session_id = db.resolve_resume_session_id(session_id) or session_id
         except Exception:
-            logger.debug("Failed to query DB for ACP session %s", session_id, exc_info=True)
+            logger.debug(
+                "Failed to resolve compression continuation for ACP session %s",
+                session_id,
+                exc_info=True,
+            )
+
+        try:
+            row = db.get_session(storage_session_id)
+        except Exception:
+            logger.debug("Failed to query DB for ACP session %s", storage_session_id, exc_info=True)
             return None
 
         if row is None:
@@ -541,15 +551,15 @@ class SessionManager:
         # for the rest of the session (see hermes_state.get_messages_as_conversation).
         try:
             history = db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                storage_session_id, repair_alternation=True
             )
         except Exception:
-            logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
+            logger.warning("Failed to load messages for ACP session %s", storage_session_id, exc_info=True)
             history = []
 
         try:
             agent = self._make_agent(
-                session_id=session_id,
+                session_id=storage_session_id,
                 cwd=cwd,
                 model=model,
                 requested_provider=requested_provider,
@@ -557,11 +567,11 @@ class SessionManager:
                 api_mode=restored_api_mode,
             )
         except Exception:
-            logger.warning("Failed to recreate agent for ACP session %s", session_id, exc_info=True)
+            logger.warning("Failed to recreate agent for ACP session %s", storage_session_id, exc_info=True)
             return None
 
         state = SessionState(
-            session_id=session_id,
+            session_id=storage_session_id,
             agent=agent,
             cwd=cwd,
             model=model or getattr(agent, "model", "") or "",
@@ -570,8 +580,13 @@ class SessionManager:
         )
         with self._lock:
             self._sessions[session_id] = state
-        _register_task_cwd(session_id, cwd)
-        logger.info("Restored ACP session %s from DB (%d messages)", session_id, len(history))
+        _register_task_cwd(storage_session_id, cwd)
+        logger.info(
+            "Restored ACP session %s as %s from DB (%d messages)",
+            session_id,
+            storage_session_id,
+            len(history),
+        )
         return state
 
     def _delete_persisted(self, session_id: str) -> bool:

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -220,6 +220,39 @@ class TestListAndCleanup:
 class TestPersistence:
     """Verify that sessions are persisted to SessionDB and can be restored."""
 
+    def test_restore_follows_compression_continuation(self, tmp_path):
+        """An ACP resume must target the live storage segment after compression."""
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session("root", source="acp", model="test")
+        db.append_message("root", role="user", content="before compression")
+        db.end_session("root", "compression")
+        db.create_session(
+            "continuation",
+            source="acp",
+            model="test",
+            parent_session_id="root",
+        )
+        db.append_message("continuation", role="assistant", content="after compression")
+
+        base = time.time() - 1000
+        assert db._conn is not None
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'root'",
+            (base, base + 10),
+        )
+        db._conn.execute(
+            "UPDATE sessions SET started_at = ? WHERE id = 'continuation'",
+            (base + 20,),
+        )
+        db._conn.commit()
+
+        manager = SessionManager(db=db, agent_factory=_mock_agent)
+        restored = manager.get_session("root")
+
+        assert restored is not None
+        assert restored.session_id == "continuation"
+        assert [message["content"] for message in restored.history] == ["after compression"]
+
 
 
 


### PR DESCRIPTION
## Summary
- Resolve the current compression-continuation session before restoring an ACP session.
- Build the restored agent and transcript from that active storage segment, while retaining the caller's ACP ID as the in-memory lookup key.
- Add a regression covering an ACP root session that was rotated by compression.

## Test plan
- `scripts/run_tests.sh tests/acp/test_session.py tests/hermes_state/test_resolve_resume_session_id.py`
- `.venv/bin/ruff check acp_adapter/session.py tests/acp/test_session.py`
- `git diff --check`

This prevents resumed ACP tasks from attempting to persist to a compression-ended parent session.
