### PR TITLE
fix: clamp reasoning_effort ultra/max to high for non-gpt-5.6 models

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -77,16 +77,29 @@ def _add_prompt_cache_key(
 
 
 def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> dict | None:
-    """Return the model's wire-compatible reasoning config."""
+    """Return the model's wire-compatible reasoning config.
+
+    ``ultra`` and ``max`` are OpenAI-specific effort levels for gpt-5.6.
+    Custom OpenAI-compatible providers typically accept only ``low``,
+    ``medium``, and ``high``; passing ``ultra`` or ``max`` to them triggers
+    HTTP 422.  Clamp unsupported levels down to ``high`` for non-gpt-5.6
+    models so the agent degrades gracefully instead of crashing.
+    """
     if not isinstance(reasoning_config, dict):
         return reasoning_config
-    if (
-        "gpt-5.6" in (model or "").lower()
-        and str(reasoning_config.get("effort") or "").strip().lower() == "ultra"
-    ):
-        normalized = dict(reasoning_config)
-        normalized["effort"] = "max"
-        return normalized
+    effort = str(reasoning_config.get("effort") or "").strip().lower()
+    if "gpt-5.6" in (model or "").lower():
+        if effort == "ultra":
+            normalized = dict(reasoning_config)
+            normalized["effort"] = "max"
+            return normalized
+    else:
+        # Non-gpt-5.6 models: clamp ultra/max to high to avoid 422s
+        # from providers that only accept low/medium/high.
+        if effort in {"ultra", "max"}:
+            normalized = dict(reasoning_config)
+            normalized["effort"] = "high"
+            return normalized
     return reasoning_config
 
 

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -39,6 +39,79 @@ class TestChatCompletionsBasic:
         assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
 
 
+    @pytest.mark.parametrize("effort", ["ultra", "max"])
+    def test_non_gpt56_ultra_max_clamped_to_high(self, transport, effort):
+        """Custom providers that only accept low/medium/high get HTTP 422
+        when ultra or max is passed through.  The transport must clamp
+        these to high for non-gpt-5.6 models.  Regression test for #80242.
+        """
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="agnes-2.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": effort},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url=profile.base_url,
+        )
+        # Custom provider surfaces reasoning as top-level reasoning_effort
+        assert kw["reasoning_effort"] == "high"
+
+    @pytest.mark.parametrize("effort", ["low", "medium", "high"])
+    def test_non_gpt56_valid_efforts_pass_through(self, transport, effort):
+        """Standard effort levels must not be altered for non-gpt-5.6 models."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("custom")
+        kw = transport.build_kwargs(
+            model="agnes-2.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": effort},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="custom",
+            base_url=profile.base_url,
+        )
+        assert kw["reasoning_effort"] == effort
+
+    def test_gpt56_max_passes_through_unchanged(self, transport):
+        """gpt-5.6 with effort=max should pass through as-is (not clamped)."""
+        from providers import get_provider_profile
+        profile = get_provider_profile("nous")
+        kw = transport.build_kwargs(
+            model="openai/gpt-5.6-sol",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "max"},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="nous",
+            base_url=profile.base_url,
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "max"}
+
+    def test_nous_non_gpt56_ultra_clamped_to_high(self, transport):
+        """Via the Nous provider, a non-gpt-5.6 model with ultra should
+        also be clamped to high (reasoning surfaces in extra_body there).
+        """
+        from providers import get_provider_profile
+        profile = get_provider_profile("nous")
+        kw = transport.build_kwargs(
+            model="agnes-2.5-flash",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[],
+            reasoning_config={"enabled": True, "effort": "ultra"},
+            supports_reasoning=True,
+            provider_profile=profile,
+            provider_name="nous",
+            base_url=profile.base_url,
+        )
+        assert kw["extra_body"]["reasoning"] == {"enabled": True, "effort": "high"}
+
+
     def test_convert_messages_no_codex_leaks(self, transport):
         msgs = [{"role": "user", "content": "hi"}]
         result = transport.convert_messages(msgs)


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible providers (e.g. agnes-ai) only accept `low`, `medium`, and `high` for `reasoning_effort`. When a user sets `/reasoning ultra`, the value passes through verbatim to non-gpt-5.6 models, triggering HTTP 422:

```
reasoning_effort: unknown variant `ultra`, expected one of `low`, `medium`, `high`
```

The existing `_reasoning_config_for_model` only normalised `ultra`→`max` for gpt-5.6 models. For all other models it returned `reasoning_config` unchanged, so unsupported effort levels leaked to providers that reject them.

## Fix

Add an `else` branch that clamps `ultra`/`max`→`high` for non-gpt-5.6 models. This lets the agent degrade gracefully (highest supported reasoning level) instead of crashing with a 422.

## Siblings checked

- Both call sites of `_reasoning_config_for_model` (lines 474 and 681) pass through `model` and `reasoning_config` — the fix at the function level covers both paths.
- Gemini has its own `_build_gemini_thinking_config` that translates effort levels separately — not affected by this change.
- LM Studio has its own `lmstudio_reasoning_options` gate in `build_kwargs` — not affected.

## Test plan

- [x] `test_gpt56_ultra_uses_max_wire_effort` — existing test, still passes (gpt-5.6 ultra→max unchanged)
- [x] `test_non_gpt56_ultra_max_clamped_to_high[ultra]` — new: custom provider, ultra→high
- [x] `test_non_gpt56_ultra_max_clamped_to_high[max]` — new: custom provider, max→high
- [x] `test_non_gpt56_valid_efforts_pass_through[low/medium/high]` — new: valid efforts unchanged
- [x] `test_gpt56_max_passes_through_unchanged` — new: gpt-5.6 with max passes through
- [x] `test_nous_non_gpt56_ultra_clamped_to_high` — new: nous provider, non-gpt-5.6 ultra→high
- [x] Full transport + reasoning test suite: **281 passed, 0 failed**
- [x] Static security scan: no secrets, shell injection, eval/exec, or pickle

## Verification

```
$ python -m pytest tests/agent/transports/test_chat_completions.py -v
52 passed in 3.00s

$ python -m pytest tests/agent/transports/ tests/agent/test_custom_provider_extra_body.py tests/cli/test_reasoning_command.py -q
281 passed in 150.36s
```

Closes #80242