### PR TITLE
fix: retain requested branch on no-op update with `--branch`

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3859,7 +3859,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     prompt_user=prompt_for_restore,
                     input_fn=gw_input_fn,
                 )
-            if current_branch not in {branch, "HEAD"}:
+            # Only restore the original branch when the user did NOT
+            # explicitly request a branch via --branch.  An explicit
+            # --branch B should leave the checkout on B even when B is
+            # already up-to-date.  See issues #80412 and #80397.
+            if (
+                getattr(args, "branch", None) is None
+                and current_branch not in {branch, "HEAD"}
+            ):
                 subprocess.run(
                     git_cmd + ["checkout", current_branch],
                     cwd=_m().PROJECT_ROOT,


### PR DESCRIPTION
## Summary

`hermes update --branch B` unconditionally restores the original branch in the no-op path (commit_count == 0), even when the user explicitly requested branch B. This leaves the checkout on the wrong branch with exit code 0.

## Root cause

In `hermes_cli/update_cmd.py` lines 3862-3869, when `HEAD..origin/{branch}` yields zero commits, the updater:
1. Restores the stash (correct)
2. Checks out the original branch (BUG when `--branch` was explicit)

The non-zero commit path (actual updates) correctly stays on the requested branch — the bug is only in the no-op path.

## Fix

Guard the branch restoration with `getattr(args, "branch", None) is None` — only restore the original branch when `--branch` was NOT explicitly passed. This is the same pattern used by `_cmd_update_check` via its `branch_explicit` parameter.

## Issues fixed

- Fixes #80412 (no-op path restores original branch)
- Fixes #80397 (remote-only branch update discarded)

## Test plan

- [ ] `hermes update --branch B` when B is already current → stays on B, prints "Already up to date!"
- [ ] `hermes update` (no --branch) → behaves as before (stays on main or restores original)
- [ ] `hermes update --branch B` when B has new commits → stays on B, applies updates