### PR TITLE
feat(desktop-sdk): expose focused-session state atoms to plugins

### DIFF
--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -32,9 +32,9 @@ describe('host.state focused-session atoms', () => {
     for (const key of ['focusedSessionId', 'focusedStoredSessionId', 'focusedUsage'] as const) {
       const store = host.state[key]
       expect(store, key).toBeDefined()
-      expect(typeof store.get, 'function', key)
-      expect(typeof store.listen, 'function', key)
-      expect(typeof store.subscribe, 'function', key)
+      expect(typeof store.get, key).toBe('function')
+      expect(typeof store.listen, key).toBe('function')
+      expect(typeof store.subscribe, key).toBe('function')
     }
   })
 
@@ -68,6 +68,7 @@ describe('host.state focused-session atoms', () => {
         title: id
       })
     }
+
     tree.declareDefaultTree(
       model.split('row', [
         model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -53,7 +53,7 @@ describe('host.state focused-session atoms', () => {
   })
 
   it('follows the interacted tile while the primary-only atom stays put', async () => {
-    const { host, session } = await setup()
+    const { host, session, states } = await setup()
     const tree = await import('@/components/pane-shell/tree/store')
     const model = await import('@/components/pane-shell/tree/model')
     const { registry } = await import('@/contrib/registry')
@@ -79,9 +79,30 @@ describe('host.state focused-session atoms', () => {
     const primaryBefore = session.$activeSessionId.get()
     const primarySelection = session.$selectedStoredSessionId.get()
 
+    // Bind the tile to a live runtime with its own usage, so the readout
+    // atoms (focusedSessionId / focusedUsage) — not just the navigation id —
+    // are proven to follow the tile.
+    const tileUsage = {
+      calls: 3,
+      input: 1200,
+      output: 300,
+      total: 1500,
+      context_used: 42000,
+      context_max: 200000,
+      context_percent: 21,
+      cost_usd: 0.0123
+    }
+
+    states.$sessionTiles.set([{ storedSessionId: 'tile-a', runtimeId: 'runtime-tile-a' }])
+    states.$sessionStates.set({
+      'runtime-tile-a': { storedSessionId: 'tile-a', usage: tileUsage } as never
+    })
+
     // Focusing the tile zone moves the focused atoms onto the tile's session…
     tree.noteActiveTreeGroup('grp-side')
     expect(host.state.focusedStoredSessionId.get()).toBe('tile-a')
+    expect(host.state.focusedSessionId.get()).toBe('runtime-tile-a')
+    expect(host.state.focusedUsage.get()).toBe(tileUsage)
     // …while the primary-only atom a plugin used to rely on does not move.
     expect(host.state.activeSessionId.get()).toBe(primaryBefore)
 

--- a/apps/desktop/src/sdk/host-state.test.ts
+++ b/apps/desktop/src/sdk/host-state.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Plugins read app state exclusively through host.state — and before this
+// contract existed, only the PRIMARY workspace tab was reachable
+// ($activeSessionId). Clicking a tile never moved any plugin-visible atom,
+// and tile focus is pure renderer state that gateway RPC can never see, so
+// no plugin-side workaround was possible. These atoms are the plugin door to
+// the same focused-session signals the core statusbar reads
+// (use-statusbar-items.tsx).
+
+describe('host.state focused-session atoms', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.resetModules()
+  })
+
+  async function setup() {
+    const { host } = await import('@/sdk/index')
+    const states = await import('@/store/session-states')
+    const session = await import('@/store/session')
+
+    return { host, states, session }
+  }
+
+  it('exposes readonly atoms for the focused session (runtime id, stored id, usage)', async () => {
+    const { host } = await setup()
+
+    for (const key of ['focusedSessionId', 'focusedStoredSessionId', 'focusedUsage'] as const) {
+      const store = host.state[key]
+      expect(store, key).toBeDefined()
+      expect(typeof store.get, 'function', key)
+      expect(typeof store.listen, 'function', key)
+      expect(typeof store.subscribe, 'function', key)
+    }
+  })
+
+  it('mirrors the primary session while no tile is focused', async () => {
+    const { host, states } = await setup()
+
+    expect(host.state.focusedSessionId.get()).toBe(states.$focusedRuntimeId.get())
+    expect(host.state.focusedStoredSessionId.get()).toBe(states.$focusedStoredSessionId.get())
+  })
+
+  it('focusedUsage projects the focused session usage, null while unresolved', async () => {
+    const { host, states } = await setup()
+
+    const focused = states.$focusedSessionState.get()
+    expect(host.state.focusedUsage.get()).toBe(focused?.usage ?? null)
+  })
+
+  it('follows the interacted tile while the primary-only atom stays put', async () => {
+    const { host, session } = await setup()
+    const tree = await import('@/components/pane-shell/tree/store')
+    const model = await import('@/components/pane-shell/tree/model')
+    const { registry } = await import('@/contrib/registry')
+
+    // A second chat zone holding a session tile, next to the main workspace.
+    for (const id of ['workspace', 'session-tile:tile-a']) {
+      registry.register({
+        area: 'panes',
+        data: id === 'workspace' ? { placement: 'main', uncloseable: true } : { placement: 'main' },
+        id,
+        render: () => null,
+        title: id
+      })
+    }
+    tree.declareDefaultTree(
+      model.split('row', [
+        model.group(['workspace'], { active: 'workspace', id: 'grp-main' }),
+        model.group(['session-tile:tile-a'], { active: 'session-tile:tile-a', id: 'grp-side' })
+      ])
+    )
+
+    const primaryBefore = session.$activeSessionId.get()
+    const primarySelection = session.$selectedStoredSessionId.get()
+
+    // Focusing the tile zone moves the focused atoms onto the tile's session…
+    tree.noteActiveTreeGroup('grp-side')
+    expect(host.state.focusedStoredSessionId.get()).toBe('tile-a')
+    // …while the primary-only atom a plugin used to rely on does not move.
+    expect(host.state.activeSessionId.get()).toBe(primaryBefore)
+
+    // Focusing back homes to the primary's selection, whatever it is.
+    tree.noteActiveTreeGroup('grp-main')
+    expect(host.state.focusedStoredSessionId.get()).toBe(primarySelection)
+  })
+})

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -18,7 +18,7 @@
  *  - `ui.*` — the design language, so plugin UI looks native by default.
  */
 
-import { atom, type ReadableAtom } from 'nanostores'
+import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $narrowViewport } from '@/components/pane-shell/tree/store'
 import { onGatewayEvent } from '@/contrib/events'
@@ -27,7 +27,13 @@ import { $gateway } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $activeSessionId, $currentCwd, $currentModel, $gatewayState } from '@/store/session'
+import {
+  $focusedRuntimeId,
+  $focusedSessionState,
+  $focusedStoredSessionId
+} from '@/store/session-states'
 import { runGatewayRestart } from '@/store/system-actions'
+import type { UsageStats } from '@/types/hermes'
 
 // -- state: readonly views over the app's live atoms -------------------------
 
@@ -55,10 +61,25 @@ if (typeof window !== 'undefined') {
   $narrowViewport.listen(refresh)
 }
 
+/** Live usage of the FOCUSED session, projected out of the streamed session
+ *  state — the same readout the core statusbar's context chip paints. */
+const $focusedUsage = computed($focusedSessionState, state => state?.usage ?? null)
+
 export const host = {
   state: {
     /** Runtime id of the active chat session (null on a fresh draft). */
     activeSessionId: readonlyAtom<null | string>($activeSessionId),
+    /** Runtime id of the FOCUSED chat session — the interacted tile, else the
+     *  primary. Prefer this over `activeSessionId` for any readout that
+     *  should follow the user between tiles (context, tokens, cost). */
+    focusedSessionId: readonlyAtom<null | string>($focusedRuntimeId),
+    /** Stored (durable) id of the focused session — for navigation and
+     *  session-list matching, where runtime ids don't survive reloads. */
+    focusedStoredSessionId: readonlyAtom<null | string>($focusedStoredSessionId),
+    /** Live usage snapshot of the focused session (`context_used` /
+     *  `context_max` / `context_percent`, token counts, `cost_usd`) —
+     *  streamed by the backend, no RPC needed. Null while unresolved. */
+    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -79,9 +79,9 @@ export const host = {
     /** Live usage snapshot of the focused session (`context_used` /
      *  `context_max` / `context_percent`, token counts, `cost_usd`) —
      *  streamed by the backend, no RPC needed. Null while unresolved.
-     *  Partial: the backend streams whichever fields changed, so every
-     *  field read needs a fallback. */
-    focusedUsage: readonlyAtom<null | Partial<UsageStats>>($focusedUsage),
+     *  The UsageStats-optional fields (context_*, cost_usd) arrive as the
+     *  backend reports them, so read them with a fallback. */
+    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -78,8 +78,10 @@ export const host = {
     focusedStoredSessionId: readonlyAtom<null | string>($focusedStoredSessionId),
     /** Live usage snapshot of the focused session (`context_used` /
      *  `context_max` / `context_percent`, token counts, `cost_usd`) —
-     *  streamed by the backend, no RPC needed. Null while unresolved. */
-    focusedUsage: readonlyAtom<null | UsageStats>($focusedUsage),
+     *  streamed by the backend, no RPC needed. Null while unresolved.
+     *  Partial: the backend streams whichever fields changed, so every
+     *  field read needs a fallback. */
+    focusedUsage: readonlyAtom<null | Partial<UsageStats>>($focusedUsage),
     /** Active workspace cwd ('' when detached). */
     cwd: readonlyAtom<string>($currentCwd),
     /** Gateway socket state: 'idle' | 'connecting' | 'open' | …. */

--- a/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
+++ b/skills/autonomous-ai-agents/hermes-agent/references/desktop-plugins.md
@@ -42,7 +42,12 @@ The ONLY import surface is `@hermes/plugin-sdk` (plus `react` /
 `jsx()` calls, not JSX syntax; the file is not compiled).
 
 - `host.state.*` — readonly reactive atoms: `activeSessionId`, `cwd`,
-  `gateway`, `model`, `profile`, `viewport`. Read with `.get()` in handlers,
+  `gateway`, `model`, `profile`, `viewport`, plus the tile-aware focused
+  session atoms: `focusedSessionId` (runtime id — key for `session.*` RPC),
+  `focusedStoredSessionId` (durable id — navigation / list matching), and
+  `focusedUsage` (live streamed `UsageStats` of the focused session, no RPC
+  needed). Prefer the focused atoms for any readout that should follow the
+  user between tiles. Read with `.get()` in handlers,
   `useValue(atom)` in components.
 - `host.request(method, params)` — gateway JSON-RPC (sessions, config,
   skills, cron — everything the app uses).

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -364,6 +364,9 @@ components.
 
 ```ts
 host.state.activeSessionId  // ReadableAtom<string | null>
+host.state.focusedSessionId // ReadableAtom<string | null>  (runtime id of the FOCUSED session — tile-aware; prefer for session.* RPC)
+host.state.focusedStoredSessionId // ReadableAtom<string | null>  (durable id — navigation / session-list matching)
+host.state.focusedUsage     // ReadableAtom<UsageStats | null>  (live streamed usage of the focused session, no RPC needed)
 host.state.cwd              // ReadableAtom<string>
 host.state.gateway          // ReadableAtom<string>  ('idle' | 'connecting' | 'open' | …)
 host.state.model            // ReadableAtom<string>


### PR DESCRIPTION
## Summary

Desktop disk plugins read app state exclusively through `host.state`, which only exposed the **primary workspace tab** (`$activeSessionId`). In the multi-tile layout, clicking a tile never touches that atom — and tile focus is a pure renderer concern, invisible to both gateway RPC and the event stream — so **a plugin cannot follow the session the user is actually looking at**. Any session-scoped plugin readout (context usage, token meters, cost trackers) silently describes the wrong chat.

The core statusbar solves this exact problem by reading the focused-session atoms directly (`use-statusbar-items.tsx`: *"Chrome that should follow the user between tiles (titlebar session title, statusbar context / timer / model) reads these instead of the primary-only atoms"*). This PR widens the generic plugin surface with the same signals, per the contribution rubric (*"if a plugin needs more, widen the generic plugin surface, don't special-case it in core"*).

## Changes

Three readonly atoms added to `host.state` — all views over atoms the shell already maintains, zero new state:

| Atom | Source | Plugin use |
|---|---|---|
| `focusedSessionId` | `$focusedRuntimeId` | Key for `session.*` RPC — follows the interacted tile, else the primary |
| `focusedStoredSessionId` | `$focusedStoredSessionId` | Durable identity for navigation / session-list matching (survives reloads) |
| `focusedUsage` | computed over `$focusedSessionState` | Live streamed `UsageStats` (`context_used/max/percent`, token counts, `cost_usd`) — the same readout the core context chip paints, **no RPC needed** |

Additive only — no existing atom, contribution area, or behavior changes. The usage projection is reference-stable (bails out unless the backend reports new usage), matching the statusbar's own memo strategy.

## Test plan

- [x] `tsc -p . --noEmit` clean
- [x] `eslint src/sdk/` clean
- [x] **New contract tests** (`src/sdk/host-state.test.ts`, 4 passing): the focused atoms exist as readonly nanostores; mirror the primary session while no tile is focused; project the focused session's usage; and — the behavior this PR exists for — follow the interacted tile while the primary-only `$activeSessionId` stays put
- [x] E2E on a local release build: rebuilt renderer, repacked asar, ran a disk plugin whose statusbar chip + side pane read `focusedSessionId`/`focusedUsage` — clicking between sidebar sessions and open tiles now repaints the plugin instantly, matching the core statusbar; pre-change it stayed pinned to the primary tab