### PR TITLE
fix(search): translate \d/\D for the grep fallback engine

### DIFF
--- a/tests/tools/test_grep_fallback_digit_classes.py
+++ b/tests/tools/test_grep_fallback_digit_classes.py
@@ -1,0 +1,88 @@
+"""The grep fallback must answer the same question ripgrep does.
+
+`_search_with_grep` runs `grep -rnHE`. POSIX ERE has no `\\d`/`\\D`; GNU grep
+reads the backslash as a literal, so `\\d+` matches runs of the letter ``d``
+instead of digits — false hits *and* missed hits, with no error. The engine is
+picked by whether ripgrep is installed, so the same search silently answers
+differently inside a container that ships grep but not rg.
+
+GNU grep does support `\\s`, `\\S`, `\\w`, `\\W`, `\\b` as extensions; only the
+digit classes need translating.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools.file_operations import ShellFileOperations
+
+BS = chr(92)  # a literal backslash, spelled without escape ambiguity
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        (BS + "d+", "[[:digit:]]+"),
+        (BS + "D", "[^[:digit:]]"),
+        ("v" + BS + "d" + BS + "." + BS + "d", "v[[:digit:]]" + BS + ".[[:digit:]]"),
+        # An escaped backslash is a literal backslash — the ``d`` after it is
+        # not a class.
+        (BS + BS + "d", BS + BS + "d"),
+        # Inside a bracket expression ``[\d]`` already means the set {\, d}.
+        ("[" + BS + "d]", "[" + BS + "d]"),
+        # ']' as the first member belongs to the set, so the set is still open.
+        ("[]" + BS + "d]", "[]" + BS + "d]"),
+        # GNU grep understands these; leave them alone.
+        (BS + "s" + BS + "w" + BS + "b", BS + "s" + BS + "w" + BS + "b"),
+        ("plain", "plain"),
+        ("", ""),
+    ],
+)
+def test_translation_covers_only_the_digit_classes(pattern, expected):
+    from tools.file_operations import _ere_translate_digit_classes
+
+    assert _ere_translate_digit_classes(pattern) == expected
+
+
+def _fops_capturing(commands):
+    env = MagicMock()
+    env.cwd = "/work"
+
+    def _execute(cmd, *args, **kwargs):
+        commands.append(cmd if isinstance(cmd, str) else " ".join(map(str, cmd)))
+        return {"output": "", "returncode": 1}
+
+    env.execute = _execute
+    fops = ShellFileOperations(env)
+    fops._has_command = lambda cmd: cmd == "grep"
+    return fops
+
+
+def test_grep_engine_receives_a_digit_class_not_a_bare_escape():
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+
+    fops._search_content(BS + "d+", "/work", None, 20, 0, "content", 0)
+
+    grep_cmds = [c for c in commands if "grep -rnHE" in c]
+    assert grep_cmds, f"no grep command was issued (commands={commands!r})"
+    assert "[[:digit:]]" in grep_cmds[0], (
+        f"grep got a pattern it cannot interpret as digits: {grep_cmds[0]!r}"
+    )
+
+
+def test_ripgrep_engine_keeps_the_pattern_verbatim():
+    """rg speaks the Perl shorthand natively — do not rewrite it there."""
+    commands: list[str] = []
+    fops = _fops_capturing(commands)
+    fops._has_command = lambda cmd: cmd == "rg"
+
+    fops._search_content(BS + "d+", "/work", None, 20, 0, "content", 0)
+
+    rg_cmds = [c for c in commands if c.startswith("rg ") or " rg " in c]
+    assert rg_cmds, f"no rg command was issued (commands={commands!r})"
+    assert "[[:digit:]]" not in rg_cmds[0], (
+        f"the rg pattern was rewritten unnecessarily: {rg_cmds[0]!r}"
+    )

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -800,6 +800,57 @@ def _maybe_warn_line_oriented_newline_pattern(result: SearchResult, pattern: str
     return result
 
 
+def _ere_translate_digit_classes(pattern: str) -> str:
+    """Rewrite ``\\d``/``\\D`` into POSIX classes for the ``grep -E`` engine.
+
+    ripgrep's Rust regex accepts the Perl shorthand classes; POSIX ERE does
+    not. GNU grep supports ``\\s``, ``\\S``, ``\\w``, ``\\W`` and ``\\b`` as
+    extensions, but **not** ``\\d``/``\\D`` — it reads the backslash as a
+    literal, so ``\\d+`` silently matches runs of the letter ``d`` instead of
+    digits: both false hits and missed hits, with no error. Translating keeps
+    the fallback engine answering the same question rg does.
+
+    Left alone: an escaped backslash (``\\\\d`` is a literal backslash then
+    ``d``) and anything inside a bracket expression, where ``[\\d]`` already
+    means the set ``{\\, d}`` in ERE and rewriting would change it.
+    """
+    if not pattern or "\\" not in pattern:
+        return pattern
+    out: list[str] = []
+    i = 0
+    in_bracket = False
+    n = len(pattern)
+    while i < n:
+        ch = pattern[i]
+        if in_bracket:
+            # A ']' closes the set unless it is the very first member.
+            if ch == "]" and out and out[-1] != "[" and not (
+                out[-1] == "^" and len(out) >= 2 and out[-2] == "["
+            ):
+                in_bracket = False
+            out.append(ch)
+            i += 1
+            continue
+        if ch == "\\" and i + 1 < n:
+            nxt = pattern[i + 1]
+            if nxt == "d":
+                out.append("[[:digit:]]")
+            elif nxt == "D":
+                out.append("[^[:digit:]]")
+            else:
+                # Any other escape (including \\) passes through untouched,
+                # consuming both characters so \\d stays literal.
+                out.append(ch)
+                out.append(nxt)
+            i += 2
+            continue
+        if ch == "[":
+            in_bracket = True
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 class ShellFileOperations(FileOperations):
     """
     File operations implemented via shell commands.
@@ -2705,9 +2756,9 @@ class ShellFileOperations(FileOperations):
             cmd_parts.append("-c")
         
         # Add pattern and path
-        cmd_parts.append(self._escape_shell_arg(pattern))
+        cmd_parts.append(self._escape_shell_arg(_ere_translate_digit_classes(pattern)))
         cmd_parts.append(self._escape_shell_arg(path))
-        
+
         # Fetch generously so we can compute total before slicing
         fetch_limit = limit + offset + (200 if context > 0 else 0)
         cmd_parts.extend(["|", "head", "-n", str(fetch_limit)])


### PR DESCRIPTION
## What

Content search picks its engine by what is installed: ripgrep when present, `grep -rnHE` otherwise. 79782 moved the fallback from BRE to ERE so alternation and `+`/`?` behave the same on both engines, and its comment reads `-E matches rg regex behavior`. ERE does not go that far.

GNU grep supports `\s`, `\S`, `\w`, `\W` and `\b` as extensions — those already agree. It does **not** support `\d`/`\D`; it reads the backslash as a literal, so `\d+` matches runs of the letter `d`. On one corpus:

```
rg   '\d+'         -> version 42 here, id=7
grep -rnHE '\d+'   -> no digits line, id=7
```

The real digit line is missed and a line containing no digits is reported. No error, no warning — the agent reads the result as fact. Verified class by class on the same file, so the scope is exactly two escapes:

```
pattern=\d  rg=1  grepE=3      <- disagree
pattern=\D  rg=4  grepE=0      <- disagree
pattern=\s  rg=2  grepE=2
pattern=\w  rg=4  grepE=4
pattern=\b  rg=4  grepE=4
pattern=\S  rg=4  grepE=4
```

Which engine answers is not a property of the query — it is a property of the machine. `ShellFileOperations` runs over local, docker, ssh, singularity, modal and vercel_sandbox backends, and container images ship grep but rarely ripgrep. The same search against the same repo therefore returns different results depending on where the agent is working, and `\d` is ordinary regex for an agent scanning for versions, ids, ports or timestamps.

## The fix

Translate the two classes ERE lacks into POSIX equivalents before the pattern reaches grep: `\d` → `[[:digit:]]`, `\D` → `[^[:digit:]]`. A POSIX bracket class needs no GNU extension, so this also holds on BSD and busybox grep rather than only where `grep -P` happens to exist.

Two things are deliberately left alone:

- an escaped backslash — `\\d` is a literal backslash followed by `d`, not a class
- bracket expressions — `[\d]` already means the set `{\, d}` in ERE, and rewriting it would change the match

The ripgrep path is untouched; it speaks the shorthand natively, and a test pins that it is not rewritten there.

## Tests and results

`tests/tools/test_grep_fallback_digit_classes.py`:

- nine translation cases covering both classes, an escaped backslash, a bracket set, `]` as a set's first member, the GNU extensions that must stay untouched, and empty input
- the grep engine must receive a pattern expressing the digit class — this one fails on `main` with the command it actually built (`grep -rnHE --exclude-dir='.*' '\d+' …`)
- the rg engine must keep the pattern verbatim — passes on `main` too, which is what a non-regression pin should do

Eleven pass with the fix. End to end after the change, `rg '\d+'` and `grep -cE '[[:digit:]]+'` both report 2 matches on the corpus above; before, grep reported 3, none of which were the digit line.

For regressions I ran the file-operations and search suites (`test_file_operations.py`, `test_file_operations_edge_cases.py`, `test_file_ops_cwd_tracking.py`, `test_search_auto_multiline.py`, `test_search_budget_truncation.py`, `test_search_error_guard.py`, `test_search_hidden_dirs.py`, `test_search_zero_match_and_multipath.py`, `test_session_search.py`) before and after and diffed the failure lists: 29 failures, byte-identical both ways, all pre-existing on `main`.