### PR TITLE
fix(web): mobile soft-keyboard inset handling for dashboard chat (salvage #74579)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <title>Hermes Agent - Dashboard</title>
   </head>

--- a/web/src/lib/keyboard-inset.test.ts
+++ b/web/src/lib/keyboard-inset.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeKeyboardInset,
+  KEYBOARD_INSET_MIN_PX,
+  shouldPinScroll,
+} from "./keyboard-inset";
+
+describe("computeKeyboardInset", () => {
+  it("returns 0 when visualViewport is unavailable", () => {
+    expect(computeKeyboardInset(null, 800)).toBe(0);
+    expect(computeKeyboardInset(undefined, 800)).toBe(0);
+  });
+
+  it("returns 0 when no keyboard is showing (vv fills layout)", () => {
+    expect(computeKeyboardInset({ height: 800, offsetTop: 0 }, 800)).toBe(0);
+  });
+
+  it("measures the obscured region below the visual viewport", () => {
+    // 800px layout, keyboard eats 320px: vv.height = 480.
+    expect(computeKeyboardInset({ height: 480, offsetTop: 0 }, 800)).toBe(320);
+  });
+
+  it("accounts for visual-viewport offsetTop (iOS keyboard scroll)", () => {
+    // iOS nudged the visual viewport down 40px; keyboard covers the rest.
+    expect(computeKeyboardInset({ height: 480, offsetTop: 40 }, 800)).toBe(
+      280,
+    );
+  });
+
+  it("ignores small deltas from collapsing browser chrome", () => {
+    // URL bar show/hide produces deltas well under a real keyboard height.
+    const delta = KEYBOARD_INSET_MIN_PX - 1;
+    expect(
+      computeKeyboardInset({ height: 800 - delta, offsetTop: 0 }, 800),
+    ).toBe(0);
+  });
+
+  it("accepts insets at exactly the threshold", () => {
+    expect(
+      computeKeyboardInset(
+        { height: 800 - KEYBOARD_INSET_MIN_PX, offsetTop: 0 },
+        800,
+      ),
+    ).toBe(KEYBOARD_INSET_MIN_PX);
+  });
+
+  it("never goes negative when vv is larger than layout height", () => {
+    // Rotation / zoom races can transiently report vv.height > innerHeight.
+    expect(computeKeyboardInset({ height: 900, offsetTop: 0 }, 800)).toBe(0);
+  });
+
+  it("returns 0 for degenerate layout heights", () => {
+    expect(computeKeyboardInset({ height: 480, offsetTop: 0 }, 0)).toBe(0);
+    expect(computeKeyboardInset({ height: 480, offsetTop: 0 }, -1)).toBe(0);
+    expect(computeKeyboardInset({ height: 480, offsetTop: 0 }, NaN)).toBe(0);
+  });
+
+  it("returns 0 for non-finite viewport values", () => {
+    expect(computeKeyboardInset({ height: NaN, offsetTop: 0 }, 800)).toBe(0);
+    expect(computeKeyboardInset({ height: 480, offsetTop: NaN }, 800)).toBe(0);
+  });
+
+  it("rounds fractional geometry to whole pixels", () => {
+    // iOS reports fractional vv heights under pinch zoom.
+    expect(
+      computeKeyboardInset({ height: 479.5, offsetTop: 0.25 }, 800),
+    ).toBe(320);
+  });
+});
+
+describe("shouldPinScroll", () => {
+  it("pins while a keyboard inset is active", () => {
+    expect(shouldPinScroll(320)).toBe(true);
+  });
+
+  it("does not pin without a keyboard", () => {
+    expect(shouldPinScroll(0)).toBe(false);
+  });
+});

--- a/web/src/lib/keyboard-inset.ts
+++ b/web/src/lib/keyboard-inset.ts
@@ -1,0 +1,71 @@
+/**
+ * Soft-keyboard inset math for the dashboard chat terminal (NS-434).
+ *
+ * Problem: when the on-screen keyboard opens on mobile, neither iOS Safari
+ * nor Android Chrome (default `interactive-widget=resizes-visual`) shrinks
+ * the *layout* viewport — the keyboard just overlays it. Our app shell is
+ * `h-dvh`, so the terminal host's bounding box doesn't change, `fit()`
+ * computes the same (cols, rows), and the PTY never re-lays-out. The Ink
+ * input line — drawn at the bottom of the grid — ends up hidden underneath
+ * the keyboard.
+ *
+ * The only reliable signal is `window.visualViewport`: its `height` shrinks
+ * to the visible region above the keyboard, and `offsetTop` reflects any
+ * visual-viewport scroll (iOS nudges the page when an input focuses). The
+ * keyboard inset is the part of the layout viewport below the visual one:
+ *
+ *   inset = layoutHeight - vv.height - vv.offsetTop
+ *
+ * ChatPage applies this as bottom padding on the terminal wrapper, which
+ * shrinks the xterm host → ResizeObserver refit → `term.onResize` sends
+ * `RESIZE` to the PTY → Ink redraws the input line above the keyboard.
+ *
+ * We also set `interactive-widget=resizes-content` in the viewport meta so
+ * Android Chrome 108+ resizes the layout viewport natively; there the inset
+ * computes ≈ 0 and this path is a harmless no-op. iOS ignores the directive
+ * and takes the JS path.
+ */
+
+/**
+ * Insets smaller than this are treated as 0. Collapsing browser chrome
+ * (URL bar show/hide) produces small transient height deltas that would
+ * otherwise thrash the terminal grid; real soft keyboards are ≥ ~150px.
+ */
+export const KEYBOARD_INSET_MIN_PX = 80;
+
+export interface ViewportGeometry {
+  /** `visualViewport.height` — visible height above the keyboard. */
+  height: number;
+  /** `visualViewport.offsetTop` — visual viewport's offset into layout. */
+  offsetTop: number;
+}
+
+/**
+ * Height (px) of the layout viewport currently obscured by the soft
+ * keyboard, or 0 when no keyboard is showing / the signal is unusable.
+ */
+export function computeKeyboardInset(
+  viewport: ViewportGeometry | null | undefined,
+  layoutHeightPx: number,
+): number {
+  if (!viewport || !Number.isFinite(layoutHeightPx) || layoutHeightPx <= 0) {
+    return 0;
+  }
+  const { height, offsetTop } = viewport;
+  if (!Number.isFinite(height) || !Number.isFinite(offsetTop)) return 0;
+  const inset = Math.round(layoutHeightPx - height - offsetTop);
+  return inset >= KEYBOARD_INSET_MIN_PX ? inset : 0;
+}
+
+/**
+ * Whether the page scroll should be pinned back to the top.
+ *
+ * The dashboard shell is a fixed `h-dvh` column and must never scroll, but
+ * iOS Safari auto-scrolls the *page* when a focused input would sit under
+ * the keyboard (xterm's hidden textarea triggers this). Pin whenever a
+ * keyboard is present so the terminal chrome stays put; the terminal's own
+ * scrollback handles content visibility.
+ */
+export function shouldPinScroll(nextInsetPx: number): boolean {
+  return nextInsetPx > 0;
+}

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -177,6 +177,11 @@ const localStorageMock = (() => {
   };
 })();
 
+// React only routes updates through act() when this flag is set; without it
+// the isActive re-renders in the keyboard-inset gate test warn.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
 async function render(ui: ReactNode) {
   container = document.createElement("div");
   document.body.append(container);
@@ -268,6 +273,53 @@ describe("ChatPage", () => {
     });
 
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
+  });
+
+  it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
+    // NS-434 follow-up: ChatPage stays mounted (hidden) on every dashboard
+    // route. The keyboard-inset/scroll-pin listeners must only be live while
+    // /chat is the active tab, or the scroll pin fires when a soft keyboard
+    // opens on Settings etc.
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: { addEventListener, removeEventListener, width: 1280 },
+    });
+
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive={false} />
+      </MemoryRouter>,
+    );
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive />
+        </MemoryRouter>,
+      ),
+    );
+    expect(addEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive={false} />
+        </MemoryRouter>,
+      ),
+    );
+    expect(removeEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
   });
 });
 

--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -137,6 +137,11 @@ type CloseEventLike = {
 let container: HTMLDivElement;
 let root: Root;
 
+// React only routes updates through act() when this flag is set; without it
+// the isActive re-renders in the keyboard-inset gate test warn.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
 async function render(ui: ReactNode) {
   container = document.createElement("div");
   document.body.append(container);
@@ -224,5 +229,52 @@ describe("ChatPage", () => {
     });
 
     expect(maybeReloadForLoopbackWsAuthFailure).toHaveBeenCalledWith(4401);
+  });
+
+  it("attaches visualViewport keyboard-inset listeners only while the chat tab is active", async () => {
+    // NS-434 follow-up: ChatPage stays mounted (hidden) on every dashboard
+    // route. The keyboard-inset/scroll-pin listeners must only be live while
+    // /chat is the active tab, or the scroll pin fires when a soft keyboard
+    // opens on Settings etc.
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    Object.defineProperty(window, "visualViewport", {
+      configurable: true,
+      value: { addEventListener, removeEventListener, width: 1280 },
+    });
+
+    const { default: ChatPage } = await import("./ChatPage");
+
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive={false} />
+      </MemoryRouter>,
+    );
+    expect(addEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive />
+        </MemoryRouter>,
+      ),
+    );
+    expect(addEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
+    expect(removeEventListener).not.toHaveBeenCalled();
+
+    await act(async () =>
+      root.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <ChatPage isActive={false} />
+        </MemoryRouter>,
+      ),
+    );
+    expect(removeEventListener.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "resize",
+      "scroll",
+    ]);
   });
 });

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -60,6 +60,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { computeKeyboardInset, shouldPinScroll } from "@/lib/keyboard-inset";
 import {
   resolvePtyKeyboardShortcut,
   sendPtyShortcutSequence,
@@ -173,6 +174,7 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const termWrapRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -503,6 +505,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     const host = hostRef.current;
     if (!host) return;
+    // Captured once so the effect cleanup doesn't re-read the ref (which
+    // may point elsewhere by then — react-hooks/exhaustive-deps).
+    const termWrap = termWrapRef.current;
 
     const token = window.__HERMES_SESSION_TOKEN__;
     const gated = !!window.__HERMES_AUTH_REQUIRED__;
@@ -956,8 +961,61 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const ro = new ResizeObserver(() => scheduleHostSync());
     ro.observe(host);
 
+    // NS-434: soft-keyboard inset. On mobile the keyboard overlays the
+    // layout viewport instead of resizing it (iOS always; Android Chrome
+    // under the default `resizes-visual` — we ask for `resizes-content`
+    // in the viewport meta, but can't rely on it). The host's bounding
+    // box therefore doesn't change when the keyboard opens, fit() computes
+    // identical (cols, rows), and Ink keeps drawing the input line under
+    // the keyboard. Measure the obscured region via visualViewport and
+    // apply it as bottom padding on the terminal wrapper — that *does*
+    // shrink the host, so the ResizeObserver refit path kicks in and the
+    // PTY re-lays-out above the keyboard.
+    let appliedKeyboardInset = 0;
+    const syncKeyboardInset = () => {
+      const wrap = termWrap;
+      if (!wrap) return;
+      const vv = window.visualViewport;
+      const inset = computeKeyboardInset(
+        vv ? { height: vv.height, offsetTop: vv.offsetTop } : null,
+        window.innerHeight,
+      );
+      if (shouldPinScroll(inset)) {
+        // iOS auto-scrolls the page to reveal xterm's hidden textarea when
+        // the keyboard opens. The shell is a fixed h-dvh column that must
+        // never scroll — pin it back so the terminal chrome stays put.
+        window.scrollTo(0, 0);
+        const scroller = document.scrollingElement;
+        if (scroller && scroller.scrollTop !== 0) scroller.scrollTop = 0;
+      }
+      if (inset === appliedKeyboardInset) return;
+      appliedKeyboardInset = inset;
+      if (inset > 0) {
+        wrap.style.paddingBottom = `${inset}px`;
+        // Keep the freshly-resized input line in view.
+        try {
+          term.scrollToBottom();
+        } catch {
+          /* ignore */
+        }
+      } else {
+        wrap.style.paddingBottom = "";
+      }
+      // The wrapper padding change resizes the host; the ResizeObserver
+      // will refit, but schedule one explicitly in case the observer
+      // coalesces with an in-flight frame.
+      scheduleHostSync();
+    };
+    const onViewportChange = () => {
+      syncKeyboardInset();
+      scheduleSyncTerminalMetrics();
+    };
+
     window.addEventListener("resize", scheduleSyncTerminalMetrics);
-    window.visualViewport?.addEventListener("resize", scheduleSyncTerminalMetrics);
+    window.visualViewport?.addEventListener("resize", onViewportChange);
+    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
+    // vv `scroll` events, not `resize`.
+    window.visualViewport?.addEventListener("scroll", onViewportChange);
     scheduleHostSync();
     requestAnimationFrame(() => scheduleHostSync());
 
@@ -1400,10 +1458,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("drop", handleBrowserDrop, true);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
-      window.visualViewport?.removeEventListener(
-        "resize",
-        scheduleSyncTerminalMetrics,
-      );
+      window.visualViewport?.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("scroll", onViewportChange);
+      const wrap = termWrap;
+      if (wrap) wrap.style.paddingBottom = "";
       ro.disconnect();
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
@@ -1673,6 +1731,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
+          ref={termWrapRef}
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
             "p-2 sm:p-3",

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -183,6 +183,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
+  // NS-434 follow-up: the keyboard-inset sync + reset closures from the main
+  // PTY effect, exposed to the visibility-gated listener effect below.
+  // ChatPage stays mounted (hidden) on every dashboard route, so the
+  // visualViewport listeners must only be attached while /chat is the active
+  // tab — otherwise the scroll pin fires when a soft keyboard opens on
+  // Settings etc. and fights iOS's own focus-scroll behavior there.
+  const keyboardInsetSyncRef = useRef<(() => void) | null>(null);
+  const keyboardInsetResetRef = useRef<(() => void) | null>(null);
   // Sticky activation latch: the PTY-connect effect below must not open
   // `/api/pty` until the chat tab has actually been active at least once.
   // The dashboard mounts ChatPage persistently (hidden) on every route, so
@@ -1012,10 +1020,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
 
     window.addEventListener("resize", scheduleSyncTerminalMetrics);
-    window.visualViewport?.addEventListener("resize", onViewportChange);
-    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
-    // vv `scroll` events, not `resize`.
-    window.visualViewport?.addEventListener("scroll", onViewportChange);
+    // The visualViewport listeners that drive `onViewportChange` are NOT
+    // attached here: ChatPage is persistently mounted (hidden) on every
+    // dashboard route, so they are attached/detached by the isActive-gated
+    // effect below via these refs. Attaching them unconditionally made the
+    // scroll pin fire when a soft keyboard opened on any page.
+    keyboardInsetSyncRef.current = onViewportChange;
+    keyboardInsetResetRef.current = () => {
+      appliedKeyboardInset = 0;
+      if (termWrap) termWrap.style.paddingBottom = "";
+    };
     scheduleHostSync();
     requestAnimationFrame(() => scheduleHostSync());
 
@@ -1458,8 +1472,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("drop", handleBrowserDrop, true);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
-      window.visualViewport?.removeEventListener("resize", onViewportChange);
-      window.visualViewport?.removeEventListener("scroll", onViewportChange);
+      keyboardInsetSyncRef.current = null;
+      keyboardInsetResetRef.current = null;
       const wrap = termWrap;
       if (wrap) wrap.style.paddingBottom = "";
       ro.disconnect();
@@ -1499,6 +1513,35 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     scopedProfile,
     reconnectNonce,
   ]);
+
+  // NS-434 follow-up: attach the visualViewport keyboard-inset listeners
+  // ONLY while the chat tab is actually visible. ChatPage stays mounted
+  // (display:none) on every other dashboard route, so unconditional
+  // listeners made the scroll pin (`window.scrollTo(0, 0)`) fire whenever a
+  // soft keyboard opened on Settings/Sessions/etc., fighting iOS Safari's
+  // own scroll-into-view for the focused input there. The handlers read
+  // through refs populated by the main PTY effect, so attach/detach here is
+  // independent of that effect's lifecycle (and a no-op before the terminal
+  // exists). On deactivation we also clear any applied inset padding so a
+  // keyboard left open during navigation can't leave the hidden terminal
+  // wrapper padded with a stale value.
+  useEffect(() => {
+    if (!isActive || typeof window === "undefined") return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const onViewportChange = () => keyboardInsetSyncRef.current?.();
+    vv.addEventListener("resize", onViewportChange);
+    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
+    // vv `scroll` events, not `resize`.
+    vv.addEventListener("scroll", onViewportChange);
+    // Catch up on any geometry change that happened while hidden.
+    onViewportChange();
+    return () => {
+      vv.removeEventListener("resize", onViewportChange);
+      vv.removeEventListener("scroll", onViewportChange);
+      keyboardInsetResetRef.current?.();
+    };
+  }, [isActive]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -58,6 +58,7 @@ import {
   normalizePtyMobileInput,
   shouldTreatInputAsMobileReplacement,
 } from "@/lib/pty-mobile-input";
+import { computeKeyboardInset, shouldPinScroll } from "@/lib/keyboard-inset";
 import {
   imageFilesFromTransfer,
   transferMayContainImage,
@@ -163,6 +164,7 @@ function terminalLineHeightForWidth(layoutWidthPx: number): number {
 
 export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const hostRef = useRef<HTMLDivElement | null>(null);
+  const termWrapRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -479,6 +481,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     const host = hostRef.current;
     if (!host) return;
+    // Captured once so the effect cleanup doesn't re-read the ref (which
+    // may point elsewhere by then — react-hooks/exhaustive-deps).
+    const termWrap = termWrapRef.current;
 
     const token = window.__HERMES_SESSION_TOKEN__;
     const gated = !!window.__HERMES_AUTH_REQUIRED__;
@@ -872,8 +877,61 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const ro = new ResizeObserver(() => scheduleHostSync());
     ro.observe(host);
 
+    // NS-434: soft-keyboard inset. On mobile the keyboard overlays the
+    // layout viewport instead of resizing it (iOS always; Android Chrome
+    // under the default `resizes-visual` — we ask for `resizes-content`
+    // in the viewport meta, but can't rely on it). The host's bounding
+    // box therefore doesn't change when the keyboard opens, fit() computes
+    // identical (cols, rows), and Ink keeps drawing the input line under
+    // the keyboard. Measure the obscured region via visualViewport and
+    // apply it as bottom padding on the terminal wrapper — that *does*
+    // shrink the host, so the ResizeObserver refit path kicks in and the
+    // PTY re-lays-out above the keyboard.
+    let appliedKeyboardInset = 0;
+    const syncKeyboardInset = () => {
+      const wrap = termWrap;
+      if (!wrap) return;
+      const vv = window.visualViewport;
+      const inset = computeKeyboardInset(
+        vv ? { height: vv.height, offsetTop: vv.offsetTop } : null,
+        window.innerHeight,
+      );
+      if (shouldPinScroll(inset)) {
+        // iOS auto-scrolls the page to reveal xterm's hidden textarea when
+        // the keyboard opens. The shell is a fixed h-dvh column that must
+        // never scroll — pin it back so the terminal chrome stays put.
+        window.scrollTo(0, 0);
+        const scroller = document.scrollingElement;
+        if (scroller && scroller.scrollTop !== 0) scroller.scrollTop = 0;
+      }
+      if (inset === appliedKeyboardInset) return;
+      appliedKeyboardInset = inset;
+      if (inset > 0) {
+        wrap.style.paddingBottom = `${inset}px`;
+        // Keep the freshly-resized input line in view.
+        try {
+          term.scrollToBottom();
+        } catch {
+          /* ignore */
+        }
+      } else {
+        wrap.style.paddingBottom = "";
+      }
+      // The wrapper padding change resizes the host; the ResizeObserver
+      // will refit, but schedule one explicitly in case the observer
+      // coalesces with an in-flight frame.
+      scheduleHostSync();
+    };
+    const onViewportChange = () => {
+      syncKeyboardInset();
+      scheduleSyncTerminalMetrics();
+    };
+
     window.addEventListener("resize", scheduleSyncTerminalMetrics);
-    window.visualViewport?.addEventListener("resize", scheduleSyncTerminalMetrics);
+    window.visualViewport?.addEventListener("resize", onViewportChange);
+    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
+    // vv `scroll` events, not `resize`.
+    window.visualViewport?.addEventListener("scroll", onViewportChange);
     scheduleHostSync();
     requestAnimationFrame(() => scheduleHostSync());
 
@@ -1240,10 +1298,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("drop", handleBrowserDrop, true);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
-      window.visualViewport?.removeEventListener(
-        "resize",
-        scheduleSyncTerminalMetrics,
-      );
+      window.visualViewport?.removeEventListener("resize", onViewportChange);
+      window.visualViewport?.removeEventListener("scroll", onViewportChange);
+      const wrap = termWrap;
+      if (wrap) wrap.style.paddingBottom = "";
       ro.disconnect();
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
@@ -1510,6 +1568,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
       <div className="flex min-h-0 flex-1 flex-col gap-2 lg:flex-row lg:gap-3">
         <div
+          ref={termWrapRef}
           className={cn(
             "relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg",
             "p-2 sm:p-3",

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -172,6 +172,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // the moment `isActive` flips back to true (display:none → display:flex
   // collapses the host's box, so ResizeObserver never fires on return).
   const syncMetricsRef = useRef<(() => void) | null>(null);
+  // NS-434 follow-up: the keyboard-inset sync + reset closures from the main
+  // PTY effect, exposed to the visibility-gated listener effect below.
+  // ChatPage stays mounted (hidden) on every dashboard route, so the
+  // visualViewport listeners must only be attached while /chat is the active
+  // tab — otherwise the scroll pin fires when a soft keyboard opens on
+  // Settings etc. and fights iOS's own focus-scroll behavior there.
+  const keyboardInsetSyncRef = useRef<(() => void) | null>(null);
+  const keyboardInsetResetRef = useRef<(() => void) | null>(null);
   // Sticky activation latch: the PTY-connect effect below must not open
   // `/api/pty` until the chat tab has actually been active at least once.
   // The dashboard mounts ChatPage persistently (hidden) on every route, so
@@ -928,10 +936,16 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
 
     window.addEventListener("resize", scheduleSyncTerminalMetrics);
-    window.visualViewport?.addEventListener("resize", onViewportChange);
-    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
-    // vv `scroll` events, not `resize`.
-    window.visualViewport?.addEventListener("scroll", onViewportChange);
+    // The visualViewport listeners that drive `onViewportChange` are NOT
+    // attached here: ChatPage is persistently mounted (hidden) on every
+    // dashboard route, so they are attached/detached by the isActive-gated
+    // effect below via these refs. Attaching them unconditionally made the
+    // scroll pin fire when a soft keyboard opened on any page.
+    keyboardInsetSyncRef.current = onViewportChange;
+    keyboardInsetResetRef.current = () => {
+      appliedKeyboardInset = 0;
+      if (termWrap) termWrap.style.paddingBottom = "";
+    };
     scheduleHostSync();
     requestAnimationFrame(() => scheduleHostSync());
 
@@ -1298,8 +1312,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       host.removeEventListener("drop", handleBrowserDrop, true);
       if (metricsDebounce) clearTimeout(metricsDebounce);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
-      window.visualViewport?.removeEventListener("resize", onViewportChange);
-      window.visualViewport?.removeEventListener("scroll", onViewportChange);
+      keyboardInsetSyncRef.current = null;
+      keyboardInsetResetRef.current = null;
       const wrap = termWrap;
       if (wrap) wrap.style.paddingBottom = "";
       ro.disconnect();
@@ -1336,6 +1350,35 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     scopedProfile,
     reconnectNonce,
   ]);
+
+  // NS-434 follow-up: attach the visualViewport keyboard-inset listeners
+  // ONLY while the chat tab is actually visible. ChatPage stays mounted
+  // (display:none) on every other dashboard route, so unconditional
+  // listeners made the scroll pin (`window.scrollTo(0, 0)`) fire whenever a
+  // soft keyboard opened on Settings/Sessions/etc., fighting iOS Safari's
+  // own scroll-into-view for the focused input there. The handlers read
+  // through refs populated by the main PTY effect, so attach/detach here is
+  // independent of that effect's lifecycle (and a no-op before the terminal
+  // exists). On deactivation we also clear any applied inset padding so a
+  // keyboard left open during navigation can't leave the hidden terminal
+  // wrapper padded with a stale value.
+  useEffect(() => {
+    if (!isActive || typeof window === "undefined") return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const onViewportChange = () => keyboardInsetSyncRef.current?.();
+    vv.addEventListener("resize", onViewportChange);
+    // offsetTop changes (keyboard-driven visual scroll on iOS) arrive as
+    // vv `scroll` events, not `resize`.
+    vv.addEventListener("scroll", onViewportChange);
+    // Catch up on any geometry change that happened while hidden.
+    onViewportChange();
+    return () => {
+      vv.removeEventListener("resize", onViewportChange);
+      vv.removeEventListener("scroll", onViewportChange);
+      keyboardInsetResetRef.current?.();
+    };
+  }, [isActive]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
Mobile soft keyboards now resize the dashboard chat terminal instead of covering the input line (ref NS-434) — and the scroll-pin behavior only runs while the chat tab is actually visible.

Salvages #74579 by @shannonsands (authorship preserved via cherry-pick); chat-visibility gate added on top.

## Changes

- **Keyboard-inset math** (new `web/src/lib/keyboard-inset.ts`): `computeKeyboardInset()` measures the layout-viewport region obscured by the soft keyboard via `window.visualViewport` (`innerHeight − vv.height − vv.offsetTop`, with an 80px floor so collapsing URL-bar chrome doesn't thrash the grid).
- **ChatPage integration**: applies the inset as bottom padding on the terminal wrapper → the existing ResizeObserver/fit path recomputes rows → `RESIZE` reaches the PTY → the Ink input line redraws above the keyboard. Listens on both `vv` `resize` and `scroll` (offsetTop changes arrive as scroll events on iOS).
- **Viewport meta**: `interactive-widget=resizes-content` so Android Chrome 108+ resizes the layout viewport natively (JS inset computes ≈0, harmless no-op); iOS ignores it and takes the JS path.
- **Scroll pinning**: while an inset is active, pins `window`/`scrollingElement` scroll back to 0 and `term.scrollToBottom()` so the fixed `h-dvh` shell isn't dragged offscreen by iOS's focus auto-scroll.
- **Chat-visibility gate (our follow-up, `caf0f06`)**: ChatPage stays mounted (hidden) on every dashboard route, so the original patch's unconditional `visualViewport` listeners made the scroll pin fire when a soft keyboard opened on *any* page (fighting iOS's own focus scroll on Settings etc.). The listeners are now attached by a separate `isActive`-gated effect — attach on chat-tab activation, detach on deactivation — with the handler reading through refs populated by the PTY effect so the two lifecycles stay independent. Deactivation also clears any applied inset padding so a keyboard left open during navigation can't strand stale bottom padding on the hidden wrapper.

## Validation

- `npx vitest run src/lib/keyboard-inset.test.ts src/pages/ChatPage.test.tsx` → **14 passed** (12 pure inset-math tests from the original PR + 1 pre-existing ChatPage test + 1 new component-level test asserting listeners attach only while `isActive` and detach on deactivation).
- `npm run typecheck` (`tsc -p . --noEmit`) → clean.
- `npx eslint` on the four touched files → 0 errors (3 pre-existing warnings elsewhere in ChatPage, untouched).
- Pre-push stale-base gate: branch base is 0 commits behind `origin/main`; diff shows only this PR's 5 files.

## Device testing needed

⚠️ **Hold for a real-device pass before merge.** DevTools emulation does not model keyboard insets — an iOS Safari + Android Chrome smoke test (keyboard open/close on /chat, keyboard open on Settings/Sessions to confirm no scroll fighting) is pending before this merges.

## Infographic

![mobile-keyboard-inset-salvage](https://v3b.fal.media/files/b/0aa5451e/US0ahO4ayLo1FonxvVWcM_TF54y1jA.png)
