### PR TITLE
feat(api-server): honor X-Hermes-User for per-user identity

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2,8 +2,8 @@
 OpenAI-compatible API server platform adapter.
 
 Exposes an HTTP server with endpoints:
-- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header)
-- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key supported)
+- POST /v1/chat/completions        — OpenAI Chat Completions format (stateless; opt-in session continuity via X-Hermes-Session-Id header; opt-in long-term memory scoping via X-Hermes-Session-Key header; opt-in per-user identity via X-Hermes-User header)
+- POST /v1/responses               — OpenAI Responses API format (stateful via previous_response_id; X-Hermes-Session-Key + X-Hermes-User supported)
 - GET  /v1/responses/{response_id} — Retrieve a stored response
 - DELETE /v1/responses/{response_id} — Delete a stored response
 - GET  /v1/models                  — lists hermes-agent and any configured model_routes aliases
@@ -987,7 +987,10 @@ class ResponseStore:
 
 _CORS_HEADERS = {
     "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
-    "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
+    "Access-Control-Allow-Headers": (
+        "Authorization, Content-Type, Idempotency-Key, "
+        "X-Hermes-User, X-Hermes-Session-Key, X-Hermes-Session-Id"
+    ),
 }
 
 
@@ -1255,9 +1258,26 @@ class _IdempotencyCache:
 _idem_cache = _IdempotencyCache()
 
 
-def _make_request_fingerprint(body: Dict[str, Any], keys: List[str]) -> str:
+def _make_request_fingerprint(
+    body: Dict[str, Any],
+    keys: List[str],
+    *,
+    user_id: Optional[str] = None,
+    gateway_session_key: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> str:
+    """Fingerprint request body keys plus validated memory-scope identity.
+
+    Identity slots (``user_id``, session key/id) are **always** hashed —
+    absent values become empty strings — so single-user callers keep a
+    stable fingerprint while an ``Idempotency-Key`` reused across different
+    authenticated end-users cannot reclaim another user's completion.
+    """
     from hashlib import sha256
     subset = {k: body.get(k) for k in keys}
+    subset["__hermes_user_id"] = user_id or ""
+    subset["__hermes_gateway_session_key"] = gateway_session_key or ""
+    subset["__hermes_session_id"] = session_id or ""
     return sha256(repr(subset).encode("utf-8")).hexdigest()
 
 
@@ -2095,6 +2115,55 @@ class APIServerAdapter(BasePlatformAdapter):
 
         return raw, None
 
+    def _parse_user_header(
+        self, request: "web.Request"
+    ) -> tuple[Optional[str], Optional["web.Response"]]:
+        """Extract and validate the ``X-Hermes-User`` header.
+
+        Opt-in end-user identity for multi-user API deployments. When
+        present after successful ``API_SERVER_KEY`` auth, the value is
+        threaded to ``AIAgent(user_id=...)`` so downstream consumers
+        (Honcho ``runtime_user_peer_name`` / ``user_peer_aliases``,
+        session scoping) receive a stable per-user identity.
+
+        Independent of ``X-Hermes-Session-Key`` (channel) and
+        ``X-Hermes-Session-Id`` (transcript): callers may send any, all,
+        or none.
+
+        Behaviour:
+        - Header absent → ``(None, None)`` (historical anonymous / peer_name fallback).
+        - No API key configured → header ignored (``(None, None)``); never
+          trusted without ``API_SERVER_KEY``.
+        - Control characters / oversize → ``400``.
+        - Valid → ``(sanitized_value, None)``.
+        """
+        raw = request.headers.get("X-Hermes-User", "").strip()
+        if not raw:
+            return None, None
+
+        if not self._api_key:
+            # Issue contract: unauthenticated / no-key deployments ignore
+            # the header rather than treating it as a hard error.
+            logger.warning(
+                "X-Hermes-User ignored: no API key configured. "
+                "Set API_SERVER_KEY to enable per-user identity."
+            )
+            return None, None
+
+        if re.search(r'[\r\n\x00]', raw):
+            return None, web.json_response(
+                {"error": {"message": "Invalid user id", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        if len(raw) > self._MAX_SESSION_HEADER_LEN:
+            return None, web.json_response(
+                {"error": {"message": "User id too long", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        return raw, None
+
     # ------------------------------------------------------------------
     # Session DB helper
     # ------------------------------------------------------------------
@@ -2531,6 +2600,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_start_callback=None,
         tool_complete_callback=None,
         gateway_session_key: Optional[str] = None,
+        user_id: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -2552,6 +2622,10 @@ class APIServerAdapter(BasePlatformAdapter):
         key is meant to persist across transcripts so long-term memory
         providers (e.g. Honcho) can scope their per-chat state correctly
         — matching the semantics of the native gateway's ``session_key``.
+
+        ``user_id`` is an optional end-user identity from ``X-Hermes-User``.
+        Threaded to ``AIAgent(user_id=...)`` so Honcho and other memory
+        providers can map the caller to a peer via ``user_peer_aliases``.
 
         ``route`` is an optional ``model_routes`` entry (per-client model
         routing).  When set — and no session ``/model`` override exists for
@@ -2836,6 +2910,8 @@ class APIServerAdapter(BasePlatformAdapter):
             "reasoning_config": reasoning_config,
             "gateway_session_key": gateway_session_key,
         }
+        if user_id:
+            agent_kwargs["user_id"] = user_id
         if request_service_tier is not _REQUEST_OPTION_MISSING:
             agent_kwargs["service_tier"] = request_service_tier
 
@@ -3064,6 +3140,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
                 "session_key_header": "X-Hermes-Session-Key",
+                "user_header": "X-Hermes-User",
                 "cors": bool(self._cors_origins),
             },
             "endpoints": {
@@ -3517,6 +3594,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        user_id, uid_err = self._parse_user_header(request)
+        if uid_err is not None:
+            return uid_err
         session_id = request.match_info["session_id"]
         session, err = await self._get_existing_session_or_404(session_id)
         if err:
@@ -3588,6 +3668,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ephemeral_system_prompt=system_prompt,
             session_id=session_id,
             gateway_session_key=gateway_session_key,
+            user_id=user_id,
             route=route,
             session_model=session_model,
             requested_runtime=runtime_request.get("requested") or {},
@@ -3600,6 +3681,8 @@ class APIServerAdapter(BasePlatformAdapter):
         headers = {"X-Hermes-Session-Id": effective_session_id or session_id}
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            headers["X-Hermes-User"] = user_id
         runtime = {}
         if isinstance(result, dict):
             runtime = result.get("runtime") or {}
@@ -3634,6 +3717,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        user_id, uid_err = self._parse_user_header(request)
+        if uid_err is not None:
+            return uid_err
         session_id = request.match_info["session_id"]
         session, err = await self._get_existing_session_or_404(session_id)
         if err:
@@ -3753,6 +3839,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     stream_delta_callback=_delta,
                     tool_progress_callback=_tool_progress,
                     gateway_session_key=gateway_session_key,
+                    user_id=user_id,
                     route=route,
                     session_model=session_model,
                     requested_runtime=runtime_request.get("requested") or {},
@@ -3820,6 +3907,8 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if gateway_session_key:
             headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            headers["X-Hermes-User"] = user_id
         response = web.StreamResponse(status=200, headers=headers)
         await response.prepare(request)
         try:
@@ -3948,6 +4037,12 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+
+        # Opt-in per-user identity via X-Hermes-User (see _parse_user_header).
+        # Threaded to AIAgent(user_id=...) for Honcho / memory peer mapping.
+        user_id, uid_err = self._parse_user_header(request)
+        if uid_err is not None:
+            return uid_err
 
         # Allow caller to continue an existing session by passing X-Hermes-Session-Id.
         # When provided, history is loaded from state.db instead of from the request body.
@@ -4114,6 +4209,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
                 **agent_overrides,
                 route=route,
             ))
@@ -4125,6 +4221,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
@@ -4135,6 +4232,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
                 **agent_overrides,
                 route=route,
             )
@@ -4144,6 +4242,9 @@ class APIServerAdapter(BasePlatformAdapter):
             fp = _make_request_fingerprint(
                 body,
                 keys=["model", "provider", "model_options", "messages", "tools", "tool_choice", "stream"],
+                user_id=user_id,
+                gateway_session_key=gateway_session_key,
+                session_id=session_id,
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_completion)
@@ -4185,6 +4286,8 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            response_headers["X-Hermes-User"] = user_id
 
         # Hard-fail path: no usable assistant text AND a real failure → 5xx
         # with OpenAI-style error envelope so SDK clients raise instead of
@@ -4246,7 +4349,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, user_id: str = None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -4269,6 +4372,8 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            sse_headers["X-Hermes-User"] = user_id
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -4453,6 +4558,7 @@ class APIServerAdapter(BasePlatformAdapter):
         store: bool,
         session_id: str,
         gateway_session_key: Optional[str] = None,
+        user_id: Optional[str] = None,
     ) -> "web.StreamResponse":
         """Write an SSE stream for POST /v1/responses (OpenAI Responses API).
 
@@ -4495,6 +4601,8 @@ class APIServerAdapter(BasePlatformAdapter):
             sse_headers["X-Hermes-Session-Id"] = session_id
         if gateway_session_key:
             sse_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            sse_headers["X-Hermes-User"] = user_id
         response = web.StreamResponse(status=200, headers=sse_headers)
         await response.prepare(request)
 
@@ -5056,6 +5164,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        user_id, uid_err = self._parse_user_header(request)
+        if uid_err is not None:
+            return uid_err
 
         # Parse request body
         try:
@@ -5225,6 +5336,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
                 **agent_overrides,
                 route=route,
             ))
@@ -5251,6 +5363,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 store=store,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
             )
 
         async def _compute_response():
@@ -5260,6 +5373,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=instructions,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                user_id=user_id,
                 **agent_overrides,
                 route=route,
             )
@@ -5278,6 +5392,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "model_options",
                     "tools",
                 ],
+                user_id=user_id,
+                gateway_session_key=gateway_session_key,
+                session_id=session_id,
             )
             try:
                 result, usage = await _idem_cache.get_or_set(idempotency_key, fp, _compute_response)
@@ -5363,6 +5480,8 @@ class APIServerAdapter(BasePlatformAdapter):
         response_headers = {"X-Hermes-Session-Id": _effective_session_id}
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            response_headers["X-Hermes-User"] = user_id
         return web.json_response(response_data, headers=response_headers)
 
     # ------------------------------------------------------------------
@@ -5966,6 +6085,7 @@ class APIServerAdapter(BasePlatformAdapter):
         tool_complete_callback=None,
         agent_ref: Optional[list] = None,
         gateway_session_key: Optional[str] = None,
+        user_id: Optional[str] = None,
         requested_model: Optional[str] = None,
         requested_provider: Optional[str] = None,
         model_options: Optional[Dict[str, Any]] = None,
@@ -6025,6 +6145,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         tool_start_callback=tool_start_callback,
                         tool_complete_callback=tool_complete_callback,
                         gateway_session_key=gateway_session_key,
+                        user_id=user_id,
                         requested_model=requested_model,
                         requested_provider=requested_provider,
                         model_options=model_options,
@@ -6301,6 +6422,9 @@ class APIServerAdapter(BasePlatformAdapter):
         gateway_session_key, key_err = self._parse_session_key_header(request)
         if key_err is not None:
             return key_err
+        user_id, uid_err = self._parse_user_header(request)
+        if uid_err is not None:
+            return uid_err
 
         # Enforce concurrency limit (shared across all agent-serving
         # endpoints; configurable via gateway.api_server.max_concurrent_runs).
@@ -6454,6 +6578,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         stream_delta_callback=_text_cb,
                         tool_progress_callback=event_cb,
                         gateway_session_key=gateway_session_key,
+                        user_id=user_id,
                         requested_model=agent_overrides.get("requested_model"),
                         requested_provider=agent_overrides.get("requested_provider"),
                         model_options=agent_overrides.get("model_options"),
@@ -6693,9 +6818,11 @@ class APIServerAdapter(BasePlatformAdapter):
         if hasattr(task, "add_done_callback"):
             task.add_done_callback(self._background_tasks.discard)
 
-        response_headers = (
-            {"X-Hermes-Session-Key": gateway_session_key} if gateway_session_key else {}
-        )
+        response_headers: Dict[str, str] = {}
+        if gateway_session_key:
+            response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if user_id:
+            response_headers["X-Hermes-User"] = user_id
         return web.json_response(
             {"run_id": run_id, "status": "started"},
             status=202,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -316,6 +316,7 @@ def _create_app(adapter: APIServerAdapter) -> web.Application:
     app.router.add_post("/api/sessions/{session_id}/chat/stream", adapter._handle_session_chat_stream)
     app.router.add_post("/v1/chat/completions", adapter._handle_chat_completions)
     app.router.add_post("/v1/responses", adapter._handle_responses)
+    app.router.add_post("/v1/runs", adapter._handle_runs)
     app.router.add_get("/v1/responses/{response_id}", adapter._handle_get_response)
     app.router.add_delete("/v1/responses/{response_id}", adapter._handle_delete_response)
     app.router.add_post(
@@ -2434,6 +2435,239 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
+
+
+# ---------------------------------------------------------------------------
+# X-Hermes-User header (per-user identity / Honcho peer mapping)
+# ---------------------------------------------------------------------------
+
+
+class TestUserHeader:
+    """Optional X-Hermes-User supplies AIAgent(user_id=...) after API-key auth.
+
+    Independent of X-Hermes-Session-Key (channel) and X-Hermes-Session-Id
+    (transcript). Absent header keeps historical anonymous / peer_name fallback.
+    """
+
+    @pytest.mark.asyncio
+    async def test_user_header_threads_into_create_agent(self, auth_adapter):
+        captured_kwargs = {}
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={
+                        "X-Hermes-User": "oliver",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert captured_kwargs.get("user_id") == "oliver"
+            assert resp.headers.get("X-Hermes-User") == "oliver"
+
+    @pytest.mark.asyncio
+    async def test_responses_endpoint_accepts_user_header(self, auth_adapter):
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    headers={
+                        "X-Hermes-User": "alice",
+                        "X-Hermes-Session-Key": "webui:chan-1",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"model": "hermes-agent", "input": "hello", "store": False},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User") == "alice"
+            assert resp.headers.get("X-Hermes-Session-Key") == "webui:chan-1"
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_id"] == "alice"
+            assert call_kwargs["gateway_session_key"] == "webui:chan-1"
+
+    @pytest.mark.asyncio
+    async def test_absent_user_header_leaves_user_id_none(self, auth_adapter):
+        captured_kwargs = {}
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer sk-secret"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert captured_kwargs.get("user_id") in (None, "")
+            assert "X-Hermes-User" not in resp.headers
+
+    @pytest.mark.asyncio
+    async def test_user_header_ignored_without_api_key(self, adapter):
+        """No API_SERVER_KEY → header is ignored (never trusted), not 403."""
+        captured_kwargs = {}
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    headers={"X-Hermes-User": "sneaky"},
+                    json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+                )
+            assert resp.status == 200
+            assert captured_kwargs.get("user_id") in (None, "")
+
+    def test_user_header_rejects_control_chars(self, auth_adapter):
+        # aiohttp's client refuses to send CR/LF in headers, so exercise the
+        # parser directly (same validation the handler runs after auth).
+        request = MagicMock()
+        request.headers = {"X-Hermes-User": "bad\r\nInjected: 1"}
+        user_id, err = auth_adapter._parse_user_header(request)
+        assert user_id is None
+        assert err is not None
+        assert err.status == 400
+
+    def test_user_header_rejects_null_byte(self, auth_adapter):
+        request = MagicMock()
+        request.headers = {"X-Hermes-User": "bad\x00user"}
+        user_id, err = auth_adapter._parse_user_header(request)
+        assert user_id is None
+        assert err is not None
+        assert err.status == 400
+
+    @pytest.mark.asyncio
+    async def test_user_header_rejects_oversized(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/chat/completions",
+                headers={
+                    "X-Hermes-User": "x" * 257,
+                    "Authorization": "Bearer sk-secret",
+                },
+                json={"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_capabilities_advertises_user_header(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get("/v1/capabilities")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["features"]["user_header"] == "X-Hermes-User"
+
+    @pytest.mark.asyncio
+    async def test_runs_endpoint_accepts_user_header(self, auth_adapter):
+        """POST /v1/runs echoes X-Hermes-User and threads it into _create_agent."""
+        import asyncio
+
+        captured_kwargs = {}
+        created = asyncio.Event()
+
+        def _fake_create_agent(**kwargs):
+            captured_kwargs.update(kwargs)
+            created.set()
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok", "messages": []}
+            mock_agent.session_prompt_tokens = 0
+            mock_agent.session_completion_tokens = 0
+            mock_agent.session_total_tokens = 0
+            return mock_agent
+
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(auth_adapter, "_create_agent", side_effect=_fake_create_agent):
+                resp = await cli.post(
+                    "/v1/runs",
+                    headers={
+                        "X-Hermes-User": "oliver",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"input": "hello"},
+                )
+                assert resp.status == 202
+                assert resp.headers.get("X-Hermes-User") == "oliver"
+                await asyncio.wait_for(created.wait(), timeout=2.0)
+            assert captured_kwargs.get("user_id") == "oliver"
+
+    @pytest.mark.asyncio
+    async def test_session_chat_accepts_user_header(self, auth_adapter):
+        """POST /api/sessions/{id}/chat echoes and threads X-Hermes-User."""
+        app = _create_app(auth_adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with (
+                patch.object(
+                    auth_adapter,
+                    "_get_existing_session_or_404",
+                    return_value=({"id": "s1"}, None),
+                ),
+                patch.object(auth_adapter, "_conversation_history_for_session", return_value=[]),
+                patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run,
+            ):
+                mock_run.return_value = (
+                    {"final_response": "ok", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+                resp = await cli.post(
+                    "/api/sessions/s1/chat",
+                    headers={
+                        "X-Hermes-User": "oliver",
+                        "Authorization": "Bearer sk-secret",
+                    },
+                    json={"message": "hi"},
+                )
+            assert resp.status == 200
+            assert resp.headers.get("X-Hermes-User") == "oliver"
+            assert mock_run.call_args.kwargs.get("user_id") == "oliver"
+
+    def test_idempotency_fingerprint_isolates_users(self):
+        """Identity keys are always hashed so empty and set users never collide."""
+        from gateway.platforms.api_server import _make_request_fingerprint
+
+        body = {"model": "hermes-agent", "messages": [{"role": "user", "content": "hi"}]}
+        keys = ["model", "messages"]
+        bare = _make_request_fingerprint(body, keys)
+        alice = _make_request_fingerprint(body, keys, user_id="alice")
+        bob = _make_request_fingerprint(body, keys, user_id="bob")
+        empty = _make_request_fingerprint(body, keys, user_id="")
+        assert bare == empty  # absent and "" both normalize to empty identity
+        assert alice != bob
+        assert alice != bare
 
 
 # ---------------------------------------------------------------------------

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -499,6 +499,30 @@ X-Hermes-Session-Key: agent:main:webui:dm:user-42
 
 Rules: max 256 chars, control characters (`\r`, `\n`, `\x00`) are rejected, and the value is echoed back on responses (JSON + SSE). `/v1/capabilities` advertises support via `"session_key_header": "X-Hermes-Session-Key"`. Without the key, Honcho's `per-session` strategy produces a different scope per `session_id` — exactly the behavior Hermes had before.
 
+## Per-user identity (`X-Hermes-User`)
+
+When a single Hermes API instance serves multiple end-users (family/team behind a reverse proxy, multi-user Open WebUI, etc.), pass an optional `X-Hermes-User` so long-term memory providers can distinguish people. Hermes threads the value to `AIAgent(user_id=...)`, which Honcho maps through `user_peer_aliases` (or falls back to `peer_name` when the header is absent).
+
+```http
+POST /v1/chat/completions HTTP/1.1
+Authorization: Bearer ***
+X-Hermes-User: oliver
+X-Hermes-Session-Key: agent:main:webui:dm:oliver
+X-Hermes-Session-Id: transcript-alpha
+```
+
+Rules:
+
+- Max 256 characters; control characters (`\r`, `\n`, `\x00`) are rejected (`400`).
+- Only honored when `API_SERVER_KEY` is configured and the request passes Bearer auth. Without an API key the header is ignored (never trusted).
+- Echoed on success for `/v1/chat/completions`, `/v1/responses`, `/v1/runs` (202), and session-chat endpoints (including SSE).
+- Advertised on `/v1/capabilities` as `"user_header": "X-Hermes-User"`.
+- Browser CORS preflight allows the header when `API_SERVER_CORS_ORIGINS` permits the origin.
+- `Idempotency-Key` fingerprints **always** include identity slots (`user_id`, session key/id), even when those headers are absent (hashed as empty strings). That keeps fingerprints stable for single-user callers while ensuring two authenticated users who reuse the same `Idempotency-Key` + body never share a cached completion.
+- This header supplies identity only. It does **not** enforce API-server `allowed_users` / allowlist gating — that remains a separate concern. Downstream consumers (e.g. Honcho `user_peer_aliases`) can use the value once it is present.
+
+`X-Hermes-User` (person), `X-Hermes-Session-Key` (channel), and `X-Hermes-Session-Id` (transcript) are independent — send any, all, or none.
+
 ## System Prompt Handling
 
 When a frontend sends a `system` message (Chat Completions) or `instructions` field (Responses API), hermes-agent **layers it on top** of its core system prompt. Your agent keeps all its tools, memory, and skills — the frontend's system prompt adds extra instructions.


### PR DESCRIPTION
## What does this PR do?

The API server authenticates via a shared `API_SERVER_KEY` but had no way to convey caller identity, so every request collapsed onto the same anonymous / `peer_name` Honcho peer.

This adds an optional `X-Hermes-User` request header. After successful Bearer auth it is sanitized and threaded to `AIAgent(user_id=...)` so downstream consumers (Honcho `user_peer_aliases`, session scoping) get a stable per-user identity. Absent header keeps historical behavior.

Mirrors the existing `X-Hermes-Session-Key` contract (parse → thread → echo → capabilities). Related open work uses different header names (`X-Hermes-User-Id` in #34609, broader `X-Hermes-User-*` set in #24423); this PR follows issue #80300's exact `X-Hermes-User` name and wires all agent entrypoints.

## Related Issue

Fixes #80300

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/api_server.py` — `_parse_user_header()`; thread `user_id` through `_create_agent` / `_run_agent` for `/v1/chat/completions`, `/v1/responses`, `/v1/runs`, and session-chat (+ SSE); echo header; advertise `features.user_header`; CORS allowlist; idempotency fingerprints always include identity slots
- `tests/gateway/test_api_server.py` — `TestUserHeader` (chat, responses, runs, session-chat, auth ignore, validation, capabilities, fingerprint isolation)
- `website/docs/user-guide/features/api-server.md` — document header, fingerprint behavior, and that API-server `allowed_users` enforcement is out of scope

## How to Test

1. Set `API_SERVER_KEY` and enable the API server; restart the gateway.
2. `curl -s http://127.0.0.1:8642/v1/capabilities -H "Authorization: Bearer $API_SERVER_KEY"` — expect `"user_header": "X-Hermes-User"`.
3. `curl -s http://127.0.0.1:8642/v1/chat/completions -H "Authorization: Bearer $API_SERVER_KEY" -H "X-Hermes-User: oliver" -H "Content-Type: application/json" -d '{"model":"hermes-agent","messages":[{"role":"user","content":"hi"}]}'` — response echoes `X-Hermes-User: oliver`; with Honcho + `user_peer_aliases`, peer maps to `oliver`.
4. Omit the header — behavior unchanged (anonymous / `peer_name` fallback).
5. Focused tests: `scripts/run_tests.sh tests/gateway/test_api_server.py -k UserHeader -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin 25)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/gateway/test_api_server.py -k UserHeader -q
→ 11 passed

Live (API_SERVER_KEY + X-Hermes-User: oliver):
  chat/completions → 200, echo oliver, AIAgent(user_id='oliver')
  /v1/capabilities → features.user_header = X-Hermes-User
```

**Notes for reviewers**

- Overlap: open #34609 (`X-Hermes-User-Id`) and #24423 (broader identity headers). This PR implements #80300’s exact header name and full entrypoint wiring.
- Non-goal: API-server `allowed_users` enforcement — identity plumbing only.
- Idempotency: fingerprints always include identity slots (empty when absent) so cross-user cache reuse is impossible.

Made with [Cursor](https://cursor.com)