### PR TITLE
feat(kanban): enforce physical-node capacity leases

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -456,6 +456,69 @@ def _merge_custom_provider_extra_body(agent, custom_providers: List[Dict[str, An
     agent.request_overrides = overrides
 
 
+def _resolve_startup_model_context_length(
+    *,
+    model_cfg: Any,
+    active_model: str,
+    active_provider: str,
+    active_base_url: str,
+) -> Optional[int]:
+    """Resolve a startup context pin scoped to the actual runtime model.
+
+    ``model.context_length`` belongs to ``model.default`` and must not leak to
+    a different ``--model`` override.  Profiles can declare truthful metadata
+    for startup overrides under ``model.models.<id>.context_length``; this
+    helper selects that value only when the configured and active routes still
+    match.
+    """
+    if not isinstance(model_cfg, dict):
+        return None
+
+    configured_provider = str(model_cfg.get("provider") or "").strip()
+    configured_base_url = model_cfg.get("base_url")
+    if _context_route_mismatch(
+        configured_base_url,
+        active_base_url,
+        configured_provider,
+        active_provider,
+    ):
+        return None
+
+    active_runtime_model = str(active_model or "").strip()
+    configured_runtime_model = str(model_cfg.get("default") or "").strip()
+    try:
+        from hermes_cli.model_normalize import normalize_model_for_provider
+
+        active_runtime_model = normalize_model_for_provider(
+            active_runtime_model, active_provider
+        )
+        configured_runtime_model = normalize_model_for_provider(
+            configured_runtime_model, active_provider
+        )
+    except Exception:
+        pass
+
+    raw_context_length: Any = None
+    if configured_runtime_model and active_runtime_model == configured_runtime_model:
+        raw_context_length = model_cfg.get("context_length")
+    else:
+        models = model_cfg.get("models")
+        if isinstance(models, dict):
+            entry = models.get(active_model)
+            if entry is None:
+                entry = models.get(active_runtime_model)
+            if isinstance(entry, dict):
+                raw_context_length = entry.get("context_length")
+
+    try:
+        if isinstance(raw_context_length, bool):
+            return None
+        parsed = int(raw_context_length)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -2304,6 +2367,19 @@ def init_agent(
                 _configured_base_url or _model_cfg.get("provider"),
             )
             _config_context_length = None
+
+    # A direct ``--model`` override may carry its own truthful profile-level
+    # metadata. Resolve it after rejecting the default model's pin so the
+    # override never inherits stale context while still avoiding a weak
+    # endpoint/catalog fallback (commonly 8K for local aliases).
+    _startup_model_context_length = _resolve_startup_model_context_length(
+        model_cfg=_model_cfg,
+        active_model=agent.model,
+        active_provider=agent.provider,
+        active_base_url=agent.base_url,
+    )
+    if _startup_model_context_length is not None:
+        _config_context_length = _startup_model_context_length
 
     # Store for reuse by _check_compression_model_feasibility (auxiliary
     # compression model context-length detection needs the same list).

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1471,6 +1471,19 @@ class GatewayKanbanWatchersMixin:
                             slug,
                             len(node_capped),
                         )
+                    node_conflicts = (
+                        getattr(res, "node_lease_conflicts", None) or []
+                        if res is not None
+                        else []
+                    )
+                    if node_conflicts:
+                        logger.error(
+                            "kanban dispatcher [%s]: %d running task(s) lack "
+                            "their configured physical-node lease: %s",
+                            slug,
+                            len(node_conflicts),
+                            node_conflicts,
+                        )
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
                         # Quiet by default — only log when something actually

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1138,6 +1138,19 @@ class GatewayKanbanWatchersMixin:
                         max_in_progress_per_profile,
                     )
 
+        node_leases = kanban_cfg.get("node_leases", {})
+        if not isinstance(node_leases, dict):
+            logger.warning(
+                "kanban dispatcher: invalid kanban.node_leases=%r; disabling",
+                node_leases,
+            )
+            node_leases = {}
+        elif node_leases.get("enabled"):
+            logger.info(
+                "kanban dispatcher: physical node leases enabled for %d profile(s)",
+                len(node_leases.get("profile_to_node", {}) or {}),
+            )
+
         # Initial delay so the gateway finishes wiring adapters before the
         # dispatcher spawns workers (those workers may hit gateway notify
         # subscriptions etc.). Matches the notifier watcher's delay.
@@ -1231,6 +1244,7 @@ class GatewayKanbanWatchersMixin:
                     stale_timeout_seconds=stale_timeout_seconds,
                     default_assignee=default_assignee,
                     max_in_progress_per_profile=max_in_progress_per_profile,
+                    node_leases=node_leases,
                 )
             except sqlite3.DatabaseError as exc:
                 if _is_corrupt_board_db_error(exc):

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1457,14 +1457,28 @@ class GatewayKanbanWatchersMixin:
                     await asyncio.to_thread(_auto_decompose_tick, _ad_per_tick)
                 results = await asyncio.to_thread(_tick_once)
                 any_spawned = False
+                node_capped_total = 0
                 for slug, res in (results or []):
+                    node_capped = (
+                        getattr(res, "skipped_node_capped", None) or []
+                        if res is not None
+                        else []
+                    )
+                    if node_capped:
+                        node_capped_total += len(node_capped)
+                        logger.debug(
+                            "kanban dispatcher [%s]: node-capped=%d",
+                            slug,
+                            len(node_capped),
+                        )
                     if res is not None and getattr(res, "spawned", None):
                         any_spawned = True
                         # Quiet by default — only log when something actually
                         # happened, so an idle gateway stays silent.
                         logger.info(
                             "kanban dispatcher [%s]: spawned=%d reclaimed=%d "
-                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d",
+                            "crashed=%d timed_out=%d promoted=%d auto_blocked=%d "
+                            "node_capped=%d",
                             slug,
                             len(res.spawned),
                             res.reclaimed,
@@ -1472,6 +1486,7 @@ class GatewayKanbanWatchersMixin:
                             len(res.timed_out) if hasattr(res.timed_out, "__len__") else 0,
                             res.promoted,
                             len(res.auto_blocked) if hasattr(res.auto_blocked, "__len__") else 0,
+                            len(node_capped),
                         )
                 # Health telemetry (aggregate across boards)
                 ready_pending = await asyncio.to_thread(_ready_nonempty)
@@ -1483,11 +1498,13 @@ class GatewayKanbanWatchersMixin:
                     now = int(time.time())
                     if now - last_warn_at >= 300:
                         logger.warning(
-                            "kanban dispatcher stuck: ready queue non-empty for "
+                            "kanban dispatcher deferred or stuck: ready queue non-empty for "
                             "%d consecutive ticks but 0 workers spawned. Check "
-                            "profile health (venv, PATH, credentials) and "
+                            "node lease capacity (last tick node-capped=%d), profile "
+                            "health (venv, PATH, credentials), and "
                             "`hermes kanban list --status ready`.",
                             bad_ticks,
+                            node_capped_total,
                         )
                         last_warn_at = now
             except asyncio.CancelledError:

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2508,6 +2508,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 {"task_id": tid, "assignee": who, "node": node}
                 for (tid, who, node) in res.skipped_node_capped
             ],
+            "node_lease_conflicts": [
+                {"task_id": tid, "assignee": who, "node": node}
+                for (tid, who, node) in res.node_lease_conflicts
+            ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
         return 0
@@ -2544,6 +2548,12 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
     if res.skipped_node_capped:
         for tid, who, node in res.skipped_node_capped:
             print(f"Deferred ({who} waiting for physical node {node or '<unmapped>'}): {tid}")
+    if res.node_lease_conflicts:
+        for tid, who, node in res.node_lease_conflicts:
+            print(
+                f"CONFLICT (running {who} lacks physical-node lease "
+                f"{node or '<unmapped>'}): {tid}"
+            )
     if res.skipped_nonspawnable:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2460,6 +2460,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             _kanban_cfg.get("max_in_progress_per_profile")
         )
         max_in_progress = _coerce_positive_int(_kanban_cfg.get("max_in_progress"))
+        node_leases = _kanban_cfg.get("node_leases", {})
+        if not isinstance(node_leases, dict):
+            node_leases = {}
         # CLI --max overrides config kanban.max_spawn when both are present;
         # CLI is the more explicit signal so it wins.
         cli_max = getattr(args, "max", None)
@@ -2470,6 +2473,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         default_assignee = None
         max_in_progress_per_profile = None
         max_in_progress = None
+        node_leases = {}
         max_spawn = getattr(args, "max", None)
     with kb.connect_closing() as conn:
         res = kb.dispatch_once(
@@ -2480,6 +2484,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            node_leases=node_leases,
         )
     if getattr(args, "json", False):
         print(json.dumps({
@@ -2498,6 +2503,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             "skipped_per_profile_capped": [
                 {"task_id": tid, "assignee": who, "current": current}
                 for (tid, who, current) in res.skipped_per_profile_capped
+            ],
+            "skipped_node_capped": [
+                {"task_id": tid, "assignee": who, "node": node}
+                for (tid, who, node) in res.skipped_node_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
         }, indent=2))
@@ -2532,6 +2541,9 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             print(
                 f"Deferred ({who} at per-profile cap, {current} running): {tid}"
             )
+    if res.skipped_node_capped:
+        for tid, who, node in res.skipped_node_capped:
+            print(f"Deferred ({who} waiting for physical node {node or '<unmapped>'}): {tid}")
     if res.skipped_nonspawnable:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6824,6 +6824,10 @@ class DispatchResult:
     """Tasks deferred by physical-node capacity as
     ``(task_id, assignee, node)``. Profiles sharing one backend therefore
     share one real concurrency budget rather than independent alias budgets."""
+    node_lease_conflicts: list[tuple[str, str, str]] = field(default_factory=list)
+    """Already-running tasks whose physical-node lease could not be refreshed,
+    as ``(task_id, assignee, node)``. This is an operator-actionable capacity
+    breach signal, not an ordinary ready-task deferral."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -8390,13 +8394,21 @@ def _dispatch_once_locked(
                 if owner.startswith(_db_owner_prefix) and owner not in running_owners:
                     _node_pool.release(owner=owner)
         for running in running_rows:
-            _node_pool.try_acquire(
+            refreshed = _node_pool.try_acquire(
                 profile=running["assignee"] or "",
                 owner=_db_owner_prefix + running["id"],
                 profile_to_node=_profile_to_node,
                 capacities=_node_capacities,
                 ttl_seconds=_node_ttl,
             )
+            if refreshed is None:
+                result.node_lease_conflicts.append(
+                    (
+                        running["id"],
+                        running["assignee"] or "",
+                        str(_profile_to_node.get(running["assignee"] or "") or ""),
+                    )
+                )
     _dry_node_counts = (
         {
             name: int(data.get("in_use", 0))

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6820,6 +6820,10 @@ class DispatchResult:
     subsequent tick when the assignee has capacity. Separate bucket so
     telemetry / dashboards can show "this profile is busy" vs
     "task is genuinely stuck"."""
+    skipped_node_capped: list[tuple[str, str, str]] = field(default_factory=list)
+    """Tasks deferred by physical-node capacity as
+    ``(task_id, assignee, node)``. Profiles sharing one backend therefore
+    share one real concurrency budget rather than independent alias budgets."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -8214,6 +8218,8 @@ def dispatch_once(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    node_leases: Optional[dict[str, Any]] = None,
+    node_lease_pool: Any = None,
 ) -> DispatchResult:
     """Run one dispatcher tick under the board's single-writer lock.
 
@@ -8248,6 +8254,8 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            node_leases=node_leases,
+            node_lease_pool=node_lease_pool,
         )
     with _dispatch_tick_lock(db_path) as held:
         if not held:
@@ -8264,6 +8272,8 @@ def dispatch_once(
             board=board,
             default_assignee=default_assignee,
             max_in_progress_per_profile=max_in_progress_per_profile,
+            node_leases=node_leases,
+            node_lease_pool=node_lease_pool,
         )
         # Still under the dispatch lock: opportunistically truncate the WAL
         # at a coarse interval so it cannot grow unbounded between restarts.
@@ -8284,6 +8294,8 @@ def _dispatch_once_locked(
     board: Optional[str] = None,
     default_assignee: Optional[str] = None,
     max_in_progress_per_profile: Optional[int] = None,
+    node_leases: Optional[dict[str, Any]] = None,
+    node_lease_pool: Any = None,
 ) -> DispatchResult:
     """Run one dispatcher tick.
 
@@ -8341,6 +8353,58 @@ def _dispatch_once_locked(
         result.rate_limited.extend(_crash_rate_limited)
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn, failure_limit=failure_limit)
+
+    # Physical-node leases are process-shared under HERMES_KANBAN_HOME. This
+    # closes the alias gap where two profiles both look idle while routing to
+    # the same capacity-1 inference backend.
+    _node_cfg = node_leases if isinstance(node_leases, dict) else {}
+    _node_leases_enabled = bool(_node_cfg.get("enabled", False))
+    _profile_to_node = _node_cfg.get("profile_to_node", {})
+    _node_capacities = _node_cfg.get("capacities", {})
+    if not isinstance(_profile_to_node, dict):
+        _profile_to_node = {}
+    if not isinstance(_node_capacities, dict):
+        _node_capacities = {}
+    try:
+        _node_ttl = max(
+            1,
+            int(_node_cfg.get("ttl_seconds", ttl_seconds or DEFAULT_CLAIM_TTL_SECONDS)),
+        )
+    except (TypeError, ValueError):
+        _node_ttl = int(ttl_seconds or DEFAULT_CLAIM_TTL_SECONDS)
+    _node_pool = node_lease_pool
+    if _node_leases_enabled and _node_pool is None:
+        from hermes_cli.node_leases import default_pool
+
+        _node_pool = default_pool()
+    _db_owner_prefix = f"{kanban_db_path(board=board).resolve()}:"
+    if _node_leases_enabled:
+        # Reconcile this board before new work: finished tasks release now;
+        # running tasks refresh before a ready task can take their slot.
+        running_rows = conn.execute(
+            "SELECT id, assignee FROM tasks WHERE status = 'running'"
+        ).fetchall()
+        running_owners = {_db_owner_prefix + row["id"] for row in running_rows}
+        for node_state in _node_pool.snapshot().values():
+            for owner in node_state.get("owners", []):
+                if owner.startswith(_db_owner_prefix) and owner not in running_owners:
+                    _node_pool.release(owner=owner)
+        for running in running_rows:
+            _node_pool.try_acquire(
+                profile=running["assignee"] or "",
+                owner=_db_owner_prefix + running["id"],
+                profile_to_node=_profile_to_node,
+                capacities=_node_capacities,
+                ttl_seconds=_node_ttl,
+            )
+    _dry_node_counts = (
+        {
+            name: int(data.get("in_use", 0))
+            for name, data in _node_pool.snapshot().items()
+        }
+        if _node_leases_enabled and dry_run
+        else {}
+    )
 
     # Count tasks already running so max_spawn enforces concurrency rather
     # than a per-tick spawn budget. See the docstring above for the full
@@ -8517,6 +8581,38 @@ def _dispatch_once_locked(
                         {"reason": guard_reason},
                     )
             continue
+        _node_lease = None
+        _node_name = str(_profile_to_node.get(row_assignee) or "").strip()
+        if _node_leases_enabled:
+            if dry_run:
+                try:
+                    _node_capacity = int(_node_capacities.get(_node_name, 0))
+                except (TypeError, ValueError):
+                    _node_capacity = 0
+                _node_current = _dry_node_counts.get(_node_name, 0)
+                if (
+                    not _node_name
+                    or _node_capacity < 1
+                    or _node_current >= _node_capacity
+                ):
+                    result.skipped_node_capped.append(
+                        (row["id"], row_assignee, _node_name)
+                    )
+                    continue
+                _dry_node_counts[_node_name] = _node_current + 1
+            else:
+                _node_lease = _node_pool.try_acquire(
+                    profile=row_assignee,
+                    owner=_db_owner_prefix + row["id"],
+                    profile_to_node=_profile_to_node,
+                    capacities=_node_capacities,
+                    ttl_seconds=_node_ttl,
+                )
+                if _node_lease is None:
+                    result.skipped_node_capped.append(
+                        (row["id"], row_assignee, _node_name)
+                    )
+                    continue
         if dry_run:
             result.spawned.append((row["id"], row_assignee, ""))
             # Increment per-profile counter even in dry_run so the cap
@@ -8530,6 +8626,8 @@ def _dispatch_once_locked(
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if _node_lease is not None:
+                _node_lease.release()
             continue
         try:
             resolved_branch_name = None
@@ -8538,6 +8636,8 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            if _node_lease is not None:
+                _node_lease.release()
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
@@ -8583,6 +8683,8 @@ def _dispatch_once_locked(
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
         except Exception as exc:
+            if _node_lease is not None:
+                _node_lease.release()
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,
@@ -8617,11 +8719,45 @@ def _dispatch_once_locked(
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
             continue
+        _review_node_lease = None
+        _review_node_name = str(_profile_to_node.get(row["assignee"]) or "").strip()
+        if _node_leases_enabled:
+            if dry_run:
+                try:
+                    _review_capacity = int(_node_capacities.get(_review_node_name, 0))
+                except (TypeError, ValueError):
+                    _review_capacity = 0
+                _review_current = _dry_node_counts.get(_review_node_name, 0)
+                if (
+                    not _review_node_name
+                    or _review_capacity < 1
+                    or _review_current >= _review_capacity
+                ):
+                    result.skipped_node_capped.append(
+                        (row["id"], row["assignee"], _review_node_name)
+                    )
+                    continue
+                _dry_node_counts[_review_node_name] = _review_current + 1
+            else:
+                _review_node_lease = _node_pool.try_acquire(
+                    profile=row["assignee"],
+                    owner=_db_owner_prefix + row["id"],
+                    profile_to_node=_profile_to_node,
+                    capacities=_node_capacities,
+                    ttl_seconds=_node_ttl,
+                )
+                if _review_node_lease is None:
+                    result.skipped_node_capped.append(
+                        (row["id"], row["assignee"], _review_node_name)
+                    )
+                    continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
             continue
         claimed = claim_review_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
+            if _review_node_lease is not None:
+                _review_node_lease.release()
             continue
         try:
             resolved_branch_name = None
@@ -8630,6 +8766,8 @@ def _dispatch_once_locked(
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
+            if _review_node_lease is not None:
+                _review_node_lease.release()
             auto = _record_spawn_failure(
                 conn, claimed.id, f"workspace: {exc}",
                 failure_limit=failure_limit,
@@ -8664,6 +8802,8 @@ def _dispatch_once_locked(
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
         except Exception as exc:
+            if _review_node_lease is not None:
+                _review_node_lease.release()
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
                 failure_limit=failure_limit,

--- a/hermes_cli/node_leases.py
+++ b/hermes_cli/node_leases.py
@@ -1,0 +1,198 @@
+"""Cross-process physical-node capacity leases for Kanban workers.
+
+The registry is intentionally filesystem-backed and guarded by POSIX
+``flock`` so independent dispatcher processes sharing ``HERMES_KANBAN_HOME``
+make one atomic capacity decision. Lease expiry provides crash recovery.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import Any, Callable, Iterator, Mapping, Optional
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - POSIX-only feature
+    fcntl = None  # type: ignore[assignment]
+
+
+@dataclass(frozen=True)
+class NodeLease:
+    """One acquired physical-node capacity slot."""
+
+    pool: "PosixNodeLeasePool"
+    node: str
+    profile: str
+    owner: str
+
+    def release(self) -> bool:
+        return self.pool.release(owner=self.owner, node=self.node)
+
+
+class PosixNodeLeasePool:
+    """Atomic, process-shared capacity registry keyed by physical node."""
+
+    def __init__(
+        self,
+        *,
+        root: Path | str,
+        now_fn: Callable[[], float] = time.time,
+    ) -> None:
+        if fcntl is None:
+            raise RuntimeError("physical node leases require POSIX fcntl.flock")
+        self.root = Path(root)
+        self._state_path = self.root / "state.json"
+        self._lock_path = self.root / "state.lock"
+        self._now_fn = now_fn
+
+    @contextmanager
+    def _locked_state(self) -> Iterator[dict[str, Any]]:
+        self.root.mkdir(parents=True, exist_ok=True)
+        fd = os.open(self._lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            state = self._read_state()
+            self._prune_expired(state)
+            yield state
+            self._write_state(state)
+        finally:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_UN)
+            finally:
+                os.close(fd)
+
+    def _read_state(self) -> dict[str, Any]:
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, TypeError):
+            return {"nodes": {}}
+        if not isinstance(data, dict) or not isinstance(data.get("nodes"), dict):
+            return {"nodes": {}}
+        return data
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        fd, temp_name = tempfile.mkstemp(prefix="state.", suffix=".tmp", dir=self.root)
+        try:
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(state, handle, sort_keys=True, separators=(",", ":"))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_name, self._state_path)
+        except Exception:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+            try:
+                os.unlink(temp_name)
+            except OSError:
+                pass
+            raise
+
+    def _prune_expired(self, state: dict[str, Any]) -> None:
+        now = float(self._now_fn())
+        nodes = state.setdefault("nodes", {})
+        for node in list(nodes):
+            node_state = nodes.get(node)
+            if not isinstance(node_state, dict):
+                nodes.pop(node, None)
+                continue
+            leases = node_state.get("leases")
+            if not isinstance(leases, list):
+                leases = []
+            node_state["leases"] = [
+                lease
+                for lease in leases
+                if isinstance(lease, dict)
+                and float(lease.get("expires_at", 0) or 0) > now
+            ]
+            if not node_state["leases"]:
+                nodes.pop(node, None)
+
+    def try_acquire(
+        self,
+        *,
+        profile: str,
+        owner: str,
+        profile_to_node: Mapping[str, str],
+        capacities: Mapping[str, int],
+        ttl_seconds: int,
+    ) -> Optional[NodeLease]:
+        node = str(profile_to_node.get(profile) or "").strip()
+        if not node or not owner:
+            return None
+        try:
+            capacity = int(capacities.get(node, 0))
+            ttl = int(ttl_seconds)
+        except (TypeError, ValueError):
+            return None
+        if capacity < 1 or ttl < 1:
+            return None
+
+        now = float(self._now_fn())
+        with self._locked_state() as state:
+            node_state = state.setdefault("nodes", {}).setdefault(
+                node, {"capacity": capacity, "leases": []}
+            )
+            node_state["capacity"] = capacity
+            leases = node_state.setdefault("leases", [])
+            for existing in leases:
+                if existing.get("owner") == owner:
+                    existing.update(
+                        profile=profile,
+                        expires_at=now + ttl,
+                    )
+                    return NodeLease(self, node, profile, owner)
+            if len(leases) >= capacity:
+                return None
+            leases.append(
+                {
+                    "owner": owner,
+                    "profile": profile,
+                    "expires_at": now + ttl,
+                }
+            )
+        return NodeLease(self, node, profile, owner)
+
+    def release(self, *, owner: str, node: Optional[str] = None) -> bool:
+        removed = False
+        with self._locked_state() as state:
+            nodes = state.setdefault("nodes", {})
+            targets = [node] if node else list(nodes)
+            for target in targets:
+                node_state = nodes.get(target)
+                if not isinstance(node_state, dict):
+                    continue
+                leases = node_state.get("leases", [])
+                kept = [lease for lease in leases if lease.get("owner") != owner]
+                if len(kept) != len(leases):
+                    removed = True
+                    node_state["leases"] = kept
+                if not kept:
+                    nodes.pop(target, None)
+        return removed
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        with self._locked_state() as state:
+            result: dict[str, dict[str, Any]] = {}
+            for node, node_state in state.get("nodes", {}).items():
+                leases = node_state.get("leases", [])
+                result[node] = {
+                    "capacity": int(node_state.get("capacity", 0) or 0),
+                    "in_use": len(leases),
+                    "owners": sorted(str(lease.get("owner") or "") for lease in leases),
+                    "profiles": sorted(str(lease.get("profile") or "") for lease in leases),
+                }
+            return result
+
+
+def default_pool() -> PosixNodeLeasePool:
+    home = Path(os.environ.get("HERMES_KANBAN_HOME") or os.environ.get("HERMES_HOME") or Path.home() / ".hermes")
+    return PosixNodeLeasePool(root=home / "kanban" / "node-leases")

--- a/tests/agent/test_startup_model_context_override.py
+++ b/tests/agent/test_startup_model_context_override.py
@@ -1,0 +1,46 @@
+"""Startup context resolution for explicit model overrides."""
+
+from agent import agent_init
+
+
+def test_model_override_uses_matching_per_model_context_metadata():
+    """`--model` must use its own metadata instead of the default model's pin."""
+    resolver = getattr(agent_init, "_resolve_startup_model_context_length", None)
+    assert resolver is not None, "startup per-model context resolver is missing"
+
+    resolved = resolver(
+        model_cfg={
+            "default": "gpu-swe-qwen3",
+            "provider": "custom",
+            "base_url": "http://192.168.0.8:4000/v1",
+            "context_length": 65_536,
+            "models": {
+                "code-gemma": {"context_length": 65_536},
+            },
+        },
+        active_model="code-gemma",
+        active_provider="custom",
+        active_base_url="http://192.168.0.8:4000/v1",
+    )
+
+    assert resolved == 65_536
+
+
+def test_model_override_does_not_inherit_unscoped_default_context_pin():
+    """A different model without metadata must not inherit the default's window."""
+    resolver = getattr(agent_init, "_resolve_startup_model_context_length", None)
+    assert resolver is not None, "startup per-model context resolver is missing"
+
+    resolved = resolver(
+        model_cfg={
+            "default": "gpu-swe-qwen3",
+            "provider": "custom",
+            "base_url": "http://192.168.0.8:4000/v1",
+            "context_length": 65_536,
+        },
+        active_model="unknown-model",
+        active_provider="custom",
+        active_base_url="http://192.168.0.8:4000/v1",
+    )
+
+    assert resolved is None

--- a/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
+++ b/tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py
@@ -43,6 +43,11 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
             "max_spawn": 5,
             "default_assignee": "default",
             "max_in_progress_per_profile": 2,
+            "node_leases": {
+                "enabled": True,
+                "profile_to_node": {"default": "local-node"},
+                "capacities": {"local-node": 1},
+            },
         }
     }
     monkeypatch.setattr(
@@ -69,6 +74,7 @@ def test_cli_dispatch_passes_max_in_progress_from_config(isolated_kanban_home, m
     )
     assert captured.get("default_assignee") == "default"
     assert captured.get("max_in_progress_per_profile") == 2
+    assert captured.get("node_leases") == fake_config["kanban"]["node_leases"]
 
 
 def test_cli_max_flag_overrides_config_max_spawn(isolated_kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_node_leases.py
+++ b/tests/hermes_cli/test_node_leases.py
@@ -1,7 +1,35 @@
 """POSIX physical-node lease regression tests."""
 
+import multiprocessing
+import os
+
+import pytest
+
 from hermes_cli import node_leases
 from hermes_cli import kanban_db as kb
+
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix",
+    reason="physical node leases require POSIX fcntl.flock",
+)
+
+
+def _acquire_in_child(root, start, release, results, owner):
+    """Contend for one slot from an independent OS process."""
+    pool = node_leases.PosixNodeLeasePool(root=root)
+    start.wait(timeout=10)
+    lease = pool.try_acquire(
+        profile="worker",
+        owner=owner,
+        profile_to_node={"worker": "shared-node"},
+        capacities={"shared-node": 1},
+        ttl_seconds=60,
+    )
+    results.put((owner, lease is not None))
+    if lease is not None:
+        release.wait(timeout=10)
+        lease.release()
 
 
 def _pool(tmp_path, now):
@@ -36,6 +64,31 @@ def test_profiles_on_same_capacity_one_node_cannot_both_acquire(tmp_path):
     assert lease is not None
     assert blocked is None
     assert first.snapshot()["m4-pro"]["in_use"] == 1
+
+
+def test_separate_processes_cannot_both_acquire_capacity_one_node(tmp_path):
+    ctx = multiprocessing.get_context("fork")
+    start = ctx.Event()
+    release = ctx.Event()
+    results = ctx.Queue()
+    processes = [
+        ctx.Process(
+            target=_acquire_in_child,
+            args=(str(tmp_path / "leases"), start, release, results, owner),
+        )
+        for owner in ("process-a", "process-b")
+    ]
+
+    for process in processes:
+        process.start()
+    start.set()
+    outcomes = [results.get(timeout=10), results.get(timeout=10)]
+    release.set()
+    for process in processes:
+        process.join(timeout=10)
+
+    assert sum(acquired for _owner, acquired in outcomes) == 1
+    assert all(process.exitcode == 0 for process in processes)
 
 
 def test_profiles_on_different_nodes_can_acquire_concurrently(tmp_path):
@@ -147,6 +200,39 @@ def test_dispatcher_allows_profiles_on_different_nodes(tmp_path, monkeypatch):
 
     assert len(result.spawned) == 2
     assert result.skipped_node_capped == []
+
+
+def test_spawn_failure_releases_node_for_next_ready_task(tmp_path, monkeypatch):
+    home = _fresh_board(tmp_path, monkeypatch)
+
+    def spawn(task, _workspace):
+        if task.assignee == "architect":
+            raise RuntimeError("synthetic spawn failure")
+        return 12345
+
+    pool = node_leases.PosixNodeLeasePool(root=home / "node-leases")
+    with kb.connect_closing() as conn:
+        failed_id = kb.create_task(conn, title="architecture", assignee="architect")
+        kb.create_task(conn, title="planning", assignee="planner")
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=spawn,
+            node_leases={
+                "enabled": True,
+                "profile_to_node": {"architect": "m4-pro", "planner": "m4-pro"},
+                "capacities": {"m4-pro": 1},
+                "ttl_seconds": 60,
+            },
+            node_lease_pool=pool,
+        )
+
+    assert [assignee for _task_id, assignee, _workspace in result.spawned] == [
+        "planner"
+    ]
+    assert result.skipped_node_capped == []
+    assert pool.snapshot()["m4-pro"]["profiles"] == ["planner"]
+    with kb.connect_closing() as conn:
+        assert kb.get_task(conn, failed_id).status == "ready"
 
 
 def test_review_worker_respects_same_physical_node_capacity(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_node_leases.py
+++ b/tests/hermes_cli/test_node_leases.py
@@ -1,0 +1,174 @@
+"""POSIX physical-node lease regression tests."""
+
+from hermes_cli import node_leases
+from hermes_cli import kanban_db as kb
+
+
+def _pool(tmp_path, now):
+    return node_leases.PosixNodeLeasePool(
+        root=tmp_path / "leases",
+        now_fn=lambda: now[0],
+    )
+
+
+def test_profiles_on_same_capacity_one_node_cannot_both_acquire(tmp_path):
+    now = [100.0]
+    first = _pool(tmp_path, now)
+    second = _pool(tmp_path, now)
+    mapping = {"architect": "m4-pro", "planner": "m4-pro"}
+    capacities = {"m4-pro": 1}
+
+    lease = first.try_acquire(
+        profile="architect",
+        owner="task-a",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=60,
+    )
+    blocked = second.try_acquire(
+        profile="planner",
+        owner="task-b",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=60,
+    )
+
+    assert lease is not None
+    assert blocked is None
+    assert first.snapshot()["m4-pro"]["in_use"] == 1
+
+
+def test_profiles_on_different_nodes_can_acquire_concurrently(tmp_path):
+    now = [100.0]
+    pool = _pool(tmp_path, now)
+    mapping = {"architect": "m4-pro", "swe": "rx7900xtx"}
+    capacities = {"m4-pro": 1, "rx7900xtx": 1}
+
+    first = pool.try_acquire(
+        profile="architect",
+        owner="task-a",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=60,
+    )
+    second = pool.try_acquire(
+        profile="swe",
+        owner="task-b",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=60,
+    )
+
+    assert first is not None
+    assert second is not None
+
+
+def test_expired_lease_is_recovered(tmp_path):
+    now = [100.0]
+    pool = _pool(tmp_path, now)
+    mapping = {"architect": "m4-pro", "planner": "m4-pro"}
+    capacities = {"m4-pro": 1}
+
+    assert pool.try_acquire(
+        profile="architect",
+        owner="task-a",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=10,
+    ) is not None
+
+    now[0] = 111.0
+    recovered = pool.try_acquire(
+        profile="planner",
+        owner="task-b",
+        profile_to_node=mapping,
+        capacities=capacities,
+        ttl_seconds=10,
+    )
+
+    assert recovered is not None
+    assert recovered.node == "m4-pro"
+    assert pool.snapshot()["m4-pro"]["owners"] == ["task-b"]
+
+
+def _fresh_board(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def test_dispatcher_excludes_profiles_sharing_capacity_one_node(tmp_path, monkeypatch):
+    home = _fresh_board(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="architecture", assignee="architect")
+        kb.create_task(conn, title="planning", assignee="planner")
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            node_leases={
+                "enabled": True,
+                "profile_to_node": {"architect": "m4-pro", "planner": "m4-pro"},
+                "capacities": {"m4-pro": 1},
+                "ttl_seconds": 60,
+            },
+            node_lease_pool=node_leases.PosixNodeLeasePool(
+                root=home / "node-leases"
+            ),
+        )
+
+    assert len(result.spawned) == 1
+    assert len(result.skipped_node_capped) == 1
+    assert result.skipped_node_capped[0][2] == "m4-pro"
+
+
+def test_dispatcher_allows_profiles_on_different_nodes(tmp_path, monkeypatch):
+    home = _fresh_board(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="architecture", assignee="architect")
+        kb.create_task(conn, title="implementation", assignee="swe")
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            node_leases={
+                "enabled": True,
+                "profile_to_node": {"architect": "m4-pro", "swe": "rx7900xtx"},
+                "capacities": {"m4-pro": 1, "rx7900xtx": 1},
+                "ttl_seconds": 60,
+            },
+            node_lease_pool=node_leases.PosixNodeLeasePool(
+                root=home / "node-leases"
+            ),
+        )
+
+    assert len(result.spawned) == 2
+    assert result.skipped_node_capped == []
+
+
+def test_review_worker_respects_same_physical_node_capacity(tmp_path, monkeypatch):
+    home = _fresh_board(tmp_path, monkeypatch)
+    with kb.connect_closing() as conn:
+        kb.create_task(conn, title="active planning", assignee="planner")
+        review_id = kb.create_task(conn, title="architecture review", assignee="architect")
+        with kb.write_txn(conn):
+            conn.execute("UPDATE tasks SET status = 'review' WHERE id = ?", (review_id,))
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: 12345,
+            node_leases={
+                "enabled": True,
+                "profile_to_node": {"architect": "m4-pro", "planner": "m4-pro"},
+                "capacities": {"m4-pro": 1},
+                "ttl_seconds": 60,
+            },
+            node_lease_pool=node_leases.PosixNodeLeasePool(
+                root=home / "node-leases"
+            ),
+        )
+
+    assert len(result.spawned) == 1
+    assert result.skipped_node_capped == [(review_id, "architect", "m4-pro")]

--- a/tests/hermes_cli/test_node_leases.py
+++ b/tests/hermes_cli/test_node_leases.py
@@ -235,6 +235,45 @@ def test_spawn_failure_releases_node_for_next_ready_task(tmp_path, monkeypatch):
         assert kb.get_task(conn, failed_id).status == "ready"
 
 
+def test_running_task_reports_conflict_when_lease_cannot_be_refreshed(
+    tmp_path, monkeypatch
+):
+    home = _fresh_board(tmp_path, monkeypatch)
+    pool = node_leases.PosixNodeLeasePool(root=home / "node-leases")
+    config = {
+        "enabled": True,
+        "profile_to_node": {"architect": "m4-pro", "planner": "m4-pro"},
+        "capacities": {"m4-pro": 1},
+        "ttl_seconds": 60,
+    }
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="architecture", assignee="architect")
+        kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+            node_leases=config,
+            node_lease_pool=pool,
+        )
+        owner = pool.snapshot()["m4-pro"]["owners"][0]
+        assert pool.release(owner=owner)
+        assert pool.try_acquire(
+            profile="planner",
+            owner="other-board:task",
+            profile_to_node=config["profile_to_node"],
+            capacities=config["capacities"],
+            ttl_seconds=60,
+        ) is not None
+
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *_args, **_kwargs: os.getpid(),
+            node_leases=config,
+            node_lease_pool=pool,
+        )
+
+    assert result.node_lease_conflicts == [(task_id, "architect", "m4-pro")]
+
+
 def test_review_worker_respects_same_physical_node_capacity(tmp_path, monkeypatch):
     home = _fresh_board(tmp_path, monkeypatch)
     with kb.connect_closing() as conn:

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -757,12 +757,25 @@ All commands are also available as a slash command in the interactive CLI and in
 |------------|---------|--------------|
 | `kanban.max_in_progress` | unset (unlimited) | Caps the number of simultaneously running tasks. When the board already has N running, the dispatcher skips spawning more — useful for slow workers (local LLMs, resource-constrained hosts) so they finish what they have before more pile up and time out. Invalid or below-1 values log a warning and behave as unlimited. |
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
+| `kanban.node_leases` | disabled | POSIX, filesystem-backed capacity leases keyed by normalized physical node. Use this when several profiles/aliases share one inference machine: `profile_to_node` maps profiles to hardware, `capacities` sets simultaneous jobs per node, and `ttl_seconds` controls crash recovery. The CLI and gateway dispatchers share the registry under `HERMES_KANBAN_HOME`. Unmapped profiles fail closed while enabled. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
 
 ```yaml
 kanban:
   max_in_progress: 2
+  node_leases:
+    enabled: true
+    ttl_seconds: 900
+    profile_to_node:
+      architect: m4-pro-24gb
+      planner: m4-pro-24gb
+      qa: m4-pro-24gb
+      devops: m4-pro-24gb
+      swe: rx7900xtx
+    capacities:
+      m4-pro-24gb: 1
+      rx7900xtx: 1
   auto_promote_children: false
   default_workdir: ~/work/active-project
 ```


### PR DESCRIPTION
## Summary

This draft adds POSIX filesystem-backed physical-node capacity leases to Kanban dispatch so profiles that resolve to aliases on the same inference machine share one real concurrency budget.

It also fixes startup context resolution for explicit `--model` overrides by consulting model-specific metadata only when it matches the active provider/model route. That prevents a valid 65,536-token override from falling back to stale catalog metadata without leaking the profile default route into an unrelated override.

## Why

Logical model aliases are not independent capacity. For example, Architect, Planner, QA, and DevOps may use different role names while all resolving to one M4 Pro. Existing global and per-profile limits cannot prevent those profiles from concurrently claiming a capacity-1 physical backend.

## Design

- `kanban.node_leases.enabled` is off by default.
- `profile_to_node` normalizes profiles to physical capacity pools.
- `capacities` declares the integer concurrency budget for each pool.
- a process-shared state file is guarded by POSIX `fcntl.flock`;
- the state update uses a same-directory temporary file, `fsync`, and atomic `os.replace`;
- expired owners are pruned by TTL for crash recovery;
- leases are acquired before claim/spawn and released on claim, workspace, or spawn failure;
- running tasks refresh their ownership each dispatch tick;
- finished tasks are reconciled out before new work is admitted;
- ready/review work is fail-closed when its profile is unmapped or its capacity is invalid/exhausted;
- already-running work that cannot refresh its configured lease is surfaced as `node_lease_conflicts` in the CLI and as a gateway error rather than remaining silent;
- dry-run dispatch reports the same physical-node deferrals without writing lease state.

## Configuration example

```yaml
kanban:
  node_leases:
    enabled: false
    ttl_seconds: 900
    profile_to_node:
      architect: node:m4-pro
      planner: node:m4-pro
      swe: node:gpu7900
    capacities:
      node:m4-pro: 1
      node:gpu7900: 1
```

## Verification

Run on current upstream `main` (`6e9cae6ac4`) plus this branch:

- `18 passed` in the focused node-lease, context-route, CLI passthrough, and gateway watcher suite.
- `8 passed` in `tests/hermes_cli/test_node_leases.py`, including:
  - two independent OS processes cannot both acquire one capacity-1 node;
  - profiles on separate nodes can acquire concurrently;
  - expired leases recover;
  - ready and review workers share the physical-node cap;
  - spawn failure releases the slot for the next eligible task;
  - running lease-refresh conflicts are surfaced.
- `38/38` relevant Kanban/context test modules pass when each module runs in an isolated pytest process.
- Ruff passes for every modified Python file.
- `git diff --check` passes.
- added-line scan found no hardcoded-secret, `shell=True`, or dynamic-eval patterns.

### Existing upstream test-isolation defect

Running all relevant Kanban modules in one pytest process produces seven order-dependent failures (`170 passed, 7 failed`) on this branch. The identical combined command on untouched upstream `main` produces the same seven failures (`159 passed, 7 failed`). Each affected module passes in isolation. This draft does not claim to fix that separate shared-test-state problem.

## Review assessment

**Verdict: suitable for draft review; not approved for deployment yet.**

Resolved during review:

- rebased the feature onto current upstream rather than publishing yesterday's shallow base;
- added a real cross-process exclusion regression test;
- added a non-POSIX test skip for the POSIX-only implementation;
- added failure-path lease-release coverage;
- added visible telemetry for ordinary node-cap deferrals and running-task lease conflicts.

Known operational constraints:

1. The lease implementation requires POSIX `fcntl.flock` and all competing dispatchers must share the same `HERMES_KANBAN_HOME` filesystem.
2. Crash recovery is TTL-based. A dead owner may conservatively hold capacity until expiry.
3. Enabling leases while tasks are already running can expose a conflict if their desired pool is already occupied. Deployment should therefore start from zero running Kanban workers and verify a dry run first.
4. Unmapped profiles fail closed. Cloud/default/heavy routes need an explicit scheduling policy before they are allowed through a node-leased dispatcher.
5. Runtime configuration, installation, service restart, and lease enablement are intentionally outside this PR and require a separate operator gate.

## Deployment boundary

No runtime config was changed, no service was restarted, no migration was run, and no node lease was enabled as part of this work.
