### PR TITLE
feat(plugins): add Telegram callback query hook

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -174,6 +174,15 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Telegram adapter hook for callback queries not claimed by a built-in
+    # prefix. The adapter passes only extracted scalar metadata, never the raw
+    # Telegram query object. Plugins must validate ``authorized`` and the
+    # source ids before acting. Return values are strictly constrained to:
+    #   {"action": "unhandled"}
+    #   {"action": "handled", "answer": str?, "edit_text": str?,
+    #    "remove_keyboard": bool?}
+    # Malformed values are ignored. See the hooks documentation for bounds.
+    "telegram_callback_query",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6310,9 +6310,11 @@ class TelegramAdapter(BasePlatformAdapter):
     @staticmethod
     def _valid_plugin_callback_result(result: Any) -> bool:
         """Validate the narrow result contract for callback-query plugins."""
-        if not isinstance(result, dict):
+        if type(result) is not dict:
             return False
         action = result.get("action")
+        if type(action) is not str:
+            return False
         if action == "unhandled":
             return set(result) == {"action"}
         if action != "handled":
@@ -6323,15 +6325,21 @@ class TelegramAdapter(BasePlatformAdapter):
             return False
         if "answer" in result:
             answer = result["answer"]
-            if not isinstance(answer, str) or utf16_len(answer) > 200:
+            if type(answer) is not str:
+                return False
+            try:
+                if utf16_len(answer) > 200:
+                    return False
+            except Exception:
                 return False
         if "edit_text" in result:
             edit_text = result["edit_text"]
-            if (
-                not isinstance(edit_text, str)
-                or not edit_text
-                or utf16_len(edit_text) > TelegramAdapter.MAX_MESSAGE_LENGTH
-            ):
+            if type(edit_text) is not str or not edit_text:
+                return False
+            try:
+                if utf16_len(edit_text) > TelegramAdapter.MAX_MESSAGE_LENGTH:
+                    return False
+            except Exception:
                 return False
         if "remove_keyboard" in result and type(result["remove_keyboard"]) is not bool:
             return False
@@ -6403,7 +6411,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
         handled = None
         for result in results:
-            if not self._valid_plugin_callback_result(result):
+            try:
+                valid_result = self._valid_plugin_callback_result(result)
+            except Exception:
+                valid_result = False
+                logger.warning(
+                    "[Telegram] Plugin callback result validation failed",
+                    exc_info=True,
+                )
+            if not valid_result:
                 logger.warning(
                     "[Telegram] Ignoring malformed telegram_callback_query result"
                 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6307,6 +6307,150 @@ class TelegramAdapter(BasePlatformAdapter):
         except Exception:
             pass
 
+    @staticmethod
+    def _valid_plugin_callback_result(result: Any) -> bool:
+        """Validate the narrow result contract for callback-query plugins."""
+        if not isinstance(result, dict):
+            return False
+        action = result.get("action")
+        if action == "unhandled":
+            return set(result) == {"action"}
+        if action != "handled":
+            return False
+        if not set(result).issubset(
+            {"action", "answer", "edit_text", "remove_keyboard"}
+        ):
+            return False
+        if "answer" in result:
+            answer = result["answer"]
+            if not isinstance(answer, str) or utf16_len(answer) > 200:
+                return False
+        if "edit_text" in result:
+            edit_text = result["edit_text"]
+            if (
+                not isinstance(edit_text, str)
+                or not edit_text
+                or utf16_len(edit_text) > TelegramAdapter.MAX_MESSAGE_LENGTH
+            ):
+                return False
+        if "remove_keyboard" in result and type(result["remove_keyboard"]) is not bool:
+            return False
+        return True
+
+    async def _handle_plugin_callback_query(
+        self,
+        query: Any,
+        data: str,
+        *,
+        query_chat_id: Any,
+        query_chat_type: Any,
+        query_thread_id: Any,
+        query_user_name: Any,
+    ) -> None:
+        """Offer an otherwise-unhandled callback to enabled plugins.
+
+        Only extracted Telegram-authenticated scalar fields cross the plugin
+        boundary. ``authorized`` is context, not an authorization grant: the
+        plugin remains responsible for checking it together with the exact
+        source and callback data before returning ``handled``.
+        """
+        from_user = getattr(query, "from_user", None)
+        user_id_raw = getattr(from_user, "id", None)
+        user_id = str(user_id_raw) if user_id_raw is not None else None
+        chat_id = str(query_chat_id) if query_chat_id is not None else None
+        chat_type_value = getattr(query_chat_type, "value", query_chat_type)
+        chat_type = str(chat_type_value) if chat_type_value is not None else None
+        thread_id = str(query_thread_id) if query_thread_id is not None else None
+        message = getattr(query, "message", None)
+        message_id_raw = getattr(message, "message_id", None)
+        message_id = str(message_id_raw) if message_id_raw is not None else None
+        inline_message_id_raw = getattr(query, "inline_message_id", None)
+        inline_message_id = (
+            str(inline_message_id_raw) if inline_message_id_raw is not None else None
+        )
+        authorized = self._is_callback_user_authorized(
+            user_id or "",
+            chat_id=chat_id,
+            chat_type=chat_type,
+            thread_id=thread_id,
+            user_name=str(query_user_name) if query_user_name is not None else None,
+        )
+
+        try:
+            from hermes_cli.lifecycle import invoke_hook
+
+            results = invoke_hook(
+                "telegram_callback_query",
+                data=data,
+                platform="telegram",
+                chat_id=chat_id,
+                chat_type=chat_type,
+                thread_id=thread_id,
+                user_id=user_id,
+                user_name=(
+                    str(query_user_name) if query_user_name is not None else None
+                ),
+                message_id=message_id,
+                inline_message_id=inline_message_id,
+                authorized=authorized,
+            )
+        except Exception:
+            logger.warning(
+                "[Telegram] telegram_callback_query hook invocation failed",
+                exc_info=True,
+            )
+            return
+
+        handled = None
+        for result in results:
+            if not self._valid_plugin_callback_result(result):
+                logger.warning(
+                    "[Telegram] Ignoring malformed telegram_callback_query result"
+                )
+                continue
+            if result["action"] == "handled":
+                handled = result
+                break
+        if handled is None:
+            return
+
+        try:
+            if "answer" in handled:
+                await query.answer(text=handled["answer"])
+            else:
+                await query.answer()
+        except Exception:
+            logger.debug("[Telegram] Plugin callback answer failed", exc_info=True)
+
+        edit_text = handled.get("edit_text")
+        remove_keyboard = handled.get("remove_keyboard", False)
+        try:
+            if edit_text is not None:
+                edit_kwargs: Dict[str, Any] = {"text": edit_text}
+                if remove_keyboard:
+                    edit_kwargs["reply_markup"] = None
+                elif message is not None:
+                    # PTB defaults reply_markup=None, which removes an existing
+                    # inline keyboard. Preserve the trusted message's current
+                    # keyboard when the plugin requested an edit only.
+                    edit_kwargs["reply_markup"] = getattr(
+                        message, "reply_markup", None
+                    )
+                else:
+                    # Inline-mode callbacks expose no Message/keyboard to
+                    # preserve. Fail closed rather than turning an edit-only
+                    # result into an implicit keyboard-removal capability.
+                    logger.warning(
+                        "[Telegram] Skipping plugin callback edit without "
+                        "message metadata or remove_keyboard=true"
+                    )
+                    return
+                await query.edit_message_text(**edit_kwargs)
+            elif remove_keyboard:
+                await query.edit_message_reply_markup(reply_markup=None)
+        except Exception:
+            logger.debug("[Telegram] Plugin callback edit failed", exc_info=True)
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -6651,6 +6795,14 @@ class TelegramAdapter(BasePlatformAdapter):
 
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
+            await self._handle_plugin_callback_query(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
         answer = data.split(":", 1)[1]  # "y" or "n"
         caller_id = str(getattr(query.from_user, "id", ""))

--- a/tests/gateway/test_telegram_callback_plugin_hook.py
+++ b/tests/gateway/test_telegram_callback_plugin_hook.py
@@ -1,0 +1,254 @@
+"""Tests for forwarding otherwise-unhandled Telegram callbacks to plugins."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = AsyncMock()
+    adapter._app = MagicMock()
+    return adapter
+
+
+def _make_query(
+    data: str,
+    *,
+    message=True,
+    user_id=123,
+    inline_message_id=None,
+):
+    if message:
+        chat = SimpleNamespace(type="private")
+        message_obj = SimpleNamespace(
+            chat_id=456,
+            chat=chat,
+            message_id=789,
+            message_thread_id=None,
+        )
+    else:
+        message_obj = None
+    return SimpleNamespace(
+        data=data,
+        message=message_obj,
+        inline_message_id=inline_message_id,
+        from_user=SimpleNamespace(id=user_id, first_name="Tester", username="tester"),
+        answer=AsyncMock(),
+        edit_message_text=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_known_callback_prefix_takes_precedence_over_plugin_hook(monkeypatch):
+    adapter = _make_adapter()
+    query = _make_query("cp:reasoning:high")
+    choice_handler = AsyncMock()
+    monkeypatch.setattr(adapter, "_handle_choice_picker_callback", choice_handler)
+    hook = MagicMock(return_value=[{"action": "handled", "answer": "plugin"}])
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    choice_handler.assert_awaited_once_with(query, query.data, "456")
+    hook.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_unknown_callback_forwards_trusted_metadata_and_applies_valid_result(
+    monkeypatch,
+):
+    adapter = _make_adapter()
+    query = _make_query("custom:approve:42")
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+    captured = {}
+
+    def hook(name, **kwargs):
+        captured["name"] = name
+        captured.update(kwargs)
+        return [{
+            "action": "handled",
+            "answer": "Approved",
+            "edit_text": "Approved by plugin",
+            "remove_keyboard": True,
+        }]
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert captured == {
+        "name": "telegram_callback_query",
+        "data": "custom:approve:42",
+        "platform": "telegram",
+        "chat_id": "456",
+        "chat_type": "private",
+        "thread_id": None,
+        "user_id": "123",
+        "user_name": "Tester",
+        "message_id": "789",
+        "inline_message_id": None,
+        "authorized": True,
+    }
+    query.answer.assert_awaited_once_with(text="Approved")
+    query.edit_message_text.assert_awaited_once_with(
+        text="Approved by plugin", reply_markup=None
+    )
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_only_preserves_existing_keyboard(monkeypatch):
+    adapter = _make_adapter()
+    query = _make_query("custom:edit-only")
+    query.message.reply_markup = "existing-keyboard"
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *a, **kw: [{"action": "handled", "edit_text": "Updated"}],
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    query.edit_message_text.assert_awaited_once_with(
+        text="Updated", reply_markup="existing-keyboard"
+    )
+
+
+@pytest.mark.asyncio
+async def test_inline_edit_only_fails_closed_when_keyboard_cannot_be_preserved(
+    monkeypatch,
+):
+    adapter = _make_adapter()
+    query = _make_query("custom:inline-edit", message=False, inline_message_id="inline-1")
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *a, **kw: [{"action": "handled", "edit_text": "Updated"}],
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    query.answer.assert_awaited_once_with()
+    query.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message", [True, False])
+async def test_remove_keyboard_only_uses_reply_markup_edit(monkeypatch, message):
+    adapter = _make_adapter()
+    query = _make_query(
+        "custom:remove-only",
+        message=message,
+        inline_message_id=None if message else "inline-1",
+    )
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook",
+        lambda *a, **kw: [{"action": "handled", "remove_keyboard": True}],
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    query.answer.assert_awaited_once_with()
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_awaited_once_with(reply_markup=None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "result",
+    [
+        "handled",
+        {"action": "handled", "answer": 123},
+        {"action": "handled", "answer": None},
+        {"action": "handled", "remove_keyboard": "yes"},
+        {"action": "handled", "remove_keyboard": None},
+        {"action": "handled", "edit_text": ""},
+        {"action": "handled", "edit_text": None},
+        {"action": "handled", "unexpected": True},
+        {"action": "allow", "answer": "nope"},
+    ],
+)
+async def test_malformed_plugin_result_fails_closed(monkeypatch, result):
+    adapter = _make_adapter()
+    query = _make_query("custom:malformed")
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: True)
+    monkeypatch.setattr(
+        "hermes_cli.lifecycle.invoke_hook", lambda *a, **kw: [result]
+    )
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_plugin_hook_exception_is_isolated(monkeypatch):
+    adapter = _make_adapter()
+    query = _make_query("custom:boom")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("plugin exploded")
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", boom)
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    query.answer.assert_not_awaited()
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_inline_callback_exposes_no_message_metadata(monkeypatch):
+    adapter = _make_adapter()
+    query = _make_query(
+        "custom:inline", message=False, user_id=999, inline_message_id="inline-1"
+    )
+    monkeypatch.setattr(adapter, "_is_callback_user_authorized", lambda *a, **kw: False)
+    captured = {}
+
+    def hook(name, **kwargs):
+        captured.update(kwargs)
+        if not kwargs["authorized"]:
+            return [{"action": "handled", "answer": "Not authorized"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", hook)
+
+    await adapter._handle_callback_query(
+        SimpleNamespace(callback_query=query), SimpleNamespace()
+    )
+
+    assert captured["chat_id"] is None
+    assert captured["chat_type"] is None
+    assert captured["thread_id"] is None
+    assert captured["message_id"] is None
+    assert captured["inline_message_id"] == "inline-1"
+    assert captured["user_id"] == "999"
+    assert captured["authorized"] is False
+    query.answer.assert_awaited_once_with(text="Not authorized")
+    query.edit_message_text.assert_not_awaited()
+    query.edit_message_reply_markup.assert_not_awaited()

--- a/tests/gateway/test_telegram_callback_plugin_hook.py
+++ b/tests/gateway/test_telegram_callback_plugin_hook.py
@@ -9,6 +9,18 @@ from gateway.config import PlatformConfig
 from plugins.platforms.telegram.adapter import TelegramAdapter
 
 
+class _RaisingEq:
+    def __eq__(self, other):
+        raise RuntimeError("malformed action comparison")
+
+
+class _PostValidationActionDict(dict):
+    def __getitem__(self, key):
+        if key == "action":
+            raise RuntimeError("post-validation action access")
+        return super().__getitem__(key)
+
+
 def _make_adapter() -> TelegramAdapter:
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
     adapter._bot = AsyncMock()
@@ -175,12 +187,16 @@ async def test_remove_keyboard_only_uses_reply_markup_edit(monkeypatch, message)
     "result",
     [
         "handled",
+        {"action": _RaisingEq()},
+        _PostValidationActionDict(action="handled"),
         {"action": "handled", "answer": 123},
         {"action": "handled", "answer": None},
+        {"action": "handled", "answer": "\ud800"},
         {"action": "handled", "remove_keyboard": "yes"},
         {"action": "handled", "remove_keyboard": None},
         {"action": "handled", "edit_text": ""},
         {"action": "handled", "edit_text": None},
+        {"action": "handled", "edit_text": "\ud800"},
         {"action": "handled", "unexpected": True},
         {"action": "allow", "answer": "nope"},
     ],

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -306,6 +306,9 @@ class TestPluginLoading:
 class TestPluginHooks:
     """Tests for lifecycle hook registration and invocation."""
 
+    def test_telegram_callback_query_is_a_supported_hook(self):
+        assert "telegram_callback_query" in VALID_HOOKS
+
 
 
     def test_pre_gateway_dispatch_collects_action_dicts(self, tmp_path, monkeypatch):

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -402,6 +402,7 @@ def register(ctx):
 | [`subagent_start`](#subagent_start) | A `delegate_task` child has been constructed and is about to run | ignored |
 | [`subagent_stop`](#subagent_stop) | A `delegate_task` child has exited | ignored |
 | [`pre_gateway_dispatch`](#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch | `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow |
+| [`telegram_callback_query`](#telegram_callback_query) | Telegram received an inline-button callback not claimed by a built-in prefix | constrained handled/unhandled result |
 | [`pre_approval_request`](#pre_approval_request) | An approval decision is requested, including smart-mode auto decisions | ignored |
 | [`post_approval_response`](#post_approval_response) | An approval decision is made (or a prompt times out) | ignored |
 | [`transform_tool_result`](#transform_tool_result) | After any tool returns, before the result is handed back to the model | `str` to replace the result, `None` to leave unchanged |
@@ -1067,6 +1068,69 @@ def buffer_or_rewrite(event, **kwargs):
 
 def register(ctx):
     ctx.register_hook("pre_gateway_dispatch", buffer_or_rewrite)
+```
+
+---
+
+### `telegram_callback_query`
+
+Fires for a Telegram inline-keyboard callback only when no built-in callback prefix claimed it. Built-in model/choice pickers, approvals, slash confirmations, clarify prompts, Gmail triage, and update prompts always take precedence. Hermes passes extracted scalar metadata rather than the raw Telegram `CallbackQuery` object.
+
+**Callback signature:**
+
+```python
+def my_callback(
+    data: str,
+    platform: str,
+    chat_id: str | None,
+    chat_type: str | None,
+    thread_id: str | None,
+    user_id: str | None,
+    user_name: str | None,
+    message_id: str | None,
+    inline_message_id: str | None,
+    authorized: bool,
+    **kwargs,
+):
+```
+
+`authorized` reports the normal Telegram/gateway authorization decision; it does not authorize the callback by itself. A plugin must fail closed unless `authorized` is true and the callback data and exact source ids match state the plugin created. Inline-mode callbacks can have `chat_id`, `chat_type`, and `message_id` set to `None`; validate `inline_message_id` instead or return `unhandled`.
+
+**Return value:**
+
+| Return | Effect |
+|--------|--------|
+| `{"action": "unhandled"}` / `None` | Leave the callback untouched. Other plugin results may still handle it. |
+| `{"action": "handled", "answer": "Done"}` | Answer the callback. `answer` is optional and limited to Telegram's 200 UTF-16-unit callback-answer limit. |
+| `{"action": "handled", "edit_text": "Confirmed", "remove_keyboard": true}` | Optionally replace the message text and/or remove its inline keyboard. `edit_text` is plain text, non-empty, and limited to 4096 UTF-16 units. |
+
+These are the only accepted keys and types. Malformed results are logged and ignored, callback operations are isolated from adapter flow, and plugin exceptions cannot break Telegram polling.
+
+An edit-only result preserves the message's existing inline keyboard. Telegram inline-mode callbacks provide no message object from which Hermes can recover that keyboard, so `edit_text` without `remove_keyboard: true` is skipped for those callbacks rather than implicitly removing controls.
+
+```python
+EXPECTED_CHAT = "123456789"
+EXPECTED_USER = "987654321"
+
+def handle_button(data, authorized, chat_id, user_id, message_id, **kwargs):
+    if not authorized:
+        return {"action": "handled", "answer": "Not authorized"}
+    if chat_id != EXPECTED_CHAT or user_id != EXPECTED_USER:
+        return {"action": "unhandled"}
+    if not message_id or not data.startswith("myplugin:approve:"):
+        return {"action": "unhandled"}
+    # Validate the callback token against plugin-owned state before mutating it.
+    if not approve_plugin_record(data, message_id):
+        return {"action": "handled", "answer": "Expired"}
+    return {
+        "action": "handled",
+        "answer": "Approved",
+        "edit_text": "Approved by plugin",
+        "remove_keyboard": True,
+    }
+
+def register(ctx):
+    ctx.register_hook("telegram_callback_query", handle_button)
 ```
 
 ---

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -201,6 +201,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`, `/clear`, idle rotation) |
 | [`subagent_stop`](/user-guide/features/hooks#subagent_stop) | Once per child after `delegate_task` finishes |
 | [`pre_gateway_dispatch`](/user-guide/features/hooks#pre_gateway_dispatch) | Gateway received a user message, before auth + dispatch. Return `{"action": "skip" \| "rewrite" \| "allow", ...}` to influence flow. |
+| [`telegram_callback_query`](/user-guide/features/hooks#telegram_callback_query) | Telegram received an inline-button callback that no built-in prefix claimed. The plugin must validate the supplied authorization and source metadata before returning `handled`. |
 
 ## Plugin types
 


### PR DESCRIPTION
## Summary

- add a generic `telegram_callback_query` plugin lifecycle hook for Telegram callbacks not claimed by built-in prefixes
- pass only authenticated scalar callback metadata and require plugins to validate authorization plus plugin-owned state
- strictly validate handled/unhandled results and isolate plugin and Telegram API failures
- support bounded callback answers, message edits, and independent keyboard removal while preserving existing markup on chat-backed edit-only results
- document the hook contract and security expectations

## Tests

- strict TDD: focused callback tests were added and witnessed failing before the adapter hook implementation, then passing after implementation
- `scripts/run_tests.sh tests/gateway/test_telegram_callback_plugin_hook.py tests/hermes_cli/test_plugins.py` — 53 passed
- `scripts/run_tests.sh tests/gateway/test_telegram*.py` — 522 passed across 55 files (one unrelated pytest temp-cleanup retry; the affected file then passed cleanly with retries disabled)
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_telegram_forum_commands.py` — 2 passed
- `git diff --cached --check` — clean before commit

## Review

Independent staged-diff review: PASS. Reviewed SHA-256 `858d10e122d8fe0d12a21df938f5714fdd922e30a1bcf06be2fd9b5dad07c38a`; no files modified by reviewer.