### PR TITLE
fix(gateway): persist per-session yolo so it survives app restarts

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -16304,6 +16304,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         session_entry = await self.async_session_store.get_or_create_session(source)
         session_key = session_entry.session_key
+        # Re-apply a persisted /yolo bypass (if any) after a gateway restart —
+        # without this the in-memory approval set starts empty and the session
+        # reverts to approvals.mode's default ("smart"). Idempotent no-op for
+        # sessions that never toggled yolo.
+        await self._hydrate_yolo_flag(session_entry, session_key)
         pinned_session_id = str(
             (getattr(event, "metadata", None) or {}).get("gateway_session_id") or ""
         ).strip()

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3790,10 +3790,60 @@ class GatewaySlashCommandsMixin:
         current = is_session_yolo_enabled(session_key)
         if current:
             disable_session_yolo(session_key)
+            await self._persist_yolo_flag(session_key, False)
             return EphemeralReply(t("gateway.yolo.disabled"))
         else:
             enable_session_yolo(session_key)
+            await self._persist_yolo_flag(session_key, True)
             return EphemeralReply(t("gateway.yolo.enabled"))
+
+    async def _persist_yolo_flag(self, session_key: str, enabled: bool) -> None:
+        """Persist a session-scoped /yolo toggle to the session row (best-effort).
+
+        The in-memory ``_session_yolo`` set is authoritative for the live
+        process; without the row flag, a gateway restart reverts the session
+        to ``approvals.mode``'s default (``smart``) and dangerous commands
+        start prompting again. Mirrors the CLI's ``_persist_session_yolo``.
+        No-op when the routing entry has no row yet (brand-new chat) or the
+        store/DB are unavailable.
+        """
+        try:
+            store = getattr(self, "session_store", None)
+            db = getattr(self, "_session_db", None)
+            if store is None or db is None:
+                return
+            session_id = store.peek_session_id(session_key)
+            if not session_id:
+                return
+            await db.set_session_yolo(session_id, enabled)
+        except Exception:
+            pass
+
+    async def _hydrate_yolo_flag(self, session_entry, session_key: str) -> None:
+        """Re-apply a persisted session /yolo bypass after a gateway restart.
+
+        ``_persist_yolo_flag`` writes the toggle to the session row; this
+        restores it into the in-memory approval set on the first message of a
+        fresh gateway process, so dangerous commands keep auto-approving
+        instead of reverting to ``approvals.mode``'s default (``smart``).
+        Idempotent and best-effort.
+        """
+        try:
+            db = getattr(self, "_session_db", None)
+            if db is None:
+                return
+            from hermes_state import SessionDB
+
+            sid = getattr(session_entry, "session_id", None) or ""
+            if not sid:
+                return
+            row = await db.get_session(sid)
+            if row and SessionDB.session_yolo_enabled(row):
+                from tools.approval import enable_session_yolo
+
+                enable_session_yolo(session_key)
+        except Exception:
+            pass
 
     async def _handle_verbose_command(self, event: MessageEvent) -> str:
         """Handle /verbose command — cycle tool progress display mode.

--- a/tests/gateway/test_yolo_command.py
+++ b/tests/gateway/test_yolo_command.py
@@ -1,6 +1,7 @@
 """Tests for gateway /yolo session scoping."""
 
 import os
+import types
 
 import pytest
 
@@ -60,3 +61,79 @@ async def test_yolo_command_toggles_only_current_session(monkeypatch):
     assert "OFF" in result_off
     assert is_session_yolo_enabled(session_a) is False
     assert os.environ.get("HERMES_YOLO_MODE") is None
+
+
+@pytest.mark.asyncio
+async def test_yolo_command_persists_flag_to_session_row():
+    """/yolo must persist yolo_mode to the session row so a gateway restart
+    can re-hydrate it — otherwise the bypass reverts to approvals.mode's
+    default ("smart") on the next process."""
+    runner = _make_runner()
+    calls = []
+
+    class _Store:
+        def peek_session_id(self, session_key):
+            return "sess-1"
+
+    class _Db:
+        async def set_session_yolo(self, session_id, enabled):
+            calls.append((session_id, enabled))
+
+    runner.session_store = _Store()
+    runner._session_db = _Db()
+
+    await runner._handle_yolo_command(_make_event("chat-a"))
+    assert calls == [("sess-1", True)]
+
+    await runner._handle_yolo_command(_make_event("chat-a"))
+    assert calls == [("sess-1", True), ("sess-1", False)]
+
+
+@pytest.mark.asyncio
+async def test_hydrate_yolo_flag_restores_persisted_bypass(tmp_path):
+    """First message in a fresh gateway process must re-apply a persisted
+    /yolo bypass from the session row."""
+    from hermes_state import AsyncSessionDB, SessionDB
+    from tools.approval import disable_session_yolo, is_session_yolo_enabled
+
+    session_key = "agent:main:telegram:dm:chat-a"
+    disable_session_yolo(session_key)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(
+            session_id="sess-1",
+            source="telegram",
+            model="m",
+            model_config={"yolo_mode": True},
+        )
+        runner = _make_runner()
+        runner._session_db = AsyncSessionDB(db)
+        entry = types.SimpleNamespace(session_id="sess-1")
+
+        await runner._hydrate_yolo_flag(entry, session_key)
+        assert is_session_yolo_enabled(session_key) is True
+    finally:
+        disable_session_yolo(session_key)
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_hydrate_yolo_flag_noop_when_flag_absent(tmp_path):
+    """Sessions that never toggled yolo must stay disarmed after restart."""
+    from hermes_state import AsyncSessionDB, SessionDB
+    from tools.approval import disable_session_yolo, is_session_yolo_enabled
+
+    session_key = "agent:main:telegram:dm:chat-b"
+    disable_session_yolo(session_key)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session(session_id="sess-2", source="telegram", model="m")
+        runner = _make_runner()
+        runner._session_db = AsyncSessionDB(db)
+        entry = types.SimpleNamespace(session_id="sess-2")
+
+        await runner._hydrate_yolo_flag(entry, session_key)
+        assert is_session_yolo_enabled(session_key) is False
+    finally:
+        disable_session_yolo(session_key)
+        db.close()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -5562,6 +5562,121 @@ def test_config_set_yolo_toggles_session_scope():
         server._sessions.clear()
 
 
+def test_config_set_yolo_session_scope_persists_flag_to_row(tmp_path, monkeypatch):
+    """The desktop zap (session scope) must persist yolo_mode to the session
+    row so a gateway restart can re-hydrate it — otherwise closing/reopening
+    the app reverts the session to approvals.mode's default (\"smart\")."""
+    from hermes_state import SessionDB
+    from tools.approval import clear_session, is_session_yolo_enabled
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    try:
+        db.create_session(
+            session_id="session-key", source="tui", model="m", cwd=str(tmp_path)
+        )
+        server._sessions["sid"] = _session()
+        try:
+            resp_on = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "config.set",
+                    "params": {"session_id": "sid", "key": "yolo"},
+                }
+            )
+            assert resp_on["result"]["value"] == "1"
+            assert is_session_yolo_enabled("session-key") is True
+            assert (
+                SessionDB.session_yolo_enabled(db.get_session("session-key"))
+                is True
+            )
+
+            resp_off = server.handle_request(
+                {
+                    "id": "2",
+                    "method": "config.set",
+                    "params": {"session_id": "sid", "key": "yolo"},
+                }
+            )
+            assert resp_off["result"]["value"] == "0"
+            assert is_session_yolo_enabled("session-key") is False
+            assert (
+                SessionDB.session_yolo_enabled(db.get_session("session-key"))
+                is False
+            )
+        finally:
+            clear_session("session-key")
+            server._sessions.clear()
+    finally:
+        db.close()
+
+
+def test_init_session_rehydrates_persisted_yolo_flag(tmp_path, monkeypatch):
+    """A resumed session whose row carries yolo_mode must re-arm the
+    in-memory bypass — this is what keeps the desktop zap lit across app
+    restarts (the gateway process starts fresh each time)."""
+    from hermes_state import SessionDB
+    from tools.approval import clear_session, is_session_yolo_enabled
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    try:
+        db.create_session(
+            session_id="session-key",
+            source="tui",
+            model="m",
+            cwd=str(tmp_path),
+            model_config={"yolo_mode": True},
+        )
+        agent = types.SimpleNamespace(
+            session_id="session-key",
+            _persist_disabled=True,
+            _session_db_created=True,
+        )
+        sid = "sid"
+        try:
+            server._init_session(
+                sid, "session-key", agent, [], cwd=str(tmp_path), session_db=db
+            )
+            assert is_session_yolo_enabled("session-key") is True
+        finally:
+            clear_session("session-key")
+            if sid in server._sessions:
+                server._teardown_session(server._sessions[sid])
+    finally:
+        db.close()
+
+
+def test_init_session_does_not_arm_yolo_without_flag(tmp_path, monkeypatch):
+    """Sessions that never toggled yolo must stay disarmed after resume."""
+    from hermes_state import SessionDB
+    from tools.approval import clear_session, is_session_yolo_enabled
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    try:
+        db.create_session(
+            session_id="session-key", source="tui", model="m", cwd=str(tmp_path)
+        )
+        agent = types.SimpleNamespace(
+            session_id="session-key",
+            _persist_disabled=True,
+            _session_db_created=True,
+        )
+        sid = "sid"
+        try:
+            server._init_session(
+                sid, "session-key", agent, [], cwd=str(tmp_path), session_db=db
+            )
+            assert is_session_yolo_enabled("session-key") is False
+        finally:
+            clear_session("session-key")
+            if sid in server._sessions:
+                server._teardown_session(server._sessions[sid])
+    finally:
+        db.close()
+
+
 def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatch):
     """Shift+click the desktop zap -> scope="global" flips persistent approvals.mode."""
     import yaml

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4814,6 +4814,17 @@ def _sync_session_key_after_compress(
                 disable_session_yolo(old_key)
             except Exception:
                 pass
+            # Keep the persisted flag in step with the in-memory transfer:
+            # the continuation row inherits the bypass, the ended parent row
+            # drops it, so a later resume in a fresh process restores the
+            # same state (see _init_session re-hydration).
+            try:
+                db = _get_db()
+                if db is not None and hasattr(db, "set_session_yolo"):
+                    db.set_session_yolo(new_session_id, True)
+                    db.set_session_yolo(old_key, False)
+            except Exception:
+                pass
         try:
             register_gateway_notify(
                 new_session_id,
@@ -6535,6 +6546,7 @@ def _init_session(
             db = _get_db()
     else:
         db = _get_db()
+    row = None
     try:
         if db is not None:
             row = db.get_session(key) if hasattr(db, "get_session") else None
@@ -6559,6 +6571,21 @@ def _init_session(
                 db.close()
             except Exception:
                 pass
+    # Re-hydrate a persisted per-session YOLO bypass into the in-memory
+    # approval state. The desktop's status-bar zap (config.set yolo, session
+    # scope) persists the flag via SessionDB.set_session_yolo; without this,
+    # closing and reopening the app — which restarts the gateway process —
+    # silently reverted the bypass to approvals.mode's default ("smart"),
+    # making dangerous commands prompt again. Mirrors the CLI's
+    # _restore_session_yolo on --resume.
+    try:
+        from hermes_state import SessionDB
+        from tools.approval import enable_session_yolo
+
+        if row and SessionDB.session_yolo_enabled(row):
+            enable_session_yolo(key)
+    except Exception:
+        pass
     _register_session_cwd(_sessions[sid])
     # No eager slash-worker pre-warm — the session dict already carries
     # slash_worker=None and slash.exec builds one on demand. See the
@@ -10834,6 +10861,18 @@ def _(rid, params: dict) -> dict:
                 else:
                     disable_session_yolo(session["session_key"])
                     nv = "0"
+                # Persist to the session row so the bypass survives a gateway
+                # restart (_init_session re-hydrates it on resume). The
+                # in-memory flag stays authoritative for the live process; the
+                # row only affects a future process, exactly like the CLI's
+                # _persist_session_yolo. Best-effort: a missing row (lazy
+                # creation) or an unavailable store must not fail the toggle.
+                try:
+                    db = _get_db()
+                    if db is not None and hasattr(db, "set_session_yolo"):
+                        db.set_session_yolo(session["session_key"], enable)
+                except Exception:
+                    pass
                 agent = session.get("agent")
                 if agent is not None:
                     _emit(


### PR DESCRIPTION
## Summary

Per-session YOLO (approval bypass) no longer silently reverts to the default `approvals.mode` ("smart") when the user closes and reopens the desktop app. The toggle is now persisted to the session row and re-hydrated on resume, mirroring the CLI's existing `_persist_session_yolo` / `_restore_session_yolo` pattern.

**Root cause:** the desktop status-bar zap (`config.set yolo`, session scope) and the messaging gateway's `/yolo` only mutated the in-memory `tools.approval._session_yolo` set. The desktop spawns the gateway with `--replace`, so closing the app restarts the process; the set came back empty and the session reverted to `approvals.mode`'s default (`smart`), making dangerous commands prompt again. The CLI already persisted the same flag via `SessionDB.set_session_yolo` and restored it on resume — the gateway paths were the only ones missing persistence.

## Changes

- `tui_gateway/server.py`: `config.set yolo` (session scope) now persists the flag via `SessionDB.set_session_yolo` (best-effort); `_init_session` re-hydrates a persisted `yolo_mode` row into the in-memory approval set on resume; `_sync_session_key_after_compress` moves the persisted flag to the continuation row so a post-compression restart restores it.
- `gateway/slash_commands.py`: new `_persist_yolo_flag` (writes the toggle to the session row via `SessionStore.peek_session_id` + `AsyncSessionDB.set_session_yolo`) and `_hydrate_yolo_flag` (re-applies a persisted bypass on the first message of a fresh process).
- `gateway/run.py`: `_handle_message_with_agent` calls `_hydrate_yolo_flag` after session resolution.
- `tests/test_tui_gateway_server.py`: persistence round-trip for the zap, `_init_session` re-hydration (armed + not-armed cases).
- `tests/gateway/test_yolo_command.py`: `/yolo` persists ON/OFF to the row; hydration restores a persisted bypass and stays a no-op without the flag.

## Validation

| Teste | Resultado |
|-------|-----------|
| `tests/gateway/test_yolo_command.py` | 4/4 passed |
| `tests/test_tui_gateway_server.py -k yolo` | 7/7 passed |
| `tests/test_tui_gateway_server.py` (full file) | 520/520 passed |
| yolo/approval related suites (tools + cli + gateway) | 64/64 passed |
| `import gateway.run / gateway.slash_commands / tui_gateway.server` | OK |

Behavior contract: a session that never toggled YOLO stays disarmed after resume (covered by `test_init_session_does_not_arm_yolo_without_flag` and `test_hydrate_yolo_flag_noop_when_flag_absent`); a row whose flag is `false` does not resurrect the bypass.