### PR TITLE
fix(gateway): reset inherited session context at ingress (#80224)

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5562,6 +5562,15 @@ class BasePlatformAdapter(ABC):
         if not self._message_handler:
             return
 
+        # Message-processing tasks inherit the ContextVars of the task that
+        # dispatches them.  Drop any sibling session identity at the adapter
+        # boundary, before topic recovery, lifecycle hooks, or typing work can
+        # run.  GatewayRunner._handle_message repeats this reset as defense in
+        # depth for synthetic/direct entrypoints that bypass the adapter.
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
+
         coerce_plaintext_gateway_command(event)
 
         # Telegram topic recovery only applies to private DM topic lanes. Do

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3567,6 +3567,11 @@ class BasePlatformAdapter(ABC):
         task so new messages (and interrupts) can arrive while an agent runs."""
         if not self._message_handler:
             return
+        # Dispatch tasks can inherit another turn's bound identity. Clear it before
+        # topic recovery, lifecycle hooks, or background tasks can spawn subprocesses.
+        from gateway.session_context import reset_session_vars
+
+        reset_session_vars()
         if event.allow_gateway_control:
             coerce_plaintext_gateway_command(event)
         # Topic recovery is Telegram-DM-only; skip the executor hop for group traffic.

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -31,6 +31,9 @@ from contextvars import copy_context
 import pytest
 
 import gateway.session_context as sc
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import SessionSource
 from gateway.session_context import (
     _SESSION_ASYNC_DELIVERY,
     _UNSET,
@@ -148,6 +151,66 @@ def test_reset_session_vars_closes_inheritance_leak():
     assert captured["bound"]["HERMES_SESSION_KEY"] == FOREIGN["session_key"]
 
 
+class _IngressProbeAdapter(BasePlatformAdapter):
+    """Capture the session env at the adapter's message-ingress boundary."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True), Platform.FEISHU)
+        self.set_message_handler(lambda _event: None)
+        self.ingress_env = None
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    def _start_session_processing(self, event, session_key, **kwargs):
+        self.ingress_env = _spawn_view()
+        return True
+
+
+def test_message_ingress_drops_inherited_session_before_adapter_work():
+    """A newly spawned message task must be clean at the adapter boundary.
+
+    ``GatewayRunner._handle_message`` also resets inherited state, but the base
+    adapter performs typing and lifecycle-hook work before it calls the runner.
+    That pre-runner window must not expose a sibling session to adapter code.
+    """
+    set_session_vars(**MINE)
+    adapter = _IngressProbeAdapter()
+    event = MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.FEISHU,
+            chat_id="FOREIGN_CHAT",
+            chat_type="dm",
+            user_id="FOREIGN_USER",
+        ),
+        message_id="FOREIGN_MSG",
+    )
+
+    async def _dispatch():
+        await asyncio.create_task(adapter.handle_message(event))
+
+    asyncio.run(_dispatch())
+
+    assert adapter.ingress_env == {
+        "HERMES_SESSION_CHAT_ID": None,
+        "HERMES_SESSION_THREAD_ID": None,
+        "HERMES_SESSION_KEY": None,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Async-delivery capability inheritance (the sibling var outside _VAR_MAP)
 # ---------------------------------------------------------------------------
@@ -198,5 +261,4 @@ def test_reset_session_vars_closes_async_delivery_leak():
         "After reset, async delivery must default to supported; "
         f"got {captured['window']!r}"
     )
-
 

--- a/tests/gateway/test_session_context_inheritance.py
+++ b/tests/gateway/test_session_context_inheritance.py
@@ -26,11 +26,18 @@ strips safe instead of leaking the sibling's. The handler then binds its own
 session a few steps later.
 """
 import asyncio
+import json
+import os
+import subprocess
+import sys
 from contextvars import copy_context
 
 import pytest
 
 import gateway.session_context as sc
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.session import SessionSource
 from gateway.session_context import (
     _SESSION_ASYNC_DELIVERY,
     _UNSET,
@@ -39,7 +46,7 @@ from gateway.session_context import (
     reset_session_vars,
     set_session_vars,
 )
-from tools.environments.local import _make_run_env
+from tools.environments.local import _make_run_env, _sanitize_subprocess_env, hermes_subprocess_env
 
 SESSION_VARS = list(_VAR_MAP.keys())
 
@@ -200,3 +207,96 @@ def test_reset_session_vars_closes_async_delivery_leak():
     )
 
 
+class _ConcurrentIngressAdapter(BasePlatformAdapter):
+    def __init__(self, platform, spawn_env):
+        super().__init__(PlatformConfig(enabled=True, typing_indicator=False), platform)
+        self.spawn_env = spawn_env
+        self.observed = {}
+        self._topic_recovery_fn = object()  # exercise Telegram's pre-background executor hop
+        self.set_message_handler(self._handle_turn)
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+    def _child_identity(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "import json, os; print(json.dumps({"
+             "k: os.environ.get(k) for k in "
+             "('HERMES_SESSION_CHAT_ID', 'HERMES_SESSION_THREAD_ID', 'HERMES_SESSION_KEY')}))"],
+            env=self.spawn_env(), capture_output=True, text=True, check=True, timeout=10,
+        )
+        return json.loads(result.stdout)
+
+    def _apply_topic_recovery(self, event):
+        if event.source.chat_id == FOREIGN["chat_id"]:
+            self.observed["topic"] = self._child_identity()
+
+    async def _run_processing_hook(self, hook, event, *args, **kwargs):
+        if hook == "on_processing_start" and event.source.chat_id == FOREIGN["chat_id"]:
+            self.observed["prebind"] = await asyncio.to_thread(self._child_identity)
+            self.observed["prebind_async"] = async_delivery_supported()
+
+    async def _handle_turn(self, event):
+        if event.source.chat_id == MINE["chat_id"]:
+            set_session_vars(**MINE, async_delivery=False)
+            self.observed["a_before"] = await asyncio.to_thread(self._child_identity)
+            # A is still active when B snapshots its already-bound context.
+            await asyncio.create_task(self.handle_message(self.foreign_event))
+            await self._session_tasks[self._event_session_key(self.foreign_event)]
+            self.observed["a_after"] = await asyncio.to_thread(self._child_identity)
+            self.observed["a_async"] = async_delivery_supported()
+        else:
+            set_session_vars(**FOREIGN)
+            self.observed["b_bound"] = await asyncio.to_thread(self._child_identity)
+
+
+@pytest.mark.parametrize("platform", [Platform.FEISHU, Platform.TELEGRAM])
+@pytest.mark.parametrize("spawn_surface", ["foreground", "background", "sibling"])
+def test_concurrent_adapter_ingress_isolates_real_subprocesses(monkeypatch, platform, spawn_surface):
+    # A foreign process-global mirror must not reappear after ingress resets ContextVars.
+    for key in ("HERMES_SESSION_CHAT_ID", "HERMES_SESSION_THREAD_ID", "HERMES_SESSION_KEY"):
+        monkeypatch.setenv(key, "stale-global")
+    builders = {
+        "foreground": lambda: _make_run_env({}),
+        "background": lambda: _sanitize_subprocess_env(os.environ),
+        "sibling": hermes_subprocess_env,
+    }
+    adapter = _ConcurrentIngressAdapter(platform, builders[spawn_surface])
+
+    def event(identity):
+        return MessageEvent(
+            text="hello", message_id=identity["message_id"],
+            source=SessionSource(platform=platform, chat_id=identity["chat_id"],
+                                 chat_type="dm", user_id=identity["user_id"]),
+        )
+
+    adapter.foreign_event = event(FOREIGN)
+    mine_event = event(MINE)
+
+    async def run():
+        await adapter.handle_message(mine_event)
+        await adapter._session_tasks[adapter._event_session_key(mine_event)]
+
+    asyncio.run(asyncio.wait_for(run(), timeout=30))
+    blank = {key: None for key in adapter.observed["prebind"]}
+    assert adapter.observed["prebind"] == blank
+    if platform == Platform.TELEGRAM:
+        assert adapter.observed["topic"] == blank
+    assert adapter.observed["prebind_async"] is True
+    for phase, identity in [("a_before", MINE), ("a_after", MINE), ("b_bound", FOREIGN)]:
+        assert adapter.observed[phase] == {
+            "HERMES_SESSION_CHAT_ID": identity["chat_id"],
+            "HERMES_SESSION_THREAD_ID": identity["thread_id"],
+            "HERMES_SESSION_KEY": identity["session_key"],
+        }
+    assert adapter.observed["a_async"] is False
+    assert not adapter._active_sessions


### PR DESCRIPTION
## What does this PR do?

Clear inherited session ContextVars at `BasePlatformAdapter.handle_message` before topic recovery, lifecycle hooks or background dispatch. When message B is spawned from an active A context, the adapter currently carries A's already-bound chat, thread and session key into subprocesses before B binds its own identity.

## Related Issue

Fixes #80224.

The existing bridge and sibling-spawn fixes (`cc395e8050d` and `daf4f1a7a91`) are verified ancestors of the tested main. They strip unbound ContextVars once session handling is engaged; this ingress reset makes inherited A values unbound before B's adapter work. The runner's reset remains for direct entrypoints, and ordinary subprocess context propagation remains intact.

## Type of Change

- [x] 🐛 Bug fix
- [x] 🔒 Security fix
- [x] ✅ Tests

## Changes Made

- Add the shared adapter-ingress reset.
- Run two interleaved adapter turns through real background tasks, with A still active while B snapshots A's context.
- Launch real Python subprocesses through foreground, background and sibling environment builders. Cover Feishu ingress and Telegram's topic-recovery executor hop; verify empty identity before B binds, B's identity afterward, and A's identity/capability unchanged.

## How to Test

Integrated on main `6b2d4faf36f107c364048e2fe17eaa02154e9ea9`. Before the fix, all six new cases launch a B subprocess that reads A's identity: **6 failed, 2 passed**. After the fix:

```bash
scripts/run_tests.sh tests/gateway/test_session_context_inheritance.py tests/tools/test_local_env_session_leak.py tests/gateway/test_platform_base.py tests/gateway/test_telegram_topic_mode.py tests/gateway/test_feishu.py -j 4 -q
```

**218 passed, 1 platform skip** on Linux, using the existing interpreter through `HERMES_PYTHON`. Ruff and `git diff --check` pass. Existing bridge tests retain the unengaged CLI environment fallback and explicitly bound session behavior.

## Checklist

- [x] Read the contributing guide and checked related coverage.
- [x] One focused ingress fix with subprocess regression coverage; tested on Linux.
- [x] Considered cross-platform behavior.
- [x] Documentation, configuration, tool schemas and new skills: N/A.

## Not checked

- Full repository suite, native Windows/macOS, and a live Feishu/Telegram deployment.
- CodeRabbit: skipped for this self-authored P2 PR.

## Attribution

[@Emotion04's issue](https://github.com/NousResearch/hermes-agent/issues/80224) and [@spfcraze's concurrent-subprocess review](https://github.com/NousResearch/hermes-agent/pull/80444#issuecomment-5211359193) informed the fix and regression. Both are commit co-authors.

## Automation disclosure

Updated by GPT-6 Astra with ultra reasoning in Codex Desktop. The account owner loosely reviews these actions and receives the usual GitHub notifications.
