### PR TITLE
feat(agent): empty-response cost guard — skip deterministic empty retries, cap expensive retry budget (salvage #75115)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1780,6 +1780,16 @@ def init_agent(
         _agent_section = {}
     agent._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
 
+    # Empty-response retry guard config (NS-503): additive
+    # ``agent.empty_response_guard`` subsection. Resolution is tolerant —
+    # a malformed section falls back to the schema defaults (guard on,
+    # $0.25 threshold), matching the guard's overall fail-open posture.
+    from agent.empty_response_guard import resolve_guard_settings
+    (
+        agent._empty_guard_enabled,
+        agent._empty_guard_cost_threshold_usd,
+    ) = resolve_guard_settings(_agent_section.get("empty_response_guard"))
+
     # Intent-ack continuation config: "auto" (default — codex_responses only,
     # the historical gate), true (all api_modes), false (never), or a list of
     # model-name substrings.  Resolved against the active api_mode/model in the

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -87,6 +87,7 @@ from agent.retry_utils import (
 )
 from agent.trajectory import has_incomplete_scratchpad
 from agent.usage_pricing import estimate_usage_cost, normalize_usage
+from agent import empty_response_guard as _empty_guard
 from hermes_constants import PARTIAL_STREAM_STUB_ID
 from hermes_logging import set_session_context
 from tools.skill_provenance import set_current_write_origin
@@ -6757,7 +6758,36 @@ def run_conversation(
                         _has_structured
                         and agent._thinking_prefill_retries >= 2
                     )
-                    if _truly_empty and (not _has_structured or _prefill_exhausted) and agent._empty_content_retries < 3:
+                    _empty_candidate = _truly_empty and (
+                        not _has_structured or _prefill_exhausted
+                    )
+                    if _empty_candidate:
+                        # NS-503: every empty attempt re-sends the full
+                        # conversation input at full price. Record the
+                        # attempt (usage/finish_reason signature) so
+                        # deterministic empties — e.g. unsignaled
+                        # provider refusals with zero output tokens —
+                        # stop burning paid retries reproducing the
+                        # same empty. Fails open: missing usage or
+                        # any generated tokens keep the full budget.
+                        _empty_guard.record_empty_attempt(
+                            agent,
+                            finish_reason=finish_reason,
+                            response=response,
+                        )
+                    _empty_retry_budget = (
+                        _empty_guard.empty_retry_budget(agent, response)
+                        if _empty_candidate
+                        else _empty_guard.DEFAULT_EMPTY_RETRY_BUDGET
+                    )
+                    _deterministic_empty = _empty_candidate and (
+                        _empty_guard.deterministic_empty(agent)
+                    )
+                    if (
+                        _empty_candidate
+                        and agent._empty_content_retries < _empty_retry_budget
+                        and not _deterministic_empty
+                    ):
                         agent._empty_content_retries += 1
                         wait_time = jittered_backoff(
                             agent._empty_content_retries,
@@ -6766,12 +6796,19 @@ def run_conversation(
                         )
                         logger.warning(
                             "Empty response (no content or reasoning) — "
-                            "retry %d/3 in %.1fs (model=%s)",
-                            agent._empty_content_retries, wait_time, agent.model,
+                            "retry %d/%d in %.1fs (model=%s)",
+                            agent._empty_content_retries,
+                            _empty_retry_budget, wait_time, agent.model,
+                        )
+                        _budget_note = (
+                            " — high-cost request, reduced retry budget"
+                            if _empty_retry_budget < _empty_guard.DEFAULT_EMPTY_RETRY_BUDGET
+                            else ""
                         )
                         agent._buffer_status(
                             f"⚠️ Empty response from model — retrying "
-                            f"({agent._empty_content_retries}/3) in {wait_time:.0f}s"
+                            f"({agent._empty_content_retries}/{_empty_retry_budget}) "
+                            f"in {wait_time:.0f}s{_budget_note}"
                         )
                         # Sleep in small increments to stay responsive to interrupts
                         sleep_end = time.time() + wait_time
@@ -6781,7 +6818,7 @@ def run_conversation(
                                 agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during empty-response retry wait, aborting.", force=True)
                                 _interrupt_text = (
                                     f"Operation interrupted: retrying empty response from model "
-                                    f"(retry {agent._empty_content_retries}/3)."
+                                    f"(retry {agent._empty_content_retries}/{_empty_retry_budget})."
                                 )
                                 close_interrupted_tool_sequence(messages, _interrupt_text)
                                 agent._persist_session(messages, conversation_history)
@@ -6797,10 +6834,24 @@ def run_conversation(
                             _backoff_touch_counter += 1
                             if _backoff_touch_counter % 150 == 0:  # 150 × 0.2s = 30s
                                 agent._touch_activity(
-                                    f"empty response retry backoff ({agent._empty_content_retries}/3), "
+                                    f"empty response retry backoff ({agent._empty_content_retries}/{_empty_retry_budget}), "
                                     f"{int(sleep_end - time.time())}s remaining"
                                 )
                         continue
+
+                    if _truly_empty and _deterministic_empty:
+                        logger.warning(
+                            "Deterministic empty response detected "
+                            "(consecutive zero-output completions, "
+                            "model=%s provider=%s finish_reason=%s) — "
+                            "skipping remaining retries",
+                            agent.model, agent.provider, finish_reason,
+                        )
+                        agent._buffer_status(
+                            "⚠️ Model is deterministically returning empty "
+                            "(zero output tokens) — skipping further retries "
+                            "to avoid repeat charges"
+                        )
 
                     # ── Exhausted retries — try fallback provider ──
                     # Before giving up with "(empty)", attempt to
@@ -6839,6 +6890,17 @@ def run_conversation(
                     # "(empty)" terminal.
                     # Surface the buffered retry/fallback trace so the
                     # user can see what was attempted before "(empty)".
+                    # NS-503: if we know roughly what the empty streak
+                    # cost (each attempt re-billed the full input), say
+                    # so — an unexplained charge for "no answer" is the
+                    # core of the complaint.
+                    _streak_cost = _empty_guard.streak_cost_usd(agent)
+                    if _streak_cost is not None:
+                        agent._buffer_status(
+                            f"ℹ️ Estimated cost of these empty attempts: "
+                            f"~${_streak_cost:.2f} (input tokens are billed "
+                            f"per attempt even when no answer is produced)"
+                        )
                     agent._flush_status_buffer()
                     _turn_exit_reason = "empty_response_exhausted"
                     reasoning_text = agent._extract_reasoning(assistant_message)

--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -26,27 +26,37 @@ Two independent guards, both failing OPEN to today's behaviour:
    and keep the full retry budget.
 
 2. **Cost-aware retry budget** — when the estimated input cost of a
-   single empty attempt exceeds ``HERMES_EMPTY_RETRY_COST_THRESHOLD_USD``
-   (default $0.25), the empty-retry budget for this streak drops from 3
-   to 1. Unknown pricing, missing usage, or included/subscription routes
+   single empty attempt exceeds the configured threshold (default
+   $0.25), the empty-retry budget for this streak drops from 3 to 1.
+   Unknown pricing, missing usage, or included/subscription routes
    leave the budget untouched.
 
-Set ``HERMES_DETERMINISTIC_EMPTY_GUARD=0`` to disable both guards.
+Configured via the additive ``agent.empty_response_guard`` section in
+``config.yaml`` (resolved once at agent init by ``agent_init``)::
+
+    agent:
+      empty_response_guard:
+        enabled: true            # false = legacy fixed 3-retry behaviour
+        cost_threshold_usd: 0.25 # per-attempt cost that halves the budget
+
+Per project policy, no ``HERMES_*`` environment variables are involved —
+``.env`` is reserved for credentials; behavioural settings live in
+``config.yaml``.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_EMPTY_RETRY_BUDGET = 3
 REDUCED_EMPTY_RETRY_BUDGET = 1
 DEFAULT_COST_THRESHOLD_USD = Decimal("0.25")
+DEFAULT_GUARD_ENABLED = True
 
 # Attribute names stashed on the agent object. State is scoped to one
 # consecutive empty streak: it is cleared whenever a streak starts
@@ -55,6 +65,8 @@ DEFAULT_COST_THRESHOLD_USD = Decimal("0.25")
 # success, fallback activation) without touching them.
 _ATTEMPTS_ATTR = "_empty_attempt_history"
 _STREAK_COST_ATTR = "_empty_streak_cost_usd"
+_ENABLED_ATTR = "_empty_guard_enabled"
+_THRESHOLD_ATTR = "_empty_guard_cost_threshold_usd"
 
 
 @dataclass(frozen=True)
@@ -72,26 +84,56 @@ class EmptyAttempt:
         return (self.model, self.provider, self.finish_reason)
 
 
-def guard_enabled() -> bool:
-    return os.environ.get("HERMES_DETERMINISTIC_EMPTY_GUARD", "1").strip().lower() not in (
-        "0",
-        "false",
-        "no",
-        "off",
-    )
+def resolve_guard_settings(section: Any) -> Tuple[bool, Decimal]:
+    """Resolve ``agent.empty_response_guard`` config into (enabled, threshold).
+
+    Tolerant of malformed input: anything that isn't a well-formed dict
+    (or well-formed values within it) falls back to the schema defaults.
+    Called once per agent at init; the resolved values are stashed on the
+    agent object so the hot loop never re-reads config.
+    """
+    if not isinstance(section, dict):
+        return (DEFAULT_GUARD_ENABLED, DEFAULT_COST_THRESHOLD_USD)
+
+    enabled_raw = section.get("enabled", DEFAULT_GUARD_ENABLED)
+    if isinstance(enabled_raw, bool):
+        enabled = enabled_raw
+    elif isinstance(enabled_raw, str):
+        # YAML quoting can turn true/false into strings.
+        enabled = enabled_raw.strip().lower() not in ("0", "false", "no", "off")
+    else:
+        enabled = DEFAULT_GUARD_ENABLED
+
+    threshold = DEFAULT_COST_THRESHOLD_USD
+    threshold_raw = section.get("cost_threshold_usd")
+    if threshold_raw is not None and not isinstance(threshold_raw, bool):
+        try:
+            candidate = Decimal(str(threshold_raw))
+            if candidate > 0:
+                threshold = candidate
+        except Exception:  # noqa: BLE001 — malformed config must not break init
+            logger.debug(
+                "empty-guard: invalid cost_threshold_usd %r, using default",
+                threshold_raw,
+            )
+    return (enabled, threshold)
 
 
-def _cost_threshold_usd() -> Decimal:
-    raw = os.environ.get("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "").strip()
-    if not raw:
-        return DEFAULT_COST_THRESHOLD_USD
-    try:
-        value = Decimal(raw)
-    except Exception:
-        return DEFAULT_COST_THRESHOLD_USD
-    if value <= 0:
-        return DEFAULT_COST_THRESHOLD_USD
-    return value
+def guard_enabled(agent: Any) -> bool:
+    """Whether the guard is enabled for this agent (config-resolved).
+
+    Agents built before the config was threaded through (tests, embedded
+    callers) simply get the default: enabled.
+    """
+    value = getattr(agent, _ENABLED_ATTR, DEFAULT_GUARD_ENABLED)
+    return value if isinstance(value, bool) else DEFAULT_GUARD_ENABLED
+
+
+def _cost_threshold_usd(agent: Any) -> Decimal:
+    value = getattr(agent, _THRESHOLD_ATTR, None)
+    if isinstance(value, Decimal) and value > 0:
+        return value
+    return DEFAULT_COST_THRESHOLD_USD
 
 
 def _attempts(agent: Any) -> List[EmptyAttempt]:
@@ -197,7 +239,7 @@ def deterministic_empty(agent: Any) -> bool:
     signature. Any attempt with missing usage or non-zero output keeps
     this False (fail open — transients deserve their retries).
     """
-    if not guard_enabled():
+    if not guard_enabled(agent):
         return False
     attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
     if len(attempts) < 2:
@@ -212,12 +254,12 @@ def deterministic_empty(agent: Any) -> bool:
 def empty_retry_budget(agent: Any, response: Any) -> int:
     """Empty-retry budget for the current streak (3, or 1 when a single
     attempt is estimated to cost more than the configured threshold)."""
-    if not guard_enabled():
+    if not guard_enabled(agent):
         return DEFAULT_EMPTY_RETRY_BUDGET
     cost = _estimate_attempt_cost(agent, response)
     if cost is None:
         return DEFAULT_EMPTY_RETRY_BUDGET
-    if cost >= _cost_threshold_usd():
+    if cost >= _cost_threshold_usd(agent):
         return REDUCED_EMPTY_RETRY_BUDGET
     return DEFAULT_EMPTY_RETRY_BUDGET
 

--- a/agent/empty_response_guard.py
+++ b/agent/empty_response_guard.py
@@ -1,0 +1,230 @@
+"""Deterministic-empty detection and cost-aware retry budgets (NS-503).
+
+When a provider returns an empty completion, the agent loop retries up to
+3 times and then walks the fallback chain. Every attempt re-sends the full
+conversation input — at large context on paid routes this bills the user
+repeatedly for a turn that produces no text (the "charged ~$2.33 for an
+empty answer" incident class).
+
+Signaled refusals (``finish_reason="content_filter"``, Anthropic
+``stop_reason="refusal"``, Bedrock guardrails) are already terminal and
+never reach the empty-retry loop. This module addresses the *unsignaled*
+empties: the provider reports a successful completion with zero output
+tokens and a generic finish reason (portal-proxied refusals commonly look
+like this).
+
+Two independent guards, both failing OPEN to today's behaviour:
+
+1. **Deterministic-empty detection** — two consecutive empty attempts,
+   both with usage present and ``output_tokens == 0``, from the same
+   (model, provider, finish_reason), are treated as deterministic: the
+   same prompt will keep producing the same empty. Remaining retries are
+   skipped and the loop proceeds straight to the fallback chain (a
+   different model may behave differently). Attempts with missing usage
+   or ``output_tokens > 0`` (model generated *something* — think-block
+   stripping, whitespace, flaky decoding) never classify as deterministic
+   and keep the full retry budget.
+
+2. **Cost-aware retry budget** — when the estimated input cost of a
+   single empty attempt exceeds ``HERMES_EMPTY_RETRY_COST_THRESHOLD_USD``
+   (default $0.25), the empty-retry budget for this streak drops from 3
+   to 1. Unknown pricing, missing usage, or included/subscription routes
+   leave the budget untouched.
+
+Set ``HERMES_DETERMINISTIC_EMPTY_GUARD=0`` to disable both guards.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EMPTY_RETRY_BUDGET = 3
+REDUCED_EMPTY_RETRY_BUDGET = 1
+DEFAULT_COST_THRESHOLD_USD = Decimal("0.25")
+
+# Attribute names stashed on the agent object. State is scoped to one
+# consecutive empty streak: it is cleared whenever a streak starts
+# (``_empty_content_retries == 0`` at record time), which transparently
+# honours every existing reset site (turn start, compaction, tool
+# success, fallback activation) without touching them.
+_ATTEMPTS_ATTR = "_empty_attempt_history"
+_STREAK_COST_ATTR = "_empty_streak_cost_usd"
+
+
+@dataclass(frozen=True)
+class EmptyAttempt:
+    """One observed empty completion within the current streak."""
+
+    model: str
+    provider: str
+    finish_reason: str
+    usage_present: bool
+    zero_output: bool
+
+    @property
+    def signature(self) -> tuple:
+        return (self.model, self.provider, self.finish_reason)
+
+
+def guard_enabled() -> bool:
+    return os.environ.get("HERMES_DETERMINISTIC_EMPTY_GUARD", "1").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _cost_threshold_usd() -> Decimal:
+    raw = os.environ.get("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "").strip()
+    if not raw:
+        return DEFAULT_COST_THRESHOLD_USD
+    try:
+        value = Decimal(raw)
+    except Exception:
+        return DEFAULT_COST_THRESHOLD_USD
+    if value <= 0:
+        return DEFAULT_COST_THRESHOLD_USD
+    return value
+
+
+def _attempts(agent: Any) -> List[EmptyAttempt]:
+    attempts = getattr(agent, _ATTEMPTS_ATTR, None)
+    if attempts is None:
+        attempts = []
+        setattr(agent, _ATTEMPTS_ATTR, attempts)
+    return attempts
+
+
+def _estimate_attempt_cost(agent: Any, response: Any) -> Optional[Decimal]:
+    """Best-effort USD estimate for one attempt. None when unknown."""
+    raw_usage = getattr(response, "usage", None)
+    if not raw_usage:
+        return None
+    try:
+        from agent.usage_pricing import estimate_usage_cost, normalize_usage
+
+        canonical = normalize_usage(
+            raw_usage,
+            provider=getattr(agent, "provider", None),
+            api_mode=getattr(agent, "api_mode", None),
+        )
+        result = estimate_usage_cost(
+            getattr(agent, "model", "") or "",
+            canonical,
+            provider=getattr(agent, "provider", None),
+            base_url=getattr(agent, "base_url", None),
+            api_key=getattr(agent, "api_key", None),
+        )
+    except Exception:  # noqa: BLE001 — pricing must never break the loop
+        logger.debug("empty-guard: cost estimation failed", exc_info=True)
+        return None
+    return getattr(result, "amount_usd", None)
+
+
+def _zero_output(agent: Any, response: Any) -> tuple:
+    """Return (usage_present, zero_output) for a response, failing open."""
+    raw_usage = getattr(response, "usage", None)
+    if not raw_usage:
+        return (False, False)
+    try:
+        from agent.usage_pricing import normalize_usage
+
+        canonical = normalize_usage(
+            raw_usage,
+            provider=getattr(agent, "provider", None),
+            api_mode=getattr(agent, "api_mode", None),
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("empty-guard: usage normalization failed", exc_info=True)
+        return (False, False)
+    output = getattr(canonical, "output_tokens", None)
+    if output is None:
+        return (False, False)
+    # A present-but-empty usage object (some proxies emit usage with no
+    # fields) normalizes to all zeros. A genuine completion always has
+    # input tokens — without them the usage is not evidence, fail open.
+    if getattr(canonical, "prompt_tokens", 0) <= 0:
+        return (False, False)
+    # Reasoning tokens count as real generation — a reasoning-only
+    # response is NOT a deterministic empty (the prefill-continuation
+    # path upstream owns that case).
+    reasoning = getattr(canonical, "reasoning_tokens", 0) or 0
+    return (True, (output + reasoning) == 0)
+
+
+def record_empty_attempt(agent: Any, *, finish_reason: str, response: Any) -> None:
+    """Record one empty completion in the current streak.
+
+    Must be called before ``_empty_content_retries`` is incremented for
+    this attempt: a counter of 0 marks the start of a new streak and
+    clears prior history (this transparently follows every existing
+    counter-reset site).
+    """
+    attempts = _attempts(agent)
+    if getattr(agent, "_empty_content_retries", 0) == 0:
+        attempts.clear()
+        setattr(agent, _STREAK_COST_ATTR, Decimal("0"))
+
+    usage_present, zero_output = _zero_output(agent, response)
+    attempts.append(
+        EmptyAttempt(
+            model=str(getattr(agent, "model", "") or ""),
+            provider=str(getattr(agent, "provider", "") or ""),
+            finish_reason=str(finish_reason or ""),
+            usage_present=usage_present,
+            zero_output=zero_output,
+        )
+    )
+
+    cost = _estimate_attempt_cost(agent, response)
+    if cost is not None and cost > 0:
+        prior = getattr(agent, _STREAK_COST_ATTR, Decimal("0")) or Decimal("0")
+        setattr(agent, _STREAK_COST_ATTR, prior + cost)
+
+
+def deterministic_empty(agent: Any) -> bool:
+    """True when the current streak looks deterministic.
+
+    Requires >= 2 consecutive attempts, ALL with usage present, zero
+    output tokens, and an identical (model, provider, finish_reason)
+    signature. Any attempt with missing usage or non-zero output keeps
+    this False (fail open — transients deserve their retries).
+    """
+    if not guard_enabled():
+        return False
+    attempts = getattr(agent, _ATTEMPTS_ATTR, None) or []
+    if len(attempts) < 2:
+        return False
+    first = attempts[0]
+    return all(
+        a.usage_present and a.zero_output and a.signature == first.signature
+        for a in attempts
+    )
+
+
+def empty_retry_budget(agent: Any, response: Any) -> int:
+    """Empty-retry budget for the current streak (3, or 1 when a single
+    attempt is estimated to cost more than the configured threshold)."""
+    if not guard_enabled():
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    cost = _estimate_attempt_cost(agent, response)
+    if cost is None:
+        return DEFAULT_EMPTY_RETRY_BUDGET
+    if cost >= _cost_threshold_usd():
+        return REDUCED_EMPTY_RETRY_BUDGET
+    return DEFAULT_EMPTY_RETRY_BUDGET
+
+
+def streak_cost_usd(agent: Any) -> Optional[Decimal]:
+    """Accumulated estimated cost of the current empty streak, if known."""
+    cost = getattr(agent, _STREAK_COST_ATTR, None)
+    if cost is None or cost <= 0:
+        return None
+    return cost

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -69,6 +69,22 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Empty-response retry guard (NS-503).  The empty-retry loop
+        # re-sends the full conversation input at full price on every
+        # attempt; these settings stop it from re-billing *deterministic*
+        # empties (unsignaled provider refusals with zero output tokens)
+        # while failing open on any ambiguous evidence (missing usage,
+        # any generated tokens, model/provider change mid-streak).
+        "empty_response_guard": {
+            # Master switch for both guards below. False restores the
+            # legacy fixed 3-retry behaviour unconditionally.
+            "enabled": True,
+            # When the estimated input cost of a single empty attempt
+            # meets or exceeds this many USD, the retry budget for the
+            # streak drops from 3 to 1. Unknown pricing or missing usage
+            # leaves the budget untouched.
+            "cost_threshold_usd": 0.25,
+        },
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -129,15 +129,32 @@ class TestDeterministicEmpty:
         _record_streak(agent, [_response(), _response()])
         assert guard.deterministic_empty(agent) is False
 
-    def test_reasoning_tokens_count_as_generation(self, monkeypatch):
+    def test_reasoning_tokens_count_as_generation(self):
         """Reasoning-only responses are owned by the prefill path; the
-        guard must not classify them as deterministic empties."""
-        canonical = SimpleNamespace(output_tokens=0, reasoning_tokens=128)
-        monkeypatch.setattr(
-            guard, "_zero_output", lambda a, r: (True, (0 + 128) == 0)
-        )
+        guard must not classify them as deterministic empties.
+
+        Exercises the real _zero_output/normalize_usage path: a chat
+        completions response with completion_tokens == 0 but
+        completion_tokens_details.reasoning_tokens > 0 (hidden thinking,
+        no visible text) counts as generation."""
+
+        def _reasoning_only_response():
+            usage = SimpleNamespace(
+                prompt_tokens=25_900,
+                completion_tokens=0,
+                total_tokens=25_900,
+                completion_tokens_details=SimpleNamespace(reasoning_tokens=128),
+            )
+            return SimpleNamespace(usage=usage)
+
         agent = _agent()
-        _record_streak(agent, [_response(), _response()])
+        present, zero = guard._zero_output(agent, _reasoning_only_response())
+        assert present is True
+        assert zero is False  # reasoning tokens are real generation
+
+        _record_streak(
+            agent, [_reasoning_only_response(), _reasoning_only_response()]
+        )
         assert guard.deterministic_empty(agent) is False
 
 
@@ -205,12 +222,9 @@ class TestEmptyRetryBudget:
             == guard.DEFAULT_EMPTY_RETRY_BUDGET
         )
 
-    def test_pricing_exception_fails_open(self, monkeypatch):
-        def _boom(a, r):
-            raise RuntimeError("pricing exploded")
-
-        # _estimate_attempt_cost itself catches internally; simulate at
-        # the normalize layer by feeding garbage usage.
+    def test_pricing_exception_fails_open(self):
+        # Garbage usage at the normalize layer must not tighten the budget;
+        # _estimate_attempt_cost catches internally and returns None.
         agent = _agent(model=None, provider=None)
         resp = SimpleNamespace(usage=object())
         assert (

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -1,0 +1,280 @@
+"""Tests for agent/empty_response_guard.py (NS-503).
+
+The guard exists to stop the empty-retry loop re-billing large inputs for
+deterministic empties (unsignaled provider refusals with zero output
+tokens) while never tightening behaviour on ambiguous evidence.
+
+Fail-open contract under test:
+- Missing usage -> never deterministic, default budget.
+- Any generated tokens (output or reasoning) -> never deterministic.
+- Different model/provider/finish_reason across attempts -> not deterministic.
+- Guard disabled via env -> everything falls back to defaults.
+"""
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from agent import empty_response_guard as guard
+
+
+def _agent(**overrides):
+    base = dict(
+        model="anthropic/claude-fable-5",
+        provider="nous",
+        api_mode="chat_completions",
+        base_url=None,
+        api_key=None,
+        _empty_content_retries=0,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _response(prompt_tokens=25_900, completion_tokens=0, usage_present=True):
+    if not usage_present:
+        return SimpleNamespace(usage=None)
+    usage = SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+    return SimpleNamespace(usage=usage)
+
+
+def _record_streak(agent, responses, finish_reasons=None):
+    """Record attempts the way the loop does: record, then increment."""
+    finish_reasons = finish_reasons or ["stop"] * len(responses)
+    for resp, reason in zip(responses, finish_reasons):
+        guard.record_empty_attempt(agent, finish_reason=reason, response=resp)
+        agent._empty_content_retries += 1
+
+
+class TestDeterministicEmpty:
+    def test_two_zero_output_attempts_same_signature_is_deterministic(self):
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.deterministic_empty(agent) is True
+
+    def test_single_attempt_is_never_deterministic(self):
+        """One empty could be a transient blip — retry #1 must always run."""
+        agent = _agent()
+        _record_streak(agent, [_response()])
+        assert guard.deterministic_empty(agent) is False
+
+    def test_missing_usage_fails_open(self):
+        agent = _agent()
+        _record_streak(
+            agent,
+            [_response(usage_present=False), _response(usage_present=False)],
+        )
+        assert guard.deterministic_empty(agent) is False
+
+    def test_mixed_usage_presence_fails_open(self):
+        agent = _agent()
+        _record_streak(agent, [_response(), _response(usage_present=False)])
+        assert guard.deterministic_empty(agent) is False
+
+    def test_nonzero_output_tokens_fails_open(self):
+        """Model generated something (whitespace, stripped think-blocks) —
+        that's the flaky-but-recoverable class, keep full retries."""
+        agent = _agent()
+        _record_streak(
+            agent,
+            [_response(completion_tokens=42), _response(completion_tokens=42)],
+        )
+        assert guard.deterministic_empty(agent) is False
+
+    def test_zero_then_nonzero_fails_open(self):
+        agent = _agent()
+        _record_streak(
+            agent,
+            [_response(completion_tokens=0), _response(completion_tokens=7)],
+        )
+        assert guard.deterministic_empty(agent) is False
+
+    def test_signature_change_resets_determinism(self):
+        """Fallback switched model mid-streak — new model deserves retries."""
+        agent = _agent()
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+        agent._empty_content_retries += 1
+        agent.model = "other/model"
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+        agent._empty_content_retries += 1
+        assert guard.deterministic_empty(agent) is False
+
+    def test_finish_reason_change_fails_open(self):
+        agent = _agent()
+        _record_streak(
+            agent,
+            [_response(), _response()],
+            finish_reasons=["stop", "length"],
+        )
+        assert guard.deterministic_empty(agent) is False
+
+    def test_new_streak_clears_history(self):
+        """Counter reset to 0 (turn start / tool success / compaction /
+        fallback) starts a fresh streak — prior attempts must not leak."""
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.deterministic_empty(agent) is True
+
+        agent._empty_content_retries = 0  # any existing reset site
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+        agent._empty_content_retries += 1
+        assert guard.deterministic_empty(agent) is False
+
+    def test_guard_disabled_via_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DETERMINISTIC_EMPTY_GUARD", "0")
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.deterministic_empty(agent) is False
+
+    def test_reasoning_tokens_count_as_generation(self, monkeypatch):
+        """Reasoning-only responses are owned by the prefill path; the
+        guard must not classify them as deterministic empties."""
+        canonical = SimpleNamespace(output_tokens=0, reasoning_tokens=128)
+        monkeypatch.setattr(
+            guard, "_zero_output", lambda a, r: (True, (0 + 128) == 0)
+        )
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.deterministic_empty(agent) is False
+
+
+class TestEmptyRetryBudget:
+    def test_default_budget_when_cost_unknown(self, monkeypatch):
+        monkeypatch.setattr(guard, "_estimate_attempt_cost", lambda a, r: None)
+        assert (
+            guard.empty_retry_budget(_agent(), _response())
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
+    def test_reduced_budget_above_threshold(self, monkeypatch):
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("0.80")
+        )
+        assert (
+            guard.empty_retry_budget(_agent(), _response())
+            == guard.REDUCED_EMPTY_RETRY_BUDGET
+        )
+
+    def test_default_budget_below_threshold(self, monkeypatch):
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("0.01")
+        )
+        assert (
+            guard.empty_retry_budget(_agent(), _response())
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
+    def test_custom_threshold_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "5.00")
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("0.80")
+        )
+        assert (
+            guard.empty_retry_budget(_agent(), _response())
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
+    def test_bad_threshold_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "banana")
+        assert guard._cost_threshold_usd() == guard.DEFAULT_COST_THRESHOLD_USD
+        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "-1")
+        assert guard._cost_threshold_usd() == guard.DEFAULT_COST_THRESHOLD_USD
+
+    def test_guard_disabled_keeps_default_budget(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DETERMINISTIC_EMPTY_GUARD", "0")
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("9.99")
+        )
+        assert (
+            guard.empty_retry_budget(_agent(), _response())
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
+    def test_pricing_exception_fails_open(self, monkeypatch):
+        def _boom(a, r):
+            raise RuntimeError("pricing exploded")
+
+        # _estimate_attempt_cost itself catches internally; simulate at
+        # the normalize layer by feeding garbage usage.
+        agent = _agent(model=None, provider=None)
+        resp = SimpleNamespace(usage=object())
+        assert (
+            guard.empty_retry_budget(agent, resp)
+            == guard.DEFAULT_EMPTY_RETRY_BUDGET
+        )
+
+
+class TestStreakCost:
+    def test_streak_cost_accumulates(self, monkeypatch):
+        costs = iter([Decimal("1.10"), Decimal("1.23")])
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: next(costs)
+        )
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.streak_cost_usd(agent) == Decimal("2.33")
+
+    def test_streak_cost_none_when_unknown(self, monkeypatch):
+        monkeypatch.setattr(guard, "_estimate_attempt_cost", lambda a, r: None)
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.streak_cost_usd(agent) is None
+
+    def test_streak_cost_resets_on_new_streak(self, monkeypatch):
+        monkeypatch.setattr(
+            guard, "_estimate_attempt_cost", lambda a, r: Decimal("1.00")
+        )
+        agent = _agent()
+        _record_streak(agent, [_response(), _response()])
+        assert guard.streak_cost_usd(agent) == Decimal("2.00")
+        agent._empty_content_retries = 0
+        guard.record_empty_attempt(agent, finish_reason="stop", response=_response())
+        assert guard.streak_cost_usd(agent) == Decimal("1.00")
+
+
+class TestZeroOutputExtraction:
+    """_zero_output goes through the real normalize_usage path."""
+
+    def test_openai_shape_zero_completion(self):
+        agent = _agent()
+        present, zero = guard._zero_output(agent, _response(completion_tokens=0))
+        assert present is True
+        assert zero is True
+
+    def test_openai_shape_with_completion(self):
+        agent = _agent()
+        present, zero = guard._zero_output(agent, _response(completion_tokens=9))
+        assert present is True
+        assert zero is False
+
+    def test_no_usage(self):
+        agent = _agent()
+        present, zero = guard._zero_output(agent, _response(usage_present=False))
+        assert present is False
+        assert zero is False
+
+    def test_anthropic_shape_zero_output(self):
+        agent = _agent(api_mode="anthropic_messages")
+        usage = SimpleNamespace(
+            input_tokens=25_900,
+            output_tokens=0,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        )
+        present, zero = guard._zero_output(agent, SimpleNamespace(usage=usage))
+        assert present is True
+        assert zero is True
+
+    def test_all_zero_usage_object_fails_open(self):
+        """Proxies that emit an empty usage object (all fields absent →
+        normalized to zeros) provide no evidence — must not classify."""
+        agent = _agent()
+        usage = SimpleNamespace()  # no token fields at all
+        present, zero = guard._zero_output(agent, SimpleNamespace(usage=usage))
+        assert present is False
+        assert zero is False

--- a/tests/agent/test_empty_response_guard.py
+++ b/tests/agent/test_empty_response_guard.py
@@ -8,13 +8,12 @@ Fail-open contract under test:
 - Missing usage -> never deterministic, default budget.
 - Any generated tokens (output or reasoning) -> never deterministic.
 - Different model/provider/finish_reason across attempts -> not deterministic.
-- Guard disabled via env -> everything falls back to defaults.
+- Guard disabled via config (agent.empty_response_guard.enabled: false) ->
+  everything falls back to defaults.
 """
 
 from decimal import Decimal
 from types import SimpleNamespace
-
-import pytest
 
 from agent import empty_response_guard as guard
 
@@ -125,9 +124,8 @@ class TestDeterministicEmpty:
         agent._empty_content_retries += 1
         assert guard.deterministic_empty(agent) is False
 
-    def test_guard_disabled_via_env(self, monkeypatch):
-        monkeypatch.setenv("HERMES_DETERMINISTIC_EMPTY_GUARD", "0")
-        agent = _agent()
+    def test_guard_disabled_via_config(self):
+        agent = _agent(_empty_guard_enabled=False)
         _record_streak(agent, [_response(), _response()])
         assert guard.deterministic_empty(agent) is False
 
@@ -169,29 +167,41 @@ class TestEmptyRetryBudget:
             == guard.DEFAULT_EMPTY_RETRY_BUDGET
         )
 
-    def test_custom_threshold_env(self, monkeypatch):
-        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "5.00")
+    def test_custom_threshold_config(self, monkeypatch):
         monkeypatch.setattr(
             guard, "_estimate_attempt_cost", lambda a, r: Decimal("0.80")
         )
         assert (
-            guard.empty_retry_budget(_agent(), _response())
+            guard.empty_retry_budget(
+                _agent(_empty_guard_cost_threshold_usd=Decimal("5.00")),
+                _response(),
+            )
             == guard.DEFAULT_EMPTY_RETRY_BUDGET
         )
 
-    def test_bad_threshold_env_falls_back(self, monkeypatch):
-        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "banana")
-        assert guard._cost_threshold_usd() == guard.DEFAULT_COST_THRESHOLD_USD
-        monkeypatch.setenv("HERMES_EMPTY_RETRY_COST_THRESHOLD_USD", "-1")
-        assert guard._cost_threshold_usd() == guard.DEFAULT_COST_THRESHOLD_USD
+    def test_bad_threshold_attr_falls_back(self):
+        # Non-Decimal or non-positive resolved values fall back to default.
+        assert (
+            guard._cost_threshold_usd(_agent(_empty_guard_cost_threshold_usd="banana"))
+            == guard.DEFAULT_COST_THRESHOLD_USD
+        )
+        assert (
+            guard._cost_threshold_usd(
+                _agent(_empty_guard_cost_threshold_usd=Decimal("-1"))
+            )
+            == guard.DEFAULT_COST_THRESHOLD_USD
+        )
+        assert (
+            guard._cost_threshold_usd(_agent())  # attr absent entirely
+            == guard.DEFAULT_COST_THRESHOLD_USD
+        )
 
     def test_guard_disabled_keeps_default_budget(self, monkeypatch):
-        monkeypatch.setenv("HERMES_DETERMINISTIC_EMPTY_GUARD", "0")
         monkeypatch.setattr(
             guard, "_estimate_attempt_cost", lambda a, r: Decimal("9.99")
         )
         assert (
-            guard.empty_retry_budget(_agent(), _response())
+            guard.empty_retry_budget(_agent(_empty_guard_enabled=False), _response())
             == guard.DEFAULT_EMPTY_RETRY_BUDGET
         )
 
@@ -278,3 +288,56 @@ class TestZeroOutputExtraction:
         present, zero = guard._zero_output(agent, SimpleNamespace(usage=usage))
         assert present is False
         assert zero is False
+
+
+class TestResolveGuardSettings:
+    """resolve_guard_settings maps the additive agent.empty_response_guard
+    config.yaml section into (enabled, threshold), tolerating malformed
+    input by falling back to schema defaults."""
+
+    def test_missing_section_uses_defaults(self):
+        assert guard.resolve_guard_settings(None) == (
+            guard.DEFAULT_GUARD_ENABLED,
+            guard.DEFAULT_COST_THRESHOLD_USD,
+        )
+
+    def test_non_dict_section_uses_defaults(self):
+        assert guard.resolve_guard_settings("nope") == (
+            guard.DEFAULT_GUARD_ENABLED,
+            guard.DEFAULT_COST_THRESHOLD_USD,
+        )
+
+    def test_disabled(self):
+        enabled, _ = guard.resolve_guard_settings({"enabled": False})
+        assert enabled is False
+
+    def test_yaml_string_bool(self):
+        enabled, _ = guard.resolve_guard_settings({"enabled": "false"})
+        assert enabled is False
+        enabled, _ = guard.resolve_guard_settings({"enabled": "true"})
+        assert enabled is True
+
+    def test_custom_threshold(self):
+        _, threshold = guard.resolve_guard_settings({"cost_threshold_usd": 5})
+        assert threshold == Decimal("5")
+        _, threshold = guard.resolve_guard_settings({"cost_threshold_usd": "1.50"})
+        assert threshold == Decimal("1.50")
+
+    def test_bad_threshold_falls_back(self):
+        _, threshold = guard.resolve_guard_settings({"cost_threshold_usd": "banana"})
+        assert threshold == guard.DEFAULT_COST_THRESHOLD_USD
+        _, threshold = guard.resolve_guard_settings({"cost_threshold_usd": -1})
+        assert threshold == guard.DEFAULT_COST_THRESHOLD_USD
+        _, threshold = guard.resolve_guard_settings({"cost_threshold_usd": True})
+        assert threshold == guard.DEFAULT_COST_THRESHOLD_USD
+
+    def test_default_config_schema_matches(self):
+        """The shipped DEFAULT_CONFIG section resolves to the module
+        defaults — keeps config_defaults.py and this module in sync."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        section = DEFAULT_CONFIG["agent"]["empty_response_guard"]
+        assert guard.resolve_guard_settings(section) == (
+            guard.DEFAULT_GUARD_ENABLED,
+            guard.DEFAULT_COST_THRESHOLD_USD,
+        )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3216,6 +3216,52 @@ class TestRunConversation:
         assert "No reply:" in result["final_response"]
         assert result["api_calls"] == 4  # 1 original + 3 retries
 
+    def test_deterministic_empty_stops_retries_early(self, agent):
+        """NS-503: consecutive zero-output-token empties with identical
+        model/provider/finish_reason are deterministic (unsignaled refusal)
+        — the loop must stop re-billing the full input after the second
+        attempt instead of burning the whole retry budget."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        zero_usage = {
+            "prompt_tokens": 25_900,
+            "completion_tokens": 0,
+            "total_tokens": 25_900,
+        }
+        empty_resp = _mock_response(
+            content=None, finish_reason="stop", usage=zero_usage
+        )
+        # Provide plenty of responses; guard should stop consuming early.
+        agent.client.chat.completions.create.side_effect = [empty_resp] * 6
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+        assert result["completed"] is True
+        assert result["final_response"] != "(empty)"
+        # 1 original + 1 retry: the second identical zero-output empty
+        # proves determinism, remaining retries are skipped.
+        assert result["api_calls"] == 2
+
+    def test_empty_without_usage_keeps_full_retry_budget(self, agent):
+        """NS-503 fail-open: no usage data means no evidence of a
+        deterministic empty — legacy 3-retry behaviour must be preserved
+        (this is the flaky-provider case retries exist for)."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        empty_resp = _mock_response(content=None, finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [empty_resp] * 4
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+        assert result["completed"] is True
+        assert result["api_calls"] == 4  # unchanged: 1 original + 3 retries
+
     def test_truly_empty_response_succeeds_on_nudge(self, agent):
         """Model produces content after being nudged for empty response."""
         self._setup_agent(agent)

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3245,6 +3245,31 @@ class TestRunConversation:
         # proves determinism, remaining retries are skipped.
         assert result["api_calls"] == 2
 
+    def test_guard_disabled_via_config_restores_legacy_retries(self, agent):
+        """NS-503: agent.empty_response_guard.enabled: false in config.yaml
+        (resolved to _empty_guard_enabled at init) restores the legacy
+        fixed 3-retry behaviour even for deterministic empties."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        agent._empty_guard_enabled = False  # as set by agent_init from config
+        zero_usage = {
+            "prompt_tokens": 25_900,
+            "completion_tokens": 0,
+            "total_tokens": 25_900,
+        }
+        empty_resp = _mock_response(
+            content=None, finish_reason="stop", usage=zero_usage
+        )
+        agent.client.chat.completions.create.side_effect = [empty_resp] * 6
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("answer me")
+        assert result["completed"] is True
+        assert result["api_calls"] == 4  # legacy: 1 original + 3 retries
+
     def test_empty_without_usage_keeps_full_retry_budget(self, agent):
         """NS-503 fail-open: no usage data means no evidence of a
         deterministic empty — legacy 3-retry behaviour must be preserved


### PR DESCRIPTION
Stops the empty-retry loop from re-billing the full conversation input on deterministic empty responses — the NS-503 incident class where a user was charged ~$2.33 for a single empty answer on a ~26K-token session.

## Changes

- **New `agent/empty_response_guard.py`** (+780/-6 across the PR): two independent guards, both failing OPEN to today's behaviour.
  - **Deterministic-empty detection**: two consecutive empty attempts with usage present, `output_tokens == 0` (reasoning tokens count as output), and identical `(model, provider, finish_reason)` signature skip the remaining retries and go straight to the fallback chain — a different model may well answer. Missing usage, nonzero output, or any signature change keeps the full budget.
  - **Cost-aware retry budget**: when a single attempt's estimated input cost exceeds the configured threshold (default $0.25), the empty-retry budget drops from 3 to 1.
- **Config-only, no env vars**: settings live in the additive `agent.empty_response_guard` section of `config.yaml` (`enabled`, `cost_threshold_usd`), resolved once at agent init. The contributor's follow-up commit removing the earlier `HERMES_*` env vars is included; a final-tree grep confirms zero `HERMES_EMPTY*`/`HERMES_DETERMINISTIC*` references remain.
- **Status trace**: accumulated streak cost surfaced in the retry status line.
- **Safety**: fail-open on missing usage, pricing errors, and malformed config; no history mutation; streak state clears at every existing `_empty_content_retries` reset site (cache-safe).

## Validation

- `scripts/run_tests.sh tests/agent/test_empty_response_guard.py tests/run_agent/test_run_agent.py` → **275 tests passed, 0 failed** (33 in the new guard test file, 242 in the run_agent integration file, which gains 3 new integration tests: early-stop at 2 calls, `enabled: false` legacy 4-call behaviour, missing-usage fail-open).
- `ruff check` clean on all touched files; `grep HERMES_EMPTY` in `agent/`/`hermes_cli/`/`tests/` returns nothing.

## Test hardening (follow-up commit)

- Rewrote `test_reasoning_tokens_count_as_generation`, which previously monkeypatched `guard._zero_output` (the code under test) into a constant — making the assertion vacuous. It now feeds a real chat-completions usage shape (`completion_tokens=0`, `completion_tokens_details.reasoning_tokens=128`) through the genuine `_zero_output` → `normalize_usage` path and asserts both the extraction result and the non-deterministic classification.
- Removed unused test variables: the dead `canonical = SimpleNamespace(...)` in that same test, and the unused `_boom` raiser + unused `monkeypatch` fixture in `test_pricing_exception_fails_open`.

Salvages #75115 by @shannonsands (authorship preserved via cherry-pick); test hardening added on top.

## Infographic

![empty-response-cost-guard](https://v3b.fal.media/files/b/0aa54512/45IWxu4dDx9z5jI7UfY3z_6sawo4nv.png)
