### PR TITLE
fix(buzz): keep kanban identity labels from becoming mentions

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -25,6 +25,22 @@ from agent.i18n import t
 logger = logging.getLogger("gateway.run")
 
 
+def _kanban_identity_tag(platform: str, assignee: Optional[str]) -> str:
+    """Render an assignee label without inventing a Buzz member mention."""
+    if not assignee:
+        return ""
+    if platform == "buzz":
+        return f"{assignee}: "
+    return f"@{assignee} "
+
+
+def _sanitize_kanban_notification(platform: str, message: str) -> str:
+    """Prevent system text from becoming accidental Buzz mentions."""
+    if platform == "buzz":
+        return message.replace("@", "@\u200b")
+    return message
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -409,7 +425,11 @@ class GatewayKanbanWatchersMixin:
                         # worker that did the work. Makes fleets (where one
                         # chat subscribes to many tasks) legible at a glance.
                         who = (task.assignee if task and task.assignee else None)
-                        tag = f"@{who} " if who else ""
+                        # Buzz uses @name as a real member mention and rejects
+                        # unknown names. In the hub-and-spoke deployment the
+                        # worker profiles are labels behind the single Satoshi
+                        # identity, not Buzz members, so render a plain label.
+                        tag = _kanban_identity_tag(platform_str, who)
                         if kind == "completed":
                             # Prefer the run's summary (the worker's
                             # intentional human-facing handoff, carried
@@ -491,6 +511,10 @@ class GatewayKanbanWatchersMixin:
                             # internal transition. They are also excluded from
                             # _WAKE_KINDS below, so they never wake the creator.
                             continue
+                        # buzz-cli interprets every visible @Name anywhere in
+                        # the message as a member mention. Neutralize handles
+                        # in all system-controlled fields before delivery.
+                        msg = _sanitize_kanban_notification(platform_str, msg)
                         delivery_metadata = sub.get("delivery_metadata")
                         metadata: dict[str, Any] = (
                             dict(delivery_metadata)

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -5,11 +5,26 @@ from pathlib import Path
 
 from gateway.config import Platform
 from gateway.kanban_watchers import (
+    _kanban_identity_tag,
+    _sanitize_kanban_notification,
     _acquire_singleton_lock,
     _release_singleton_lock,
 )
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
+
+
+def test_buzz_assignee_is_a_plain_identity_label():
+    assert _kanban_identity_tag("buzz", "pikachu") == "pikachu: "
+    assert _kanban_identity_tag("telegram", "pikachu") == "@pikachu "
+
+
+def test_buzz_notification_neutralizes_all_visible_handles():
+    text = _sanitize_kanban_notification(
+        "buzz", "pikachu: finished @owner work for @scope/package",
+    )
+    assert text == "pikachu: finished @\u200bowner work for @\u200bscope/package"
+    assert _sanitize_kanban_notification("telegram", "hello @owner") == "hello @owner"
 
 
 class RecordingAdapter:


### PR DESCRIPTION
## Summary

Prevent Buzz Kanban notifications from treating Hermes profile labels or arbitrary `@` text as member mentions. Other platforms are unchanged.

## Validation

- 52 targeted gateway tests passed