### PR TITLE
feat(kanban): add fail-closed completion broker and review gates

### DIFF
--- a/docs/security/kanban-completion-governance-candidate.md
+++ b/docs/security/kanban-completion-governance-candidate.md
@@ -1,0 +1,146 @@
+# Governed Kanban completion — 2B patch candidate
+
+Status: **candidate only; not installed, not activated**
+
+This document describes the provider-free 2B candidate. It is not a deployment
+instruction and does not authorize a live database migration, permission change,
+service install, gateway restart, worker dispatch, provider inference, or E2E run.
+
+## Security invariant
+
+A governed task may become `done` only when all of the following are true in the
+same `BEGIN IMMEDIATE` transaction as the final task-state CAS:
+
+1. exactly one hash-valid policy and activation record exists;
+2. activation is enabled and the kill switch is false;
+3. the authoritative SQLite path equals the activated board path;
+4. the caller source and runtime profile are allowlisted;
+5. a structured completion context binds caller profile, native task and native run;
+6. task status is `running`, `expected_run_id` is present, and the native run matches;
+7. one hash-valid task/profile/prompt/task-envelope binding exists;
+8. the result is valid JSON and passes the hash-bound Draft 2020-12 result schema;
+9. result task, agent, prompt, approval, QA gate and evidence match the binding;
+10. no open question remains and every evidence item is `verified`;
+11. a transaction-local trigger permit exists for the exact task/result pair;
+12. the task CAS, closing run, completed event and immutable receipt all commit;
+13. receipt failure rolls back task/run/event/permit state and removes any newly
+    staged scratch artifact copy.
+
+Presence of any policy, activation or binding row opts the board into governance.
+Partial, malformed, unreadable or inconsistent state denies completion. A board
+with no governance rows retains legacy behavior.
+
+## Implemented candidate components
+
+- `hermes_cli/kanban_completion_guard.py`
+  - strict policy/activation/binding parser;
+  - `CompletionContext` and semantic result-envelope validator;
+  - receipt construction and insertion;
+  - worker isolation policy loader;
+  - fail-closed completed-result immutability.
+- `hermes_cli/kanban_db.py`
+  - governance tables, transaction-local permits and persistent receipts;
+  - triggers against direct completion, result replacement and reopening;
+  - guard execution inside the completion write transaction before the CAS;
+  - atomic receipt/event/run/task mutation;
+  - governed `edit_completed_task_result()` denial;
+  - governed dispatcher isolation pin.
+- `hermes_cli/kanban_completion_broker.py`
+  - strict newline-delimited JSON protocol over a Unix socket;
+  - Linux `SO_PEERCRED` UID authentication;
+  - UID-to-profile allowlist;
+  - broker-generated `CompletionContext(source="broker")`;
+  - no host-artifact-copy support for lower-privilege clients;
+  - same transactional kernel as in-process callers.
+- `tools/kanban_tools.py`
+  - worker completion uses the broker when
+    `HERMES_KANBAN_BROKER_SOCKET` is pinned by policy;
+  - no direct DB connection occurs on that completion path.
+- `tools/terminal_tool.py` and `tools/environments/docker.py`
+  - isolated workers are forced to Docker regardless of inherited/profile config;
+  - only the task workspace is mounted;
+  - network, arbitrary volumes, forwarded environment, credentials, skills,
+    cache mounts, egress proxy mounts, host UID, persistence and reuse are disabled.
+- `plugins/kanban/systemd/`
+  - non-installed system service and strict example configuration.
+
+## Trust boundaries
+
+### Transactional kernel
+
+All official in-process completion paths converge on `complete_task()`. Governed
+CLI, dashboard or direct-Python callers without a trusted `CompletionContext`
+are denied. The model tool constructs a worker context only from dispatcher-pinned
+environment; the broker constructs one only after `SO_PEERCRED` authorization.
+
+### SQLite triggers
+
+Triggers are defense in depth against accidental raw SQL. They are **not** the
+ultimate boundary because a process that owns the DB can drop triggers or forge
+permit rows.
+
+### DB owner and OS identity
+
+For hostile-worker safety, the DB, WAL and SHM files must be owned by a dedicated
+`hermes-kanban-broker` Unix user and inaccessible to Coordinator and worker UIDs.
+Each specialist profile must have a distinct UID (or an equally strong container /
+mandatory-access-control identity); otherwise a shared UID can impersonate another
+profile at the broker socket.
+
+The socket group grants only broker access, never DB-directory access. The systemd
+candidate uses a broker-owned `0700` state directory and a group-accessible `0660`
+Unix socket. The Coordinator Telegram gateway remains a separate service and is
+not disabled or reconfigured by this design.
+
+## Non-live activation sequence requiring separate approval
+
+The following is intentionally **NOT RUN**:
+
+1. Freeze and independently QA the exact candidate diff.
+2. Back up and hash-read-back the live DB, WAL/SHM state, policy artifacts and
+   current ownership/modes.
+3. Stop all writers in a maintenance window.
+4. Create dedicated broker and per-profile OS identities.
+5. Copy the DB to a staging path, run schema initialization, load policy,
+   activation and task bindings with activation still disabled / kill switch true.
+6. Install the reviewed broker binary/config/unit and apply broker-only DB ownership.
+7. Prove unauthorized UIDs cannot open the DB/WAL/SHM but can reach only their
+   authorized socket profile.
+8. Start the broker, run `ping`/negative synthetic checks without task completion.
+9. Run approved synthetic staging completion and rollback rehearsal.
+10. Obtain independent Security and QA PASS for the frozen diff and evidence.
+11. Obtain explicit human approval for the exact live diff, identities, DB hash,
+    migration, service unit and activation change.
+12. Only then enable the policy and disengage the kill switch in one controlled
+    activation transaction.
+
+## Rollback plan
+
+Rollback must happen in the approved maintenance window and fail closed:
+
+1. Engage kill switch and disable governed completion; stop dispatcher/broker
+   completion intake without stopping the Coordinator Telegram conversation surface.
+2. Stop all Kanban writers and verify no process holds the DB/WAL/SHM files.
+3. Archive and hash the failed state for forensics; do not overwrite evidence.
+4. Restore the pre-migration DB/WAL/SHM backup as one consistent set and read back
+   its hashes and `PRAGMA integrity_check` result.
+5. Restore the recorded DB owner, group and mode; remove only the reviewed broker
+   socket/unit/config artifacts installed by the activation change.
+6. Restore the pre-candidate Hermes source/package and verify its hash.
+7. Keep activation disabled and kill switch engaged.
+8. Start only the previously running services; verify the Coordinator Telegram
+   gateway without sending a message.
+9. Do not resume specialist dispatch until a new QA/Security decision and explicit
+   human approval.
+
+## Known candidate limits
+
+- The broker currently exposes completion only. Other write operations (claim,
+  heartbeat, comment, block, create) need equivalent broker endpoints before a
+  full separate-UID worker can operate with all direct DB access removed.
+- Artifact promotion is intentionally rejected by the broker until a separately
+  owned staging protocol is designed.
+- Docker availability/image provenance and the complete per-profile UID rollout
+  remain deployment prerequisites and are not proven by unit tests.
+- No live migration, real Unix-user permission test, container execution,
+  provider-backed E2E, gateway restart or rollback rehearsal has been run.

--- a/hermes_cli/kanban_completion_broker.py
+++ b/hermes_cli/kanban_completion_broker.py
@@ -1,0 +1,337 @@
+"""Least-privilege Unix-socket broker for governed Kanban completion.
+
+The intended production topology is:
+
+* the Kanban database is owned and writable only by a dedicated broker UID;
+* worker/coordinator processes can reach a group-owned Unix socket but cannot
+  open the database or its WAL/SHM files for writing;
+* Linux ``SO_PEERCRED`` binds each request to an explicitly configured UID and
+  profile before the broker constructs :class:`CompletionContext`;
+* the broker calls the same transactional kernel guard as every in-process
+  completion path.
+
+This module is an opt-in candidate. Merely importing it does not create sockets,
+change permissions, migrate a database, or start a service.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import stat
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from hermes_cli import kanban_completion_guard as guard
+from hermes_cli import kanban_db
+
+
+_PROTOCOL_VERSION = "1.0.0"
+_MAX_REQUEST_BYTES = 1_048_576
+_REQUEST_FIELDS = {
+    "version",
+    "operation",
+    "request_id",
+    "profile",
+    "task_id",
+    "run_id",
+    "result",
+    "summary",
+    "metadata",
+    "created_cards",
+}
+
+
+class BrokerProtocolError(ValueError):
+    """A request was malformed or not authorized for the connected peer."""
+
+
+@dataclass(frozen=True)
+class PeerCredentials:
+    pid: int
+    uid: int
+    gid: int
+
+
+@dataclass(frozen=True)
+class BrokerConfig:
+    db_path: Path
+    socket_path: Path
+    uid_profiles: Mapping[int, frozenset[str]]
+    socket_mode: int = 0o660
+    request_timeout_seconds: float = 10.0
+
+    @classmethod
+    def from_json(cls, value: Mapping[str, Any]) -> "BrokerConfig":
+        expected = {
+            "schema_version",
+            "db_path",
+            "socket_path",
+            "uid_profiles",
+            "socket_mode",
+            "request_timeout_seconds",
+        }
+        if set(value) != expected or value.get("schema_version") != _PROTOCOL_VERSION:
+            raise BrokerProtocolError("broker config does not match schema 1.0.0")
+        raw_profiles = value.get("uid_profiles")
+        if not isinstance(raw_profiles, dict) or not raw_profiles:
+            raise BrokerProtocolError("uid_profiles must be a non-empty object")
+        uid_profiles: dict[int, frozenset[str]] = {}
+        for raw_uid, raw_names in raw_profiles.items():
+            try:
+                uid = int(raw_uid)
+            except (TypeError, ValueError) as exc:
+                raise BrokerProtocolError("uid_profiles contains an invalid UID") from exc
+            if uid < 0 or not isinstance(raw_names, list) or not raw_names:
+                raise BrokerProtocolError("uid_profiles contains an invalid profile list")
+            names = frozenset(name for name in raw_names if isinstance(name, str) and name)
+            if len(names) != len(raw_names):
+                raise BrokerProtocolError("uid_profiles contains an invalid profile name")
+            uid_profiles[uid] = names
+        mode_raw = value.get("socket_mode")
+        try:
+            mode = int(str(mode_raw), 8)
+        except (TypeError, ValueError) as exc:
+            raise BrokerProtocolError("socket_mode must be an octal string") from exc
+        timeout = value.get("request_timeout_seconds")
+        if not isinstance(timeout, (int, float)) or timeout <= 0 or timeout > 60:
+            raise BrokerProtocolError("request timeout is outside 0..60 seconds")
+        db_path = Path(str(value.get("db_path", ""))).expanduser().resolve()
+        socket_path = Path(str(value.get("socket_path", ""))).expanduser().resolve()
+        if not db_path.is_absolute() or not socket_path.is_absolute():
+            raise BrokerProtocolError("broker paths must be absolute")
+        return cls(
+            db_path=db_path,
+            socket_path=socket_path,
+            uid_profiles=uid_profiles,
+            socket_mode=mode,
+            request_timeout_seconds=float(timeout),
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> "BrokerConfig":
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise BrokerProtocolError("broker config is unreadable or malformed") from exc
+        if not isinstance(value, dict):
+            raise BrokerProtocolError("broker config must be an object")
+        return cls.from_json(value)
+
+
+def peer_credentials(conn: socket.socket) -> PeerCredentials:
+    """Return Linux peer credentials or fail closed on unsupported platforms."""
+
+    if not hasattr(socket, "SO_PEERCRED"):
+        raise BrokerProtocolError("SO_PEERCRED is unavailable")
+    raw = conn.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i"))
+    pid, uid, gid = struct.unpack("3i", raw)
+    return PeerCredentials(pid=pid, uid=uid, gid=gid)
+
+
+def _read_request(conn: socket.socket) -> dict[str, Any]:
+    chunks: list[bytes] = []
+    total = 0
+    while True:
+        chunk = conn.recv(min(65536, _MAX_REQUEST_BYTES + 1 - total))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        total += len(chunk)
+        if total > _MAX_REQUEST_BYTES:
+            raise BrokerProtocolError("request exceeds the maximum size")
+        if b"\n" in chunk:
+            break
+    raw = b"".join(chunks)
+    line, separator, trailing = raw.partition(b"\n")
+    if not separator or trailing:
+        raise BrokerProtocolError("request must be exactly one newline-terminated JSON object")
+    try:
+        value = json.loads(line.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise BrokerProtocolError("request JSON is malformed") from exc
+    if not isinstance(value, dict) or set(value) != _REQUEST_FIELDS:
+        raise BrokerProtocolError("request fields do not match protocol 1.0.0")
+    return value
+
+
+def _validate_request(
+    request: Mapping[str, Any],
+    peer: PeerCredentials,
+    config: BrokerConfig,
+) -> None:
+    if request.get("version") != _PROTOCOL_VERSION:
+        raise BrokerProtocolError("unsupported protocol version")
+    if request.get("operation") != "complete":
+        raise BrokerProtocolError("unsupported broker operation")
+    for name in ("request_id", "profile", "task_id", "result"):
+        if not isinstance(request.get(name), str) or not request[name]:
+            raise BrokerProtocolError(f"{name} is required")
+    if not isinstance(request.get("run_id"), int) or int(request["run_id"]) <= 0:
+        raise BrokerProtocolError("run_id must be a positive integer")
+    if request.get("summary") is not None and not isinstance(request["summary"], str):
+        raise BrokerProtocolError("summary must be a string or null")
+    metadata = request.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        raise BrokerProtocolError("metadata must be an object or null")
+    if isinstance(metadata, dict) and "artifacts" in metadata:
+        # Never let a lower-privilege caller turn the broker UID into a host-file
+        # copy oracle. Artifact ingestion needs a separately owned staging API.
+        raise BrokerProtocolError("artifact promotion is not supported by this broker")
+    created_cards = request.get("created_cards")
+    if created_cards is not None and (
+        not isinstance(created_cards, list)
+        or any(not isinstance(item, str) or not item for item in created_cards)
+    ):
+        raise BrokerProtocolError("created_cards must be a list of task ids or null")
+    allowed = config.uid_profiles.get(peer.uid, frozenset())
+    if request["profile"] not in allowed:
+        raise BrokerProtocolError("peer UID is not authorized for the requested profile")
+
+
+def _response(request_id: Optional[str], **payload: Any) -> bytes:
+    value = {
+        "version": _PROTOCOL_VERSION,
+        "request_id": request_id,
+        **payload,
+    }
+    return (guard.canonical_json(value) + "\n").encode("utf-8")
+
+
+def handle_connection(conn: socket.socket, config: BrokerConfig) -> None:
+    """Handle one authenticated request; intended for tests and serve_forever."""
+
+    request_id: Optional[str] = None
+    try:
+        conn.settimeout(config.request_timeout_seconds)
+        peer = peer_credentials(conn)
+        request = _read_request(conn)
+        raw_id = request.get("request_id")
+        request_id = raw_id if isinstance(raw_id, str) else None
+        _validate_request(request, peer, config)
+        context = guard.CompletionContext(
+            caller_profile=str(request["profile"]),
+            native_task_id=str(request["task_id"]),
+            native_run_id=int(request["run_id"]),
+            source="broker",
+            peer_uid=peer.uid,
+        )
+        with kanban_db.connect(db_path=config.db_path) as db:
+            completed = kanban_db.complete_task(
+                db,
+                str(request["task_id"]),
+                result=str(request["result"]),
+                summary=request["summary"],
+                metadata=request["metadata"],
+                created_cards=request["created_cards"],
+                expected_run_id=int(request["run_id"]),
+                completion_context=context,
+            )
+            receipt = db.execute(
+                "SELECT receipt_sha256 FROM completion_governance_receipts "
+                "WHERE native_task_id = ?",
+                (str(request["task_id"]),),
+            ).fetchone()
+        conn.sendall(
+            _response(
+                request_id,
+                ok=True,
+                completed=bool(completed),
+                receipt_sha256=receipt["receipt_sha256"] if receipt else None,
+            )
+        )
+    except guard.CompletionGovernanceDenied as exc:
+        conn.sendall(_response(request_id, ok=False, code="denied", error=str(exc)))
+    except BrokerProtocolError as exc:
+        conn.sendall(_response(request_id, ok=False, code="invalid_request", error=str(exc)))
+    except Exception:
+        # Do not expose DB paths, SQL, or tracebacks to a lower-privilege peer.
+        conn.sendall(
+            _response(
+                request_id,
+                ok=False,
+                code="internal_error",
+                error="broker request failed",
+            )
+        )
+
+
+def _prepare_socket_path(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        existing = path.lstat()
+    except FileNotFoundError:
+        return
+    if not stat.S_ISSOCK(existing.st_mode):
+        raise BrokerProtocolError("refusing to replace a non-socket path")
+    path.unlink()
+
+
+def serve_forever(config: BrokerConfig) -> None:
+    """Serve serial completion requests on a local Unix socket."""
+
+    if not config.db_path.is_file():
+        raise BrokerProtocolError("configured Kanban database does not exist")
+    _prepare_socket_path(config.socket_path)
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        server.bind(str(config.socket_path))
+        os.chmod(config.socket_path, config.socket_mode)
+        server.listen(16)
+        while True:
+            client, _ = server.accept()
+            with client:
+                handle_connection(client, config)
+    finally:
+        server.close()
+
+
+def request_completion(socket_path: Path, request: Mapping[str, Any]) -> dict[str, Any]:
+    """Small strict client used by trusted completion adapters."""
+
+    raw = (guard.canonical_json(dict(request)) + "\n").encode("utf-8")
+    if len(raw) > _MAX_REQUEST_BYTES:
+        raise BrokerProtocolError("request exceeds the maximum size")
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.connect(str(socket_path))
+        client.sendall(raw)
+        response = _read_response(client)
+    return response
+
+
+def _read_response(conn: socket.socket) -> dict[str, Any]:
+    raw = bytearray()
+    while b"\n" not in raw:
+        chunk = conn.recv(65536)
+        if not chunk:
+            break
+        raw.extend(chunk)
+        if len(raw) > _MAX_REQUEST_BYTES:
+            raise BrokerProtocolError("response exceeds the maximum size")
+    line, separator, trailing = bytes(raw).partition(b"\n")
+    if not separator or trailing:
+        raise BrokerProtocolError("broker response framing is invalid")
+    try:
+        value = json.loads(line.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise BrokerProtocolError("broker response JSON is malformed") from exc
+    if not isinstance(value, dict) or value.get("version") != _PROTOCOL_VERSION:
+        raise BrokerProtocolError("broker response protocol is invalid")
+    return value
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Hermes governed Kanban completion broker")
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args(argv)
+    config = BrokerConfig.load(args.config)
+    serve_forever(config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hermes_cli/kanban_completion_guard.py
+++ b/hermes_cli/kanban_completion_guard.py
@@ -1,0 +1,568 @@
+"""Transactional, opt-in governance for Kanban completion.
+
+The guard is intentionally implemented beside the Kanban persistence layer,
+not as a model-tool plugin.  A board with no governance rows keeps legacy
+behaviour.  Presence of any governance row opts the database into fail-closed
+mode: partial configuration, malformed JSON, a missing schema validator, or a
+semantic mismatch denies completion.
+
+This module is deployment-agnostic.  Privileged installation of policy,
+activation, and binding rows belongs to the DB owner/broker boundary; ordinary
+worker-facing APIs never expose an installer or mutable evaluator registry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, NoReturn, Optional
+
+
+_POLICY_TABLE = "completion_governance_policy"
+_ACTIVATION_TABLE = "completion_governance_activation"
+_BINDING_TABLE = "completion_governance_bindings"
+_RECEIPT_TABLE = "completion_governance_receipts"
+_PERMIT_TABLE = "completion_governance_permits"
+_GOVERNANCE_TABLES = (_POLICY_TABLE, _ACTIVATION_TABLE, _BINDING_TABLE)
+
+
+class CompletionGovernanceDenied(ValueError):
+    """Raised when a governed completion or result mutation is not authorized."""
+
+
+@dataclass(frozen=True)
+class CompletionContext:
+    """Caller identity supplied by an OS-isolated adapter or DB broker."""
+
+    caller_profile: str
+    native_task_id: str
+    native_run_id: int
+    source: str
+    peer_uid: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CompletionAuthorization:
+    """Trusted policy decision retained only for the current DB transaction."""
+
+    native_task_id: str
+    external_task_id: str
+    result_run_id: str
+    policy_version: str
+    policy_sha256: str
+    activation_sha256: str
+    binding_sha256: str
+    task_envelope_sha256: str
+    result_sha256: str
+    runtime_profile: str
+    result_envelope: Mapping[str, Any]
+
+    def receipt(self, *, native_run_id: int, created_at: int) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": "1.0.0",
+            "native_task_id": self.native_task_id,
+            "external_task_id": self.external_task_id,
+            "native_run_id": int(native_run_id),
+            "result_run_id": self.result_run_id,
+            "policy_version": self.policy_version,
+            "policy_sha256": self.policy_sha256,
+            "activation_sha256": self.activation_sha256,
+            "binding_sha256": self.binding_sha256,
+            "task_envelope_sha256": self.task_envelope_sha256,
+            "result_sha256": self.result_sha256,
+            "runtime_profile": self.runtime_profile,
+            "created_at": int(created_at),
+        }
+        payload["receipt_sha256"] = canonical_sha256(payload)
+        return payload
+
+
+def canonical_json(value: Any) -> str:
+    """Return the single canonical JSON representation used by all hashes."""
+
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def text_sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _deny(reason: str) -> NoReturn:
+    raise CompletionGovernanceDenied(f"governed completion denied: {reason}")
+
+
+def _table_has_rows(conn: sqlite3.Connection, table: str) -> bool:
+    try:
+        return conn.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone() is not None
+    except sqlite3.OperationalError:
+        # A partially installed database is governed-but-broken, never legacy.
+        return True
+
+
+def governance_rows_present(conn: sqlite3.Connection) -> bool:
+    """Return True when any opt-in governance state is present or malformed."""
+
+    return any(_table_has_rows(conn, table) for table in _GOVERNANCE_TABLES)
+
+
+def _one_row(conn: sqlite3.Connection, sql: str, params: tuple = ()) -> sqlite3.Row:
+    rows = conn.execute(sql, params).fetchall()
+    if len(rows) != 1:
+        _deny("governance state is missing or ambiguous")
+    return rows[0]
+
+
+def _verified_json(raw: Any, expected_sha256: Any, label: str) -> tuple[dict[str, Any], str]:
+    if not isinstance(raw, str) or not isinstance(expected_sha256, str):
+        _deny(f"{label} JSON/hash is missing")
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        _deny(f"{label} JSON is malformed")
+    if not isinstance(value, dict):
+        _deny(f"{label} must be an object")
+    actual = canonical_sha256(value)
+    if actual != expected_sha256:
+        _deny(f"{label} hash mismatch")
+    return value, actual
+
+
+def _require_exact_keys(value: Mapping[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        _deny(f"{label} fields do not match the 1.0.0 contract")
+
+
+def _database_path(conn: sqlite3.Connection) -> str:
+    rows = conn.execute("PRAGMA database_list").fetchall()
+    for row in rows:
+        name = row[1] if not isinstance(row, sqlite3.Row) else row["name"]
+        if name == "main":
+            raw = row[2] if not isinstance(row, sqlite3.Row) else row["file"]
+            if not raw:
+                _deny("in-memory databases cannot use path-bound governance")
+            return str(Path(raw).resolve())
+    _deny("main database path is unavailable")
+    raise AssertionError("unreachable")
+
+
+def _load_policy_activation(
+    conn: sqlite3.Connection,
+) -> tuple[dict[str, Any], str, str, dict[str, Any], str]:
+    policy_row = _one_row(
+        conn,
+        f"SELECT policy_version, policy_json, policy_sha256 FROM {_POLICY_TABLE}",
+    )
+    policy, policy_sha = _verified_json(
+        policy_row["policy_json"], policy_row["policy_sha256"], "policy"
+    )
+    _require_exact_keys(
+        policy,
+        {
+            "schema_version",
+            "policy_id",
+            "board",
+            "database_path",
+            "result_schema",
+            "result_schema_sha256",
+            "allowed_profiles",
+            "allowed_completion_sources",
+            "require_deliverables",
+            "worker_isolation",
+        },
+        "policy",
+    )
+    if policy.get("schema_version") != "1.0.0":
+        _deny("unsupported policy schema version")
+    if policy_row["policy_version"] != policy.get("policy_id"):
+        _deny("policy identity mismatch")
+    if policy.get("database_path") != _database_path(conn):
+        _deny("database path is outside the activated board scope")
+    profiles = policy.get("allowed_profiles")
+    if not isinstance(profiles, list) or not profiles or any(
+        not isinstance(item, str) or not item for item in profiles
+    ):
+        _deny("allowed_profiles is invalid")
+    sources = policy.get("allowed_completion_sources")
+    if not isinstance(sources, list) or not sources or any(
+        not isinstance(item, str) or not item for item in sources
+    ):
+        _deny("allowed_completion_sources is invalid")
+    schema = policy.get("result_schema")
+    if not isinstance(schema, dict):
+        _deny("result_schema is missing")
+    if canonical_sha256(schema) != policy.get("result_schema_sha256"):
+        _deny("result_schema hash mismatch")
+    isolation = policy.get("worker_isolation")
+    _validate_worker_isolation(isolation)
+
+    activation_row = _one_row(
+        conn,
+        f"SELECT activation_json, activation_sha256 FROM {_ACTIVATION_TABLE}",
+    )
+    activation, activation_sha = _verified_json(
+        activation_row["activation_json"],
+        activation_row["activation_sha256"],
+        "activation",
+    )
+    _require_exact_keys(
+        activation,
+        {"schema_version", "enabled", "kill_switch", "policy_sha256"},
+        "activation",
+    )
+    if activation.get("schema_version") != "1.0.0":
+        _deny("unsupported activation schema version")
+    if activation.get("enabled") is not True:
+        _deny("activation is disabled")
+    if activation.get("kill_switch") is not False:
+        _deny("kill switch is engaged")
+    if activation.get("policy_sha256") != policy_sha:
+        _deny("activation is not bound to the active policy")
+    return policy, str(policy_row["policy_version"]), policy_sha, activation, activation_sha
+
+
+def _validate_worker_isolation(value: Any) -> None:
+    if not isinstance(value, dict):
+        _deny("worker isolation policy is missing")
+    _require_exact_keys(
+        value,
+        {
+            "mode",
+            "network",
+            "toolsets",
+            "mount_hermes_resources",
+            "broker_socket",
+        },
+        "worker isolation",
+    )
+    if value.get("mode") != "docker":
+        _deny("worker isolation mode must be docker")
+    if value.get("network") is not False:
+        _deny("governed worker network must be disabled")
+    if value.get("mount_hermes_resources") is not False:
+        _deny("governed workers must not mount Hermes resources")
+    toolsets = value.get("toolsets")
+    if toolsets != ["terminal"]:
+        _deny("governed worker toolsets must be exactly ['terminal']")
+    broker_socket = value.get("broker_socket")
+    if not isinstance(broker_socket, str) or not Path(broker_socket).is_absolute():
+        _deny("worker broker socket must be an absolute path")
+
+
+def _validate_result_schema(
+    policy: Mapping[str, Any],
+    envelope: Any,
+    label: str,
+) -> dict[str, Any]:
+    if not isinstance(envelope, dict):
+        _deny(f"{label} must be an object")
+    try:
+        import jsonschema
+    except ImportError:
+        _deny("JSON Schema validator is unavailable")
+    try:
+        jsonschema.Draft202012Validator(
+            policy["result_schema"],
+            format_checker=jsonschema.FormatChecker(),
+        ).validate(envelope)
+    except Exception:
+        _deny(f"{label} schema validation failed")
+    return envelope
+
+
+def _validate_approval_and_qa(
+    policy: Mapping[str, Any],
+    binding: Mapping[str, Any],
+) -> None:
+    approval = binding.get("approval")
+    if not isinstance(approval, dict):
+        _deny("binding approval is missing")
+    approval_state = approval.get("state")
+    if approval_state not in {"approved", "not_required"}:
+        _deny("required human approval is not effective")
+    if approval_state == "approved" and not approval.get("approval_ref"):
+        _deny("approved scope has no approval reference")
+
+    workflow_type = binding.get("workflow_type")
+    if workflow_type not in {
+        "simple",
+        "major_development",
+        "publishing",
+        "legal_financial",
+        "research",
+        "vault_maintenance",
+    }:
+        _deny("binding workflow type is invalid")
+    qa_gate = binding.get("qa_gate")
+    if not isinstance(qa_gate, dict):
+        _deny("binding QA gate is missing")
+    qa_required = qa_gate.get("required") is True
+    if workflow_type in {"major_development", "publishing"} and not qa_required:
+        _deny("workflow requires independent QA")
+    if not qa_required:
+        if qa_gate != {
+            "required": False,
+            "status": "not_required",
+            "review_task_id": None,
+        }:
+            _deny("non-required QA gate is inconsistent")
+        if binding.get("qa_result") is not None or binding.get("qa_result_sha256") is not None:
+            _deny("unexpected QA result on a non-required gate")
+        return
+    if qa_gate.get("status") != "pass" or not isinstance(
+        qa_gate.get("review_task_id"), str
+    ):
+        _deny("required QA gate is not pass")
+    qa_result = binding.get("qa_result")
+    qa_hash = binding.get("qa_result_sha256")
+    if not isinstance(qa_result, dict) or not isinstance(qa_hash, str):
+        _deny("required QA result is missing")
+    if canonical_sha256(qa_result) != qa_hash:
+        _deny("QA result hash mismatch")
+    qa_result = _validate_result_schema(policy, qa_result, "QA result envelope")
+    if qa_result.get("task_id") != qa_gate.get("review_task_id"):
+        _deny("QA result task identity mismatch")
+    if qa_result.get("agent") != "QA_Tester_Agent":
+        _deny("QA result was not issued by QA_Tester_Agent")
+    if qa_result.get("status") != "completed":
+        _deny("QA result status is not completed")
+    if qa_result.get("open_questions") != []:
+        _deny("QA result has open questions")
+    qa_evidence = qa_result.get("evidence")
+    if not isinstance(qa_evidence, list) or not qa_evidence or any(
+        not isinstance(item, dict) or item.get("status") != "verified"
+        for item in qa_evidence
+    ):
+        _deny("QA result evidence is not fully verified")
+    if qa_result.get("qa_gate") != {
+        "required": False,
+        "status": "not_required",
+        "review_task_id": None,
+    }:
+        _deny("QA review result cannot recursively require QA")
+
+
+def load_worker_isolation(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
+    """Return the active fail-closed worker isolation contract for a board."""
+
+    if not governance_rows_present(conn):
+        return None
+    policy, _version, _policy_sha, _activation, _activation_sha = (
+        _load_policy_activation(conn)
+    )
+    return dict(policy["worker_isolation"])
+
+
+def authorize_completion(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    result: Optional[str],
+    expected_run_id: Optional[int],
+    completion_context: Optional[CompletionContext],
+) -> Optional[CompletionAuthorization]:
+    """Authorize a completion from the same write transaction as its CAS.
+
+    ``None`` means the database has no governance rows and retains legacy
+    behaviour.  Every configured, partial, or corrupt state raises instead.
+    """
+
+    if not governance_rows_present(conn):
+        return None
+    policy, policy_version, policy_sha, _activation, activation_sha = (
+        _load_policy_activation(conn)
+    )
+
+    if expected_run_id is None:
+        _deny("expected_run_id is mandatory")
+    if completion_context is None:
+        _deny("completion context is mandatory")
+    if completion_context.native_task_id != task_id:
+        _deny("completion context task mismatch")
+    if int(completion_context.native_run_id) != int(expected_run_id):
+        _deny("completion context run mismatch")
+    if completion_context.source not in policy["allowed_completion_sources"]:
+        _deny("completion source is not allowlisted")
+    if not isinstance(result, str) or not result.strip():
+        _deny("result-envelope JSON is mandatory")
+
+    task = _one_row(
+        conn,
+        "SELECT id, assignee, status, current_run_id FROM tasks WHERE id = ?",
+        (task_id,),
+    )
+    if task["status"] != "running":
+        _deny("governed tasks may complete only from running")
+    if task["current_run_id"] is None or int(task["current_run_id"]) != int(expected_run_id):
+        _deny("native run binding mismatch")
+
+    binding_row = _one_row(
+        conn,
+        f"SELECT binding_json, binding_sha256 FROM {_BINDING_TABLE} WHERE native_task_id = ?",
+        (task_id,),
+    )
+    binding, binding_sha = _verified_json(
+        binding_row["binding_json"], binding_row["binding_sha256"], "binding"
+    )
+    _require_exact_keys(
+        binding,
+        {
+            "schema_version",
+            "native_task_id",
+            "external_task_id",
+            "assigned_agent",
+            "runtime_profile",
+            "prompt_version",
+            "task_envelope_sha256",
+            "workflow_type",
+            "approval",
+            "qa_gate",
+            "qa_result",
+            "qa_result_sha256",
+        },
+        "binding",
+    )
+    if binding.get("schema_version") != "1.0.0":
+        _deny("unsupported binding schema version")
+    if binding.get("native_task_id") != task_id:
+        _deny("native task binding mismatch")
+    runtime_profile = binding.get("runtime_profile")
+    if task["assignee"] != runtime_profile:
+        _deny("current assignee/profile binding mismatch")
+    if completion_context.caller_profile != runtime_profile:
+        _deny("caller profile binding mismatch")
+    if runtime_profile not in policy["allowed_profiles"]:
+        _deny("runtime profile is not allowlisted")
+    if not isinstance(binding.get("task_envelope_sha256"), str):
+        _deny("task envelope hash is missing")
+    _validate_approval_and_qa(policy, binding)
+
+    try:
+        envelope = json.loads(result)
+    except (TypeError, ValueError):
+        _deny("result is not valid JSON")
+    envelope = _validate_result_schema(policy, envelope, "result envelope")
+
+    if envelope.get("schema_version") != "1.0.0":
+        _deny("unsupported result envelope version")
+    if envelope.get("status") != "completed":
+        _deny("result status is not completed")
+    if envelope.get("task_id") != binding.get("external_task_id"):
+        _deny("external task identity mismatch")
+    if envelope.get("agent") != binding.get("assigned_agent"):
+        _deny("agent identity mismatch")
+    if envelope.get("prompt_version") != binding.get("prompt_version"):
+        _deny("prompt version mismatch")
+    if envelope.get("approval") != binding.get("approval"):
+        _deny("approval scope mismatch")
+    if envelope.get("qa_gate") != binding.get("qa_gate"):
+        _deny("QA gate mismatch")
+    if envelope.get("open_questions") != []:
+        _deny("open questions remain")
+    deliverables = envelope.get("deliverables")
+    if policy.get("require_deliverables") is True and (
+        not isinstance(deliverables, list) or not deliverables
+    ):
+        _deny("deliverables are required")
+    evidence = envelope.get("evidence")
+    if not isinstance(evidence, list) or not evidence:
+        _deny("verified evidence is required")
+    if any(not isinstance(item, dict) or item.get("status") != "verified" for item in evidence):
+        _deny("all evidence must be verified")
+    result_run_id = envelope.get("run_id")
+    if not isinstance(result_run_id, str) or not result_run_id:
+        _deny("result run identity is missing")
+
+    return CompletionAuthorization(
+        native_task_id=task_id,
+        external_task_id=str(binding["external_task_id"]),
+        result_run_id=result_run_id,
+        policy_version=policy_version,
+        policy_sha256=policy_sha,
+        activation_sha256=activation_sha,
+        binding_sha256=binding_sha,
+        task_envelope_sha256=str(binding["task_envelope_sha256"]),
+        result_sha256=text_sha256(result),
+        runtime_profile=str(runtime_profile),
+        result_envelope=envelope,
+    )
+
+
+def insert_completion_permit(
+    conn: sqlite3.Connection,
+    authorization: CompletionAuthorization,
+    *,
+    result: Optional[str],
+    created_at: int,
+) -> None:
+    conn.execute(
+        f"INSERT INTO {_PERMIT_TABLE}(native_task_id, result, created_at) VALUES (?, ?, ?)",
+        (authorization.native_task_id, result, int(created_at)),
+    )
+
+
+def remove_completion_permit(conn: sqlite3.Connection, task_id: str) -> None:
+    conn.execute(
+        f"DELETE FROM {_PERMIT_TABLE} WHERE native_task_id = ?",
+        (task_id,),
+    )
+
+
+def insert_completion_receipt(
+    conn: sqlite3.Connection,
+    authorization: CompletionAuthorization,
+    *,
+    native_run_id: int,
+    created_at: int,
+) -> dict[str, Any]:
+    receipt = authorization.receipt(
+        native_run_id=native_run_id,
+        created_at=created_at,
+    )
+    conn.execute(
+        f"""
+        INSERT INTO {_RECEIPT_TABLE}(
+            receipt_sha256, native_task_id, external_task_id,
+            native_run_id, result_run_id, policy_version,
+            policy_sha256, activation_sha256, binding_sha256,
+            task_envelope_sha256, result_sha256, runtime_profile,
+            receipt_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            receipt["receipt_sha256"],
+            receipt["native_task_id"],
+            receipt["external_task_id"],
+            receipt["native_run_id"],
+            receipt["result_run_id"],
+            receipt["policy_version"],
+            receipt["policy_sha256"],
+            receipt["activation_sha256"],
+            receipt["binding_sha256"],
+            receipt["task_envelope_sha256"],
+            receipt["result_sha256"],
+            receipt["runtime_profile"],
+            canonical_json(receipt),
+            receipt["created_at"],
+        ),
+    )
+    return receipt
+
+
+def assert_completed_result_mutable(conn: sqlite3.Connection, task_id: str) -> None:
+    """Deny post-completion result replacement on governed boards."""
+
+    del task_id
+    if governance_rows_present(conn):
+        _deny("completed governed results are immutable")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1364,6 +1364,102 @@ CREATE TABLE IF NOT EXISTS kanban_notify_subs (
     PRIMARY KEY (task_id, platform, chat_id, thread_id)
 );
 
+-- Optional per-board completion governance. These tables are empty on legacy
+-- boards. Presence of ANY policy/activation/binding row opts the database into
+-- fail-closed mode; the kernel guard validates their exact content and hashes.
+CREATE TABLE IF NOT EXISTS completion_governance_policy (
+    policy_version TEXT PRIMARY KEY,
+    policy_json    TEXT NOT NULL,
+    policy_sha256  TEXT NOT NULL,
+    created_at     INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS completion_governance_activation (
+    singleton_id       INTEGER PRIMARY KEY CHECK (singleton_id = 1),
+    activation_json    TEXT NOT NULL,
+    activation_sha256  TEXT NOT NULL,
+    updated_at         INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS completion_governance_bindings (
+    native_task_id  TEXT PRIMARY KEY,
+    binding_json    TEXT NOT NULL,
+    binding_sha256  TEXT NOT NULL,
+    created_at      INTEGER NOT NULL
+);
+
+-- Transaction-local permit consumed by the persistent trigger. The guarded
+-- helper inserts and removes it inside the same BEGIN IMMEDIATE transaction,
+-- so no committed permit survives. This blocks accidental/direct SQL that
+-- skips the kernel helper; same-UID arbitrary code remains an OS boundary.
+CREATE TABLE IF NOT EXISTS completion_governance_permits (
+    native_task_id TEXT PRIMARY KEY,
+    result         TEXT,
+    created_at     INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS completion_governance_receipts (
+    receipt_sha256       TEXT PRIMARY KEY,
+    native_task_id       TEXT NOT NULL UNIQUE,
+    external_task_id     TEXT NOT NULL,
+    native_run_id        INTEGER NOT NULL,
+    result_run_id        TEXT NOT NULL,
+    policy_version       TEXT NOT NULL,
+    policy_sha256        TEXT NOT NULL,
+    activation_sha256    TEXT NOT NULL,
+    binding_sha256       TEXT NOT NULL,
+    task_envelope_sha256 TEXT NOT NULL,
+    result_sha256        TEXT NOT NULL,
+    runtime_profile      TEXT NOT NULL,
+    receipt_json         TEXT NOT NULL,
+    created_at           INTEGER NOT NULL
+);
+
+CREATE TRIGGER IF NOT EXISTS trg_governed_completion_requires_permit
+BEFORE UPDATE OF status ON tasks
+WHEN NEW.status = 'done'
+ AND OLD.status <> 'done'
+ AND (
+      EXISTS (SELECT 1 FROM completion_governance_policy)
+   OR EXISTS (SELECT 1 FROM completion_governance_activation)
+   OR EXISTS (SELECT 1 FROM completion_governance_bindings)
+ )
+ AND NOT EXISTS (
+     SELECT 1 FROM completion_governance_permits
+      WHERE native_task_id = NEW.id
+        AND result IS NEW.result
+ )
+BEGIN
+    SELECT RAISE(ABORT, 'governed completion requires a kernel permit');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_governed_completed_result_immutable
+BEFORE UPDATE OF result ON tasks
+WHEN OLD.status = 'done'
+ AND NEW.status = 'done'
+ AND OLD.result IS NOT NEW.result
+ AND (
+      EXISTS (SELECT 1 FROM completion_governance_policy)
+   OR EXISTS (SELECT 1 FROM completion_governance_activation)
+   OR EXISTS (SELECT 1 FROM completion_governance_bindings)
+ )
+BEGIN
+    SELECT RAISE(ABORT, 'governed completed results are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_governed_completed_task_no_reopen
+BEFORE UPDATE OF status ON tasks
+WHEN OLD.status = 'done'
+ AND NEW.status <> 'done'
+ AND (
+      EXISTS (SELECT 1 FROM completion_governance_policy)
+   OR EXISTS (SELECT 1 FROM completion_governance_activation)
+   OR EXISTS (SELECT 1 FROM completion_governance_bindings)
+ )
+BEGIN
+    SELECT RAISE(ABORT, 'governed completed tasks cannot be reopened');
+END;
+
 CREATE INDEX IF NOT EXISTS idx_tasks_assignee_status ON tasks(assignee, status);
 CREATE INDEX IF NOT EXISTS idx_tasks_status          ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_links_child           ON task_links(child_id);
@@ -1374,6 +1470,8 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+CREATE INDEX IF NOT EXISTS idx_completion_receipts_external
+    ON completion_governance_receipts(external_task_id);
 """
 
 
@@ -4842,6 +4940,7 @@ def complete_task(
     metadata: Optional[dict] = None,
     created_cards: Optional[Iterable[str]] = None,
     expected_run_id: Optional[int] = None,
+    completion_context=None,
 ) -> bool:
     """Transition ``running|ready -> done`` and record ``result``.
 
@@ -4873,12 +4972,16 @@ def complete_task(
     """
     now = int(time.time())
 
+    from hermes_cli.kanban_completion_guard import governance_rows_present
+
+    governed_before_txn = governance_rows_present(conn)
+
     # Gate: verify created_cards BEFORE the main write txn. A rejected
     # completion still needs an auditable event, so we emit it in a
     # tiny dedicated txn, then raise. The caller is responsible for
     # surfacing HallucinatedCardsError to the worker; this function
     # never mutates task state on a phantom-card rejection.
-    if created_cards:
+    if created_cards and not governed_before_txn:
         verified_cards, phantom_cards = _verify_created_cards(
             conn, task_id, created_cards
         )
@@ -4903,7 +5006,40 @@ def complete_task(
     metadata = _merge_completion_prose_artifacts(
         conn, task_id, metadata, summary=summary, result=result,
     )
+    staged_artifacts_for_rollback: list[Path] = []
     with write_txn(conn):
+        from hermes_cli.kanban_completion_guard import (
+            CompletionGovernanceDenied,
+            authorize_completion,
+            insert_completion_permit,
+            insert_completion_receipt,
+            remove_completion_permit,
+        )
+
+        authorization = authorize_completion(
+            conn,
+            task_id,
+            result=result,
+            expected_run_id=expected_run_id,
+            completion_context=completion_context,
+        )
+        if authorization is not None:
+            # Re-check card provenance under the same BEGIN IMMEDIATE snapshot
+            # as policy evaluation and the final task-state CAS.
+            if created_cards:
+                verified_cards, phantom_cards = _verify_created_cards(
+                    conn, task_id, created_cards
+                )
+                if phantom_cards:
+                    raise CompletionGovernanceDenied(
+                        "governed completion denied: created_cards provenance mismatch"
+                    )
+            insert_completion_permit(
+                conn,
+                authorization,
+                result=result,
+                created_at=now,
+            )
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -4940,11 +5076,14 @@ def complete_task(
                 (result, now, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
+            if authorization is not None:
+                remove_completion_permit(conn, task_id)
             return False
         if isinstance(metadata, dict):
             _persist_scratch_completion_artifacts(conn, task_id, metadata)
             for stored_path in metadata.pop("_staged_artifacts", []):
                 path = Path(stored_path)
+                staged_artifacts_for_rollback.append(path)
                 _insert_completion_attachment(
                     conn,
                     task_id,
@@ -4970,6 +5109,32 @@ def complete_task(
                 summary=summary if summary is not None else result,
                 metadata=metadata,
             )
+        governance_receipt: Optional[dict] = None
+        if authorization is not None:
+            if run_id is None:
+                raise CompletionGovernanceDenied(
+                    "governed completion denied: native run was not finalized"
+                )
+            try:
+                governance_receipt = insert_completion_receipt(
+                    conn,
+                    authorization,
+                    native_run_id=run_id,
+                    created_at=now,
+                )
+            except Exception:
+                # SQLite rollback cannot undo files copied from a scratch
+                # workspace. Remove only copies staged by this completion.
+                for staged_path in reversed(staged_artifacts_for_rollback):
+                    try:
+                        staged_path.unlink(missing_ok=True)
+                    except OSError:
+                        _log.warning(
+                            "completion rollback could not remove staged artifact %s",
+                            staged_path,
+                        )
+                raise
+            remove_completion_permit(conn, task_id)
         # Carry the handoff summary in the event payload so gateway
         # notifiers and dashboard WS consumers can render it without a
         # second SQL round-trip. First line only, 400 char cap — the
@@ -4980,6 +5145,10 @@ def complete_task(
             "result_len": len(result) if result else 0,
             "summary": ev_summary or None,
         }
+        if governance_receipt is not None:
+            completed_payload["governance_receipt_sha256"] = (
+                governance_receipt["receipt_sha256"]
+            )
         if verified_cards:
             completed_payload["verified_cards"] = verified_cards
         # Carry artifact paths in the event payload so the gateway
@@ -5559,6 +5728,11 @@ def edit_completed_task_result(
     """Backfill the user-visible result for an already completed task."""
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
+        from hermes_cli.kanban_completion_guard import (
+            assert_completed_result_mutable,
+        )
+
+        assert_completed_result_mutable(conn, task_id)
         row = conn.execute(
             "SELECT status FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
@@ -8935,6 +9109,51 @@ def _resolve_worker_cli_toolsets(hermes_home: Optional[str]) -> Optional[list[st
         return None
 
 
+def _apply_governed_worker_isolation(
+    env: dict[str, str],
+    isolation: Optional[dict],
+) -> Optional[list[str]]:
+    """Pin a governed worker to a no-network Docker terminal surface.
+
+    The model-facing process keeps only ``terminal`` plus the lifecycle Kanban
+    tools automatically added for ``HERMES_KANBAN_TASK``. The terminal tool
+    itself sees the marker below and ignores profile/env attempts to restore a
+    local backend, arbitrary volumes, credentials, network, or container reuse.
+    """
+
+    if isolation is None:
+        return None
+    if set(isolation) != {
+        "mode",
+        "network",
+        "toolsets",
+        "mount_hermes_resources",
+        "broker_socket",
+    } or any(
+        (
+            isolation.get("mode") != "docker",
+            isolation.get("network") is not False,
+            isolation.get("toolsets") != ["terminal"],
+            isolation.get("mount_hermes_resources") is not False,
+            not isinstance(isolation.get("broker_socket"), str),
+            not os.path.isabs(str(isolation.get("broker_socket", ""))),
+        )
+    ):
+        raise RuntimeError("governed worker isolation contract is invalid")
+    env["HERMES_KANBAN_ISOLATED_WORKER"] = "1"
+    env["TERMINAL_ENV"] = "docker"
+    env["TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE"] = "true"
+    env["TERMINAL_DOCKER_NETWORK"] = "false"
+    env["TERMINAL_CONTAINER_PERSISTENT"] = "false"
+    env["TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES"] = "false"
+    env["TERMINAL_DOCKER_FORWARD_ENV"] = "[]"
+    env["TERMINAL_DOCKER_VOLUMES"] = "[]"
+    env["TERMINAL_DOCKER_ENV"] = "{}"
+    env["TERMINAL_DOCKER_EXTRA_ARGS"] = "[]"
+    env["HERMES_KANBAN_BROKER_SOCKET"] = str(isolation["broker_socket"])
+    return ["terminal"]
+
+
 _retagged_workspace_roots: set[str] = set()
 
 
@@ -9079,6 +9298,11 @@ def _default_spawn(
     # board slug still forces it to the right directory.
     resolved_board = _normalize_board_slug(board) or get_current_board()
     env["HERMES_KANBAN_BOARD"] = resolved_board
+
+    from hermes_cli.kanban_completion_guard import load_worker_isolation
+
+    with connect(board=board) as governance_conn:
+        worker_isolation = load_worker_isolation(governance_conn)
     # HERMES_PROFILE is the author the kanban_comment tool defaults to.
     # `hermes -p <assignee>` activates the profile, but the env var is
     # what the tool reads — set it explicitly here so comments are
@@ -9125,7 +9349,9 @@ def _default_spawn(
     # branch, not a nested one.
     if task.reasoning_effort:
         cmd.extend(["--reasoning", task.reasoning_effort])
-    worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
+    worker_toolsets = _apply_governed_worker_isolation(env, worker_isolation)
+    if worker_toolsets is None:
+        worker_toolsets = _resolve_worker_cli_toolsets(env.get("HERMES_HOME"))
     if worker_toolsets:
         cmd.extend(["--toolsets", ",".join(worker_toolsets)])
     cmd.extend([

--- a/plugins/kanban/systemd/hermes-kanban-completion-broker.config.example.json
+++ b/plugins/kanban/systemd/hermes-kanban-completion-broker.config.example.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0.0",
+  "db_path": "/var/lib/hermes-kanban/hghome-aios/kanban.db",
+  "socket_path": "/run/hermes-kanban-broker/completion.sock",
+  "uid_profiles": {
+    "21001": ["hghome-backend"],
+    "21002": ["hghome-frontend"],
+    "21003": ["hghome-qa"]
+  },
+  "socket_mode": "0660",
+  "request_timeout_seconds": 10
+}

--- a/plugins/kanban/systemd/hermes-kanban-completion-broker.service
+++ b/plugins/kanban/systemd/hermes-kanban-completion-broker.service
@@ -1,0 +1,43 @@
+[Unit]
+Description=Hermes governed Kanban completion DB broker (candidate)
+Documentation=file:///opt/hermes-agent/docs/security/kanban-completion-governance-candidate.md
+After=local-fs.target
+ConditionPathExists=/etc/hermes-kanban-broker/config.json
+
+[Service]
+Type=simple
+User=hermes-kanban-broker
+Group=hermes-kanban-clients
+UMask=0007
+RuntimeDirectory=hermes-kanban-broker
+RuntimeDirectoryMode=0750
+StateDirectory=hermes-kanban
+StateDirectoryMode=0700
+ExecStart=/opt/hermes-agent/venv/bin/python -m hermes_cli.kanban_completion_broker --config /etc/hermes-kanban-broker/config.json
+Restart=on-failure
+RestartSec=2s
+
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+ReadWritePaths=/run/hermes-kanban-broker /var/lib/hermes-kanban
+RestrictAddressFamilies=AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+CapabilityBoundingSet=
+AmbientCapabilities=
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/hermes_cli/test_kanban_completion_governance.py
+++ b/tests/hermes_cli/test_kanban_completion_governance.py
@@ -1,0 +1,653 @@
+"""Provider-free tests for the transactional Kanban completion guard."""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_completion_broker as broker
+from hermes_cli import kanban_completion_guard as guard
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+RESULT_SCHEMA = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": False,
+    "required": [
+        "schema_version",
+        "task_id",
+        "run_id",
+        "agent",
+        "prompt_version",
+        "status",
+        "summary",
+        "deliverables",
+        "evidence",
+        "open_questions",
+        "approval",
+        "qa_gate",
+    ],
+    "properties": {
+        "schema_version": {"const": "1.0.0"},
+        "task_id": {"type": "string", "minLength": 1},
+        "run_id": {"type": "string", "minLength": 1},
+        "agent": {"type": "string", "minLength": 1},
+        "prompt_version": {"type": "string", "minLength": 1},
+        "status": {"const": "completed"},
+        "summary": {"type": "string", "minLength": 1},
+        "deliverables": {"type": "array", "minItems": 1},
+        "evidence": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "required": ["status", "ref"],
+                "properties": {
+                    "status": {"const": "verified"},
+                    "ref": {"type": "string", "minLength": 1},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "open_questions": {"type": "array", "maxItems": 0},
+        "approval": {"type": "object"},
+        "qa_gate": {"type": "object"},
+    },
+}
+
+APPROVAL = {
+    "state": "approved",
+    "required_actions": ["synthetic completion fixture"],
+    "approval_ref": "human:test-approval",
+}
+QA_GATE = {
+    "required": True,
+    "status": "pass",
+    "review_task_id": "qa-test-1",
+}
+QA_RESULT = {
+    "schema_version": "1.0.0",
+    "task_id": "qa-test-1",
+    "run_id": "qa-result-run-test-1",
+    "agent": "QA_Tester_Agent",
+    "prompt_version": "1.0.0",
+    "status": "completed",
+    "summary": "Synthetic independent QA passed.",
+    "deliverables": [{"path": "qa-report.json"}],
+    "evidence": [{"status": "verified", "ref": "pytest:synthetic-qa"}],
+    "open_questions": [],
+    "approval": {
+        "state": "not_required",
+        "required_actions": [],
+        "approval_ref": None,
+    },
+    "qa_gate": {
+        "required": False,
+        "status": "not_required",
+        "review_task_id": None,
+    },
+}
+
+
+def _db_path(conn) -> str:
+    row = conn.execute("PRAGMA database_list").fetchone()
+    return str(Path(row["file"]).resolve())
+
+
+def _policy(conn, **overrides):
+    value = {
+        "schema_version": "1.0.0",
+        "policy_id": "test-policy-v1",
+        "board": "synthetic-governed-board",
+        "database_path": _db_path(conn),
+        "result_schema": RESULT_SCHEMA,
+        "result_schema_sha256": guard.canonical_sha256(RESULT_SCHEMA),
+        "allowed_profiles": ["profile-test"],
+        "allowed_completion_sources": ["worker-tool", "broker", "test"],
+        "require_deliverables": True,
+        "worker_isolation": {
+            "mode": "docker",
+            "network": False,
+            "toolsets": ["terminal"],
+            "mount_hermes_resources": False,
+            "broker_socket": "/run/hermes-kanban-broker/completion.sock",
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def _activation(policy, **overrides):
+    value = {
+        "schema_version": "1.0.0",
+        "enabled": True,
+        "kill_switch": False,
+        "policy_sha256": guard.canonical_sha256(policy),
+    }
+    value.update(overrides)
+    return value
+
+
+def _binding(task_id: str, **overrides):
+    value = {
+        "schema_version": "1.0.0",
+        "native_task_id": task_id,
+        "external_task_id": "task-envelope-test-1",
+        "assigned_agent": "Backend_Developer_Agent",
+        "runtime_profile": "profile-test",
+        "prompt_version": "1.0.0",
+        "task_envelope_sha256": "a" * 64,
+        "workflow_type": "major_development",
+        "approval": APPROVAL,
+        "qa_gate": QA_GATE,
+        "qa_result": QA_RESULT,
+        "qa_result_sha256": guard.canonical_sha256(QA_RESULT),
+    }
+    value.update(overrides)
+    return value
+
+
+def _envelope(**overrides):
+    value = {
+        "schema_version": "1.0.0",
+        "task_id": "task-envelope-test-1",
+        "run_id": "result-run-test-1",
+        "agent": "Backend_Developer_Agent",
+        "prompt_version": "1.0.0",
+        "status": "completed",
+        "summary": "Synthetic guarded completion passed.",
+        "deliverables": [{"path": "artifact.txt"}],
+        "evidence": [{"status": "verified", "ref": "pytest:synthetic"}],
+        "open_questions": [],
+        "approval": APPROVAL,
+        "qa_gate": QA_GATE,
+    }
+    value.update(overrides)
+    return value
+
+
+def _insert_json_row(conn, table: str, columns: tuple[str, str], value: dict, *, extra=()):
+    raw = guard.canonical_json(value)
+    digest = guard.canonical_sha256(value)
+    names = ", ".join((*[item[0] for item in extra], *columns))
+    placeholders = ", ".join("?" for _ in range(len(extra) + 2))
+    values = (*[item[1] for item in extra], raw, digest)
+    conn.execute(f"INSERT INTO {table}({names}) VALUES ({placeholders})", values)
+
+
+def _install_governance(
+    conn,
+    task_id: str,
+    *,
+    policy_overrides=None,
+    activation_overrides=None,
+    binding_overrides=None,
+    omit: str | None = None,
+):
+    policy = _policy(conn, **(policy_overrides or {}))
+    activation = _activation(policy, **(activation_overrides or {}))
+    binding = _binding(task_id, **(binding_overrides or {}))
+    if omit != "policy":
+        _insert_json_row(
+            conn,
+            "completion_governance_policy",
+            ("policy_json", "policy_sha256"),
+            policy,
+            extra=(("policy_version", policy["policy_id"]), ("created_at", 1)),
+        )
+    if omit != "activation":
+        _insert_json_row(
+            conn,
+            "completion_governance_activation",
+            ("activation_json", "activation_sha256"),
+            activation,
+            extra=(("singleton_id", 1), ("updated_at", 1)),
+        )
+    if omit != "binding":
+        _insert_json_row(
+            conn,
+            "completion_governance_bindings",
+            ("binding_json", "binding_sha256"),
+            binding,
+            extra=(("native_task_id", task_id), ("created_at", 1)),
+        )
+    conn.commit()
+    return policy, activation, binding
+
+
+def _running_task(conn):
+    task_id = kb.create_task(conn, title="governed synthetic", assignee="profile-test")
+    assert kb.claim_task(conn, task_id) is not None
+    task = kb.get_task(conn, task_id)
+    assert task is not None and task.current_run_id is not None
+    return task_id, int(task.current_run_id)
+
+
+def _complete(conn, task_id: str, run_id: int, envelope=None):
+    return kb.complete_task(
+        conn,
+        task_id,
+        result=json.dumps(envelope or _envelope(), ensure_ascii=False),
+        summary="Synthetic guarded completion passed.",
+        expected_run_id=run_id,
+        completion_context=guard.CompletionContext(
+            caller_profile="profile-test",
+            native_task_id=task_id,
+            native_run_id=run_id,
+            source="test",
+        ),
+    )
+
+
+def _broker_payload(task_id: str, run_id: int, **overrides):
+    value = {
+        "version": "1.0.0",
+        "operation": "complete",
+        "request_id": "request-test-1",
+        "profile": "profile-test",
+        "task_id": task_id,
+        "run_id": run_id,
+        "result": json.dumps(_envelope()),
+        "summary": "Synthetic broker completion passed.",
+        "metadata": None,
+        "created_cards": None,
+    }
+    value.update(overrides)
+    return value
+
+
+def _call_broker(conn, task_id: str, run_id: int, **overrides):
+    config = broker.BrokerConfig(
+        db_path=Path(_db_path(conn)),
+        socket_path=Path(_db_path(conn)).with_suffix(".sock"),
+        uid_profiles={os.getuid(): frozenset({"profile-test"})},
+    )
+    client, server = socket.socketpair()
+    try:
+        raw = guard.canonical_json(_broker_payload(task_id, run_id, **overrides))
+        client.sendall((raw + "\n").encode("utf-8"))
+        broker.handle_connection(server, config)
+        response = client.recv(65536)
+        return json.loads(response.decode("utf-8"))
+    finally:
+        client.close()
+        server.close()
+
+
+def test_legacy_board_completion_remains_compatible(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="legacy")
+        assert kb.complete_task(conn, task_id, result="legacy result") is True
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_plain_sqlite_legacy_completion_needs_no_application_udf(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="plain sqlite legacy")
+        database_path = _db_path(conn)
+
+    with sqlite3.connect(database_path) as plain_conn:
+        governance_rows = plain_conn.execute(
+            """
+            SELECT
+                (SELECT COUNT(*) FROM completion_governance_policy) +
+                (SELECT COUNT(*) FROM completion_governance_activation) +
+                (SELECT COUNT(*) FROM completion_governance_bindings)
+            """
+        ).fetchone()[0]
+        trigger_sql = plain_conn.execute(
+            """
+            SELECT sql FROM sqlite_master
+             WHERE type = 'trigger'
+               AND name = 'trg_governed_completion_requires_permit'
+            """
+        ).fetchone()
+
+        assert governance_rows == 0
+        assert trigger_sql is not None
+        updated = plain_conn.execute(
+            "UPDATE tasks SET status = 'done', result = ? WHERE id = ?",
+            ("plain sqlite legacy result", task_id),
+        )
+        assert updated.rowcount == 1
+        assert plain_conn.execute(
+            "SELECT status, result FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone() == ("done", "plain sqlite legacy result")
+
+
+def test_governed_completion_atomically_writes_receipt(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+
+        assert _complete(conn, task_id, run_id) is True
+        task = kb.get_task(conn, task_id)
+        receipt = conn.execute(
+            "SELECT * FROM completion_governance_receipts WHERE native_task_id = ?",
+            (task_id,),
+        ).fetchone()
+        event = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'completed'",
+            (task_id,),
+        ).fetchone()
+
+        assert task.status == "done"
+        assert receipt is not None
+        assert json.loads(event["payload"])["governance_receipt_sha256"] == receipt["receipt_sha256"]
+        assert conn.execute("SELECT COUNT(*) FROM completion_governance_permits").fetchone()[0] == 0
+
+
+def test_result_receipt_digest_binds_original_utf8_text(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        raw_result = json.dumps(_envelope(summary="Árvíztűrő tükörfúrógép"), ensure_ascii=False, indent=2)
+
+        assert kb.complete_task(
+            conn,
+            task_id,
+            result=raw_result,
+            summary="Unicode digest fixture.",
+            expected_run_id=run_id,
+            completion_context=guard.CompletionContext(
+                caller_profile="profile-test",
+                native_task_id=task_id,
+                native_run_id=run_id,
+                source="test",
+            ),
+        )
+        receipt = conn.execute(
+            "SELECT result_sha256 FROM completion_governance_receipts WHERE native_task_id=?",
+            (task_id,),
+        ).fetchone()
+        assert receipt["result_sha256"] == guard.text_sha256(raw_result)
+        assert receipt["result_sha256"] != guard.canonical_sha256(json.loads(raw_result))
+
+
+def test_cas_ineligible_completion_leaves_no_orphan_receipt_or_permit(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        conn.execute(
+            """
+            CREATE TRIGGER synthetic_cas_ineligible
+            BEFORE UPDATE OF status ON tasks
+            WHEN NEW.id = OLD.id AND NEW.status = 'done'
+            BEGIN
+                SELECT RAISE(IGNORE);
+            END
+            """
+        )
+        conn.commit()
+
+        assert _complete(conn, task_id, run_id) is False
+        task = kb.get_task(conn, task_id)
+        assert task is not None and task.status == "running"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM completion_governance_receipts"
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM completion_governance_permits"
+        ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'",
+            (task_id,),
+        ).fetchone()[0] == 0
+        run = conn.execute("SELECT status, outcome FROM task_runs WHERE id=?", (run_id,)).fetchone()
+        assert run["status"] == "running"
+        assert run["outcome"] is None
+
+
+@pytest.mark.parametrize(
+    ("activation_overrides", "expected_reason"),
+    [
+        ({"enabled": False}, "activation is disabled"),
+        ({"kill_switch": True}, "kill switch is engaged"),
+    ],
+)
+def test_activation_controls_fail_closed(
+    kanban_home, activation_overrides, expected_reason
+):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(
+            conn,
+            task_id,
+            activation_overrides=activation_overrides,
+        )
+        with pytest.raises(guard.CompletionGovernanceDenied, match=expected_reason):
+            _complete(conn, task_id, run_id)
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+@pytest.mark.parametrize("missing", ["policy", "activation", "binding"])
+def test_partial_governance_state_denies(kanban_home, missing):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id, omit=missing)
+        with pytest.raises(guard.CompletionGovernanceDenied):
+            _complete(conn, task_id, run_id)
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+@pytest.mark.parametrize(
+    "envelope_overrides",
+    [
+        {"task_id": "wrong-task"},
+        {"agent": "Wrong_Agent"},
+        {"prompt_version": "stale"},
+        {"approval": {"required": True, "status": "missing"}},
+        {"qa_gate": {"required": True, "status": "fail", "review_task_id": "qa-test-1"}},
+        {"evidence": [{"status": "not_run", "ref": "none"}]},
+        {"open_questions": ["still blocked"]},
+    ],
+)
+def test_result_binding_semantics_deny_mismatch(kanban_home, envelope_overrides):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        envelope = _envelope(**envelope_overrides)
+        with pytest.raises(guard.CompletionGovernanceDenied):
+            _complete(conn, task_id, run_id, envelope)
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_expected_run_id_is_mandatory_and_bound(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        result = json.dumps(_envelope())
+        with pytest.raises(guard.CompletionGovernanceDenied, match="expected_run_id"):
+            kb.complete_task(conn, task_id, result=result)
+        with pytest.raises(guard.CompletionGovernanceDenied, match="run binding"):
+            kb.complete_task(
+                conn,
+                task_id,
+                result=result,
+                expected_run_id=run_id + 1,
+                completion_context=guard.CompletionContext(
+                    caller_profile="profile-test",
+                    native_task_id=task_id,
+                    native_run_id=run_id + 1,
+                    source="test",
+                ),
+            )
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_missing_or_mismatched_completion_context_denies(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        result = json.dumps(_envelope())
+        with pytest.raises(guard.CompletionGovernanceDenied, match="context is mandatory"):
+            kb.complete_task(conn, task_id, result=result, expected_run_id=run_id)
+        with pytest.raises(guard.CompletionGovernanceDenied, match="caller profile"):
+            kb.complete_task(
+                conn,
+                task_id,
+                result=result,
+                expected_run_id=run_id,
+                completion_context=guard.CompletionContext(
+                    caller_profile="wrong-profile",
+                    native_task_id=task_id,
+                    native_run_id=run_id,
+                    source="test",
+                ),
+            )
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_raw_sql_completion_and_reopen_are_blocked_by_trigger(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        with pytest.raises(Exception, match="kernel permit"):
+            conn.execute(
+                "UPDATE tasks SET status='done', result='raw bypass' WHERE id=?",
+                (task_id,),
+            )
+        conn.rollback()
+        assert kb.get_task(conn, task_id).status == "running"
+
+        assert _complete(conn, task_id, run_id)
+        with pytest.raises(Exception, match="cannot be reopened"):
+            conn.execute("UPDATE tasks SET status='ready' WHERE id=?", (task_id,))
+        conn.rollback()
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_completed_result_is_immutable_through_sql_and_helper(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        assert _complete(conn, task_id, run_id)
+
+        with pytest.raises(Exception, match="immutable"):
+            conn.execute("UPDATE tasks SET result='tampered' WHERE id=?", (task_id,))
+        conn.rollback()
+        with pytest.raises(guard.CompletionGovernanceDenied, match="immutable"):
+            kb.edit_completed_task_result(conn, task_id, result="tampered")
+        assert json.loads(kb.get_task(conn, task_id).result)["task_id"] == "task-envelope-test-1"
+
+
+def test_receipt_write_failure_rolls_back_task_run_event_and_permit(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        workspace = kb.resolve_workspace(task)
+        kb.set_workspace_path(conn, task_id, workspace)
+        artifact = workspace / "synthetic.txt"
+        artifact.write_text("synthetic", encoding="utf-8")
+        staged_copy = kb.task_attachments_dir(task_id) / artifact.name
+        _install_governance(conn, task_id)
+        conn.execute(
+            """
+            CREATE TRIGGER synthetic_receipt_failure
+            BEFORE INSERT ON completion_governance_receipts
+            BEGIN
+                SELECT RAISE(ABORT, 'synthetic receipt failure');
+            END
+            """
+        )
+        conn.commit()
+
+        with pytest.raises(Exception, match="synthetic receipt failure"):
+            kb.complete_task(
+                conn,
+                task_id,
+                result=json.dumps(_envelope()),
+                summary="Synthetic guarded completion passed.",
+                metadata={"artifacts": [str(artifact)]},
+                expected_run_id=run_id,
+                completion_context=guard.CompletionContext(
+                    caller_profile="profile-test",
+                    native_task_id=task_id,
+                    native_run_id=run_id,
+                    source="test",
+                ),
+            )
+
+        task = kb.get_task(conn, task_id)
+        run = conn.execute("SELECT status, outcome FROM task_runs WHERE id=?", (run_id,)).fetchone()
+        assert task.status == "running"
+        assert run["status"] == "running"
+        assert run["outcome"] is None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM task_events WHERE task_id=? AND kind='completed'",
+            (task_id,),
+        ).fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM completion_governance_receipts").fetchone()[0] == 0
+        assert conn.execute("SELECT COUNT(*) FROM completion_governance_permits").fetchone()[0] == 0
+        assert not staged_copy.exists()
+        assert artifact.exists(), "rollback must preserve the original workspace artifact"
+
+
+def test_malformed_policy_json_denies_without_mutation(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        conn.execute(
+            "UPDATE completion_governance_policy SET policy_json='{', policy_sha256=?",
+            ("0" * 64,),
+        )
+        conn.commit()
+        with pytest.raises(guard.CompletionGovernanceDenied, match="malformed"):
+            _complete(conn, task_id, run_id)
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_unix_peer_authenticated_broker_completes_through_same_kernel(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        response = _call_broker(conn, task_id, run_id)
+
+        assert response["ok"] is True
+        assert response["completed"] is True
+        assert isinstance(response["receipt_sha256"], str)
+        assert kb.get_task(conn, task_id).status == "done"
+
+
+def test_broker_rejects_profile_not_bound_to_peer_uid(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        response = _call_broker(conn, task_id, run_id, profile="other-profile")
+
+        assert response["ok"] is False
+        assert response["code"] == "invalid_request"
+        assert kb.get_task(conn, task_id).status == "running"
+
+
+def test_broker_rejects_host_artifact_copy_oracle(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _running_task(conn)
+        _install_governance(conn, task_id)
+        response = _call_broker(
+            conn,
+            task_id,
+            run_id,
+            metadata={"artifacts": ["/etc/passwd"]},
+        )
+
+        assert response["ok"] is False
+        assert response["code"] == "invalid_request"
+        assert kb.get_task(conn, task_id).status == "running"

--- a/tests/tools/test_governed_kanban_worker_isolation.py
+++ b/tests/tools/test_governed_kanban_worker_isolation.py
@@ -1,0 +1,148 @@
+"""Provider-free tests for governed Kanban worker process isolation."""
+
+from __future__ import annotations
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_completion_broker as broker
+from tools import terminal_tool
+from tools import kanban_tools
+
+
+ISOLATION = {
+    "mode": "docker",
+    "network": False,
+    "toolsets": ["terminal"],
+    "mount_hermes_resources": False,
+    "broker_socket": "/run/hermes-kanban-broker/completion.sock",
+}
+
+
+def test_dispatcher_isolation_marker_replaces_profile_toolsets():
+    env = {
+        "TERMINAL_ENV": "local",
+        "TERMINAL_DOCKER_NETWORK": "true",
+        "TERMINAL_DOCKER_VOLUMES": '["/:/host"]',
+    }
+    toolsets = kb._apply_governed_worker_isolation(env, ISOLATION)
+
+    assert toolsets == ["terminal"]
+    assert env["HERMES_KANBAN_ISOLATED_WORKER"] == "1"
+    assert env["TERMINAL_ENV"] == "docker"
+    assert env["TERMINAL_DOCKER_NETWORK"] == "false"
+    assert env["TERMINAL_DOCKER_VOLUMES"] == "[]"
+    assert env["TERMINAL_DOCKER_FORWARD_ENV"] == "[]"
+    assert env["TERMINAL_DOCKER_EXTRA_ARGS"] == "[]"
+    assert env["HERMES_KANBAN_BROKER_SOCKET"] == ISOLATION["broker_socket"]
+
+
+def test_dispatcher_rejects_weakened_isolation_contract():
+    weakened = dict(ISOLATION, network=True)
+    try:
+        kb._apply_governed_worker_isolation({}, weakened)
+    except RuntimeError as exc:
+        assert "isolation contract is invalid" in str(exc)
+    else:
+        raise AssertionError("weakened isolation must fail closed")
+
+
+def test_terminal_marker_overrides_unsafe_profile_and_environment(monkeypatch, tmp_path):
+    monkeypatch.setattr(terminal_tool, "_terminal_config_bridge_attempted", True)
+    monkeypatch.setenv("HERMES_KANBAN_ISOLATED_WORKER", "1")
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setenv("TERMINAL_DOCKER_IMAGE", "untrusted-image")
+    monkeypatch.setenv("TERMINAL_DOCKER_NETWORK", "true")
+    monkeypatch.setenv("TERMINAL_CONTAINER_PERSISTENT", "true")
+    monkeypatch.setenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "true")
+    monkeypatch.setenv("TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true")
+    monkeypatch.setenv("TERMINAL_DOCKER_FORWARD_ENV", '["SECRET"]')
+    monkeypatch.setenv("TERMINAL_DOCKER_VOLUMES", '["/:/host"]')
+    monkeypatch.setenv("TERMINAL_DOCKER_ENV", '{"SECRET":"value"}')
+    monkeypatch.setenv("TERMINAL_DOCKER_EXTRA_ARGS", '["--privileged"]')
+
+    config = terminal_tool._get_env_config()
+
+    assert config["env_type"] == "docker"
+    assert config["host_cwd"] == str(tmp_path)
+    assert config["cwd"] == "/workspace"
+    assert config["docker_mount_cwd_to_workspace"] is True
+    assert config["docker_network"] is False
+    assert config["container_persistent"] is False
+    assert config["docker_run_as_host_user"] is False
+    assert config["docker_persist_across_processes"] is False
+    assert config["docker_orphan_reaper"] is False
+    assert config["docker_forward_env"] == []
+    assert config["docker_volumes"] == []
+    assert config["docker_env"] == {}
+    assert config["docker_extra_args"] == []
+    assert config["docker_mount_hermes_resources"] is False
+    assert config["docker_image"] != "untrusted-image"
+
+
+def test_environment_factory_forwards_resource_mount_denial(monkeypatch):
+    captured = {}
+
+    class FakeDockerEnvironment:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr(terminal_tool, "_DockerEnvironment", FakeDockerEnvironment)
+    monkeypatch.setattr(terminal_tool, "_maybe_reap_docker_orphans", lambda _cc: None)
+
+    terminal_tool._create_environment(
+        "docker",
+        "synthetic-image",
+        "/workspace",
+        30,
+        container_config={
+            "docker_orphan_reaper": False,
+            "docker_mount_hermes_resources": False,
+            "docker_network": False,
+        },
+        host_cwd="/synthetic/workspace",
+    )
+
+    assert captured["mount_hermes_resources"] is False
+    assert captured["network"] is False
+
+
+def test_worker_complete_adapter_uses_broker_without_opening_db(monkeypatch):
+    captured = {}
+
+    def fake_request(socket_path, request):
+        captured["socket_path"] = socket_path
+        captured["request"] = request
+        return {
+            "version": "1.0.0",
+            "request_id": request["request_id"],
+            "ok": True,
+            "completed": True,
+            "receipt_sha256": "b" * 64,
+        }
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_testbroker")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setenv("HERMES_PROFILE", "profile-test")
+    monkeypatch.setenv(
+        "HERMES_KANBAN_BROKER_SOCKET",
+        "/run/hermes-kanban-broker/completion.sock",
+    )
+    monkeypatch.setattr(broker, "request_completion", fake_request)
+    monkeypatch.setattr(
+        kanban_tools,
+        "_connect",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("DB path bypassed broker")),
+    )
+
+    response = kanban_tools._handle_complete(
+        {
+            "task_id": "t_testbroker",
+            "result": "{}",
+            "summary": "synthetic",
+        }
+    )
+
+    assert '"ok": true' in response.lower()
+    assert str(captured["socket_path"]) == ISOLATION["broker_socket"]
+    assert captured["request"]["profile"] == "profile-test"
+    assert captured["request"]["run_id"] == 42

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -870,6 +870,7 @@ class DockerEnvironment(BaseEnvironment):
         extra_args: list = None,
         persist_across_processes: bool = True,
         shm_size: str = _DEFAULT_SHM_SIZE,
+        mount_hermes_resources: bool = True,
     ):
         if cwd == "~":
             cwd = "/root"
@@ -988,8 +989,11 @@ class DockerEnvironment(BaseEnvironment):
             logger.debug("Skipping docker cwd mount: /workspace already mounted by user config")
 
         # Mount credential files (OAuth tokens, etc.) declared by skills.
-        # Read-only so the container can authenticate but not modify host creds.
+        # Governed Kanban workers disable this entire block: the container gets
+        # only its task workspace and no profile credentials, skills, or cache.
         try:
+            if not mount_hermes_resources:
+                raise StopIteration
             from tools.credential_files import (
                 get_credential_file_mounts,
                 get_skills_directory_mount,
@@ -1064,6 +1068,8 @@ class DockerEnvironment(BaseEnvironment):
                     cache_mount["host_path"],
                     cache_mount["container_path"],
                 )
+        except StopIteration:
+            logger.info("Docker: Hermes resource mounts disabled by isolation policy")
         except Exception as e:
             logger.debug("Docker: could not load credential file mounts: %s", e)
 
@@ -1071,9 +1077,12 @@ class DockerEnvironment(BaseEnvironment):
         # mount the CA cert into the sandbox and set HTTPS_PROXY + CA-bundle
         # env vars so outbound traffic routes through the host-side proxy.
         # The sandbox receives PROXY tokens instead of real API keys.
-        egress_volume_args, egress_env_overrides, egress_host_args = (
-            _egress_proxy_args_for_docker()
-        )
+        if mount_hermes_resources:
+            egress_volume_args, egress_env_overrides, egress_host_args = (
+                _egress_proxy_args_for_docker()
+            )
+        else:
+            egress_volume_args, egress_env_overrides, egress_host_args = [], {}, []
         egress_label = _egress_reuse_fingerprint(
             egress_volume_args, egress_env_overrides, egress_host_args,
         )

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -720,6 +720,44 @@ def _handle_complete(args: dict, **kw) -> str:
             f"metadata must be an object/dict, got {type(metadata).__name__}"
         )
     metadata = _stamp_worker_session_metadata(tid, metadata)
+    broker_socket = os.environ.get("HERMES_KANBAN_BROKER_SOCKET", "").strip()
+    if broker_socket:
+        import secrets
+        from pathlib import Path
+
+        from hermes_cli.kanban_completion_broker import request_completion
+
+        worker_run_id = _worker_run_id(tid)
+        worker_profile = os.environ.get("HERMES_PROFILE", "").strip()
+        if worker_run_id is None or not worker_profile:
+            return tool_error(
+                "kanban_complete: broker mode requires dispatcher-bound profile and run identity"
+            )
+        response = request_completion(
+            Path(broker_socket),
+            {
+                "version": "1.0.0",
+                "operation": "complete",
+                "request_id": f"{tid}:{worker_run_id}:{secrets.token_hex(8)}",
+                "profile": worker_profile,
+                "task_id": tid,
+                "run_id": worker_run_id,
+                "result": result,
+                "summary": summary,
+                "metadata": metadata,
+                "created_cards": created_cards,
+            },
+        )
+        if response.get("ok") is not True or response.get("completed") is not True:
+            return tool_error(
+                f"kanban_complete broker denied completion: "
+                f"{response.get('error') or response.get('code') or 'unknown error'}"
+            )
+        return _ok(
+            task_id=tid,
+            run_id=worker_run_id,
+            governance_receipt_sha256=response.get("receipt_sha256"),
+        )
     board = args.get("board")
     try:
         kb, conn = _connect(board=board)
@@ -761,11 +799,24 @@ def _handle_complete(args: dict, **kw) -> str:
                     )
 
             try:
+                from hermes_cli.kanban_completion_guard import CompletionContext
+
+                worker_run_id = _worker_run_id(tid)
+                worker_profile = os.environ.get("HERMES_PROFILE", "").strip()
+                completion_context = None
+                if worker_run_id is not None and worker_profile:
+                    completion_context = CompletionContext(
+                        caller_profile=worker_profile,
+                        native_task_id=tid,
+                        native_run_id=worker_run_id,
+                        source="worker-tool",
+                    )
                 ok = kb.complete_task(
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,
                     created_cards=created_cards,
-                    expected_run_id=_worker_run_id(tid),
+                    expected_run_id=worker_run_id,
+                    completion_context=completion_context,
                 )
             except kb.ArtifactPreservationError as artifact_err:
                 return tool_error(

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1463,9 +1463,14 @@ def _get_env_config() -> Dict[str, Any]:
     # Default image with Python and Node.js for maximum compatibility
     default_image = "nikolaik/python-nodejs:python3.11-nodejs20"
     _ensure_terminal_env_bridged()
-    env_type = os.getenv("TERMINAL_ENV", "local")
+    isolated_kanban_worker = (
+        os.getenv("HERMES_KANBAN_ISOLATED_WORKER", "").strip() == "1"
+    )
+    env_type = "docker" if isolated_kanban_worker else os.getenv("TERMINAL_ENV", "local")
     
-    mount_docker_cwd = os.getenv("TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false").lower() in {"true", "1", "yes"}
+    mount_docker_cwd = isolated_kanban_worker or os.getenv(
+        "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE", "false"
+    ).lower() in {"true", "1", "yes"}
     container_backend = env_type in {"docker", "singularity", "modal", "daytona", "vercel_sandbox"}
     docker_backend = env_type == "docker"
 
@@ -1494,6 +1499,13 @@ def _get_env_config() -> Dict[str, Any]:
         docker_env = {}
         docker_extra_args = []
         docker_shm_size = "1g"
+
+    if isolated_kanban_worker:
+        # Profile config and inherited env must not reopen host/network access.
+        docker_forward_env = []
+        docker_volumes = []
+        docker_env = {}
+        docker_extra_args = []
 
     # Default cwd: local uses the host's current directory, ssh uses the
     # remote home, Vercel uses its documented workspace root, and everything
@@ -1535,7 +1547,11 @@ def _get_env_config() -> Dict[str, Any]:
     return {
         "env_type": env_type,
         "modal_mode": coerce_modal_mode(os.getenv("TERMINAL_MODAL_MODE", "auto")),
-        "docker_image": os.getenv("TERMINAL_DOCKER_IMAGE", default_image),
+        "docker_image": (
+            default_image
+            if isolated_kanban_worker
+            else os.getenv("TERMINAL_DOCKER_IMAGE", default_image)
+        ),
         "docker_forward_env": docker_forward_env,
         "singularity_image": os.getenv("TERMINAL_SINGULARITY_IMAGE", f"docker://{default_image}"),
         "modal_image": os.getenv("TERMINAL_MODAL_IMAGE", default_image),
@@ -1564,11 +1580,27 @@ def _get_env_config() -> Dict[str, Any]:
         "container_cpu": container_cpu,
         "container_memory": container_memory,     # MB (default 5GB)
         "container_disk": container_disk,        # MB (default 50GB)
-        "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in {"true", "1", "yes"},
+        "container_persistent": (
+            False
+            if isolated_kanban_worker
+            else os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower()
+            in {"true", "1", "yes"}
+        ),
         "docker_volumes": docker_volumes,
         "docker_env": docker_env,
-        "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in {"true", "1", "yes"},
-        "docker_network": os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower() in {"true", "1", "yes"},
+        "docker_run_as_host_user": (
+            False
+            if isolated_kanban_worker
+            else os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower()
+            in {"true", "1", "yes"}
+        ),
+        "docker_network": (
+            False
+            if isolated_kanban_worker
+            else os.getenv("TERMINAL_DOCKER_NETWORK", "true").lower()
+            in {"true", "1", "yes"}
+        ),
+        "docker_mount_hermes_resources": not isolated_kanban_worker,
         "docker_extra_args": docker_extra_args,
         "docker_shm_size": docker_shm_size,
         # Cross-process container reuse (issue #20561).  The docs claim
@@ -1577,16 +1609,23 @@ def _get_env_config() -> Dict[str, Any]:
         # attaching to it instead of always starting a fresh one.  Set to
         # ``false`` for hard per-process isolation (no reuse, container is
         # removed on exit).
-        "docker_persist_across_processes": os.getenv(
-            "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_persist_across_processes": (
+            False
+            if isolated_kanban_worker
+            else os.getenv(
+                "TERMINAL_DOCKER_PERSIST_ACROSS_PROCESSES", "true"
+            ).lower() in {"true", "1", "yes"}
+        ),
         # Startup orphan reaper for hermes-tagged containers left behind by
         # crashed / SIGKILL'd previous processes that bypassed atexit.
         # Conservative: only sweeps Exited containers older than 2× the
         # idle-reap window AND scoped to the current profile. Issue #20561.
-        "docker_orphan_reaper": os.getenv(
-            "TERMINAL_DOCKER_ORPHAN_REAPER", "true"
-        ).lower() in {"true", "1", "yes"},
+        "docker_orphan_reaper": (
+            False
+            if isolated_kanban_worker
+            else os.getenv("TERMINAL_DOCKER_ORPHAN_REAPER", "true").lower()
+            in {"true", "1", "yes"}
+        ),
     }
 
 
@@ -1657,6 +1696,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             extra_args=docker_extra_args,
             persist_across_processes=cc.get("docker_persist_across_processes", True),
             shm_size=cc.get("docker_shm_size", "1g"),
+            mount_hermes_resources=cc.get("docker_mount_hermes_resources", True),
         )
     
     elif env_type == "singularity":


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in, fail-closed Kanban completion-governance path for deployments that need stronger separation between task workers and the authority that marks tasks `done`.

The candidate introduces:

- a transactional DB-layer completion guard with compare-and-swap semantics;
- policy-, approval-, and independent QA-result binding before governed completion;
- an optional Unix-socket broker that authenticates callers through `SO_PEERCRED` and maps OS UIDs to profiles;
- completion receipts written in the same SQLite transaction as the terminal state transition;
- worker isolation controls that remove direct completion authority, network access, and governed DB resource mounts;
- legacy compatibility: governance remains opt-in and plain `sqlite3.connect()` clients continue to work without application-specific UDFs.

This candidate was reintegrated onto upstream commit `9d4ef04ed00055414c13fcf33925d85790221a3f`. The rebased candidate commit is `cb6806e58daec66fe4660b5df35f4ab878b77e38`, with tree `70563680483f90eea5eeeb582a98f32e45485e6e`. Its stable patch ID remains `e884d3637f1c34396825966fc8a06ed00dd410ac`.

### Existing work / overlap

A duplicate search found related open work, especially #73543, #68281, #61857, #57960, and #51052. This PR overlaps in completion evidence and transactional completion, but its distinguishing scope is the external authority boundary: OS-principal-authenticated broker, policy/approval/QA hash binding, transactional receipts, and removal of governed workers' direct DB/network authority. The draft is opened for maintainers to decide whether this should be reshaped, split, or folded into one of those efforts.

## Related Issue

Related to #70806 and #32746.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `hermes_cli/kanban_completion_guard.py` for strict policy/approval/QA bindings and transactional completion receipts.
- Add `hermes_cli/kanban_completion_broker.py` for Unix-socket, `SO_PEERCRED`-authenticated completion requests.
- Harden completion paths in `hermes_cli/kanban_db.py` and `tools/kanban_tools.py` without weakening legacy behavior.
- Remove governed worker access to completion authority, governed SQLite resources, and network paths in `tools/terminal_tool.py` and `tools/environments/docker.py`.
- Add systemd/config deployment candidates under `plugins/kanban/systemd/` (not auto-installed or activated).
- Add focused completion-governance and worker-isolation regression suites.
- Document the security model, rollout gates, rollback requirements, and residual risks.

## How to Test

The repository's canonical runner uses a fresh Python process per test file.

1. Run the focused modules:
   ```bash
   UV_OFFLINE=1 PYTHONDONTWRITEBYTECODE=1 HERMES_TEST_FILE_RETRIES=0 HERMES_TEST_WORKERS=8 \
     scripts/run_tests.sh \
       tests/hermes_cli/test_kanban_completion_governance.py \
       tests/tools/test_governed_kanban_worker_isolation.py
   ```
   Expected reviewed result: **31 passed, 0 failed**.
2. Run the affected and adjacent Kanban, terminal, Docker, and governed-worker regression set with the same environment and `scripts/run_tests.sh`.
   Independently reviewed result: **68 files, 462 passed, 0 failed**.
3. Verify `git diff --check` and confirm a failed CAS leaves no receipt/permit, receipt failure rolls back the state transition, and a rival plain SQLite writer cannot enter during the authorization transaction.

The all-repository canonical runner was also executed with retries disabled. Its non-passing files were rerun identically against the exact base: candidate **24 failing files / 62 failed tests / 11 no-test files**, base **26 / 65 / 11**. The candidate introduced no new failing or no-test file; none of the recorded nonpasses intersects the 11-file candidate scope.

Independent QA and the independent defensive repository-code review both returned unqualified PASS on the exact frozen rebased candidate. Review envelope identities:

- QA: `af5b434f2ad118169ea2052788f91dfe5d56126376b345235ba967d348f7d313`
- Security: `52657141760675c899ceae3d976e006e73e5dc12eadca6ee8e98b9ac88b440b8`

The reviewed component identity is:

`9a64ee294fd0a54eb63d7f5b7b96e6d58f9e00f61921eaa72cfecf43fabdfefa`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full canonical suite was run, but the offline minimal-optional-dependency environment has base-reproducible nonpasses; comparative reruns found zero candidate-introduced failing/no-test files, and the affected 68-file suite passed 462/462
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux 6.8 x86_64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; this candidate uses a separate opt-in broker config example
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; rollout and trust-boundary documentation is scoped to `docs/security/`
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Linux-only broker/systemd activation is opt-in; legacy behavior remains unchanged elsewhere
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no public tool schema is changed

## Screenshots / Logs

No UI changes. Provider calls, live Kanban mutation, installation, service start, deployment, and production activation were not part of validation.
