### PR TITLE
fix(weixin): recover from stale context_token on outbound sends

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -118,12 +118,21 @@ MESSAGE_DEDUP_TTL_SECONDS = 300
 def _is_stale_session_ret(
     ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
 ) -> bool:
-    """True when iLink returns ret=-2 / errcode=-2 with 'unknown error',
-    which is a stale-session signal (same as errcode=-14) rather than
-    a genuine rate limit."""
+    """True when iLink returns the known stale-session ret/errcode -2."""
     if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
         return False
-    return (errmsg or "").lower() == "unknown error"
+    return (errmsg or "").strip().lower() == "unknown error"
+
+
+def _is_stale_context_token_ret(
+    ret: "Optional[int]", errcode: "Optional[int]", errmsg: "Optional[str]",
+) -> bool:
+    """True when an outbound send reports a stale ``context_token``."""
+    if _is_stale_session_ret(ret, errcode, errmsg):
+        return True
+    if ret != RATE_LIMIT_ERRCODE and errcode != RATE_LIMIT_ERRCODE:
+        return False
+    return (errmsg or "").strip().lower() == "prepare failed"
 
 
 MEDIA_IMAGE = 1
@@ -331,6 +340,14 @@ class ContextTokenStore:
     def set(self, account_id: str, user_id: str, token: str) -> None:
         self._cache[self._key(account_id, user_id)] = token
         self._persist(account_id)
+
+    def delete(self, account_id: str, user_id: str, expected_token: str) -> bool:
+        key = self._key(account_id, user_id)
+        if self._cache.get(key) != expected_token:
+            return False
+        self._cache.pop(key, None)
+        self._persist(account_id)
+        return True
 
     def _persist(self, account_id: str) -> None:
         prefix = f"{account_id}:"
@@ -1762,17 +1779,16 @@ class WeixinAdapter(BasePlatformAdapter):
         *,
         chat_id: str,
         chunk: str,
-        context_token: Optional[str],
         client_id: str,
     ) -> None:
         """Send a single text chunk with per-chunk retry and backoff.
 
-        On session-expired errors (errcode -14), automatically retries
-        *without* ``context_token`` — iLink accepts tokenless sends as a
-        degraded fallback, which keeps cron-initiated push messages working
-        even when no user message has refreshed the session recently.
+        On session-expired or stale-context errors, automatically retries
+        *without* ``context_token``.  The recovery send does not consume the
+        configured transient retry budget.
         """
         async with self._send_text_gate:
+            context_token = self._token_store.get(self._account_id, chat_id)
             await self._send_text_chunk_locked(
                 chat_id=chat_id,
                 chunk=chunk,
@@ -1790,8 +1806,8 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> None:
         """Send a text chunk while holding the adapter-wide outbound text gate."""
         last_error: Optional[Exception] = None
-        retried_without_token = False
-        for attempt in range(self._send_chunk_retries + 1):
+        attempt = 0
+        while attempt <= self._send_chunk_retries:
             if self._rate_limit_cooldown_remaining() > 0:
                 raise self._rate_limit_error()
             try:
@@ -1812,20 +1828,35 @@ class WeixinAdapter(BasePlatformAdapter):
                         is_session_expired = (
                             ret == SESSION_EXPIRED_ERRCODE
                             or errcode == SESSION_EXPIRED_ERRCODE
-                            or _is_stale_session_ret(ret, errcode, resp.get("errmsg"))
+                            or _is_stale_context_token_ret(
+                                ret,
+                                errcode,
+                                resp.get("errmsg"),
+                            )
                         )
                         # Session expired — strip token and retry once
-                        if is_session_expired and not retried_without_token and context_token:
-                            retried_without_token = True
+                        if is_session_expired and context_token:
+                            stale_token = context_token
                             context_token = None
-                            self._token_store._cache.pop(
-                                self._token_store._key(self._account_id, chat_id), None
+                            self._token_store.delete(
+                                self._account_id,
+                                chat_id,
+                                stale_token,
                             )
                             logger.warning(
                                 "[%s] session expired for %s; retrying without context_token",
                                 self.name, _safe_id(chat_id),
                             )
                             continue
+                        if is_session_expired:
+                            # Tokenless recovery also reported a stale session.
+                            # This is not a genuine rate limit — do NOT open
+                            # the rate-limit circuit; surface a clear error.
+                            last_error = RuntimeError(
+                                "iLink sendmessage stale session: no fresh context_token; "
+                                "wait for a new inbound message to refresh the session"
+                            )
+                            break
                         # Rate limit (-2) — backoff and retry
                         is_rate_limited = (
                             ret == RATE_LIMIT_ERRCODE
@@ -1850,6 +1881,7 @@ class WeixinAdapter(BasePlatformAdapter):
                                 self.name, _safe_id(chat_id), wait,
                             )
                             await asyncio.sleep(wait)
+                            attempt += 1
                             continue
                         errmsg = resp.get("errmsg") or resp.get("msg") or "unknown error"
                         raise RuntimeError(
@@ -1873,6 +1905,7 @@ class WeixinAdapter(BasePlatformAdapter):
                 )
                 if wait > 0:
                     await asyncio.sleep(wait)
+                attempt += 1
         assert last_error is not None
         raise last_error
 
@@ -1885,7 +1918,6 @@ class WeixinAdapter(BasePlatformAdapter):
     ) -> SendResult:
         if not self._send_session or not self._token:
             return SendResult(success=False, error="Not connected")
-        context_token = self._token_store.get(self._account_id, chat_id)
         last_message_id: Optional[str] = None
 
         # Extract MEDIA: tags and bare local file paths before text delivery.
@@ -1932,7 +1964,6 @@ class WeixinAdapter(BasePlatformAdapter):
                 await self._send_text_chunk(
                     chat_id=chat_id,
                     chunk=chunk,
-                    context_token=context_token,
                     client_id=client_id,
                 )
                 last_message_id = client_id

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -214,6 +214,10 @@ class TestWeixinChunkDelivery:
         adapter._token_store.get = lambda account_id, chat_id: "ctx-token"
         return adapter
 
+    def _adapter_with_store(self, tmp_path) -> WeixinAdapter:
+        adapter = self._connected_adapter()
+        adapter._token_store = weixin.ContextTokenStore(str(tmp_path))
+        return adapter
 
     @patch("gateway.platforms.weixin.asyncio.sleep", new_callable=AsyncMock)
     @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
@@ -269,6 +273,161 @@ class TestWeixinChunkDelivery:
         # rest of the current chunk and follow-up sends fail fast.
         assert send_message_mock.await_count == 2
         assert sleep_mock.await_count == 1
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_stale_context_token_recovers_with_zero_retry_budget(self, send_message_mock, tmp_path):
+        adapter = self._adapter_with_store(tmp_path)
+        adapter._send_chunk_retries = 0
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+        send_message_mock.side_effect = [
+            {"ret": -2, "errmsg": "prepare failed"},
+            {"ret": 0},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is True
+        assert [
+            call.kwargs["context_token"]
+            for call in send_message_mock.await_args_list
+        ] == ["ctx-token", None]
+        assert adapter._token_store.get(adapter._account_id, "wxid_test123") is None
+
+        restored_store = weixin.ContextTokenStore(str(tmp_path))
+        restored_store.restore(adapter._account_id)
+        assert restored_store.get(adapter._account_id, "wxid_test123") is None
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_stale_context_token_is_not_reused_for_later_chunks(self, send_message_mock, tmp_path):
+        adapter = self._adapter_with_store(tmp_path)
+        adapter.MAX_MESSAGE_LENGTH = 12
+        adapter._send_chunk_delay_seconds = 0
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+        send_message_mock.side_effect = [
+            {"ret": -2, "errmsg": "prepare failed"},
+            {"ret": 0},
+            {"ret": 0},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "first\n\nsecond"))
+
+        assert result.success is True
+        assert [
+            call.kwargs["context_token"]
+            for call in send_message_mock.await_args_list
+        ] == ["ctx-token", None, None]
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_failed_stale_recovery_does_not_restart_with_original_token(self, send_message_mock, tmp_path):
+        adapter = self._adapter_with_store(tmp_path)
+        adapter._send_chunk_retries = 1
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+        send_message_mock.side_effect = [
+            {"ret": -2, "errmsg": "prepare failed"},
+            RuntimeError("tokenless recovery failed"),
+            RuntimeError("tokenless retry failed"),
+            {"ret": 0},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert [
+            call.kwargs["context_token"]
+            for call in send_message_mock.await_args_list
+        ] == ["ctx-token", None, None]
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_stale_tokenless_failure_does_not_open_rate_limit_circuit(self, send_message_mock, tmp_path):
+        """#74572 follow-up: a stale session that survives the tokenless
+        recovery is not a genuine rate limit and must not trip the breaker."""
+        adapter = self._adapter_with_store(tmp_path)
+        adapter._send_chunk_retries = 1
+        adapter._send_chunk_retry_delay_seconds = 0
+        adapter._rate_limit_circuit_threshold = 1
+        adapter._rate_limit_circuit_open_seconds = 60
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+        send_message_mock.side_effect = [
+            {"ret": -2, "errmsg": "prepare failed"},
+            {"ret": -2, "errmsg": "prepare failed"},
+        ]
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is False
+        assert "stale session" in (result.error or "").lower()
+        assert adapter._rate_limit_circuit_until == 0.0
+        assert [
+            call.kwargs["context_token"]
+            for call in send_message_mock.await_args_list
+        ] == ["ctx-token", None]
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_stale_response_does_not_delete_newer_context_token(self, send_message_mock, tmp_path):
+        adapter = self._adapter_with_store(tmp_path)
+        adapter._send_chunk_retries = 0
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "ctx-token")
+
+        async def refresh_before_stale_response(*args, **kwargs):
+            if kwargs["context_token"] == "ctx-token":
+                adapter._token_store.set(
+                    adapter._account_id,
+                    "wxid_test123",
+                    "fresh-token",
+                )
+                return {"ret": -2, "errmsg": "prepare failed"}
+            return {"ret": 0}
+
+        send_message_mock.side_effect = refresh_before_stale_response
+
+        result = asyncio.run(adapter.send("wxid_test123", "hello"))
+
+        assert result.success is True
+        assert adapter._token_store.get(
+            adapter._account_id,
+            "wxid_test123",
+        ) == "fresh-token"
+
+        restored_store = weixin.ContextTokenStore(str(tmp_path))
+        restored_store.restore(adapter._account_id)
+        assert restored_store.get(
+            adapter._account_id,
+            "wxid_test123",
+        ) == "fresh-token"
+
+
+    @patch("gateway.platforms.weixin._send_message", new_callable=AsyncMock)
+    def test_context_token_is_loaded_after_send_gate_is_acquired(self, send_message_mock, tmp_path):
+        adapter = self._adapter_with_store(tmp_path)
+        adapter._token_store.set(adapter._account_id, "wxid_test123", "old-token")
+        send_message_mock.return_value = {"ret": 0}
+
+        async def send_after_refresh():
+            await adapter._send_text_gate.acquire()
+            try:
+                send_task = asyncio.create_task(
+                    adapter.send("wxid_test123", "hello")
+                )
+                await asyncio.sleep(0)
+                adapter._token_store.set(
+                    adapter._account_id,
+                    "wxid_test123",
+                    "fresh-token",
+                )
+            finally:
+                adapter._send_text_gate.release()
+            return await send_task
+
+        result = asyncio.run(send_after_refresh())
+
+        assert result.success is True
+        assert send_message_mock.await_args.kwargs["context_token"] == "fresh-token"
 
 
 class TestWeixinOutboundMedia:
@@ -500,6 +659,18 @@ class TestIsStaleSessionRet:
     """Regression test for #17228: distinguish stale-session ret=-2 from rate-limit ret=-2."""
 
 
+    def test_prepare_failed_is_only_an_outbound_context_token_signal(self):
+        # ``prepare failed`` is a stale ``context_token`` variant on the
+        # outbound send path only; the shared poll-path classifier keeps
+        # the narrower ``unknown error`` semantics.
+        assert weixin._is_stale_session_ret(-2, None, "prepare failed") is False
+        assert weixin._is_stale_context_token_ret(
+            -2,
+            None,
+            "prepare failed",
+        ) is True
+
+
     def test_ret_minus_2_with_freq_limit_is_not_stale(self):
         # Genuine rate limit — must NOT be treated as stale session.
         assert weixin._is_stale_session_ret(-2, None, "freq limit") is False
@@ -509,6 +680,30 @@ class TestIsStaleSessionRet:
         # -14 is handled by the separate SESSION_EXPIRED_ERRCODE path; the
         # helper only disambiguates -2 from a genuine rate limit.
         assert weixin._is_stale_session_ret(-14, None, "session expired") is False
+
+
+class TestContextTokenStore:
+    def test_delete_removes_only_matching_peer_and_persists(self, tmp_path):
+        store = weixin.ContextTokenStore(str(tmp_path))
+        store.set("account-a", "peer-a", "stale-token")
+        store.set("account-a", "peer-b", "fresh-token")
+        store.set("account-b", "peer-a", "other-account-token")
+
+        assert store.delete("account-a", "peer-a", "replacement-token") is False
+        assert store.get("account-a", "peer-a") == "stale-token"
+
+        assert store.delete("account-a", "peer-a", "stale-token") is True
+
+        assert store.get("account-a", "peer-a") is None
+        assert store.get("account-a", "peer-b") == "fresh-token"
+        assert store.get("account-b", "peer-a") == "other-account-token"
+
+        restored_store = weixin.ContextTokenStore(str(tmp_path))
+        restored_store.restore("account-a")
+        restored_store.restore("account-b")
+        assert restored_store.get("account-a", "peer-a") is None
+        assert restored_store.get("account-a", "peer-b") == "fresh-token"
+        assert restored_store.get("account-b", "peer-a") == "other-account-token"
 
 
 class TestWeixinContentDedup:


### PR DESCRIPTION
## What does this PR do?

Fixes outbound Weixin delivery when iLink reports a stale session as
`ret=-2, errmsg="prepare failed"` on `sendmessage`. The current adapter
only recognizes `errmsg="unknown error"` (or `errcode=-14`) as a
stale-session signal, so `prepare failed` falls through to rate-limit
handling: it opens the rate-limit circuit and puts Weixin into a
30-60s cooldown lockout. Long-running agent turns or cron-initiated
pushes that outlive the session regularly hit this, and every follow-up
send then fails fast with a misleading "rate limited" error.

This PR:

- adds an **outbound-only** stale-context classifier that also recognizes
  `prepare failed`; the shared poll-path classifier keeps the narrower
  `unknown error` semantics;
- deletes the cached `context_token` only if it still matches the token
  that failed (compare-and-delete), so a concurrently refreshed token is
  preserved;
- loads the context token after acquiring the outbound send gate, so a
  fresh inbound token is picked up between chunks;
- performs one tokenless recovery send **without** consuming the normal
  transient retry budget, and keeps later retries tokenless;
- if the tokenless recovery also reports a stale session, raises a clear
  `stale session` error and does **not** open the rate-limit circuit;
  genuine rate limits (e.g. `freq limit`) still open the breaker.

## Related Issue

Follow-up to #17228; complements #74572.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/weixin.py`: `_is_stale_context_token_ret()` classifier,
  `ContextTokenStore.delete()` compare-and-delete, under-gate token load,
  explicit retry accounting, and no-circuit stale-session error path.
- `tests/gateway/test_weixin.py`: coverage for zero-retry tokenless recovery,
  multi-chunk tokenless continuation, bounded recovery without original-token
  reuse, circuit-not-opened on stale-session failure, concurrent fresh-token
  preservation, under-gate token load, classifier semantics, and
  `ContextTokenStore.delete()` persistence.

## How to Test

1. Let a Weixin chat idle until iLink starts returning
   `ret=-2 errmsg="prepare failed"`, then attempt an outbound send
   (e.g. `hermes send -t weixin "hello"`).
2. Before: logs show `iLink sendmessage rate limited; cooldown active for
   30.0s/60.0s` and subsequent sends fail fast while the circuit is open.
3. After: logs show `session expired ... retrying without context_token`;
   if the tokenless recovery succeeds the message is delivered, otherwise a
   clear `stale session ... wait for a new inbound message` error is raised
   and no cooldown is opened.
4. Unit: `pytest tests/gateway/test_weixin.py -q` -> 38 passed;
   `ruff check gateway/platforms/weixin.py tests/gateway/test_weixin.py`
   -> clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass
      (weixin suite and ruff are green on this host; full repo suite not run)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (VPS), Ubuntu-style install

### Documentation & Housekeeping

- [x] N/A: no user-facing documentation/config/tool-schema changes
- [x] N/A: no cli-config.yaml.example changes
- [x] N/A: no CONTRIBUTING.md / AGENTS.md changes
- [x] N/A: cross-platform impact limited to one Python file + tests
- [x] N/A: no tool descriptions/schemas changed

## Screenshots / Logs

Production log after the fix (stale startup notification):

```
WARNING gateway.platforms.weixin: [Weixin] session expired for o9cq800k; retrying without context_token
ERROR   gateway.platforms.weixin: [Weixin] send failed to=o9cq800k: iLink sendmessage stale session: no fresh context_token; wait for a new inbound message to refresh the session
```

No `cooldown active` line is emitted for the stale-session case.
