### PR TITLE
fix(delegation): honor worker fallback providers

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1695,7 +1695,7 @@ class TestSubagentApprovalCallback(unittest.TestCase):
 
 
 class TestFallbackModelInheritance(unittest.TestCase):
-    """Subagents must inherit the parent's fallback provider chain."""
+    """Subagent fallback routing respects delegation-specific configuration."""
 
     def test_child_inherits_fallback_chain(self):
         """_build_child_agent passes parent._fallback_chain as fallback_model."""
@@ -1703,7 +1703,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,
@@ -1724,11 +1727,83 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         parent._fallback_chain = []
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,
                 goal="test no fallback",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_child_uses_delegation_specific_fallback_chain(self):
+        """A configured worker chain must not silently use the parent's chain."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "head", "model": "head-fallback"}]
+        delegation_chain = [
+            {
+                "provider": " worker-provider ",
+                "model": " worker-fallback ",
+                "base_url": "https://worker.example/v1/",
+            },
+            {"provider": "", "model": "invalid"},
+        ]
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={"fallback_providers": delegation_chain},
+            ),
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test delegation fallback",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(
+            kwargs["fallback_model"],
+            [{
+                "provider": "worker-provider",
+                "model": "worker-fallback",
+                "base_url": "https://worker.example/v1",
+            }],
+        )
+
+    def test_explicit_empty_delegation_chain_disables_parent_inheritance(self):
+        """``delegation.fallback_providers: []`` means no child fallback."""
+        parent = _make_mock_parent(depth=0)
+        parent._fallback_chain = [{"provider": "head", "model": "head-fallback"}]
+
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch(
+                "tools.delegate_tool._load_config",
+                return_value={"fallback_providers": []},
+            ),
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test explicit empty fallback",
                 context=None,
                 toolsets=None,
                 model=None,

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1462,11 +1462,20 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # A delegation-specific fallback chain isolates worker recovery from the
+    # head agent's routing policy.  Preserve the historical parent-chain
+    # inheritance only when the delegation config omits this key entirely;
+    # an explicit empty list deliberately disables fallback inheritance.
+    # Reuse the canonical normalizer so malformed entries and duplicate routes
+    # behave exactly like top-level ``fallback_providers``.
+    if "fallback_providers" in delegation_cfg:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        child_fallback = get_fallback_chain(
+            {"fallback_providers": delegation_cfg["fallback_providers"]}
+        ) or None
+    else:
+        child_fallback = getattr(parent_agent, "_fallback_chain", None) or None
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1521,7 +1530,7 @@ def _build_child_agent(
 
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
-            fallback_model=parent_fallback,
+            fallback_model=child_fallback,
             enabled_toolsets=child_toolsets,
             disabled_toolsets=child_disabled_toolsets,
             quiet_mode=True,


### PR DESCRIPTION
## Summary

- honor `delegation.fallback_providers` when constructing delegated child agents
- preserve parent-chain inheritance when the delegation key is absent
- treat an explicit empty delegation chain as disabling inherited fallbacks
- normalize worker fallback entries through the shared fallback-chain helper

Fixes #65038

## Validation

- `python -m pytest tests/tools/test_delegate.py tests/run_agent/test_provider_fallback.py -q` (79 passed)
- `ruff check tools/delegate_tool.py tests/tools/test_delegate.py`
- `git diff --check origin/main...HEAD`