### PR TITLE
ci: #79771 follow-ups — dep-bootstrap policy gate, slice-gen in detect, 16 slices, treeless lint clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       ci_review: ${{ steps.classify.outputs.ci_review }}
       ci_review_files: ${{ steps.classify.outputs.ci_review_files }}
       event_name: ${{ github.event_name }}
+      test_matrix: ${{ steps.test-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Detect affected areas
@@ -61,6 +62,30 @@ jobs:
         uses: ./.github/actions/detect-changes
         with:
           github-token: ${{ github.token }}
+
+      # Test-slice generation lives here (not in a dedicated job inside
+      # tests.yml) so the test matrix jobs start straight off detect —
+      # a separate generate job added a full runner spin-up (~10-14s) to
+      # the merge-gate critical path (#79771 follow-up).
+      - name: Restore test duration cache
+        if: steps.classify.outputs.python == 'true'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: test_durations.json
+          key: test-durations
+          # Saves use test-durations-${run_id}, so the exact key above never
+          # matches — without this prefix fallback the cache ALWAYS missed,
+          # LPT slicing ran on no data, and unbalanced slices pushed heavy
+          # files toward the per-file timeout under load.
+          restore-keys: |
+            test-durations-
+
+      - name: Generate test slices
+        if: steps.classify.outputs.python == 'true'
+        id: test-matrix
+        run: |
+          MATRIX=$(python3 scripts/run_tests_parallel.py --generate-slices 16)
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   # ─────────────────────────────────────────────────────────────────────
   # Lane-gated sub-workflows. Each runs in parallel after detect finishes.
@@ -72,7 +97,8 @@ jobs:
     if: needs.detect.outputs.python == 'true'
     uses: ./.github/workflows/tests.yml
     with:
-      slice_count: 12
+      slice_count: 16
+      matrix: ${{ needs.detect.outputs.test_matrix }}
 
   lint:
     name: Python lints

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # need full history for merge-base + worktree
+          # Treeless clone: full commit history (merge-base still works) but
+          # blobs/trees are fetched lazily on demand. Cuts the ~31s full
+          # checkout to ~8s; the base-worktree step later faults in only the
+          # single base tree it needs (#79771 follow-up).
+          filter: tree:0
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,15 @@ on:
         description: Number of parallel test slices
         type: number
         default: 8
+      matrix:
+        description: >-
+          Pre-computed slice matrix JSON from the orchestrator's detect job
+          (scripts/run_tests_parallel.py --generate-slices). Generated there
+          rather than in a job here so the test slices start straight off
+          detect — a dedicated generate job added a full runner spin-up
+          (~10-14s) to the merge-gate critical path.
+        type: string
+        required: true
 
 permissions:
   contents: read
@@ -17,42 +26,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  generate:
-    name: "Generate slices"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Restore duration cache
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: test_durations.json
-          key: test-durations
-          # Saves use test-durations-${run_id}, so the exact key above never
-          # matches — without this prefix fallback the cache ALWAYS missed,
-          # LPT slicing ran on no data, and unbalanced slices pushed heavy
-          # files toward the per-file timeout under load.
-          restore-keys: |
-            test-durations-
-
-      - name: Generate test slices
-        id: matrix
-        run: |
-          MATRIX=$(python3 scripts/run_tests_parallel.py --generate-slices ${{ inputs.slice_count }})
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-
   test:
     name: Run tests slice ${{ matrix.slice.index }}/${{ inputs.slice_count }}
-    needs: generate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.generate.outputs.matrix) }}
+      matrix: ${{ fromJSON(inputs.matrix) }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/hermes_cli/dep_ensure.py
+++ b/hermes_cli/dep_ensure.py
@@ -117,6 +117,19 @@ def ensure_dependency(
     if check():
         return True
 
+    # Honor the lazy-install policy before prompting or shelling out to the
+    # install script. This is the same gate pip-based lazy installs go
+    # through (config kill switch security.allow_lazy_installs, and the
+    # sealed-venv HERMES_DISABLE_LAZY_INSTALLS env var) — without it, a
+    # sealed environment (Docker image, hermetic test run) that hits a
+    # missing dep spawns a real bash install.sh run.
+    try:
+        from tools.lazy_deps import lazy_installs_allowed
+        if not lazy_installs_allowed():
+            return False
+    except ImportError:
+        pass
+
     script, shell = _find_install_script()
     if script is None:
         if interactive:

--- a/tests/hermes_cli/test_dep_ensure.py
+++ b/tests/hermes_cli/test_dep_ensure.py
@@ -16,6 +16,32 @@ def test_find_install_script_from_checkout(tmp_path):
     assert shell == "bash"
 
 
+def test_ensure_dependency_honors_sealed_env(monkeypatch):
+    """HERMES_DISABLE_LAZY_INSTALLS=1 (no durable target) must block the
+    install.sh shell-out — same policy gate as pip lazy installs. Regression:
+    before this gate, every hermetic test / sealed container that hit a
+    missing dep spawned a real ~2-7s bash install.sh run (issue #79771
+    follow-up: test_browser_homebrew_paths.py spent 8s of its 36s here)."""
+    from hermes_cli.dep_ensure import ensure_dependency
+    monkeypatch.setenv("HERMES_DISABLE_LAZY_INSTALLS", "1")
+    monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+    with patch("hermes_cli.dep_ensure._DEP_CHECKS", {"node": lambda: False}), \
+         patch("subprocess.run") as mock_run:
+        assert ensure_dependency("node", interactive=False) is False
+    mock_run.assert_not_called()
+
+
+def test_ensure_dependency_honors_config_kill_switch(monkeypatch):
+    """security.allow_lazy_installs: false must block the install.sh path."""
+    from hermes_cli.dep_ensure import ensure_dependency
+    monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+    with patch("hermes_cli.dep_ensure._DEP_CHECKS", {"node": lambda: False}), \
+         patch("tools.lazy_deps._allow_lazy_installs", return_value=False), \
+         patch("subprocess.run") as mock_run:
+        assert ensure_dependency("node", interactive=False) is False
+    mock_run.assert_not_called()
+
+
 
 
 
@@ -29,6 +55,7 @@ def test_ensure_dependency_uses_powershell_on_windows(tmp_path):
     (scripts_dir / "install.ps1").write_text("# fake")
     with patch("hermes_cli.dep_ensure._IS_WINDOWS", True), \
          patch("hermes_cli.dep_ensure._DEP_CHECKS", {"node": lambda: False}), \
+         patch("tools.lazy_deps.lazy_installs_allowed", return_value=True), \
          patch("hermes_cli.dep_ensure._find_install_script", return_value=(scripts_dir / "install.ps1", "powershell")), \
          patch("hermes_cli.dep_ensure.shutil") as mock_shutil, \
          patch("hermes_constants.get_hermes_home", return_value=tmp_path / "fakehome"), \

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -497,6 +497,18 @@ def activate_durable_lazy_target() -> None:
         logger.debug("Failed to activate durable lazy target %s: %s", target, e)
 
 
+def lazy_installs_allowed() -> bool:
+    """Public policy check: may this process install dependencies at runtime?
+
+    Single owner for the lazy-install policy. Non-pip installers (e.g.
+    ``hermes_cli.dep_ensure`` shelling out to install.sh for node/browser
+    deps) must consult this instead of re-deriving the rules — the config
+    kill switch and the sealed-venv env var apply to every runtime install,
+    not just pip ones.
+    """
+    return _allow_lazy_installs()
+
+
 def _allow_lazy_installs() -> bool:
     """Return whether lazy installs are permitted in this environment.
 


### PR DESCRIPTION
## Summary
Ships three follow-ups from the CI-speed tracker #79771: the dep-bootstrap policy gap that burned ~8s per hermetic run, slice generation folded into detect (kills a runner spin-up on the merge-gate critical path), 12 → 16 test slices, and a treeless clone for the lint diff.

## Changes
- `hermes_cli/dep_ensure.py` + `tools/lazy_deps.py`: `ensure_dependency()` now consults the lazy-install policy (new public `lazy_installs_allowed()`, single owner: `security.allow_lazy_installs` config kill switch + sealed-venv `HERMES_DISABLE_LAZY_INSTALLS` with durable-target redirect) before prompting or shelling out to install.sh. Previously any sealed environment (hermetic test run, immutable Docker image) that hit a missing dep spawned a real bash install run.
- `.github/workflows/ci.yml` + `tests.yml`: slice generation (duration-cache restore + one python call) moves into the detect job; `tests.yml` takes the matrix as a required `workflow_call` input. Test slices start straight off detect — removes a full runner spin-up (~10-14s) from the gate's critical path. Slice count 12 → 16.
- `.github/workflows/lint.yml`: `filter: tree:0` on the `fetch-depth: 0` checkout — full history for merge-base at ~8s instead of ~31s.
- `tests/hermes_cli/test_dep_ensure.py`: sealed-env + config-kill-switch regression tests (both proven to fail without the gate via sabotage run).

## Validation
| | Before | After |
|---|---|---|
| `test_browser_homebrew_paths.py` (local, hermetic) | 8.6s | 0.17s |
| LPT makespan per slice (fresh durations cache, run 31112804908) | 706s @12 | 529s @16 |
| Gate critical path | detect → generate job → slices | detect (+~2s of steps) → slices |
| Targeted tests | — | 80 passed (dep_ensure, lazy_deps, browser_homebrew_paths, run_tests_parallel) |

actionlint clean on all three workflows; `--generate-slices 16` verified locally against the live durations cache (16 slices, correct schema).

Slice-16 justification: the tracker gated this on #79769's floor drop reaching the durations cache — confirmed absorbed (`test_hermes_state.py` now 27.9s; new floor `test_run_agent.py` 43.6s, far under the 529s/slice budget).

Follow-ups #79771 still open after this: Docker-lane gating decision + merge queue (team calls).

## Infographic

![CI speed follow-ups](https://v3b.fal.media/files/b/0aa5455e/jAffSMNZT03hcsFfNtRZf_nXZEcVHv.png)
