### PR TITLE
fix(agent): scrub lone surrogates at the run_conversation egress boundary (#80366 class)

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -462,8 +462,33 @@ def _sanitize_structure_non_ascii(payload: Any) -> bool:
     return found
 
 
+# Text fields of a run_conversation result that flow to UTF-8 sinks
+# (oneshot stdout, gateway sends, session export). Every runtime — chat
+# completions, the codex app-server, the responses adapters — converges on
+# one result dict, so sanitizing these fields once at that boundary closes
+# the lone-surrogate crash class (#80366) for all of them: chat-completions
+# ingestion already scrubs, but the other runtimes and the failure-string
+# paths (which can embed model text) do not.
+_RESULT_TEXT_EGRESS_FIELDS = ("final_response", "error", "interrupt_message")
+
+
+def _sanitize_result_egress(result):
+    """Scrub lone surrogates from a run result's text egress fields.
+
+    In-place and idempotent; a fast no-op for results without surrogates.
+    Non-dict results and non-string fields pass through untouched.
+    """
+    if isinstance(result, dict):
+        for key in _RESULT_TEXT_EGRESS_FIELDS:
+            value = result.get(key)
+            if isinstance(value, str) and _SURROGATE_RE.search(value):
+                result[key] = _SURROGATE_RE.sub("\ufffd", value)
+    return result
+
+
 __all__ = [
     "_SURROGATE_RE",
+    "_sanitize_result_egress",
     "close_interrupted_tool_sequence",
     "_sanitize_surrogates",
     "_sanitize_structure_surrogates",

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -167,6 +167,23 @@ def _write_usage_file(path: Optional[str], result: dict, failure: Optional[str] 
         pass
 
 
+def _emit_response(stream, response: str) -> None:
+    """Write the final response to stdout, scrubbing lone surrogates.
+
+    Defense-in-depth for #80366: ``run_conversation`` sanitizes its result
+    at the egress boundary, but any string written to a UTF-8 stream must
+    be encodable regardless of origin (e.g. text resumed from sessions
+    persisted before the boundary fix), so the sink protects itself too.
+    """
+    from agent.message_sanitization import _sanitize_surrogates
+
+    text = _sanitize_surrogates(response)
+    stream.write(text)
+    if not text.endswith("\n"):
+        stream.write("\n")
+    stream.flush()
+
+
 def run_oneshot(
     prompt: str,
     model: Optional[str] = None,
@@ -278,10 +295,7 @@ def run_oneshot(
     _write_usage_file(usage_file, result)
 
     if response:
-        real_stdout.write(response)
-        if not response.endswith("\n"):
-            real_stdout.write("\n")
-        real_stdout.flush()
+        _emit_response(real_stdout, response)
 
     if (result.get("failed") or result.get("partial")) and not (response or "").strip():
         return 2

--- a/run_agent.py
+++ b/run_agent.py
@@ -176,6 +176,7 @@ from agent.process_bootstrap import _get_proxy_from_env  # noqa: F401
 from agent.message_sanitization import (  # noqa: F401
     _SURROGATE_RE,
     _sanitize_surrogates,
+    _sanitize_result_egress,
     _sanitize_structure_surrogates,
     _sanitize_messages_surrogates,
     _escape_invalid_chars_in_json_strings,
@@ -7863,6 +7864,10 @@ class AIAgent:
                     persist_user_display_metadata=persist_user_display_metadata,
                     moa_config=moa_config,
                 )
+            # Egress boundary for the lone-surrogate class (#80366): every
+            # runtime converges here before callers hand the text to UTF-8
+            # sinks (oneshot stdout, gateway sends, exports).
+            result = _sanitize_result_egress(result)
             terminal = result if isinstance(result, dict) else {}
             if terminal.get("interrupted") is True:
                 relay_outcome = "cancelled"

--- a/tests/hermes_cli/test_oneshot_surrogate.py
+++ b/tests/hermes_cli/test_oneshot_surrogate.py
@@ -1,0 +1,93 @@
+"""Regression tests for the lone-surrogate output class (#80366).
+
+Model text can carry lone UTF-16 surrogates (e.g. an OpenAI-compatible
+provider returning a raw ``\\ud800`` escape). Any UTF-8 sink then raises
+UnicodeEncodeError. Fragment fixes #80429 (@hudsonwa), #80374
+(@rainbowgore) and #80409 (@RelaxJonh) each scrubbed the oneshot stdout
+sink; the boundary fix sanitizes every runtime's result once at
+``run_conversation`` egress, with the sink keeping a defensive scrub.
+"""
+
+import io
+
+from agent.message_sanitization import _sanitize_result_egress
+from hermes_cli.oneshot import _emit_response
+
+
+def _utf8_stream():
+    """A stream that actually UTF-8-encodes, like real stdout."""
+    return io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+
+
+def _read(stream):
+    stream.flush()
+    return stream.buffer.getvalue().decode("utf-8")
+
+
+class TestCrashMechanism:
+    def test_raw_write_of_lone_surrogate_crashes_utf8_stream(self):
+        # Documents the failure mode the class is about: this is what
+        # oneshot did on main, minus the scrub.
+        stream = _utf8_stream()
+        try:
+            stream.write("hello \ud800 world")
+            stream.flush()
+        except UnicodeEncodeError:
+            return
+        raise AssertionError("expected UnicodeEncodeError from raw write")
+
+
+class TestEmitResponse:
+    def test_lone_high_surrogate_prints_replacement_char(self):
+        stream = _utf8_stream()
+        _emit_response(stream, "hello \ud800 world")
+        assert _read(stream) == "hello \ufffd world\n"
+
+    def test_lone_low_surrogate_prints_replacement_char(self):
+        stream = _utf8_stream()
+        _emit_response(stream, "text \udc00 end")
+        assert _read(stream) == "text \ufffd end\n"
+
+    def test_valid_text_and_astral_emoji_unchanged(self):
+        stream = _utf8_stream()
+        _emit_response(stream, "emoji: \U0001f600\n")
+        assert _read(stream) == "emoji: \U0001f600\n"
+
+    def test_trailing_newline_added_once(self):
+        stream = _utf8_stream()
+        _emit_response(stream, "no newline")
+        assert _read(stream) == "no newline\n"
+
+
+class TestResultEgressBoundary:
+    def test_scrubs_final_response_error_and_interrupt_message(self):
+        result = {
+            "final_response": "ok \ud800",
+            "error": "bad \udfff turn",
+            "interrupt_message": "\ud800",
+            "messages": [{"role": "assistant", "content": "untouched \ud800"}],
+        }
+        out = _sanitize_result_egress(result)
+        assert out is result
+        assert result["final_response"] == "ok \ufffd"
+        assert result["error"] == "bad \ufffd turn"
+        assert result["interrupt_message"] == "\ufffd"
+        # messages persistence has its own sanitization path; egress only
+        # touches the text fields handed to sinks.
+        assert result["messages"][0]["content"] == "untouched \ud800"
+
+    def test_codex_runtime_shaped_result(self):
+        # codex_runtime returns final_text verbatim with no ingestion scrub;
+        # the boundary must cover it.
+        result = {"final_response": "turn \ud800 text", "completed": True}
+        assert _sanitize_result_egress(result)["final_response"] == "turn \ufffd text"
+
+    def test_clean_result_untouched_and_fast(self):
+        result = {"final_response": "all good", "error": None}
+        assert _sanitize_result_egress(result)["final_response"] == "all good"
+        assert result["error"] is None
+
+    def test_non_dict_and_missing_fields_pass_through(self):
+        assert _sanitize_result_egress(None) is None
+        assert _sanitize_result_egress("s") == "s"
+        assert _sanitize_result_egress({}) == {}


### PR DESCRIPTION
## Summary

Boundary fix for the lone-surrogate output class reported in #80366. Model text carrying an unpaired UTF-16 surrogate (e.g. a raw `\ud800` escape in an OpenAI-compatible response) is now scrubbed once at the `run_conversation` egress boundary — where every runtime converges — instead of separately at each UTF-8 sink that crashes.

## Root cause (the class, not the instance)

Lone surrogates are invalid in UTF-8, so any sink that encodes — oneshot stdout (`UnicodeEncodeError` at `oneshot.py:281`, the reported member), gateway sends, exports, `ensure_ascii=False` writers — fails independently. The codebase already has the doctrine (`agent/message_sanitization.py`; chat-completions ingestion scrubs at `chat_completion_helpers.py:1467`) but other paths bypass it: the codex app-server runtime returns `turn.final_text` verbatim, the responses/anthropic/bedrock adapters have no surrogate handling, and failure strings that embed model text skip it. That's why sink patches keep being needed — #80429 (@hudsonwa), #80374 (@rainbowgore), #80409 (@RelaxJonh) each correctly scrubbed the stdout sink; this PR closes the class they were each catching one member of. (Thanks @fd3518 for the precise report with the traceback.)

## Changes

- `agent/message_sanitization.py`: `_sanitize_result_egress(result)` — scrubs `final_response` / `error` / `interrupt_message` in-place with the existing `_SURROGATE_RE`; idempotent, fast no-op when clean; non-dict results pass through. Exported alongside the existing helpers.
- `run_agent.py` (`run_conversation` forwarder): apply it at the single point every runtime's result passes through, before callers receive it.
- `hermes_cli/oneshot.py`: response write extracted to `_emit_response`, which keeps a defensive `_sanitize_surrogates` scrub at the sink for text that predates the boundary (e.g. sessions persisted before this fix, then resumed).

## Validation

- New `tests/hermes_cli/test_oneshot_surrogate.py` (9 tests) against a genuinely UTF-8-encoding stream (`io.TextIOWrapper`), so the crash mechanism itself is exercised: raw write of a lone surrogate raises `UnicodeEncodeError` (documents main's failure mode); `_emit_response` prints U+FFFD for high/low surrogates, leaves astral emoji intact, adds the trailing newline once; egress boundary scrubs all three text fields, covers a codex-runtime-shaped result, leaves `messages` to the existing persistence sanitizer, passes through non-dict results. Red on main: the suite fails collection (helpers don't exist).
- `scripts/run_tests.sh`: new suite 9/9; neighbors green — `test_oneshot_usage_file`, `test_message_sanitization_policy`, `test_anthropic_kwargs_sanitize`, `test_run_agent` (292 tests, 0 failed).

## Scope notes

- Fragment tests in #80429/#80374 validated a local copy of the scrub; this suite adopts their scenarios (high/low surrogate, clean-text passthrough) against the real helpers so they can fail — credit to those authors for mapping the sink.
- `messages` content is intentionally not touched at egress: persistence has its own sanitization path (`_sanitize_messages_surrogates`), and double-scrubbing at egress would mask gaps in it.
- Behavior matches the reporter's expectation exactly: `hermes -z` prints `�` and exits 0.
