### PR TITLE
feat(providers): Claude subscription support via the official Agent SDK

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -178,3 +178,98 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+  claude-boundary:
+    # Claude subscription boundary: Hermes must not read Claude credentials,
+    # send a Claude OAuth token to api.anthropic.com, or impersonate Claude
+    # Code (spoofed user-agent / x-app / beta flags / prompt rewriting).
+    # Subscription inference goes through the official claude-agent-sdk.
+    # See scripts/check_claude_boundary.py for the rules and the allow-list.
+    name: Claude boundary (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Claude boundary checker
+        run: python scripts/check_claude_boundary.py
+
+  claude-sdk-integration:
+    # The sanitized transport subclasses the SDK's SubprocessCLITransport and
+    # overrides a private connect(). Nothing else in CI installs the optional
+    # `claude-code` extra, so every requires_sdk / importorskip test silently
+    # skips and that override — the single mechanism the billing guarantee
+    # rests on — is validated by nothing against a >=0.2.140,<0.4 range pin.
+    # An SDK patch release that refactors connect() would break it silently.
+    # This job installs the real extra and runs those tests. It makes no
+    # network calls to Anthropic and needs no credentials: every test here
+    # asserts on the environment and argv handed to the spawn, never on a
+    # model response.
+    name: Claude Agent SDK integration (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # 8.2.0
+        with:
+          # Pinned: unpinned setup-uv fetches a 'latest' manifest from
+          # raw.githubusercontent.com every job; transient fetch failures
+          # fail the job (2026-07-28 incident). Keep in sync with tests.yml.
+          version: "0.9.28"
+
+      - name: Install the project with the claude-code extra
+        # The gated tests import the runtime, which pulls in the rest of the
+        # agent package (yaml, the display helpers, ...), so install from the
+        # lockfile like tests.yml does instead of pip-installing the SDK alone.
+        # `--locked` also pins the SDK to the version uv.lock resolved.
+        uses: ./.github/actions/retry
+        with:
+          command: uv sync --locked --python 3.11 --extra dev --extra claude-code
+
+      - name: Assert the SDK internals the transport depends on still exist
+        # Fail with a precise message when an SDK release moves them, rather
+        # than as an opaque error inside a test.
+        run: |
+          uv run --no-sync python - <<'PROBE'
+          import inspect
+          from claude_agent_sdk._internal.transport import subprocess_cli as s
+          missing = [n for n in ("SubprocessCLITransport",) if not hasattr(s, n)]
+          t = getattr(s, "SubprocessCLITransport", None)
+          if t is not None and not hasattr(t, "connect"):
+              missing.append("SubprocessCLITransport.connect")
+          if missing:
+              raise SystemExit(
+                  "claude-agent-sdk moved internals the sanitized transport "
+                  "depends on: " + ", ".join(missing)
+              )
+          src = inspect.getsource(t.connect)
+          if "os.environ" not in src:
+              raise SystemExit(
+                  "SubprocessCLITransport.connect() no longer reads os.environ; "
+                  "agent/transports/claude_sanitized_transport.py overrides it "
+                  "to sanitize the child environment and must be re-verified."
+              )
+          print("SDK internals OK")
+          PROBE
+
+      - name: Run the SDK-gated tests
+        env:
+          # The suite must never resolve a real credential; these also exercise
+          # the refusal path the way a polluted developer shell would.
+          ANTHROPIC_API_KEY: ""
+        run: |
+          uv run --no-sync python -m pytest -q \
+            tests/agent/test_claude_billing_source.py \
+            tests/agent/test_claude_session_store.py \
+            tests/agent/test_claude_runtime.py \
+            tests/agent/test_claude_agent_session.py \
+            tests/agent/test_claude_tool_bridge.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -170,3 +170,92 @@ jobs:
 
       - name: Run footgun checker
         run: python scripts/check-windows-footguns.py --all
+
+  claude-boundary:
+    # Claude subscription boundary: Hermes must not read Claude credentials,
+    # send a Claude OAuth token to api.anthropic.com, or impersonate Claude
+    # Code (spoofed user-agent / x-app / beta flags / prompt rewriting).
+    # Subscription inference goes through the official claude-agent-sdk.
+    # See scripts/check_claude_boundary.py for the rules and the allow-list.
+    name: Claude boundary (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Run Claude boundary checker
+        run: python scripts/check_claude_boundary.py
+
+  claude-sdk-integration:
+    # The sanitized transport subclasses the SDK's SubprocessCLITransport and
+    # overrides a private connect(). Nothing else in CI installs the optional
+    # `claude-code` extra, so every requires_sdk / importorskip test silently
+    # skips and that override — the single mechanism the billing guarantee
+    # rests on — is validated by nothing against a >=0.2.128,<0.4 range pin.
+    # An SDK patch release that refactors connect() would break it silently.
+    # This job installs the real extra and runs those tests. It makes no
+    # network calls to Anthropic and needs no credentials: every test here
+    # asserts on the environment and argv handed to the spawn, never on a
+    # model response.
+    name: Claude Agent SDK integration (blocking)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install the claude-code extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          pip install 'claude-agent-sdk>=0.2.128,<0.4'
+
+      - name: Assert the SDK internals the transport depends on still exist
+        # Fail with a precise message when an SDK release moves them, rather
+        # than as an opaque error inside a test.
+        run: |
+          python - <<'PROBE'
+          import inspect
+          from claude_agent_sdk._internal.transport import subprocess_cli as s
+          missing = [n for n in ("SubprocessCLITransport",) if not hasattr(s, n)]
+          t = getattr(s, "SubprocessCLITransport", None)
+          if t is not None and not hasattr(t, "connect"):
+              missing.append("SubprocessCLITransport.connect")
+          if missing:
+              raise SystemExit(
+                  "claude-agent-sdk moved internals the sanitized transport "
+                  "depends on: " + ", ".join(missing)
+              )
+          src = inspect.getsource(t.connect)
+          if "os.environ" not in src:
+              raise SystemExit(
+                  "SubprocessCLITransport.connect() no longer reads os.environ; "
+                  "agent/transports/claude_sanitized_transport.py overrides it "
+                  "to sanitize the child environment and must be re-verified."
+              )
+          print("SDK internals OK")
+          PROBE
+
+      - name: Run the SDK-gated tests
+        env:
+          # The suite must never resolve a real credential; these also exercise
+          # the refusal path the way a polluted developer shell would.
+          ANTHROPIC_API_KEY: ""
+        run: |
+          python -m pytest -q \
+            tests/agent/test_claude_billing_source.py \
+            tests/agent/test_claude_session_store.py \
+            tests/agent/test_claude_runtime.py \
+            tests/agent/test_claude_agent_session.py \
+            tests/agent/test_claude_tool_bridge.py

--- a/acp_adapter/auth.py
+++ b/acp_adapter/auth.py
@@ -16,6 +16,12 @@ def detect_provider() -> Optional[str]:
     credential. Without this, ACP sessions for Entra-configured Foundry
     deployments silently default to ``"openrouter"`` and the ACP auth
     handshake rejects the legitimate provider.
+
+    Also treats a provider that *owns its own credentials* as configured. The
+    Claude subscription runtime returns ``api_key: ""`` by contract — the Agent
+    SDK resolves the user's own ``claude`` login and Hermes holds nothing — so
+    a key-presence test reads a correctly configured account as unconfigured
+    and the handshake rejects it.
     """
     try:
         from hermes_cli.runtime_provider import resolve_runtime_provider
@@ -26,11 +32,18 @@ def detect_provider() -> Optional[str]:
             return None
         is_string_key = isinstance(api_key, str) and api_key.strip()
         is_callable_provider = callable(api_key) and not isinstance(api_key, str)
-        if is_string_key or is_callable_provider:
+        if is_string_key or is_callable_provider or owns_its_own_credentials(runtime):
             return provider.strip().lower()
     except Exception:
         return None
     return None
+
+
+def owns_its_own_credentials(runtime: dict) -> bool:
+    """True when a resolved runtime deliberately exposes no API key."""
+    if str(runtime.get("credentials_owner") or "").strip() == "claude-agent-sdk":
+        return True
+    return str(runtime.get("api_mode") or "").strip() == "claude_agent_sdk"
 
 
 def has_provider() -> bool:

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -275,7 +275,30 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:
         logger.exception("ACP agent crashed")
+        _close_live_agents(agent)
         sys.exit(1)
+    _close_live_agents(agent)
+
+
+def _close_live_agents(acp_agent) -> None:
+    """Close every live session agent on the way out. Never raises.
+
+    A session agent can own an OS thread and a provider subprocess (the Claude
+    Agent SDK runtime owns both). Dropping them at process exit leaves the child
+    to be killed rather than shut down, so release them explicitly.
+    """
+    manager = getattr(acp_agent, "session_manager", None)
+    if manager is None:
+        return
+    close_agent = getattr(manager, "close_agent", None)
+    if not callable(close_agent):
+        return
+    try:
+        states = list(getattr(manager, "_sessions", {}).values())
+    except Exception:
+        return
+    for state in states:
+        close_agent(getattr(state, "agent", None))
 
 
 if __name__ == "__main__":

--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -267,7 +267,30 @@ def main(argv: list[str] | None = None) -> None:
         logger.info("Shutting down (KeyboardInterrupt)")
     except Exception:
         logger.exception("ACP agent crashed")
+        _close_live_agents(agent)
         sys.exit(1)
+    _close_live_agents(agent)
+
+
+def _close_live_agents(acp_agent) -> None:
+    """Close every live session agent on the way out. Never raises.
+
+    A session agent can own an OS thread and a provider subprocess (the Claude
+    Agent SDK runtime owns both). Dropping them at process exit leaves the child
+    to be killed rather than shut down, so release them explicitly.
+    """
+    manager = getattr(acp_agent, "session_manager", None)
+    if manager is None:
+        return
+    close_agent = getattr(manager, "close_agent", None)
+    if not callable(close_agent):
+        return
+    try:
+        states = list(getattr(manager, "_sessions", {}).values())
+    except Exception:
+        return
+    for state in states:
+        close_agent(getattr(state, "agent", None))
 
 
 if __name__ == "__main__":

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2322,6 +2322,62 @@ class HermesACPAgent(acp.Agent):
         lines.append("Unrecognized /commands are sent to the model as normal messages.")
         return "\n".join(lines)
 
+    def _retarget_session_model(
+        self,
+        state: SessionState,
+        new_model: str,
+        target_provider: str | None,
+        *,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+    ):
+        """Point *state* at *new_model*, preserving the session where possible.
+
+        ACP historically rebuilt the whole ``AIAgent`` for a model switch, which
+        is merely wasteful for an HTTP provider but destructive for the Claude
+        subscription runtime: the SDK owns the conversation context and the warm
+        prompt cache, and a rebuilt session starts from neither. When the switch
+        stays on that runtime and on the same provider, retarget in place
+        instead; otherwise rebuild — and close the agent being discarded, which
+        the previous code never did.
+        """
+        agent = state.agent
+        current_provider = getattr(agent, "provider", None)
+        staying_on_claude = (
+            getattr(agent, "api_mode", None) == "claude_agent_sdk"
+            and (not target_provider or target_provider == current_provider)
+        )
+        if staying_on_claude:
+            from hermes_cli.models import (
+                claude_subscription_models,
+                is_valid_claude_subscription_model,
+            )
+
+            if not is_valid_claude_subscription_model(new_model):
+                raise ValueError(
+                    f"`{new_model}` is not a known Claude subscription model. "
+                    "Available: " + ", ".join(claude_subscription_models()) + "."
+                )
+            agent.switch_model(
+                new_model,
+                current_provider,
+                api_key="",
+                base_url=getattr(agent, "base_url", "") or "",
+                api_mode="claude_agent_sdk",
+            )
+            return agent
+
+        new_agent = self.session_manager._make_agent(
+            session_id=state.session_id,
+            cwd=state.cwd,
+            model=new_model,
+            requested_provider=target_provider,
+            base_url=base_url,
+            api_mode=api_mode,
+        )
+        self.session_manager.replace_agent(state, new_agent)
+        return new_agent
+
     def _cmd_model(self, args: str, state: SessionState) -> str:
         if not args:
             model = state.model or getattr(state.agent, "model", "unknown")
@@ -2332,12 +2388,7 @@ class HermesACPAgent(acp.Agent):
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
 
         state.model = new_model
-        state.agent = self.session_manager._make_agent(
-            session_id=state.session_id,
-            cwd=state.cwd,
-            model=new_model,
-            requested_provider=target_provider,
-        )
+        self._retarget_session_model(state, new_model, target_provider)
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
@@ -2582,11 +2633,10 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            state.agent = self.session_manager._make_agent(
-                session_id=session_id,
-                cwd=state.cwd,
-                model=resolved_model,
-                requested_provider=requested_provider,
+            self._retarget_session_model(
+                state,
+                resolved_model,
+                requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
             )

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2089,6 +2089,62 @@ class HermesACPAgent(acp.Agent):
         lines.append("Unrecognized /commands are sent to the model as normal messages.")
         return "\n".join(lines)
 
+    def _retarget_session_model(
+        self,
+        state: SessionState,
+        new_model: str,
+        target_provider: str | None,
+        *,
+        base_url: str | None = None,
+        api_mode: str | None = None,
+    ):
+        """Point *state* at *new_model*, preserving the session where possible.
+
+        ACP historically rebuilt the whole ``AIAgent`` for a model switch, which
+        is merely wasteful for an HTTP provider but destructive for the Claude
+        subscription runtime: the SDK owns the conversation context and the warm
+        prompt cache, and a rebuilt session starts from neither. When the switch
+        stays on that runtime and on the same provider, retarget in place
+        instead; otherwise rebuild — and close the agent being discarded, which
+        the previous code never did.
+        """
+        agent = state.agent
+        current_provider = getattr(agent, "provider", None)
+        staying_on_claude = (
+            getattr(agent, "api_mode", None) == "claude_agent_sdk"
+            and (not target_provider or target_provider == current_provider)
+        )
+        if staying_on_claude:
+            from hermes_cli.models import (
+                claude_subscription_models,
+                is_valid_claude_subscription_model,
+            )
+
+            if not is_valid_claude_subscription_model(new_model):
+                raise ValueError(
+                    f"`{new_model}` is not a known Claude subscription model. "
+                    "Available: " + ", ".join(claude_subscription_models()) + "."
+                )
+            agent.switch_model(
+                new_model,
+                current_provider,
+                api_key="",
+                base_url=getattr(agent, "base_url", "") or "",
+                api_mode="claude_agent_sdk",
+            )
+            return agent
+
+        new_agent = self.session_manager._make_agent(
+            session_id=state.session_id,
+            cwd=state.cwd,
+            model=new_model,
+            requested_provider=target_provider,
+            base_url=base_url,
+            api_mode=api_mode,
+        )
+        self.session_manager.replace_agent(state, new_agent)
+        return new_agent
+
     def _cmd_model(self, args: str, state: SessionState) -> str:
         if not args:
             model = state.model or getattr(state.agent, "model", "unknown")
@@ -2099,12 +2155,7 @@ class HermesACPAgent(acp.Agent):
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
 
         state.model = new_model
-        state.agent = self.session_manager._make_agent(
-            session_id=state.session_id,
-            cwd=state.cwd,
-            model=new_model,
-            requested_provider=target_provider,
-        )
+        self._retarget_session_model(state, new_model, target_provider)
         self.session_manager.save_session(state.session_id)
         provider_label = getattr(state.agent, "provider", None) or target_provider or current_provider
         logger.info("Session %s: model switched to %s", state.session_id, new_model)
@@ -2349,11 +2400,10 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
-            state.agent = self.session_manager._make_agent(
-                session_id=session_id,
-                cwd=state.cwd,
-                model=resolved_model,
-                requested_provider=requested_provider,
+            self._retarget_session_model(
+                state,
+                resolved_model,
+                requested_provider,
                 base_url=current_base_url,
                 api_mode=current_api_mode,
             )

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -109,6 +109,16 @@ def _updated_at_sort_key(value: Any) -> float:
             return float("-inf")
 
 
+def _wants_claude_subscription(provider: Any) -> bool:
+    """True when *provider* names the Claude subscription runtime."""
+    try:
+        from hermes_cli.models import is_claude_subscription_slug
+
+        return is_claude_subscription_slug(provider if isinstance(provider, str) else None)
+    except Exception:
+        return False
+
+
 def _acp_stderr_print(*args, **kwargs) -> None:
     """Best-effort human-readable output sink for ACP stdio sessions.
 
@@ -241,10 +251,38 @@ class SessionManager:
         # Attempt to restore from database.
         return self._restore(session_id)
 
+    @staticmethod
+    def close_agent(agent: Any) -> None:
+        """Release an agent's process-level resources. Never raises.
+
+        ACP is a long-lived daemon: dropping an agent on the floor used to be
+        merely wasteful, but a ``claude_agent_sdk`` agent owns an OS thread and
+        a Claude Code subprocess, so an unclosed one leaks both for the life of
+        the daemon. Every path that discards an agent goes through here.
+        """
+        if agent is None:
+            return
+        close = getattr(agent, "close", None)
+        if not callable(close):
+            return
+        try:
+            close()
+        except Exception:
+            logger.debug("Failed to close ACP agent", exc_info=True)
+
+    def replace_agent(self, state: Any, agent: Any) -> None:
+        """Swap *state*'s agent for *agent*, closing the one being discarded."""
+        previous = getattr(state, "agent", None)
+        state.agent = agent
+        if previous is not agent:
+            self.close_agent(previous)
+
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
         with self._lock:
-            existed = self._sessions.pop(session_id, None) is not None
+            removed = self._sessions.pop(session_id, None)
+        existed = removed is not None
+        self.close_agent(getattr(removed, "agent", None))
         db_existed = self._delete_persisted(session_id)
         if existed or db_existed:
             _clear_task_cwd(session_id)
@@ -368,8 +406,11 @@ class SessionManager:
     def cleanup(self) -> None:
         """Remove all sessions (memory and database) and clear task-specific cwd overrides."""
         with self._lock:
+            states = list(self._sessions.values())
             session_ids = list(self._sessions.keys())
             self._sessions.clear()
+        for state in states:
+            self.close_agent(getattr(state, "agent", None))
         for session_id in session_ids:
             _clear_task_cwd(session_id)
             self._delete_persisted(session_id)
@@ -657,7 +698,24 @@ class SessionManager:
                 }
             )
         except Exception:
+            if _wants_claude_subscription(requested_provider or config_provider):
+                # ACP is non-interactive. Swallowing the error here would build
+                # a chat_completions agent with an empty key and the user would
+                # first hear about it as a mid-turn 401 from the wrong provider.
+                # The Claude credential errors are actionable ("Install Claude
+                # Code, then run `claude auth login`"), so surface them now.
+                raise
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+
+        if kwargs.get("api_mode") == "claude_agent_sdk":
+            # Fail fast rather than at the first turn: the gate, the optional
+            # extra, and the login are three independent problems with three
+            # different fixes, and each preflight message names its own.
+            from agent.claude_runtime import claude_runtime_preflight
+
+            preflight_error = claude_runtime_preflight(config)
+            if preflight_error:
+                raise RuntimeError(preflight_error)
 
         _register_task_cwd(session_id, cwd)
 

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -98,6 +98,16 @@ def _updated_at_sort_key(value: Any) -> float:
             return float("-inf")
 
 
+def _wants_claude_subscription(provider: Any) -> bool:
+    """True when *provider* names the Claude subscription runtime."""
+    try:
+        from hermes_cli.models import is_claude_subscription_slug
+
+        return is_claude_subscription_slug(provider if isinstance(provider, str) else None)
+    except Exception:
+        return False
+
+
 def _acp_stderr_print(*args, **kwargs) -> None:
     """Best-effort human-readable output sink for ACP stdio sessions.
 
@@ -230,10 +240,38 @@ class SessionManager:
         # Attempt to restore from database.
         return self._restore(session_id)
 
+    @staticmethod
+    def close_agent(agent: Any) -> None:
+        """Release an agent's process-level resources. Never raises.
+
+        ACP is a long-lived daemon: dropping an agent on the floor used to be
+        merely wasteful, but a ``claude_agent_sdk`` agent owns an OS thread and
+        a Claude Code subprocess, so an unclosed one leaks both for the life of
+        the daemon. Every path that discards an agent goes through here.
+        """
+        if agent is None:
+            return
+        close = getattr(agent, "close", None)
+        if not callable(close):
+            return
+        try:
+            close()
+        except Exception:
+            logger.debug("Failed to close ACP agent", exc_info=True)
+
+    def replace_agent(self, state: Any, agent: Any) -> None:
+        """Swap *state*'s agent for *agent*, closing the one being discarded."""
+        previous = getattr(state, "agent", None)
+        state.agent = agent
+        if previous is not agent:
+            self.close_agent(previous)
+
     def remove_session(self, session_id: str) -> bool:
         """Remove a session from memory and database. Returns True if it existed."""
         with self._lock:
-            existed = self._sessions.pop(session_id, None) is not None
+            removed = self._sessions.pop(session_id, None)
+        existed = removed is not None
+        self.close_agent(getattr(removed, "agent", None))
         db_existed = self._delete_persisted(session_id)
         if existed or db_existed:
             _clear_task_cwd(session_id)
@@ -357,8 +395,11 @@ class SessionManager:
     def cleanup(self) -> None:
         """Remove all sessions (memory and database) and clear task-specific cwd overrides."""
         with self._lock:
+            states = list(self._sessions.values())
             session_ids = list(self._sessions.keys())
             self._sessions.clear()
+        for state in states:
+            self.close_agent(getattr(state, "agent", None))
         for session_id in session_ids:
             _clear_task_cwd(session_id)
             self._delete_persisted(session_id)
@@ -645,7 +686,24 @@ class SessionManager:
                 }
             )
         except Exception:
+            if _wants_claude_subscription(requested_provider or config_provider):
+                # ACP is non-interactive. Swallowing the error here would build
+                # a chat_completions agent with an empty key and the user would
+                # first hear about it as a mid-turn 401 from the wrong provider.
+                # The Claude credential errors are actionable ("Install Claude
+                # Code, then run `claude auth login`"), so surface them now.
+                raise
             logger.debug("ACP session falling back to default provider resolution", exc_info=True)
+
+        if kwargs.get("api_mode") == "claude_agent_sdk":
+            # Fail fast rather than at the first turn: the gate, the optional
+            # extra, and the login are three independent problems with three
+            # different fixes, and each preflight message names its own.
+            from agent.claude_runtime import claude_runtime_preflight
+
+            preflight_error = claude_runtime_preflight(config)
+            if preflight_error:
+                raise RuntimeError(preflight_error)
 
         _register_task_cwd(session_id, cwd)
         agent = AIAgent(**kwargs)

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -715,7 +715,7 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_agent_sdk"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -1257,6 +1257,32 @@ def init_agent(
         agent.base_url = "moa://local"
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
+    elif agent.api_mode == "claude_agent_sdk":
+        # Claude subscription via the official Agent SDK. There is nothing to
+        # construct here: Hermes holds no Claude credential and the SDK owns
+        # the endpoint, so a client built from an api_key/base_url pair would
+        # be meaningless. The runtime spawns its own session lazily on the
+        # first turn (agent/claude_runtime.py). base_url stays the internal
+        # `claude-sdk://subscription` scheme — never a reachable REST endpoint.
+        agent.client = None
+        agent._client_kwargs = {}
+        agent.api_key = ""
+        agent._claude_session = None
+        agent._claude_sdk_session_id = None
+        if not (agent.model or "").strip():
+            # Surfaces that resolve the model from config can hand this branch
+            # an empty string (the TUI did — #trial). An empty model reaches
+            # the SDK as "use the CLI's own default", silently running a model
+            # the user never picked, and resolves a 256k fallback context in
+            # the compressor. Pin the curated default instead.
+            from hermes_cli.claude_code import DEFAULT_SUBSCRIPTION_MODEL
+
+            agent.model = DEFAULT_SUBSCRIPTION_MODEL
+        if not agent.quiet_mode:
+            print(
+                f"🤖 AI Agent initialized with model: {agent.model} "
+                "(Claude subscription via Agent SDK)"
+            )
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
         # Region is extracted from the base_url or defaults to us-east-1.

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -612,7 +612,7 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "claude_agent_sdk"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"
@@ -1082,6 +1082,32 @@ def init_agent(
         agent.base_url = "moa://local"
         if not agent.quiet_mode:
             print(f"🤖 AI Agent initialized with MoA preset: {agent.model}")
+    elif agent.api_mode == "claude_agent_sdk":
+        # Claude subscription via the official Agent SDK. There is nothing to
+        # construct here: Hermes holds no Claude credential and the SDK owns
+        # the endpoint, so a client built from an api_key/base_url pair would
+        # be meaningless. The runtime spawns its own session lazily on the
+        # first turn (agent/claude_runtime.py). base_url stays the internal
+        # `claude-sdk://subscription` scheme — never a reachable REST endpoint.
+        agent.client = None
+        agent._client_kwargs = {}
+        agent.api_key = ""
+        agent._claude_session = None
+        agent._claude_sdk_session_id = None
+        if not (agent.model or "").strip():
+            # Surfaces that resolve the model from config can hand this branch
+            # an empty string (the TUI did — #trial). An empty model reaches
+            # the SDK as "use the CLI's own default", silently running a model
+            # the user never picked, and resolves a 256k fallback context in
+            # the compressor. Pin the curated default instead.
+            from hermes_cli.claude_code import DEFAULT_SUBSCRIPTION_MODEL
+
+            agent.model = DEFAULT_SUBSCRIPTION_MODEL
+        if not agent.quiet_mode:
+            print(
+                f"🤖 AI Agent initialized with model: {agent.model} "
+                "(Claude subscription via Agent SDK)"
+            )
     elif agent.api_mode == "bedrock_converse":
         # AWS Bedrock — uses boto3 directly, no OpenAI client needed.
         # Region is extracted from the base_url or defaults to us-east-1.

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2722,6 +2722,61 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
+def switch_claude_agent_sdk_model(agent, model) -> str:
+    """Retarget a live Claude Agent SDK session at *model*, in place.
+
+    Returns what happened, for logging and for tests:
+
+    ``"none"``
+        No live session yet — the next turn connects with the new model anyway.
+    ``"set_model"``
+        The SDK's control plane accepted the switch. Claude keeps its context,
+        its message UUIDs, and its warm prompt cache; nothing is rebuilt.
+    ``"retired"``
+        The control-plane call failed. A session still pinned to the old model
+        would answer as the wrong model without saying so, which is worse than
+        paying for one reconnect — so the session is torn down and the next
+        turn rebuilds it.
+    """
+    session = getattr(agent, "_claude_session", None)
+    if session is None or getattr(session, "closed", False):
+        return "none"
+
+    accepted = False
+    try:
+        accepted = bool(session.set_model(model or None))
+    except Exception:  # noqa: BLE001 - set_model is documented never to raise
+        logger.debug("switch_model: Claude set_model raised", exc_info=True)
+        accepted = False
+
+    if accepted:
+        logger.info(
+            "switch_model: Claude Agent SDK session retargeted at %s in place "
+            "(context and prompt cache preserved)",
+            model,
+        )
+        return "set_model"
+
+    logger.warning(
+        "switch_model: Claude Agent SDK refused the in-place switch to %s; "
+        "retiring the session so the next turn reconnects with the new model",
+        model,
+    )
+    release = getattr(agent, "_release_claude_agent_sdk_session", None)
+    if callable(release):
+        try:
+            release()
+        except Exception:  # noqa: BLE001
+            logger.debug("switch_model: session release failed", exc_info=True)
+    else:  # pragma: no cover - AIAgent always defines the releaser
+        try:
+            session.close()
+        except Exception:  # noqa: BLE001
+            pass
+        agent._claude_session = None
+    return "retired"
+
+
 def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
     """Switch the model/provider in-place for a live agent.
 
@@ -2762,6 +2817,23 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_api_mode = getattr(agent, "api_mode", "")
+
+    # Leaving the Claude subscription runtime: the live SDK session owns an OS
+    # thread and a Claude Code subprocess pinned to the old provider. Release it
+    # here, before the new transport is built, so a provider switch cannot leak
+    # either. Staying on the runtime does NOT come through here — that case is
+    # handled in place by switch_claude_agent_sdk_model() below.
+    if old_api_mode == "claude_agent_sdk" and api_mode != "claude_agent_sdk":
+        _release = getattr(agent, "_release_claude_agent_sdk_session", None)
+        if callable(_release):
+            try:
+                _release()
+            except Exception:  # noqa: BLE001 - teardown must not block a switch
+                logger.debug(
+                    "switch_model: Claude Agent SDK session release failed",
+                    exc_info=True,
+                )
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -2902,6 +2974,20 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = build_moa_facade(agent, agent.model)
+        elif api_mode == "claude_agent_sdk":
+            # The Claude subscription runtime owns its own endpoint and its own
+            # credential, so there is no HTTP client to rebuild — falling into
+            # the generic branch below would try to construct an OpenAI client
+            # against ``claude-sdk://subscription``.
+            #
+            # The live session's model is switched *in place* through the SDK
+            # control plane. Retiring and reconnecting would throw away Claude's
+            # conversation context and its warm prompt cache, which AGENTS.md's
+            # caching rule forbids and which the user would pay for twice.
+            agent.api_key = ""
+            agent.client = None
+            agent._client_kwargs = {}
+            switch_claude_agent_sdk_model(agent, agent.model)
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2094,6 +2094,61 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     return client
 
 
+def switch_claude_agent_sdk_model(agent, model) -> str:
+    """Retarget a live Claude Agent SDK session at *model*, in place.
+
+    Returns what happened, for logging and for tests:
+
+    ``"none"``
+        No live session yet — the next turn connects with the new model anyway.
+    ``"set_model"``
+        The SDK's control plane accepted the switch. Claude keeps its context,
+        its message UUIDs, and its warm prompt cache; nothing is rebuilt.
+    ``"retired"``
+        The control-plane call failed. A session still pinned to the old model
+        would answer as the wrong model without saying so, which is worse than
+        paying for one reconnect — so the session is torn down and the next
+        turn rebuilds it.
+    """
+    session = getattr(agent, "_claude_session", None)
+    if session is None or getattr(session, "closed", False):
+        return "none"
+
+    accepted = False
+    try:
+        accepted = bool(session.set_model(model or None))
+    except Exception:  # noqa: BLE001 - set_model is documented never to raise
+        logger.debug("switch_model: Claude set_model raised", exc_info=True)
+        accepted = False
+
+    if accepted:
+        logger.info(
+            "switch_model: Claude Agent SDK session retargeted at %s in place "
+            "(context and prompt cache preserved)",
+            model,
+        )
+        return "set_model"
+
+    logger.warning(
+        "switch_model: Claude Agent SDK refused the in-place switch to %s; "
+        "retiring the session so the next turn reconnects with the new model",
+        model,
+    )
+    release = getattr(agent, "_release_claude_agent_sdk_session", None)
+    if callable(release):
+        try:
+            release()
+        except Exception:  # noqa: BLE001
+            logger.debug("switch_model: session release failed", exc_info=True)
+    else:  # pragma: no cover - AIAgent always defines the releaser
+        try:
+            session.close()
+        except Exception:  # noqa: BLE001
+            pass
+        agent._claude_session = None
+    return "retired"
+
+
 def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mode=''):
     """Switch the model/provider in-place for a live agent.
 
@@ -2132,6 +2187,23 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
 
     old_model = agent.model
     old_provider = agent.provider
+    old_api_mode = getattr(agent, "api_mode", "")
+
+    # Leaving the Claude subscription runtime: the live SDK session owns an OS
+    # thread and a Claude Code subprocess pinned to the old provider. Release it
+    # here, before the new transport is built, so a provider switch cannot leak
+    # either. Staying on the runtime does NOT come through here — that case is
+    # handled in place by switch_claude_agent_sdk_model() below.
+    if old_api_mode == "claude_agent_sdk" and api_mode != "claude_agent_sdk":
+        _release = getattr(agent, "_release_claude_agent_sdk_session", None)
+        if callable(_release):
+            try:
+                _release()
+            except Exception:  # noqa: BLE001 - teardown must not block a switch
+                logger.debug(
+                    "switch_model: Claude Agent SDK session release failed",
+                    exc_info=True,
+                )
 
     # ── Snapshot all fields the swap+rebuild can mutate ──
     # If the rebuild raises (bad API key, network error, build_anthropic_client
@@ -2268,6 +2340,20 @@ def switch_model(agent, new_model, new_provider, api_key='', base_url='', api_mo
             agent.base_url = "moa://local"
             agent._client_kwargs = {}
             agent.client = build_moa_facade(agent, agent.model)
+        elif api_mode == "claude_agent_sdk":
+            # The Claude subscription runtime owns its own endpoint and its own
+            # credential, so there is no HTTP client to rebuild — falling into
+            # the generic branch below would try to construct an OpenAI client
+            # against ``claude-sdk://subscription``.
+            #
+            # The live session's model is switched *in place* through the SDK
+            # control plane. Retiring and reconnecting would throw away Claude's
+            # conversation context and its warm prompt cache, which AGENTS.md's
+            # caching rule forbids and which the user would pay for twice.
+            agent.api_key = ""
+            agent.client = None
+            agent._client_kwargs = {}
+            switch_claude_agent_sdk_model(agent, agent.model)
         elif api_mode == "anthropic_messages":
             from agent.anthropic_adapter import (
                 build_anthropic_client,

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -588,7 +588,11 @@ _PROVIDER_ALIASES = {
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    # These take effect only once the Claude subscription gate is open;
+    # _normalize_aux_provider() below short-circuits `claude-code` /
+    # `claude-oauth` to anthropic while it is closed.
+    "claude-oauth": "claude-code",
+    "claude-subscription": "claude-code",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-model": "copilot",
@@ -619,7 +623,12 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
             normalized = main_prov
         else:
             return "custom"
-    return _PROVIDER_ALIASES.get(normalized, normalized)
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+        legacy = legacy_alias_target(normalized)
+    except Exception:
+        legacy = None
+    return legacy or _PROVIDER_ALIASES.get(normalized, normalized)
 
 
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must
@@ -3959,6 +3968,96 @@ def _try_azure_foundry(
     return client, final_model
 
 
+def _is_claude_subscription_provider(provider: Optional[str]) -> bool:
+    """True when *provider* is the Claude subscription provider (Agent SDK).
+
+    Never true for ``anthropic``: the two are separate providers on purpose
+    (``docs/design/claude-subscription-via-agent-sdk.md`` § 1), and while the
+    subscription gate is closed ``_normalize_aux_provider`` has already rewritten
+    ``claude-code`` to ``anthropic`` before resolution reaches here.
+    """
+    from agent.claude_auxiliary import is_claude_subscription_provider
+
+    return is_claude_subscription_provider(provider)
+
+
+def _claude_subscription_is_active_main_provider() -> bool:
+    """True when the user's *main* runtime is the Claude subscription.
+
+    Used to keep auxiliary work off the pre-SDK direct-OAuth path.  Reads the
+    resolved main provider rather than the gate alone: a user can have the gate
+    open and still be running some other provider, and their explicitly
+    configured Anthropic API key must keep working untouched.
+    """
+    try:
+        return _is_claude_subscription_provider(_read_main_provider())
+    except Exception:
+        return False
+
+
+def _resolve_claude_subscription_client(
+    *,
+    model: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
+    async_mode: bool,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Auxiliary client for the Claude subscription runtime (Agent SDK).
+
+    ``resolve_external_process_provider_credentials("claude-code")`` returns
+    ``api_key: ""`` with ``credentials_owner: "claude-agent-sdk"`` — deliberately
+    no credential material, because Hermes holds none.  The only coherent thing
+    to do with that bundle is to *not* build an HTTP client: the one-shot SDK
+    adapter makes the call and the SDK resolves the user's own login.
+
+    Returns ``(None, None)`` on any failure so the caller's normal
+    "provider unavailable" handling applies — but note the companion guard in
+    :func:`_try_anthropic`, which stops that fallback from landing on the
+    pre-SDK direct-OAuth path.
+    """
+    from agent.claude_auxiliary import (
+        CLAUDE_CODE_PROVIDER_ID,
+        build_claude_auxiliary_client,
+    )
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    try:
+        creds = resolve_external_process_provider_credentials(CLAUDE_CODE_PROVIDER_ID)
+    except Exception as exc:
+        # Missing `claude` CLI is the common case; it carries its own
+        # actionable message ("Install Claude Code, then run `claude auth login`").
+        logger.warning(
+            "resolve_provider_client: claude-code auxiliary unavailable: %s", exc
+        )
+        return None, None
+
+    if str(creds.get("api_key") or "").strip():
+        # A non-empty key here would mean something upstream started handing
+        # Hermes a Claude credential. Refuse rather than forward it.
+        logger.error(
+            "resolve_provider_client: claude-code returned credential material; "
+            "refusing to use it (the SDK owns Claude auth)."
+        )
+        return None, None
+
+    final_model = _normalize_resolved_model(
+        model
+        or (main_runtime.get("model") if main_runtime else None)
+        or _read_main_model_for_aux(),
+        CLAUDE_CODE_PROVIDER_ID,
+    )
+    try:
+        client = build_claude_auxiliary_client(
+            final_model or "", async_mode=async_mode
+        )
+    except ImportError as exc:
+        logger.warning("resolve_provider_client: %s", exc)
+        return None, None
+    logger.debug(
+        "resolve_provider_client: claude-code one-shot SDK (%s)", final_model
+    )
+    return client, final_model
+
+
 def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -3983,6 +4082,26 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         token = explicit_api_key or resolve_anthropic_token()
     if not token:
         return None, None
+
+    # A user on the Claude subscription runtime opted out of the direct-OAuth
+    # path entirely. resolve_anthropic_token() still finds their Claude login
+    # (env var, credential file, pool entry), so without this guard any
+    # auxiliary fallback would quietly resume billing their plan's extra-usage
+    # meter — the exact behaviour the SDK runtime exists to remove. An explicit
+    # ANTHROPIC_API_KEY is unaffected: this only refuses OAuth-shaped tokens.
+    try:
+        from agent.anthropic_adapter import _is_oauth_token as _is_oauth_probe
+
+        if _is_oauth_probe(token) and _claude_subscription_is_active_main_provider():
+            logger.info(
+                "Auxiliary client: refusing the Claude OAuth token — this account "
+                "runs on the Claude subscription runtime (Agent SDK). Set an "
+                "explicit auxiliary provider in config.yaml to use a different "
+                "backend for side tasks."
+            )
+            return None, None
+    except ImportError:
+        pass
 
     # Allow base URL override from config.yaml model.base_url, but only when:
     #   1. the configured provider is anthropic (otherwise a non-Anthropic
@@ -6988,6 +7107,15 @@ def resolve_provider_client(
                 else (client, final_model))
 
     if pconfig.auth_type == "external_process":
+        if _is_claude_subscription_provider(provider):
+            # Handled ahead of the shared credential lookup below because the
+            # Claude subscription has no credential to look up — see
+            # _resolve_claude_subscription_client for why that is the point.
+            return _resolve_claude_subscription_client(
+                model=model,
+                main_runtime=main_runtime,
+                async_mode=async_mode,
+            )
         creds = resolve_external_process_provider_credentials(provider)
         final_model = _normalize_resolved_model(
             model
@@ -9036,13 +9164,24 @@ def _aux_stream_total_ceiling(effective_timeout: Optional[float]) -> float:
 def _client_streams_internally(client: Any) -> bool:
     """Wire adapters that consume a stream inside .create() already tick the
     progress hook themselves (Codex per SSE event, Anthropic per stream
-    event); Bedrock's Converse shim cannot stream at all. None of them
+    event); Bedrock's Converse shim cannot stream at all, and the Claude
+    subscription one-shot adapter returns a complete response. None of them
     accept chat-completions ``stream=True`` semantics from us."""
-    return isinstance(client, (
+    internal_types: List[type] = [
         CodexAuxiliaryClient,
         AnthropicAuxiliaryClient,
         BedrockAuxiliaryClient,
-    ))
+    ]
+    try:
+        from agent.claude_auxiliary import (
+            AsyncClaudeAuxiliaryClient,
+            ClaudeAuxiliaryClient,
+        )
+
+        internal_types.extend([ClaudeAuxiliaryClient, AsyncClaudeAuxiliaryClient])
+    except ImportError:  # pragma: no cover - module ships with core
+        pass
+    return isinstance(client, tuple(internal_types))
 
 
 def _is_streaming_rejected_error(exc: Exception) -> bool:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -334,7 +334,11 @@ _PROVIDER_ALIASES = {
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    # These take effect only once the Claude subscription gate is open;
+    # _normalize_aux_provider() below short-circuits `claude-code` /
+    # `claude-oauth` to anthropic while it is closed.
+    "claude-oauth": "claude-code",
+    "claude-subscription": "claude-code",
     "github": "copilot",
     "github-copilot": "copilot",
     "github-model": "copilot",
@@ -365,7 +369,12 @@ def _normalize_aux_provider(provider: Optional[str]) -> str:
             normalized = main_prov
         else:
             return "custom"
-    return _PROVIDER_ALIASES.get(normalized, normalized)
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+        legacy = legacy_alias_target(normalized)
+    except Exception:
+        legacy = None
+    return legacy or _PROVIDER_ALIASES.get(normalized, normalized)
 
 
 # Sentinel: when returned by _fixed_temperature_for_model(), callers must
@@ -3132,6 +3141,96 @@ def _try_azure_foundry(
     return client, final_model
 
 
+def _is_claude_subscription_provider(provider: Optional[str]) -> bool:
+    """True when *provider* is the Claude subscription provider (Agent SDK).
+
+    Never true for ``anthropic``: the two are separate providers on purpose
+    (``docs/design/claude-subscription-via-agent-sdk.md`` § 1), and while the
+    subscription gate is closed ``_normalize_aux_provider`` has already rewritten
+    ``claude-code`` to ``anthropic`` before resolution reaches here.
+    """
+    from agent.claude_auxiliary import is_claude_subscription_provider
+
+    return is_claude_subscription_provider(provider)
+
+
+def _claude_subscription_is_active_main_provider() -> bool:
+    """True when the user's *main* runtime is the Claude subscription.
+
+    Used to keep auxiliary work off the pre-SDK direct-OAuth path.  Reads the
+    resolved main provider rather than the gate alone: a user can have the gate
+    open and still be running some other provider, and their explicitly
+    configured Anthropic API key must keep working untouched.
+    """
+    try:
+        return _is_claude_subscription_provider(_read_main_provider())
+    except Exception:
+        return False
+
+
+def _resolve_claude_subscription_client(
+    *,
+    model: Optional[str],
+    main_runtime: Optional[Dict[str, Any]],
+    async_mode: bool,
+) -> Tuple[Optional[Any], Optional[str]]:
+    """Auxiliary client for the Claude subscription runtime (Agent SDK).
+
+    ``resolve_external_process_provider_credentials("claude-code")`` returns
+    ``api_key: ""`` with ``credentials_owner: "claude-agent-sdk"`` — deliberately
+    no credential material, because Hermes holds none.  The only coherent thing
+    to do with that bundle is to *not* build an HTTP client: the one-shot SDK
+    adapter makes the call and the SDK resolves the user's own login.
+
+    Returns ``(None, None)`` on any failure so the caller's normal
+    "provider unavailable" handling applies — but note the companion guard in
+    :func:`_try_anthropic`, which stops that fallback from landing on the
+    pre-SDK direct-OAuth path.
+    """
+    from agent.claude_auxiliary import (
+        CLAUDE_CODE_PROVIDER_ID,
+        build_claude_auxiliary_client,
+    )
+    from hermes_cli.auth import resolve_external_process_provider_credentials
+
+    try:
+        creds = resolve_external_process_provider_credentials(CLAUDE_CODE_PROVIDER_ID)
+    except Exception as exc:
+        # Missing `claude` CLI is the common case; it carries its own
+        # actionable message ("Install Claude Code, then run `claude auth login`").
+        logger.warning(
+            "resolve_provider_client: claude-code auxiliary unavailable: %s", exc
+        )
+        return None, None
+
+    if str(creds.get("api_key") or "").strip():
+        # A non-empty key here would mean something upstream started handing
+        # Hermes a Claude credential. Refuse rather than forward it.
+        logger.error(
+            "resolve_provider_client: claude-code returned credential material; "
+            "refusing to use it (the SDK owns Claude auth)."
+        )
+        return None, None
+
+    final_model = _normalize_resolved_model(
+        model
+        or (main_runtime.get("model") if main_runtime else None)
+        or _read_main_model_for_aux(),
+        CLAUDE_CODE_PROVIDER_ID,
+    )
+    try:
+        client = build_claude_auxiliary_client(
+            final_model or "", async_mode=async_mode
+        )
+    except ImportError as exc:
+        logger.warning("resolve_provider_client: %s", exc)
+        return None, None
+    logger.debug(
+        "resolve_provider_client: claude-code one-shot SDK (%s)", final_model
+    )
+    return client, final_model
+
+
 def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optional[str]]:
     try:
         from agent.anthropic_adapter import build_anthropic_client, resolve_anthropic_token
@@ -3156,6 +3255,26 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
         token = explicit_api_key or resolve_anthropic_token()
     if not token:
         return None, None
+
+    # A user on the Claude subscription runtime opted out of the direct-OAuth
+    # path entirely. resolve_anthropic_token() still finds their Claude login
+    # (env var, credential file, pool entry), so without this guard any
+    # auxiliary fallback would quietly resume billing their plan's extra-usage
+    # meter — the exact behaviour the SDK runtime exists to remove. An explicit
+    # ANTHROPIC_API_KEY is unaffected: this only refuses OAuth-shaped tokens.
+    try:
+        from agent.anthropic_adapter import _is_oauth_token as _is_oauth_probe
+
+        if _is_oauth_probe(token) and _claude_subscription_is_active_main_provider():
+            logger.info(
+                "Auxiliary client: refusing the Claude OAuth token — this account "
+                "runs on the Claude subscription runtime (Agent SDK). Set an "
+                "explicit auxiliary provider in config.yaml to use a different "
+                "backend for side tasks."
+            )
+            return None, None
+    except ImportError:
+        pass
 
     # Allow base URL override from config.yaml model.base_url, but only when:
     #   1. the configured provider is anthropic (otherwise a non-Anthropic
@@ -5779,6 +5898,15 @@ def resolve_provider_client(
                 else (client, final_model))
 
     if pconfig.auth_type == "external_process":
+        if _is_claude_subscription_provider(provider):
+            # Handled ahead of the shared credential lookup below because the
+            # Claude subscription has no credential to look up — see
+            # _resolve_claude_subscription_client for why that is the point.
+            return _resolve_claude_subscription_client(
+                model=model,
+                main_runtime=main_runtime,
+                async_mode=async_mode,
+            )
         creds = resolve_external_process_provider_credentials(provider)
         final_model = _normalize_resolved_model(
             model
@@ -7606,13 +7734,24 @@ def _aux_stream_total_ceiling(effective_timeout: Optional[float]) -> float:
 def _client_streams_internally(client: Any) -> bool:
     """Wire adapters that consume a stream inside .create() already tick the
     progress hook themselves (Codex per SSE event, Anthropic per stream
-    event); Bedrock's Converse shim cannot stream at all. None of them
+    event); Bedrock's Converse shim cannot stream at all, and the Claude
+    subscription one-shot adapter returns a complete response. None of them
     accept chat-completions ``stream=True`` semantics from us."""
-    return isinstance(client, (
+    internal_types: List[type] = [
         CodexAuxiliaryClient,
         AnthropicAuxiliaryClient,
         BedrockAuxiliaryClient,
-    ))
+    ]
+    try:
+        from agent.claude_auxiliary import (
+            AsyncClaudeAuxiliaryClient,
+            ClaudeAuxiliaryClient,
+        )
+
+        internal_types.extend([ClaudeAuxiliaryClient, AsyncClaudeAuxiliaryClient])
+    except ImportError:  # pragma: no cover - module ships with core
+        pass
+    return isinstance(client, tuple(internal_types))
 
 
 def _is_streaming_rejected_error(exc: Exception) -> bool:

--- a/agent/claude_auxiliary.py
+++ b/agent/claude_auxiliary.py
@@ -1,0 +1,508 @@
+"""One-shot Claude Agent SDK adapter for Hermes' auxiliary (side-LLM) work.
+
+``agent/auxiliary_client.py`` runs everything that is not the conversation:
+title generation, classification, extraction, vision, the compression fallback,
+session search, and plugin LLM calls.  When the user is on the Claude
+subscription runtime those calls must go through the official SDK like every
+other Claude request — otherwise a side channel keeps hitting the pre-SDK
+direct-OAuth HTTP path, which is exactly the billing surprise this work exists
+to remove (``docs/design/claude-subscription-via-agent-sdk.md`` § 3).
+
+Four properties define this adapter, and each of them is a decision, not a
+detail:
+
+* **One-shot ``query()``, never ``ClaudeSDKClient``.**  An auxiliary call is
+  stateless.  ``query()`` spawns, answers, and exits; a client would mean a
+  second long-lived CLI subprocess and a second event-loop thread per agent.
+* **No tools, ever.**  ``tools=[]`` + ``mcp_servers={}`` +
+  ``strict_mcp_config=True`` + ``setting_sources=[]``.  A title generator that
+  can run Bash is a security bug, and a user/project ``.mcp.json`` must not be
+  able to hand it one.
+* **Never touches the conversation.**  No ``resume``, no ``continue_conversation``,
+  no ``session_id``, no ``fork_session``, and no ``session_store``.  The SDK
+  mints a throwaway session per call; the main session id is untouched.
+* **Bounded.**  ``max_turns=1`` and a wall-clock timeout.  Auxiliary work that
+  runs away is worse than auxiliary work that fails.
+
+The returned object is the same OpenAI-shaped facade every other auxiliary
+transport exposes (``client.chat.completions.create(...)`` →
+``.choices[0].message.content``), so no call site in ``auxiliary_client.py``
+needs to know which transport answered.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+from agent.claude_sdk_input import (
+    ClaudeImageInputUnsupported,
+    VISION_PROVIDER_REQUIRED_MESSAGE,
+    blocks_to_text,
+    content_has_images,
+    content_to_sdk_blocks,
+    make_sdk_stream_prompt,
+    sdk_supports_streaming_input,
+)
+
+logger = logging.getLogger(__name__)
+
+# The provider id whose auxiliary work belongs here.  Kept as a module constant
+# so ``auxiliary_client`` can route without importing the CLI provider module
+# (which PR7 owns) on a hot path.
+CLAUDE_CODE_PROVIDER_ID = "claude-code"
+
+# An auxiliary prompt is a single question. Anything that wants a second turn
+# is agentic work and does not belong on this path.
+CLAUDE_AUX_MAX_TURNS = 1
+
+# Wall-clock bound. Generous relative to an HTTP aux call because the SDK pays
+# a CLI cold start, but far below the conversation runtime's 1800s.
+DEFAULT_CLAUDE_AUX_TIMEOUT_SECONDS = 180.0
+
+# How long we wait for the worker thread to unwind after its coroutine was
+# cancelled, before giving up on a clean join.
+_THREAD_JOIN_GRACE_SECONDS = 10.0
+
+INSTALL_HINT = (
+    "The Claude subscription runtime needs the optional `claude-code` extra. "
+    "Install it with: pip install 'hermes-agent[claude-code]'"
+)
+
+
+class ClaudeAuxiliaryError(RuntimeError):
+    """Raised when a one-shot Claude auxiliary call cannot be made or completed."""
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+def _import_sdk() -> Any:
+    """Import ``claude_agent_sdk`` lazily, with an actionable ImportError."""
+    try:
+        import claude_agent_sdk  # noqa: PLC0415 - optional extra, imported on use
+    except ImportError as exc:
+        raise ImportError(INSTALL_HINT) from exc
+    return claude_agent_sdk
+
+
+def is_claude_subscription_provider(provider: Optional[str]) -> bool:
+    """True when *provider* is the Claude subscription provider.
+
+    Note what this does NOT do: it never answers True for ``anthropic``.  The
+    two are separate providers on purpose — ``anthropic`` means "an API key you
+    pasted, billed to your Console org".  While the subscription gate is closed
+    ``hermes_cli.claude_code.legacy_alias_target`` rewrites ``claude-code`` to
+    ``anthropic`` before resolution ever reaches here, and when it is open it
+    stops rewriting, so the slug is unambiguous at this layer either way.
+    """
+    return (provider or "").strip().lower() == CLAUDE_CODE_PROVIDER_ID
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+def build_claude_auxiliary_options(
+    *,
+    system_prompt: Optional[str],
+    model: Optional[str],
+    max_turns: int = CLAUDE_AUX_MAX_TURNS,
+) -> Any:
+    """Build the locked-down ``ClaudeAgentOptions`` for a one-shot aux call."""
+    sdk = _import_sdk()
+    return sdk.ClaudeAgentOptions(
+        system_prompt=system_prompt or None,
+        # No tools of any kind: not the SDK built-ins, not Hermes' MCP bridge,
+        # and not whatever a project .mcp.json would like to add.
+        tools=[],
+        allowed_tools=[],
+        mcp_servers={},
+        strict_mcp_config=True,
+        setting_sources=[],
+        max_turns=max_turns,
+        model=model or None,
+        # Belt and braces: with no tools registered there is nothing to permit,
+        # but "deny anything not pre-approved" is the right posture for a call
+        # that must never execute anything.
+        permission_mode="dontAsk",
+        include_partial_messages=False,
+        # Explicit rather than defaulted, because these four are precisely how
+        # an auxiliary call would leak into the conversation's session.
+        continue_conversation=False,
+        resume=None,
+        fork_session=False,
+        session_store=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Message flattening
+# ---------------------------------------------------------------------------
+
+
+def split_messages(messages: Any) -> Tuple[Optional[str], Any]:
+    """Split OpenAI-shaped *messages* into (system_prompt, prompt_content).
+
+    The SDK carries the system prompt as an option, not as a message, and the
+    one-shot path takes a single user prompt.  A multi-message auxiliary
+    conversation (rare — a few tasks send a worked example) is flattened into
+    one labelled prompt rather than dropped, so the example still reaches the
+    model.
+    """
+    if not isinstance(messages, list):
+        return None, str(messages or "")
+
+    system_parts: List[str] = []
+    turns: List[Tuple[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            turns.append(("user", str(message)))
+            continue
+        role = str(message.get("role") or "user").strip().lower()
+        content = message.get("content")
+        if role == "system":
+            system_parts.append(blocks_to_text(content_to_sdk_blocks(content)))
+        else:
+            turns.append((role, content))
+
+    system_prompt = "\n\n".join(p for p in system_parts if p) or None
+
+    if len(turns) == 1:
+        return system_prompt, turns[0][1]
+
+    # More than one turn: keep any image parts, label the rest.
+    flattened: List[Any] = []
+    for role, content in turns:
+        label = "User" if role == "user" else "Assistant"
+        blocks = content_to_sdk_blocks(content)
+        if any(b.get("type") == "image" for b in blocks):
+            flattened.append({"type": "text", "text": f"{label}:"})
+            flattened.extend(blocks)
+        else:
+            text = blocks_to_text(blocks)
+            if text:
+                flattened.append({"type": "text", "text": f"{label}: {text}"})
+    if not flattened:
+        return system_prompt, ""
+    if not any(block.get("type") == "image" for block in flattened):
+        # No image survived: send plain text, which is both the cheapest prompt
+        # and the only shape that avoids the streaming-input path entirely.
+        return system_prompt, "\n\n".join(
+            block["text"] for block in flattened if block.get("type") == "text"
+        )
+    return system_prompt, flattened
+
+
+def build_prompt(content: Any) -> Any:
+    """Return the SDK prompt for auxiliary *content* (string or parts).
+
+    Raises :class:`ClaudeAuxiliaryError` when the content carries an image the
+    installed SDK cannot deliver, naming the one supported alternative.
+    """
+    if isinstance(content, str):
+        return content
+    blocks = content_to_sdk_blocks(content)
+    if not content_has_images(content):
+        return blocks_to_text(blocks)
+    if not sdk_supports_streaming_input():
+        raise ClaudeAuxiliaryError(VISION_PROVIDER_REQUIRED_MESSAGE)
+    return make_sdk_stream_prompt(blocks)
+
+
+# ---------------------------------------------------------------------------
+# The call
+# ---------------------------------------------------------------------------
+
+
+async def _collect(prompt: Any, options: Any) -> Dict[str, Any]:
+    """Drive one ``query()`` and reduce the stream to a plain result dict."""
+    sdk = _import_sdk()
+    # Same sanitized spawn as the conversation runtime: options.env can
+    # override but never delete an inherited credential, so removal has to
+    # happen at the transport. query() accepts a pre-built transport. Only
+    # built when the options came from the real package — a test stand-in
+    # spawns nothing, and the real transport reads real-SDK option fields.
+    transport = None
+    if type(options).__module__.startswith("claude_agent_sdk"):
+        from agent.transports.claude_sanitized_transport import (
+            build_sanitized_transport,
+        )
+
+        transport = build_sanitized_transport(options, prompt=prompt)
+    text_parts: List[str] = []
+    result: Dict[str, Any] = {
+        "text": "",
+        "usage": None,
+        "model": getattr(options, "model", None),
+        "is_error": False,
+        "error": None,
+        "session_id": None,
+    }
+    async for message in sdk.query(prompt=prompt, options=options, transport=transport):
+        # Dispatch on class name so this behaves identically against the real
+        # extra and against a stand-in, matching agent/claude_runtime.py.
+        kind = type(message).__name__
+        if kind == "AssistantMessage":
+            for block in getattr(message, "content", None) or []:
+                if type(block).__name__ == "TextBlock":
+                    text_parts.append(str(getattr(block, "text", "") or ""))
+            model = getattr(message, "model", None)
+            if model:
+                result["model"] = str(model)
+        elif kind == "ResultMessage":
+            result["session_id"] = getattr(message, "session_id", None)
+            usage = getattr(message, "usage", None)
+            if isinstance(usage, dict):
+                result["usage"] = usage
+            if getattr(message, "is_error", False):
+                result["is_error"] = True
+                text = getattr(message, "result", None)
+                result["error"] = str(text or "Claude Agent SDK reported an error")
+            else:
+                text = getattr(message, "result", None)
+                if isinstance(text, str) and text.strip() and not text_parts:
+                    text_parts.append(text)
+    result["text"] = "".join(text_parts)
+    return result
+
+
+def run_claude_auxiliary_query(
+    prompt: Any,
+    *,
+    system_prompt: Optional[str] = None,
+    model: Optional[str] = None,
+    timeout: Optional[float] = None,
+    max_turns: int = CLAUDE_AUX_MAX_TURNS,
+) -> Dict[str, Any]:
+    """Run one bounded, tool-less SDK query and return a plain result dict.
+
+    Executes on a short-lived worker thread with its own event loop.  The
+    conversation's :class:`~agent.transports.claude_agent_session.ClaudeAgentSession`
+    owns a loop thread of its own and its anyio streams are bound to it; an
+    auxiliary call must not borrow that loop, and it must not assume the caller
+    has one.  A fresh loop per call is the only arrangement that is correct from
+    every thread Hermes calls auxiliary work from.
+    """
+    # The same two guarantees the conversation runtime gives, because an
+    # auxiliary call bills the same account: refuse when a higher-precedence
+    # credential would win, and spawn the CLI from a sanitized environment.
+    # Without these, a title-generation call with ANTHROPIC_API_KEY exported
+    # silently bills metered API usage while the conversation is correctly
+    # refused — the exact split-billing failure this provider exists to end.
+    from agent.claude_billing import static_billing_refusal
+
+    refusal = static_billing_refusal()
+    if refusal is not None:
+        raise ClaudeAuxiliaryError(refusal)
+
+    options = build_claude_auxiliary_options(
+        system_prompt=system_prompt, model=model, max_turns=max_turns
+    )
+    deadline = float(timeout or DEFAULT_CLAUDE_AUX_TIMEOUT_SECONDS)
+    box: Dict[str, Any] = {}
+
+    def _runner() -> None:
+        try:
+            box["value"] = asyncio.run(
+                asyncio.wait_for(_collect(prompt, options), deadline)
+            )
+        except BaseException as exc:  # noqa: BLE001 - relayed to the caller
+            box["error"] = exc
+
+    thread = threading.Thread(
+        target=_runner, name="hermes-claude-aux", daemon=True
+    )
+    thread.start()
+    # ``wait_for`` already bounds the coroutine; this join only covers the
+    # unwind, so a wedged SDK cannot pin the calling thread for the full
+    # deadline a second time.
+    thread.join(deadline + _THREAD_JOIN_GRACE_SECONDS)
+    if thread.is_alive():
+        raise ClaudeAuxiliaryError(
+            f"Claude auxiliary call did not finish within {deadline:.0f}s."
+        )
+
+    error = box.get("error")
+    if isinstance(error, asyncio.TimeoutError):
+        raise ClaudeAuxiliaryError(
+            f"Claude auxiliary call timed out after {deadline:.0f}s."
+        )
+    if isinstance(error, BaseException):
+        raise error
+
+    result = box.get("value") or {}
+    if result.get("is_error"):
+        raise ClaudeAuxiliaryError(
+            str(result.get("error") or "Claude Agent SDK reported an error")
+        )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-shaped facade
+# ---------------------------------------------------------------------------
+
+
+def _usage_namespace(usage: Any) -> Optional[SimpleNamespace]:
+    if not isinstance(usage, dict) or not usage:
+        return None
+
+    def _num(key: str) -> int:
+        value = usage.get(key)
+        return int(value) if isinstance(value, (int, float)) and value > 0 else 0
+
+    prompt_tokens = (
+        _num("input_tokens")
+        + _num("cache_read_input_tokens")
+        + _num("cache_creation_input_tokens")
+    )
+    completion_tokens = _num("output_tokens")
+    return SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+
+class _ClaudeAuxiliaryCompletionsAdapter:
+    """Translates ``chat.completions.create(**kwargs)`` into one SDK query."""
+
+    def __init__(self, model: str, timeout: Optional[float] = None) -> None:
+        self._model = model
+        self._timeout = timeout
+
+    def create(self, **kwargs: Any) -> Any:
+        if kwargs.get("tools"):
+            # Loud rather than silent: a caller asking for function calling on
+            # this path would otherwise get a plausible-looking text answer with
+            # the tool contract quietly dropped.
+            raise ClaudeAuxiliaryError(
+                "The Claude subscription auxiliary adapter runs with no tools; "
+                "configure an explicit `auxiliary.<task>.provider` for "
+                "tool-calling side tasks."
+            )
+        if kwargs.get("stream"):
+            # Same contract as the Bedrock Converse shim: return a complete
+            # response and let call_llm's consumer downgrade to non-live output.
+            logger.debug(
+                "ClaudeAuxiliaryClient: stream=True requested — returning a "
+                "complete response (the one-shot SDK path does not stream)."
+            )
+
+        model = str(kwargs.get("model") or self._model or "") or None
+        system_prompt, content = split_messages(kwargs.get("messages", []))
+        prompt = build_prompt(content)
+        timeout = kwargs.get("timeout") or self._timeout
+
+        result = run_claude_auxiliary_query(
+            prompt,
+            system_prompt=system_prompt,
+            model=model,
+            timeout=float(timeout) if timeout else None,
+        )
+
+        message = SimpleNamespace(
+            content=result.get("text") or "",
+            tool_calls=None,
+            reasoning=None,
+        )
+        choice = SimpleNamespace(index=0, message=message, finish_reason="stop")
+        return SimpleNamespace(
+            choices=[choice],
+            model=result.get("model") or model,
+            usage=_usage_namespace(result.get("usage")),
+        )
+
+
+class _ClaudeAuxiliaryChatShim:
+    def __init__(self, adapter: _ClaudeAuxiliaryCompletionsAdapter) -> None:
+        self.completions = adapter
+
+
+class ClaudeAuxiliaryClient:
+    """OpenAI-client-compatible facade over one-shot Claude Agent SDK calls.
+
+    ``api_key`` is the empty string on purpose and is never read: Hermes holds
+    no Claude credential.  ``base_url`` is the internal
+    ``claude-sdk://subscription`` scheme — not a reachable endpoint — so nothing
+    downstream can mistake this client for an HTTP transport.
+    """
+
+    def __init__(self, model: str, *, timeout: Optional[float] = None) -> None:
+        self._model = model
+        self.chat = _ClaudeAuxiliaryChatShim(
+            _ClaudeAuxiliaryCompletionsAdapter(model, timeout=timeout)
+        )
+        self.api_key = ""
+        self.base_url = "claude-sdk://subscription"
+
+    def close(self) -> None:
+        """No-op: every call owns and retires its own subprocess."""
+
+
+class _AsyncClaudeAuxiliaryCompletionsAdapter:
+    def __init__(self, sync_adapter: _ClaudeAuxiliaryCompletionsAdapter) -> None:
+        self._sync = sync_adapter
+
+    async def create(self, **kwargs: Any) -> Any:
+        return await asyncio.to_thread(self._sync.create, **kwargs)
+
+
+class _AsyncClaudeAuxiliaryChatShim:
+    def __init__(self, adapter: _AsyncClaudeAuxiliaryCompletionsAdapter) -> None:
+        self.completions = adapter
+
+
+class AsyncClaudeAuxiliaryClient:
+    """Async counterpart — the sync call runs on a worker thread."""
+
+    def __init__(self, sync_wrapper: ClaudeAuxiliaryClient) -> None:
+        self.chat = _AsyncClaudeAuxiliaryChatShim(
+            _AsyncClaudeAuxiliaryCompletionsAdapter(sync_wrapper.chat.completions)
+        )
+        self.api_key = sync_wrapper.api_key
+        self.base_url = sync_wrapper.base_url
+        self._real_client = sync_wrapper
+
+    def close(self) -> None:
+        """No-op — see :meth:`ClaudeAuxiliaryClient.close`."""
+
+
+def build_claude_auxiliary_client(
+    model: str,
+    *,
+    async_mode: bool = False,
+    timeout: Optional[float] = None,
+) -> Any:
+    """Build the auxiliary client, raising an actionable error when unusable.
+
+    The SDK import happens here rather than at first call so a missing extra is
+    reported while the caller can still fall back, instead of mid-task.
+    """
+    _import_sdk()
+    client = ClaudeAuxiliaryClient(model, timeout=timeout)
+    return AsyncClaudeAuxiliaryClient(client) if async_mode else client
+
+
+__all__ = [
+    "CLAUDE_AUX_MAX_TURNS",
+    "CLAUDE_CODE_PROVIDER_ID",
+    "DEFAULT_CLAUDE_AUX_TIMEOUT_SECONDS",
+    "AsyncClaudeAuxiliaryClient",
+    "ClaudeAuxiliaryClient",
+    "ClaudeAuxiliaryError",
+    "ClaudeImageInputUnsupported",
+    "build_claude_auxiliary_client",
+    "build_claude_auxiliary_options",
+    "build_prompt",
+    "is_claude_subscription_provider",
+    "run_claude_auxiliary_query",
+    "split_messages",
+]

--- a/agent/claude_billing.py
+++ b/agent/claude_billing.py
@@ -1,0 +1,560 @@
+"""Billing-source guard for the Claude subscription runtime.
+
+This module answers one question before a subscription turn is allowed to
+start: **which account pays for it?**
+
+The Claude Code CLI picks a credential in a fixed order (see
+``docs/design/claude-subscription-via-agent-sdk.md`` §5, from
+<https://code.claude.com/docs/en/iam>) and the user's subscription is *last*.
+A developer with ``ANTHROPIC_API_KEY`` exported — the common case for Hermes
+users, because the setup wizard asks for one — selects "Claude subscription"
+and gets billed as metered API usage instead, silently, because that ordering
+is correct behavior for the CLI.
+
+Two mechanisms, deliberately overlapping:
+
+* :func:`sanitized_child_env` builds the environment the CLI subprocess is
+  launched from, with every higher-precedence credential **removed**.  This is
+  structural: it is what
+  :mod:`agent.transports.claude_sanitized_transport` hands to
+  ``anyio.open_process``.  ``ClaudeAgentOptions.env`` cannot do this — the SDK
+  merges it *over* ``os.environ`` (``subprocess_cli.py``: ``{**inherited_env,
+  ..., **options.env, ...}``), so it can override a key but never delete one.
+* :func:`static_billing_refusal` and :func:`probe_claude_billing_source`
+  **refuse the turn** when a higher-precedence credential is present at all.
+  Refusing costs the user a message; guessing wrong costs them money, so the
+  guard errs toward refusing and names the exact variable and the exact fix.
+
+Nothing here reads a credential *value*.  Presence is the only signal, and no
+value is ever logged or included in a message.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import threading
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# T3 Code found 8s too short because a Bedrock-configured CLI is slow to
+# initialize, and raised their equivalent probe to 25s.
+CLAUDE_INIT_PROBE_TIMEOUT_SECONDS = 25.0
+
+
+# ---------------------------------------------------------------------------
+# Credential precedence
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CredentialSlot:
+    """One credential the CLI would prefer over the user's subscription.
+
+    ``rank`` mirrors the documented precedence order; 6 (subscription OAuth
+    from ``/login``) is the only rank we want to win, so every slot recorded
+    here outranks it.
+    """
+
+    rank: int
+    name: str
+    kind: str  # "env" | "setting"
+    bills: str
+    fix: str
+
+
+# Ranks 1-5 of the documented precedence list. Rank 6 — the subscription OAuth
+# session from `claude auth login` — is the one we want to win and therefore
+# has no entry.
+#
+# The rank-1 entries are the *selectors*: the CLI only reaches for cloud
+# credentials when one of these is set, so removing the selector is what
+# removes the whole slot. The list is wider than the three the docs name
+# (BEDROCK / VERTEX / FOUNDRY) because the shipped CLI (2.1.220) also honors
+# ANTHROPIC_AWS, ANTHROPIC_GOOGLE_CLOUD, MANTLE, and GATEWAY.
+CLAUDE_CREDENTIAL_PRECEDENCE: Tuple[CredentialSlot, ...] = (
+    *(
+        CredentialSlot(
+            rank=1,
+            name=name,
+            kind="env",
+            bills="a cloud provider account (Bedrock / Vertex / Foundry / gateway)",
+            fix=f"unset {name}",
+        )
+        for name in (
+            "CLAUDE_CODE_USE_BEDROCK",
+            "CLAUDE_CODE_USE_VERTEX",
+            "CLAUDE_CODE_USE_FOUNDRY",
+            "CLAUDE_CODE_USE_ANTHROPIC_AWS",
+            "CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD",
+            "CLAUDE_CODE_USE_MANTLE",
+            "CLAUDE_CODE_USE_GATEWAY",
+        )
+    ),
+    CredentialSlot(
+        rank=2,
+        name="ANTHROPIC_AUTH_TOKEN",
+        kind="env",
+        bills="whatever account issued that bearer token",
+        fix="unset ANTHROPIC_AUTH_TOKEN",
+    ),
+    CredentialSlot(
+        rank=3,
+        name="ANTHROPIC_API_KEY",
+        kind="env",
+        bills="your Anthropic Console account, as metered API usage",
+        fix="unset ANTHROPIC_API_KEY",
+    ),
+    # Not honored by the shipped CLI (2.1.220 reads ANTHROPIC_API_KEY and
+    # ANTHROPIC_AUTH_TOKEN, not this name), but wrappers and older builds do.
+    # A credential-shaped variable we cannot rule out is treated as one.
+    CredentialSlot(
+        rank=3,
+        name="ANTHROPIC_TOKEN",
+        kind="env",
+        bills="whatever account issued that token",
+        fix="unset ANTHROPIC_TOKEN",
+    ),
+    CredentialSlot(
+        rank=4,
+        name="apiKeyHelper",
+        kind="setting",
+        bills="whatever account the helper script's key belongs to",
+        fix="remove `apiKeyHelper` from your Claude settings.json",
+    ),
+    CredentialSlot(
+        rank=5,
+        name="CLAUDE_CODE_OAUTH_TOKEN",  # claude-boundary: ok — variable name only, never read as a credential
+        kind="env",
+        # This one does draw on the plan, but through the extra-usage meter
+        # rather than plan limits — a different bucket, and not what the user
+        # picked when they picked "Claude subscription".
+        bills="your plan's extra-usage credits, not its included limits",
+        fix="unset CLAUDE_CODE_OAUTH_TOKEN",  # claude-boundary: ok — variable name only, never read as a credential
+    ),
+)
+
+# Companions that carry the same credential in another form. They are stripped
+# from the child environment but do not, on their own, trigger a refusal: none
+# of them selects a billing source without its primary above also being set.
+_COMPANION_ENV_VARS: Tuple[str, ...] = (
+    "CLAUDE_CODE_OAUTH_REFRESH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR",  # claude-boundary: ok — variable name only, never read as a credential
+    "ANTHROPIC_AWS_API_KEY",
+    "ANTHROPIC_FOUNDRY_API_KEY",
+    "ANTHROPIC_FOUNDRY_AUTH_TOKEN",
+    "ANTHROPIC_IDENTITY_TOKEN_FILE",
+)
+
+# Everything removed from the child environment in subscription mode.
+BLOCKED_CHILD_ENV_VARS: frozenset = frozenset(
+    [slot.name for slot in CLAUDE_CREDENTIAL_PRECEDENCE if slot.kind == "env"]
+    + list(_COMPANION_ENV_VARS)
+)
+
+# Named so the intent survives a future edit to the blocklist. CLAUDE_CONFIG_DIR
+# is how a caller isolates Claude's config; HOME must never be rewritten,
+# because on macOS that relocates the login-keychain lookup
+# ($HOME/Library/Keychains) and the CLI then cannot find its stored OAuth
+# credentials and reports "Not logged in".
+PASS_THROUGH_ENV_VARS: Tuple[str, ...] = ("CLAUDE_CONFIG_DIR", "HOME")
+
+
+def sanitized_child_env(
+    base: Optional[Mapping[str, str]] = None,
+) -> Dict[str, str]:
+    """Return a filtered copy of *base* (default ``os.environ``) for the child.
+
+    A copy — ``os.environ`` itself is never mutated.  Hermes is multi-threaded
+    and other providers run concurrently; a process-global mutation around a
+    spawn would leak into them.
+    """
+    source = os.environ if base is None else base
+    return {
+        key: value
+        for key, value in source.items()
+        if key not in BLOCKED_CHILD_ENV_VARS
+    }
+
+
+def blocking_credentials(
+    env: Optional[Mapping[str, str]] = None,
+    *,
+    settings_keys: Optional[Mapping[str, Any]] = None,
+) -> List[CredentialSlot]:
+    """Credential slots present in *env* that would outrank the subscription.
+
+    Presence only: a value is never read, compared, or logged.  An
+    empty-valued variable does not count — the shipped CLI treats ``FOO=`` as
+    absent, and refusing on it would block users whose shell exports a blank
+    placeholder.
+    """
+    source = os.environ if env is None else env
+    found: List[CredentialSlot] = []
+    for slot in CLAUDE_CREDENTIAL_PRECEDENCE:
+        if slot.kind == "env":
+            if (source.get(slot.name) or "").strip():
+                found.append(slot)
+        elif settings_keys is not None and settings_keys.get(slot.name):
+            found.append(slot)
+    return sorted(found, key=lambda s: s.rank)
+
+
+def credential_refusal_message(slots: List[CredentialSlot]) -> str:
+    """Refusal text naming each offending variable and its exact fix."""
+    lines = [
+        "Refusing to start the Claude subscription runtime: this turn would "
+        "not be billed to your Claude plan."
+    ]
+    for slot in slots:
+        noun = "is set" if slot.kind == "env" else "is configured"
+        lines.append(
+            f"  • {slot.name} {noun}, and the Claude Code CLI prefers it over "
+            f"your subscription — requests would bill {slot.bills}."
+        )
+        lines.append(f"    Fix: {slot.fix}")
+    lines.append("  Check what the CLI would use with: claude auth status")
+    return "\n".join(lines)
+
+
+def static_billing_refusal(
+    env: Optional[Mapping[str, str]] = None,
+) -> Optional[str]:
+    """Refusal string when *env* carries a higher-precedence credential.
+
+    ``None`` means nothing in the environment outranks the subscription.
+    """
+    slots = blocking_credentials(env)
+    if not slots:
+        return None
+    return credential_refusal_message(slots)
+
+
+# ---------------------------------------------------------------------------
+# Billing-source classification
+# ---------------------------------------------------------------------------
+
+
+def _normalize(value: Any) -> str:
+    """Lowercase and strip separators, so ``claude.ai`` == ``claudeAi``."""
+    return re.sub(r"[^a-z0-9]", "", str(value or "").lower())
+
+
+# ``tokenSource`` values that mean "a key/token resolved from configuration",
+# not "the signed-in plan".
+_API_TOKEN_SOURCES = frozenset(
+    {"apikey", "anthropicapikey", "anthropicauthtoken", "apikeyhelper"}
+)
+_OAUTH_TOKEN_SOURCES = frozenset({"claudecodeoauthtoken"})
+# Normalized ``apiProvider`` values that are Anthropic's own first-party
+# service. Anything else is a cloud reseller.
+_FIRST_PARTY_PROVIDERS = frozenset({"firstparty", "anthropic", ""})
+
+
+@dataclass(frozen=True)
+class BillingSource:
+    """What the CLI says it would bill, as reported by its own init payload."""
+
+    kind: str  # subscription | api_key | oauth_token | cloud | unauthenticated | unknown
+    detail: str = ""  # the variable / provider that decided it
+    plan: str = ""
+    account: str = ""
+
+    @property
+    def is_subscription(self) -> bool:
+        return self.kind == "subscription"
+
+
+def classify_account(account: Optional[Mapping[str, Any]]) -> BillingSource:
+    """Classify the ``account`` block of the CLI's initialize response.
+
+    Observed shapes (Claude Code 2.1.220), in order of the checks below:
+
+    * plan login — ``{"email", "organization", "subscriptionType",
+      "apiProvider": "firstParty"}``
+    * ``ANTHROPIC_API_KEY`` set — ``{"tokenSource": "claude.ai",
+      "apiKeySource": "ANTHROPIC_API_KEY", "apiProvider": "firstParty"}``.
+      Note ``tokenSource`` still says ``claude.ai`` here, so ``apiKeySource``
+      is the load-bearing field and must be checked first.
+    * ``ANTHROPIC_AUTH_TOKEN`` set — ``{"tokenSource": "ANTHROPIC_AUTH_TOKEN"}``
+    * nothing signed in — ``{"tokenSource": "none"}``
+    """
+    if not isinstance(account, Mapping):
+        return BillingSource(kind="unknown")
+
+    provider = _normalize(account.get("apiProvider"))
+    if provider not in _FIRST_PARTY_PROVIDERS:
+        return BillingSource(
+            kind="cloud", detail=str(account.get("apiProvider") or "").strip()
+        )
+
+    api_key_source = str(account.get("apiKeySource") or "").strip()
+    if api_key_source:
+        return BillingSource(kind="api_key", detail=api_key_source)
+
+    token_source = str(account.get("tokenSource") or "").strip()
+    normalized_token = _normalize(token_source)
+    if normalized_token in _API_TOKEN_SOURCES:
+        return BillingSource(kind="api_key", detail=token_source)
+    if normalized_token in _OAUTH_TOKEN_SOURCES:
+        return BillingSource(kind="oauth_token", detail=token_source)
+    if normalized_token == "none":
+        return BillingSource(kind="unauthenticated")
+
+    plan = str(account.get("subscriptionType") or "").strip()
+    email = str(account.get("email") or "").strip()
+    if plan:
+        return BillingSource(kind="subscription", plan=plan, account=email)
+    if normalized_token and email:
+        # A signed-in session whose tier the CLI did not name.
+        return BillingSource(kind="subscription", detail=token_source, account=email)
+    return BillingSource(kind="unknown", detail=token_source)
+
+
+def billing_source_refusal(source: BillingSource) -> Optional[str]:
+    """Refusal string for a classified billing source, or None when it pays."""
+    if source.is_subscription:
+        return None
+    if source.kind == "api_key":
+        named = source.detail
+        if named == "apiKeyHelper":
+            fix = "remove `apiKeyHelper` from your Claude settings.json"
+        elif named:
+            fix = f"unset {named}"
+        else:
+            fix = (
+                "unset ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN, or remove "
+                "`apiKeyHelper` from your Claude settings.json"
+            )
+        return (
+            "Refusing to start the Claude subscription runtime: the Claude Code "
+            f"CLI resolved an API key from {named or 'your configuration'}, so "
+            "this turn would be billed as metered Anthropic API usage rather "
+            "than to your Claude plan.\n"
+            f"  Fix: {fix}, then start Hermes again.\n"
+            "  Check with: claude auth status"
+        )
+    if source.kind == "oauth_token":
+        return (
+            "Refusing to start the Claude subscription runtime: the Claude Code "
+            f"CLI is using {source.detail or 'CLAUDE_CODE_OAUTH_TOKEN'}, which "  # claude-boundary: ok — variable name only, never read as a credential
+            "draws on your plan's extra-usage credits instead of its included "
+            "limits.\n"
+            f"  Fix: unset {source.detail or 'CLAUDE_CODE_OAUTH_TOKEN'} and sign "  # claude-boundary: ok — variable name only, never read as a credential
+            "in with `claude auth login`.\n"
+            "  Check with: claude auth status"
+        )
+    if source.kind == "cloud":
+        return (
+            "Refusing to start the Claude subscription runtime: the Claude Code "
+            f"CLI is pointed at the '{source.detail}' provider, which bills a "
+            "cloud account, not your Claude plan.\n"
+            "  Fix: unset CLAUDE_CODE_USE_BEDROCK / CLAUDE_CODE_USE_VERTEX / "
+            "CLAUDE_CODE_USE_FOUNDRY, then start Hermes again.\n"
+            "  Check with: claude auth status"
+        )
+    if source.kind == "unauthenticated":
+        return (
+            "Refusing to start the Claude subscription runtime: the Claude Code "
+            "CLI has no signed-in account.\n"
+            "  Fix: run `claude auth login`."
+        )
+    return (
+        "Refusing to start the Claude subscription runtime: could not confirm "
+        "that this turn would be billed to your Claude plan.\n"
+        "  Check with: claude auth status"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Zero-cost billing probe
+# ---------------------------------------------------------------------------
+
+
+def probe_options() -> Any:
+    """Options for a probe-only session: no tools, no MCP servers, no prompt.
+
+    ``setting_sources=[]`` is load-bearing beyond context isolation: it is also
+    what stops the CLI running an ``apiKeyHelper`` from the user's settings
+    (verified against Claude Code 2.1.220 — with ``["user"]`` the helper runs
+    and the account reports ``tokenSource: apiKeyHelper``; with ``[]`` it never
+    runs and the account reports the plan).
+    """
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    return ClaudeAgentOptions(tools=[], setting_sources=[], allowed_tools=[])
+
+
+def _probe_account_payload(
+    *,
+    timeout: float,
+    client_factory: Optional[Callable[..., Any]] = None,
+    options_factory: Optional[Callable[[], Any]] = None,
+    transport_factory: Optional[Callable[[Any], Any]] = None,
+) -> Optional[Mapping[str, Any]]:
+    """Read the CLI's initialize response without issuing a model request.
+
+    The SDK's ``initialize`` control request is answered from the subprocess's
+    *local* startup: the CLI reports the account it resolved before any prompt
+    exists.  We connect, read that response, and disconnect — no user message
+    is ever written to the child's stdin, so there is nothing for it to send
+    to Anthropic and the probe costs no tokens and no quota.
+
+    The three factories are injection points for tests; each defaults to the
+    real SDK path and is imported only when it is used, so this module still
+    imports without the optional extra.
+    """
+    import asyncio
+
+    if client_factory is None:
+        from claude_agent_sdk import ClaudeSDKClient
+
+        client_factory = ClaudeSDKClient
+    if transport_factory is None:
+        from agent.transports.claude_sanitized_transport import (
+            build_sanitized_transport,
+        )
+
+        transport_factory = build_sanitized_transport
+
+    factory = client_factory
+    options = (options_factory or probe_options)()
+
+    result: Dict[str, Any] = {}
+
+    async def _run() -> None:
+        client = factory(options=options, transport=transport_factory(options))
+        try:
+            await client.connect()
+            info = await client.get_server_info()
+            if isinstance(info, Mapping):
+                account = info.get("account")
+                if isinstance(account, Mapping):
+                    result["account"] = dict(account)
+        finally:
+            try:
+                await client.disconnect()
+            except Exception:
+                logger.debug("claude billing probe disconnect failed", exc_info=True)
+
+    def _thread() -> None:
+        try:
+            asyncio.run(asyncio.wait_for(_run(), timeout))
+        except Exception as exc:
+            result["error"] = str(exc)
+
+    # Its own loop on its own thread: the caller is Hermes' synchronous turn
+    # thread, which may already be inside another runtime's event loop.
+    thread = threading.Thread(target=_thread, name="hermes-claude-billing-probe")
+    thread.start()
+    thread.join(timeout + 10.0)
+    if thread.is_alive():
+        logger.warning("claude billing probe did not finish within %.0fs", timeout)
+        return None
+    if "error" in result:
+        logger.info("claude billing probe failed: %s", result["error"])
+        return None
+    return result.get("account")
+
+
+def probe_claude_billing_source(
+    *,
+    timeout: float = CLAUDE_INIT_PROBE_TIMEOUT_SECONDS,
+    client_factory: Optional[Callable[..., Any]] = None,
+    options_factory: Optional[Callable[[], Any]] = None,
+    transport_factory: Optional[Callable[[Any], Any]] = None,
+) -> BillingSource:
+    """Ask the CLI which account it would bill. Never raises.
+
+    Falls back to ``claude auth status`` (:func:`hermes_cli.claude_code.
+    probe_claude_auth`) when the SDK probe cannot run or reports nothing.
+    """
+    try:
+        account = _probe_account_payload(
+            timeout=timeout,
+            client_factory=client_factory,
+            options_factory=options_factory,
+            transport_factory=transport_factory,
+        )
+    except Exception:
+        logger.debug("claude billing probe raised", exc_info=True)
+        account = None
+
+    if account is not None:
+        source = classify_account(account)
+        if source.kind != "unknown":
+            return source
+
+    return _fallback_billing_source()
+
+
+def _fallback_billing_source() -> BillingSource:
+    """Classify from ``claude auth status`` when the SDK probe is unavailable."""
+    try:
+        from hermes_cli.claude_code import probe_claude_auth
+
+        probe = probe_claude_auth()
+    except Exception:
+        logger.debug("claude auth status fallback failed", exc_info=True)
+        return BillingSource(kind="unknown")
+
+    if not probe.get("logged_in"):
+        return BillingSource(kind="unauthenticated")
+    if probe.get("auth_method") == "api-key":
+        # `claude auth status` says "api-key" without naming the source, so the
+        # message stays generic rather than guessing a variable.
+        return BillingSource(kind="api_key")
+    return BillingSource(
+        kind="subscription",
+        plan=str(probe.get("subscription_type") or ""),
+        account=str(probe.get("account") or ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The gate the runtime calls
+# ---------------------------------------------------------------------------
+
+
+def verify_claude_billing_source(
+    *,
+    env: Optional[Mapping[str, str]] = None,
+    probe: bool = True,
+    timeout: float = CLAUDE_INIT_PROBE_TIMEOUT_SECONDS,
+    client_factory: Optional[Callable[..., Any]] = None,
+) -> Optional[str]:
+    """Return a refusal string, or None when the turn bills the user's plan.
+
+    Static first (free, and it names the variable the user has to act on),
+    then the subprocess probe (exact, and catches anything the static list
+    does not know about).
+    """
+    refusal = static_billing_refusal(env)
+    if refusal is not None:
+        return refusal
+    if not probe:
+        return None
+    source = probe_claude_billing_source(timeout=timeout, client_factory=client_factory)
+    return billing_source_refusal(source)
+
+
+__all__ = [
+    "BLOCKED_CHILD_ENV_VARS",
+    "CLAUDE_CREDENTIAL_PRECEDENCE",
+    "CLAUDE_INIT_PROBE_TIMEOUT_SECONDS",
+    "PASS_THROUGH_ENV_VARS",
+    "BillingSource",
+    "CredentialSlot",
+    "billing_source_refusal",
+    "blocking_credentials",
+    "classify_account",
+    "credential_refusal_message",
+    "probe_options",
+    "probe_claude_billing_source",
+    "sanitized_child_env",
+    "static_billing_refusal",
+    "verify_claude_billing_source",
+]

--- a/agent/claude_runtime.py
+++ b/agent/claude_runtime.py
@@ -1,0 +1,1918 @@
+"""Claude Agent SDK runtime — whole-turn path for ``api_mode="claude_agent_sdk"``.
+
+Hands one user turn to the official ``claude-agent-sdk`` (which drives the
+Claude Code CLI) and projects the SDK's message stream back into Hermes'
+canonical callbacks and message shape, so a Claude turn renders identically
+on the CLI, TUI, Desktop, gateway, and ACP without surface-specific code.
+
+The ownership split is the whole point (see
+``docs/design/claude-subscription-via-agent-sdk.md``):
+
+* **Hermes keeps** the system prompt, the tool implementations, approvals,
+  environments, checkpoints, plugins, memory, skills, and UI history.  Every
+  tool call comes back through the in-process MCP bridge in
+  :mod:`agent.transports.claude_tool_bridge`, which funnels into
+  ``execute_one_tool``.
+* **The SDK keeps** Claude-native context, prompt-cache continuity,
+  automatic compaction, alternation, the resume cursor, and turn usage.
+
+Called from ``run_conversation()`` via ``AIAgent._run_claude_agent_sdk_turn``.
+Returns the same dict shape as the chat_completions path.
+
+The runtime ships default-off behind ``claude_subscription.enabled``; see
+:mod:`hermes_cli.claude_subscription`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import time
+import uuid
+from typing import Any, Callable, Dict, List, Optional
+
+from agent.transports.claude_tool_bridge import (
+    MCP_SERVER_NAME,
+    MCP_TOOL_PREFIX,
+    bridged_allowed_tools,
+    build_hermes_sdk_mcp_server,
+)
+
+logger = logging.getLogger(__name__)
+
+RUNTIME_LABEL = "claude_agent_sdk"
+
+# The turn is bounded by the session facade's deadline, not by Hermes'
+# per-call timeout: the SDK runs an entire agentic loop inside one query.
+DEFAULT_TURN_TIMEOUT_SECONDS = 1800.0
+
+# Claude's stderr is diagnostic, not user-facing: it goes to agent.log at DEBUG
+# so it is there when someone asks "why did the CLI die", without spamming
+# errors.log. The first few error-shaped lines are also escalated to WARNING —
+# capped, because a wedged CLI can emit thousands.
+MAX_ESCALATED_STDERR_LINES = 10
+_STDERR_ERROR_PATTERN = re.compile(
+    r"\b(error|fatal|panic|traceback|exception|econnrefused)\b", re.IGNORECASE
+)
+
+stderr_logger = logging.getLogger(f"{__name__}.claude_stderr")
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def claude_runtime_preflight(config: Optional[dict] = None) -> Optional[str]:
+    """Return an actionable error string, or None when the runtime may start.
+
+    Four independent gates, each with its own fix, because "it didn't work"
+    is useless to a user who has to know *which* of them to act on: the config
+    gate, the optional extra, the billing source, and the login.
+
+    The billing gate comes before the login probe because it is free — it only
+    reads variable *names* out of the environment — and because a credential
+    that outranks the user's subscription means this turn would be billed to a
+    different account, which is a refusal no matter what the login says.  The
+    exact subprocess probe runs once per session in
+    :func:`verify_claude_billing_for_agent`.
+    """
+    from hermes_cli.claude_subscription import (
+        claude_agent_sdk_available,
+        claude_subscription_enabled,
+    )
+
+    if config is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            config = load_config_readonly()
+        except Exception:
+            logger.debug("claude runtime preflight config load failed", exc_info=True)
+            config = {}
+
+    if not claude_subscription_enabled(config):
+        return (
+            "The Claude subscription runtime is turned off. Set "
+            "`claude_subscription.enabled: true` in config.yaml to use it."
+        )
+
+    if not claude_agent_sdk_available():
+        return (
+            "The Claude subscription runtime needs the optional `claude-code` "
+            "extra. Install it with: pip install 'hermes-agent[claude-code]'"
+        )
+
+    from agent.claude_billing import static_billing_refusal
+
+    refusal = static_billing_refusal()
+    if refusal is not None:
+        return refusal
+
+    from hermes_cli.claude_code import CLAUDE_LOGIN_COMMAND, probe_claude_auth_cached
+
+    probe = probe_claude_auth_cached()
+    if not probe.get("logged_in"):
+        return (
+            probe.get("message")
+            or f"Not signed in to Claude — run `{CLAUDE_LOGIN_COMMAND}`."
+        )
+    return None
+
+
+_UNSET = object()
+
+
+def verify_claude_billing_for_agent(agent) -> Optional[str]:
+    """Prove this agent's session bills the user's plan. Cached per session.
+
+    The proof is the Claude Code CLI's own initialize response, read through a
+    throwaway SDK connection that never writes a user message — so the child
+    completes its local startup, reports the account it resolved, and exits
+    without ever issuing a model request.  Costs no tokens and no quota.
+
+    Cached on the agent because it spawns a subprocess: it must not run per
+    turn.  ``_retire_session`` clears it, so a rebuilt session re-proves.
+    """
+    cached = getattr(agent, "_claude_billing_refusal", _UNSET)
+    if cached is not _UNSET:
+        return cached
+
+    from agent.claude_billing import verify_claude_billing_source
+
+    refusal = verify_claude_billing_source()
+    agent._claude_billing_refusal = refusal
+    if refusal is None:
+        logger.info("claude_agent_sdk billing source confirmed as the user's plan")
+    return refusal
+
+
+def _make_stderr_logger() -> Callable[[str], None]:
+    """Route the Claude child's stderr into Hermes' logs.
+
+    The SDK inherits the parent's stderr unless ``options.stderr`` is set, and
+    under Electron that handle can be closed or unusable — so a callback is
+    always registered, both to keep the child's diagnostics and to keep it off
+    a handle it cannot write to.
+    """
+    escalated = [0]
+
+    def _on_stderr(line: str) -> None:
+        text = (line or "").rstrip()
+        if not text:
+            return
+        stderr_logger.debug("claude: %s", text)
+        if (
+            escalated[0] < MAX_ESCALATED_STDERR_LINES
+            and _STDERR_ERROR_PATTERN.search(text)
+        ):
+            escalated[0] += 1
+            stderr_logger.warning("claude: %s", text)
+
+    return _on_stderr
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+# Appended to the claude_code preset in subscription mode.
+#
+# Identity has to live HERE, not only in the first-turn context, because the
+# system prompt is the only channel that persists for the life of the session.
+# A one-time user-turn injection binds identity on turn 1 and then decays: by
+# turn 3 of a real conversation the model drifts back to the preset's "You are
+# Claude Code" (measured). The full operating instructions still arrive as the
+# first user turn — this is the short, durable anchor that keeps pointing at
+# them.
+#
+# Keep it short. The billing classifier reads appended system-prompt content:
+# ~700 chars of identity and persona bills to the plan, while Hermes' full
+# prompt does not (decision record §11). This text is byte-stable for the life
+# of the conversation, so prompt caching is preserved.
+def hermes_identity_anchor(agent=None) -> str:
+    """Hermes' own identity text, verbatim — nothing authored here.
+
+    The subscription runtime cannot put Hermes' full prompt in the system
+    slot (the billing classifier re-bills that to extra usage, decision
+    record §11), and the full prompt delivered as a first user turn decays:
+    by turn 3 the preset's own identity line wins and the model reintroduces
+    itself as the CLI rather than as Hermes (measured).
+
+    So the system slot carries exactly one thing: the same identity section
+    Hermes already puts at the top of its own prompt for every other
+    provider — the user's ``SOUL.md`` when they have one, otherwise
+    ``DEFAULT_AGENT_IDENTITY``. This adds no provider-specific persona: a
+    user who customises their identity gets their customisation here too,
+    and the rest of the prompt is unchanged and delivered in full one
+    message later.
+    """
+    try:
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, load_soul_md
+
+        soul = None
+        # Honour SOUL.md only when this agent would load it for its own
+        # prompt, so the anchor never contradicts the prompt it anchors.
+        if agent is None or getattr(agent, "load_soul_identity", False) or not getattr(
+            agent, "skip_context_files", False
+        ):
+            soul = load_soul_md()
+        identity = (soul or "").strip() or DEFAULT_AGENT_IDENTITY
+    except Exception:
+        logger.debug("identity anchor lookup failed; using the default", exc_info=True)
+        from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+        identity = DEFAULT_AGENT_IDENTITY
+    return identity.strip()
+
+
+# Operational fact about this runtime, not persona: the tools genuinely carry
+# the mcp__hermes__ prefix here, and the built-ins genuinely are denied (the
+# PreToolUse hook). Hermes' own prompt references its tools by bare name, so
+# without this line the model only discovers the routing when a denial bounces
+# it — measured in a clean container as the model complaining about blocked
+# tools instead of switching. Keeps the append far below the classifier
+# threshold (§11).
+CLAUDE_TOOL_ROUTING_NOTE = (
+    "In this session your tools are the mcp__hermes__* tools (for example "
+    "mcp__hermes__read_file, mcp__hermes__terminal); use them for file, "
+    "terminal, web, and delegation work. The built-in tools are disabled and "
+    "their calls will be denied."
+)
+
+
+def claude_subscription_append(agent=None) -> str:
+    """The system-prompt append: Hermes' own identity section, plus one
+    factual note about this runtime's tool naming. No persona is authored."""
+    return hermes_identity_anchor(agent) + "\n\n" + CLAUDE_TOOL_ROUTING_NOTE
+
+
+def _bridge_only_hooks() -> Dict[str, Any]:
+    """PreToolUse hook that pins execution to the Hermes MCP bridge.
+
+    The billing classifier requires the built-in toolset to stay in context
+    (see ``build_claude_agent_options``), but the built-ins must never run —
+    the SDK's Bash/Read/Edit would execute outside Hermes' environments,
+    checkpoints, approvals, and plugins.  A hook is the reliable choke point:
+    unlike ``can_use_tool`` it fires for every call, including tools the CLI
+    would auto-allow without a permission prompt (Read/Glob/Grep), which
+    matters when Hermes routes execution to a remote backend and a local read
+    would leak host files into the session.
+    """
+    from claude_agent_sdk import HookMatcher
+
+    bridge_prefix = f"mcp__{MCP_SERVER_NAME}__"
+
+    async def _deny_non_bridge_tools(hook_input, _tool_use_id, _context):
+        name = str((hook_input or {}).get("tool_name") or "")
+        if name.startswith(bridge_prefix):
+            return {}
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"Hermes owns tool execution. Use the {bridge_prefix}* "
+                    f"equivalent of {name or 'this tool'} instead."
+                ),
+            }
+        }
+
+    return {"PreToolUse": [HookMatcher(matcher=None, hooks=[_deny_non_bridge_tools])]}
+
+
+def build_claude_agent_options(
+    agent,
+    *,
+    system_prompt: str,
+    effective_task_id: Callable[[], str],
+    cwd: str,
+) -> Any:
+    """Build ``ClaudeAgentOptions`` for this agent's session.
+
+    Every field below is load-bearing:
+
+    ``system_prompt`` (preset + Hermes' own identity section)
+        The ``claude_code`` preset with Hermes' identity section appended —
+        the same ``SOUL.md``-or-``DEFAULT_AGENT_IDENTITY`` text Hermes already
+        puts at the top of its prompt for every other provider. Nothing is
+        authored for this provider.
+
+        Two measured constraints force this shape (decision record §11):
+        replacing the preset, or appending Hermes' *full* prompt, is billed to
+        the plan's extra-usage pool; and the full prompt delivered only as a
+        first user turn decays — by turn 3 the preset's own identity line
+        wins. The identity section is short enough to bill to the plan and
+        durable enough to hold, and the rest of the prompt is unchanged and
+        delivered in full one message later.
+    ``tools`` unset (built-ins stay in context)
+        Required by the same classifier finding.  The built-ins are *visible*
+        but never *run*: a PreToolUse hook denies every non-bridge tool call
+        and redirects Claude to the ``mcp__hermes__*`` equivalent, so Hermes'
+        environments, checkpoints, approvals, and plugins still own all
+        execution.  Denial happens client-side in the CLI and does not change
+        the API-visible request shape.
+    ``setting_sources=[]``
+        Stops the CLI loading CLAUDE.md, skills, hooks, settings, and plugins
+        a second time and competing with Hermes' context assembly.
+    ``strict_mcp_config=True``
+        Pins the toolset to the bridge; a user/project ``.mcp.json`` cannot
+        widen it mid-conversation.
+    ``stderr``
+        The SDK inherits the parent's stderr unless a callback is registered,
+        and under Electron that handle can be closed or unusable.
+    ``session_store`` + ``session_store_flush="eager"``
+        Mirrors Claude's own transcript into ``state.db`` so the session
+        survives a process restart and can be rewound or branched.  Eager
+        because Hermes' rewind boundary is a message UUID: a batched flush
+        that lands after the turn would leave the most recent turn unmappable
+        until the next one.  Deliberately NOT combined with
+        ``enable_file_checkpointing`` — the SDK rejects the pair, and Hermes
+        has its own checkpoint system (see the decision record).
+    ``resume``
+        The SDK session bound to this Hermes session, when there is one.  This
+        is what keeps Claude's context, compaction state, and prompt cache
+        alive across restarts instead of replaying history every turn.
+    """
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    # A zero-arg callable, so a long-lived server follows the turn's task id
+    # and therefore the execution environment (local / Docker / SSH / Modal /
+    # Daytona / Singularity) the tools run in.
+    mcp_server = build_hermes_sdk_mcp_server(agent, effective_task_id)
+
+    # Deliberately empty. The child environment is NOT assembled here: the SDK
+    # merges `options.env` over a copy of os.environ, so it can override a key
+    # but never delete one, and `ANTHROPIC_API_KEY=""` is still a set key.
+    # Removal happens in agent.transports.claude_sanitized_transport, which
+    # spawns the CLI from an explicitly-filtered environment. Anything added
+    # here is re-filtered against the blocklist before the spawn.
+    child_env: Dict[str, str] = {}
+
+    from agent.claude_session_store import build_claude_session_store
+
+    store = build_claude_session_store(getattr(agent, "_session_db", None))
+    # Resolved on the turn thread by _prepare_sdk_session() before the session
+    # is built, because a pending rewind/branch has to fork the stored
+    # transcript first and that is async work the loop thread must not own.
+    resume = getattr(agent, "_claude_sdk_resume_id", None) if store else None
+
+    options: Dict[str, Any] = dict(
+        system_prompt={
+            "type": "preset",
+            "preset": "claude_code",
+            # Resolved once per session; byte-stable for its lifetime, which
+            # is what the prompt cache requires.
+            "append": claude_subscription_append(agent),
+        },
+        allowed_tools=bridged_allowed_tools(agent),
+        mcp_servers={MCP_SERVER_NAME: mcp_server},
+        strict_mcp_config=True,
+        setting_sources=[],
+        cwd=cwd,
+        env=child_env,
+        stderr=_make_stderr_logger(),
+        model=getattr(agent, "model", None) or None,
+        include_partial_messages=True,
+        hooks=_bridge_only_hooks(),
+    )
+    if store is not None:
+        options["session_store"] = store
+        options["session_store_flush"] = "eager"
+        if resume:
+            options["resume"] = resume
+    return ClaudeAgentOptions(**options)
+
+
+# ---------------------------------------------------------------------------
+# Durable sessions: binding, resume, fork, bootstrap, recovery
+# ---------------------------------------------------------------------------
+#
+# Hermes owns the visible transcript; the SDK owns Claude's context and the
+# resume cursor. Durability is therefore NOT "replay Hermes' history into
+# Claude every turn" — that would rebuild the exact state the SDK is supposed
+# to own and would throw away the upstream prompt cache on every message,
+# which AGENTS.md treats as sacred. It is: mirror Claude's own transcript into
+# state.db, remember which SDK session belongs to which Hermes session, and
+# resume it.
+#
+# Canonical history is replayed exactly ONCE, and only when there is nothing
+# to resume: a user switching into Claude mid-conversation, or a session that
+# predates the mirror. After that bootstrap the binding exists and every
+# later turn resumes.
+
+#: Hard cap on stale-session recoveries for one Hermes session. A binding that
+#: keeps going stale is a broken binding, not a transient one — after this
+#: many attempts the runtime stops bootstrapping and just runs fresh turns,
+#: so a permanently-unresumable session cannot spin forever.
+MAX_SESSION_RECOVERIES = 3
+
+#: How much canonical history a one-time bootstrap replays. Bounded because
+#: this text becomes part of a single Claude user message.
+BOOTSTRAP_MAX_MESSAGES = 200
+BOOTSTRAP_MAX_CHARS = 60_000
+
+# Substrings the CLI/SDK use when a --resume target no longer exists. Matched
+# case-insensitively and only as a *second* signal — the primary one is
+# structural (a connect that failed while a resume id was set).
+_STALE_SESSION_MARKERS = (
+    "no conversation found",
+    "session not found",
+    "no session found",
+    "could not find session",
+    "invalid session id",
+)
+
+
+def _session_cwd(agent) -> str:
+    from agent.runtime_cwd import resolve_agent_cwd
+
+    return getattr(agent, "session_cwd", None) or str(resolve_agent_cwd())
+
+
+def claude_project_key(cwd: str) -> str:
+    """The SDK's ``project_key`` for *cwd*.
+
+    Must match what the SDK derives internally, or mirrored entries land under
+    one key and resume looks for them under another.
+    """
+    try:
+        from claude_agent_sdk import project_key_for_directory
+
+        return project_key_for_directory(cwd)
+    except Exception:  # pragma: no cover - optional extra absent
+        return str(cwd)
+
+
+def _run_async(coro: Any) -> Any:
+    """Run *coro* to completion from Hermes' synchronous turn thread.
+
+    A private loop, not the session's: the session's loop owns anyio streams
+    and a subprocess and must not be borrowed for unrelated work, and this
+    runs *before* that loop exists. The store only touches SQLite (through
+    ``asyncio.to_thread``), so it has no loop affinity of its own.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        try:
+            loop.close()
+        finally:
+            asyncio.set_event_loop(None)
+
+
+def _fork_stored_session(
+    store: Any, source_session_id: str, cwd: str, up_to_message_id: Optional[str]
+) -> Optional[str]:
+    """Fork a mirrored SDK session; return the new session id or None.
+
+    Delegated to the SDK's ``fork_session_via_store`` rather than copying rows:
+    a fork is not a byte copy.  It remaps every message UUID, rewrites
+    ``sessionId`` on each entry, and stamps ``forkedFrom``, so the data has to
+    pass through that transform once.  The source is left untouched, which is
+    what keeps a rewound parent transcript immutable.
+    """
+    try:
+        from claude_agent_sdk import fork_session_via_store
+    except Exception:  # pragma: no cover - optional extra absent
+        return None
+    try:
+        result = _run_async(
+            fork_session_via_store(
+                store,
+                source_session_id,
+                directory=cwd,
+                up_to_message_id=up_to_message_id,
+            )
+        )
+    except Exception as exc:
+        logger.warning(
+            "claude_agent_sdk fork of %s failed (%s); falling back to a fresh "
+            "session bootstrapped from Hermes history",
+            source_session_id,
+            exc,
+        )
+        return None
+    return getattr(result, "session_id", None)
+
+
+def prepare_claude_sdk_session(agent, cwd: str) -> Dict[str, Any]:
+    """Resolve what this turn should resume from, forking first if asked to.
+
+    Returns ``{"resume": str|None, "bootstrap": bool, "recoveries": int}`` and
+    caches the resume id on the agent, where
+    :func:`build_claude_agent_options` reads it.  Runs on the turn thread
+    before the session is built, because a pending rewind or branch has to
+    rewrite the stored transcript before the CLI is pointed at it.
+    """
+    state: Dict[str, Any] = {"resume": None, "bootstrap": False, "recoveries": 0}
+    db = getattr(agent, "_session_db", None)
+    hermes_session = getattr(agent, "session_id", None)
+    if db is None or not hermes_session:
+        # No durable store (persistence disabled, a background-review fork, a
+        # bare harness). The turn still runs; it just is not resumable.
+        agent._claude_sdk_resume_id = None
+        return state
+
+    from agent.claude_session_store import RUNTIME, build_claude_session_store
+
+    project_key = claude_project_key(cwd)
+    agent._claude_project_key = project_key
+
+    binding = db.get_provider_runtime_session(hermes_session, RUNTIME) or {}
+    state["recoveries"] = int(binding.get("recovery_count") or 0)
+    resume = binding.get("provider_session_id") or None
+    pending_rewind = binding.get("pending_rewind_ordinal")
+    pending_fork = binding.get("pending_fork_source")
+
+    store = build_claude_session_store(db)
+    if store is None:
+        # Resuming requires materializing the stored transcript, so without a
+        # store there is nothing to resume from — and a stale pending marker
+        # must not survive as a resume id pointing at discarded history.
+        agent._claude_sdk_resume_id = None
+        return state
+    if pending_fork or pending_rewind is not None:
+        # A live session is already connected to the OLD transcript; the fork
+        # below only changes what a *new* connection resumes. Retire it so the
+        # next turn reconnects against the branch the user asked for.
+        _retire_session(agent)
+
+    if pending_fork:
+        # Branch: an SDK fork, so the child keeps Claude's context and prompt
+        # cache but cannot see or affect the parent's future turns.
+        forked = _fork_stored_session(store, pending_fork, cwd, None)
+        db.clear_provider_pending(hermes_session, RUNTIME)
+        if forked:
+            db.bind_provider_runtime_session(
+                hermes_session, RUNTIME, forked, project_key=project_key
+            )
+            resume = forked
+        else:
+            resume = None
+
+    elif pending_rewind is not None and resume:
+        ordinal = int(pending_rewind)
+        forked = None
+        if ordinal > 0:
+            boundary = db.get_provider_message_binding(hermes_session, ordinal) or {}
+            boundary_uuid = boundary.get("fork_boundary_uuid")
+            if boundary_uuid:
+                forked = _fork_stored_session(store, resume, cwd, boundary_uuid)
+            else:
+                logger.info(
+                    "claude_agent_sdk rewind to turn %s has no mirrored boundary "
+                    "UUID; starting a fresh Claude session instead of forking",
+                    ordinal,
+                )
+        db.clear_provider_pending(hermes_session, RUNTIME)
+        db.prune_provider_message_bindings(hermes_session, ordinal)
+        if forked:
+            db.bind_provider_runtime_session(
+                hermes_session, RUNTIME, forked, project_key=project_key
+            )
+            resume = forked
+        else:
+            # Rewinding to zero surviving turns, or no usable boundary: the
+            # binding is dropped and the next turn starts clean. Not a
+            # recovery — the user asked for this — so recovery_count is
+            # untouched.
+            db.clear_provider_runtime_session(hermes_session, RUNTIME)
+            resume = None
+
+    state["resume"] = resume
+    # Bootstrap exactly once, and only when there is nothing to resume: with a
+    # resume cursor the SDK already has the context, and replaying history on
+    # top of it would duplicate the conversation AND break the prompt cache.
+    if not resume and not binding.get("bootstrapped"):
+        state["bootstrap"] = True
+    agent._claude_sdk_resume_id = resume
+    return state
+
+
+def _render_bootstrap_message(message: Dict[str, Any]) -> Optional[str]:
+    role = message.get("role")
+    if role not in ("user", "assistant"):
+        return None
+    content = message.get("content")
+    if isinstance(content, list):
+        content = "\n".join(
+            str(part.get("text", ""))
+            for part in content
+            if isinstance(part, dict) and part.get("type") == "text"
+        )
+    text = str(content or "").strip()
+    if not text:
+        return None
+    return f"{'User' if role == 'user' else 'Assistant'}: {text}"
+
+
+def _hermes_system_prompt(agent) -> str:
+    """The one Hermes prompt string this conversation uses, built at most once.
+
+    AGENTS.md requires it to be byte-stable for the life of a conversation, so
+    it is cached on the agent and shared by the session builder and the
+    first-turn context bootstrap.
+    """
+    cached = getattr(agent, "_cached_system_prompt", None)
+    if not cached:
+        cached = agent._build_system_prompt()
+        agent._cached_system_prompt = cached
+    return cached
+
+
+def claude_context_prefix(agent, system_prompt: str) -> str:
+    """Deliver Hermes' identity, memory, and skills as the first user turn.
+
+    In subscription mode the system prompt belongs to the ``claude_code``
+    preset — appending Hermes' full prompt there re-bills the session to extra
+    usage (decision record §11).  Hermes already has an established pattern for
+    exactly this: ``agent/skill_commands.py`` injects skill content as a user
+    message rather than the system prompt.  We reuse it, so nothing about
+    Hermes' behavior is lost — persona, memory instructions, context files, and
+    skills all still reach the model.
+
+    Sent once per session, inside the same bootstrap turn as any prior history,
+    so role alternation is untouched.  Every later turn resumes the SDK session,
+    which already holds this content — so it is never re-sent and the prompt
+    cache stays warm.
+    """
+    body = (system_prompt or "").strip()
+    if not body:
+        return ""
+    # The framing has to be explicit about superseding the harness identity.
+    # The system prompt belongs to the claude_code preset, and a mild "here is
+    # some context" wrapper loses to it on identity questions once the body is
+    # large enough for the identity line to be buried — measured at ~86k chars,
+    # which is the real size once context files, skills, and memory load.
+    return (
+        "<operating_instructions>\n"
+        "The system prompt that started this process describes the harness, "
+        "not your role. For this conversation you are the assistant defined "
+        "below: adopt its identity, persona, and instructions for every turn, "
+        "including all later ones and including how you answer questions about "
+        "who you are. Do not describe yourself as Claude Code.\n\n"
+        f"{body}\n"
+        "</operating_instructions>\n\n"
+    )
+
+
+def claude_bootstrap_prefix(messages: List[Dict[str, Any]]) -> str:
+    """Render prior Hermes history for a one-time bootstrap into Claude.
+
+    Deterministic and bounded.  Used only when a conversation reaches the
+    Claude runtime with history but no SDK session to resume — a provider
+    switch, or a session older than the mirror.  It is sent as part of the
+    first user message so role alternation is untouched, and it happens once:
+    the binding recorded after this turn makes every later turn a resume.
+
+    Tool calls and tool results are omitted on purpose. Replaying them would
+    imply Claude issued them, which it did not, and Claude's own transcript
+    from here on is the SDK's to own.
+    """
+    rendered: List[str] = []
+    for message in messages[-BOOTSTRAP_MAX_MESSAGES:]:
+        line = _render_bootstrap_message(message)
+        if line:
+            rendered.append(line)
+    if not rendered:
+        return ""
+    body = "\n\n".join(rendered)
+    if len(body) > BOOTSTRAP_MAX_CHARS:
+        body = "…\n\n" + body[-BOOTSTRAP_MAX_CHARS:]
+    return (
+        "<prior_conversation>\n"
+        "This conversation started with a different model. The exchange so far "
+        "is reproduced below for context; it is history, not a new request.\n\n"
+        f"{body}\n"
+        "</prior_conversation>\n\n"
+    )
+
+
+def _looks_stale(error: Optional[str]) -> bool:
+    if not error:
+        return False
+    lowered = error.lower()
+    return any(marker in lowered for marker in _STALE_SESSION_MARKERS)
+
+
+def record_claude_session_binding(
+    agent, projector: "ClaudeEventProjector", *, cwd: str, user_ordinal: int,
+    watermark: int,
+) -> None:
+    """Persist the SDK session id and this turn's rewind boundary.
+
+    Called after the turn.  Two writes:
+
+    * the Hermes-session → SDK-session binding, which is what a later process
+      resumes from, and
+    * the visible user row → SDK message UUID mapping, resolved from the
+      mirrored entries appended past *watermark*, which is what a later
+      rewind forks at.
+
+    Both are best-effort: a Claude turn that succeeded must not be reported as
+    failed because bookkeeping did not land.
+    """
+    db = getattr(agent, "_session_db", None)
+    hermes_session = getattr(agent, "session_id", None)
+    sdk_session = projector.session_id
+    if db is None or not hermes_session or not sdk_session:
+        return
+
+    from agent.claude_session_store import RUNTIME, is_visible_user_entry
+
+    project_key = getattr(agent, "_claude_project_key", None) or claude_project_key(cwd)
+    try:
+        # bootstrapped=True in the same write: whatever this turn was, the
+        # session now exists and every later turn resumes it.
+        db.bind_provider_runtime_session(
+            hermes_session,
+            RUNTIME,
+            sdk_session,
+            project_key=project_key,
+            bootstrapped=True,
+        )
+    except Exception:
+        logger.debug("claude_agent_sdk session binding failed", exc_info=True)
+        return
+
+    if user_ordinal < 0:
+        return
+    try:
+        db.record_provider_message_binding(
+            hermes_session,
+            user_ordinal,
+            RUNTIME,
+            sdk_session,
+            project_key=project_key,
+            after_entry_id=watermark,
+        )
+        # The mirror is asynchronous, so the UUID that opened this turn only
+        # exists in the store now that the turn is over.
+        entries = db.provider_transcript_entries_after(
+            RUNTIME, project_key, sdk_session, watermark
+        )
+        for row_id, entry_uuid, entry in entries:
+            if not is_visible_user_entry(entry) or not entry_uuid:
+                continue
+            db.set_provider_message_binding_uuids(
+                hermes_session,
+                user_ordinal,
+                provider_message_uuid=entry_uuid,
+                fork_boundary_uuid=db.provider_transcript_uuid_before(
+                    RUNTIME, project_key, sdk_session, row_id
+                ),
+            )
+            break
+    except Exception:
+        logger.debug("claude_agent_sdk message binding failed", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Event projection
+# ---------------------------------------------------------------------------
+
+
+def display_tool_name(name: str) -> str:
+    """Strip the bridge's MCP namespacing for display.
+
+    Users think of ``mcp__hermes__terminal`` as the ``terminal`` tool; the
+    codex runtime makes the same call for its internal MCP server.
+    """
+    if name.startswith(MCP_TOOL_PREFIX):
+        return name[len(MCP_TOOL_PREFIX):]
+    return name
+
+
+def _blocks(message: Any) -> List[Any]:
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        return content
+    return []
+
+
+def _block_kind(block: Any) -> str:
+    return type(block).__name__
+
+
+def _tool_result_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for part in content:
+            if isinstance(part, dict) and part.get("type") == "text":
+                parts.append(str(part.get("text", "")))
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    return str(content)
+
+
+def _tool_result_content(agent, tool_name: str, content: Any) -> Any:
+    """Convert an SDK tool-result payload into Hermes tool-message content.
+
+    MCP carries images as ``{"type": "image", "data", "mimeType"}`` blocks.
+    Rebuild the OpenAI-style multimodal envelope so vision-capable models see
+    the screenshot and text-only providers get the summary — the same
+    downgrade the normal tool path applies.
+    """
+    if not isinstance(content, list):
+        return _tool_result_text(content)
+
+    parts: List[Dict[str, Any]] = []
+    has_image = False
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") == "text":
+            parts.append({"type": "text", "text": str(part.get("text", ""))})
+        elif part.get("type") == "image" and part.get("data"):
+            has_image = True
+            mime = str(part.get("mimeType") or "image/png")
+            parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": f"data:{mime};base64,{part['data']}",
+                    },
+                }
+            )
+    if not has_image:
+        return _tool_result_text(content)
+
+    envelope = {
+        "_multimodal": True,
+        "content": parts,
+        "text_summary": "\n".join(
+            p["text"] for p in parts if p.get("type") == "text"
+        ),
+    }
+    resolve = getattr(agent, "_tool_result_content_for_active_model", None)
+    if callable(resolve):
+        try:
+            return resolve(tool_name, envelope)
+        except Exception:
+            logger.debug("tool-result content resolution failed", exc_info=True)
+    return envelope["text_summary"]
+
+
+class ClaudeEventProjector:
+    """Project one SDK response stream into Hermes callbacks + messages.
+
+    Mirrors ``make_codex_app_server_event_bridge``: every Hermes-visible
+    effect is fired from here so no surface needs Claude-specific rendering.
+    Callback invocations are individually guarded — a buggy display callback
+    must not tear down the turn.
+
+    Instances are single-turn.  ``finalize()`` is idempotent so the projected
+    messages can only ever be spliced into the conversation once, including
+    when trailing events arrive after ``ResultMessage``.
+    """
+
+    def __init__(self, agent) -> None:
+        self._agent = agent
+        self.projected_messages: List[Dict[str, Any]] = []
+        self.tool_iterations = 0
+        self.session_id: Optional[str] = None
+        self.terminal_reason: Optional[str] = None
+        self.usage: Optional[Dict[str, Any]] = None
+        self.total_cost_usd: Optional[float] = None
+        self.result_text: Optional[str] = None
+        self.compacted = False
+        self.is_error = False
+        self.error: Optional[str] = None
+        self.stop_reason: Optional[str] = None
+        self.mirror_errors: List[str] = []
+
+        self._assistant_text_parts: List[str] = []
+        self._streamed_text = False
+        self._streamed_thinking = False
+        self._pending_calls: List[Dict[str, Any]] = []
+        self._pending_results: Dict[str, Any] = {}
+        self._tool_started_at: Dict[str, float] = {}
+        self._finalized = False
+
+    # -- entry point -------------------------------------------------------
+
+    def __call__(self, message: Any) -> None:
+        try:
+            self._dispatch(message)
+        except Exception:
+            logger.debug(
+                "claude_agent_sdk projection failed for %s",
+                type(message).__name__,
+                exc_info=True,
+            )
+
+    def _dispatch(self, message: Any) -> None:
+        # Dispatch on class name rather than isinstance so the projector
+        # behaves identically against the real optional extra and the stand-in
+        # the suite installs when it is absent.
+        kind = type(message).__name__
+        if kind == "StreamEvent":
+            self._on_stream_event(message)
+        elif kind == "AssistantMessage":
+            self._on_assistant(message)
+        elif kind == "UserMessage":
+            self._on_user(message)
+        elif kind == "MirrorErrorMessage":
+            # A SystemMessage SUBCLASS, so a name-based dispatch has to name it
+            # explicitly. Dispatched before the SystemMessage branch for the
+            # same reason.
+            self._on_mirror_error(message)
+        elif kind == "SystemMessage":
+            self._on_system(message)
+        elif kind == "ResultMessage":
+            self._on_result(message)
+
+    # -- callbacks ---------------------------------------------------------
+
+    def _fire(self, name: str, *args: Any, **kwargs: Any) -> None:
+        callback = getattr(self._agent, name, None)
+        if callback is None:
+            return
+        try:
+            callback(*args, **kwargs)
+        except Exception:
+            logger.debug("%s raised on claude_agent_sdk turn", name, exc_info=True)
+
+    # -- handlers ----------------------------------------------------------
+
+    def _on_stream_event(self, message: Any) -> None:
+        self._note_session_id(getattr(message, "session_id", None))
+        event = getattr(message, "event", None)
+        if not isinstance(event, dict):
+            return
+        if event.get("type") != "content_block_delta":
+            return
+        delta = event.get("delta")
+        if not isinstance(delta, dict):
+            return
+        delta_type = delta.get("type")
+        if delta_type == "text_delta":
+            text = delta.get("text") or ""
+            if text:
+                self._streamed_text = True
+                self._fire("_fire_stream_delta", text)
+        elif delta_type == "thinking_delta":
+            thinking = delta.get("thinking") or ""
+            if thinking:
+                self._streamed_thinking = True
+                self._fire("_fire_reasoning_delta", thinking)
+
+    def _on_assistant(self, message: Any) -> None:
+        self._note_session_id(getattr(message, "session_id", None))
+        stop_reason = getattr(message, "stop_reason", None)
+        if stop_reason:
+            self.stop_reason = str(stop_reason)
+        error = getattr(message, "error", None)
+        if error:
+            self.is_error = True
+            self.error = str(error)
+
+        # A new assistant turn closes the previous one's tool round.
+        self._flush_pending_tools()
+
+        text_parts: List[str] = []
+        thinking_parts: List[str] = []
+        tool_calls: List[Dict[str, Any]] = []
+        for block in _blocks(message):
+            kind = _block_kind(block)
+            if kind == "TextBlock":
+                text = getattr(block, "text", "") or ""
+                if text:
+                    text_parts.append(text)
+            elif kind == "ThinkingBlock":
+                thinking = getattr(block, "thinking", "") or ""
+                if thinking:
+                    thinking_parts.append(thinking)
+            elif kind == "ToolUseBlock":
+                tool_calls.append(
+                    {
+                        "id": str(getattr(block, "id", "") or f"claude_{uuid.uuid4().hex[:16]}"),
+                        "name": str(getattr(block, "name", "") or "unknown"),
+                        "input": getattr(block, "input", None) or {},
+                    }
+                )
+
+        if thinking_parts and not self._streamed_thinking:
+            self._fire("_fire_reasoning_delta", "\n".join(thinking_parts))
+        text = "".join(text_parts)
+        if text:
+            self._assistant_text_parts.append(text)
+            if not self._streamed_text:
+                self._fire("_fire_stream_delta", text)
+            if tool_calls and getattr(self._agent, "show_commentary", True):
+                # Mid-turn narration alongside a tool call — same contract as
+                # the codex runtime's interim commentary channel.
+                self._fire(
+                    "_emit_interim_assistant_message",
+                    {"role": "assistant", "content": text},
+                )
+
+        self._append_assistant_message(
+            text,
+            tool_calls,
+            reasoning="\n".join(thinking_parts) if thinking_parts else None,
+        )
+
+        for call in tool_calls:
+            self._start_tool(call)
+
+    def _on_user(self, message: Any) -> None:
+        for block in _blocks(message):
+            if _block_kind(block) != "ToolResultBlock":
+                continue
+            self._complete_tool(block)
+        if self._pending_calls and all(
+            call["id"] in self._pending_results for call in self._pending_calls
+        ):
+            self._flush_pending_tools()
+
+    def _on_system(self, message: Any) -> None:
+        data = getattr(message, "data", None)
+        if isinstance(data, dict):
+            self._note_session_id(data.get("session_id"))
+        if getattr(message, "subtype", "") == "mirror_error":
+            # The stand-in SDK the suite installs when the extra is absent may
+            # deliver this as a plain SystemMessage.
+            self._on_mirror_error(message)
+            return
+        if getattr(message, "subtype", "") == "compact_boundary":
+            self.compacted = True
+
+    def _on_mirror_error(self, message: Any) -> None:
+        """A transcript-mirror batch was dropped after its retries.
+
+        Not fatal and NOT a turn failure: Claude's own local JSONL is already
+        durable, so the conversation continues intact — what is lost is a slice
+        of Hermes' copy, which degrades a later resume or rewind. Surfaced as a
+        Hermes warning rather than swallowed, because silently losing
+        durability is exactly the failure mode a mirror is supposed to prevent.
+        """
+        detail = getattr(message, "error", "") or ""
+        if not detail:
+            data = getattr(message, "data", None)
+            if isinstance(data, dict):
+                detail = str(data.get("error") or "")
+        self.mirror_errors.append(detail or "unknown mirror error")
+        logger.warning(
+            "claude_agent_sdk transcript mirror dropped a batch (session=%s): %s "
+            "— this turn is unaffected, but the durable copy is now incomplete",
+            self.session_id or "unknown",
+            detail or "no detail reported",
+        )
+        self._fire(
+            "_emit_status",
+            "Claude transcript mirror failed — this session may not resume cleanly.",
+        )
+
+    def _on_result(self, message: Any) -> None:
+        self._note_session_id(getattr(message, "session_id", None))
+        self._flush_pending_tools()
+        self.usage = getattr(message, "usage", None)
+        self.total_cost_usd = getattr(message, "total_cost_usd", None)
+        self.terminal_reason = getattr(message, "terminal_reason", None) or getattr(
+            message, "subtype", None
+        )
+        result = getattr(message, "result", None)
+        if isinstance(result, str) and result.strip():
+            self.result_text = result
+        if getattr(message, "is_error", False):
+            self.is_error = True
+            errors = getattr(message, "errors", None)
+            if not self.error:
+                self.error = (
+                    "; ".join(str(e) for e in errors)
+                    if isinstance(errors, list) and errors
+                    else (result or "Claude Agent SDK reported an error")
+                )
+
+    # -- tool lifecycle ----------------------------------------------------
+
+    def _start_tool(self, call: Dict[str, Any]) -> None:
+        name = display_tool_name(call["name"])
+        args = call["input"] if isinstance(call["input"], dict) else {}
+        self._tool_started_at[call["id"]] = time.monotonic()
+        self.tool_iterations += 1
+        try:
+            preview = json.dumps(args, ensure_ascii=False)[:120] if args else None
+        except (TypeError, ValueError):
+            preview = None
+        self._fire("tool_progress_callback", "tool.started", name, preview, args)
+        self._fire("tool_start_callback", call["id"], name, args)
+
+    def _complete_tool(self, block: Any) -> None:
+        tool_use_id = str(getattr(block, "tool_use_id", "") or "")
+        call = next(
+            (c for c in self._pending_calls if c["id"] == tool_use_id),
+            None,
+        )
+        name = display_tool_name(call["name"]) if call else tool_use_id or "tool"
+        args = (call or {}).get("input") or {}
+        content = _tool_result_content(self._agent, name, getattr(block, "content", None))
+        self._pending_results[tool_use_id] = content
+        is_error = bool(getattr(block, "is_error", False))
+        started = self._tool_started_at.pop(tool_use_id, None)
+        duration = time.monotonic() - started if started is not None else None
+        self._fire(
+            "tool_progress_callback",
+            "tool.completed",
+            name,
+            None,
+            None,
+            duration=duration,
+            is_error=is_error,
+            result=content,
+        )
+        self._fire("tool_complete_callback", tool_use_id, name, args, content)
+
+    # -- message projection ------------------------------------------------
+
+    def _append_assistant_message(
+        self,
+        text: str,
+        tool_calls: List[Dict[str, Any]],
+        *,
+        reasoning: Optional[str] = None,
+    ) -> None:
+        if not text and not tool_calls:
+            return
+        if not tool_calls and self._can_merge_assistant_text():
+            previous = self.projected_messages[-1]
+            previous["content"] = f"{previous.get('content') or ''}\n\n{text}".strip()
+            return
+        message: Dict[str, Any] = {
+            "role": "assistant",
+            "content": text or None,
+        }
+        if reasoning:
+            message["reasoning"] = reasoning
+        if tool_calls:
+            message["tool_calls"] = [
+                {
+                    "id": call["id"],
+                    "type": "function",
+                    "function": {
+                        "name": display_tool_name(call["name"]),
+                        "arguments": _dump_args(call["input"]),
+                    },
+                }
+                for call in tool_calls
+            ]
+            self._pending_calls = list(tool_calls)
+            self._pending_results = {}
+        self.projected_messages.append(message)
+
+    def _can_merge_assistant_text(self) -> bool:
+        """Two assistant messages in a row would break role alternation."""
+        if not self.projected_messages:
+            return False
+        last = self.projected_messages[-1]
+        return last.get("role") == "assistant" and not last.get("tool_calls")
+
+    def _flush_pending_tools(self) -> None:
+        """Emit one tool message per pending call, in tool_calls order.
+
+        Results can arrive out of order (parallel tools land as they finish),
+        but a provider replaying this transcript expects each ``tool_calls``
+        entry to be answered in the order it was issued, and every one of them
+        to be answered at all — an unanswered id breaks the next request.
+        """
+        if not self._pending_calls:
+            return
+        for call in self._pending_calls:
+            content = self._pending_results.get(call["id"])
+            if content is None:
+                content = "[no result returned by the Claude Agent SDK]"
+            self.projected_messages.append(
+                {
+                    "role": "tool",
+                    "name": display_tool_name(call["name"]),
+                    "tool_name": display_tool_name(call["name"]),
+                    "tool_call_id": call["id"],
+                    "content": content,
+                }
+            )
+        self._pending_calls = []
+        self._pending_results = {}
+
+    def _note_session_id(self, session_id: Any) -> None:
+        if not session_id:
+            return
+        session_id = str(session_id)
+        if session_id == self.session_id:
+            return
+        self.session_id = session_id
+        # PR5 resumes from this. Stored on the agent so a rebuilt session
+        # facade (or a durable SessionStore mirror) can pick it back up.
+        self._agent._claude_sdk_session_id = session_id
+
+    # -- terminal ----------------------------------------------------------
+
+    def finalize(self) -> List[Dict[str, Any]]:
+        """Close out the turn and return the projected messages, once.
+
+        Idempotent: a second call returns an empty list so a caller that
+        finalizes on both the normal and the error path cannot splice the same
+        messages into the conversation twice.
+        """
+        if self._finalized:
+            return []
+        self._finalized = True
+        self._flush_pending_tools()
+        return self.projected_messages
+
+    @property
+    def final_text(self) -> str:
+        if self.result_text:
+            return self.result_text
+        return "".join(self._assistant_text_parts)
+
+
+def _dump_args(args: Any) -> str:
+    try:
+        return json.dumps(args or {}, ensure_ascii=False)
+    except (TypeError, ValueError):
+        return json.dumps({"_raw": str(args)}, ensure_ascii=False)
+
+
+def make_claude_event_projector(agent) -> ClaudeEventProjector:
+    """Build the per-turn projector bound to *agent*."""
+    return ClaudeEventProjector(agent)
+
+
+# ---------------------------------------------------------------------------
+# Accounting
+# ---------------------------------------------------------------------------
+
+
+def _coerce_usage_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)):
+        return max(int(value), 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+def record_claude_usage(agent, projector: ClaudeEventProjector) -> Dict[str, Any]:
+    """Translate the SDK's turn usage into Hermes accounting.
+
+    Claude reports Anthropic-shaped usage (``input_tokens``,
+    ``output_tokens``, ``cache_creation_input_tokens``,
+    ``cache_read_input_tokens``).  Hermes' canonical prompt bucket is
+    uncached input + cached input, same as every other Anthropic path.
+
+    A turn with no usage still counts as one API call for session/status
+    accounting, mirroring the codex app-server runtime.
+    """
+    agent.session_api_calls += 1
+
+    usage = projector.usage
+    if not isinstance(usage, dict) or not usage:
+        compressor = getattr(agent, "context_compressor", None)
+        if compressor is not None and getattr(
+            compressor, "awaiting_real_usage_after_compression", False
+        ):
+            compressor.update_from_response({})
+        _persist_api_call_only(agent)
+        return {}
+
+    from agent.usage_pricing import CanonicalUsage, estimate_usage_cost
+
+    canonical_usage = CanonicalUsage(
+        input_tokens=_coerce_usage_int(usage.get("input_tokens")),
+        output_tokens=_coerce_usage_int(usage.get("output_tokens")),
+        cache_read_tokens=_coerce_usage_int(usage.get("cache_read_input_tokens")),
+        cache_write_tokens=_coerce_usage_int(usage.get("cache_creation_input_tokens")),
+        reasoning_tokens=0,
+        raw_usage=usage,
+    )
+    usage_dict = {
+        "prompt_tokens": canonical_usage.prompt_tokens,
+        "completion_tokens": canonical_usage.output_tokens,
+        "total_tokens": canonical_usage.total_tokens,
+        "input_tokens": canonical_usage.input_tokens,
+        "output_tokens": canonical_usage.output_tokens,
+        "cache_read_tokens": canonical_usage.cache_read_tokens,
+        "cache_write_tokens": canonical_usage.cache_write_tokens,
+        "reasoning_tokens": canonical_usage.reasoning_tokens,
+    }
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        try:
+            compressor.update_from_response(usage_dict)
+        except Exception:
+            logger.debug("claude_agent_sdk usage update failed", exc_info=True)
+
+    agent.session_prompt_tokens += canonical_usage.prompt_tokens
+    agent.session_completion_tokens += canonical_usage.output_tokens
+    agent.session_total_tokens += canonical_usage.total_tokens
+    agent.session_input_tokens += canonical_usage.input_tokens
+    agent.session_output_tokens += canonical_usage.output_tokens
+    agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
+    agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
+    agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+
+    cost_result = estimate_usage_cost(
+        agent.model,
+        canonical_usage,
+        provider=agent.provider,
+        base_url=agent.base_url,
+        api_key="",
+    )
+    if cost_result.amount_usd is not None:
+        agent.session_estimated_cost_usd += float(cost_result.amount_usd)
+    agent.session_cost_status = cost_result.status
+    agent.session_cost_source = cost_result.source
+
+    if agent._session_db and agent.session_id:
+        try:
+            if not agent._session_db_created:
+                agent._ensure_db_session()
+            agent._session_db.queue_token_counts(
+                agent.session_id,
+                input_tokens=canonical_usage.input_tokens,
+                output_tokens=canonical_usage.output_tokens,
+                cache_read_tokens=canonical_usage.cache_read_tokens,
+                cache_write_tokens=canonical_usage.cache_write_tokens,
+                reasoning_tokens=canonical_usage.reasoning_tokens,
+                estimated_cost_usd=float(cost_result.amount_usd)
+                if cost_result.amount_usd is not None
+                else None,
+                cost_status=cost_result.status,
+                cost_source=cost_result.source,
+                billing_provider=agent.provider,
+                billing_base_url=agent.base_url,
+                billing_mode="subscription_included"
+                if cost_result.status == "included"
+                else None,
+                model=agent.model,
+                api_call_count=1,
+            )
+        except Exception as exc:
+            logger.debug(
+                "claude_agent_sdk token persistence failed (session=%s): %s",
+                agent.session_id,
+                exc,
+            )
+
+    return {
+        **usage_dict,
+        "last_prompt_tokens": canonical_usage.prompt_tokens,
+        "estimated_cost_usd": float(cost_result.amount_usd)
+        if cost_result.amount_usd is not None
+        else None,
+        "cost_status": cost_result.status,
+        "cost_source": cost_result.source,
+        # What the SDK says the same turn would have cost on the API. Under a
+        # subscription this is not what the user is charged; it is reported so
+        # the two billing sources can be compared, never summed.
+        "claude_sdk_reported_cost_usd": projector.total_cost_usd,
+    }
+
+
+def _persist_api_call_only(agent) -> None:
+    if not (agent._session_db and agent.session_id):
+        return
+    try:
+        if not agent._session_db_created:
+            agent._ensure_db_session()
+        agent._session_db.queue_token_counts(
+            agent.session_id,
+            model=agent.model,
+            billing_provider=agent.provider,
+            billing_base_url=agent.base_url,
+            billing_mode="subscription_included",
+            api_call_count=1,
+        )
+    except Exception as exc:
+        logger.debug(
+            "claude_agent_sdk api-call persistence failed (session=%s): %s",
+            agent.session_id,
+            exc,
+        )
+
+
+def record_claude_compaction(agent, projector: ClaudeEventProjector) -> bool:
+    """Record a Claude-native compaction boundary in Hermes state.
+
+    The SDK owns the compacted context, so Hermes does not rewrite local
+    transcript rows here — it records the boundary while preserving the
+    visible transcript, exactly as the codex app-server runtime does.
+    """
+    if not projector.compacted:
+        return False
+
+    logger.info(
+        "claude_agent_sdk compaction observed: session=%s sdk_session=%s",
+        getattr(agent, "session_id", None) or "none",
+        projector.session_id or "none",
+    )
+    try:
+        from agent.conversation_compression import COMPACTION_STATUS
+
+        agent._emit_status(COMPACTION_STATUS)
+    except Exception:
+        pass
+
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is not None:
+        compressor.compression_count = getattr(compressor, "compression_count", 0) + 1
+        record_boundary = getattr(type(compressor), "record_completed_compaction", None)
+        if callable(record_boundary):
+            # Claude owns this summary; a prior Hermes deterministic-fallback
+            # flag must not leak into the native boundary's quality verdict.
+            record_boundary(compressor, used_fallback=False)
+        elif hasattr(compressor, "_verify_compaction_cleared_threshold"):
+            compressor._verify_compaction_cleared_threshold = True
+
+    agent._last_compaction_in_place = False
+    try:
+        if getattr(agent, "event_callback", None):
+            agent.event_callback(
+                "session:compress",
+                {
+                    "platform": getattr(agent, "platform", None) or "",
+                    "session_id": getattr(agent, "session_id", None) or "",
+                    "old_session_id": "",
+                    "in_place": False,
+                    "compression_count": getattr(compressor, "compression_count", 0)
+                    if compressor is not None
+                    else 0,
+                    "runtime": RUNTIME_LABEL,
+                    "claude_session_id": projector.session_id or "",
+                },
+            )
+    except Exception:
+        logger.debug("event_callback error on claude session:compress", exc_info=True)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Turn runner
+# ---------------------------------------------------------------------------
+
+
+def _ensure_session(agent, effective_task_id: str) -> Any:
+    """Return this agent's ``ClaudeAgentSession``, building it on first turn.
+
+    ``effective_task_id`` is captured by reference through a mutable holder so
+    the long-lived MCP server follows the *current* turn's task id, not the
+    one that happened to be active when the session was built.
+    """
+    from agent.transports.claude_agent_session import ClaudeAgentSession
+
+    holder = getattr(agent, "_claude_task_id_holder", None)
+    if holder is None:
+        holder = {"task_id": effective_task_id}
+        agent._claude_task_id_holder = holder
+    else:
+        holder["task_id"] = effective_task_id
+
+    session = getattr(agent, "_claude_session", None)
+    if session is not None and not session.closed:
+        return session
+
+    cwd = _session_cwd(agent)
+
+    # Reuse the exact string the normal path already built for this
+    # conversation — never a second render. AGENTS.md requires the system
+    # prompt to be byte-stable for the life of a conversation, and the SDK
+    # keeps whatever we hand it at connect time for every later turn. The
+    # rebuild below only covers a caller that reached here without going
+    # through build_turn_context, and it caches back so it stays the one
+    # string this session uses.
+    system_prompt = getattr(agent, "_cached_system_prompt", None)
+    if not system_prompt:
+        system_prompt = agent._build_system_prompt()
+        agent._cached_system_prompt = system_prompt
+
+    def _options_factory() -> Any:
+        return build_claude_agent_options(
+            agent,
+            system_prompt=system_prompt,
+            effective_task_id=lambda: holder["task_id"],
+            cwd=cwd,
+        )
+
+    from agent.transports.claude_sanitized_transport import build_sanitized_transport
+
+    session = ClaudeAgentSession(
+        options_factory=_options_factory,
+        # The CLI is spawned from a sanitized environment, not from a copy of
+        # os.environ — see the transport module for why options.env cannot do
+        # this.
+        transport_factory=build_sanitized_transport,
+    )
+    agent._claude_session = session
+    # Connect here, not lazily inside the first run_turn: a connect that
+    # fails while a resume id is set is the *structural* stale-session
+    # signal, and the caller's `at_connect=True` handler is wrapped around
+    # this function. Deferring the connect would route that failure through
+    # the mid-turn handler instead, leaving recovery to depend entirely on
+    # matching the CLI's error strings. Idempotent for an already-started
+    # session.
+    session.ensure_started()
+    return session
+
+
+def _retire_session(agent) -> None:
+    # The next session re-proves its billing source rather than trusting a
+    # verdict taken before the environment could have changed.
+    agent._claude_billing_refusal = _UNSET
+    session = getattr(agent, "_claude_session", None)
+    if session is None:
+        return
+    try:
+        session.close()
+    except Exception:
+        logger.debug("claude_agent_sdk session close failed", exc_info=True)
+    agent._claude_session = None
+
+
+def _mirror_watermark(agent, resume: Optional[str]) -> int:
+    """Highest mirrored entry id before this turn (0 for a fresh session)."""
+    db = getattr(agent, "_session_db", None)
+    if db is None or not resume:
+        return 0
+    from agent.claude_session_store import RUNTIME
+
+    try:
+        return db.provider_transcript_watermark(
+            RUNTIME,
+            getattr(agent, "_claude_project_key", "") or "",
+            resume,
+        )
+    except Exception:
+        logger.debug("claude_agent_sdk watermark read failed", exc_info=True)
+        return 0
+
+
+def _can_recover(
+    agent,
+    sdk_state: Dict[str, Any],
+    already_tried: bool,
+    error: str,
+    *,
+    at_connect: bool,
+) -> bool:
+    """Should this failure be retried as a stale-session recovery?
+
+    Four independent conditions, all required, so a broken binding can never
+    loop: one recovery per turn, a persisted per-session ceiling, evidence
+    that we were actually resuming something (a fresh session that fails is a
+    real failure, not a stale cursor), and evidence that the resume is what
+    broke — a connect that fails while resuming, or a CLI error that names a
+    missing session. A mid-turn network blip does not qualify and is reported
+    as the failure it is.
+    """
+    if already_tried or not sdk_state.get("resume"):
+        return False
+    if not (at_connect or _looks_stale(error)):
+        return False
+    if int(sdk_state.get("recoveries") or 0) >= MAX_SESSION_RECOVERIES:
+        logger.warning(
+            "claude_agent_sdk session recovery cap (%s) reached for session %s; "
+            "not retrying",
+            MAX_SESSION_RECOVERIES,
+            getattr(agent, "session_id", None) or "none",
+        )
+        return False
+    return True
+
+
+def _recover_stale_session(
+    agent,
+    sdk_state: Dict[str, Any],
+    messages: List[Dict[str, Any]],
+    user_message: str,
+) -> str:
+    """Drop a stale binding, start clean, and bootstrap history once.
+
+    Returns the prompt for the retry.  The user's turn is submitted exactly
+    once overall — this replaces the failed attempt, it does not add one.
+    """
+    db = getattr(agent, "_session_db", None)
+    hermes_session = getattr(agent, "session_id", None)
+    logger.warning(
+        "claude_agent_sdk session %s could not be resumed; starting a fresh "
+        "Claude session and replaying Hermes history once",
+        sdk_state.get("resume"),
+    )
+    if db is not None and hermes_session:
+        from agent.claude_session_store import RUNTIME
+
+        try:
+            sdk_state["recoveries"] = db.clear_provider_runtime_session(
+                hermes_session, RUNTIME
+            )
+        except Exception:
+            logger.debug("claude_agent_sdk binding clear failed", exc_info=True)
+    sdk_state["resume"] = None
+    agent._claude_sdk_resume_id = None
+    agent._claude_sdk_session_id = None
+    _retire_session(agent)
+    prefix = claude_bootstrap_prefix(messages[:-1] if messages else [])
+    from agent.claude_sdk_input import prepend_text_to_prompt
+
+    return prepend_text_to_prompt(user_message, prefix)
+
+
+def _failure_result(
+    agent,
+    messages: List[Dict[str, Any]],
+    *,
+    final_response: str,
+    error: str,
+) -> Dict[str, Any]:
+    user_interrupted = bool(getattr(agent, "_interrupt_requested", False))
+    interrupt_message = (
+        getattr(agent, "_interrupt_message", None) if user_interrupted else None
+    )
+    if user_interrupted:
+        agent.clear_interrupt()
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "api_calls": 0,
+        "completed": False,
+        "partial": True,
+        "failed": True,
+        "interrupted": user_interrupted,
+        **({"interrupt_message": interrupt_message} if interrupt_message else {}),
+        "error": error,
+    }
+
+
+def run_claude_agent_sdk_turn(
+    agent,
+    *,
+    user_message: str,
+    original_user_message: Any,
+    messages: List[Dict[str, Any]],
+    effective_task_id: str,
+    should_review_memory: bool = False,
+) -> Dict[str, Any]:
+    """Claude Agent SDK runtime path — hands the whole turn to the SDK.
+
+    Called from ``run_conversation()`` when ``agent.api_mode ==
+    "claude_agent_sdk"``.  Returns the same dict shape as the
+    chat_completions path.
+    """
+    preflight_error = claude_runtime_preflight()
+    if preflight_error:
+        logger.info("claude_agent_sdk turn refused: %s", preflight_error)
+        return _failure_result(
+            agent,
+            messages,
+            final_response=preflight_error,
+            error=preflight_error,
+        )
+
+    # Refuse rather than mis-bill: a turn that would be charged to an API
+    # account instead of the user's plan does not run at all.
+    billing_refusal = verify_claude_billing_for_agent(agent)
+    if billing_refusal:
+        logger.info("claude_agent_sdk turn refused: %s", billing_refusal)
+        return _failure_result(
+            agent,
+            messages,
+            final_response=billing_refusal,
+            error=billing_refusal,
+        )
+
+    cwd = _session_cwd(agent)
+    # Resolve the durable binding BEFORE the session is built: a pending
+    # rewind or branch forks the mirrored transcript first, and the resume id
+    # that comes out of it is what build_claude_agent_options() reads.
+    sdk_state = prepare_claude_sdk_session(agent, cwd)
+
+    # NOTE: the user message is ALREADY appended to messages by the standard
+    # run_conversation() flow before the early return reaches us. Do NOT
+    # append again — that would duplicate it.
+    #
+    # ``user_ordinal`` is this turn's position among the visible user rows;
+    # it is the anchor a later rewind looks the SDK message UUID up by. Taken
+    # from the in-memory transcript so it matches what the DB holds after the
+    # turn-start flush.
+    user_ordinal = (
+        sum(
+            1
+            for m in messages
+            if m.get("role") == "user" and not m.get("display_kind")
+        )
+        - 1
+    )
+
+    projector = make_claude_event_projector(agent)
+    turn_error: Optional[str] = None
+    should_retire = False
+    attempted_recovery = False
+    prompt = user_message
+    if sdk_state.get("bootstrap"):
+        # Exactly once per conversation: a provider switch into Claude, or a
+        # session older than the mirror. Everything after this resumes.
+        prefix = claude_bootstrap_prefix(messages[:-1] if messages else [])
+        context = claude_context_prefix(agent, _hermes_system_prompt(agent))
+        if prefix or context:
+            logger.info(
+                "claude_agent_sdk bootstrapping Hermes context%s into a new "
+                "session (session=%s)",
+                " and canonical history" if prefix else "",
+                getattr(agent, "session_id", None) or "none",
+            )
+            from agent.claude_sdk_input import prepend_text_to_prompt
+
+            prompt = prepend_text_to_prompt(user_message, context + prefix)
+
+    while True:
+        try:
+            session = _ensure_session(agent, effective_task_id)
+        except Exception as exc:
+            # A connect that fails while a resume id is set is the structural
+            # signature of a stale or deleted SDK session: the CLI was asked
+            # to resume a transcript that no longer resolves.
+            if _can_recover(
+                agent, sdk_state, attempted_recovery, str(exc), at_connect=True
+            ):
+                attempted_recovery = True
+                prompt = _recover_stale_session(
+                    agent, sdk_state, messages, user_message
+                )
+                continue
+            logger.exception("claude_agent_sdk session construction failed")
+            detail = f"Claude Agent SDK could not start: {exc}"
+            _retire_session(agent)
+            return _failure_result(
+                agent, messages, final_response=detail, error=str(exc)
+            )
+
+        watermark = _mirror_watermark(agent, sdk_state.get("resume"))
+        turn_error = None
+        try:
+            session.run_turn(
+                prompt,
+                on_message=projector,
+                timeout=DEFAULT_TURN_TIMEOUT_SECONDS,
+            )
+        except TimeoutError as exc:
+            turn_error = str(exc)
+            should_retire = True
+            logger.warning("claude_agent_sdk turn timed out: %s", exc)
+        except Exception as exc:
+            turn_error = str(exc)
+            should_retire = True
+            if _can_recover(
+                agent, sdk_state, attempted_recovery, str(exc), at_connect=False
+            ):
+                attempted_recovery = True
+                should_retire = False
+                projector = make_claude_event_projector(agent)
+                prompt = _recover_stale_session(
+                    agent, sdk_state, messages, user_message
+                )
+                continue
+            logger.exception("claude_agent_sdk turn failed")
+        break
+
+    projected = projector.finalize()
+    if projector.session_id:
+        session.note_session_id(projector.session_id)
+        record_claude_session_binding(
+            agent,
+            projector,
+            cwd=cwd,
+            user_ordinal=user_ordinal,
+            watermark=watermark,
+        )
+    if turn_error is None and projector.error:
+        turn_error = projector.error
+
+    # A wedged or crashed client must not be reused: the next turn respawns
+    # the CLI from scratch rather than riding a broken subprocess.
+    if should_retire:
+        _retire_session(agent)
+
+    user_interrupted = bool(getattr(agent, "_interrupt_requested", False))
+    interrupt_message = (
+        getattr(agent, "_interrupt_message", None) if user_interrupted else None
+    )
+    if user_interrupted:
+        agent.clear_interrupt()
+
+    if projected:
+        messages.extend(projected)
+        # This path is an early return that bypasses conversation_loop, whose
+        # per-step _persist_session() calls would otherwise flush these rows.
+        # The inbound user turn was already flushed at turn start and the
+        # flush dedups via _DB_PERSISTED_MARKER, so this writes ONLY the new
+        # rows — which is what lets us report agent_persisted=True below and
+        # keep the gateway from re-INSERTing the user turn (#860 / #42039).
+        if getattr(agent, "_session_db", None) is not None:
+            try:
+                flushed = agent._flush_messages_to_session_db(messages)
+            except Exception:
+                flushed = False
+                logger.warning(
+                    "claude_agent_sdk projected-message flush failed", exc_info=True
+                )
+            if flushed is False:
+                logger.warning(
+                    "claude_agent_sdk turn was delivered but could NOT be "
+                    "persisted to the session DB (session=%s) — this turn "
+                    "will be missing after restart/resume",
+                    getattr(agent, "session_id", None),
+                )
+
+    # _turns_since_memory / _user_turn_count are already incremented in the
+    # run_conversation() pre-loop block; only the skill counter needs an
+    # explicit bump because the tool-iteration loop is bypassed here.
+    agent._iters_since_skill = (
+        getattr(agent, "_iters_since_skill", 0) + projector.tool_iterations
+    )
+    record_claude_compaction(agent, projector)
+    usage_result = record_claude_usage(agent, projector)
+
+    should_review_skills = False
+    if (
+        agent._skill_nudge_interval > 0
+        and agent._iters_since_skill >= agent._skill_nudge_interval
+        and "skill_manage" in agent.valid_tool_names
+    ):
+        should_review_skills = True
+        agent._iters_since_skill = 0
+
+    final_text = projector.final_text
+    completed = turn_error is None and not user_interrupted and not projector.is_error
+
+    if completed:
+        try:
+            agent._sync_external_memory_for_turn(
+                original_user_message=original_user_message,
+                final_response=final_text,
+                interrupted=False,
+                messages=messages,
+            )
+        except Exception:
+            logger.debug("external memory sync raised", exc_info=True)
+
+    if final_text and completed and (should_review_memory or should_review_skills):
+        try:
+            agent._spawn_background_review(
+                messages_snapshot=list(messages),
+                review_memory=should_review_memory,
+                review_skills=should_review_skills,
+            )
+        except Exception:
+            logger.debug("background review spawn raised", exc_info=True)
+
+    if turn_error and not final_text:
+        final_text = f"Claude Agent SDK turn failed: {turn_error}"
+
+    return {
+        "final_response": final_text,
+        "messages": messages,
+        "api_calls": 1,
+        "completed": completed,
+        "partial": not completed,
+        "interrupted": user_interrupted,
+        **({"interrupt_message": interrupt_message} if interrupt_message else {}),
+        "error": turn_error,
+        "agent_persisted": True,
+        "claude_session_id": projector.session_id,
+        "claude_terminal_reason": projector.terminal_reason,
+        **usage_result,
+    }
+
+
+__all__ = [
+    "BOOTSTRAP_MAX_CHARS",
+    "BOOTSTRAP_MAX_MESSAGES",
+    "MAX_SESSION_RECOVERIES",
+    "RUNTIME_LABEL",
+    "ClaudeEventProjector",
+    "build_claude_agent_options",
+    "claude_bootstrap_prefix",
+    "claude_project_key",
+    "claude_runtime_preflight",
+    "display_tool_name",
+    "make_claude_event_projector",
+    "prepare_claude_sdk_session",
+    "record_claude_compaction",
+    "record_claude_session_binding",
+    "record_claude_usage",
+    "run_claude_agent_sdk_turn",
+    "verify_claude_billing_for_agent",
+]

--- a/agent/claude_sdk_input.py
+++ b/agent/claude_sdk_input.py
@@ -1,0 +1,337 @@
+"""Input shaping for the Claude Agent SDK — text, images, and the capability probe.
+
+Hermes carries user turns and auxiliary prompts as OpenAI-shaped content
+(a string, or a list of ``{"type": "text"|"image_url", ...}`` parts).  The SDK
+takes either a plain string or an async iterable of *stream-json* frames — the
+same envelope the Claude Code CLI reads on stdin — whose ``content`` is
+Anthropic-shaped blocks.
+
+This module owns that translation, and the honest answer to "can the installed
+SDK carry an image at all?".  Both matter because the alternative behaviours are
+unacceptable: silently dropping the image, or falling back to the pre-SDK direct
+HTTP path this runtime exists to remove
+(``docs/design/claude-subscription-via-agent-sdk.md`` § 3).
+
+Deliberately free of any dependency on :mod:`agent.anthropic_adapter`: that
+module is the legacy direct-OAuth path and is scheduled for deletion, so the
+SDK runtime must not grow a link to it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import re
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ClaudeImageInputUnsupported(RuntimeError):
+    """Raised when an image cannot be delivered through the installed SDK."""
+
+
+# OpenAI-shaped part types that carry an image.
+IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
+
+_DATA_URL_RE = re.compile(
+    r"^data:(?P<mime>[\w.+-]+/[\w.+-]+)?(?P<params>;[^,]*)?,(?P<data>.*)$",
+    re.DOTALL,
+)
+
+# What a caller is told when the runtime cannot carry the image itself. Points
+# at the one supported alternative rather than at a provider we would pick for
+# the user: the vision task's provider is an explicit config decision because it
+# is a second billing source.
+VISION_PROVIDER_REQUIRED_MESSAGE = (
+    "The installed claude-agent-sdk cannot carry image input, so the Claude "
+    "subscription runtime cannot see this image. Configure an explicit vision "
+    "backend under `auxiliary.vision` in config.yaml (provider + model) and "
+    "Hermes will describe the image through it instead. The image was NOT sent."
+)
+
+
+# ---------------------------------------------------------------------------
+# Capability probe
+# ---------------------------------------------------------------------------
+
+
+def _accepts_async_iterable(fn: Any) -> bool:
+    """True when *fn*'s ``prompt`` parameter is annotated to take a stream.
+
+    Signature introspection rather than a version comparison: the pin in
+    ``pyproject.toml`` is a range, and what matters is what the installed
+    package can actually be handed.
+    """
+    try:
+        parameters = inspect.signature(fn).parameters
+    except (TypeError, ValueError):  # pragma: no cover - exotic callables
+        return False
+    param = parameters.get("prompt")
+    if param is None:
+        return False
+    annotation = param.annotation
+    if annotation is inspect.Parameter.empty:
+        return False
+    return "asynciterable" in str(annotation).lower().replace(" ", "")
+
+
+def sdk_supports_streaming_input() -> bool:
+    """True when this SDK build accepts structured (image-capable) input.
+
+    Checks both entry points Hermes uses — the one-shot ``query()`` for
+    auxiliary work and ``ClaudeSDKClient.query()`` for the conversation — because
+    a build that only supports one of them supports neither for our purposes.
+    Never raises: a missing extra is simply "no".
+    """
+    try:
+        from claude_agent_sdk import ClaudeSDKClient, query
+    except Exception:
+        return False
+    return _accepts_async_iterable(query) and _accepts_async_iterable(
+        ClaudeSDKClient.query
+    )
+
+
+# ---------------------------------------------------------------------------
+# Content translation
+# ---------------------------------------------------------------------------
+
+
+def _part_type(part: Any) -> str:
+    if isinstance(part, dict):
+        return str(part.get("type") or "")
+    return ""
+
+
+def content_has_images(content: Any) -> bool:
+    """True when OpenAI-shaped *content* carries at least one image part."""
+    if not isinstance(content, list):
+        return False
+    return any(_part_type(part) in IMAGE_PART_TYPES for part in content)
+
+
+def messages_have_images(messages: Any) -> bool:
+    """True when any message in an OpenAI-shaped list carries an image."""
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if isinstance(message, dict) and content_has_images(message.get("content")):
+            return True
+    return False
+
+
+def _image_source_from_url(url: str) -> Optional[Dict[str, Any]]:
+    """Build an Anthropic image ``source`` from an OpenAI image URL.
+
+    Handles the two forms Hermes actually produces: a base64 data URL (the
+    common case — screenshots, pasted images, tool results) and a remote
+    ``http(s)`` URL.  Anything else returns None so the caller can drop the part
+    rather than send a block the CLI will reject.
+    """
+    url = str(url or "").strip()
+    if not url:
+        return None
+    if url.startswith("data:"):
+        match = _DATA_URL_RE.match(url)
+        if not match:
+            return None
+        params = match.group("params") or ""
+        if "base64" not in params.lower():
+            # Only base64 payloads are representable as an Anthropic source.
+            return None
+        data = (match.group("data") or "").strip()
+        if not data:
+            return None
+        return {
+            "type": "base64",
+            "media_type": match.group("mime") or "image/png",
+            "data": data,
+        }
+    if url.startswith(("http://", "https://")):
+        return {"type": "url", "url": url}
+    return None
+
+
+def content_to_sdk_blocks(content: Any) -> List[Dict[str, Any]]:
+    """Translate OpenAI-shaped content into Anthropic-shaped SDK blocks.
+
+    A bare string becomes a single text block.  Unrepresentable image parts are
+    replaced with a visible text note instead of being dropped silently — a
+    turn that quietly loses the user's screenshot reads to the user as the model
+    ignoring them.
+    """
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        return [{"type": "text", "text": str(content)}]
+
+    blocks: List[Dict[str, Any]] = []
+    for part in content:
+        if isinstance(part, str):
+            if part:
+                blocks.append({"type": "text", "text": part})
+            continue
+        if not isinstance(part, dict):
+            blocks.append({"type": "text", "text": str(part)})
+            continue
+        ptype = _part_type(part)
+        if ptype in {"text", "input_text"}:
+            text = str(part.get("text") or "")
+            if text:
+                blocks.append({"type": "text", "text": text})
+        elif ptype in IMAGE_PART_TYPES:
+            raw = part.get("image_url")
+            url = raw.get("url", "") if isinstance(raw, dict) else str(raw or "")
+            source = _image_source_from_url(url)
+            if source is not None:
+                blocks.append({"type": "image", "source": source})
+            else:
+                logger.debug("claude sdk input: unsupported image url form")
+                blocks.append(
+                    {
+                        "type": "text",
+                        "text": "[an image was attached but could not be encoded]",
+                    }
+                )
+        elif ptype:
+            # Already-Anthropic blocks (thinking, tool_result, ...) pass through.
+            blocks.append(dict(part))
+    return blocks
+
+
+def blocks_to_text(blocks: List[Dict[str, Any]]) -> str:
+    """Flatten SDK blocks back to plain text (images become a placeholder)."""
+    parts: List[str] = []
+    for block in blocks:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "text":
+            parts.append(str(block.get("text") or ""))
+        elif block.get("type") == "image":
+            parts.append("[image]")
+    return "\n".join(p for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
+# Stream-json prompt
+# ---------------------------------------------------------------------------
+
+
+def build_sdk_user_frame(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """One stream-json user frame carrying *blocks*.
+
+    ``session_id`` is deliberately absent: both ``ClaudeSDKClient.query`` and
+    the one-shot ``query()`` fill it in for us, and hard-coding one here is how
+    an auxiliary call would end up writing into the conversation's session.
+    """
+    return {
+        "type": "user",
+        "message": {"role": "user", "content": blocks},
+        "parent_tool_use_id": None,
+    }
+
+
+class ReplayableStreamPrompt:
+    """An async-iterable prompt over materialized frames, safe to re-send.
+
+    A bare async generator is single-use: the stale-session recovery path
+    re-submits the prompt after a failed attempt, and a consumed generator
+    would silently send an empty turn. This object returns a fresh iterator
+    from every ``__aiter__`` call, so a retry replays the same frames.
+
+    Frames are built eagerly on the calling thread but only iterated inside
+    the SDK's own event loop, which keeps it safe to hand across the session
+    facade's thread boundary.
+    """
+
+    def __init__(self, frames: List[Dict[str, Any]]) -> None:
+        self.frames = list(frames)
+
+    def __aiter__(self):
+        async def _iterate():
+            for frame in self.frames:
+                yield frame
+
+        return _iterate()
+
+    def with_prefixed_text(self, text: str) -> "ReplayableStreamPrompt":
+        """A copy whose first user frame carries *text* as its leading block.
+
+        This is how the one-time context/history bootstrap rides an image
+        turn: string prompts are concatenated, frame prompts get the same
+        text as the first content block of the same user message — one turn
+        either way, so role alternation is untouched.
+        """
+        if not text:
+            return self
+        frames = [dict(f) for f in self.frames]
+        first = frames[0]
+        message = dict(first.get("message") or {})
+        content = [{"type": "text", "text": text}, *(message.get("content") or [])]
+        message["content"] = content
+        first["message"] = message
+        frames[0] = first
+        return ReplayableStreamPrompt(frames)
+
+
+def make_sdk_stream_prompt(blocks: List[Dict[str, Any]]) -> Any:
+    """Return a replayable async-iterable prompt yielding one user frame."""
+    return ReplayableStreamPrompt([build_sdk_user_frame(blocks)])
+
+
+def prepend_text_to_prompt(prompt: Any, text: str) -> Any:
+    """Attach bootstrap *text* ahead of *prompt*, whatever shape it has.
+
+    The Claude runtime's one-time bootstrap (Hermes context + prior history)
+    used to do ``text + prompt`` unconditionally, which raises on the frame
+    shape image turns produce — and bootstrap runs on the first turn of every
+    session, so an image in the opening message crashed the turn.
+    """
+    if not text:
+        return prompt
+    if isinstance(prompt, str):
+        return text + prompt
+    if isinstance(prompt, ReplayableStreamPrompt):
+        return prompt.with_prefixed_text(text)
+    raise TypeError(
+        f"cannot prepend bootstrap text to prompt of type {type(prompt).__name__}"
+    )
+
+
+def prompt_for_content(content: Any) -> Any:
+    """Return the prompt to hand the SDK for OpenAI-shaped *content*.
+
+    A plain string stays a plain string — the overwhelmingly common case, and
+    the cheapest thing to send.  Structured content becomes a stream-json frame.
+
+    Raises ``ClaudeImageInputUnsupported`` when the content carries an image and
+    the installed SDK cannot carry one.
+    """
+    if isinstance(content, str):
+        return content
+    if not content_has_images(content):
+        blocks = content_to_sdk_blocks(content)
+        return blocks_to_text(blocks)
+    if not sdk_supports_streaming_input():
+        raise ClaudeImageInputUnsupported(VISION_PROVIDER_REQUIRED_MESSAGE)
+    return make_sdk_stream_prompt(content_to_sdk_blocks(content))
+
+
+__all__ = [
+    "ClaudeImageInputUnsupported",
+    "IMAGE_PART_TYPES",
+    "VISION_PROVIDER_REQUIRED_MESSAGE",
+    "blocks_to_text",
+    "build_sdk_user_frame",
+    "content_has_images",
+    "content_to_sdk_blocks",
+    "make_sdk_stream_prompt",
+    "prepend_text_to_prompt",
+    "ReplayableStreamPrompt",
+    "messages_have_images",
+    "prompt_for_content",
+    "sdk_supports_streaming_input",
+]

--- a/agent/claude_session_store.py
+++ b/agent/claude_session_store.py
@@ -1,0 +1,210 @@
+"""``SessionStore`` adapter: the Claude Agent SDK's transcript mirror → Hermes' DB.
+
+The SDK's ``SessionStore`` protocol is how an embedder gets a durable copy of
+the Claude-native transcript the CLI subprocess writes.  Without it a Claude
+session lives and dies with ``~/.claude/projects/<key>/<uuid>.jsonl`` on one
+machine; with it, Hermes owns a copy in ``state.db`` and can resume, rewind,
+and branch a Claude conversation the same way it does for every other
+provider.
+
+Two boundaries this module is careful about (see
+``docs/design/claude-subscription-via-agent-sdk.md``):
+
+* **Entries are opaque.**  Nothing here reads inside a transcript entry except
+  to pull ``uuid`` for idempotency.  The shape is the CLI's internal JSONL
+  union; interpreting it would be Hermes reimplementing Claude's context, and
+  the SDK's own contract is only that entries round-trip *deep-equal*, not
+  byte-equal.
+* **Summaries are folded by the SDK, not by us.**  ``fold_session_summary`` is
+  a pure function the SDK exports precisely so adapters do not have to know
+  what a summary contains.  We call it inside the DB's write transaction so
+  concurrent appends cannot interleave read-fold-write on the sidecar, and we
+  stamp ``mtime`` afterwards because the fold deliberately never does.
+
+``SessionDB`` is synchronous SQLite and the SDK calls the store from an async
+context, so every method hops through :func:`asyncio.to_thread`.  No
+connection is opened here: the adapter reuses the ``SessionDB`` instance the
+agent already holds, whose writer connection is lock-guarded and whose readers
+are thread-local and tracked.  That is deliberate — this repo has a history of
+SQLite fd leaks from per-operation connections (see
+``relatorio-issue-69678-sqlite-fd-leaks.md``), and the cheapest way to not
+leak a connection is to not open one.
+
+``claude-agent-sdk`` is an optional extra: this module imports cleanly without
+it, and only :func:`build_claude_session_store` needs the SDK present (for the
+exported ``fold_session_summary``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Discriminator written into every ``provider_*`` row this adapter owns.
+#: Matches ``agent.claude_runtime.RUNTIME_LABEL``; duplicated as a literal so
+#: importing the store does not drag in the runtime.
+RUNTIME = "claude_agent_sdk"
+
+#: Entry types that represent a real conversation message in Claude's JSONL.
+#: Used only to find the boundary of a *visible* user turn — never to
+#: interpret an entry's payload.
+
+
+def is_visible_user_entry(entry: Any) -> bool:
+    """True when *entry* is the user message that opened a visible turn.
+
+    Claude's JSONL records tool results as ``type="user"`` entries too, and
+    marks synthetic lines with ``isMeta`` / ``isCompactSummary``.  Only a
+    plain user message with real content corresponds to something the Hermes
+    transcript shows, which is the boundary a rewind has to land on.
+    """
+    if not isinstance(entry, dict) or entry.get("type") != "user":
+        return False
+    if entry.get("isMeta") is True or entry.get("isCompactSummary") is True:
+        return False
+    if entry.get("isSidechain") is True:
+        return False
+    message = entry.get("message")
+    if not isinstance(message, dict):
+        return False
+    content = message.get("content")
+    if isinstance(content, list) and any(
+        isinstance(block, dict) and block.get("type") == "tool_result"
+        for block in content
+    ):
+        return False
+    return True
+
+
+class HermesClaudeSessionStore:
+    """``SessionStore`` backed by Hermes' ``SessionDB``.
+
+    Implements all six protocol methods.  The four "optional" ones are not
+    optional in practice for Hermes:
+
+    * ``list_sessions`` / ``list_session_summaries`` back the session picker
+      and ``--continue``-style resolution.
+    * ``list_subkeys`` is what restores subagent transcripts on resume —
+      without it a resumed session silently loses every subagent's history.
+    * ``delete`` must cascade to subkeys and drop the summary, or a deleted
+      session leaves orphaned subagent transcripts behind forever (the SDK
+      never deletes from a store on its own; retention is ours).
+
+    Duck-typed rather than subclassing ``SessionStore``: the SDK explicitly
+    never uses ``isinstance`` for this, and not subclassing keeps the module
+    importable without the optional extra.
+    """
+
+    def __init__(self, session_db: Any, *, summary_fold: Any = None) -> None:
+        self._db = session_db
+        self._summary_fold = summary_fold
+
+    # -- protocol ----------------------------------------------------------
+
+    async def append(self, key: Dict[str, Any], entries: List[Any]) -> None:
+        """Mirror a batch of transcript entries.
+
+        Deduplication by ``entry["uuid"]`` happens in SQLite (a partial unique
+        index), because a failed batch is retried up to twice more and a retry
+        can re-deliver entries that already landed.  Entries without a uuid
+        are appended unconditionally — the CLI emits uuid-less lines (titles,
+        tags, mode markers) that legitimately repeat.
+        """
+        project_key, session_id, subpath = _split(key)
+        fold = None
+        if self._summary_fold is not None and not subpath:
+            def fold(previous, batch, _key=key):
+                return self._summary_fold(previous, _key, batch)
+
+        await asyncio.to_thread(
+            self._db.append_provider_transcript_entries,
+            RUNTIME,
+            project_key,
+            session_id,
+            subpath,
+            list(entries),
+            summary_fold=fold,
+        )
+
+    async def load(self, key: Dict[str, Any]) -> Optional[List[Any]]:
+        project_key, session_id, subpath = _split(key)
+        return await asyncio.to_thread(
+            self._db.load_provider_transcript_entries,
+            RUNTIME,
+            project_key,
+            session_id,
+            subpath,
+        )
+
+    async def list_sessions(self, project_key: str) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(
+            self._db.list_provider_transcript_sessions, RUNTIME, project_key
+        )
+
+    async def list_session_summaries(self, project_key: str) -> List[Dict[str, Any]]:
+        return await asyncio.to_thread(
+            self._db.list_provider_transcript_summaries, RUNTIME, project_key
+        )
+
+    async def delete(self, key: Dict[str, Any]) -> None:
+        project_key, session_id, subpath = _split(key)
+        await asyncio.to_thread(
+            self._db.delete_provider_transcript,
+            RUNTIME,
+            project_key,
+            session_id,
+            # None (not "") means "the main key" — which cascades. An explicit
+            # subpath deletes only that one transcript.
+            subpath or None,
+        )
+
+    async def list_subkeys(self, key: Dict[str, Any]) -> List[str]:
+        project_key, session_id, _ = _split(key)
+        return await asyncio.to_thread(
+            self._db.list_provider_transcript_subkeys,
+            RUNTIME,
+            project_key,
+            session_id,
+        )
+
+
+def _split(key: Dict[str, Any]) -> tuple:
+    """``SessionKey`` → ``(project_key, session_id, subpath)``.
+
+    ``subpath`` is absent for a main transcript and opaque otherwise — it is
+    used purely as a storage key suffix, never parsed.
+    """
+    return (
+        str(key.get("project_key") or ""),
+        str(key.get("session_id") or ""),
+        str(key.get("subpath") or ""),
+    )
+
+
+def build_claude_session_store(session_db: Any) -> Optional[HermesClaudeSessionStore]:
+    """Build the adapter for *session_db*, or None when it cannot be used.
+
+    Returns None when there is no session DB (persistence disabled, a
+    background-review fork, a test harness) so the caller can simply omit
+    ``session_store`` — a Claude turn without a mirror still works, it just
+    is not durable.
+    """
+    if session_db is None:
+        return None
+    try:
+        from claude_agent_sdk import fold_session_summary
+    except Exception:  # pragma: no cover - optional extra absent
+        logger.debug("claude_agent_sdk absent; session store disabled", exc_info=True)
+        return None
+    return HermesClaudeSessionStore(session_db, summary_fold=fold_session_summary)
+
+
+__all__ = [
+    "RUNTIME",
+    "HermesClaudeSessionStore",
+    "build_claude_session_store",
+    "is_visible_user_entry",
+]

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2015,6 +2015,21 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Optional opt-in runtime: if api_mode == claude_agent_sdk, hand the turn
+    # to the official claude-agent-sdk (which drives the Claude Code CLI).
+    # Claude owns its own model/tool loop, so the default Hermes path is
+    # bypassed entirely; Hermes still owns tool execution via the in-process
+    # MCP bridge. See agent/claude_runtime.py and
+    # docs/design/claude-subscription-via-agent-sdk.md for the ownership split.
+    if agent.api_mode == "claude_agent_sdk":
+        return agent._run_claude_agent_sdk_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1255,6 +1255,21 @@ def run_conversation(
             should_review_memory=_should_review_memory,
         )
 
+    # Optional opt-in runtime: if api_mode == claude_agent_sdk, hand the turn
+    # to the official claude-agent-sdk (which drives the Claude Code CLI).
+    # Claude owns its own model/tool loop, so the default Hermes path is
+    # bypassed entirely; Hermes still owns tool execution via the in-process
+    # MCP bridge. See agent/claude_runtime.py and
+    # docs/design/claude-subscription-via-agent-sdk.md for the ownership split.
+    if agent.api_mode == "claude_agent_sdk":
+        return agent._run_claude_agent_sdk_turn(
+            user_message=user_message,
+            original_user_message=original_user_message,
+            messages=messages,
+            effective_task_id=effective_task_id,
+            should_review_memory=_should_review_memory,
+        )
+
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -8,6 +8,13 @@ functions that take the parent ``AIAgent`` as their first argument.
 that patch ``run_agent._set_interrupt`` are honored because the
 extracted functions reach back through the ``run_agent`` module via
 ``_ra()`` for that symbol.
+
+Runtimes that own their own agent loop (the ``claude_agent_sdk`` bridge in
+``agent/transports/claude_tool_bridge.py``) must route their tool calls
+through :func:`execute_one_tool` rather than reaching
+``model_tools.handle_function_call`` directly — approvals, guardrails,
+plugin hooks, checkpoints, and environment routing all live in the wrappers
+it applies, and it mirrors the per-tool lifecycle of the two dispatchers.
 """
 
 from __future__ import annotations
@@ -1087,6 +1094,361 @@ def _begin_tool_execution(
                 )
         except Exception:
             pass
+
+
+@dataclass
+class PreparedToolCall:
+    """One model-emitted tool call resolved to the tool Hermes will run.
+
+    Kept separate from :func:`execute_one_tool` so a caller can see the
+    resolved name before execution starts — the ``claude_agent_sdk`` bridge
+    uses it to shape the MCP response for the tool that actually ran.
+    """
+
+    tool_call: Any
+    tool_call_id: str
+    function_name: str
+    function_args: dict[str, Any]
+    middleware_trace: list[dict[str, Any]]
+    scope_block: Optional[str] = None
+    malformed_result: Optional[str] = None
+
+
+@dataclass
+class ToolExecutionOutcome:
+    """One tool call's result after every Hermes wrapper has run."""
+
+    tool_call: Any
+    tool_call_id: str
+    function_name: str
+    function_args: dict[str, Any]
+    result: Any
+    duration: float
+    is_error: bool
+    blocked: bool
+    cancelled: bool
+    malformed: bool
+    middleware_trace: list[dict[str, Any]]
+
+
+def _flatten_probe_schema_error(probe_error: str) -> str:
+    """Flatten a deferred-call probe payload into one plain string.
+
+    A ``scope_block`` is re-wrapped as ``{"error": ...}`` downstream, so the
+    probe's own JSON payload cannot be passed through verbatim without
+    nesting one JSON document inside another.
+    """
+    try:
+        probe = json.loads(probe_error)
+        return (
+            f"{probe.get('error', '')} Parameters schema: "
+            f"{json.dumps(probe.get('parameters', {}), ensure_ascii=False)}. "
+            f"{probe.get('hint', '')}"
+        ).strip()
+    except Exception:
+        return probe_error
+
+
+def prepare_tool_call(agent, tool_call) -> PreparedToolCall:
+    """Parse a tool call's arguments and resolve the tool it really targets.
+
+    Mirrors the argument parsing and Tool Search unwrap both dispatchers
+    perform inline (see ``execute_tool_calls_concurrent`` for the rationale,
+    including the session-scope gate the unwrap has to enforce itself).
+    """
+    function_name = tool_call.function.name
+    function_args, malformed_args_result = _parse_tool_arguments(
+        tool_call.function.arguments
+    )
+    prepared = PreparedToolCall(
+        tool_call=tool_call,
+        tool_call_id=_pairing_tool_call_id(tool_call),
+        function_name=function_name,
+        function_args=function_args,
+        middleware_trace=[],
+    )
+    if malformed_args_result is not None:
+        prepared.malformed_result = malformed_args_result
+        return prepared
+
+    try:
+        from tools import tool_search as _ts
+        if function_name == _ts.TOOL_CALL_NAME:
+            _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+            if not _err and _underlying:
+                if _underlying in _tool_search_scoped_names(agent):
+                    # Probe-validate before unwrapping (ironclaw#5149):
+                    # missing required args return the parameter schema
+                    # instead of dispatching into an opaque failure.
+                    _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                    if _probe_err is not None:
+                        prepared.scope_block = _flatten_probe_schema_error(_probe_err)
+                    else:
+                        prepared.function_name = _underlying
+                        prepared.function_args = _underlying_args
+                else:
+                    prepared.scope_block = (
+                        f"'{_underlying}' is not available in this session. "
+                        "Use tool_search to find tools you can call."
+                    )
+    except Exception:
+        pass
+
+    return prepared
+
+
+def _tool_dispatcher(agent, prepared: PreparedToolCall, effective_task_id: str,
+                     messages: Optional[list], state: dict):
+    """Build the single dispatch callback for one prepared tool call.
+
+    Everything except the context-engine tools routes through
+    ``AIAgent._invoke_tool`` — the same ladder the concurrent dispatcher
+    uses, which owns the terminal ``post_tool_call`` hook for the agent-level
+    tools ``handle_function_call`` does not cover.  Context-engine tools are
+    not in that ladder (they need the live message list, so the sequential
+    dispatcher runs them inline); they are dispatched here and their hook is
+    emitted by :func:`execute_one_tool` (``state["inline_post_hook"]``).
+    """
+    function_name = prepared.function_name
+
+    context_engine_names = getattr(agent, "_context_engine_tool_names", None)
+    if context_engine_names and function_name in context_engine_names:
+        state["inline_post_hook"] = True
+
+        def _execute_context_engine(next_args: dict) -> Any:
+            return agent.context_compressor.handle_tool_call(
+                function_name, next_args, messages=messages,
+            )
+
+        return _execute_context_engine
+
+    def _execute(next_args: dict) -> Any:
+        return agent._invoke_tool(
+            function_name,
+            next_args,
+            effective_task_id,
+            prepared.tool_call_id,
+            messages=messages,
+            pre_tool_block_checked=True,
+            skip_tool_request_middleware=True,
+            skip_tool_execution_middleware=True,
+            tool_request_middleware_trace=list(prepared.middleware_trace),
+        )
+
+    return _execute
+
+
+def _dispatcher_error_result(agent, function_name: str, tool_error: BaseException) -> str:
+    """Format a dispatcher exception the way the sequential path does.
+
+    Context-engine and memory-provider tools have no registry error wrapper,
+    so the executor is the only layer that can keep a provider fault from
+    aborting the whole turn; everything else gets the generic wrapper.
+    """
+    context_engine_names = getattr(agent, "_context_engine_tool_names", None)
+    if context_engine_names and function_name in context_engine_names:
+        logger.error(
+            "context_engine.handle_tool_call raised for %s: %s",
+            function_name, tool_error, exc_info=True,
+        )
+        return json.dumps(
+            {"error": f"Context engine tool '{function_name}' failed: {tool_error}"}
+        )
+    memory_manager = getattr(agent, "_memory_manager", None)
+    if memory_manager is not None and memory_manager.has_tool(function_name):
+        logger.error(
+            "memory_manager.handle_tool_call raised for %s: %s",
+            function_name, tool_error, exc_info=True,
+        )
+        return json.dumps(
+            {"error": f"Memory tool '{function_name}' failed: {tool_error}"}
+        )
+    logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+    return f"Error executing tool '{function_name}': {tool_error}"
+
+
+def execute_one_tool(
+    agent,
+    tool_call,
+    effective_task_id: str,
+    *,
+    messages: Optional[list] = None,
+    prepared: Optional[PreparedToolCall] = None,
+    display_index: Optional[int] = None,
+    begin_execution=None,
+    authorization_gate: Optional[_ConcurrentToolAuthorizationGate] = None,
+) -> ToolExecutionOutcome:
+    """Run one tool call through the whole Hermes tool lifecycle.
+
+    This is the sanctioned entry point for a runtime that owns its own agent
+    loop and therefore cannot use the two batch dispatchers.  Calling
+    ``model_tools.handle_function_call`` directly skips every wrapper applied
+    here: argument parsing, Tool Search unwrap and session-scope gating, Relay
+    rewrites, the tool request/execution middleware chain, plugin
+    ``pre_tool_call`` blocks, user approvals, before-call guardrails, file
+    checkpoints, tool-start display and progress callbacks, the in-flight
+    activity heartbeat, environment routing through ``effective_task_id``
+    (local / Docker / SSH / Modal / Daytona / Singularity), dispatch, and the
+    terminal ``post_tool_call`` hook.
+
+    The per-tool body deliberately matches the concurrent dispatcher's worker
+    (``_run_tool``): same middleware call, same cancelled/error handling, and
+    the same rule for who emits the terminal hook.  Callers keep scheduling,
+    display, transcript mutation, output budgets, and the after-call tail
+    (:func:`finalize_tool_outcome`) — those are per-path concerns.
+
+    ``begin_execution`` and ``authorization_gate`` are the concurrent path's
+    start-ordering and approval-serialization hooks; both are optional.
+    """
+    prep = prepared if prepared is not None else prepare_tool_call(agent, tool_call)
+    function_name = prep.function_name
+    tool_call_id = prep.tool_call_id
+
+    if prep.malformed_result is not None:
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args=prep.function_args,
+            result=prep.malformed_result,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            status="error",
+            error_type="invalid_tool_arguments",
+            error_message="Tool arguments must be a valid JSON object",
+        )
+        return ToolExecutionOutcome(
+            tool_call=prep.tool_call,
+            tool_call_id=tool_call_id,
+            function_name=function_name,
+            function_args=prep.function_args,
+            result=prep.malformed_result,
+            duration=0.0,
+            is_error=True,
+            blocked=True,
+            cancelled=False,
+            malformed=True,
+            middleware_trace=prep.middleware_trace,
+        )
+
+    state = {"inline_post_hook": False}
+    execute = _tool_dispatcher(agent, prep, effective_task_id, messages, state)
+    function_args = prep.function_args
+    middleware_trace = prep.middleware_trace
+    blocked = False
+    dispatched = False
+    start = time.time()
+
+    try:
+        managed = _run_agent_tool_execution_middleware(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            execute=execute,
+            scope_block=prep.scope_block,
+            display_index=display_index,
+            middleware_trace=middleware_trace,
+            begin_execution=begin_execution,
+            authorization_gate=authorization_gate,
+        )
+        result, function_args, middleware_trace, blocked, dispatched = (
+            _managed_values(managed)
+        )
+    except _BatchAbandoned:
+        # Only reachable through ``begin_execution``; the batch owner already
+        # synthesized this call's result, so there is no outcome to build.
+        raise
+    except KeyboardInterrupt:
+        try:
+            agent.interrupt("keyboard interrupt")
+        except Exception:
+            pass
+        result = _emit_cancelled_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            start_time=start,
+            middleware_trace=list(middleware_trace),
+        )
+        return ToolExecutionOutcome(
+            tool_call=prep.tool_call,
+            tool_call_id=tool_call_id,
+            function_name=function_name,
+            function_args=function_args,
+            result=result,
+            duration=time.time() - start,
+            is_error=True,
+            blocked=False,
+            cancelled=True,
+            malformed=False,
+            middleware_trace=middleware_trace,
+        )
+    except Exception as tool_error:
+        result = _dispatcher_error_result(agent, function_name, tool_error)
+
+    duration = time.time() - start
+    # The dispatch ladder emits the terminal post_tool_call hook for the
+    # calls it ran. The executor owns it when the middleware chain never
+    # dispatched, when the dispatcher raised (``dispatched`` is still False
+    # then), and for the inline context-engine branch.
+    if not blocked and (not dispatched or state["inline_post_hook"]):
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=function_name,
+            function_args=function_args,
+            result=result,
+            effective_task_id=effective_task_id,
+            tool_call_id=tool_call_id,
+            duration_ms=int(duration * 1000),
+            middleware_trace=list(middleware_trace),
+        )
+    is_error, _ = _detect_tool_failure(function_name, result)
+
+    return ToolExecutionOutcome(
+        tool_call=prep.tool_call,
+        tool_call_id=tool_call_id,
+        function_name=function_name,
+        function_args=function_args,
+        result=result,
+        duration=duration,
+        is_error=is_error,
+        blocked=blocked,
+        cancelled=False,
+        malformed=False,
+        middleware_trace=middleware_trace,
+    )
+
+
+def finalize_tool_outcome(agent, outcome: ToolExecutionOutcome) -> Any:
+    """Apply the after-call guardrail observation and file-mutation record.
+
+    Kept out of :func:`execute_one_tool` because the dispatchers run this
+    on the collection thread in tool-call order — ``ToolGuardrails.after_call``
+    and the turn-end file-mutation verifier are single-threaded state that a
+    worker pool must not touch. Blocked calls never ran, so a guardrail block
+    counts as neither a failure nor a success.
+    """
+    if outcome.blocked:
+        return outcome.result
+
+    result = agent._append_guardrail_observation(
+        outcome.function_name,
+        outcome.function_args,
+        outcome.result,
+        failed=outcome.is_error,
+        tool_call_id=outcome.tool_call_id,
+    )
+    try:
+        agent._record_file_mutation_result(
+            outcome.function_name, outcome.function_args, result, outcome.is_error,
+        )
+    except Exception as _ver_err:
+        logging.debug("file-mutation verifier record failed: %s", _ver_err)
+    return result
+
 
 
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -8,6 +8,14 @@ functions that take the parent ``AIAgent`` as their first argument.
 that patch ``run_agent._set_interrupt`` are honored because the
 extracted functions reach back through the ``run_agent`` module via
 ``_ra()`` for that symbol.
+
+The per-tool lifecycle both dispatchers share lives in
+:func:`execute_one_tool`.  Any runtime that owns its own agent loop (the
+``claude_agent_sdk`` bridge in ``agent/transports/claude_tool_bridge.py``)
+must route its tool calls through that function rather than reaching
+``model_tools.handle_function_call`` directly — approvals, guardrails,
+plugin hooks, checkpoints, and environment routing all live in the
+wrappers it applies.
 """
 
 from __future__ import annotations
@@ -626,6 +634,342 @@ def _begin_tool_execution(
             pass
 
 
+@dataclass
+class PreparedToolCall:
+    """One model-emitted tool call resolved to the tool Hermes will run.
+
+    Separate from :func:`execute_one_tool` because both dispatchers need the
+    resolved name before execution starts — the concurrent path to plan its
+    batch and log it, the sequential path to pick the tool's display mode.
+    """
+
+    tool_call: Any
+    tool_call_id: str
+    function_name: str
+    function_args: dict[str, Any]
+    middleware_trace: list[dict[str, Any]]
+    scope_block: Optional[str] = None
+    malformed_result: Optional[str] = None
+
+
+@dataclass
+class ToolExecutionOutcome:
+    """One tool call's result after every Hermes wrapper has run."""
+
+    tool_call: Any
+    tool_call_id: str
+    function_name: str
+    function_args: dict[str, Any]
+    result: Any
+    duration: float
+    is_error: bool
+    blocked: bool
+    cancelled: bool
+    malformed: bool
+    middleware_trace: list[dict[str, Any]]
+
+
+def _flatten_probe_schema_error(probe_error: str) -> str:
+    """Flatten a deferred-call probe payload into one plain string.
+
+    A ``scope_block`` is re-wrapped as ``{"error": ...}`` downstream, so the
+    probe's own JSON payload cannot be passed through verbatim without
+    nesting one JSON document inside another.
+    """
+    try:
+        probe = json.loads(probe_error)
+        return (
+            f"{probe.get('error', '')} Parameters schema: "
+            f"{json.dumps(probe.get('parameters', {}), ensure_ascii=False)}. "
+            f"{probe.get('hint', '')}"
+        ).strip()
+    except Exception:
+        return probe_error
+
+
+def prepare_tool_call(agent, tool_call) -> PreparedToolCall:
+    """Parse a tool call's arguments and resolve the tool it really targets."""
+    function_name = tool_call.function.name
+    function_args, malformed_args_result = _parse_tool_arguments(
+        tool_call.function.arguments
+    )
+    prepared = PreparedToolCall(
+        tool_call=tool_call,
+        tool_call_id=getattr(tool_call, "id", "") or "",
+        function_name=function_name,
+        function_args=function_args,
+        middleware_trace=[],
+    )
+    if malformed_args_result is not None:
+        prepared.malformed_result = malformed_args_result
+        return prepared
+
+    # ── Tool Search unwrap ────────────────────────────────────────────
+    # When the model invokes the tool_call bridge, peel it open so every
+    # downstream check (checkpointing, guardrails, plugin pre-tool-call
+    # hooks, the display/activity feed, the post-call callback) sees the
+    # underlying tool — not the bridge. This is the OpenClaw lesson: hooks
+    # must observe the real tool name.
+    #
+    # The original tool_call entry on ``tool_call.function`` is left
+    # untouched so the conversation transcript and the matching
+    # tool_call_id are preserved exactly as the model emitted them.
+    #
+    # Scope gate: the unwrap dispatches the underlying tool directly
+    # (bypassing the bridge branch in handle_function_call and its scope
+    # check), so we enforce session toolset scope HERE. A tool the session
+    # was not granted is rejected before any checkpoint, hook, or dispatch
+    # fires.
+    try:
+        from tools import tool_search as _ts
+        if function_name == _ts.TOOL_CALL_NAME:
+            _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
+            if not _err and _underlying:
+                if _underlying in _tool_search_scoped_names(agent):
+                    # Probe-validate before unwrapping (ironclaw#5149):
+                    # missing required args return the parameter schema
+                    # instead of dispatching into an opaque failure.
+                    _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
+                    if _probe_err is not None:
+                        prepared.scope_block = _flatten_probe_schema_error(_probe_err)
+                    else:
+                        prepared.function_name = _underlying
+                        prepared.function_args = _underlying_args
+                else:
+                    prepared.scope_block = (
+                        f"'{_underlying}' is not available in this session. "
+                        "Use tool_search to find tools you can call."
+                    )
+    except Exception:
+        pass
+
+    return prepared
+
+
+def _tool_dispatcher(agent, prepared: PreparedToolCall, effective_task_id: str,
+                     messages: Optional[list], state: dict):
+    """Build the single dispatch callback for one prepared tool call.
+
+    Everything except the context-engine tools routes through
+    ``AIAgent._invoke_tool``, which owns the one agent-level/registry
+    dispatch ladder and fires the terminal ``post_tool_call`` hook for the
+    branches ``handle_function_call`` does not cover.  Context-engine tools
+    are not in the registry and need the live message list, so they are
+    dispatched here and their hook is emitted by :func:`execute_one_tool`
+    (``state["inline_post_hook"]``).
+    """
+    function_name = prepared.function_name
+
+    context_engine_names = getattr(agent, "_context_engine_tool_names", None)
+    if context_engine_names and function_name in context_engine_names:
+        state["inline_post_hook"] = True
+
+        def _execute_context_engine(next_args: dict) -> Any:
+            try:
+                return agent.context_compressor.handle_tool_call(
+                    function_name, next_args, messages=messages,
+                )
+            except Exception as tool_error:
+                logger.error(
+                    "context_engine.handle_tool_call raised for %s: %s",
+                    function_name, tool_error, exc_info=True,
+                )
+                return json.dumps(
+                    {"error": f"Context engine tool '{function_name}' failed: {tool_error}"}
+                )
+
+        return _execute_context_engine
+
+    def _execute(next_args: dict) -> Any:
+        try:
+            return agent._invoke_tool(
+                function_name,
+                next_args,
+                effective_task_id,
+                prepared.tool_call_id,
+                messages=messages,
+                pre_tool_block_checked=True,
+                skip_tool_request_middleware=True,
+                skip_tool_execution_middleware=True,
+                tool_request_middleware_trace=list(prepared.middleware_trace),
+            )
+        except Exception as tool_error:
+            memory_manager = getattr(agent, "_memory_manager", None)
+            if memory_manager is not None and memory_manager.has_tool(function_name):
+                # Memory-provider tools have no registry error wrapper; the
+                # executor is the only layer that can stop a provider fault
+                # from aborting the whole turn.
+                logger.error(
+                    "memory_manager.handle_tool_call raised for %s: %s",
+                    function_name, tool_error, exc_info=True,
+                )
+                state["inline_post_hook"] = True
+                return json.dumps(
+                    {"error": f"Memory tool '{function_name}' failed: {tool_error}"}
+                )
+            from agent.agent_runtime_helpers import AGENT_RUNTIME_POST_HOOK_TOOL_NAMES
+            if function_name in AGENT_RUNTIME_POST_HOOK_TOOL_NAMES:
+                raise
+            logger.error(
+                "handle_function_call raised for %s: %s",
+                function_name, tool_error, exc_info=True,
+            )
+            return f"Error executing tool '{function_name}': {tool_error}"
+
+    return _execute
+
+
+def execute_one_tool(
+    agent,
+    tool_call,
+    effective_task_id: str,
+    *,
+    messages: Optional[list] = None,
+    prepared: Optional[PreparedToolCall] = None,
+    display_index: Optional[int] = None,
+    begin_execution=None,
+    authorization_gate: Optional[_ConcurrentToolAuthorizationGate] = None,
+) -> ToolExecutionOutcome:
+    """Run one tool call through the whole Hermes tool lifecycle.
+
+    This is the only sanctioned entry point for executing a model tool call.
+    Calling ``model_tools.handle_function_call`` directly skips every wrapper
+    applied here: argument parsing, Tool Search unwrap and session-scope
+    gating, Relay rewrites, the tool request/execution middleware chain,
+    plugin ``pre_tool_call`` blocks, user approvals, before-call guardrails,
+    file checkpoints, tool-start display and progress callbacks, environment
+    routing through ``effective_task_id`` (local / Docker / SSH / Modal /
+    Daytona / Singularity), dispatch, and the terminal ``post_tool_call``
+    hook.
+
+    Callers keep scheduling, display, transcript mutation, output budgets,
+    and the after-call tail (:func:`finalize_tool_outcome`) — those are
+    per-path concerns that cannot be shared without changing behavior.
+
+    ``begin_execution`` and ``authorization_gate`` are the concurrent path's
+    start-ordering and approval-serialization hooks; both are optional.
+    """
+    prep = prepared if prepared is not None else prepare_tool_call(agent, tool_call)
+
+    if prep.malformed_result is not None:
+        return ToolExecutionOutcome(
+            tool_call=prep.tool_call,
+            tool_call_id=prep.tool_call_id,
+            function_name=prep.function_name,
+            function_args=prep.function_args,
+            result=prep.malformed_result,
+            duration=0.0,
+            is_error=True,
+            blocked=True,
+            cancelled=False,
+            malformed=True,
+            middleware_trace=prep.middleware_trace,
+        )
+
+    state = {"inline_post_hook": False}
+    execute = _tool_dispatcher(agent, prep, effective_task_id, messages, state)
+    start = time.time()
+
+    try:
+        managed = _run_agent_tool_execution_middleware(
+            agent,
+            function_name=prep.function_name,
+            function_args=prep.function_args,
+            effective_task_id=effective_task_id,
+            tool_call_id=prep.tool_call_id,
+            execute=execute,
+            scope_block=prep.scope_block,
+            display_index=display_index,
+            middleware_trace=prep.middleware_trace,
+            begin_execution=begin_execution,
+            authorization_gate=authorization_gate,
+        )
+    except KeyboardInterrupt:
+        result = _emit_cancelled_terminal_post_tool_call(
+            agent,
+            function_name=prep.function_name,
+            function_args=prep.function_args,
+            effective_task_id=effective_task_id,
+            tool_call_id=prep.tool_call_id,
+            start_time=start,
+            middleware_trace=list(prep.middleware_trace),
+        )
+        try:
+            agent.interrupt("keyboard interrupt")
+        except Exception:
+            pass
+        return ToolExecutionOutcome(
+            tool_call=prep.tool_call,
+            tool_call_id=prep.tool_call_id,
+            function_name=prep.function_name,
+            function_args=prep.function_args,
+            result=result,
+            duration=time.time() - start,
+            is_error=True,
+            blocked=False,
+            cancelled=True,
+            malformed=False,
+            middleware_trace=prep.middleware_trace,
+        )
+
+    result, function_args, middleware_trace, blocked = _managed_values(managed)
+    duration = time.time() - start
+    is_error, _ = _detect_tool_failure(prep.function_name, result)
+
+    if state["inline_post_hook"] and not blocked:
+        _emit_terminal_post_tool_call(
+            agent,
+            function_name=prep.function_name,
+            function_args=function_args,
+            result=result,
+            effective_task_id=effective_task_id,
+            tool_call_id=prep.tool_call_id,
+            duration_ms=int(duration * 1000),
+            middleware_trace=list(middleware_trace),
+        )
+
+    return ToolExecutionOutcome(
+        tool_call=prep.tool_call,
+        tool_call_id=prep.tool_call_id,
+        function_name=prep.function_name,
+        function_args=function_args,
+        result=result,
+        duration=duration,
+        is_error=is_error,
+        blocked=blocked,
+        cancelled=False,
+        malformed=False,
+        middleware_trace=middleware_trace,
+    )
+
+
+def finalize_tool_outcome(agent, outcome: ToolExecutionOutcome) -> Any:
+    """Apply the after-call guardrail observation and file-mutation record.
+
+    Kept out of :func:`execute_one_tool` because the concurrent path runs it
+    on the collection thread in tool-call order — ``ToolGuardrails.after_call``
+    and the turn-end file-mutation verifier are single-threaded state that a
+    worker pool must not touch. Blocked calls never ran, so a guardrail block
+    counts as neither a failure nor a success.
+    """
+    if outcome.blocked:
+        return outcome.result
+
+    result = agent._append_guardrail_observation(
+        outcome.function_name,
+        outcome.function_args,
+        outcome.result,
+        failed=outcome.is_error,
+    )
+    try:
+        agent._record_file_mutation_result(
+            outcome.function_name, outcome.function_args, result, outcome.is_error,
+        )
+    except Exception as _ver_err:
+        logging.debug("file-mutation verifier record failed: %s", _ver_err)
+    return result
+
+
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute multiple tool calls concurrently using a thread pool.
 
@@ -661,84 +1005,31 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         return
 
     # ── Parse args + pre-execution bookkeeping ───────────────────────
-    # (tool call, resolved name, parsed args, middleware trace, parse error,
-    # tool-search scope block)
-    parsed_calls = []
-    for tool_call in tool_calls:
-        function_name = tool_call.function.name
-
-        function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
-        )
-
-        if malformed_args_result is not None:
-            parsed_calls.append(
-                (
-                    tool_call,
-                    function_name,
-                    function_args,
-                    [],
-                    malformed_args_result,
-                    None,
-                )
-            )
-            continue
-
-        # ── Tool Search unwrap ────────────────────────────────────────
-        # When the model invokes the tool_call bridge, peel it open so
-        # every downstream check (checkpointing, guardrails, plugin
-        # pre-tool-call hooks, the display/activity feed, the post-call
-        # callback) sees the underlying tool — not the bridge. This is
-        # the OpenClaw lesson: hooks must observe the real tool name.
-        #
-        # The original tool_call entry on ``tool_call.function`` is left
-        # untouched so the conversation transcript and the matching
-        # tool_call_id are preserved exactly as the model emitted them.
-        #
-        # Scope gate: the unwrap dispatches the underlying tool directly
-        # (bypassing the bridge branch in handle_function_call and its
-        # scope check), so we enforce session toolset scope HERE. A tool
-        # the session was not granted is rejected before any checkpoint,
-        # hook, or dispatch fires.
-        _ts_scope_block = None
-        try:
-            from tools import tool_search as _ts
-            if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
-                if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
-                        # Probe-validate before unwrapping (ironclaw#5149):
-                        # missing required args return the parameter schema
-                        # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
-                        if _probe_err is not None:
-                            _ts_scope_block = _probe_err
-                        else:
-                            function_name = _underlying
-                            function_args = _underlying_args
-                    else:
-                        _ts_scope_block = (
-                            f"'{_underlying}' is not available in this session. "
-                            "Use tool_search to find tools you can call."
-                        )
-        except Exception:
-            pass
-
-        parsed_calls.append(
-            (tool_call, function_name, function_args, [], None, _ts_scope_block)
-        )
+    parsed_calls = [prepare_tool_call(agent, tool_call) for tool_call in tool_calls]
 
     # ── Logging / callbacks ──────────────────────────────────────────
-    tool_names_str = ", ".join(name for _, name, _, _, _, _ in parsed_calls)
+    tool_names_str = ", ".join(prep.function_name for prep in parsed_calls)
     if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
 
     # ── Concurrent execution ─────────────────────────────────────────
-    # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag, middleware_trace)
-    results = [None] * num_tools
-    for i, (tc, name, args, middleware_trace, block_result, _scope_block) in enumerate(parsed_calls):
-        if block_result is not None:
-            results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
+    # Each slot holds the call's ``ToolExecutionOutcome`` once it lands.
+    results: list = [None] * num_tools
+    for i, prep in enumerate(parsed_calls):
+        if prep.malformed_result is not None:
+            results[i] = ToolExecutionOutcome(
+                tool_call=prep.tool_call,
+                tool_call_id=prep.tool_call_id,
+                function_name=prep.function_name,
+                function_args=prep.function_args,
+                result=prep.malformed_result,
+                duration=0.0,
+                is_error=True,
+                blocked=True,
+                cancelled=False,
+                malformed=True,
+                middleware_trace=prep.middleware_trace,
+            )
 
     start_condition = threading.Condition()
     next_start_order = 0
@@ -760,15 +1051,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     agent._current_tool = tool_names_str
     agent._touch_activity(f"executing {num_tools} tools concurrently: {tool_names_str}")
 
-    def _run_tool(
-        index,
-        tool_call,
-        function_name,
-        function_args,
-        middleware_trace,
-        scope_block,
-        start_order,
-    ):
+    def _run_tool(index, prep, start_order):
         """Worker function executed in a thread."""
         # Register this worker tid so the agent can fan out an interrupt
         # to it — see AIAgent.interrupt().  Must happen first thing, and
@@ -797,8 +1080,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         # Approval/sudo callbacks (thread-local) and the agent turn's
         # ContextVars are propagated by propagate_context_to_thread() at the
         # submit site below (GHSA-qg5c-hvr5-hjgr, #13617).
+        function_name = prep.function_name
         start = time.time()
-        blocked = False
         start_advanced = False
 
         def _advance_start(callback=None) -> None:
@@ -812,80 +1095,45 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
         try:
             try:
-                def _execute(next_args: dict[str, Any]) -> Any:
-                    return agent._invoke_tool(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call.id,
-                        messages=messages,
-                        pre_tool_block_checked=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                    )
-
-                managed = _run_agent_tool_execution_middleware(
+                outcome = execute_one_tool(
                     agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    execute=_execute,
-                    scope_block=scope_block,
+                    prep.tool_call,
+                    effective_task_id,
+                    messages=messages,
+                    prepared=prep,
                     display_index=index + 1,
-                    middleware_trace=middleware_trace,
                     begin_execution=_advance_start,
                     authorization_gate=authorization_gate,
                 )
-                result = managed.result
-                function_args = managed.args
-                middleware_trace = managed.middleware_trace
-                blocked = managed.blocked
-            except KeyboardInterrupt:
-                try:
-                    agent.interrupt("keyboard interrupt")
-                except Exception:
-                    pass
-                result = _emit_cancelled_terminal_post_tool_call(
-                    agent,
+            except Exception as tool_error:
+                logger.error("execute_one_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+                results[index] = ToolExecutionOutcome(
+                    tool_call=prep.tool_call,
+                    tool_call_id=prep.tool_call_id,
                     function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    start_time=start,
-                    middleware_trace=list(middleware_trace),
-                )
-                duration = time.time() - start
-                logger.info("tool %s cancelled (%.2fs)", function_name, duration)
-                results[index] = (
-                    function_name,
-                    function_args,
-                    result,
-                    duration,
-                    True,
-                    False,
-                    middleware_trace,
+                    function_args=prep.function_args,
+                    result=f"Error executing tool '{function_name}': {tool_error}",
+                    duration=time.time() - start,
+                    is_error=True,
+                    blocked=False,
+                    cancelled=False,
+                    malformed=False,
+                    middleware_trace=prep.middleware_trace,
                 )
                 return
-            except Exception as tool_error:
-                result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
-            duration = time.time() - start
-            is_error, _ = _detect_tool_failure(function_name, result)
-            if is_error:
-                logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
+            if outcome.cancelled:
+                logger.info("tool %s cancelled (%.2fs)", function_name, outcome.duration)
+            elif outcome.is_error:
+                logger.info(
+                    "tool %s failed (%.2fs): %s",
+                    function_name, outcome.duration, str(outcome.result)[:200],
+                )
             else:
-                logger.info("tool %s completed (%.2fs, %d chars)", function_name, duration, len(result))
-            results[index] = (
-                function_name,
-                function_args,
-                result,
-                duration,
-                is_error,
-                blocked,
-                middleware_trace,
-            )
+                logger.info(
+                    "tool %s completed (%.2fs, %d chars)",
+                    function_name, outcome.duration, len(outcome.result),
+                )
+            results[index] = outcome
         finally:
             _advance_start()
             # Tear down worker-tid tracking.  Clear any interrupt bit we may
@@ -910,11 +1158,9 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
     try:
         runnable_calls = [
-            (i, tc, name, args, scope_block)
-            for i, (tc, name, args, _trace, parse_error, scope_block) in enumerate(
-                parsed_calls
-            )
-            if parse_error is None
+            (i, prep)
+            for i, prep in enumerate(parsed_calls)
+            if prep.malformed_result is None
         ]
         futures = []
         future_to_index = {}
@@ -932,9 +1178,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             executor = DaemonThreadPoolExecutor(max_workers=max_workers)
             abandon_executor = False
             try:
-                for submit_index, (i, tc, name, args, scope_block) in enumerate(
-                    runnable_calls
-                ):
+                for submit_index, (i, prep) in enumerate(runnable_calls):
                     # Propagate the agent turn's ContextVars (e.g.
                     # _approval_session_key) AND thread-local approval/sudo
                     # callbacks into the worker thread; clears callbacks on exit.
@@ -942,11 +1186,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         f = executor.submit(
                             propagate_context_to_thread(_run_tool),
                             i,
-                            tc,
-                            name,
-                            args,
-                            parsed_calls[i][3],
-                            scope_block,
+                            prep,
                             submit_index,
                         )
                     except RuntimeError as submit_error:
@@ -958,27 +1198,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             "skipping %d unsubmitted tool(s)",
                             len(skipped_calls),
                         )
-                        for (
-                            skipped_i,
-                            _tc,
-                            skipped_name,
-                            skipped_args,
-                            _scope_block,
-                        ) in skipped_calls:
+                        for skipped_i, skipped_prep in skipped_calls:
                             if results[skipped_i] is None:
-                                middleware_trace = parsed_calls[skipped_i][3]
-                                result = (
-                                    f"Error executing tool '{skipped_name}': "
-                                    "Python interpreter is shutting down; tool was not started"
-                                )
-                                results[skipped_i] = (
-                                    skipped_name,
-                                    skipped_args,
-                                    result,
-                                    0.0,
-                                    True,
-                                    False,
-                                    middleware_trace,
+                                results[skipped_i] = ToolExecutionOutcome(
+                                    tool_call=skipped_prep.tool_call,
+                                    tool_call_id=skipped_prep.tool_call_id,
+                                    function_name=skipped_prep.function_name,
+                                    function_args=skipped_prep.function_args,
+                                    result=(
+                                        f"Error executing tool '{skipped_prep.function_name}': "
+                                        "Python interpreter is shutting down; tool was not started"
+                                    ),
+                                    duration=0.0,
+                                    is_error=True,
+                                    blocked=False,
+                                    cancelled=False,
+                                    malformed=False,
+                                    middleware_trace=skipped_prep.middleware_trace,
                                 )
                         break
                     futures.append(f)
@@ -1026,7 +1262,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             if f in future_to_index
                         }
                         _still_running = [
-                            parsed_calls[i][1]
+                            parsed_calls[i].function_name
                             for i in timed_out_indices
                         ]
                         logger.warning(
@@ -1072,7 +1308,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     # Heartbeat every ~30s (6 × 5s poll intervals)
                     if _conc_elapsed > 0 and _conc_elapsed % 30 < 6:
                         _still_running = [
-                            parsed_calls[future_to_index[f]][1]
+                            parsed_calls[future_to_index[f]].function_name
                             for f in not_done
                             if f in future_to_index
                         ]
@@ -1094,13 +1330,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         if spinner:
             # Build a summary message for the spinner stop
             completed = sum(1 for r in results if r is not None)
-            total_dur = sum(r[3] for r in results if r is not None)
+            total_dur = sum(r.duration for r in results if r is not None)
             spinner.stop(f"⚡ {completed}/{num_tools} tools completed in {total_dur:.1f}s total")
 
     # ── Post-execution: display per-tool results ─────────────────────
-    for i, (tc, name, args, middleware_trace, _parse_error, _scope_block) in enumerate(
-        parsed_calls
-    ):
+    for i, prep in enumerate(parsed_calls):
+        tc = prep.tool_call
+        name = prep.function_name
+        args = prep.function_args
+        middleware_trace = prep.middleware_trace
         r = results[i]
         blocked = False
         is_error = True
@@ -1159,36 +1397,24 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
             tool_duration = 0.0
         else:
-            function_name, function_args, function_result, tool_duration, is_error, blocked, middleware_trace = r
+            function_name = r.function_name
+            function_args = r.function_args
+            tool_duration = r.duration
+            is_error = r.is_error
+            blocked = r.blocked
+            middleware_trace = r.middleware_trace
             name = function_name
             args = function_args
             progress_function_name = function_name
             if blocked:
                 effect_disposition = "none"
 
-            if not blocked:
-                function_result = agent._append_guardrail_observation(
-                    function_name,
-                    function_args,
-                    function_result,
-                    failed=is_error,
-                )
+            function_result = finalize_tool_outcome(agent, r)
 
             if is_error:
                 _err_text = _multimodal_text_summary(function_result)
                 result_preview = _err_text[:200] if len(_err_text) > 200 else _err_text
                 logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
-
-            # Track file-mutation outcome for the turn-end verifier.
-            # `blocked` calls never actually ran — don't let a guardrail
-            # block count as either a failure or a success.
-            if not blocked:
-                try:
-                    agent._record_file_mutation_result(
-                        function_name, function_args, function_result, is_error,
-                    )
-                except Exception as _ver_err:
-                    logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
             if agent.verbose_logging:
                 logging.debug(f"Tool {function_name} completed in {tool_duration:.2f}s")
@@ -1314,6 +1540,96 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
 
 
 
+# Agent-level tools whose sequential display is a single cute line after the
+# call — they return fast enough that a spinner would flash and vanish.
+_SEQUENTIAL_MESSAGE_TOOLS = frozenset(
+    {"todo", "session_search", "memory", "clarify", "read_terminal"}
+)
+
+
+def _start_sequential_tool_display(agent, function_name: str, function_args: dict):
+    """Pick the sequential path's display mode for one tool and start its spinner.
+
+    Returns ``(mode, spinner)`` where mode is ``"message"`` (cute line after
+    the call), ``"spinner"`` (live spinner, replaced by the cute line), or
+    ``"silent"`` (the verbose per-tool tail prints instead).
+    """
+    if function_name in _SEQUENTIAL_MESSAGE_TOOLS:
+        return "message", None
+
+    context_engine_names = getattr(agent, "_context_engine_tool_names", None)
+    is_context_engine = bool(
+        context_engine_names and function_name in context_engine_names
+    )
+    memory_manager = getattr(agent, "_memory_manager", None)
+    is_memory_manager = bool(
+        memory_manager is not None and memory_manager.has_tool(function_name)
+    )
+    is_delegate = function_name == "delegate_task"
+
+    if not (is_delegate or is_context_engine or is_memory_manager or agent.quiet_mode):
+        return "silent", None
+
+    if is_delegate:
+        tasks_arg = function_args.get("tasks")
+        if tasks_arg and isinstance(tasks_arg, list):
+            label = f"🔀 delegating {len(tasks_arg)} tasks · (/agents to monitor)"
+        else:
+            goal_preview = (function_args.get("goal") or "")[:30]
+            label = (
+                f"🔀 {goal_preview} · (/agents to monitor)"
+                if goal_preview
+                else "🔀 delegating · (/agents to monitor)"
+            )
+        allowed = (
+            agent._should_emit_quiet_tool_messages()
+            and agent._should_start_quiet_spinner()
+        )
+    else:
+        emoji = _get_tool_emoji(function_name)
+        display_args = (
+            _redact_tool_args_for_display(function_name, function_args) or function_args
+        )
+        preview = _build_tool_label(function_name, display_args) or function_name
+        label = f"{emoji} {preview}"
+        # Context-engine tools spin even when the quiet-spinner gate is
+        # closed: they hold the loop for seconds with no other output.
+        allowed = agent._should_emit_quiet_tool_messages() and (
+            is_context_engine or agent._should_start_quiet_spinner()
+        )
+
+    spinner = None
+    if allowed:
+        face = random.choice(KawaiiSpinner.get_waiting_faces())
+        spinner = KawaiiSpinner(
+            f"{face} {label}", spinner_type='dots', print_fn=agent._print_fn,
+        )
+        spinner.start()
+    return "spinner", spinner
+
+
+def _finish_sequential_tool_display(
+    agent, mode: str, spinner, function_name: str, function_args: dict,
+    duration: float, result: Any,
+) -> None:
+    """Close out the display started by :func:`_start_sequential_tool_display`."""
+    if mode == "silent":
+        return
+    if mode == "message":
+        if agent._should_emit_quiet_tool_messages():
+            agent._vprint(
+                f"  {_get_cute_tool_message_impl(function_name, function_args, duration, result=result)}"
+            )
+        return
+    cute_msg = _get_cute_tool_message_impl(
+        function_name, function_args, duration, result=result,
+    )
+    if spinner:
+        spinner.stop(cute_msg)
+    elif agent._should_emit_quiet_tool_messages():
+        agent._vprint(f"  {cute_msg}")
+
+
 def execute_tool_calls_sequential(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:
     """Execute tool calls sequentially (original behavior). Used for single calls or interactive tools.
 
@@ -1349,16 +1665,14 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     return
             break
 
-        function_name = tool_call.function.name
+        prep = prepare_tool_call(agent, tool_call)
+        function_name = prep.function_name
 
-        function_args, malformed_args_result = _parse_tool_arguments(
-            tool_call.function.arguments
-        )
-        if malformed_args_result is not None:
+        if prep.malformed_result is not None:
             messages.append(
                 make_tool_result_message(
                     function_name,
-                    malformed_args_result,
+                    prep.malformed_result,
                     tool_call.id,
                 )
             )
@@ -1371,434 +1685,47 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             agent._apply_pending_steer_to_tool_results(messages, 1)
             continue
 
-        # Tool Search unwrap — see execute_tool_calls_concurrent for full
-        # rationale, including the scope gate (the unwrap dispatches the
-        # underlying tool directly, so session toolset scope is enforced here).
-        _ts_scope_block: Optional[str] = None
-        try:
-            from tools import tool_search as _ts
-            if function_name == _ts.TOOL_CALL_NAME:
-                _underlying, _underlying_args, _err = _ts.resolve_underlying_call(function_args)
-                if not _err and _underlying:
-                    if _underlying in _tool_search_scoped_names(agent):
-                        # Probe-validate before unwrapping (ironclaw#5149):
-                        # missing required args return the parameter schema
-                        # instead of dispatching into an opaque failure.
-                        _probe_err = _ts.validate_deferred_call_args(_underlying, _underlying_args)
-                        if _probe_err is not None:
-                            # This path wraps _block_msg in {"error": ...} —
-                            # flatten the probe payload to one plain string.
-                            try:
-                                _probe = json.loads(_probe_err)
-                                _ts_scope_block = (
-                                    f"{_probe.get('error', '')} Parameters schema: "
-                                    f"{json.dumps(_probe.get('parameters', {}), ensure_ascii=False)}. "
-                                    f"{_probe.get('hint', '')}"
-                                ).strip()
-                            except Exception:
-                                _ts_scope_block = _probe_err
-                        else:
-                            function_name = _underlying
-                            function_args = _underlying_args
-                    else:
-                        _ts_scope_block = (
-                            f"'{_underlying}' is not available in this session. "
-                            "Use tool_search to find tools you can call."
-                        )
-        except Exception:
-            pass
-
-        middleware_trace: list[dict[str, Any]] = []
-        _execution_blocked = False
-
         tool_start_time = time.time()
-
-        if function_name == "todo":
-            def _execute(next_args: dict) -> Any:
-                from tools.todo_tool import todo_tool as _todo_tool
-                return _todo_tool(
-                    todos=next_args.get("todos"),
-                    merge=next_args.get("merge", False),
-                    store=agent._todo_store,
-                )
-            function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                execute=_execute,
-                scope_block=_ts_scope_block,
-                display_index=i,
-            ))
-            tool_duration = time.time() - tool_start_time
-            if agent._should_emit_quiet_tool_messages():
-                agent._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
-        elif function_name == "session_search":
-            def _execute(next_args: dict) -> Any:
-                session_db = agent._get_session_db_for_recall()
-                if not session_db:
-                    from hermes_state import format_session_db_unavailable
-                    return json.dumps({"success": False, "error": format_session_db_unavailable()})
-                from tools.session_search_tool import session_search as _session_search
-                return _session_search(
-                    query=next_args.get("query", ""),
-                    role_filter=next_args.get("role_filter"),
-                    limit=next_args.get("limit", 3),
-                    session_id=next_args.get("session_id"),
-                    around_message_id=next_args.get("around_message_id"),
-                    window=next_args.get("window", 5),
-                    sort=next_args.get("sort"),
-                    db=session_db,
-                    current_session_id=agent.session_id,
-                )
-            function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                execute=_execute,
-                scope_block=_ts_scope_block,
-                display_index=i,
-            ))
-            tool_duration = time.time() - tool_start_time
-            if agent._should_emit_quiet_tool_messages():
-                agent._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
-        elif function_name == "memory":
-            def _execute(next_args: dict) -> Any:
-                target = next_args.get("target", "memory")
-                operations = next_args.get("operations")
-                from tools.memory_tool import memory_tool as _memory_tool
-                result = _memory_tool(
-                    action=next_args.get("action"),
-                    target=target,
-                    content=next_args.get("content"),
-                    old_text=next_args.get("old_text"),
-                    operations=operations,
-                    store=agent._memory_store,
-                )
-                # Mirror successful built-in memory writes to external
-                # providers. All gating/op-expansion lives behind the manager
-                # interface (MemoryManager.notify_memory_tool_write).
-                if agent._memory_manager:
-                    agent._memory_manager.notify_memory_tool_write(
-                        result,
-                        next_args,
-                        build_metadata=lambda: agent._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=getattr(tool_call, "id", None),
-                        ),
-                    )
-                return result
-            function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                execute=_execute,
-                scope_block=_ts_scope_block,
-                display_index=i,
-            ))
-            tool_duration = time.time() - tool_start_time
-            if agent._should_emit_quiet_tool_messages():
-                agent._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")
-        elif function_name == "clarify":
-            def _execute(next_args: dict) -> Any:
-                from tools.clarify_tool import clarify_tool as _clarify_tool
-                return _clarify_tool(
-                    question=next_args.get("question", ""),
-                    choices=next_args.get("choices"),
-                    multi_select=next_args.get("multi_select", False),
-                    callback=agent.clarify_callback,
-                )
-            function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                execute=_execute,
-                scope_block=_ts_scope_block,
-                display_index=i,
-            ))
-            tool_duration = time.time() - tool_start_time
-            if agent._should_emit_quiet_tool_messages():
-                agent._vprint(f"  {_get_cute_tool_message_impl('clarify', function_args, tool_duration, result=function_result)}")
-        elif function_name == "read_terminal":
-            def _execute(next_args: dict) -> Any:
-                from tools.read_terminal_tool import read_terminal_tool as _read_terminal_tool
-                return _read_terminal_tool(
-                    start_line=next_args.get("start_line"),
-                    count=next_args.get("count"),
-                    callback=getattr(agent, "read_terminal_callback", None),
-                )
-            function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                execute=_execute,
-                scope_block=_ts_scope_block,
-                display_index=i,
-            ))
-            tool_duration = time.time() - tool_start_time
-            if agent._should_emit_quiet_tool_messages():
-                agent._vprint(f"  {_get_cute_tool_message_impl('read_terminal', function_args, tool_duration, result=function_result)}")
-        elif function_name == "delegate_task":
-            tasks_arg = function_args.get("tasks")
-            if tasks_arg and isinstance(tasks_arg, list):
-                spinner_label = f"🔀 delegating {len(tasks_arg)} tasks · (/agents to monitor)"
-            else:
-                goal_preview = (function_args.get("goal") or "")[:30]
-                spinner_label = (
-                    f"🔀 {goal_preview} · (/agents to monitor)"
-                    if goal_preview
-                    else "🔀 delegating · (/agents to monitor)"
-                )
-            spinner = None
-            if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
-                face = random.choice(KawaiiSpinner.get_waiting_faces())
-                spinner = KawaiiSpinner(f"{face} {spinner_label}", spinner_type='dots', print_fn=agent._print_fn)
-                spinner.start()
+        display_mode, spinner = _start_sequential_tool_display(
+            agent, function_name, prep.function_args
+        )
+        if function_name == "delegate_task":
             agent._delegate_spinner = spinner
-            _delegate_result = None
-            try:
-                def _execute(next_args: dict) -> Any:
-                    return agent._dispatch_delegate_task(next_args)
-                function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    execute=_execute,
-                    scope_block=_ts_scope_block,
-                    display_index=i,
-                ))
-                _delegate_result = function_result
-            finally:
+        outcome = None
+        try:
+            outcome = execute_one_tool(
+                agent,
+                tool_call,
+                effective_task_id,
+                messages=messages,
+                prepared=prep,
+                display_index=i,
+            )
+        finally:
+            if function_name == "delegate_task":
                 agent._delegate_spinner = None
-                tool_duration = time.time() - tool_start_time
-                cute_msg = _get_cute_tool_message_impl('delegate_task', function_args, tool_duration, result=_delegate_result)
-                if spinner:
-                    spinner.stop(cute_msg)
-                elif agent._should_emit_quiet_tool_messages():
-                    agent._vprint(f"  {cute_msg}")
-        elif agent._context_engine_tool_names and function_name in agent._context_engine_tool_names:
-            # Context engine tools (lcm_grep, lcm_describe, lcm_expand, etc.)
-            spinner = None
-            if agent._should_emit_quiet_tool_messages():
-                face = random.choice(KawaiiSpinner.get_waiting_faces())
-                emoji = _get_tool_emoji(function_name)
-                display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
-                preview = _build_tool_label(function_name, display_args) or function_name
-                spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=agent._print_fn)
-                spinner.start()
-            _ce_result = None
-            try:
-                def _execute(next_args: dict) -> Any:
-                    return agent.context_compressor.handle_tool_call(function_name, next_args, messages=messages)
-                function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
+            # A tool that raised past execute_one_tool leaves no outcome; only
+            # the spinner modes have to be closed out in that case.
+            if outcome is not None or display_mode == "spinner":
+                _finish_sequential_tool_display(
                     agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    execute=_execute,
-                    scope_block=_ts_scope_block,
-                    display_index=i,
-                ))
-                _ce_result = function_result
-            except Exception as tool_error:
-                function_result = json.dumps({"error": f"Context engine tool '{function_name}' failed: {tool_error}"})
-                logger.error("context_engine.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            finally:
-                tool_duration = time.time() - tool_start_time
-                cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_ce_result)
-                if spinner:
-                    spinner.stop(cute_msg)
-                elif agent._should_emit_quiet_tool_messages():
-                    agent._vprint(f"  {cute_msg}")
-        elif agent._memory_manager and agent._memory_manager.has_tool(function_name):
-            # Memory provider tools (hindsight_retain, honcho_search, etc.)
-            # These are not in the tool registry — route through MemoryManager.
-            spinner = None
-            if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
-                face = random.choice(KawaiiSpinner.get_waiting_faces())
-                emoji = _get_tool_emoji(function_name)
-                display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
-                preview = _build_tool_label(function_name, display_args) or function_name
-                spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=agent._print_fn)
-                spinner.start()
-            _mem_result = None
-            try:
-                def _execute(next_args: dict) -> Any:
-                    return agent._memory_manager.handle_tool_call(function_name, next_args)
-                function_result, function_args, middleware_trace, _execution_blocked = _managed_values(_run_agent_tool_execution_middleware(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    execute=_execute,
-                    scope_block=_ts_scope_block,
-                    display_index=i,
-                ))
-                _mem_result = function_result
-            except Exception as tool_error:
-                function_result = json.dumps({"error": f"Memory tool '{function_name}' failed: {tool_error}"})
-                logger.error("memory_manager.handle_tool_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            finally:
-                tool_duration = time.time() - tool_start_time
-                cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_mem_result)
-                if spinner:
-                    spinner.stop(cute_msg)
-                elif agent._should_emit_quiet_tool_messages():
-                    agent._vprint(f"  {cute_msg}")
-        elif agent.quiet_mode:
-            spinner = None
-            if agent._should_emit_quiet_tool_messages() and agent._should_start_quiet_spinner():
-                face = random.choice(KawaiiSpinner.get_waiting_faces())
-                emoji = _get_tool_emoji(function_name)
-                display_args = _redact_tool_args_for_display(function_name, function_args) or function_args
-                preview = _build_tool_label(function_name, display_args) or function_name
-                spinner = KawaiiSpinner(f"{face} {emoji} {preview}", spinner_type='dots', print_fn=agent._print_fn)
-                spinner.start()
-            _spinner_result = None
-            try:
-                def _execute(next_args: dict) -> Any:
-                    return _ra().handle_function_call(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=agent.session_id or "",
-                        turn_id=getattr(agent, "_current_turn_id", "") or "",
-                        api_request_id=getattr(agent, "_current_api_request_id", "")
-                        or "",
-                        enabled_tools=(
-                            list(agent.valid_tool_names)
-                            if agent.valid_tool_names
-                            else None
-                        ),
-                        skip_pre_tool_call_hook=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    )
+                    display_mode,
+                    spinner,
+                    function_name,
+                    outcome.function_args if outcome is not None else prep.function_args,
+                    outcome.duration if outcome is not None else time.time() - tool_start_time,
+                    outcome.result if outcome is not None else None,
+                )
 
-                (
-                    function_result,
-                    function_args,
-                    middleware_trace,
-                    _execution_blocked,
-                ) = _managed_values(
-                    _run_agent_tool_execution_middleware(
-                        agent,
-                        function_name=function_name,
-                        function_args=function_args,
-                        effective_task_id=effective_task_id,
-                        tool_call_id=getattr(tool_call, "id", "") or "",
-                        execute=_execute,
-                        scope_block=_ts_scope_block,
-                        display_index=i,
-                        middleware_trace=middleware_trace,
-                    )
-                )
-                _spinner_result = function_result
-            except KeyboardInterrupt:
-                function_result = _emit_cancelled_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    start_time=tool_start_time,
-                    middleware_trace=list(middleware_trace),
-                )
-                _spinner_result = function_result
-                try:
-                    agent.interrupt("keyboard interrupt")
-                except Exception:
-                    pass
-                raise
-            except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            finally:
-                tool_duration = time.time() - tool_start_time
-                cute_msg = _get_cute_tool_message_impl(function_name, function_args, tool_duration, result=_spinner_result)
-                if spinner:
-                    spinner.stop(cute_msg)
-                elif agent._should_emit_quiet_tool_messages():
-                    agent._vprint(f"  {cute_msg}")
-        else:
-            try:
-                def _execute(next_args: dict) -> Any:
-                    return _ra().handle_function_call(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call_id=tool_call.id,
-                        session_id=agent.session_id or "",
-                        turn_id=getattr(agent, "_current_turn_id", "") or "",
-                        api_request_id=getattr(agent, "_current_api_request_id", "")
-                        or "",
-                        enabled_tools=(
-                            list(agent.valid_tool_names)
-                            if agent.valid_tool_names
-                            else None
-                        ),
-                        skip_pre_tool_call_hook=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                        enabled_toolsets=getattr(agent, "enabled_toolsets", None),
-                        disabled_toolsets=getattr(agent, "disabled_toolsets", None),
-                    )
+        if outcome.cancelled:
+            raise KeyboardInterrupt
 
-                (
-                    function_result,
-                    function_args,
-                    middleware_trace,
-                    _execution_blocked,
-                ) = _managed_values(
-                    _run_agent_tool_execution_middleware(
-                        agent,
-                        function_name=function_name,
-                        function_args=function_args,
-                        effective_task_id=effective_task_id,
-                        tool_call_id=getattr(tool_call, "id", "") or "",
-                        execute=_execute,
-                        scope_block=_ts_scope_block,
-                        display_index=i,
-                        middleware_trace=middleware_trace,
-                    )
-                )
-            except KeyboardInterrupt:
-                _emit_cancelled_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=getattr(tool_call, "id", "") or "",
-                    start_time=tool_start_time,
-                    middleware_trace=list(middleware_trace),
-                )
-                try:
-                    agent.interrupt("keyboard interrupt")
-                except Exception:
-                    pass
-                raise
-            except Exception as tool_error:
-                function_result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
-            tool_duration = time.time() - tool_start_time
+        function_args = outcome.function_args
+        function_result = outcome.result
+        tool_duration = outcome.duration
+        _execution_blocked = outcome.blocked
+        _is_error_result = outcome.is_error
+
 
         if isinstance(function_result, str):
             result_preview = function_result if agent.verbose_logging else (
@@ -1812,36 +1739,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
         # Log tool errors to the persistent error log so [error] tags
         # in the UI always have a corresponding detailed entry on disk.
-        _is_error_result, _ = _detect_tool_failure(function_name, function_result)
-        # The agent-runtime tools above (todo, session_search, memory,
-        # context-engine, memory-manager, clarify, delegate_task) are
-        # dispatched inline — they never reach handle_function_call, so the
-        # executor is the one that has to fire post_tool_call. For
-        # registry-dispatched tools the else-branch above invoked
-        # handle_function_call, which already fires the hook.
-        from agent.agent_runtime_helpers import agent_runtime_owns_post_tool_hook
-        _executor_must_emit_post_hook = (
-            not _execution_blocked
-            and agent_runtime_owns_post_tool_hook(agent, function_name)
-        )
-        if _executor_must_emit_post_hook:
-            _emit_terminal_post_tool_call(
-                agent,
-                function_name=function_name,
-                function_args=function_args,
-                result=function_result,
-                effective_task_id=effective_task_id,
-                tool_call_id=getattr(tool_call, "id", "") or "",
-                duration_ms=int(tool_duration * 1000),
-                middleware_trace=list(middleware_trace),
-            )
         if not _execution_blocked:
-            function_result = agent._append_guardrail_observation(
-                function_name,
-                function_args,
-                function_result,
-                failed=_is_error_result,
-            )
+            function_result = finalize_tool_outcome(agent, outcome)
             result_preview = function_result if agent.verbose_logging else (
                 function_result[:200] if len(function_result) > 200 else function_result
             )
@@ -1849,18 +1748,6 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             logger.warning("Tool %s returned error (%.2fs): %s", function_name, tool_duration, result_preview)
         else:
             logger.info("tool %s completed (%.2fs, %d chars)", function_name, tool_duration, _result_len)
-
-        # Track file-mutation outcome for the turn-end verifier.  See
-        # the concurrent path for the rationale; both paths must feed
-        # the same state so the footer reflects every tool call in the
-        # turn, not just the parallel ones.
-        if not _execution_blocked:
-            try:
-                agent._record_file_mutation_result(
-                    function_name, function_args, function_result, _is_error_result,
-                )
-            except Exception as _ver_err:
-                logging.debug("file-mutation verifier record failed: %s", _ver_err)
 
         agent._current_tool = None
         _status_suffix = " (error)" if _is_error_result else ""
@@ -2054,6 +1941,11 @@ def execute_tool_calls_segmented(agent, assistant_message, messages: list, effec
 
 
 __all__ = [
+    "PreparedToolCall",
+    "ToolExecutionOutcome",
+    "prepare_tool_call",
+    "execute_one_tool",
+    "finalize_tool_outcome",
     "execute_tool_calls_concurrent",
     "execute_tool_calls_sequential",
     "execute_tool_calls_segmented",

--- a/agent/transports/claude_agent_session.py
+++ b/agent/transports/claude_agent_session.py
@@ -1,0 +1,503 @@
+"""Synchronous facade over the async ``claude-agent-sdk`` client.
+
+``ClaudeSDKClient`` is asyncio-only; Hermes' conversation loop is entirely
+synchronous (AGENTS.md § Agent Loop).  This module owns the bridge: one
+``ClaudeAgentSession`` per :class:`AIAgent`, holding one long-lived
+``ClaudeSDKClient`` on a dedicated event-loop thread it created itself.
+
+Two rules make the difference between this working and wedging:
+
+* The client is constructed *and* connected on the owned loop, and every
+  later call is submitted back to that same loop.  ``anyio`` memory streams
+  and subprocess handles are bound to the loop that created them; touching
+  them from another loop (or from a bare ``asyncio.run``) corrupts the
+  transport.
+* A turn drains the response stream past ``ResultMessage`` rather than
+  stopping on it.  ``receive_response()`` returns the moment the result
+  arrives, which drops trailing frames (late tool results, the post-result
+  system events).  We keep pulling until the stream goes quiet.
+
+Projection into Hermes' message shape deliberately does NOT happen here —
+SDK messages are handed to the caller's thread through a queue so the
+Hermes-side callbacks run on the turn thread, exactly like every other
+runtime.  See :mod:`agent.claude_runtime`.
+
+The public surface mirrors ``CodexAppServerSession``: ``ensure_started``,
+``run_turn``, ``request_interrupt``, ``set_model``, ``close``.
+
+``claude_agent_sdk`` is an optional extra and is imported lazily, so this
+module imports cleanly without it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# How long a turn keeps reading after ``ResultMessage`` before deciding the
+# stream is quiet. The CLI emits the result before its trailing frames are
+# flushed, so stopping on the result truncates them.
+DEFAULT_TRAILING_DRAIN_SECONDS = 1.0
+
+DEFAULT_START_TIMEOUT_SECONDS = 60.0
+DEFAULT_TURN_TIMEOUT_SECONDS = 1800.0
+DEFAULT_CLOSE_TIMEOUT_SECONDS = 15.0
+# Bound on a control-plane round trip (interrupt / set_model). These go to a
+# live subprocess; a hung one must not block the turn thread forever.
+DEFAULT_CONTROL_TIMEOUT_SECONDS = 30.0
+
+
+class ClaudeAgentSessionError(RuntimeError):
+    """Raised for session-level failures (startup, teardown, wedged turn)."""
+
+
+def is_result_message(message: Any) -> bool:
+    """True when *message* is the SDK's terminal ``ResultMessage``.
+
+    Matched by class name rather than ``isinstance``: this module must behave
+    identically against the real optional extra and against the stand-in
+    module the suite installs when the extra is absent.
+    """
+    return type(message).__name__ == "ResultMessage"
+
+
+class ClaudeAgentSession:
+    """One ``ClaudeSDKClient`` on one owned event-loop thread.
+
+    Not thread-safe for concurrent turns — one caller drives it at a time,
+    matching how ``run_conversation()`` is structured.  ``request_interrupt``
+    and ``close`` are the exceptions and may be called from another thread.
+    """
+
+    def __init__(
+        self,
+        *,
+        options_factory: Callable[[], Any],
+        client_factory: Optional[Callable[..., Any]] = None,
+        transport_factory: Optional[Callable[[Any], Any]] = None,
+        start_timeout: float = DEFAULT_START_TIMEOUT_SECONDS,
+        turn_timeout: float = DEFAULT_TURN_TIMEOUT_SECONDS,
+        close_timeout: float = DEFAULT_CLOSE_TIMEOUT_SECONDS,
+        trailing_drain_seconds: float = DEFAULT_TRAILING_DRAIN_SECONDS,
+    ) -> None:
+        self._options_factory = options_factory
+        self._client_factory = client_factory
+        self._transport_factory = transport_factory
+        self._start_timeout = start_timeout
+        self._turn_timeout = turn_timeout
+        self._close_timeout = close_timeout
+        self._trailing_drain_seconds = trailing_drain_seconds
+
+        self._lock = threading.RLock()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._client: Any = None
+        self._closed = False
+        self._session_id: Optional[str] = None
+        self._turn_count = 0
+        # Temp CLAUDE_CONFIG_DIR holding a materialized resume, when this
+        # session was started from a SessionStore-backed transcript.
+        self._materialized: Any = None
+
+    # ---------- introspection ----------
+
+    @property
+    def started(self) -> bool:
+        return self._client is not None
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    @property
+    def turn_count(self) -> int:
+        return self._turn_count
+
+    @property
+    def session_id(self) -> Optional[str]:
+        """The SDK's own session id, once a turn has reported one.
+
+        PR5 reads this to drive ``resume`` / the ``SessionStore`` mirror.
+        """
+        return self._session_id
+
+    def note_session_id(self, session_id: Optional[str]) -> None:
+        """Record the SDK session id observed by the caller's projector."""
+        if session_id and session_id != self._session_id:
+            self._session_id = str(session_id)
+
+    # ---------- lifecycle ----------
+
+    def ensure_started(self) -> None:
+        """Spawn the loop thread and connect the client. Idempotent."""
+        with self._lock:
+            if self._closed:
+                raise ClaudeAgentSessionError(
+                    "Claude Agent SDK session is closed; build a new one."
+                )
+            if self._client is not None:
+                return
+
+            loop = asyncio.new_event_loop()
+            ready = threading.Event()
+            thread = threading.Thread(
+                target=self._run_loop,
+                args=(loop, ready),
+                name="hermes-claude-agent-sdk",
+                daemon=True,
+            )
+            thread.start()
+            if not ready.wait(self._start_timeout):
+                loop.call_soon_threadsafe(loop.stop)
+                raise ClaudeAgentSessionError(
+                    "Claude Agent SDK event loop failed to start "
+                    f"within {self._start_timeout:.0f}s."
+                )
+            self._loop = loop
+            self._thread = thread
+
+            try:
+                self._client = self._submit(
+                    self._connect(), timeout=self._start_timeout
+                )
+            except BaseException:
+                # A half-started session must not linger: the loop thread and
+                # any spawned CLI child are unreachable once __init__ returns
+                # without a client.
+                self._teardown_loop()
+                raise
+            logger.info(
+                "claude_agent_sdk session connected (loop thread=%s)",
+                thread.name,
+            )
+
+    def close(self) -> None:
+        """Disconnect the client, stop the loop, join the thread. Idempotent.
+
+        Safe from ``__del__`` / atexit: every step is independently guarded and
+        joining is skipped when called from the loop thread itself.
+        """
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            client = self._client
+            self._client = None
+
+        if client is not None:
+            try:
+                self._submit(client.disconnect(), timeout=self._close_timeout)
+            except Exception:
+                logger.debug("claude_agent_sdk disconnect failed", exc_info=True)
+        if self._materialized is not None:
+            # Ordered after disconnect: the child is pointed at this directory
+            # and must exit before it is removed. It holds a copy of the
+            # user's credentials, so it is not left behind on a failed close.
+            try:
+                self._submit(
+                    self._cleanup_materialized(), timeout=self._close_timeout
+                )
+            except Exception:
+                logger.debug("claude_agent_sdk resume cleanup failed", exc_info=True)
+        self._teardown_loop()
+
+    def __enter__(self) -> "ClaudeAgentSession":
+        self.ensure_started()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def __del__(self) -> None:  # pragma: no cover - interpreter shutdown path
+        try:
+            self.close()
+        except Exception:
+            pass
+
+    # ---------- control plane ----------
+
+    def request_interrupt(self) -> bool:
+        """Ask the CLI to abort the active turn. Never raises.
+
+        Only half of the interrupt: the caller must keep draining until the
+        interrupted response's ``ResultMessage`` lands before issuing the next
+        ``query()``. ``run_turn`` does that automatically — it does not return
+        early on interrupt.
+        """
+        client = self._client
+        if client is None or self._closed:
+            return False
+        try:
+            self._submit(client.interrupt(), timeout=DEFAULT_CONTROL_TIMEOUT_SECONDS)
+            return True
+        except Exception:
+            logger.debug("claude_agent_sdk interrupt failed", exc_info=True)
+            return False
+
+    def set_model(self, model: Optional[str]) -> bool:
+        """Switch the model for subsequent turns. Never raises."""
+        client = self._client
+        if client is None or self._closed:
+            return False
+        try:
+            self._submit(
+                client.set_model(model), timeout=DEFAULT_CONTROL_TIMEOUT_SECONDS
+            )
+            return True
+        except Exception:
+            logger.debug("claude_agent_sdk set_model failed", exc_info=True)
+            return False
+
+    # ---------- per-turn ----------
+
+    def run_turn(
+        self,
+        prompt: str,
+        *,
+        on_message: Callable[[Any], None],
+        timeout: Optional[float] = None,
+    ) -> int:
+        """Send *prompt* and block until the response stream goes quiet.
+
+        ``on_message`` is invoked once per SDK message, in arrival order, on
+        the **calling** thread — Hermes' display/tool callbacks are
+        thread-affine and must not run on the SDK's event loop.
+
+        Returns the number of messages delivered.  Raises ``TimeoutError``
+        when the turn blows its deadline (the caller should retire the
+        session) and re-raises whatever the SDK raised otherwise.
+        """
+        self.ensure_started()
+        inbox: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+        future = asyncio.run_coroutine_threadsafe(
+            self._pump_turn(prompt, inbox), self._require_loop()
+        )
+        self._turn_count += 1
+
+        deadline = time.monotonic() + (timeout or self._turn_timeout)
+        delivered = 0
+        try:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        "Claude Agent SDK turn exceeded "
+                        f"{timeout or self._turn_timeout:.0f}s without completing."
+                    )
+                try:
+                    kind, payload = inbox.get(timeout=min(remaining, 0.25))
+                except queue.Empty:
+                    continue
+                if kind == "message":
+                    delivered += 1
+                    on_message(payload)
+                    continue
+                if kind == "error":
+                    raise payload
+                break
+        except BaseException:
+            future.cancel()
+            raise
+        # The pump has already signalled completion; this only surfaces an
+        # exception raised after the last message was queued.
+        future.result(timeout=self._close_timeout)
+        return delivered
+
+    # ---------- internals ----------
+
+    def _run_loop(
+        self, loop: asyncio.AbstractEventLoop, ready: threading.Event
+    ) -> None:
+        asyncio.set_event_loop(loop)
+        try:
+            loop.call_soon(ready.set)
+            loop.run_forever()
+        finally:
+            try:
+                loop.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                pass
+
+    def _require_loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            raise ClaudeAgentSessionError(
+                "Claude Agent SDK session has no running event loop."
+            )
+        return loop
+
+    def _submit(self, coro: Any, *, timeout: float) -> Any:
+        """Run *coro* on the owned loop and wait, bounded by *timeout*."""
+        future = asyncio.run_coroutine_threadsafe(coro, self._require_loop())
+        try:
+            return future.result(timeout=timeout)
+        except TimeoutError:
+            future.cancel()
+            raise
+
+    async def _materialize(self, options: Any) -> Any:
+        """Resolve a ``session_store`` + ``resume`` pair into real options.
+
+        ``ClaudeSDKClient.connect()`` skips ``materialize_resume_session()``
+        whenever a custom transport is supplied — the materialized options
+        would never reach a transport that was already constructed, so the SDK
+        does not bother.  Subscription mode *requires* the custom transport
+        (it is the only thing that removes a stray ``ANTHROPIC_API_KEY`` from
+        the child environment), so the materialization has to happen here
+        instead, one step earlier: before the transport is built, so both the
+        transport and the client see the same repointed options.
+
+        What the SDK's helper does, and why none of it can be skipped: it
+        loads the session from the store, writes it back out as JSONL into a
+        temp directory laid out like ``~/.claude/`` (the CLI only knows how to
+        resume from a local file), copies the caller's auth files into that
+        directory with ``refreshToken`` redacted, materializes every subagent
+        transcript ``list_subkeys()`` reports, and hands back the directory to
+        point ``CLAUDE_CONFIG_DIR`` at.
+
+        Returns ``(options, materialized_or_None)``.  When nothing needed
+        materializing — no store, no resume, or an empty/unknown session — the
+        options come back untouched and ``CLAUDE_CONFIG_DIR`` passes through
+        to the child exactly as PR7 arranged.
+        """
+        if getattr(options, "session_store", None) is None:
+            return options, None
+        if not getattr(options, "resume", None) and not getattr(
+            options, "continue_conversation", False
+        ):
+            return options, None
+        from claude_agent_sdk._internal.session_resume import (
+            apply_materialized_options,
+            materialize_resume_session,
+        )
+
+        materialized = await materialize_resume_session(options)
+        if materialized is None:
+            return options, None
+        # Repoints env["CLAUDE_CONFIG_DIR"] at the temp dir and rewrites
+        # `resume` to the resolved id. Handing THESE options to the client (not
+        # just to the transport) also keeps the transcript mirror correct: the
+        # SDK resolves the batcher's projects_dir from `options.env`, so it
+        # must see the same temp dir the subprocess writes into.
+        return apply_materialized_options(options, materialized), materialized
+
+    async def _connect(self) -> Any:
+        factory = self._client_factory
+        if factory is None:
+            # Deferred so this module imports without the optional extra.
+            from claude_agent_sdk import ClaudeSDKClient
+
+            factory = ClaudeSDKClient
+        options = self._options_factory()
+        if self._transport_factory is not None:
+            options, self._materialized = await self._materialize(options)
+        kwargs: dict = {"options": options}
+        if self._transport_factory is not None:
+            # The transport owns the child environment; without one the SDK
+            # spawns from a copy of os.environ, where a higher-precedence
+            # credential would outrank the user's subscription.
+            transport = self._transport_factory(options)
+            if transport is not None:
+                kwargs["transport"] = transport
+        try:
+            client = factory(**kwargs)
+            await client.connect()
+        except BaseException:
+            # A failed connect leaves nobody to clean up the temp config dir,
+            # and it contains credentials.
+            await self._cleanup_materialized()
+            raise
+        return client
+
+    async def _cleanup_materialized(self) -> None:
+        """Remove the temp resume dir. Never raises.
+
+        ``ClaudeSDKClient.disconnect()`` cleans up only what *it* materialized,
+        and with a custom transport it materializes nothing — so the directory
+        (which holds a copy of the user's credentials) is ours to remove.
+        """
+        materialized = self._materialized
+        self._materialized = None
+        if materialized is None:
+            return
+        try:
+            await materialized.cleanup()
+        except Exception:  # pragma: no cover - best-effort cleanup
+            logger.debug("claude_agent_sdk resume temp cleanup failed", exc_info=True)
+
+    async def _pump_turn(
+        self, prompt: str, inbox: "queue.Queue[tuple[str, Any]]"
+    ) -> None:
+        """Drive one query and forward every message to the caller's queue."""
+        client = self._client
+        if client is None:
+            inbox.put(
+                ("error", ClaudeAgentSessionError("Claude Agent SDK session is closed."))
+            )
+            return
+        iterator = None
+        try:
+            await client.query(prompt)
+            iterator = client.receive_messages().__aiter__()
+            saw_result = False
+            while True:
+                try:
+                    if saw_result:
+                        # Past the result the stream never ends on its own, so
+                        # quiet-for-a-beat is the only end-of-response signal.
+                        message = await asyncio.wait_for(
+                            iterator.__anext__(), self._trailing_drain_seconds
+                        )
+                    else:
+                        message = await iterator.__anext__()
+                except (StopAsyncIteration, asyncio.TimeoutError):
+                    break
+                if is_result_message(message):
+                    saw_result = True
+                inbox.put(("message", message))
+            inbox.put(("done", None))
+        except BaseException as exc:  # noqa: BLE001 - relayed to the caller
+            inbox.put(("error", exc))
+        finally:
+            if iterator is not None:
+                aclose = getattr(iterator, "aclose", None)
+                if aclose is not None:
+                    try:
+                        await aclose()
+                    except Exception:  # pragma: no cover - generator teardown
+                        logger.debug(
+                            "claude_agent_sdk stream aclose failed", exc_info=True
+                        )
+
+    def _teardown_loop(self) -> None:
+        with self._lock:
+            loop = self._loop
+            thread = self._thread
+            self._loop = None
+            self._thread = None
+        if loop is not None and not loop.is_closed():
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except RuntimeError:  # pragma: no cover - already stopping
+                pass
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=self._close_timeout)
+            if thread.is_alive():  # pragma: no cover - wedged child
+                logger.warning(
+                    "claude_agent_sdk loop thread did not exit within %.0fs",
+                    self._close_timeout,
+                )
+
+
+__all__ = [
+    "ClaudeAgentSession",
+    "ClaudeAgentSessionError",
+    "DEFAULT_TRAILING_DRAIN_SECONDS",
+    "is_result_message",
+]

--- a/agent/transports/claude_sanitized_transport.py
+++ b/agent/transports/claude_sanitized_transport.py
@@ -1,0 +1,211 @@
+"""Claude Code subprocess transport that launches from a sanitized environment.
+
+``ClaudeAgentOptions.env`` cannot express "do not pass this variable through".
+The SDK builds the child environment as::
+
+    process_env = {**inherited_env, "CLAUDE_CODE_ENTRYPOINT": ..., **options.env, ...}
+
+(``claude_agent_sdk/_internal/transport/subprocess_cli.py``) — ``options.env``
+is merged *over* a copy of ``os.environ``, so it can override a key but never
+delete one.  Setting ``ANTHROPIC_API_KEY=""`` leaves the name present, and
+whether the CLI then treats it as absent is a per-variable, per-version
+accident rather than a contract.
+
+Mutating ``os.environ`` around the spawn is not an option either: Hermes is
+multi-threaded and other providers run concurrently, so a process-global
+mutation would leak into them.
+
+So the removal happens where it actually can: this transport subclasses the
+SDK's ``SubprocessCLITransport`` and overrides ``connect()`` — the one method
+that reads ``os.environ`` — to spawn from
+:func:`agent.claude_billing.sanitized_child_env` instead.  Everything else
+(command construction, CLI discovery, stdout framing, stdin, stderr pumping,
+teardown) is inherited unchanged.
+
+The class is built lazily inside :func:`build_sanitized_transport` because
+``claude-agent-sdk`` is an optional extra and this module must import without
+it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, AsyncIterator, Dict, Optional
+
+from agent.claude_billing import BLOCKED_CHILD_ENV_VARS, sanitized_child_env
+
+logger = logging.getLogger(__name__)
+
+_TRANSPORT_CLASS: Any = None
+
+
+async def _empty_stream() -> AsyncIterator[Dict[str, Any]]:
+    """A prompt stream that never yields, matching ``ClaudeSDKClient``.
+
+    The client writes turns with ``transport.write()``; the transport only
+    needs *an* async iterable to hold the connection open.
+    """
+    return
+    yield {}  # pragma: no cover - unreachable, marks this an async generator
+
+
+def build_child_env(options: Any, *, cwd: Optional[str] = None) -> Dict[str, str]:
+    """Build the child environment for a subscription-mode Claude spawn.
+
+    Mirrors the SDK's own merge, minus the credentials that outrank the user's
+    subscription.  Split out from the transport so the launcher's output can be
+    asserted on directly, without spawning anything.
+    """
+    try:
+        from claude_agent_sdk._version import __version__ as sdk_version
+    except Exception:  # pragma: no cover - SDK absent or restructured
+        sdk_version = ""
+
+    env = sanitized_child_env()
+    # CLAUDECODE would make the child believe it is nested inside a Claude Code
+    # parent; the SDK drops it for the same reason.
+    env.pop("CLAUDECODE", None)
+    env["CLAUDE_CODE_ENTRYPOINT"] = "sdk-py"
+    env.update(getattr(options, "env", None) or {})
+    if sdk_version:
+        env["CLAUDE_AGENT_SDK_VERSION"] = sdk_version
+
+    # Re-applied after options.env: a caller-supplied override must not be able
+    # to put a higher-precedence credential back into the child.
+    for key in BLOCKED_CHILD_ENV_VARS:
+        env.pop(key, None)
+
+    if getattr(options, "enable_file_checkpointing", False):
+        env["CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING"] = "true"
+    resolved_cwd = cwd if cwd is not None else getattr(options, "cwd", None)
+    if resolved_cwd:
+        env["PWD"] = str(resolved_cwd)
+    # HOME is deliberately absent from every write above. Overriding it
+    # relocates the macOS login-keychain lookup ($HOME/Library/Keychains), so
+    # the CLI cannot find its stored OAuth credentials and reports
+    # "Not logged in". CLAUDE_CONFIG_DIR is the supported way to isolate config
+    # and passes through untouched.
+    return env
+
+
+def _build_transport_class() -> Any:
+    """Define the transport subclass against the installed SDK."""
+    import anyio
+    from anyio.streams.text import TextReceiveStream, TextSendStream
+    from subprocess import PIPE
+
+    from claude_agent_sdk._errors import CLIConnectionError, CLINotFoundError
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        _ACTIVE_CHILDREN,
+        SubprocessCLITransport,
+    )
+    from claude_agent_sdk._internal._task_compat import spawn_detached
+
+    class SanitizedSubprocessCLITransport(SubprocessCLITransport):
+        """``SubprocessCLITransport`` that spawns from a sanitized environment.
+
+        Only ``connect()`` differs from the base class, and only in the
+        ``env=`` it hands to ``anyio.open_process``.
+        """
+
+        def build_child_env(self) -> Dict[str, str]:
+            return build_child_env(self._options, cwd=self._cwd)
+
+        async def connect(self) -> None:
+            if self._process:
+                return
+
+            if self._cli_path is None:
+                self._cli_path = await anyio.to_thread.run_sync(self._find_cli)
+            self._reject_windows_batch_cli(self._cli_path)
+            if not os.environ.get("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK"):
+                await self._check_claude_version()
+
+            cmd = self._build_command()
+            try:
+                process_env = self.build_child_env()
+
+                # The SDK pipes stderr only when a callback is registered;
+                # otherwise the child inherits the parent's stderr, which under
+                # Electron can be a closed handle. Hermes always registers one
+                # (see agent.claude_runtime).
+                stderr_dest = PIPE if self._options.stderr is not None else None
+
+                self._process = await anyio.open_process(
+                    cmd,
+                    # stdin is always a pipe: Claude Code probes stdin and
+                    # blocks forever on an unusable inherited one.
+                    stdin=PIPE,
+                    stdout=PIPE,
+                    stderr=stderr_dest,
+                    cwd=self._cwd,
+                    env=process_env,
+                    user=self._options.user,
+                )
+                _ACTIVE_CHILDREN.add(self._process)
+
+                if self._process.stdout:
+                    self._stdout_stream = TextReceiveStream(self._process.stdout)
+                if stderr_dest is PIPE and self._process.stderr:
+                    self._stderr_stream = TextReceiveStream(self._process.stderr)
+                    self._stderr_task = spawn_detached(self._handle_stderr())
+                if self._process.stdin:
+                    self._stdin_stream = TextSendStream(self._process.stdin)
+
+                self._ready = True
+            except FileNotFoundError as exc:
+                if self._cwd and not os.path.exists(self._cwd):
+                    error: Exception = CLIConnectionError(
+                        f"Working directory does not exist: {self._cwd}"
+                    )
+                else:
+                    error = CLINotFoundError(
+                        f"Claude Code not found at: {self._cli_path}"
+                    )
+                self._exit_error = error
+                raise error from exc
+            except Exception as exc:
+                error = CLIConnectionError(f"Failed to start Claude Code: {exc}")
+                self._exit_error = error
+                raise error from exc
+
+    return SanitizedSubprocessCLITransport
+
+
+def sanitized_transport_class() -> Any:
+    """The transport subclass, built once per process."""
+    global _TRANSPORT_CLASS
+    if _TRANSPORT_CLASS is None:
+        _TRANSPORT_CLASS = _build_transport_class()
+    return _TRANSPORT_CLASS
+
+
+def build_sanitized_transport(options: Any, *, prompt: Any = None) -> Any:
+    """Construct the transport ``ClaudeSDKClient`` should use for *options*.
+
+    Supplying a custom transport makes ``ClaudeSDKClient.connect()`` skip
+    ``materialize_resume_session()`` — the materialized options would never
+    reach a transport that is already constructed, so the SDK does not bother.
+    :meth:`agent.transports.claude_agent_session.ClaudeAgentSession._materialize`
+    therefore runs it one step earlier, *before* calling this factory, and
+    passes the repointed options here.  Nothing in this module needs to change
+    for that: the materialized ``options.env["CLAUDE_CONFIG_DIR"]`` flows
+    through :func:`build_child_env` like any other caller-supplied variable
+    (it is a pass-through, not a blocked one), and ``options.resume`` becomes
+    ``--resume=<id>`` in the inherited ``_build_command()``.  The blocklist is
+    still re-applied after ``options.env``, so materialization cannot
+    reintroduce a credential that outranks the user's subscription.
+    """
+    transport_class = sanitized_transport_class()
+    return transport_class(
+        prompt=prompt if prompt is not None else _empty_stream(),
+        options=options,
+    )
+
+
+__all__ = [
+    "build_child_env",
+    "build_sanitized_transport",
+    "sanitized_transport_class",
+]

--- a/agent/transports/claude_tool_bridge.py
+++ b/agent/transports/claude_tool_bridge.py
@@ -1,0 +1,319 @@
+"""In-process MCP bridge from the Claude Agent SDK back into Hermes tools.
+
+When ``api_mode="claude_agent_sdk"`` is active the SDK owns the agent loop,
+so Claude's tool calls arrive as MCP invocations instead of OpenAI-shaped
+``tool_calls``.  Hermes still owns tool execution: every generated handler
+here funnels into :func:`agent.tool_executor.execute_one_tool`, which is the
+one place that applies approvals, guardrails, plugin hooks, checkpoints,
+progress callbacks, and task/environment routing.  A handler must never call
+``model_tools.handle_function_call`` directly — that skips all of it.
+
+The server is built from the schemas the bound ``AIAgent`` already has
+enabled (``agent.tools``), so the bridge cannot widen the model's tool
+surface beyond what the agent's toolset resolution produced.
+
+``claude_agent_sdk`` is an optional extra and is imported lazily inside
+:func:`build_hermes_sdk_mcp_server` — this module imports cleanly without it.
+
+Unrelated to ``hermes_tools_mcp_server``: that one is a stateless stdio
+subset for the codex runtime and deliberately excludes the AIAgent-bound
+tools.  This bridge is bound to a live agent and exposes the full enabled
+set.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+from types import SimpleNamespace
+from typing import Any, Callable, Optional
+
+from agent.display import _detect_tool_failure
+from agent.tool_dispatch_helpers import (
+    _is_multimodal_tool_result,
+    _multimodal_text_summary,
+)
+from agent.tool_executor import execute_one_tool, finalize_tool_outcome
+from tools.thread_context import propagate_context_to_thread
+
+logger = logging.getLogger(__name__)
+
+MCP_SERVER_NAME = "hermes"
+MCP_SERVER_VERSION = "1.0.0"
+# The SDK namespaces in-process servers as ``mcp__<server>__<tool>``; PR4 has
+# to list every one of these in ``allowed_tools`` or Claude cannot call them.
+MCP_TOOL_PREFIX = f"mcp__{MCP_SERVER_NAME}__"
+
+_DATA_URL_PREFIX = "data:"
+
+
+def mcp_tool_name(tool_name: str) -> str:
+    """Return the name Claude sees for a Hermes tool."""
+    return f"{MCP_TOOL_PREFIX}{tool_name}"
+
+
+def agent_tool_specs(agent) -> list[dict[str, Any]]:
+    """Return ``{name, description, parameters}`` for the agent's enabled tools.
+
+    Reads ``agent.tools`` — the already-resolved, toolset-filtered definitions
+    the agent sends on every API call. Nothing else is exposed.
+    """
+    specs: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for entry in getattr(agent, "tools", None) or []:
+        if not isinstance(entry, dict):
+            continue
+        function = entry.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        specs.append(
+            {
+                "name": name,
+                "description": function.get("description") or f"Hermes {name} tool",
+                "parameters": function.get("parameters")
+                or {"type": "object", "properties": {}},
+            }
+        )
+    return specs
+
+
+def is_read_only_tool(tool_name: str) -> bool:
+    """Whether Claude may batch *tool_name* in parallel with other reads.
+
+    Hermes has no per-tool read-only flag on the registry; the closest
+    authority is ``_PARALLEL_SAFE_TOOLS`` — the conservative allowlist of
+    read-only tools with no shared mutable session state that the batch
+    segment planner already trusts to run concurrently.  Anything not on it
+    (including MCP tools whose server merely opted into parallel calls)
+    defaults to False so a mutating tool is never announced as read-only.
+    """
+    try:
+        from agent.tool_dispatch_helpers import _PARALLEL_SAFE_TOOLS
+
+        return tool_name in _PARALLEL_SAFE_TOOLS
+    except Exception:
+        return False
+
+
+def _image_block(data: str, mime_type: str) -> dict[str, Any]:
+    return {"type": "image", "data": data, "mimeType": mime_type}
+
+
+def _image_block_from_url(url: str) -> Optional[dict[str, Any]]:
+    """Convert an OpenAI ``image_url`` payload into an MCP image block.
+
+    MCP carries raw base64 with a separate ``mimeType``; the ``data:`` prefix
+    an OpenAI content part uses must be stripped, not forwarded.
+    """
+    if not isinstance(url, str) or not url.startswith(_DATA_URL_PREFIX):
+        return None
+    header, _, payload = url[len(_DATA_URL_PREFIX):].partition(",")
+    if not payload:
+        return None
+    mime_type = header.split(";", 1)[0] or "image/png"
+    return _image_block(payload, mime_type)
+
+
+def tool_result_content_blocks(result: Any) -> list[dict[str, Any]]:
+    """Convert a Hermes tool result into MCP content blocks.
+
+    Registry handlers return a JSON string; multimodal tools return the
+    ``{"_multimodal": True, "content": [...]}`` envelope whose image parts
+    become MCP image blocks.
+    """
+    if _is_multimodal_tool_result(result):
+        blocks: list[dict[str, Any]] = []
+        for part in result.get("content") or []:
+            if not isinstance(part, dict):
+                continue
+            part_type = part.get("type")
+            if part_type == "text":
+                blocks.append({"type": "text", "text": str(part.get("text", ""))})
+            elif part_type == "image_url":
+                image_url = part.get("image_url")
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+                block = _image_block_from_url(url)
+                if block is not None:
+                    blocks.append(block)
+            elif part_type == "image" and part.get("data"):
+                blocks.append(
+                    _image_block(
+                        str(part["data"]),
+                        str(part.get("mimeType") or "image/png"),
+                    )
+                )
+        if not blocks:
+            blocks.append({"type": "text", "text": _multimodal_text_summary(result)})
+        return blocks
+
+    if isinstance(result, str):
+        return [{"type": "text", "text": result}]
+    return [{"type": "text", "text": _multimodal_text_summary(result)}]
+
+
+def build_tool_response(tool_name: str, result: Any) -> dict[str, Any]:
+    """Build the MCP tool response for a completed Hermes tool result."""
+    is_error, _ = _detect_tool_failure(tool_name, result)
+    response: dict[str, Any] = {"content": tool_result_content_blocks(result)}
+    if is_error:
+        # Python SDK spells this snake_case; the TypeScript SDK uses isError.
+        response["is_error"] = True
+    return response
+
+
+def _resolve_task_id(effective_task_id: Any) -> str:
+    if callable(effective_task_id):
+        return str(effective_task_id() or "")
+    return str(effective_task_id or "")
+
+
+def run_bridged_tool(
+    agent,
+    tool_name: str,
+    args: dict[str, Any],
+    effective_task_id: Any,
+    *,
+    messages: Optional[list] = None,
+) -> dict[str, Any]:
+    """Execute one Claude tool call through the Hermes lifecycle.
+
+    Synchronous by design: the whole executor stack (approvals, terminal
+    backends, checkpoints) is blocking, so handlers run this on a worker
+    thread rather than the SDK's event loop.
+    """
+    tool_call = SimpleNamespace(
+        id=f"claude_{uuid.uuid4().hex[:24]}",
+        function=SimpleNamespace(
+            name=tool_name,
+            arguments=json.dumps(args or {}, ensure_ascii=False),
+        ),
+    )
+    outcome = execute_one_tool(
+        agent,
+        tool_call,
+        _resolve_task_id(effective_task_id),
+        messages=messages,
+    )
+    result = finalize_tool_outcome(agent, outcome)
+    response = build_tool_response(outcome.function_name, result)
+    if (outcome.is_error or outcome.blocked or outcome.cancelled) and not response.get(
+        "is_error"
+    ):
+        response["is_error"] = True
+    return response
+
+
+def build_bridged_sdk_tools(
+    agent,
+    effective_task_id: Any,
+    *,
+    messages: Optional[list] = None,
+) -> list:
+    """Every Hermes tool for *agent*, wrapped as an SDK ``@tool``.
+
+    Split out of :func:`build_hermes_sdk_mcp_server` so callers can inspect
+    what the bridge composed without reaching into the value
+    ``create_sdk_mcp_server`` returns, which is an SDK-internal shape that
+    differs between the real package and a stub.
+    """
+    try:
+        from claude_agent_sdk import ToolAnnotations, tool
+    except ImportError as exc:  # pragma: no cover - install hint
+        raise ImportError(
+            "api_mode='claude_agent_sdk' requires the claude-agent-sdk package: "
+            f"pip install claude-agent-sdk ({exc})"
+        ) from exc
+
+    handlers = []
+    for spec in agent_tool_specs(agent):
+        tool_name = spec["name"]
+
+        def _make_handler(name: str):
+            def _invoke(call_args: dict[str, Any]) -> dict[str, Any]:
+                return run_bridged_tool(
+                    agent, name, call_args, effective_task_id, messages=messages,
+                )
+
+            async def _handler(call_args: dict[str, Any]) -> dict[str, Any]:
+                # propagate_context_to_thread carries the turn's ContextVars
+                # and thread-local approval/sudo callbacks into the worker,
+                # the same way the concurrent executor does.
+                return await asyncio.to_thread(
+                    propagate_context_to_thread(_invoke), call_args or {},
+                )
+
+            _handler.__name__ = name
+            return _handler
+
+        handlers.append(
+            tool(
+                tool_name,
+                spec["description"],
+                spec["parameters"],
+                annotations=ToolAnnotations(readOnlyHint=is_read_only_tool(tool_name)),
+            )(_make_handler(tool_name))
+        )
+
+    logger.info(
+        "claude_agent_sdk bridge exposing %d Hermes tool(s) as %s*",
+        len(handlers),
+        MCP_TOOL_PREFIX,
+    )
+    return handlers
+
+
+def build_hermes_sdk_mcp_server(
+    agent,
+    effective_task_id: Any,
+    *,
+    messages: Optional[list] = None,
+    server_name: str = MCP_SERVER_NAME,
+    version: str = MCP_SERVER_VERSION,
+) -> Any:
+    """Build an in-process ``claude_agent_sdk`` MCP server bound to *agent*.
+
+    ``effective_task_id`` may be a string or a zero-argument callable, so a
+    long-lived server can follow the turn's task id (and therefore the
+    local / Docker / SSH / Modal / Daytona / Singularity environment the
+    tools execute in).
+
+    Raises ``ImportError`` when the optional ``claude-agent-sdk`` extra is
+    not installed; the import is deliberately deferred to here so importing
+    this module never requires it.
+    """
+    handlers = build_bridged_sdk_tools(
+        agent, effective_task_id, messages=messages,
+    )
+    from claude_agent_sdk import create_sdk_mcp_server
+
+    return create_sdk_mcp_server(name=server_name, version=version, tools=handlers)
+
+
+def bridged_allowed_tools(agent) -> list[str]:
+    """Every ``mcp__hermes__<tool>`` name the bridge exposes for *agent*.
+
+    PR4 passes this straight into the SDK's ``allowed_tools``.
+    """
+    return [mcp_tool_name(spec["name"]) for spec in agent_tool_specs(agent)]
+
+
+__all__ = [
+    "MCP_SERVER_NAME",
+    "MCP_SERVER_VERSION",
+    "MCP_TOOL_PREFIX",
+    "mcp_tool_name",
+    "agent_tool_specs",
+    "is_read_only_tool",
+    "tool_result_content_blocks",
+    "build_tool_response",
+    "run_bridged_tool",
+    "build_bridged_sdk_tools",
+    "build_hermes_sdk_mcp_server",
+    "bridged_allowed_tools",
+]

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1091,6 +1091,11 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    if provider_name == "claude-code" or base == "claude-sdk://subscription":
+        # Claude subscription via the Agent SDK: turns draw on the user's plan
+        # limits, the same bucket as openai-codex. The SDK reports an estimated
+        # total_cost_usd per turn; it is informational, not an invoice.
+        return BillingRoute(provider="claude-code", model=model.split("/")[-1], base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "nous" or base_url_host_matches(base_url or "", "inference-api.nousresearch.com"):

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1003,6 +1003,11 @@ def resolve_billing_route(
 
     if provider_name == "openai-codex":
         return BillingRoute(provider="openai-codex", model=model, base_url=base_url or "", billing_mode="subscription_included")
+    if provider_name == "claude-code" or base == "claude-sdk://subscription":
+        # Claude subscription via the Agent SDK: turns draw on the user's plan
+        # limits, the same bucket as openai-codex. The SDK reports an estimated
+        # total_cost_usd per turn; it is informational, not an invoice.
+        return BillingRoute(provider="claude-code", model=model.split("/")[-1], base_url=base_url or "", billing_mode="subscription_included")
     if provider_name == "openrouter" or base_url_host_matches(base_url or "", "openrouter.ai"):
         return BillingRoute(provider="openrouter", model=model, base_url=base_url or "", billing_mode="official_models_api")
     if provider_name == "nous" or base_url_host_matches(base_url or "", "inference-api.nousresearch.com"):

--- a/apps/desktop/src/components/onboarding/providers.tsx
+++ b/apps/desktop/src/components/onboarding/providers.tsx
@@ -10,9 +10,10 @@ const PROVIDER_DISPLAY: Record<string, { order: number; title: string }> = {
   'qwen-oauth': { order: 3, title: 'Qwen Code' },
   'xai-oauth': { order: 4, title: 'xAI Grok' },
   // Both Anthropic entries sit at the bottom: the API-key path first, then
-  // the subscription OAuth path (only works with extra usage credits).
+  // the Claude subscription path. They bill differently — per-token API usage
+  // vs. the user's Claude plan — so the titles must stay distinguishable.
   anthropic: { order: 5, title: 'Anthropic API Key' },
-  'claude-code': { order: 6, title: 'Anthropic OAuth: Required Extra Usage Credits to Use Subscription' }
+  'claude-code': { order: 6, title: 'Claude subscription (Agent SDK)' }
 }
 
 const assetPath = (path: string) => `${import.meta.env.BASE_URL}${path.replace(/^\/+/, '')}`

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -313,6 +313,7 @@ def _process_single_prompt(
         if config.get("verbose"):
             print(f"   Prompt {prompt_index}: Using container image {container_image}")
     
+    agent = None
     try:
         # Sample toolsets from distribution for this prompt
         selected_toolsets = sample_toolsets_from_distribution(config["distribution"])
@@ -325,6 +326,13 @@ def _process_single_prompt(
         agent = AIAgent(
             base_url=config.get("base_url"),
             api_key=config.get("api_key"),
+            # Provider + api_mode were never forwarded, so a batch run silently
+            # fell back to chat_completions regardless of the configured
+            # provider — which meant a subscription-mode user's batch went out
+            # over the legacy HTTP path. Both are optional: a config without
+            # them behaves exactly as before.
+            provider=config.get("provider"),
+            api_mode=config.get("api_mode"),
             model=config["model"],
             max_iterations=config["max_iterations"],
             enabled_toolsets=selected_toolsets,
@@ -395,6 +403,18 @@ def _process_single_prompt(
                 "timestamp": datetime.now().isoformat()
             }
         }
+
+    finally:
+        # A worker process handles many prompts in a row and the pool has no
+        # maxtasksperchild, so an unclosed agent accumulates for the life of the
+        # pool. That was merely wasteful for an HTTP client; a claude_agent_sdk
+        # agent owns an OS thread and a Claude Code subprocess per prompt.
+        if agent is not None:
+            try:
+                agent.close()
+            except Exception:
+                if config.get("verbose"):
+                    traceback.print_exc()
 
 
 def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
@@ -580,6 +600,8 @@ class BatchRunner:
         max_iterations: int = 10,
         base_url: str = None,
         api_key: str = None,
+        provider: str = None,
+        api_mode: str = None,
         model: str = "claude-opus-4-20250514",
         num_workers: int = 4,
         verbose: bool = False,
@@ -630,6 +652,8 @@ class BatchRunner:
         self.max_iterations = max_iterations
         self.base_url = base_url
         self.api_key = api_key
+        self.provider = provider
+        self.api_mode = api_mode
         self.model = model
         self.num_workers = num_workers
         self.verbose = verbose
@@ -847,6 +871,22 @@ class BatchRunner:
         
         return filtered_dataset, skipped_indices
     
+    def _preflight_runtime(self) -> None:
+        """Refuse to start when the configured runtime cannot serve the run.
+
+        Batch runs are non-interactive, so a runtime that would prompt for a
+        login has to be caught before any worker is spawned. Only the Claude
+        subscription runtime has such a gate today; every other provider keeps
+        its existing per-prompt error behaviour untouched.
+        """
+        if (self.api_mode or "").strip() != "claude_agent_sdk":
+            return
+        from agent.claude_runtime import claude_runtime_preflight
+
+        error = claude_runtime_preflight()
+        if error:
+            raise RuntimeError(f"Cannot start batch run: {error}")
+
     def run(self, resume: bool = False):
         """
         Run the batch processing pipeline.
@@ -928,6 +968,8 @@ class BatchRunner:
             "max_iterations": self.max_iterations,
             "base_url": self.base_url,
             "api_key": worker_api_key,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
             "verbose": self.verbose,
             "ephemeral_system_prompt": self.ephemeral_system_prompt,
             "log_prefix_chars": self.log_prefix_chars,
@@ -948,7 +990,13 @@ class BatchRunner:
         total_tool_stats = {}
         
         start_time = time.time()
-        
+
+        # Fail the whole run once, up front, rather than N times mid-flight.
+        # A batch run is unattended: without this, a not-signed-in Claude
+        # subscription produces one identical error per prompt after the pool
+        # has already spun up, and the actionable message is buried in them.
+        self._preflight_runtime()
+
         print(f"\n🔧 Initializing {self.num_workers} worker processes...")
         
         # Checkpoint writes happen in the parent process; keep a lock for safety.
@@ -1211,6 +1259,8 @@ def main(
     model: str = "anthropic/claude-sonnet-4.6",
     api_key: str = None,
     base_url: str = "https://openrouter.ai/api/v1",
+    provider: str = None,
+    api_mode: str = None,
     max_turns: int = 10,
     num_workers: int = 4,
     resume: bool = False,
@@ -1239,6 +1289,9 @@ def main(
         model (str): Model name to use (default: "claude-opus-4-20250514")
         api_key (str): API key for model authentication
         base_url (str): Base URL for model API
+        provider (str): Provider id (e.g. "claude-code"). Optional; when omitted
+            the agent derives its transport from base_url as before.
+        api_mode (str): Transport override (e.g. "claude_agent_sdk"). Optional.
         max_turns (int): Maximum number of tool calling iterations per prompt (default: 10)
         num_workers (int): Number of parallel worker processes (default: 4)
         resume (bool): Resume from checkpoint if run was interrupted (default: False)
@@ -1351,6 +1404,8 @@ def main(
             max_iterations=max_turns,
             base_url=base_url,
             api_key=api_key,
+            provider=provider,
+            api_mode=api_mode,
             model=model,
             num_workers=num_workers,
             verbose=verbose,

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -313,6 +313,7 @@ def _process_single_prompt(
         if config.get("verbose"):
             print(f"   Prompt {prompt_index}: Using container image {container_image}")
     
+    agent = None
     try:
         # Sample toolsets from distribution for this prompt
         selected_toolsets = sample_toolsets_from_distribution(config["distribution"])
@@ -325,6 +326,13 @@ def _process_single_prompt(
         agent = AIAgent(
             base_url=config.get("base_url"),
             api_key=config.get("api_key"),
+            # Provider + api_mode were never forwarded, so a batch run silently
+            # fell back to chat_completions regardless of the configured
+            # provider — which meant a subscription-mode user's batch went out
+            # over the legacy HTTP path. Both are optional: a config without
+            # them behaves exactly as before.
+            provider=config.get("provider"),
+            api_mode=config.get("api_mode"),
             model=config["model"],
             max_iterations=config["max_iterations"],
             enabled_toolsets=selected_toolsets,
@@ -395,6 +403,18 @@ def _process_single_prompt(
                 "timestamp": datetime.now().isoformat()
             }
         }
+
+    finally:
+        # A worker process handles many prompts in a row and the pool has no
+        # maxtasksperchild, so an unclosed agent accumulates for the life of the
+        # pool. That was merely wasteful for an HTTP client; a claude_agent_sdk
+        # agent owns an OS thread and a Claude Code subprocess per prompt.
+        if agent is not None:
+            try:
+                agent.close()
+            except Exception:
+                if config.get("verbose"):
+                    traceback.print_exc()
 
 
 def _process_batch_worker(args: Tuple) -> Dict[str, Any]:
@@ -538,6 +558,8 @@ class BatchRunner:
         max_iterations: int = 10,
         base_url: str = None,
         api_key: str = None,
+        provider: str = None,
+        api_mode: str = None,
         model: str = "claude-opus-4-20250514",
         num_workers: int = 4,
         verbose: bool = False,
@@ -588,6 +610,8 @@ class BatchRunner:
         self.max_iterations = max_iterations
         self.base_url = base_url
         self.api_key = api_key
+        self.provider = provider
+        self.api_mode = api_mode
         self.model = model
         self.num_workers = num_workers
         self.verbose = verbose
@@ -807,6 +831,22 @@ class BatchRunner:
         
         return filtered_dataset, skipped_indices
     
+    def _preflight_runtime(self) -> None:
+        """Refuse to start when the configured runtime cannot serve the run.
+
+        Batch runs are non-interactive, so a runtime that would prompt for a
+        login has to be caught before any worker is spawned. Only the Claude
+        subscription runtime has such a gate today; every other provider keeps
+        its existing per-prompt error behaviour untouched.
+        """
+        if (self.api_mode or "").strip() != "claude_agent_sdk":
+            return
+        from agent.claude_runtime import claude_runtime_preflight
+
+        error = claude_runtime_preflight()
+        if error:
+            raise RuntimeError(f"Cannot start batch run: {error}")
+
     def run(self, resume: bool = False):
         """
         Run the batch processing pipeline.
@@ -888,6 +928,8 @@ class BatchRunner:
             "max_iterations": self.max_iterations,
             "base_url": self.base_url,
             "api_key": worker_api_key,
+            "provider": self.provider,
+            "api_mode": self.api_mode,
             "verbose": self.verbose,
             "ephemeral_system_prompt": self.ephemeral_system_prompt,
             "log_prefix_chars": self.log_prefix_chars,
@@ -908,7 +950,13 @@ class BatchRunner:
         total_tool_stats = {}
         
         start_time = time.time()
-        
+
+        # Fail the whole run once, up front, rather than N times mid-flight.
+        # A batch run is unattended: without this, a not-signed-in Claude
+        # subscription produces one identical error per prompt after the pool
+        # has already spun up, and the actionable message is buried in them.
+        self._preflight_runtime()
+
         print(f"\n🔧 Initializing {self.num_workers} worker processes...")
         
         # Checkpoint writes happen in the parent process; keep a lock for safety.
@@ -1152,6 +1200,8 @@ def main(
     model: str = "anthropic/claude-sonnet-4.6",
     api_key: str = None,
     base_url: str = "https://openrouter.ai/api/v1",
+    provider: str = None,
+    api_mode: str = None,
     max_turns: int = 10,
     num_workers: int = 4,
     resume: bool = False,
@@ -1180,6 +1230,9 @@ def main(
         model (str): Model name to use (default: "claude-opus-4-20250514")
         api_key (str): API key for model authentication
         base_url (str): Base URL for model API
+        provider (str): Provider id (e.g. "claude-code"). Optional; when omitted
+            the agent derives its transport from base_url as before.
+        api_mode (str): Transport override (e.g. "claude_agent_sdk"). Optional.
         max_turns (int): Maximum number of tool calling iterations per prompt (default: 10)
         num_workers (int): Number of parallel worker processes (default: 4)
         resume (bool): Resume from checkpoint if run was interrupted (default: False)
@@ -1292,6 +1345,8 @@ def main(
             max_iterations=max_turns,
             base_url=base_url,
             api_key=api_key,
+            provider=provider,
+            api_mode=api_mode,
             model=model,
             num_workers=num_workers,
             verbose=verbose,

--- a/docs/design/claude-subscription-via-agent-sdk.md
+++ b/docs/design/claude-subscription-via-agent-sdk.md
@@ -1,0 +1,479 @@
+# Claude Subscription via the Agent SDK — Decision Record
+
+> **Status:** accepted; runtime ships default-off behind `claude_subscription.enabled`
+> **Audience:** Hermes maintainers working on providers, auth, or the agent loop
+> **Sources retrieved:** 30 Jul 2026
+> **Last updated:** 2026-07-30
+
+Hermes today reaches a Claude subscription by extracting the OAuth credential
+Claude Code stores in `~/.claude/.credentials.json` (or the macOS Keychain),
+hand-building an Anthropic `/v1/messages` request, and attaching Claude Code's
+identity headers to it (`agent/anthropic_adapter.py` — the
+`claude-code/<version> (external, cli)` user-agent and `x-app: cli` around
+line 882). That path is why subscribers get billed as extra usage: the request
+is ours, not Claude Code's, and nothing about it is sanctioned.
+
+The replacement is to stop imitating Claude Code and to *call* it, through
+Anthropic's official `claude-agent-sdk`, which wraps the Claude Code CLI as a
+subprocess. This document records the decision, the ownership split, the policy
+gate that keeps it default-off, and the rollback contract.
+
+---
+
+## 1. Two providers, not one
+
+`claude-code` is currently an alias of `anthropic`
+(`plugins/model-providers/anthropic/__init__.py:46`,
+`hermes_cli/providers.py:309`). The two are split into distinct providers:
+
+| | **Anthropic API** | **Claude subscription via Agent SDK** |
+|---|---|---|
+| Provider id | `anthropic` | `claude-code` |
+| Auth | API key only | `auth_type="external_process"` |
+| Request shape | `api_mode="anthropic_messages"` | `api_mode="claude_agent_sdk"` |
+| API URL | Anthropic base URL | none — the SDK owns the endpoint |
+| Credential env var | `ANTHROPIC_API_KEY` | none — Hermes holds no Claude credential |
+
+The split is the point. "Anthropic API" keeps meaning exactly what it means
+today: a key you pasted, billed to your Console org, running Hermes' own loop.
+"Claude subscription via Agent SDK" is an account you signed into with
+`claude` itself, running Claude's loop, with Hermes holding no credential at
+all. Anything that blurs the two reintroduces the billing surprise this work
+exists to remove.
+
+## 2. Ownership boundary
+
+The runtime is only tractable if each side owns its half completely and neither
+reconstructs the other's state.
+
+**Hermes keeps:** the system prompt; tool implementations; permissions and
+approvals; plugins; memory; skills; checkpoints; UI history; environments
+(Docker / SSH / Modal / Daytona / Singularity); cross-provider config; the
+session picker; analytics.
+
+**The SDK keeps:** Claude-native context and opaque frames; prompt-cache
+continuity; automatic compaction; assistant/tool-result alternation; the resume
+cursor and message UUIDs; Claude turn usage; the terminal reason.
+
+The asymmetry is deliberate. Everything Hermes keeps is *user-visible product*
+that must behave identically across every provider. Everything the SDK keeps is
+*conversation-internal state* whose exact bytes we cannot reproduce and must not
+try to — reconstructing Claude's context is precisely how prompt caching dies
+and how alternation invariants get violated.
+
+## 3. What we stop doing
+
+> **Status (2026-07-31):** the subscription runtime no longer does any of
+> this, and `scripts/check_claude_boundary.py` forbids reintroducing it. The
+> *legacy* direct-OAuth path still contains all of it, allow-listed under
+> `TODO(legacy-retirement)` markers — it is what current users run while the
+> gate is closed, and it is deleted only when the subscription runtime is
+> enabled and users have migrated. Until then, read "remove" as the end state,
+> not the current tree.
+
+Every item below is behavior we remove, not behavior we gate:
+
+- Reading, copying, refreshing, or deleting Claude's credential files.
+- Sending subscription OAuth tokens to `/v1/messages` directly.
+- Spoofing the `claude-code/<version> (external, cli)` user-agent, `x-app: cli`,
+  and Claude Code beta flags.
+- Rewriting the system prompt to strip "Hermes" / "Nous".
+- Renaming Hermes tools so they look like Claude Code tools.
+
+Nothing here is a capability the user asked for; all of it exists only to make
+our traffic pass as Claude Code's. Under the SDK the traffic *is* Claude Code's,
+so the disguise has no remaining purpose.
+
+## 4. The policy gate
+
+Anthropic's Agent SDK overview
+(<https://code.claude.com/docs/en/agent-sdk/overview>, retrieved 30 Jul 2026)
+states:
+
+> Unless previously approved, Anthropic does not allow third party developers to
+> offer claude.ai login or rate limits for their products, including agents built
+> on the Claude Agent SDK. Use the API key authentication methods described in the
+> Quickstart instead.
+
+Anthropic's Help Center takes a different position. "Use the Claude Agent SDK
+with your Claude plan" (last updated 16 Jun 2026) says a planned change was
+paused and that "For now, nothing has changed: Claude Agent SDK, `claude -p`,
+and third-party app usage still draw from your subscription's usage limits."
+
+So one Anthropic surface says the mechanism works and is metered against the
+subscription, and another says third parties may not *offer* it. Those are not
+reconcilable by reading harder, and the risk of guessing wrong lands on users'
+accounts, not on us.
+
+**Conclusion: the runtime ships default-off, and public enablement requires
+written confirmation from Anthropic.** Private technical validation against a
+developer-controlled, consenting account is fine and is how PRs 2-7 are
+verified; shipping it enabled, advertising it, or defaulting any user onto it is
+not, until that confirmation exists.
+
+## 5. Credential precedence — why a subscription silently becomes API billing
+
+From <https://code.claude.com/docs/en/iam> (retrieved 30 Jul 2026), when
+multiple credentials are present the CLI chooses one in this order:
+
+1. Cloud provider credentials, when `CLAUDE_CODE_USE_BEDROCK`,
+   `CLAUDE_CODE_USE_VERTEX`, or `CLAUDE_CODE_USE_FOUNDRY` is set.
+2. `ANTHROPIC_AUTH_TOKEN`.
+3. `ANTHROPIC_API_KEY`.
+4. `apiKeyHelper` script output.
+5. `CLAUDE_CODE_OAUTH_TOKEN`.
+6. Subscription OAuth credentials from `/login`.
+
+The subscription is *last*. A user with a valid `/login` session and a stale
+`ANTHROPIC_API_KEY` exported in their shell gets billed to the API key — with no
+error, because that ordering is correct behavior for the CLI. Hermes users are
+disproportionately exposed here: `ANTHROPIC_API_KEY` is a first-class Hermes
+credential that the setup wizard actively encourages, so the collision is the
+common case rather than the edge case. (A signed-in Claude apps gateway session
+sits outside the list entirely and outranks all six.)
+
+This cannot be fixed with `options.env`. The Python SDK builds the subprocess
+environment as `{**os.environ, "CLAUDE_CODE_ENTRYPOINT": ..., **options.env}`
+(`claude_agent_sdk/_internal/transport/subprocess_cli.py`), so `options.env`
+**overrides** inherited keys and **cannot delete** them — setting
+`ANTHROPIC_API_KEY=""` is still a set key, not an absent one.
+
+### 5.1 How PR7 resolves it
+
+Three layers, in the order a turn hits them:
+
+1. **Refuse (static).** `agent/claude_billing.py` holds the precedence table.
+   If any rank-1..5 credential is present in the environment,
+   `claude_runtime_preflight()` refuses the turn with a message naming that
+   variable and the exact `unset`. Refusing is the conservative direction:
+   a refusal costs a message, a wrong guess costs money, and *which account
+   pays* is the user's decision, not ours.
+2. **Refuse (dynamic).** Once per session, `verify_claude_billing_for_agent()`
+   asks the CLI itself. It connects the SDK to the child, reads the
+   `initialize` control response — which the CLI answers from local startup,
+   before any prompt exists — and disconnects without ever writing a user
+   message. No model request, so no tokens and no quota. The response's
+   `account` block is the ground truth (`ClaudeSDKClient.get_server_info()`).
+3. **Sanitize (structural).** `agent/transports/claude_sanitized_transport.py`
+   subclasses the SDK's `SubprocessCLITransport` and overrides `connect()` —
+   the single method that reads `os.environ` — to spawn from an explicitly
+   filtered copy. `os.environ` itself is never mutated: Hermes is
+   multi-threaded and other providers run concurrently.
+
+Measured against Claude Code 2.1.220 (30 Jul 2026), the `account` block reads:
+
+| environment | `account` |
+|---|---|
+| plan login, clean env | `{"email", "organization", "subscriptionType": "Claude Max", "apiProvider": "firstParty"}` |
+| `ANTHROPIC_API_KEY` set | `{"tokenSource": "claude.ai", "apiKeySource": "ANTHROPIC_API_KEY", "apiProvider": "firstParty"}` |
+| `ANTHROPIC_AUTH_TOKEN` set | `{"tokenSource": "ANTHROPIC_AUTH_TOKEN", "apiProvider": "firstParty"}` |
+| `CLAUDE_CODE_OAUTH_TOKEN` set | `{"tokenSource": "CLAUDE_CODE_OAUTH_TOKEN", "apiProvider": "firstParty"}` |
+| `apiKeyHelper` in settings, `setting_sources=["user"]` | `{"tokenSource": "apiKeyHelper", "apiKeySource": "apiKeyHelper"}` |
+| no login | `{"tokenSource": "none"}` |
+
+Two findings worth recording because they contradict reasonable assumptions:
+
+- **`tokenSource` is not sufficient.** With `ANTHROPIC_API_KEY` set it still
+  reports `claude.ai`; `apiKeySource` is the field that tells the truth, so it
+  is checked first.
+- **`setting_sources=[]` does suppress `apiKeyHelper`.** Verified by pointing
+  `CLAUDE_CONFIG_DIR` at a settings file whose helper touches a marker: with
+  `["user"]` the helper runs, with `[]` it never does. The runtime already
+  sets `setting_sources=[]`, so rank 4 cannot reach the child and is not a
+  refusal trigger — but it stays in the precedence table so the classifier
+  recognises it if the CLI ever changes.
+
+The blocklist is derived from the precedence order, then widened to what the
+shipped CLI actually reads: the selectors `CLAUDE_CODE_USE_ANTHROPIC_AWS`,
+`CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD`, `CLAUDE_CODE_USE_MANTLE` and
+`CLAUDE_CODE_USE_GATEWAY` are honored alongside the three the docs name.
+`ANTHROPIC_TOKEN` is *not* read by 2.1.220 but is stripped and refused anyway,
+because a credential-shaped variable we cannot rule out is treated as one.
+
+Empty-string overrides are not a substitute for removal. On 2.1.220
+`ANTHROPIC_API_KEY=`, `ANTHROPIC_AUTH_TOKEN=`, `CLAUDE_CODE_OAUTH_TOKEN=` and
+`CLAUDE_CODE_USE_BEDROCK=` all behave as absent — but that is an
+implementation detail of one build, per variable, with no documented contract,
+and an empty string still occupies the slot for anything else reading the
+environment. Removal is the only guarantee.
+
+`HOME` is never overridden and `CLAUDE_CONFIG_DIR` passes through: rewriting
+`HOME` relocates the macOS login-keychain lookup (`$HOME/Library/Keychains`),
+so the CLI cannot find its stored OAuth credentials and reports
+"Not logged in".
+
+## 6. Rollback
+
+The runtime is additive and gated:
+
+- Rollback flips `claude_subscription.enabled` to `false` and disables the
+  catalog entry. Nothing else is required.
+- It never alters or deletes Hermes transcripts, provider bindings, or Claude's
+  own credentials.
+- "Anthropic API" and every other provider stay available and unchanged —
+  a rolled-back user is on exactly the configuration they had before.
+- Database migration rollback must never depend on deleting SDK transcript
+  data. The PR5 `SessionStore` mirror is additive: a downgrade leaves the mirror
+  rows in place and simply stops reading them. Concretely, PR5 adds five
+  tables to `SCHEMA_SQL` (`provider_runtime_sessions`,
+  `provider_transcript_entries`, `provider_transcript_keys`,
+  `provider_transcript_summaries`, `provider_message_bindings`) through the
+  declarative-reconciliation path — `CREATE TABLE IF NOT EXISTS` on every
+  open, no `SCHEMA_VERSION` bump, no data migration, no foreign keys into
+  `sessions`/`messages`. An older Hermes opens the same database, ignores the
+  tables, and loses nothing.
+
+### 6.1 What PR5 owns vs what the SDK owns
+
+The mirror does not change the ownership split; it makes Hermes' half durable.
+
+| | Hermes (`state.db`) | Claude Agent SDK |
+|---|---|---|
+| Visible transcript | ✅ `messages` | — |
+| Which Claude session a conversation uses | ✅ `provider_runtime_sessions` | — |
+| Claude-native transcript bytes | mirror only, opaque | ✅ authoritative |
+| Message UUIDs / resume cursor | mirrored, never minted | ✅ |
+| Rewind boundary | ✅ visible-user-turn ordinal → SDK UUID | — |
+| Fork transform (UUID remap, `sessionId` rewrite) | — | ✅ `fork_session_via_store` |
+| Summary derivation | persisted verbatim | ✅ `fold_session_summary` |
+
+Canonical history is replayed into Claude **exactly once**, and only when
+there is no session to resume (a provider switch into Claude, or a session
+older than the mirror). Every later turn resumes, which is what keeps the
+upstream prompt cache warm.
+
+## 7. Pinned versions and packaging
+
+| | |
+|---|---|
+| `claude-agent-sdk` | 0.2.140 (first release whose `mcp` range admits the 2.x that Hermes pins; 18 Aug 2026) |
+| `requires_python` | `>=3.10` |
+| Runtime deps | `anyio>=4.0.0`, `mcp>=1.23.0,<2.0.0`, `sniffio>=1.0.0` |
+| Claude Code CLI | tested at 2.1.220 |
+
+The `mcp` range is compatible with the `mcp==1.26.0` Hermes already pins in the
+`[mcp]` extra, so the SDK adds no new resolver conflict.
+
+The platform wheels are 71.7-81.7 MB each (macOS arm64/x86_64, manylinux
+aarch64/x86_64, win_amd64) because they bundle the Claude executable; the sdist
+is 0.3 MB and does not. That size makes it an **optional extra and never a base
+dependency**, and keeps it out of `[all]` and `[termux-all]` — those bundles are
+paid for by every fresh install, and this runtime is off by default.
+
+Per AGENTS.md § "Dependency Pinning Policy", a pre-1.0 package is pinned
+`>=current,<0.(minor+2)`:
+
+```toml
+claude-code = ["claude-agent-sdk>=0.2.140,<0.4"]
+```
+
+This diverges from the exact pins used by neighbouring extras
+(`anthropic==0.87.0`, `exa-py==2.10.2`, …). Those are exact because they are
+mirrored in `tools/lazy_deps.py` and locked to it by
+`tests/test_project_metadata.py`; this extra is not lazy-installed, so the
+written pre-1.0 policy applies directly.
+
+**`uv lock` has not been run in this PR** — the extra is opt-in and regenerating
+the lockfile here would churn it for no consumer. It must be run before merge,
+per AGENTS.md step 4 of the pinning policy.
+
+## 8. The gate
+
+`hermes_cli/claude_subscription.py` is the single source of truth. It is
+dependency-light and import-safe by contract, because the provider catalog and
+the dashboard web server both import it on ordinary startup paths.
+
+- `claude_subscription_enabled(config)` — reads `claude_subscription.enabled`,
+  defaults `False`, tolerates a missing or partial config dict.
+- `claude_agent_sdk_available()` — cached `find_spec` probe, returns a bool,
+  never raises.
+- `CLAUDE_AGENT_SDK_MIN_VERSION` / `CLAUDE_CLI_MIN_VERSION` — the pins above.
+
+The config key is a top-level `claude_subscription:` root in
+`hermes_cli/config_defaults.py` rather than a key under `model:`, because
+`DEFAULT_CONFIG["model"]` is a plain string (only `cli.py`'s CLI defaults shape
+`model` as a dict), so a nested key would be invisible to `load_config()` and to
+the gateway's raw-YAML reader. There is no `HERMES_*` env var: `.env` is secrets
+only, and this is a feature flag.
+
+```yaml
+claude_subscription:
+  enabled: false   # default-off pending written Anthropic policy clearance
+```
+
+## 9. Delivery order
+
+1. **This PR** — decision record, `[claude-code]` extra, config gate, gate module.
+2. Split provider identity; use official `claude auth` commands; CI boundary script.
+3. Extract one canonical `execute_one_tool()` lifecycle + in-process SDK MCP bridge.
+4. Whole-turn `ClaudeAgentRuntime` (`api_mode="claude_agent_sdk"`) + event projector.
+5. Durable `SessionStore` mirror, rewind/fork.
+6. Auxiliary one-shot adapter, subagents, model switching, surfaces.
+7. Sanitized-environment launch + billing-source proof + controlled enablement.
+
+## 10. Enablement checklist
+
+`claude_subscription.enabled` stays `false`. It is flipped only when **every**
+line below is true, and the last one is not a technical judgement.
+
+**Technical acceptance**
+
+- [x] The CLI subprocess is launched from an explicitly-constructed
+      environment; every rank-1..5 credential is absent from it, and
+      `os.environ` is not mutated (`agent/transports/claude_sanitized_transport.py`).
+- [x] A turn that would be billed to any account other than the user's plan is
+      **refused**, with a message naming the offending variable and its fix.
+- [x] The billing source is proven per session from the CLI's own initialize
+      response, at zero token and quota cost.
+- [x] `HOME` is never overridden; `CLAUDE_CONFIG_DIR` passes through.
+- [x] The child's stderr is routed into Hermes' logs rather than an inherited
+      handle that may be closed under Electron.
+- [x] `scripts/check_claude_boundary.py` is green: Hermes reads no Claude
+      credential, sends no subscription token to Anthropic directly, and does
+      not impersonate Claude Code.
+- [x] A live turn has been proven to run on the subscription rather than an
+      API key, by falsification rather than by reading a dashboard. In an
+      unprivileged container (`--cap-drop=ALL --security-opt=no-new-privileges`,
+      uid 1000) holding a copy of a consenting maintainer's credentials and a
+      deliberately **invalid** `ANTHROPIC_API_KEY`:
+
+      | path | result |
+      |---|---|
+      | stock SDK transport | `apiKeySource: ANTHROPIC_API_KEY`, classified `api_key` |
+      | sanitized transport | `subscriptionType: Claude Max`, classified `subscription` |
+      | live turn, sanitized transport | succeeded (`OK`, 167 in / 4 out) |
+      | live turn, bare CLI, key inherited | `Execution error` |
+
+      The last row is what makes the third meaningful: the CLI does **not**
+      fall back from a bad key to the subscription, so a turn that succeeds
+      with an invalid key in the environment can only have used the plan
+      credential. This is stronger than a dashboard reading, which cannot
+      distinguish "billed to the plan" from "billed to an org with no visible
+      line item yet".
+
+- [ ] Written policy clearance from Anthropic (see §4). Not a technical
+      judgement, and the only remaining blocker.
+- [x] PR5's resume path is verified through the sanitized transport. Supplying
+      a custom transport makes the SDK skip `materialize_resume_session()`, so
+      `session_store` + `resume` are handled by PR5 rather than inherited:
+      `ClaudeAgentSession._materialize()` runs `materialize_resume_session()`
+      itself, *before* building the transport, and passes the repointed
+      options (`env["CLAUDE_CONFIG_DIR"]` → temp dir, `resume` → resolved id)
+      to both the transport and the client. Nothing in the transport changed;
+      the sanitization blocklist is still applied after `options.env`, so
+      materialization cannot reintroduce a higher-precedence credential.
+      Verified in `tests/agent/test_claude_session_store.py`.
+
+**Policy clearance** — required in addition to all of the above
+
+- [ ] Written confirmation from Anthropic that a third-party product may offer
+      claude.ai login through the Agent SDK, resolving the contradiction in §4.
+
+Until both blocks are complete the runtime remains opt-in per user, for their
+own account, knowingly. Nothing in PR7 changes a default.
+
+---
+
+## 11. The billing classifier constrains request shape (measured 2026-07-31)
+
+Getting subscription auth right is necessary but **not sufficient**. With the
+plan credential correctly resolved and every API-key path removed, requests
+were still rejected with:
+
+```
+API Error: 400 You're out of extra usage. Add more at claude.ai/settings/usage
+```
+
+while a bare `claude -p` on the same account, at the same moment, succeeded.
+So this is not quota exhaustion — it is a classifier deciding the *request*
+looks like a third-party product and routing it to the plan's extra-usage
+pool, which is empty by default.
+
+Bisected against the live API. Everything else held constant:
+
+| request shape | outcome |
+| --- | --- |
+| `claude -p` (bare CLI) | plan |
+| preset replaced by Hermes' prompt + `tools=[]` | **extra usage** |
+| preset kept, Hermes' prompt appended, `tools=[]` | **extra usage** |
+| preset kept, `tools` unset, Hermes' full prompt appended | **extra usage** |
+| preset kept, `tools` unset, short routing note appended | plan |
+| ...with 30 Hermes MCP tools attached | plan |
+
+Two independent triggers, both required to be absent:
+
+1. **Stripping the built-in toolset** (`tools=[]`).
+2. **Carrying a product identity in the system prompt** — whether by replacing
+   the preset or appending a full agent prompt to it. Length is not the
+   variable: a short tool-routing note passes, a 10k-character identity prompt
+   does not.
+
+Attaching foreign MCP tools does **not** trigger it. That is the officially
+supported extension path, and it is what T3 Code and Codemux do.
+
+### What the runtime does
+
+- `system_prompt` = the `claude_code` preset + **Hermes' own identity section**
+  (`SOUL.md` when the user has one, else `DEFAULT_AGENT_IDENTITY` from
+  `agent/prompt_builder.py`). No text is authored for this provider: a user who
+  customises their identity gets that customisation here too.
+- `tools` unset, so the built-ins stay in context — but a `PreToolUse` hook
+  denies every non-`mcp__hermes__*` call, so Hermes still owns all execution.
+  Denial is client-side and does not change the API-visible request shape.
+- The **rest** of Hermes' prompt (memory, skills, project context, tool
+  guidance) is delivered as the first user turn, reusing the pattern
+  `agent/skill_commands.py` already uses for skills. Sent once per session;
+  every later turn resumes, so it is never re-sent and the cache stays warm.
+
+Why not put the whole prompt in the system slot, or nothing at all: both were
+measured. The full prompt there is billed to extra usage. Nothing there means
+identity decays — the full prompt as a first user turn alone holds on turn 1
+and loses to the preset's "You are Claude Code" by turn 3. The identity section
+is the smallest thing that bills to the plan and survives the conversation, and
+it is Hermes' text rather than ours.
+
+### Identity: solved, and why the first attempt failed
+
+An earlier draft of this section recorded "the model self-identifies as Claude
+Code" as an unavoidable tradeoff. That was wrong, and the correction matters.
+
+Two facts settled it, both measured:
+
+1. **Identity content does not trip the classifier.** An append reading "You
+   are Hermes Agent, a personal AI assistant by Nous Research" bills to the
+   plan, as does a 900-char version with persona and behaviour. What trips it
+   is specific content between chars ~4000-4500 of Hermes' full prompt — the
+   dense memory/skills scaffolding — not the identity claim and not length
+   (5974 chars of neutral filler passes; 4500 chars of Hermes' prompt does
+   not).
+2. **The system prompt was never the only lever.** Hermes' prompt rides as the
+   first user turn, which has no classifier interaction at all — the full
+   ~86k-char prompt goes through unremarked.
+
+The first attempt at (2) still answered "I'm Claude Code" because the framing
+was too mild. A `<hermes_context>` wrapper saying "here are your operating
+instructions" loses to the preset's "You are Claude Code" once the body is
+large enough to bury the identity line — and the real body is ~86k chars once
+context files, skills, and memory load, not the 10k a stripped test agent
+produces. The wrapper now states the override explicitly, and the model
+answers "I'm Hermes Agent, created by Nous Research" through the product CLI,
+on a plan-billed turn, with tools working.
+
+**We deliberately do not tune Hermes' system prompt to sit under the
+classifier threshold.** That would be fragile against a rule we cannot see and
+is the same category of behaviour this runtime replaced. The user-turn channel
+is unbounded, legitimate, and already how Hermes ships skill content.
+
+### What still differs from other providers
+
+The `system_prompt` the SDK receives is the `claude_code` preset plus a short
+routing note. Hermes' persona and instructions arrive one message later, in
+the first user turn. Functionally the agent behaves as Hermes — identity,
+persona, memory, and skills all bind — but a reader of the raw request will
+see Claude Code's preset in the system slot. That is the honest shape: Hermes
+is *driving* Claude Code through the supported SDK, not impersonating it.
+
+Note this is a per-request SDK parameter. It does not read or write
+`~/.claude`, and a user's own Claude Code installation is completely
+unaffected — verified: no Hermes or Nous string appears in their
+`settings.json`, and no `systemPrompt` key is written.

--- a/docs/design/claude-subscription-via-agent-sdk.md
+++ b/docs/design/claude-subscription-via-agent-sdk.md
@@ -1,0 +1,479 @@
+# Claude Subscription via the Agent SDK — Decision Record
+
+> **Status:** accepted; runtime ships default-off behind `claude_subscription.enabled`
+> **Audience:** Hermes maintainers working on providers, auth, or the agent loop
+> **Sources retrieved:** 30 Jul 2026
+> **Last updated:** 2026-07-30
+
+Hermes today reaches a Claude subscription by extracting the OAuth credential
+Claude Code stores in `~/.claude/.credentials.json` (or the macOS Keychain),
+hand-building an Anthropic `/v1/messages` request, and attaching Claude Code's
+identity headers to it (`agent/anthropic_adapter.py` — the
+`claude-code/<version> (external, cli)` user-agent and `x-app: cli` around
+line 882). That path is why subscribers get billed as extra usage: the request
+is ours, not Claude Code's, and nothing about it is sanctioned.
+
+The replacement is to stop imitating Claude Code and to *call* it, through
+Anthropic's official `claude-agent-sdk`, which wraps the Claude Code CLI as a
+subprocess. This document records the decision, the ownership split, the policy
+gate that keeps it default-off, and the rollback contract.
+
+---
+
+## 1. Two providers, not one
+
+`claude-code` is currently an alias of `anthropic`
+(`plugins/model-providers/anthropic/__init__.py:46`,
+`hermes_cli/providers.py:309`). The two are split into distinct providers:
+
+| | **Anthropic API** | **Claude subscription via Agent SDK** |
+|---|---|---|
+| Provider id | `anthropic` | `claude-code` |
+| Auth | API key only | `auth_type="external_process"` |
+| Request shape | `api_mode="anthropic_messages"` | `api_mode="claude_agent_sdk"` |
+| API URL | Anthropic base URL | none — the SDK owns the endpoint |
+| Credential env var | `ANTHROPIC_API_KEY` | none — Hermes holds no Claude credential |
+
+The split is the point. "Anthropic API" keeps meaning exactly what it means
+today: a key you pasted, billed to your Console org, running Hermes' own loop.
+"Claude subscription via Agent SDK" is an account you signed into with
+`claude` itself, running Claude's loop, with Hermes holding no credential at
+all. Anything that blurs the two reintroduces the billing surprise this work
+exists to remove.
+
+## 2. Ownership boundary
+
+The runtime is only tractable if each side owns its half completely and neither
+reconstructs the other's state.
+
+**Hermes keeps:** the system prompt; tool implementations; permissions and
+approvals; plugins; memory; skills; checkpoints; UI history; environments
+(Docker / SSH / Modal / Daytona / Singularity); cross-provider config; the
+session picker; analytics.
+
+**The SDK keeps:** Claude-native context and opaque frames; prompt-cache
+continuity; automatic compaction; assistant/tool-result alternation; the resume
+cursor and message UUIDs; Claude turn usage; the terminal reason.
+
+The asymmetry is deliberate. Everything Hermes keeps is *user-visible product*
+that must behave identically across every provider. Everything the SDK keeps is
+*conversation-internal state* whose exact bytes we cannot reproduce and must not
+try to — reconstructing Claude's context is precisely how prompt caching dies
+and how alternation invariants get violated.
+
+## 3. What we stop doing
+
+> **Status (2026-07-31):** the subscription runtime no longer does any of
+> this, and `scripts/check_claude_boundary.py` forbids reintroducing it. The
+> *legacy* direct-OAuth path still contains all of it, allow-listed under
+> `TODO(legacy-retirement)` markers — it is what current users run while the
+> gate is closed, and it is deleted only when the subscription runtime is
+> enabled and users have migrated. Until then, read "remove" as the end state,
+> not the current tree.
+
+Every item below is behavior we remove, not behavior we gate:
+
+- Reading, copying, refreshing, or deleting Claude's credential files.
+- Sending subscription OAuth tokens to `/v1/messages` directly.
+- Spoofing the `claude-code/<version> (external, cli)` user-agent, `x-app: cli`,
+  and Claude Code beta flags.
+- Rewriting the system prompt to strip "Hermes" / "Nous".
+- Renaming Hermes tools so they look like Claude Code tools.
+
+Nothing here is a capability the user asked for; all of it exists only to make
+our traffic pass as Claude Code's. Under the SDK the traffic *is* Claude Code's,
+so the disguise has no remaining purpose.
+
+## 4. The policy gate
+
+Anthropic's Agent SDK overview
+(<https://code.claude.com/docs/en/agent-sdk/overview>, retrieved 30 Jul 2026)
+states:
+
+> Unless previously approved, Anthropic does not allow third party developers to
+> offer claude.ai login or rate limits for their products, including agents built
+> on the Claude Agent SDK. Use the API key authentication methods described in the
+> Quickstart instead.
+
+Anthropic's Help Center takes a different position. "Use the Claude Agent SDK
+with your Claude plan" (last updated 16 Jun 2026) says a planned change was
+paused and that "For now, nothing has changed: Claude Agent SDK, `claude -p`,
+and third-party app usage still draw from your subscription's usage limits."
+
+So one Anthropic surface says the mechanism works and is metered against the
+subscription, and another says third parties may not *offer* it. Those are not
+reconcilable by reading harder, and the risk of guessing wrong lands on users'
+accounts, not on us.
+
+**Conclusion: the runtime ships default-off, and public enablement requires
+written confirmation from Anthropic.** Private technical validation against a
+developer-controlled, consenting account is fine and is how PRs 2-7 are
+verified; shipping it enabled, advertising it, or defaulting any user onto it is
+not, until that confirmation exists.
+
+## 5. Credential precedence — why a subscription silently becomes API billing
+
+From <https://code.claude.com/docs/en/iam> (retrieved 30 Jul 2026), when
+multiple credentials are present the CLI chooses one in this order:
+
+1. Cloud provider credentials, when `CLAUDE_CODE_USE_BEDROCK`,
+   `CLAUDE_CODE_USE_VERTEX`, or `CLAUDE_CODE_USE_FOUNDRY` is set.
+2. `ANTHROPIC_AUTH_TOKEN`.
+3. `ANTHROPIC_API_KEY`.
+4. `apiKeyHelper` script output.
+5. `CLAUDE_CODE_OAUTH_TOKEN`.
+6. Subscription OAuth credentials from `/login`.
+
+The subscription is *last*. A user with a valid `/login` session and a stale
+`ANTHROPIC_API_KEY` exported in their shell gets billed to the API key — with no
+error, because that ordering is correct behavior for the CLI. Hermes users are
+disproportionately exposed here: `ANTHROPIC_API_KEY` is a first-class Hermes
+credential that the setup wizard actively encourages, so the collision is the
+common case rather than the edge case. (A signed-in Claude apps gateway session
+sits outside the list entirely and outranks all six.)
+
+This cannot be fixed with `options.env`. The Python SDK builds the subprocess
+environment as `{**os.environ, "CLAUDE_CODE_ENTRYPOINT": ..., **options.env}`
+(`claude_agent_sdk/_internal/transport/subprocess_cli.py`), so `options.env`
+**overrides** inherited keys and **cannot delete** them — setting
+`ANTHROPIC_API_KEY=""` is still a set key, not an absent one.
+
+### 5.1 How PR7 resolves it
+
+Three layers, in the order a turn hits them:
+
+1. **Refuse (static).** `agent/claude_billing.py` holds the precedence table.
+   If any rank-1..5 credential is present in the environment,
+   `claude_runtime_preflight()` refuses the turn with a message naming that
+   variable and the exact `unset`. Refusing is the conservative direction:
+   a refusal costs a message, a wrong guess costs money, and *which account
+   pays* is the user's decision, not ours.
+2. **Refuse (dynamic).** Once per session, `verify_claude_billing_for_agent()`
+   asks the CLI itself. It connects the SDK to the child, reads the
+   `initialize` control response — which the CLI answers from local startup,
+   before any prompt exists — and disconnects without ever writing a user
+   message. No model request, so no tokens and no quota. The response's
+   `account` block is the ground truth (`ClaudeSDKClient.get_server_info()`).
+3. **Sanitize (structural).** `agent/transports/claude_sanitized_transport.py`
+   subclasses the SDK's `SubprocessCLITransport` and overrides `connect()` —
+   the single method that reads `os.environ` — to spawn from an explicitly
+   filtered copy. `os.environ` itself is never mutated: Hermes is
+   multi-threaded and other providers run concurrently.
+
+Measured against Claude Code 2.1.220 (30 Jul 2026), the `account` block reads:
+
+| environment | `account` |
+|---|---|
+| plan login, clean env | `{"email", "organization", "subscriptionType": "Claude Max", "apiProvider": "firstParty"}` |
+| `ANTHROPIC_API_KEY` set | `{"tokenSource": "claude.ai", "apiKeySource": "ANTHROPIC_API_KEY", "apiProvider": "firstParty"}` |
+| `ANTHROPIC_AUTH_TOKEN` set | `{"tokenSource": "ANTHROPIC_AUTH_TOKEN", "apiProvider": "firstParty"}` |
+| `CLAUDE_CODE_OAUTH_TOKEN` set | `{"tokenSource": "CLAUDE_CODE_OAUTH_TOKEN", "apiProvider": "firstParty"}` |
+| `apiKeyHelper` in settings, `setting_sources=["user"]` | `{"tokenSource": "apiKeyHelper", "apiKeySource": "apiKeyHelper"}` |
+| no login | `{"tokenSource": "none"}` |
+
+Two findings worth recording because they contradict reasonable assumptions:
+
+- **`tokenSource` is not sufficient.** With `ANTHROPIC_API_KEY` set it still
+  reports `claude.ai`; `apiKeySource` is the field that tells the truth, so it
+  is checked first.
+- **`setting_sources=[]` does suppress `apiKeyHelper`.** Verified by pointing
+  `CLAUDE_CONFIG_DIR` at a settings file whose helper touches a marker: with
+  `["user"]` the helper runs, with `[]` it never does. The runtime already
+  sets `setting_sources=[]`, so rank 4 cannot reach the child and is not a
+  refusal trigger — but it stays in the precedence table so the classifier
+  recognises it if the CLI ever changes.
+
+The blocklist is derived from the precedence order, then widened to what the
+shipped CLI actually reads: the selectors `CLAUDE_CODE_USE_ANTHROPIC_AWS`,
+`CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD`, `CLAUDE_CODE_USE_MANTLE` and
+`CLAUDE_CODE_USE_GATEWAY` are honored alongside the three the docs name.
+`ANTHROPIC_TOKEN` is *not* read by 2.1.220 but is stripped and refused anyway,
+because a credential-shaped variable we cannot rule out is treated as one.
+
+Empty-string overrides are not a substitute for removal. On 2.1.220
+`ANTHROPIC_API_KEY=`, `ANTHROPIC_AUTH_TOKEN=`, `CLAUDE_CODE_OAUTH_TOKEN=` and
+`CLAUDE_CODE_USE_BEDROCK=` all behave as absent — but that is an
+implementation detail of one build, per variable, with no documented contract,
+and an empty string still occupies the slot for anything else reading the
+environment. Removal is the only guarantee.
+
+`HOME` is never overridden and `CLAUDE_CONFIG_DIR` passes through: rewriting
+`HOME` relocates the macOS login-keychain lookup (`$HOME/Library/Keychains`),
+so the CLI cannot find its stored OAuth credentials and reports
+"Not logged in".
+
+## 6. Rollback
+
+The runtime is additive and gated:
+
+- Rollback flips `claude_subscription.enabled` to `false` and disables the
+  catalog entry. Nothing else is required.
+- It never alters or deletes Hermes transcripts, provider bindings, or Claude's
+  own credentials.
+- "Anthropic API" and every other provider stay available and unchanged —
+  a rolled-back user is on exactly the configuration they had before.
+- Database migration rollback must never depend on deleting SDK transcript
+  data. The PR5 `SessionStore` mirror is additive: a downgrade leaves the mirror
+  rows in place and simply stops reading them. Concretely, PR5 adds five
+  tables to `SCHEMA_SQL` (`provider_runtime_sessions`,
+  `provider_transcript_entries`, `provider_transcript_keys`,
+  `provider_transcript_summaries`, `provider_message_bindings`) through the
+  declarative-reconciliation path — `CREATE TABLE IF NOT EXISTS` on every
+  open, no `SCHEMA_VERSION` bump, no data migration, no foreign keys into
+  `sessions`/`messages`. An older Hermes opens the same database, ignores the
+  tables, and loses nothing.
+
+### 6.1 What PR5 owns vs what the SDK owns
+
+The mirror does not change the ownership split; it makes Hermes' half durable.
+
+| | Hermes (`state.db`) | Claude Agent SDK |
+|---|---|---|
+| Visible transcript | ✅ `messages` | — |
+| Which Claude session a conversation uses | ✅ `provider_runtime_sessions` | — |
+| Claude-native transcript bytes | mirror only, opaque | ✅ authoritative |
+| Message UUIDs / resume cursor | mirrored, never minted | ✅ |
+| Rewind boundary | ✅ visible-user-turn ordinal → SDK UUID | — |
+| Fork transform (UUID remap, `sessionId` rewrite) | — | ✅ `fork_session_via_store` |
+| Summary derivation | persisted verbatim | ✅ `fold_session_summary` |
+
+Canonical history is replayed into Claude **exactly once**, and only when
+there is no session to resume (a provider switch into Claude, or a session
+older than the mirror). Every later turn resumes, which is what keeps the
+upstream prompt cache warm.
+
+## 7. Pinned versions and packaging
+
+| | |
+|---|---|
+| `claude-agent-sdk` | 0.2.128 (latest on PyPI, 30 Jul 2026) |
+| `requires_python` | `>=3.10` |
+| Runtime deps | `anyio>=4.0.0`, `mcp>=1.23.0,<2.0.0`, `sniffio>=1.0.0` |
+| Claude Code CLI | tested at 2.1.220 |
+
+The `mcp` range is compatible with the `mcp==1.26.0` Hermes already pins in the
+`[mcp]` extra, so the SDK adds no new resolver conflict.
+
+The platform wheels are 71.7-81.7 MB each (macOS arm64/x86_64, manylinux
+aarch64/x86_64, win_amd64) because they bundle the Claude executable; the sdist
+is 0.3 MB and does not. That size makes it an **optional extra and never a base
+dependency**, and keeps it out of `[all]` and `[termux-all]` — those bundles are
+paid for by every fresh install, and this runtime is off by default.
+
+Per AGENTS.md § "Dependency Pinning Policy", a pre-1.0 package is pinned
+`>=current,<0.(minor+2)`:
+
+```toml
+claude-code = ["claude-agent-sdk>=0.2.128,<0.4"]
+```
+
+This diverges from the exact pins used by neighbouring extras
+(`anthropic==0.87.0`, `exa-py==2.10.2`, …). Those are exact because they are
+mirrored in `tools/lazy_deps.py` and locked to it by
+`tests/test_project_metadata.py`; this extra is not lazy-installed, so the
+written pre-1.0 policy applies directly.
+
+**`uv lock` has not been run in this PR** — the extra is opt-in and regenerating
+the lockfile here would churn it for no consumer. It must be run before merge,
+per AGENTS.md step 4 of the pinning policy.
+
+## 8. The gate
+
+`hermes_cli/claude_subscription.py` is the single source of truth. It is
+dependency-light and import-safe by contract, because the provider catalog and
+the dashboard web server both import it on ordinary startup paths.
+
+- `claude_subscription_enabled(config)` — reads `claude_subscription.enabled`,
+  defaults `False`, tolerates a missing or partial config dict.
+- `claude_agent_sdk_available()` — cached `find_spec` probe, returns a bool,
+  never raises.
+- `CLAUDE_AGENT_SDK_MIN_VERSION` / `CLAUDE_CLI_MIN_VERSION` — the pins above.
+
+The config key is a top-level `claude_subscription:` root in
+`hermes_cli/config_defaults.py` rather than a key under `model:`, because
+`DEFAULT_CONFIG["model"]` is a plain string (only `cli.py`'s CLI defaults shape
+`model` as a dict), so a nested key would be invisible to `load_config()` and to
+the gateway's raw-YAML reader. There is no `HERMES_*` env var: `.env` is secrets
+only, and this is a feature flag.
+
+```yaml
+claude_subscription:
+  enabled: false   # default-off pending written Anthropic policy clearance
+```
+
+## 9. Delivery order
+
+1. **This PR** — decision record, `[claude-code]` extra, config gate, gate module.
+2. Split provider identity; use official `claude auth` commands; CI boundary script.
+3. Extract one canonical `execute_one_tool()` lifecycle + in-process SDK MCP bridge.
+4. Whole-turn `ClaudeAgentRuntime` (`api_mode="claude_agent_sdk"`) + event projector.
+5. Durable `SessionStore` mirror, rewind/fork.
+6. Auxiliary one-shot adapter, subagents, model switching, surfaces.
+7. Sanitized-environment launch + billing-source proof + controlled enablement.
+
+## 10. Enablement checklist
+
+`claude_subscription.enabled` stays `false`. It is flipped only when **every**
+line below is true, and the last one is not a technical judgement.
+
+**Technical acceptance**
+
+- [x] The CLI subprocess is launched from an explicitly-constructed
+      environment; every rank-1..5 credential is absent from it, and
+      `os.environ` is not mutated (`agent/transports/claude_sanitized_transport.py`).
+- [x] A turn that would be billed to any account other than the user's plan is
+      **refused**, with a message naming the offending variable and its fix.
+- [x] The billing source is proven per session from the CLI's own initialize
+      response, at zero token and quota cost.
+- [x] `HOME` is never overridden; `CLAUDE_CONFIG_DIR` passes through.
+- [x] The child's stderr is routed into Hermes' logs rather than an inherited
+      handle that may be closed under Electron.
+- [x] `scripts/check_claude_boundary.py` is green: Hermes reads no Claude
+      credential, sends no subscription token to Anthropic directly, and does
+      not impersonate Claude Code.
+- [x] A live turn has been proven to run on the subscription rather than an
+      API key, by falsification rather than by reading a dashboard. In an
+      unprivileged container (`--cap-drop=ALL --security-opt=no-new-privileges`,
+      uid 1000) holding a copy of a consenting maintainer's credentials and a
+      deliberately **invalid** `ANTHROPIC_API_KEY`:
+
+      | path | result |
+      |---|---|
+      | stock SDK transport | `apiKeySource: ANTHROPIC_API_KEY`, classified `api_key` |
+      | sanitized transport | `subscriptionType: Claude Max`, classified `subscription` |
+      | live turn, sanitized transport | succeeded (`OK`, 167 in / 4 out) |
+      | live turn, bare CLI, key inherited | `Execution error` |
+
+      The last row is what makes the third meaningful: the CLI does **not**
+      fall back from a bad key to the subscription, so a turn that succeeds
+      with an invalid key in the environment can only have used the plan
+      credential. This is stronger than a dashboard reading, which cannot
+      distinguish "billed to the plan" from "billed to an org with no visible
+      line item yet".
+
+- [ ] Written policy clearance from Anthropic (see §4). Not a technical
+      judgement, and the only remaining blocker.
+- [x] PR5's resume path is verified through the sanitized transport. Supplying
+      a custom transport makes the SDK skip `materialize_resume_session()`, so
+      `session_store` + `resume` are handled by PR5 rather than inherited:
+      `ClaudeAgentSession._materialize()` runs `materialize_resume_session()`
+      itself, *before* building the transport, and passes the repointed
+      options (`env["CLAUDE_CONFIG_DIR"]` → temp dir, `resume` → resolved id)
+      to both the transport and the client. Nothing in the transport changed;
+      the sanitization blocklist is still applied after `options.env`, so
+      materialization cannot reintroduce a higher-precedence credential.
+      Verified in `tests/agent/test_claude_session_store.py`.
+
+**Policy clearance** — required in addition to all of the above
+
+- [ ] Written confirmation from Anthropic that a third-party product may offer
+      claude.ai login through the Agent SDK, resolving the contradiction in §4.
+
+Until both blocks are complete the runtime remains opt-in per user, for their
+own account, knowingly. Nothing in PR7 changes a default.
+
+---
+
+## 11. The billing classifier constrains request shape (measured 2026-07-31)
+
+Getting subscription auth right is necessary but **not sufficient**. With the
+plan credential correctly resolved and every API-key path removed, requests
+were still rejected with:
+
+```
+API Error: 400 You're out of extra usage. Add more at claude.ai/settings/usage
+```
+
+while a bare `claude -p` on the same account, at the same moment, succeeded.
+So this is not quota exhaustion — it is a classifier deciding the *request*
+looks like a third-party product and routing it to the plan's extra-usage
+pool, which is empty by default.
+
+Bisected against the live API. Everything else held constant:
+
+| request shape | outcome |
+| --- | --- |
+| `claude -p` (bare CLI) | plan |
+| preset replaced by Hermes' prompt + `tools=[]` | **extra usage** |
+| preset kept, Hermes' prompt appended, `tools=[]` | **extra usage** |
+| preset kept, `tools` unset, Hermes' full prompt appended | **extra usage** |
+| preset kept, `tools` unset, short routing note appended | plan |
+| ...with 30 Hermes MCP tools attached | plan |
+
+Two independent triggers, both required to be absent:
+
+1. **Stripping the built-in toolset** (`tools=[]`).
+2. **Carrying a product identity in the system prompt** — whether by replacing
+   the preset or appending a full agent prompt to it. Length is not the
+   variable: a short tool-routing note passes, a 10k-character identity prompt
+   does not.
+
+Attaching foreign MCP tools does **not** trigger it. That is the officially
+supported extension path, and it is what T3 Code and Codemux do.
+
+### What the runtime does
+
+- `system_prompt` = the `claude_code` preset + **Hermes' own identity section**
+  (`SOUL.md` when the user has one, else `DEFAULT_AGENT_IDENTITY` from
+  `agent/prompt_builder.py`). No text is authored for this provider: a user who
+  customises their identity gets that customisation here too.
+- `tools` unset, so the built-ins stay in context — but a `PreToolUse` hook
+  denies every non-`mcp__hermes__*` call, so Hermes still owns all execution.
+  Denial is client-side and does not change the API-visible request shape.
+- The **rest** of Hermes' prompt (memory, skills, project context, tool
+  guidance) is delivered as the first user turn, reusing the pattern
+  `agent/skill_commands.py` already uses for skills. Sent once per session;
+  every later turn resumes, so it is never re-sent and the cache stays warm.
+
+Why not put the whole prompt in the system slot, or nothing at all: both were
+measured. The full prompt there is billed to extra usage. Nothing there means
+identity decays — the full prompt as a first user turn alone holds on turn 1
+and loses to the preset's "You are Claude Code" by turn 3. The identity section
+is the smallest thing that bills to the plan and survives the conversation, and
+it is Hermes' text rather than ours.
+
+### Identity: solved, and why the first attempt failed
+
+An earlier draft of this section recorded "the model self-identifies as Claude
+Code" as an unavoidable tradeoff. That was wrong, and the correction matters.
+
+Two facts settled it, both measured:
+
+1. **Identity content does not trip the classifier.** An append reading "You
+   are Hermes Agent, a personal AI assistant by Nous Research" bills to the
+   plan, as does a 900-char version with persona and behaviour. What trips it
+   is specific content between chars ~4000-4500 of Hermes' full prompt — the
+   dense memory/skills scaffolding — not the identity claim and not length
+   (5974 chars of neutral filler passes; 4500 chars of Hermes' prompt does
+   not).
+2. **The system prompt was never the only lever.** Hermes' prompt rides as the
+   first user turn, which has no classifier interaction at all — the full
+   ~86k-char prompt goes through unremarked.
+
+The first attempt at (2) still answered "I'm Claude Code" because the framing
+was too mild. A `<hermes_context>` wrapper saying "here are your operating
+instructions" loses to the preset's "You are Claude Code" once the body is
+large enough to bury the identity line — and the real body is ~86k chars once
+context files, skills, and memory load, not the 10k a stripped test agent
+produces. The wrapper now states the override explicitly, and the model
+answers "I'm Hermes Agent, created by Nous Research" through the product CLI,
+on a plan-billed turn, with tools working.
+
+**We deliberately do not tune Hermes' system prompt to sit under the
+classifier threshold.** That would be fragile against a rule we cannot see and
+is the same category of behaviour this runtime replaced. The user-turn channel
+is unbounded, legitimate, and already how Hermes ships skill content.
+
+### What still differs from other providers
+
+The `system_prompt` the SDK receives is the `claude_code` preset plus a short
+routing note. Hermes' persona and instructions arrive one message later, in
+the first user turn. Functionally the agent behaves as Hermes — identity,
+persona, memory, and skills all bind — but a reader of the raw request will
+see Claude Code's preset in the system slot. That is the honest shape: Hermes
+is *driving* Claude Code through the supported SDK, not impersonating it.
+
+Note this is a per-request SDK parameter. It does not read or write
+`~/.claude`, and a user's own Claude Code installation is completely
+unaffected — verified: no Hermes or Nous string appears in their
+`settings.json`, and no `systemPrompt` key is written.

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -87,6 +87,11 @@ from hermes_cli.config import (
     read_raw_config,
     require_readable_config_before_write,
 )
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_BASE_URL,
+    CLAUDE_CODE_DISPLAY_NAME,
+    CLAUDE_CODE_PROVIDER_ID,
+)
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -304,6 +309,15 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    # Claude subscription via the official Claude Agent SDK. No
+    # api_key_env_vars and no base_url_env_var on purpose: Hermes holds no
+    # Claude credential and the SDK owns the transport.
+    "claude-code": ProviderConfig(
+        id=CLAUDE_CODE_PROVIDER_ID,
+        name=CLAUDE_CODE_DISPLAY_NAME,
+        auth_type="external_process",
+        inference_base_url=CLAUDE_CODE_BASE_URL,
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -2225,7 +2239,7 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
+        "claude": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -2257,7 +2271,25 @@ def resolve_provider(
                     _PROVIDER_ALIASES[_alias] = _pp.name
     except Exception:
         pass
-    normalized = _PROVIDER_ALIASES.get(normalized, normalized)
+    # `claude-code` / `claude-oauth` used to be aliases of `anthropic`. They are
+    # now the Claude Agent SDK provider's own slugs, but only once the user opts
+    # in — until then the legacy mapping stays live so an existing config keeps
+    # resolving instead of erroring out on an "unknown provider".
+    _requested_slug = normalized
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+        _legacy_target = legacy_alias_target(normalized)
+    except Exception:
+        _legacy_target = None
+    normalized = _legacy_target or _PROVIDER_ALIASES.get(normalized, normalized)
+
+    # One-time notice when the resolved setup still bills through the direct
+    # Claude OAuth path. Never blocks and never changes the resolution.
+    try:
+        from hermes_cli.claude_code import warn_legacy_provider_once
+        warn_legacy_provider_once(_requested_slug)
+    except Exception:
+        pass
 
     if normalized == "openrouter":
         return "openrouter"
@@ -7266,6 +7298,29 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
+    if provider_id == CLAUDE_CODE_PROVIDER_ID:
+        # Official CLI probe (`claude auth status` / `claude --version`), never
+        # a credential-file read. Degrades to an "unknown" status rather than
+        # raising, so a missing or wedged CLI cannot break the provider list.
+        from hermes_cli.claude_code import provider_status as _claude_provider_status
+
+        try:
+            return _claude_provider_status(pconfig.name)
+        except Exception as exc:
+            logger.debug("claude-code status probe failed: %s", exc)
+            return {
+                "configured": False,
+                "provider": provider_id,
+                "name": pconfig.name,
+                "command": "claude",
+                "args": [],
+                "resolved_command": None,
+                "base_url": pconfig.inference_base_url,
+                "logged_in": False,
+                "status": "unknown",
+                "message": f"Could not determine Claude login state: {exc}",
+            }
+
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
@@ -7307,7 +7362,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", CLAUDE_CODE_PROVIDER_ID}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -7492,6 +7547,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             provider=provider_id,
             code="invalid_provider",
         )
+
+    if provider_id == CLAUDE_CODE_PROVIDER_ID:
+        # Deliberately returns NO credential material. The Claude Agent SDK
+        # resolves the user's login itself; Hermes never holds, forwards, or
+        # refreshes a Claude token. ``api_key`` is empty rather than a marker
+        # so nothing downstream can mistake it for a usable secret.
+        from hermes_cli.claude_code import CLAUDE_LOGIN_COMMAND
+
+        status = get_external_process_provider_status(provider_id)
+        if not status.get("resolved_command"):
+            raise AuthError(
+                "Could not find the `claude` CLI. Install Claude Code, then run "
+                f"`{CLAUDE_LOGIN_COMMAND}`.",
+                provider=provider_id,
+                code="missing_claude_cli",
+            )
+        return {
+            "provider": provider_id,
+            "api_key": "",
+            "base_url": CLAUDE_CODE_BASE_URL,
+            "command": status.get("resolved_command") or "claude",
+            "args": [],
+            "credentials_owner": "claude-agent-sdk",
+            "source": "claude_agent_sdk",
+        }
 
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -49,6 +49,11 @@ from hermes_cli.config import (
     read_raw_config,
     require_readable_config_before_write,
 )
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_BASE_URL,
+    CLAUDE_CODE_DISPLAY_NAME,
+    CLAUDE_CODE_PROVIDER_ID,
+)
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -231,6 +236,15 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="external_process",
         inference_base_url=DEFAULT_COPILOT_ACP_BASE_URL,
         base_url_env_var="COPILOT_ACP_BASE_URL",
+    ),
+    # Claude subscription via the official Claude Agent SDK. No
+    # api_key_env_vars and no base_url_env_var on purpose: Hermes holds no
+    # Claude credential and the SDK owns the transport.
+    "claude-code": ProviderConfig(
+        id=CLAUDE_CODE_PROVIDER_ID,
+        name=CLAUDE_CODE_DISPLAY_NAME,
+        auth_type="external_process",
+        inference_base_url=CLAUDE_CODE_BASE_URL,
     ),
     "gemini": ProviderConfig(
         id="gemini",
@@ -1893,7 +1907,7 @@ def resolve_provider(
         "minimax-portal": "minimax-oauth", "minimax-global": "minimax-oauth", "minimax_oauth": "minimax-oauth",
         "alibaba_coding": "alibaba-coding-plan", "alibaba-coding": "alibaba-coding-plan",
         "alibaba_coding_plan": "alibaba-coding-plan",
-        "claude": "anthropic", "claude-code": "anthropic",
+        "claude": "anthropic",
         "github": "copilot", "github-copilot": "copilot",
         "github-models": "copilot", "github-model": "copilot",
         "github-copilot-acp": "copilot-acp", "copilot-acp-agent": "copilot-acp",
@@ -1924,7 +1938,25 @@ def resolve_provider(
                     _PROVIDER_ALIASES[_alias] = _pp.name
     except Exception:
         pass
-    normalized = _PROVIDER_ALIASES.get(normalized, normalized)
+    # `claude-code` / `claude-oauth` used to be aliases of `anthropic`. They are
+    # now the Claude Agent SDK provider's own slugs, but only once the user opts
+    # in — until then the legacy mapping stays live so an existing config keeps
+    # resolving instead of erroring out on an "unknown provider".
+    _requested_slug = normalized
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+        _legacy_target = legacy_alias_target(normalized)
+    except Exception:
+        _legacy_target = None
+    normalized = _legacy_target or _PROVIDER_ALIASES.get(normalized, normalized)
+
+    # One-time notice when the resolved setup still bills through the direct
+    # Claude OAuth path. Never blocks and never changes the resolution.
+    try:
+        from hermes_cli.claude_code import warn_legacy_provider_once
+        warn_legacy_provider_once(_requested_slug)
+    except Exception:
+        pass
 
     if normalized == "openrouter":
         return "openrouter"
@@ -6796,6 +6828,29 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
 
+    if provider_id == CLAUDE_CODE_PROVIDER_ID:
+        # Official CLI probe (`claude auth status` / `claude --version`), never
+        # a credential-file read. Degrades to an "unknown" status rather than
+        # raising, so a missing or wedged CLI cannot break the provider list.
+        from hermes_cli.claude_code import provider_status as _claude_provider_status
+
+        try:
+            return _claude_provider_status(pconfig.name)
+        except Exception as exc:
+            logger.debug("claude-code status probe failed: %s", exc)
+            return {
+                "configured": False,
+                "provider": provider_id,
+                "name": pconfig.name,
+                "command": "claude",
+                "args": [],
+                "resolved_command": None,
+                "base_url": pconfig.inference_base_url,
+                "logged_in": False,
+                "status": "unknown",
+                "message": f"Could not determine Claude login state: {exc}",
+            }
+
     command = (
         os.getenv("HERMES_COPILOT_ACP_COMMAND", "").strip()
         or os.getenv("COPILOT_CLI_PATH", "").strip()
@@ -6837,7 +6892,7 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
+    if target in {"copilot-acp", CLAUDE_CODE_PROVIDER_ID}:
         return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
@@ -7015,6 +7070,31 @@ def resolve_external_process_provider_credentials(provider_id: str) -> Dict[str,
             provider=provider_id,
             code="invalid_provider",
         )
+
+    if provider_id == CLAUDE_CODE_PROVIDER_ID:
+        # Deliberately returns NO credential material. The Claude Agent SDK
+        # resolves the user's login itself; Hermes never holds, forwards, or
+        # refreshes a Claude token. ``api_key`` is empty rather than a marker
+        # so nothing downstream can mistake it for a usable secret.
+        from hermes_cli.claude_code import CLAUDE_LOGIN_COMMAND
+
+        status = get_external_process_provider_status(provider_id)
+        if not status.get("resolved_command"):
+            raise AuthError(
+                "Could not find the `claude` CLI. Install Claude Code, then run "
+                f"`{CLAUDE_LOGIN_COMMAND}`.",
+                provider=provider_id,
+                code="missing_claude_cli",
+            )
+        return {
+            "provider": provider_id,
+            "api_key": "",
+            "base_url": CLAUDE_CODE_BASE_URL,
+            "command": status.get("resolved_command") or "claude",
+            "args": [],
+            "credentials_owner": "claude-agent-sdk",
+            "source": "claude_agent_sdk",
+        }
 
     base_url = os.getenv(pconfig.base_url_env_var, "").strip() if pconfig.base_url_env_var else ""
     if not base_url:

--- a/hermes_cli/claude_code.py
+++ b/hermes_cli/claude_code.py
@@ -1,0 +1,491 @@
+"""Claude subscription provider (official Claude Agent SDK) — identity + auth surface.
+
+This module owns everything core Hermes needs to know about the ``claude-code``
+provider *except* the inference runtime (which routes through the official
+``claude-agent-sdk``).
+
+**Credential boundary — the whole point of this provider.**  Hermes never
+reads, writes, refreshes, or deletes Claude credentials.  There is no
+authorize URL, no client id, no PKCE, no token exchange, no token storage, and
+no credential-file inspection anywhere in this module.  The user runs
+``claude auth login`` themselves and the SDK resolves credentials on its own;
+Hermes only asks the official CLI *whether* a login exists so the UI can say
+so.
+
+Two constraints that look like details and are not:
+
+* Config isolation, when a caller needs it, goes through ``CLAUDE_CONFIG_DIR``
+  — never by overriding ``HOME``.  Overriding ``HOME`` also relocates the
+  macOS login-keychain lookup (``$HOME/Library/Keychains``), so the spawned
+  CLI cannot find its stored credentials and reports "Not logged in".
+* Every probe spawns with ``stdin`` set to ``DEVNULL``.  Claude Code probes
+  stdin and blocks indefinitely when it inherits an unusable parent stdin
+  (e.g. from a GUI parent); ``--print`` does not override this.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ── Identity ────────────────────────────────────────────────────────────────
+
+CLAUDE_CODE_PROVIDER_ID = "claude-code"
+CLAUDE_CODE_DISPLAY_NAME = "Claude subscription (Agent SDK)"
+CLAUDE_CODE_DESCRIPTION = (
+    "Claude subscription (Agent SDK) — uses your Claude Pro/Max/Team/Enterprise "
+    "plan through the official Claude Agent SDK; run `claude auth login` first"
+)
+CLAUDE_CODE_API_MODE = "claude_agent_sdk"
+
+# Internal scheme, mirroring ``acp://copilot``.  Deliberately not an HTTP URL:
+# nothing in Hermes may treat this provider as a reachable REST endpoint.
+CLAUDE_CODE_BASE_URL = "claude-sdk://subscription"
+
+# Curated default when no model is configured for this provider. Every
+# surface that can hand the runtime an empty model (TUI startup resolution,
+# bare provider switches) falls back to this rather than letting the CLI's
+# own default silently pick the model.
+DEFAULT_SUBSCRIPTION_MODEL = "claude-sonnet-5"
+
+CLAUDE_BINARY = "claude"
+CLAUDE_LOGIN_COMMAND = "claude auth login"
+CLAUDE_LOGOUT_COMMAND = "claude auth logout"
+CLAUDE_DOCS_URL = "https://docs.claude.com/en/docs/claude-code"
+
+# Slugs that meant "anthropic, authenticated with a Claude Code OAuth token"
+# before this provider existed.  They keep resolving to ``anthropic`` while the
+# subscription gate is closed so existing configs are not silently repointed at
+# a different billing source; see :func:`legacy_alias_target`.
+LEGACY_ANTHROPIC_ALIASES = ("claude-code", "claude-oauth")
+
+# CodeMux's probe budget: 5s per subprocess, 10s for the whole status call.
+_PROBE_TIMEOUT_SECONDS = 5.0
+_STATUS_TIMEOUT_SECONDS = 10.0
+
+
+# ── Config gate (PR1's ``claude_subscription.enabled``) ─────────────────────
+
+_gate_cache: Optional[bool] = None
+
+
+def subscription_enabled(config: Optional[Dict[str, Any]] = None) -> bool:
+    """Return True when the Claude subscription provider is turned on.
+
+    Thin, never-raising wrapper around
+    ``hermes_cli.claude_subscription.claude_subscription_enabled``.  The result
+    is cached per process: the gate decides module-import-time membership in
+    ``CANONICAL_PROVIDERS``, so re-reading it mid-process could only produce a
+    universe that disagrees with itself.
+    """
+    global _gate_cache
+    if config is None and _gate_cache is not None:
+        return _gate_cache
+    try:
+        from hermes_cli.claude_subscription import claude_subscription_enabled
+    except ImportError:
+        # The gate module ships alongside this provider; treat a missing gate
+        # as "off" so a partial checkout degrades to today's behavior.
+        if config is None:
+            _gate_cache = False
+        return False
+    resolved = config
+    if resolved is None:
+        # claude_subscription_enabled() reads a dict and treats None as off, so
+        # a no-arg call has to load the config itself or the gate is pinned
+        # False no matter what config.yaml says. Read-only: this runs from the
+        # provider catalog and alias resolution, which must not write config.
+        try:
+            from hermes_cli.config import load_config_readonly
+
+            resolved = load_config_readonly()
+        except Exception as exc:
+            logger.debug("load_config_readonly() failed for the gate: %s", exc)
+            resolved = None
+    try:
+        enabled = bool(claude_subscription_enabled(resolved))
+    except Exception as exc:
+        logger.debug("claude_subscription_enabled() failed: %s", exc)
+        enabled = False
+    if config is None:
+        _gate_cache = enabled
+    return enabled
+
+
+def reset_subscription_gate_cache() -> None:
+    """Drop the cached gate value (tests and config-mutating flows)."""
+    global _gate_cache
+    _gate_cache = None
+
+
+def legacy_alias_target(slug: str) -> Optional[str]:
+    """Return ``"anthropic"`` when *slug* is a pre-SDK Claude alias to keep.
+
+    ``claude-code`` used to be an alias of ``anthropic``.  It is now a provider
+    in its own right, but only once the user opts in — until then the old
+    mapping stays live so an existing ``provider: claude-code`` config keeps
+    resolving instead of erroring out.
+    """
+    if (slug or "").strip().lower() not in LEGACY_ANTHROPIC_ALIASES:
+        return None
+    return None if subscription_enabled() else "anthropic"
+
+
+# ── Official CLI probes ─────────────────────────────────────────────────────
+
+
+def resolve_claude_binary() -> Optional[str]:
+    """Absolute path to the ``claude`` CLI, or None when none is available.
+
+    PATH first (a user-managed install is newer or deliberately pinned), then
+    the executable bundled inside the ``claude-agent-sdk`` wheel. The bundled
+    fallback matters for exactly the install this provider documents:
+    ``pip install 'hermes-agent[claude-code]'`` on a machine that never
+    installed Claude Code separately. The SDK spawns its own bundled CLI in
+    that layout, so the auth probe must find the same binary or preflight
+    refuses a setup that would actually work.
+    """
+    try:
+        found = shutil.which(CLAUDE_BINARY)
+        if found:
+            return found
+    except Exception:
+        pass
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("claude_agent_sdk")
+        if spec and spec.origin:
+            bundled = os.path.join(
+                os.path.dirname(spec.origin), "_bundled", CLAUDE_BINARY
+            )
+            if os.path.isfile(bundled) and os.access(bundled, os.X_OK):
+                return bundled
+    except Exception:
+        pass
+    return None
+
+
+def _run_claude(
+    binary: str, args: list[str], timeout: float
+) -> tuple[Optional[int], str, str]:
+    """Run ``claude <args>``; return ``(returncode, stdout, stderr)``.
+
+    ``returncode`` is None when the call timed out or could not be spawned.
+    Never raises.
+    """
+    try:
+        proc = subprocess.run(
+            [binary, *args],
+            # Claude Code probes stdin and hangs forever on an unusable
+            # inherited stdin (GUI parent, closed fd). DEVNULL is required.
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        logger.debug("claude %s timed out after %ss", " ".join(args), timeout)
+        return None, "", "timed out"
+    except Exception as exc:
+        logger.debug("claude %s failed to spawn: %s", " ".join(args), exc)
+        return None, "", str(exc)
+    return proc.returncode, proc.stdout or "", proc.stderr or ""
+
+
+def _parse_auth_status(returncode: Optional[int], stdout: str, stderr: str) -> Dict[str, Any]:
+    """Map a ``claude auth status`` result onto Hermes' status fields.
+
+    ``claude auth status`` emits JSON (``{"loggedIn": true, "authMethod":
+    "claude.ai", ...}``) and exits 0 when logged in, 1 when not.  JSON is the
+    target; the documented text patterns are the fallback for older CLIs whose
+    output is prose.
+    """
+    if returncode is None:
+        return {
+            "status": "unknown",
+            "logged_in": False,
+            "auth_method": "",
+            "account": "",
+            "organization": "",
+            "subscription_type": "",
+            "subscription": False,
+            "message": f"Could not read `claude auth status` ({stderr.strip() or 'no output'}).",
+        }
+
+    payload: Any = None
+    text = (stdout or "").strip()
+    if text:
+        try:
+            payload = json.loads(text)
+        except (ValueError, TypeError):
+            payload = None
+
+    if isinstance(payload, dict):
+        logged_in = bool(payload.get("loggedIn"))
+        auth_method = str(payload.get("authMethod") or "").strip()
+        info: Dict[str, Any] = {
+            "status": "logged_in" if logged_in else "logged_out",
+            "logged_in": logged_in,
+            "auth_method": auth_method,
+            "account": str(payload.get("email") or "").strip(),
+            "organization": str(payload.get("orgName") or "").strip(),
+            "subscription_type": str(payload.get("subscriptionType") or "").strip(),
+        }
+        info["subscription"] = logged_in and auth_method != "api-key"
+        info["message"] = _status_message(info)
+        return info
+
+    # Fallback: prose output. Exit code is the authoritative signal.
+    lowered = (text + " " + (stderr or "")).lower()
+    logged_in = returncode == 0 and "not logged in" not in lowered
+    auth_method = ""
+    if "api key" in lowered or "api-key" in lowered:
+        auth_method = "api-key"
+    elif logged_in:
+        auth_method = "claude.ai"
+    info = {
+        "status": "logged_in" if logged_in else "logged_out",
+        "logged_in": logged_in,
+        "auth_method": auth_method,
+        "account": "",
+        "organization": "",
+        "subscription_type": "",
+        "subscription": logged_in and auth_method != "api-key",
+    }
+    info["message"] = _status_message(info)
+    return info
+
+
+def _status_message(info: Dict[str, Any]) -> str:
+    """Human-readable one-liner for a parsed auth status."""
+    if not info.get("logged_in"):
+        return f"Not signed in to Claude — run `{CLAUDE_LOGIN_COMMAND}`."
+    if info.get("auth_method") == "api-key":
+        # Load-bearing distinction: an API-key login is metered API billing,
+        # not the user's Claude plan. Saying "subscription" here would be a lie.
+        return (
+            "Signed in with an Anthropic API key, not a Claude plan — requests are "
+            f"billed as API usage. Run `{CLAUDE_LOGIN_COMMAND}` to use your subscription."
+        )
+    plan = info.get("subscription_type") or ""
+    account = info.get("account") or ""
+    detail = " ".join(p for p in (f"({plan})" if plan else "", account) if p).strip()
+    return f"Signed in to Claude{' — ' + detail if detail else ''}."
+
+
+_PROBE_CACHE_TTL_SECONDS = 45.0
+_probe_cache: Optional[Dict[str, Any]] = None
+_probe_cache_at: float = 0.0
+
+
+def probe_claude_auth_cached(ttl: float = _PROBE_CACHE_TTL_SECONDS) -> Dict[str, Any]:
+    """`probe_claude_auth`, memoized for *ttl* seconds.
+
+    The probe spawns two subprocesses (`auth status` + `--version`, up to 5s
+    each). The per-turn preflight and the provider picker both consult it, so
+    without a cache an interactive session pays that cost on every turn and
+    every picker open. Login state changes on human timescales; a short TTL
+    keeps the answer honest without the spawn cost.
+    """
+    global _probe_cache, _probe_cache_at
+    now = time.monotonic()
+    if _probe_cache is not None and (now - _probe_cache_at) < ttl:
+        return _probe_cache
+    result = probe_claude_auth()
+    _probe_cache, _probe_cache_at = result, now
+    return result
+
+
+def reset_probe_cache() -> None:
+    """Drop the memoized auth probe (tests and login/logout flows)."""
+    global _probe_cache, _probe_cache_at
+    _probe_cache, _probe_cache_at = None, 0.0
+
+
+def probe_claude_auth() -> Dict[str, Any]:
+    """Ask the official CLI whether a Claude login exists.
+
+    Reads no credential file and holds no token.  Never raises — an
+    uninstalled CLI, a timeout, or malformed output all degrade to a status
+    dict carrying an actionable ``message``.
+    """
+    resolved = resolve_claude_binary()
+    if not resolved:
+        return {
+            "status": "cli_missing",
+            "logged_in": False,
+            "subscription": False,
+            "auth_method": "",
+            "account": "",
+            "organization": "",
+            "subscription_type": "",
+            "cli_version": "",
+            "command": CLAUDE_BINARY,
+            "resolved_command": None,
+            "message": (
+                "Claude Code is not installed — install it, then run "
+                f"`{CLAUDE_LOGIN_COMMAND}`."
+            ),
+        }
+
+    # Per-probe cap, plus an overall cap so two slow probes can't stall a
+    # provider list for twice the per-probe timeout.
+    deadline = time.monotonic() + _STATUS_TIMEOUT_SECONDS
+    rc, out, err = _run_claude(resolved, ["auth", "status"], _PROBE_TIMEOUT_SECONDS)
+    info = _parse_auth_status(rc, out, err)
+
+    version = ""
+    remaining = deadline - time.monotonic()
+    if remaining > 0:
+        vrc, vout, _ = _run_claude(
+            resolved, ["--version"], min(_PROBE_TIMEOUT_SECONDS, remaining)
+        )
+        if vrc == 0 and vout.strip():
+            version = vout.strip().splitlines()[0].strip()
+
+    info.setdefault("subscription", False)
+    info.update(
+        {
+            "cli_version": version,
+            "command": CLAUDE_BINARY,
+            "resolved_command": resolved,
+        }
+    )
+    return info
+
+
+def provider_status(provider_name: str = CLAUDE_CODE_DISPLAY_NAME) -> Dict[str, Any]:
+    """Status snapshot in the shape ``get_external_process_provider_status`` returns.
+
+    Keeps ``configured`` / ``provider`` / ``name`` / ``command`` / ``args`` /
+    ``resolved_command`` / ``base_url`` / ``logged_in`` so every existing
+    external-process consumer keeps working, and adds the Claude-specific
+    fields the UI needs to distinguish a plan login from an API-key login.
+    """
+    probe = probe_claude_auth()
+    return {
+        "configured": bool(probe.get("resolved_command")),
+        "provider": CLAUDE_CODE_PROVIDER_ID,
+        "name": provider_name,
+        "command": probe.get("command", CLAUDE_BINARY),
+        # No args: Hermes does not spawn the CLI for inference, the SDK does.
+        "args": [],
+        "resolved_command": probe.get("resolved_command"),
+        "base_url": CLAUDE_CODE_BASE_URL,
+        "logged_in": bool(probe.get("logged_in")),
+        "status": probe.get("status", "unknown"),
+        "auth_method": probe.get("auth_method", ""),
+        "subscription": bool(probe.get("subscription")),
+        "subscription_type": probe.get("subscription_type", ""),
+        "account": probe.get("account", ""),
+        "organization": probe.get("organization", ""),
+        "cli_version": probe.get("cli_version", ""),
+        "message": probe.get("message", ""),
+        "login_command": CLAUDE_LOGIN_COMMAND,
+        "logout_command": CLAUDE_LOGOUT_COMMAND,
+    }
+
+
+# ── Migration notice for the pre-SDK direct-OAuth path ──────────────────────
+
+_LEGACY_NOTICE_EMITTED = False
+
+
+def _anthropic_would_use_a_claude_login(environ: Dict[str, Any]) -> bool:
+    """True when picking ``anthropic`` would ride the user's Claude login.
+
+    The ``anthropic`` picker row reports itself authenticated when a Claude
+    Code credential exists on disk (``hermes_cli/model_switch.py``), because
+    the legacy direct-OAuth path can use it. Selecting that row then bills the
+    plan's *extra-usage* pool rather than the plan — the surprise this whole
+    provider split exists to end — and it looks identical to a configured API
+    key in the picker.
+
+    Detected without reading any credential: an API key set in the environment
+    wins outright, so there is nothing to warn about; otherwise ask the
+    official CLI whether a login exists.
+    """
+    for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"):
+        if (environ.get(name) or "").strip():
+            return False
+    try:
+        return bool(probe_claude_auth_cached().get("logged_in"))
+    except Exception:
+        return False
+
+
+def legacy_provider_notice(
+    provider: str,
+    *,
+    env: Optional[Dict[str, str]] = None,
+) -> str:
+    """Return a migration notice for configs still on the direct-OAuth path.
+
+    Applies when the user asked for one of the legacy Claude slugs, or is on
+    ``anthropic`` with a Claude Code OAuth token supplying the credential.
+    Those two setups bill against the Claude subscription's extra-usage meter,
+    which is not the same source as either replacement — so the user has to
+    choose, we do not choose for them.  Returns "" when nothing applies.
+    """
+    environ = os.environ if env is None else env
+    slug = (provider or "").strip().lower()
+    # A legacy slug only *rides* the legacy path while the gate is shut and
+    # the alias still rewrites it to the direct-OAuth provider. Once the gate
+    # is open the same slug names the SDK runtime, and warning about it would
+    # tell a correctly-configured user their setup is the thing it replaced.
+    is_legacy_slug = (
+        slug in LEGACY_ANTHROPIC_ALIASES and legacy_alias_target(slug) is not None
+    )
+    # Presence check only — the value is never read into a request. This is how
+    # we recognise a user still on the legacy path so we can tell them about it.
+    legacy_token = environ.get("CLAUDE_CODE_OAUTH_TOKEN")  # claude-boundary: ok — presence only
+    has_oauth_token = bool((legacy_token or "").strip())
+    anthropic_on_oauth = slug == "anthropic" and (
+        has_oauth_token or _anthropic_would_use_a_claude_login(environ)
+    )
+    if not is_legacy_slug and not anthropic_on_oauth:
+        return ""
+
+    label = f"'{slug}'" if slug else "your Claude provider"
+    return (
+        f"Notice: {label} still uses Hermes' direct Claude OAuth path, which bills "
+        "against your Claude plan's extra-usage credits.\n"
+        "  Two supported replacements, billed differently — pick one:\n"
+        "    • Anthropic API  — provider 'anthropic' with an ANTHROPIC_API_KEY "
+        "(metered API billing).\n"
+        f"    • Claude subscription — provider '{CLAUDE_CODE_PROVIDER_ID}' via the "
+        f"official Claude Agent SDK; run `{CLAUDE_LOGIN_COMMAND}`, then enable "
+        "`claude_subscription.enabled` in config.yaml.\n"
+        "  Nothing has changed automatically; your current setup keeps working."
+    )
+
+
+def warn_legacy_provider_once(provider: str) -> bool:
+    """Print :func:`legacy_provider_notice` to stderr at most once per process.
+
+    Returns True when a notice was emitted.  Never raises — a notice must not
+    be able to break provider resolution.
+    """
+    global _LEGACY_NOTICE_EMITTED
+    if _LEGACY_NOTICE_EMITTED:
+        return False
+    try:
+        notice = legacy_provider_notice(provider)
+        if not notice:
+            return False
+        _LEGACY_NOTICE_EMITTED = True
+        sys.stderr.write("\n" + notice + "\n\n")
+        return True
+    except Exception:
+        return False

--- a/hermes_cli/claude_subscription.py
+++ b/hermes_cli/claude_subscription.py
@@ -1,0 +1,58 @@
+"""Release gate for the "Claude subscription via Agent SDK" runtime.
+
+The runtime ships default-off because Anthropic's Agent SDK overview states
+that third party developers may not offer claude.ai login or rate limits for
+their products without prior approval, while their Help Center simultaneously
+says SDK usage still draws from subscription limits — an unresolved tension.
+Until Anthropic confirms in writing, only a developer running private
+validation on their own consenting account may flip this on; see
+`docs/design/claude-subscription-via-agent-sdk.md` for the full record.
+
+This module is imported by the provider catalog and the dashboard web server,
+so it must stay dependency-light and must never raise at import time.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+from typing import Any, Optional
+
+# Pinned floors, recorded here so the runtime, the `hermes doctor` probe, and
+# the packaging extra all read the same numbers. `claude-agent-sdk` ships the
+# Claude executable inside its platform wheels, so the SDK floor also fixes a
+# CLI floor; a separately installed newer CLI is fine, an older one is not.
+CLAUDE_AGENT_SDK_MIN_VERSION = "0.2.140"
+CLAUDE_CLI_MIN_VERSION = "2.1.220"
+
+_CONFIG_SECTION = "claude_subscription"
+
+
+def claude_subscription_enabled(config: Optional[dict] = None) -> bool:
+    """True when `claude_subscription.enabled` is explicitly set in config.
+
+    Tolerates a missing, empty, or partially-shaped config dict: anything
+    that isn't an explicit truthy `enabled` reads as off. Callers pass the
+    already-loaded config rather than loading one, so the gate is usable from
+    all three config loaders (CLI, `load_config()`, raw gateway YAML).
+    """
+    if not isinstance(config, dict):
+        return False
+    section: Any = config.get(_CONFIG_SECTION)
+    if not isinstance(section, dict):
+        return False
+    return bool(section.get("enabled", False))
+
+
+@functools.lru_cache(maxsize=1)
+def claude_agent_sdk_available() -> bool:
+    """True when `claude_agent_sdk` is importable in this interpreter.
+
+    Uses `find_spec` rather than a real import: the package is an ~80 MB
+    wheel that bundles the Claude executable, and every caller only needs to
+    know whether the optional `claude-code` extra is installed.
+    """
+    try:
+        return importlib.util.find_spec("claude_agent_sdk") is not None
+    except (ImportError, ValueError):
+        return False

--- a/hermes_cli/claude_subscription.py
+++ b/hermes_cli/claude_subscription.py
@@ -1,0 +1,58 @@
+"""Release gate for the "Claude subscription via Agent SDK" runtime.
+
+The runtime ships default-off because Anthropic's Agent SDK overview states
+that third party developers may not offer claude.ai login or rate limits for
+their products without prior approval, while their Help Center simultaneously
+says SDK usage still draws from subscription limits — an unresolved tension.
+Until Anthropic confirms in writing, only a developer running private
+validation on their own consenting account may flip this on; see
+`docs/design/claude-subscription-via-agent-sdk.md` for the full record.
+
+This module is imported by the provider catalog and the dashboard web server,
+so it must stay dependency-light and must never raise at import time.
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+from typing import Any, Optional
+
+# Pinned floors, recorded here so the runtime, the `hermes doctor` probe, and
+# the packaging extra all read the same numbers. `claude-agent-sdk` ships the
+# Claude executable inside its platform wheels, so the SDK floor also fixes a
+# CLI floor; a separately installed newer CLI is fine, an older one is not.
+CLAUDE_AGENT_SDK_MIN_VERSION = "0.2.128"
+CLAUDE_CLI_MIN_VERSION = "2.1.220"
+
+_CONFIG_SECTION = "claude_subscription"
+
+
+def claude_subscription_enabled(config: Optional[dict] = None) -> bool:
+    """True when `claude_subscription.enabled` is explicitly set in config.
+
+    Tolerates a missing, empty, or partially-shaped config dict: anything
+    that isn't an explicit truthy `enabled` reads as off. Callers pass the
+    already-loaded config rather than loading one, so the gate is usable from
+    all three config loaders (CLI, `load_config()`, raw gateway YAML).
+    """
+    if not isinstance(config, dict):
+        return False
+    section: Any = config.get(_CONFIG_SECTION)
+    if not isinstance(section, dict):
+        return False
+    return bool(section.get("enabled", False))
+
+
+@functools.lru_cache(maxsize=1)
+def claude_agent_sdk_available() -> bool:
+    """True when `claude_agent_sdk` is importable in this interpreter.
+
+    Uses `find_spec` rather than a real import: the package is an ~80 MB
+    wheel that bundles the Claude executable, and every caller only needs to
+    know whether the optional `claude-code` extra is installed.
+    """
+    try:
+        return importlib.util.find_spec("claude_agent_sdk") is not None
+    except (ImportError, ValueError):
+        return False

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3806,6 +3806,20 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # "Claude subscription via Agent SDK" runtime (provider "claude-code",
+    # api_mode "claude_agent_sdk"). A top-level root rather than a key under
+    # `model` because DEFAULT_CONFIG's `model` is a plain string here (only
+    # cli.py's CLI defaults shape it as a dict), so a nested key would be
+    # invisible to load_config() and to the gateway's raw-YAML reader.
+    # Read through hermes_cli/claude_subscription.py, never inline.
+    "claude_subscription": {
+        # Default-off pending written policy clearance from Anthropic; see
+        # docs/design/claude-subscription-via-agent-sdk.md. Flipping this on
+        # is only sanctioned for private validation against a
+        # developer-controlled, consenting Claude account.
+        "enabled": False,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 39,
 }

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3010,6 +3010,20 @@ DEFAULT_CONFIG = {
         "region": "global",
     },
 
+    # "Claude subscription via Agent SDK" runtime (provider "claude-code",
+    # api_mode "claude_agent_sdk"). A top-level root rather than a key under
+    # `model` because DEFAULT_CONFIG's `model` is a plain string here (only
+    # cli.py's CLI defaults shape it as a dict), so a nested key would be
+    # invisible to load_config() and to the gateway's raw-YAML reader.
+    # Read through hermes_cli/claude_subscription.py, never inline.
+    "claude_subscription": {
+        # Default-off pending written policy clearance from Anthropic; see
+        # docs/design/claude-subscription-via-agent-sdk.md. Flipping this on
+        # is only sanctioned for private validation against a
+        # developer-controlled, consenting Claude account.
+        "enabled": False,
+    },
+
     # Config schema version - bump this when adding new required fields
     "_config_version": 33,
 }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -824,6 +824,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_claude_code,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -4158,6 +4159,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-code":
+        _model_flow_claude_code(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -786,6 +786,7 @@ from hermes_cli.model_setup_flows import (
     _model_flow_named_custom,
     _model_flow_copilot,
     _model_flow_copilot_acp,
+    _model_flow_claude_code,
     _model_flow_kimi,
     _model_flow_stepfun,
     _model_flow_bedrock_api_key,
@@ -3385,6 +3386,8 @@ def select_provider_and_model(args=None):
         _model_flow_minimax_oauth(config, current_model, args=args)
     elif selected_provider == "copilot-acp":
         _model_flow_copilot_acp(config, current_model)
+    elif selected_provider == "claude-code":
+        _model_flow_claude_code(config, current_model)
     elif selected_provider == "copilot":
         _model_flow_copilot(config, current_model)
     elif selected_provider == "custom":

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2113,6 +2113,86 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_claude_code(config, current_model=""):
+    """Claude subscription flow — sign-in is delegated to the official CLI.
+
+    Hermes deliberately runs no OAuth flow here and stores no credential: it
+    reports what ``claude auth status`` says and tells the user which command
+    to run.  Signing in and out is the Claude CLI's job.
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+    )
+    from hermes_cli.claude_code import (
+        CLAUDE_CODE_API_MODE,
+        CLAUDE_CODE_BASE_URL,
+        CLAUDE_LOGIN_COMMAND,
+        CLAUDE_LOGOUT_COMMAND,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-code"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+
+    print(f"  {pconfig.name} runs inference through the official Claude Agent SDK.")
+    print("  Hermes never reads, stores, or refreshes your Claude credentials —")
+    print("  the SDK resolves them from your own `claude` login.")
+    if status.get("cli_version"):
+        print(f"  Claude Code: {status['cli_version']}")
+    print(f"  {status.get('message', '')}")
+    print(f"  Sign in:  {CLAUDE_LOGIN_COMMAND}")
+    print(f"  Sign out: {CLAUDE_LOGOUT_COMMAND}")
+    print()
+
+    if not status.get("subscription"):
+        # Selecting the provider without a plan login would route every turn
+        # to a billing source the user did not choose. Stop before writing.
+        print("  No Claude plan login detected — run the sign-in command, then retry.")
+        print("  No change.")
+        return
+
+    try:
+        selected = input(f"Model name [{current_model or 'keep current'}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        selected = ""
+    selected = selected or current_model
+    if selected:
+        from hermes_cli.models import (
+            claude_subscription_models,
+            is_valid_claude_subscription_model,
+        )
+
+        # validate_requested_model rejects unknown slugs at runtime, so a
+        # free-form save here would persist a model that every later turn
+        # refuses. Same curated set, checked at entry.
+        if not is_valid_claude_subscription_model(selected):
+            print(f"Unknown Claude subscription model: {selected!r}")
+            print("Choose one of: " + ", ".join(sorted(claude_subscription_models())))
+            return
+        _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = CLAUDE_CODE_BASE_URL
+    model["api_mode"] = CLAUDE_CODE_API_MODE
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Provider set to: {pconfig.name}")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -2009,6 +2009,86 @@ def _model_flow_copilot_acp(config, current_model=""):
 
     print(f"Default model set to: {selected} (via {pconfig.name})")
 
+
+def _model_flow_claude_code(config, current_model=""):
+    """Claude subscription flow — sign-in is delegated to the official CLI.
+
+    Hermes deliberately runs no OAuth flow here and stores no credential: it
+    reports what ``claude auth status`` says and tells the user which command
+    to run.  Signing in and out is the Claude CLI's job.
+    """
+    from hermes_cli.auth import (
+        PROVIDER_REGISTRY,
+        _save_model_choice,
+        deactivate_provider,
+        get_external_process_provider_status,
+    )
+    from hermes_cli.claude_code import (
+        CLAUDE_CODE_API_MODE,
+        CLAUDE_CODE_BASE_URL,
+        CLAUDE_LOGIN_COMMAND,
+        CLAUDE_LOGOUT_COMMAND,
+    )
+    from hermes_cli.config import load_config, save_config
+
+    del config
+
+    provider_id = "claude-code"
+    pconfig = PROVIDER_REGISTRY[provider_id]
+    status = get_external_process_provider_status(provider_id)
+
+    print(f"  {pconfig.name} runs inference through the official Claude Agent SDK.")
+    print("  Hermes never reads, stores, or refreshes your Claude credentials —")
+    print("  the SDK resolves them from your own `claude` login.")
+    if status.get("cli_version"):
+        print(f"  Claude Code: {status['cli_version']}")
+    print(f"  {status.get('message', '')}")
+    print(f"  Sign in:  {CLAUDE_LOGIN_COMMAND}")
+    print(f"  Sign out: {CLAUDE_LOGOUT_COMMAND}")
+    print()
+
+    if not status.get("subscription"):
+        # Selecting the provider without a plan login would route every turn
+        # to a billing source the user did not choose. Stop before writing.
+        print("  No Claude plan login detected — run the sign-in command, then retry.")
+        print("  No change.")
+        return
+
+    try:
+        selected = input(f"Model name [{current_model or 'keep current'}]: ").strip()
+    except (KeyboardInterrupt, EOFError):
+        selected = ""
+    selected = selected or current_model
+    if selected:
+        from hermes_cli.models import (
+            claude_subscription_models,
+            is_valid_claude_subscription_model,
+        )
+
+        # validate_requested_model rejects unknown slugs at runtime, so a
+        # free-form save here would persist a model that every later turn
+        # refuses. Same curated set, checked at entry.
+        if not is_valid_claude_subscription_model(selected):
+            print(f"Unknown Claude subscription model: {selected!r}")
+            print("Choose one of: " + ", ".join(sorted(claude_subscription_models())))
+            return
+        _save_model_choice(selected)
+
+    cfg = load_config()
+    model = cfg.get("model")
+    if not isinstance(model, dict):
+        model = {"default": model} if model else {}
+        cfg["model"] = model
+    model["provider"] = provider_id
+    model["base_url"] = CLAUDE_CODE_BASE_URL
+    model["api_mode"] = CLAUDE_CODE_API_MODE
+    clear_model_endpoint_credentials(model, clear_api_mode=False)
+    save_config(cfg)
+    deactivate_provider()
+
+    print(f"Provider set to: {pconfig.name}")
+
+
 def _model_flow_kimi(config, current_model=""):
     """Kimi / Moonshot model selection with automatic endpoint routing.
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2964,6 +2964,20 @@ def list_authenticated_providers(
                 has_creds = has_vertex_credentials()
             except Exception as exc:
                 logger.debug("Vertex credential check failed: %s", exc)
+        elif hermes_slug == "claude-code":
+            # No env var and no pool entry by design — the Claude Code CLI
+            # owns the credential. "Authenticated" for the picker means the
+            # CLI reports a claude.ai login (cached probe: two subprocesses
+            # cost too much per picker open otherwise). Without this branch
+            # the provider shows "(needs setup)" even while it is signed in
+            # and actively serving the current session.
+            try:
+                from hermes_cli.claude_code import probe_claude_auth_cached
+
+                probe = probe_claude_auth_cached()
+                has_creds = bool(probe.get("logged_in"))
+            except Exception as exc:
+                logger.debug("claude-code auth probe failed: %s", exc)
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2241,6 +2241,20 @@ def list_authenticated_providers(
                 has_creds = has_vertex_credentials()
             except Exception as exc:
                 logger.debug("Vertex credential check failed: %s", exc)
+        elif hermes_slug == "claude-code":
+            # No env var and no pool entry by design — the Claude Code CLI
+            # owns the credential. "Authenticated" for the picker means the
+            # CLI reports a claude.ai login (cached probe: two subprocesses
+            # cost too much per picker open otherwise). Without this branch
+            # the provider shows "(needs setup)" even while it is signed in
+            # and actively serving the current session.
+            try:
+                from hermes_cli.claude_code import probe_claude_auth_cached
+
+                probe = probe_claude_auth_cached()
+                has_creds = bool(probe.get("logged_in"))
+            except Exception as exc:
+                logger.debug("claude-code auth probe failed: %s", exc)
         elif overlay.extra_env_vars:
             has_creds = any(os.environ.get(ev) for ev in overlay.extra_env_vars)
         # Also check api_key_env_vars from PROVIDER_REGISTRY for api_key auth_type

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -716,6 +716,77 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
 _PROVIDER_MODELS["ai-gateway"] = [mid for mid, _ in VERCEL_AI_GATEWAY_MODELS]
 
 # ---------------------------------------------------------------------------
+# Claude subscription (Agent SDK) — curated, derived, not discovered
+# ---------------------------------------------------------------------------
+# The Python `claude-agent-sdk` has no `supportedModels()` (the TypeScript SDK
+# does), and the provider profile's `fetch_models()` returns None on purpose:
+# there is no REST catalog behind `claude-sdk://subscription` to ask. So this
+# picker list is curated. It is *derived* from the Claude entries this module
+# already maintains rather than hand-copied into a second list that would drift
+# the first time a Claude model ships — same pattern as `ai-gateway` above.
+#
+# Dated API pins (`claude-opus-4-5-20251101`) are dropped: they are Anthropic
+# API request ids, not how the Claude CLI names a model. `-fast` variants are
+# an OpenRouter routing product, not a Claude model.
+
+_CLAUDE_DATED_PIN_RE = re.compile(r"-\d{8}$")
+
+# The Claude CLI's own short aliases. Rejecting these would be user-hostile —
+# `sonnet` is what the CLI's own docs tell people to type.
+CLAUDE_SUBSCRIPTION_MODEL_ALIASES: tuple[str, ...] = (
+    "default",
+    "opus",
+    "sonnet",
+    "haiku",
+)
+
+
+def claude_subscription_models() -> list[str]:
+    """Curated Claude model ids for the subscription runtime, plus CLI aliases."""
+    seen: dict[str, None] = {}
+    for model_id in _PROVIDER_MODELS.get("anthropic", ()):
+        if not _CLAUDE_DATED_PIN_RE.search(model_id):
+            seen.setdefault(model_id, None)
+    for model_id, _desc in OPENROUTER_MODELS:
+        if not model_id.startswith("anthropic/"):
+            continue
+        slug = model_id.split("/", 1)[1].replace(".", "-")
+        if slug.endswith("-fast"):
+            continue
+        seen.setdefault(slug, None)
+    return [*seen, *CLAUDE_SUBSCRIPTION_MODEL_ALIASES]
+
+
+def is_claude_subscription_slug(provider: Optional[str]) -> bool:
+    """True when *provider* names the Claude subscription runtime, right now.
+
+    ``normalize_provider()`` still maps ``claude-code`` → ``anthropic`` while
+    the subscription gate is closed (that legacy mapping is what keeps existing
+    configs resolving), so callers that need to tell the two apart must ask
+    before normalizing. ``legacy_alias_target`` returns ``"anthropic"`` while
+    the gate is closed and ``None`` once it is open — one source of truth.
+    """
+    if (provider or "").strip().lower() != "claude-code":
+        return False
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+
+        return legacy_alias_target("claude-code") is None
+    except Exception:
+        return False
+
+
+def is_valid_claude_subscription_model(model_name: str) -> bool:
+    """True when *model_name* is in the curated set (case-insensitive)."""
+    wanted = (model_name or "").strip().lower()
+    if not wanted:
+        return False
+    return wanted in {m.lower() for m in claude_subscription_models()}
+
+
+_PROVIDER_MODELS["claude-code"] = claude_subscription_models()
+
+# ---------------------------------------------------------------------------
 # Nous Portal free-model helper
 # ---------------------------------------------------------------------------
 # The Nous Portal models endpoint is the source of truth for which models
@@ -1248,6 +1319,32 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
 ]
 
+# The Claude subscription provider (Agent SDK) is opt-in: it only joins the
+# universe once ``claude_subscription.enabled`` is true in config.yaml.  The
+# gate is applied HERE rather than in provider_catalog() because the catalog's
+# parity contract is that the union of its two desktop tabs equals this list —
+# gating downstream would make one surface disagree with the other.  Its
+# auth_type is external_process, so the auto-extend block below would skip it
+# anyway; this is the only place it can enter.
+try:
+    from hermes_cli.claude_code import (
+        CLAUDE_CODE_DESCRIPTION as _CLAUDE_CODE_DESC,
+        CLAUDE_CODE_DISPLAY_NAME as _CLAUDE_CODE_LABEL,
+        CLAUDE_CODE_PROVIDER_ID as _CLAUDE_CODE_ID,
+        subscription_enabled as _claude_subscription_enabled,
+    )
+    if _claude_subscription_enabled():
+        _anthropic_idx = next(
+            (i for i, _p in enumerate(CANONICAL_PROVIDERS) if _p.slug == "anthropic"),
+            len(CANONICAL_PROVIDERS) - 1,
+        )
+        CANONICAL_PROVIDERS.insert(
+            _anthropic_idx + 1,
+            ProviderEntry(_CLAUDE_CODE_ID, _CLAUDE_CODE_LABEL, _CLAUDE_CODE_DESC),
+        )
+except Exception:
+    pass
+
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
 # that is not already in the list above.  Adding plugins/model-providers/<name>/
 # is sufficient to expose a new provider in the model picker, /model, and all
@@ -1415,7 +1512,10 @@ _PROVIDER_ALIASES = {
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    # "claude-code" is gate-dependent and handled in normalize_provider():
+    # its own provider when the subscription gate is open, the legacy
+    # "anthropic" alias when it is shut. A static entry here would pin the
+    # closed-gate answer for every surface that renders provider labels.
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
@@ -3580,6 +3680,10 @@ def normalize_provider(provider: Optional[str]) -> str:
     provider based on credentials and environment.
     """
     normalized = (provider or "openrouter").strip().lower()
+    if normalized in ("claude-code", "claude-oauth"):
+        from hermes_cli.claude_code import legacy_alias_target
+
+        return legacy_alias_target(normalized) or "claude-code"
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
@@ -6367,6 +6471,29 @@ def validate_requested_model(
                 "accepted": False, "persist": False, "recognized": False,
                 "message": f"Could not read MoA presets: {exc}",
             }
+
+    if is_claude_subscription_slug(provider):
+        # No live probe: `claude-sdk://subscription` is an internal scheme, not
+        # a reachable endpoint, and the Python SDK exposes no model listing. An
+        # unknown string would be handed straight to the CLI's `--model`, which
+        # fails deep inside a spawned subprocess with a message the user cannot
+        # act on — so validate against the curated set and say what is allowed.
+        if is_valid_claude_subscription_model(requested):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        return {
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
+            "message": (
+                f"`{requested}` is not a known Claude subscription model. "
+                "Available: " + ", ".join(claude_subscription_models()) + "."
+            ),
+        }
 
     if any(ch.isspace() for ch in requested):
         return {

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -612,6 +612,77 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
 _PROVIDER_MODELS["ai-gateway"] = [mid for mid, _ in VERCEL_AI_GATEWAY_MODELS]
 
 # ---------------------------------------------------------------------------
+# Claude subscription (Agent SDK) — curated, derived, not discovered
+# ---------------------------------------------------------------------------
+# The Python `claude-agent-sdk` has no `supportedModels()` (the TypeScript SDK
+# does), and the provider profile's `fetch_models()` returns None on purpose:
+# there is no REST catalog behind `claude-sdk://subscription` to ask. So this
+# picker list is curated. It is *derived* from the Claude entries this module
+# already maintains rather than hand-copied into a second list that would drift
+# the first time a Claude model ships — same pattern as `ai-gateway` above.
+#
+# Dated API pins (`claude-opus-4-5-20251101`) are dropped: they are Anthropic
+# API request ids, not how the Claude CLI names a model. `-fast` variants are
+# an OpenRouter routing product, not a Claude model.
+
+_CLAUDE_DATED_PIN_RE = re.compile(r"-\d{8}$")
+
+# The Claude CLI's own short aliases. Rejecting these would be user-hostile —
+# `sonnet` is what the CLI's own docs tell people to type.
+CLAUDE_SUBSCRIPTION_MODEL_ALIASES: tuple[str, ...] = (
+    "default",
+    "opus",
+    "sonnet",
+    "haiku",
+)
+
+
+def claude_subscription_models() -> list[str]:
+    """Curated Claude model ids for the subscription runtime, plus CLI aliases."""
+    seen: dict[str, None] = {}
+    for model_id in _PROVIDER_MODELS.get("anthropic", ()):
+        if not _CLAUDE_DATED_PIN_RE.search(model_id):
+            seen.setdefault(model_id, None)
+    for model_id, _desc in OPENROUTER_MODELS:
+        if not model_id.startswith("anthropic/"):
+            continue
+        slug = model_id.split("/", 1)[1].replace(".", "-")
+        if slug.endswith("-fast"):
+            continue
+        seen.setdefault(slug, None)
+    return [*seen, *CLAUDE_SUBSCRIPTION_MODEL_ALIASES]
+
+
+def is_claude_subscription_slug(provider: Optional[str]) -> bool:
+    """True when *provider* names the Claude subscription runtime, right now.
+
+    ``normalize_provider()`` still maps ``claude-code`` → ``anthropic`` while
+    the subscription gate is closed (that legacy mapping is what keeps existing
+    configs resolving), so callers that need to tell the two apart must ask
+    before normalizing. ``legacy_alias_target`` returns ``"anthropic"`` while
+    the gate is closed and ``None`` once it is open — one source of truth.
+    """
+    if (provider or "").strip().lower() != "claude-code":
+        return False
+    try:
+        from hermes_cli.claude_code import legacy_alias_target
+
+        return legacy_alias_target("claude-code") is None
+    except Exception:
+        return False
+
+
+def is_valid_claude_subscription_model(model_name: str) -> bool:
+    """True when *model_name* is in the curated set (case-insensitive)."""
+    wanted = (model_name or "").strip().lower()
+    if not wanted:
+        return False
+    return wanted in {m.lower() for m in claude_subscription_models()}
+
+
+_PROVIDER_MODELS["claude-code"] = claude_subscription_models()
+
+# ---------------------------------------------------------------------------
 # Nous Portal free-model helper
 # ---------------------------------------------------------------------------
 # The Nous Portal models endpoint is the source of truth for which models
@@ -1110,7 +1181,7 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("moa",            "Mixture of Agents",        "Mixture of Agents (named presets; aggregator acts after reference models)"),
     ProviderEntry("novita",         "NovitaAI",                 "NovitaAI (Cloud: Model API, Agent Sandbox, GPU Cloud)"),
     ProviderEntry("lmstudio",       "LM Studio",                "LM Studio (Local desktop app with built-in model server)"),
-    ProviderEntry("anthropic",      "Anthropic",                "Anthropic (Claude models via API key or Claude Code)"),
+    ProviderEntry("anthropic",      "Anthropic API",            "Anthropic API (Claude models, billed per token with an API key)"),
     ProviderEntry("openai-codex",   "OpenAI Codex",             "OpenAI Codex (Codex CLI via ChatGPT subscription or API key)"),
     ProviderEntry("openai-api",     "OpenAI API",               "OpenAI API (api.openai.com, API key)"),
     ProviderEntry("alibaba",        "Qwen Cloud",               "Qwen Cloud / DashScope (Qwen + multi-provider)"),
@@ -1143,6 +1214,32 @@ CANONICAL_PROVIDERS: list[ProviderEntry] = [
     ProviderEntry("ai-gateway",     "Vercel AI Gateway",        "Vercel AI Gateway (Multi-model aggregator)"),
     ProviderEntry("qwen-oauth",     "Qwen OAuth (Portal)",      "Qwen OAuth (Reuses local Qwen CLI login)"),
 ]
+
+# The Claude subscription provider (Agent SDK) is opt-in: it only joins the
+# universe once ``claude_subscription.enabled`` is true in config.yaml.  The
+# gate is applied HERE rather than in provider_catalog() because the catalog's
+# parity contract is that the union of its two desktop tabs equals this list —
+# gating downstream would make one surface disagree with the other.  Its
+# auth_type is external_process, so the auto-extend block below would skip it
+# anyway; this is the only place it can enter.
+try:
+    from hermes_cli.claude_code import (
+        CLAUDE_CODE_DESCRIPTION as _CLAUDE_CODE_DESC,
+        CLAUDE_CODE_DISPLAY_NAME as _CLAUDE_CODE_LABEL,
+        CLAUDE_CODE_PROVIDER_ID as _CLAUDE_CODE_ID,
+        subscription_enabled as _claude_subscription_enabled,
+    )
+    if _claude_subscription_enabled():
+        _anthropic_idx = next(
+            (i for i, _p in enumerate(CANONICAL_PROVIDERS) if _p.slug == "anthropic"),
+            len(CANONICAL_PROVIDERS) - 1,
+        )
+        CANONICAL_PROVIDERS.insert(
+            _anthropic_idx + 1,
+            ProviderEntry(_CLAUDE_CODE_ID, _CLAUDE_CODE_LABEL, _CLAUDE_CODE_DESC),
+        )
+except Exception:
+    pass
 
 # Auto-extend CANONICAL_PROVIDERS with any provider registered in providers/
 # that is not already in the list above.  Adding plugins/model-providers/<name>/
@@ -1308,7 +1405,10 @@ _PROVIDER_ALIASES = {
     "minimax-global": "minimax-oauth",
     "minimax_oauth": "minimax-oauth",
     "claude": "anthropic",
-    "claude-code": "anthropic",
+    # "claude-code" is gate-dependent and handled in normalize_provider():
+    # its own provider when the subscription gate is open, the legacy
+    # "anthropic" alias when it is shut. A static entry here would pin the
+    # closed-gate answer for every surface that renders provider labels.
     "deep-seek": "deepseek",
     "opencode": "opencode-zen",
     "zen": "opencode-zen",
@@ -2518,6 +2618,10 @@ def normalize_provider(provider: Optional[str]) -> str:
     provider based on credentials and environment.
     """
     normalized = (provider or "openrouter").strip().lower()
+    if normalized in ("claude-code", "claude-oauth"):
+        from hermes_cli.claude_code import legacy_alias_target
+
+        return legacy_alias_target(normalized) or "claude-code"
     return _PROVIDER_ALIASES.get(normalized, normalized)
 
 
@@ -4685,6 +4789,29 @@ def validate_requested_model(
                 "accepted": False, "persist": False, "recognized": False,
                 "message": f"Could not read MoA presets: {exc}",
             }
+
+    if is_claude_subscription_slug(provider):
+        # No live probe: `claude-sdk://subscription` is an internal scheme, not
+        # a reachable endpoint, and the Python SDK exposes no model listing. An
+        # unknown string would be handed straight to the CLI's `--model`, which
+        # fails deep inside a spawned subprocess with a message the user cannot
+        # act on — so validate against the curated set and say what is allowed.
+        if is_valid_claude_subscription_model(requested):
+            return {
+                "accepted": True,
+                "persist": True,
+                "recognized": True,
+                "message": None,
+            }
+        return {
+            "accepted": False,
+            "persist": False,
+            "recognized": False,
+            "message": (
+                f"`{requested}` is not a known Claude subscription model. "
+                "Available: " + ", ".join(claude_subscription_models()) + "."
+            ),
+        }
 
     if any(ch.isspace() for ch in requested):
         return {

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -23,6 +23,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli.claude_code import legacy_alias_target
 from utils import base_url_host_matches, base_url_hostname
 
 logger = logging.getLogger(__name__)
@@ -101,7 +102,16 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",
-        extra_env_vars=("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        # API-key only: the Claude subscription OAuth token belongs to the
+        # `claude-code` provider (Claude Agent SDK), not to this endpoint.
+        extra_env_vars=("ANTHROPIC_TOKEN",),
+    ),
+    # Claude subscription via the official Claude Agent SDK. No credential env
+    # var and no HTTP base URL: the SDK resolves auth and transport itself.
+    "claude-code": HermesOverlay(
+        transport="claude_agent_sdk",
+        auth_type="external_process",
+        base_url_override="claude-sdk://subscription",
     ),
     "zai": HermesOverlay(
         transport="openai_chat",
@@ -319,7 +329,13 @@ ALIASES: Dict[str, str] = {
 
     # anthropic
     "claude": "anthropic",
-    "claude-code": "anthropic",
+
+    # claude-code (Claude Agent SDK). These mappings only take effect once the
+    # subscription gate is open: normalize_provider() below short-circuits both
+    # slugs to anthropic while it is closed, preserving pre-SDK configs.
+    "claude-oauth": "claude-code",
+    "claude-subscription": "claude-code",
+    "claude-agent-sdk": "claude-code",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -426,6 +442,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "ChatGPT or Codex Subscription",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-code": "Claude subscription (Agent SDK)",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
@@ -449,6 +466,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
     "bedrock_converse": "bedrock_converse",
+    "claude_agent_sdk": "claude_agent_sdk",
 }
 
 
@@ -461,6 +479,9 @@ def normalize_provider(name: str) -> str:
     corresponds to a known provider.
     """
     key = name.strip().lower()
+    legacy = legacy_alias_target(key)
+    if legacy:
+        return legacy
     return ALIASES.get(key, key)
 
 

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -23,6 +23,7 @@ import logging
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
 
+from hermes_cli.claude_code import legacy_alias_target
 from utils import base_url_host_matches, base_url_hostname
 
 logger = logging.getLogger(__name__)
@@ -100,7 +101,16 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
     ),
     "anthropic": HermesOverlay(
         transport="anthropic_messages",
-        extra_env_vars=("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+        # API-key only: the Claude subscription OAuth token belongs to the
+        # `claude-code` provider (Claude Agent SDK), not to this endpoint.
+        extra_env_vars=("ANTHROPIC_TOKEN",),
+    ),
+    # Claude subscription via the official Claude Agent SDK. No credential env
+    # var and no HTTP base URL: the SDK resolves auth and transport itself.
+    "claude-code": HermesOverlay(
+        transport="claude_agent_sdk",
+        auth_type="external_process",
+        base_url_override="claude-sdk://subscription",
     ),
     "zai": HermesOverlay(
         transport="openai_chat",
@@ -306,7 +316,13 @@ ALIASES: Dict[str, str] = {
 
     # anthropic
     "claude": "anthropic",
-    "claude-code": "anthropic",
+
+    # claude-code (Claude Agent SDK). These mappings only take effect once the
+    # subscription gate is open: normalize_provider() below short-circuits both
+    # slugs to anthropic while it is closed, preserving pre-SDK configs.
+    "claude-oauth": "claude-code",
+    "claude-subscription": "claude-code",
+    "claude-agent-sdk": "claude-code",
 
     # github-copilot (models.dev ID)
     "copilot": "github-copilot",
@@ -404,6 +420,7 @@ _LABEL_OVERRIDES: Dict[str, str] = {
     "nous": "Nous Portal",
     "openai-codex": "OpenAI Codex",
     "copilot-acp": "GitHub Copilot ACP",
+    "claude-code": "Claude subscription (Agent SDK)",
     "stepfun": "StepFun Step Plan",
     "xiaomi": "Xiaomi MiMo",
     "gmi": "GMI Cloud",
@@ -425,6 +442,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
     "bedrock_converse": "bedrock_converse",
+    "claude_agent_sdk": "claude_agent_sdk",
 }
 
 
@@ -437,6 +455,9 @@ def normalize_provider(name: str) -> str:
     corresponds to a known provider.
     """
     key = name.strip().lower()
+    legacy = legacy_alias_target(key)
+    if legacy:
+        return legacy
     return ALIASES.get(key, key)
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -40,6 +40,11 @@ from hermes_cli.auth import (
     is_actual_local_base_url,
     normalize_actual_base_url,
 )
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_API_MODE,
+    CLAUDE_CODE_BASE_URL,
+    CLAUDE_CODE_PROVIDER_ID,
+)
 from hermes_cli.config import (
     get_compatible_custom_providers,
     load_config,
@@ -2154,6 +2159,28 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "oauth"),
                 "requested_provider": requested_provider,
             }
+
+    if provider == CLAUDE_CODE_PROVIDER_ID:
+        # The Claude subscription runtime. The credential lookup is called for
+        # its *validation* only — it raises an actionable AuthError when the
+        # `claude` CLI is missing — because the bundle it returns deliberately
+        # carries no credential: the Agent SDK resolves the user's own login.
+        # Every non-interactive surface (cron, ACP, batch, delegation) reaches
+        # the runtime through here, so without this branch they fall back to
+        # `anthropic` and silently resume the pre-SDK direct-OAuth billing path.
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": CLAUDE_CODE_PROVIDER_ID,
+            "api_mode": CLAUDE_CODE_API_MODE,
+            "base_url": CLAUDE_CODE_BASE_URL,
+            # Empty by contract, not by accident — see hermes_cli/auth.py.
+            "api_key": "",
+            "credentials_owner": creds.get("credentials_owner", "claude-agent-sdk"),
+            "command": creds.get("command", ""),
+            "args": [],
+            "source": creds.get("source", "claude_agent_sdk"),
+            "requested_provider": requested_provider,
+        }
 
     if provider == "copilot-acp":
         creds = resolve_external_process_provider_credentials(provider)

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -37,6 +37,11 @@ from hermes_cli.auth import (
     resolve_external_process_provider_credentials,
     has_usable_secret,
 )
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_API_MODE,
+    CLAUDE_CODE_BASE_URL,
+    CLAUDE_CODE_PROVIDER_ID,
+)
 from hermes_cli.config import (
     get_compatible_custom_providers,
     load_config,
@@ -1986,6 +1991,28 @@ def resolve_runtime_provider(
                 "source": creds.get("source", "oauth"),
                 "requested_provider": requested_provider,
             }
+
+    if provider == CLAUDE_CODE_PROVIDER_ID:
+        # The Claude subscription runtime. The credential lookup is called for
+        # its *validation* only — it raises an actionable AuthError when the
+        # `claude` CLI is missing — because the bundle it returns deliberately
+        # carries no credential: the Agent SDK resolves the user's own login.
+        # Every non-interactive surface (cron, ACP, batch, delegation) reaches
+        # the runtime through here, so without this branch they fall back to
+        # `anthropic` and silently resume the pre-SDK direct-OAuth billing path.
+        creds = resolve_external_process_provider_credentials(provider)
+        return {
+            "provider": CLAUDE_CODE_PROVIDER_ID,
+            "api_mode": CLAUDE_CODE_API_MODE,
+            "base_url": CLAUDE_CODE_BASE_URL,
+            # Empty by contract, not by accident — see hermes_cli/auth.py.
+            "api_key": "",
+            "credentials_owner": creds.get("credentials_owner", "claude-agent-sdk"),
+            "command": creds.get("command", ""),
+            "args": [],
+            "source": creds.get("source", "claude_agent_sdk"),
+            "requested_provider": requested_provider,
+        }
 
     if provider == "copilot-acp":
         creds = resolve_external_process_provider_credentials(provider)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,6 +47,13 @@ import urllib.parse
 import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_DISPLAY_NAME,
+    CLAUDE_CODE_PROVIDER_ID,
+    CLAUDE_DOCS_URL,
+    CLAUDE_LOGIN_COMMAND,
+    CLAUDE_LOGOUT_COMMAND,
+)
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -1398,6 +1405,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `session.terminal_continue` is the only schema-surfaced session field —
     # fold it into general rather than spawning a one-field orphan category.
     "session": "general",
+    # `claude_subscription.enabled` is a release gate for the Claude Agent SDK
+    # runtime, not a settings group, and it is the section's only field — fold
+    # it into the agent tab rather than spawning a one-field orphan category.
+    "claude_subscription": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
@@ -10872,27 +10883,31 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
 
 
 def _claude_code_only_status() -> Dict[str, Any]:
-    """Surface Claude Code CLI credentials as their own provider entry.
+    """Status for the Claude subscription card, from the official CLI.
 
-    Independent of the Anthropic entry above so users can see whether their
-    Claude Code subscription tokens are actively flowing into Hermes even
-    when they also have a separate Hermes-managed PKCE login.
+    Asks ``claude auth status`` whether a login exists; it never reads,
+    writes, or previews a Claude credential — the Claude Agent SDK owns them.
+    ``token_preview`` is therefore always None, and ``source_label`` carries
+    the CLI's own account/auth-method summary so the UI can distinguish a
+    claude.ai plan login (subscription billing) from an API-key login (metered
+    API billing), which are not the same thing.
     """
     try:
-        from agent.anthropic_adapter import read_claude_code_credentials
-        creds = read_claude_code_credentials()
-    except Exception:
-        creds = None
-    if creds and creds.get("accessToken"):
-        return {
-            "logged_in": True,
-            "source": "claude_code_cli",
-            "source_label": "~/.claude/.credentials.json",
-            "token_preview": _truncate_token(creds.get("accessToken")),
-            "expires_at": creds.get("expiresAt"),
-            "has_refresh_token": bool(creds.get("refreshToken")),
-        }
-    return {"logged_in": False, "source": None}
+        from hermes_cli.claude_code import provider_status
+        status = provider_status()
+    except Exception as exc:
+        return {"logged_in": False, "source": "claude_cli", "error": str(exc)}
+    return {
+        "logged_in": bool(status.get("logged_in")) and bool(status.get("subscription")),
+        "source": "claude_cli",
+        "source_label": status.get("message") or "Managed by the Claude CLI",
+        "token_preview": None,  # Hermes never holds a Claude credential.
+        "expires_at": None,
+        "has_refresh_token": False,
+        "auth_method": status.get("auth_method", ""),
+        "subscription": bool(status.get("subscription")),
+        "cli_version": status.get("cli_version", ""),
+    }
 
 
 def _copilot_acp_status() -> Dict[str, Any]:
@@ -10918,9 +10933,10 @@ def _copilot_acp_status() -> Dict[str, Any]:
 # display order. They are the OVERRIDE BASE for ``_build_oauth_catalog()``,
 # which unions them with every accounts-tab provider in ``provider_catalog()``
 # so newly-added OAuth/external providers appear automatically (no hand edit).
-# This tuple also still includes two entries that are NOT catalog providers but
-# must show on the Accounts tab: the api-key Anthropic PKCE card and the
-# synthetic ``claude-code`` subscription row.
+# This tuple also still includes the api-key Anthropic PKCE card, which is not
+# a catalog provider but must show on the Accounts tab, and pins the metadata
+# for ``claude-code`` (a catalog provider only once the Claude subscription
+# gate is open) so its card renders identically either way.
 # ``flow`` describes the OAuth shape so the modal can pick the right UI:
 # ``pkce`` = open URL + paste callback code, ``device_code`` = show code +
 # verification URL + poll, ``external`` = read-only (delegated to a third-party
@@ -10983,8 +10999,9 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": _copilot_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
-    # first, then the subscription OAuth path (which only works with extra
-    # usage credits on top of a Claude Max plan — see disclaimer in name).
+    # first, then the Claude subscription (Agent SDK) path. They are billed
+    # differently — API tokens vs. the user's Claude plan — so the copy must
+    # keep them distinguishable.
     {
         "id": "anthropic",
         "name": "Anthropic API Key",
@@ -10994,11 +11011,11 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": _anthropic_oauth_status,
     },
     {
-        "id": "claude-code",
-        "name": "Anthropic OAuth: Required Extra Usage Credits to Use Subscription",
+        "id": CLAUDE_CODE_PROVIDER_ID,
+        "name": CLAUDE_CODE_DISPLAY_NAME,
         "flow": "external",
-        "cli_command": "claude setup-token",
-        "docs_url": "https://docs.claude.com/en/docs/claude-code",
+        "cli_command": CLAUDE_LOGIN_COMMAND,
+        "docs_url": CLAUDE_DOCS_URL,
         "status_fn": _claude_code_only_status,
     },
 )
@@ -11109,19 +11126,17 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
     instead hand the GUI a command it can *run in the embedded terminal* — the
     user sees exactly what executes, and Hermes then stops resolving the token.
 
-    Claude Code has no scriptable logout (only the interactive ``/logout``), so
-    we remove the credential the same way logout does: the macOS Keychain entry
-    (``Claude Code-credentials``) and/or the ``~/.claude/.credentials.json``
-    file — the two sources ``read_claude_code_credentials()`` consults. Returns
-    None for providers we can't safely clear (the GUI shows a manual hint).
+    For the Claude subscription that command is the CLI's own
+    ``claude auth logout``. Hermes must never delete or rewrite Anthropic's
+    credential store itself — the CLI owns those files and the keychain entry,
+    and reaching into them is exactly the boundary this provider exists to
+    respect. Returns None for providers we can't safely clear (the GUI shows a
+    manual hint).
     """
     if provider.get("flow") != "external":
         return None
-    if provider.get("id") == "claude-code":
-        rm_file = "rm -f ~/.claude/.credentials.json"
-        if sys.platform == "darwin":
-            return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
-        return rm_file
+    if provider.get("id") == CLAUDE_CODE_PROVIDER_ID:
+        return CLAUDE_LOGOUT_COMMAND
     return None
 
 
@@ -11144,8 +11159,7 @@ def _build_oauth_catalog() -> list[Dict[str, Any]]:
     MEMBERSHIP is the union of:
       1. ``_OAUTH_PROVIDER_CATALOG`` — the explicit, hand-tuned cards that carry
          bespoke flow / status_fn / cli_command (including the api-key Anthropic
-         PKCE card and the synthetic claude-code subscription row, which are not
-         catalog providers), and
+         PKCE card, which is not a catalog provider), and
       2. every accounts-tab provider in the unified ``provider_catalog()`` (the
          ``hermes model`` universe) — so any OAuth/external provider added as a
          plugin appears automatically, with sensible defaults, even if no

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -46,6 +46,13 @@ import urllib.parse
 import zipfile
 
 from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_DISPLAY_NAME,
+    CLAUDE_CODE_PROVIDER_ID,
+    CLAUDE_DOCS_URL,
+    CLAUDE_LOGIN_COMMAND,
+    CLAUDE_LOGOUT_COMMAND,
+)
 import urllib.request
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
@@ -1019,6 +1026,10 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # `telemetry.shared_metrics.enabled` is the only schema-surfaced telemetry
     # field — fold it into security alongside the other privacy-posture toggles.
     "telemetry": "security",
+    # `claude_subscription.enabled` is a release gate for the Claude Agent SDK
+    # runtime, not a settings group, and it is the section's only field — fold
+    # it into the agent tab rather than spawning a one-field orphan category.
+    "claude_subscription": "agent",
 }
 
 # Display order for tabs — unlisted categories sort alphabetically after these.
@@ -9445,27 +9456,31 @@ def _anthropic_oauth_status() -> Dict[str, Any]:
 
 
 def _claude_code_only_status() -> Dict[str, Any]:
-    """Surface Claude Code CLI credentials as their own provider entry.
+    """Status for the Claude subscription card, from the official CLI.
 
-    Independent of the Anthropic entry above so users can see whether their
-    Claude Code subscription tokens are actively flowing into Hermes even
-    when they also have a separate Hermes-managed PKCE login.
+    Asks ``claude auth status`` whether a login exists; it never reads,
+    writes, or previews a Claude credential — the Claude Agent SDK owns them.
+    ``token_preview`` is therefore always None, and ``source_label`` carries
+    the CLI's own account/auth-method summary so the UI can distinguish a
+    claude.ai plan login (subscription billing) from an API-key login (metered
+    API billing), which are not the same thing.
     """
     try:
-        from agent.anthropic_adapter import read_claude_code_credentials
-        creds = read_claude_code_credentials()
-    except Exception:
-        creds = None
-    if creds and creds.get("accessToken"):
-        return {
-            "logged_in": True,
-            "source": "claude_code_cli",
-            "source_label": "~/.claude/.credentials.json",
-            "token_preview": _truncate_token(creds.get("accessToken")),
-            "expires_at": creds.get("expiresAt"),
-            "has_refresh_token": bool(creds.get("refreshToken")),
-        }
-    return {"logged_in": False, "source": None}
+        from hermes_cli.claude_code import provider_status
+        status = provider_status()
+    except Exception as exc:
+        return {"logged_in": False, "source": "claude_cli", "error": str(exc)}
+    return {
+        "logged_in": bool(status.get("logged_in")) and bool(status.get("subscription")),
+        "source": "claude_cli",
+        "source_label": status.get("message") or "Managed by the Claude CLI",
+        "token_preview": None,  # Hermes never holds a Claude credential.
+        "expires_at": None,
+        "has_refresh_token": False,
+        "auth_method": status.get("auth_method", ""),
+        "subscription": bool(status.get("subscription")),
+        "cli_version": status.get("cli_version", ""),
+    }
 
 
 def _copilot_acp_status() -> Dict[str, Any]:
@@ -9491,9 +9506,10 @@ def _copilot_acp_status() -> Dict[str, Any]:
 # display order. They are the OVERRIDE BASE for ``_build_oauth_catalog()``,
 # which unions them with every accounts-tab provider in ``provider_catalog()``
 # so newly-added OAuth/external providers appear automatically (no hand edit).
-# This tuple also still includes two entries that are NOT catalog providers but
-# must show on the Accounts tab: the api-key Anthropic PKCE card and the
-# synthetic ``claude-code`` subscription row.
+# This tuple also still includes the api-key Anthropic PKCE card, which is not
+# a catalog provider but must show on the Accounts tab, and pins the metadata
+# for ``claude-code`` (a catalog provider only once the Claude subscription
+# gate is open) so its card renders identically either way.
 # ``flow`` describes the OAuth shape so the modal can pick the right UI:
 # ``pkce`` = open URL + paste callback code, ``device_code`` = show code +
 # verification URL + poll, ``external`` = read-only (delegated to a third-party
@@ -9556,8 +9572,9 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": _copilot_acp_status,
     },
     # ── Anthropic / Claude entries sit at the bottom: the API-key path
-    # first, then the subscription OAuth path (which only works with extra
-    # usage credits on top of a Claude Max plan — see disclaimer in name).
+    # first, then the Claude subscription (Agent SDK) path. They are billed
+    # differently — API tokens vs. the user's Claude plan — so the copy must
+    # keep them distinguishable.
     {
         "id": "anthropic",
         "name": "Anthropic API Key",
@@ -9567,11 +9584,11 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "status_fn": _anthropic_oauth_status,
     },
     {
-        "id": "claude-code",
-        "name": "Anthropic OAuth: Required Extra Usage Credits to Use Subscription",
+        "id": CLAUDE_CODE_PROVIDER_ID,
+        "name": CLAUDE_CODE_DISPLAY_NAME,
         "flow": "external",
-        "cli_command": "claude setup-token",
-        "docs_url": "https://docs.claude.com/en/docs/claude-code",
+        "cli_command": CLAUDE_LOGIN_COMMAND,
+        "docs_url": CLAUDE_DOCS_URL,
         "status_fn": _claude_code_only_status,
     },
 )
@@ -9682,19 +9699,17 @@ def _oauth_provider_disconnect_command(provider: Dict[str, Any]) -> Optional[str
     instead hand the GUI a command it can *run in the embedded terminal* — the
     user sees exactly what executes, and Hermes then stops resolving the token.
 
-    Claude Code has no scriptable logout (only the interactive ``/logout``), so
-    we remove the credential the same way logout does: the macOS Keychain entry
-    (``Claude Code-credentials``) and/or the ``~/.claude/.credentials.json``
-    file — the two sources ``read_claude_code_credentials()`` consults. Returns
-    None for providers we can't safely clear (the GUI shows a manual hint).
+    For the Claude subscription that command is the CLI's own
+    ``claude auth logout``. Hermes must never delete or rewrite Anthropic's
+    credential store itself — the CLI owns those files and the keychain entry,
+    and reaching into them is exactly the boundary this provider exists to
+    respect. Returns None for providers we can't safely clear (the GUI shows a
+    manual hint).
     """
     if provider.get("flow") != "external":
         return None
-    if provider.get("id") == "claude-code":
-        rm_file = "rm -f ~/.claude/.credentials.json"
-        if sys.platform == "darwin":
-            return f'security delete-generic-password -s "Claude Code-credentials" 2>/dev/null; {rm_file}'
-        return rm_file
+    if provider.get("id") == CLAUDE_CODE_PROVIDER_ID:
+        return CLAUDE_LOGOUT_COMMAND
     return None
 
 
@@ -9717,8 +9732,7 @@ def _build_oauth_catalog() -> list[Dict[str, Any]]:
     MEMBERSHIP is the union of:
       1. ``_OAUTH_PROVIDER_CATALOG`` — the explicit, hand-tuned cards that carry
          bespoke flow / status_fn / cli_command (including the api-key Anthropic
-         PKCE card and the synthetic claude-code subscription row, which are not
-         catalog providers), and
+         PKCE card, which is not a catalog provider), and
       2. every accounts-tab provider in the unified ``provider_catalog()`` (the
          ``hermes model`` universe) — so any OAuth/external provider added as a
          plugin appears automatically, with sensible defaults, even if no

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -389,6 +389,23 @@ _READ_POOL_MAX = 8
 _IMPORT_DEFAULT_DB_PATH = DEFAULT_DB_PATH
 
 
+def _branched_from_parent(model_config: Any) -> Optional[str]:
+    """Extract ``_branched_from`` from a session's ``model_config``.
+
+    ``model_config`` reaches ``create_session`` as either a dict or the JSON
+    string it is stored as, depending on the caller.
+    """
+    if isinstance(model_config, str):
+        try:
+            model_config = json.loads(model_config)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(model_config, dict):
+        return None
+    parent = model_config.get("_branched_from")
+    return parent if isinstance(parent, str) and parent else None
+
+
 def _default_db_path() -> Path:
     """Resolve the default state DB path at call time.
 
@@ -5770,6 +5787,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
+        # A branch (/branch, session.branch, the gateway's branch command) is
+        # the one create_session that inherits a conversation. All three
+        # implementations stamp ``_branched_from`` into model_config, so this
+        # is the single place that sees every branch. If a whole-turn runtime
+        # held a session for the parent, the child forks it rather than
+        # replaying history — context stays warm, and the two sessions stay
+        # isolated.
+        parent = _branched_from_parent(kwargs.get("model_config"))
+        if parent:
+            self.seed_provider_branch(parent, session_id)
         return session_id
 
     def record_gateway_session_peer(
@@ -11182,6 +11209,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, session_id),
             )
+            # This is the durable half of prompt.submit's
+            # ``truncate_user_ordinal`` (Desktop edit / regenerate / restore),
+            # and of /retry and /compress. A whole-turn runtime bound to this
+            # session forks at the surviving boundary on its next turn.
+            self._note_provider_rewind_boundary(
+                conn,
+                session_id,
+                sum(1 for m in messages if self._is_visible_user_message(m)),
+            )
 
         self._execute_write(_do)
 
@@ -12543,6 +12579,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "WHERE id = ?",
                 (session_id,),
             )
+            # A whole-turn runtime holding its own session for this
+            # conversation must fork at this boundary on its next turn — its
+            # resume cursor now points past history the user just discarded.
+            surviving = conn.execute(
+                f"SELECT COUNT(*) FROM messages WHERE session_id = ? "
+                f"AND id < ? AND {self._VISIBLE_USER_ROW_CLAUSE}",
+                (session_id, target_message_id),
+            ).fetchone()
+            self._note_provider_rewind_boundary(
+                conn, session_id, int((surviving[0] if surviving else 0) or 0)
+            )
             message_count, tool_call_count = self._active_transcript_counts(
                 conn, session_id
             )
@@ -12995,6 +13042,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            # The runtime binding dies with the Hermes session; the mirrored
+            # SDK transcript does NOT (see provider_transcript_entries: a
+            # downgrade must be able to leave it in place, and the SDK's own
+            # retention contract puts deletion in the adapter's hands via
+            # delete_session_via_store()).
+            conn.execute(
+                "DELETE FROM provider_runtime_sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.execute(
+                "DELETE FROM provider_message_bindings WHERE session_id = ?",
+                (session_id,),
+            )
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             self._delete_unreferenced_system_prompts(conn)
             return True
@@ -14658,6 +14718,821 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (error[:500], session_id),
             )
         self._execute_write(_do)
+
+
+    # ══════════════════════════════════════════════════════════════════
+    # Whole-turn provider runtimes: session binding + transcript mirror
+    # ══════════════════════════════════════════════════════════════════
+    #
+    # A whole-turn runtime (Claude's Agent SDK, Codex's app-server) owns a
+    # session of its own that Hermes cannot reconstruct: the provider-native
+    # context, the prompt-cache prefix, the compaction state, the resume
+    # cursor, and the message UUIDs. Hermes owns the visible transcript.
+    # These methods are the seam.
+    #
+    # Everything here is provider-generic — the ``runtime`` argument is the
+    # discriminator — because Hermes already runs two such runtimes and a
+    # second copy of this table would be the wrong shape by the third.
+    #
+    # Transcript entries are OPAQUE. They are stored in append order,
+    # returned in the same order, and round-trip through json so a caller
+    # gets deep-equal (not necessarily byte-equal) objects back.
+
+    @staticmethod
+    def _provider_now_ms() -> int:
+        return int(time.time() * 1000)
+
+    # ── Session binding ──
+
+    def bind_provider_runtime_session(
+        self,
+        session_id: str,
+        runtime: str,
+        provider_session_id: str,
+        *,
+        project_key: str = "",
+        bootstrapped: Optional[bool] = None,
+    ) -> None:
+        """Bind *session_id* to the runtime-owned *provider_session_id*.
+
+        Idempotent and last-writer-wins on the id: a runtime is allowed to
+        rotate its own session id (Claude does exactly this on a fork), and
+        the binding must follow it. ``recovery_count`` is deliberately NOT
+        reset here — it is the cap that stops a stale-session recovery from
+        looping, and a successful rebind is not evidence the loop ended.
+        """
+        if not session_id or not runtime or not provider_session_id:
+            return
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_runtime_sessions ("
+                "  session_id, runtime, provider_session_id, project_key,"
+                "  bootstrapped, created_at, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                "  provider_session_id = excluded.provider_session_id,"
+                "  project_key = excluded.project_key,"
+                "  bootstrapped = CASE WHEN ? IS NULL"
+                "    THEN provider_runtime_sessions.bootstrapped ELSE ? END,"
+                "  updated_at = excluded.updated_at",
+                (
+                    session_id,
+                    runtime,
+                    provider_session_id,
+                    project_key or "",
+                    1 if bootstrapped else 0,
+                    now,
+                    now,
+                    None if bootstrapped is None else 1,
+                    1 if bootstrapped else 0,
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "bind_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+
+    def get_provider_runtime_session(
+        self, session_id: str, runtime: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the binding row for (*session_id*, *runtime*), or None.
+
+        ``provider_session_id`` is an empty string when the binding has been
+        cleared by a stale-session recovery — the row survives so
+        ``recovery_count`` survives with it.
+        """
+        if not session_id or not runtime:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT session_id, runtime, provider_session_id, project_key,"
+                    "       bootstrapped, recovery_count, pending_rewind_ordinal,"
+                    "       pending_fork_source, created_at, updated_at "
+                    "FROM provider_runtime_sessions "
+                    "WHERE session_id = ? AND runtime = ?",
+                    (session_id, runtime),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "get_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+            return None
+        if row is None:
+            return None
+        keys = (
+            "session_id",
+            "runtime",
+            "provider_session_id",
+            "project_key",
+            "bootstrapped",
+            "recovery_count",
+            "pending_rewind_ordinal",
+            "pending_fork_source",
+            "created_at",
+            "updated_at",
+        )
+        if isinstance(row, sqlite3.Row):
+            out = {k: row[k] for k in keys}
+        else:
+            out = dict(zip(keys, row))
+        out["bootstrapped"] = bool(out["bootstrapped"])
+        out["recovery_count"] = int(out["recovery_count"] or 0)
+        return out
+
+    def clear_provider_runtime_session(self, session_id: str, runtime: str) -> int:
+        """Drop the runtime session id and count the recovery. Returns the count.
+
+        Called when the runtime reports the bound session is gone. The row is
+        kept (with an empty id) rather than deleted so ``recovery_count``
+        accumulates across attempts — that counter is the only thing standing
+        between a permanently-broken binding and an infinite
+        bootstrap/retry loop.
+        """
+        if not session_id or not runtime:
+            return 0
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_runtime_sessions ("
+                "  session_id, runtime, provider_session_id, project_key,"
+                "  bootstrapped, recovery_count, created_at, updated_at"
+                ") VALUES (?, ?, '', '', 0, 1, ?, ?) "
+                "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                "  provider_session_id = '',"
+                "  bootstrapped = 0,"
+                "  recovery_count = provider_runtime_sessions.recovery_count + 1,"
+                "  updated_at = excluded.updated_at",
+                (session_id, runtime, now, now),
+            )
+            row = conn.execute(
+                "SELECT recovery_count FROM provider_runtime_sessions "
+                "WHERE session_id = ? AND runtime = ?",
+                (session_id, runtime),
+            ).fetchone()
+            if row is None:
+                return 0
+            return int(row["recovery_count"] if isinstance(row, sqlite3.Row) else row[0])
+
+        try:
+            return int(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+            return 0
+
+    # ── Transcript mirror ──
+
+    def append_provider_transcript_entries(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: str,
+        entries: List[Dict[str, Any]],
+        *,
+        summary_fold: Optional[Callable[[Optional[dict], list], dict]] = None,
+    ) -> None:
+        """Mirror a batch of opaque transcript entries.
+
+        Deduplicated on ``entry_uuid`` via a partial unique index, because a
+        failed batch is retried and a retry can re-deliver entries that
+        already landed. Entries with no uuid are appended unconditionally —
+        the runtime uses uuid-less lines (titles, tags, mode markers) that
+        legitimately repeat.
+
+        *summary_fold* is a PURE ``(previous_summary_or_None, entries) ->
+        summary`` callable owned by the caller (the runtime's SDK ships one).
+        It runs INSIDE this write transaction so concurrent appends for the
+        same session cannot interleave read-fold-write on the sidecar. It is
+        skipped for subagent keys: a subagent transcript must not contribute
+        to the main session's summary.
+        """
+        subpath = subpath or ""
+        now = time.time()
+        now_ms = self._provider_now_ms()
+
+        def _do(conn):
+            # Storage write time, forced strictly forward per key. Callers
+            # sort sessions on it and compare it against the summary sidecar's
+            # mtime, so a coarse clock must never make it go backwards.
+            row = conn.execute(
+                "SELECT mtime_ms FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchone()
+            prev_mtime = 0
+            if row is not None:
+                prev_mtime = int(row["mtime_ms"] if isinstance(row, sqlite3.Row) else row[0])
+            stamp = now_ms if now_ms > prev_mtime else prev_mtime + 1
+
+            conn.execute(
+                "INSERT INTO provider_transcript_keys ("
+                "  runtime, project_key, provider_session_id, subpath,"
+                "  mtime_ms, created_at"
+                ") VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(runtime, project_key, provider_session_id, subpath) "
+                "DO UPDATE SET mtime_ms = excluded.mtime_ms",
+                (runtime, project_key, provider_session_id, subpath, stamp, now),
+            )
+
+            for entry in entries:
+                entry_uuid = None
+                if isinstance(entry, dict):
+                    raw_uuid = entry.get("uuid")
+                    if isinstance(raw_uuid, str) and raw_uuid:
+                        entry_uuid = raw_uuid
+                conn.execute(
+                    "INSERT OR IGNORE INTO provider_transcript_entries ("
+                    "  runtime, project_key, provider_session_id, subpath,"
+                    "  entry_uuid, entry_json, created_at"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        runtime,
+                        project_key,
+                        provider_session_id,
+                        subpath,
+                        entry_uuid,
+                        json.dumps(entry, ensure_ascii=False),
+                        now,
+                    ),
+                )
+
+            if summary_fold is None or subpath:
+                return
+
+            srow = conn.execute(
+                "SELECT summary_json FROM provider_transcript_summaries "
+                "WHERE runtime = ? AND project_key = ? AND provider_session_id = ?",
+                (runtime, project_key, provider_session_id),
+            ).fetchone()
+            previous = None
+            if srow is not None:
+                raw = srow["summary_json"] if isinstance(srow, sqlite3.Row) else srow[0]
+                try:
+                    previous = json.loads(raw)
+                except (TypeError, ValueError):
+                    previous = None
+            folded = summary_fold(previous, list(entries))
+            if not isinstance(folded, dict):
+                return
+            # The fold never sets mtime — it is storage write time and must
+            # share a clock with the key row stamped above.
+            folded = {**folded, "mtime": stamp}
+            conn.execute(
+                "INSERT INTO provider_transcript_summaries ("
+                "  runtime, project_key, provider_session_id, summary_json,"
+                "  mtime_ms, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(runtime, project_key, provider_session_id) "
+                "DO UPDATE SET summary_json = excluded.summary_json,"
+                "  mtime_ms = excluded.mtime_ms, updated_at = excluded.updated_at",
+                (
+                    runtime,
+                    project_key,
+                    provider_session_id,
+                    json.dumps(folded, ensure_ascii=False),
+                    stamp,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def load_provider_transcript_entries(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: str = "",
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return every mirrored entry for a key in append order, or None.
+
+        None means "never written" — distinguishable from "written then
+        emptied" because the key row outlives its entries.
+        """
+        subpath = subpath or ""
+        with self._read_ctx() as conn:
+            key_row = conn.execute(
+                "SELECT 1 FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchone()
+            if key_row is None:
+                return None
+            rows = conn.execute(
+                "SELECT entry_json FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ? "
+                "ORDER BY id",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchall()
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            raw = row["entry_json"] if isinstance(row, sqlite3.Row) else row[0]
+            try:
+                out.append(json.loads(raw))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "provider transcript entry for %s/%s is not valid JSON; skipping",
+                    provider_session_id,
+                    subpath or "<main>",
+                )
+        return out
+
+    def list_provider_transcript_sessions(
+        self, runtime: str, project_key: str
+    ) -> List[Dict[str, Any]]:
+        """List main-transcript session ids + storage mtimes for a project key."""
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT provider_session_id, mtime_ms FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? AND subpath = '' "
+                "ORDER BY mtime_ms DESC",
+                (runtime, project_key),
+            ).fetchall()
+        return [
+            {
+                "session_id": r["provider_session_id"]
+                if isinstance(r, sqlite3.Row)
+                else r[0],
+                "mtime": int(r["mtime_ms"] if isinstance(r, sqlite3.Row) else r[1]),
+            }
+            for r in rows
+        ]
+
+    def list_provider_transcript_summaries(
+        self, runtime: str, project_key: str
+    ) -> List[Dict[str, Any]]:
+        """Return the folded summary sidecars for a project key.
+
+        ``summary_json`` is opaque runtime-owned state, returned verbatim with
+        the stored storage-write ``mtime`` re-applied.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT provider_session_id, summary_json, mtime_ms "
+                "FROM provider_transcript_summaries "
+                "WHERE runtime = ? AND project_key = ?",
+                (runtime, project_key),
+            ).fetchall()
+        out: List[Dict[str, Any]] = []
+        for r in rows:
+            if isinstance(r, sqlite3.Row):
+                sid, raw, mtime = r["provider_session_id"], r["summary_json"], r["mtime_ms"]
+            else:
+                sid, raw, mtime = r[0], r[1], r[2]
+            try:
+                summary = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(summary, dict):
+                continue
+            summary["session_id"] = sid
+            summary["mtime"] = int(mtime)
+            out.append(summary)
+        return out
+
+    def list_provider_transcript_subkeys(
+        self, runtime: str, project_key: str, provider_session_id: str
+    ) -> List[str]:
+        """List the subagent subpaths mirrored under a session.
+
+        Without this a resume rebuilds only the main transcript and every
+        subagent transcript is silently lost.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT subpath FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath != '' "
+                "ORDER BY subpath",
+                (runtime, project_key, provider_session_id),
+            ).fetchall()
+        return [r["subpath"] if isinstance(r, sqlite3.Row) else r[0] for r in rows]
+
+    def delete_provider_transcript(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: Optional[str] = None,
+    ) -> None:
+        """Delete a mirrored transcript.
+
+        Deleting the main key (``subpath is None``) cascades to every subkey
+        and drops the summary sidecar, so subagent transcripts are never
+        orphaned. A targeted delete with an explicit subpath removes only
+        that one.
+        """
+
+        def _do(conn):
+            if subpath is None:
+                conn.execute(
+                    "DELETE FROM provider_transcript_entries "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                conn.execute(
+                    "DELETE FROM provider_transcript_keys "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                conn.execute(
+                    "DELETE FROM provider_transcript_summaries "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                return
+            conn.execute(
+                "DELETE FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            )
+            conn.execute(
+                "DELETE FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            )
+
+        self._execute_write(_do)
+
+    # ── Visible user row ↔ runtime message UUID ──
+
+    def provider_transcript_watermark(
+        self, runtime: str, project_key: str, provider_session_id: str
+    ) -> int:
+        """Highest mirrored entry row id for a main transcript (0 when empty).
+
+        Recorded when a turn is submitted so the runtime UUID that opened the
+        turn can be resolved afterwards, once the mirror has caught up —
+        the mirror is asynchronous, so the id is not available at submit time.
+        """
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT MAX(id) FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ''",
+                (runtime, project_key, provider_session_id),
+            ).fetchone()
+        value = row[0] if row is not None else None
+        return int(value or 0)
+
+    _VISIBLE_USER_ROW_CLAUSE = (
+        "role = 'user' AND active = 1 "
+        "AND (display_kind IS NULL OR display_kind = '')"
+    )
+
+    @classmethod
+    def _is_visible_user_message(cls, msg: Dict[str, Any]) -> bool:
+        """The one predicate every rewind path in Hermes agrees on.
+
+        A "visible user turn" is an active user row that is not display
+        bookkeeping (``display_kind`` marks model-switch notices, background
+        process notifications, and similar rows that /undo, session.undo,
+        rollback.restore and ``truncate_user_ordinal`` all skip).
+        """
+        return bool(
+            msg.get("role") == "user"
+            and not msg.get("display_kind")
+            and msg.get("active", 1)
+        )
+
+    def record_provider_message_binding(
+        self,
+        session_id: str,
+        user_ordinal: int,
+        runtime: str,
+        provider_session_id: str,
+        *,
+        message_id: int = 0,
+        project_key: str = "",
+        after_entry_id: int = 0,
+    ) -> None:
+        """Bind a visible Hermes user turn to the turn it opened in the runtime.
+
+        *user_ordinal* is 0-based over visible user rows — the same anchor
+        ``prompt.submit``'s ``truncate_user_ordinal`` uses, so the binding
+        survives both of Hermes' rewind mechanics (soft-delete and
+        delete-and-reinsert).
+        """
+        if not session_id or user_ordinal is None or not provider_session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_message_bindings ("
+                "  session_id, user_ordinal, message_id, runtime, project_key,"
+                "  provider_session_id, after_entry_id, created_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(session_id, user_ordinal) DO UPDATE SET "
+                "  message_id = excluded.message_id,"
+                "  runtime = excluded.runtime,"
+                "  project_key = excluded.project_key,"
+                "  provider_session_id = excluded.provider_session_id,"
+                "  after_entry_id = excluded.after_entry_id",
+                (
+                    session_id,
+                    int(user_ordinal),
+                    int(message_id or 0),
+                    runtime,
+                    project_key or "",
+                    provider_session_id,
+                    int(after_entry_id or 0),
+                    time.time(),
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_provider_message_binding(%s, #%s) failed: %s",
+                session_id,
+                user_ordinal,
+                exc,
+            )
+
+    def get_provider_message_binding(
+        self, session_id: str, user_ordinal: int
+    ) -> Optional[Dict[str, Any]]:
+        """Return the binding row for a visible Hermes user turn, or None."""
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT session_id, user_ordinal, message_id, runtime, project_key,"
+                "       provider_session_id, after_entry_id,"
+                "       provider_message_uuid, fork_boundary_uuid "
+                "FROM provider_message_bindings "
+                "WHERE session_id = ? AND user_ordinal = ?",
+                (session_id, int(user_ordinal)),
+            ).fetchone()
+        if row is None:
+            return None
+        keys = (
+            "session_id",
+            "user_ordinal",
+            "message_id",
+            "runtime",
+            "project_key",
+            "provider_session_id",
+            "after_entry_id",
+            "provider_message_uuid",
+            "fork_boundary_uuid",
+        )
+        if isinstance(row, sqlite3.Row):
+            return {k: row[k] for k in keys}
+        return dict(zip(keys, row))
+
+    def set_provider_message_binding_uuids(
+        self,
+        session_id: str,
+        user_ordinal: int,
+        *,
+        provider_message_uuid: Optional[str],
+        fork_boundary_uuid: Optional[str],
+    ) -> None:
+        """Persist the resolved runtime UUIDs for a visible user turn."""
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE provider_message_bindings SET "
+                "  provider_message_uuid = ?, fork_boundary_uuid = ? "
+                "WHERE session_id = ? AND user_ordinal = ?",
+                (
+                    provider_message_uuid,
+                    fork_boundary_uuid,
+                    session_id,
+                    int(user_ordinal),
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "set_provider_message_binding_uuids(%s, #%s) failed: %s",
+                session_id,
+                user_ordinal,
+                exc,
+            )
+
+    # ── Rewind / branch signalling ──
+    #
+    # Every durable rewind in Hermes funnels through exactly two SessionDB
+    # methods — rewind_to_message (CLI /undo, gateway /undo) and
+    # replace_messages (prompt.submit's truncate_user_ordinal, which is what
+    # Desktop's edit / regenerate / restore-checkpoint all submit, plus
+    # /retry and /compress). Signalling from there covers every surface at
+    # once instead of bolting a hook onto each one, and it cannot be bypassed
+    # by a surface that reaches the transcript another way.
+    #
+    # The signal is a boundary, not an action: a whole-turn runtime consumes
+    # it on its NEXT turn by forking its own session there. Doing the fork
+    # here would mean the state layer talking to a provider SDK, and would
+    # fork on every rewind even for sessions that never reach that runtime
+    # again.
+
+    def _note_provider_rewind_boundary(
+        self, conn, session_id: str, surviving_user_turns: int
+    ) -> None:
+        """Mark bound runtimes for a fork at *surviving_user_turns*.
+
+        Runs inside the caller's write transaction. The bindings for the
+        discarded turns are deliberately NOT dropped here: the binding at
+        ordinal ``surviving_user_turns`` is the first discarded turn, and its
+        ``fork_boundary_uuid`` is exactly the point the runtime forks at. The
+        runtime prunes them once it has consumed the boundary
+        (:meth:`prune_provider_message_bindings`).
+        """
+        if not session_id:
+            return
+        try:
+            conn.execute(
+                "UPDATE provider_runtime_sessions "
+                "SET pending_rewind_ordinal = ?, updated_at = ? "
+                "WHERE session_id = ? AND provider_session_id != ''",
+                (int(surviving_user_turns), time.time(), session_id),
+            )
+        except sqlite3.Error as exc:
+            # A missing table means a downgrade dropped it; the transcript
+            # rewrite itself must still commit.
+            logger.debug("provider rewind boundary not recorded: %s", exc)
+
+    def seed_provider_branch(
+        self, parent_session_id: str, new_session_id: str
+    ) -> None:
+        """Give a freshly-branched session its parent's runtime session to fork.
+
+        A branch is a fork, not a replay: the child starts from the parent's
+        runtime-native context so the provider's prompt cache stays warm and
+        no history is reconstructed. Marked pending here; the runtime performs
+        the fork on the branch's first turn.
+        """
+        if not parent_session_id or not new_session_id:
+            return
+
+        def _do(conn):
+            rows = conn.execute(
+                "SELECT runtime, provider_session_id, project_key "
+                "FROM provider_runtime_sessions "
+                "WHERE session_id = ? AND provider_session_id != ''",
+                (parent_session_id,),
+            ).fetchall()
+            now = time.time()
+            for row in rows:
+                if isinstance(row, sqlite3.Row):
+                    runtime, source, project_key = (
+                        row["runtime"],
+                        row["provider_session_id"],
+                        row["project_key"],
+                    )
+                else:
+                    runtime, source, project_key = row[0], row[1], row[2]
+                conn.execute(
+                    "INSERT INTO provider_runtime_sessions ("
+                    "  session_id, runtime, provider_session_id, project_key,"
+                    "  bootstrapped, pending_fork_source, created_at, updated_at"
+                    ") VALUES (?, ?, '', ?, 1, ?, ?, ?) "
+                    "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                    "  pending_fork_source = excluded.pending_fork_source,"
+                    "  project_key = excluded.project_key,"
+                    "  updated_at = excluded.updated_at",
+                    (new_session_id, runtime, project_key, source, now, now),
+                )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug("seed_provider_branch(%s) failed: %s", new_session_id, exc)
+
+    def prune_provider_message_bindings(
+        self, session_id: str, from_ordinal: int
+    ) -> None:
+        """Drop bindings for user turns at or past *from_ordinal*.
+
+        Called once the runtime has forked at that boundary — from then on
+        those UUIDs describe a branch the user abandoned.
+        """
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM provider_message_bindings "
+                "WHERE session_id = ? AND user_ordinal >= ?",
+                (session_id, int(from_ordinal)),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug(
+                "prune_provider_message_bindings(%s) failed: %s", session_id, exc
+            )
+
+    def clear_provider_pending(self, session_id: str, runtime: str) -> None:
+        """Clear both pending markers once the runtime has acted on them."""
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE provider_runtime_sessions SET pending_rewind_ordinal = NULL, "
+                "pending_fork_source = NULL, updated_at = ? "
+                "WHERE session_id = ? AND runtime = ?",
+                (time.time(), session_id, runtime),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug("clear_provider_pending(%s) failed: %s", session_id, exc)
+
+    def provider_transcript_entries_after(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        after_entry_id: int,
+        limit: int = 200,
+    ) -> List[Tuple[int, Optional[str], Dict[str, Any]]]:
+        """Return ``(row_id, entry_uuid, entry)`` triples past a watermark.
+
+        The caller decides which entry shape counts as "the visible user
+        turn" — that is runtime-specific knowledge and does not belong in the
+        state layer.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT id, entry_uuid, entry_json FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = '' AND id > ? "
+                "ORDER BY id LIMIT ?",
+                (
+                    runtime,
+                    project_key,
+                    provider_session_id,
+                    int(after_entry_id or 0),
+                    int(limit),
+                ),
+            ).fetchall()
+        out: List[Tuple[int, Optional[str], Dict[str, Any]]] = []
+        for row in rows:
+            if isinstance(row, sqlite3.Row):
+                rid, ruuid, raw = row["id"], row["entry_uuid"], row["entry_json"]
+            else:
+                rid, ruuid, raw = row[0], row[1], row[2]
+            try:
+                entry = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            out.append((int(rid), ruuid, entry))
+        return out
+
+    def provider_transcript_uuid_before(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        entry_row_id: int,
+    ) -> Optional[str]:
+        """The last entry UUID strictly before *entry_row_id* on the main key.
+
+        This is the fork boundary for a rewind: forking a session inclusive of
+        this UUID reproduces everything the user is keeping and nothing they
+        are replacing.
+        """
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT entry_uuid FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = '' "
+                "AND id < ? AND entry_uuid IS NOT NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (runtime, project_key, provider_session_id, int(entry_row_id)),
+            ).fetchone()
+        if row is None:
+            return None
+        return row["entry_uuid"] if isinstance(row, sqlite3.Row) else row[0]
 
 
 class AsyncSessionDB:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -239,6 +239,23 @@ DEFAULT_DB_PATH = get_hermes_home() / "state.db"
 _IMPORT_DEFAULT_DB_PATH = DEFAULT_DB_PATH
 
 
+def _branched_from_parent(model_config: Any) -> Optional[str]:
+    """Extract ``_branched_from`` from a session's ``model_config``.
+
+    ``model_config`` reaches ``create_session`` as either a dict or the JSON
+    string it is stored as, depending on the caller.
+    """
+    if isinstance(model_config, str):
+        try:
+            model_config = json.loads(model_config)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(model_config, dict):
+        return None
+    parent = model_config.get("_branched_from")
+    return parent if isinstance(parent, str) and parent else None
+
+
 def _default_db_path() -> Path:
     """Resolve the default state DB path at call time.
 
@@ -2774,6 +2791,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def create_session(self, session_id: str, source: str, **kwargs) -> str:
         """Create a new session record. Returns the session_id."""
         self._insert_session_row(session_id, source, **kwargs)
+        # A branch (/branch, session.branch, the gateway's branch command) is
+        # the one create_session that inherits a conversation. All three
+        # implementations stamp ``_branched_from`` into model_config, so this
+        # is the single place that sees every branch. If a whole-turn runtime
+        # held a session for the parent, the child forks it rather than
+        # replaying history — context stays warm, and the two sessions stay
+        # isolated.
+        parent = _branched_from_parent(kwargs.get("model_config"))
+        if parent:
+            self.seed_provider_branch(parent, session_id)
         return session_id
 
     def record_gateway_session_peer(
@@ -6007,6 +6034,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET message_count = ?, tool_call_count = ? WHERE id = ?",
                 (total_messages, total_tool_calls, session_id),
             )
+            # This is the durable half of prompt.submit's
+            # ``truncate_user_ordinal`` (Desktop edit / regenerate / restore),
+            # and of /retry and /compress. A whole-turn runtime bound to this
+            # session forks at the surviving boundary on its next turn.
+            self._note_provider_rewind_boundary(
+                conn,
+                session_id,
+                sum(1 for m in messages if self._is_visible_user_message(m)),
+            )
 
         self._execute_write(_do)
 
@@ -6736,6 +6772,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "WHERE id = ?",
                 (session_id,),
             )
+            # A whole-turn runtime holding its own session for this
+            # conversation must fork at this boundary on its next turn — its
+            # resume cursor now points past history the user just discarded.
+            surviving = conn.execute(
+                f"SELECT COUNT(*) FROM messages WHERE session_id = ? "
+                f"AND id < ? AND {self._VISIBLE_USER_ROW_CLAUSE}",
+                (session_id, target_message_id),
+            ).fetchone()
+            self._note_provider_rewind_boundary(
+                conn, session_id, int((surviving[0] if surviving else 0) or 0)
+            )
             return ids
 
         rewound = self._execute_write(_do)
@@ -7137,6 +7184,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
             conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
+            # The runtime binding dies with the Hermes session; the mirrored
+            # SDK transcript does NOT (see provider_transcript_entries: a
+            # downgrade must be able to leave it in place, and the SDK's own
+            # retention contract puts deletion in the adapter's hands via
+            # delete_session_via_store()).
+            conn.execute(
+                "DELETE FROM provider_runtime_sessions WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.execute(
+                "DELETE FROM provider_message_bindings WHERE session_id = ?",
+                (session_id,),
+            )
             conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
             return True
 
@@ -8550,6 +8610,821 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (error[:500], session_id),
             )
         self._execute_write(_do)
+
+
+    # ══════════════════════════════════════════════════════════════════
+    # Whole-turn provider runtimes: session binding + transcript mirror
+    # ══════════════════════════════════════════════════════════════════
+    #
+    # A whole-turn runtime (Claude's Agent SDK, Codex's app-server) owns a
+    # session of its own that Hermes cannot reconstruct: the provider-native
+    # context, the prompt-cache prefix, the compaction state, the resume
+    # cursor, and the message UUIDs. Hermes owns the visible transcript.
+    # These methods are the seam.
+    #
+    # Everything here is provider-generic — the ``runtime`` argument is the
+    # discriminator — because Hermes already runs two such runtimes and a
+    # second copy of this table would be the wrong shape by the third.
+    #
+    # Transcript entries are OPAQUE. They are stored in append order,
+    # returned in the same order, and round-trip through json so a caller
+    # gets deep-equal (not necessarily byte-equal) objects back.
+
+    @staticmethod
+    def _provider_now_ms() -> int:
+        return int(time.time() * 1000)
+
+    # ── Session binding ──
+
+    def bind_provider_runtime_session(
+        self,
+        session_id: str,
+        runtime: str,
+        provider_session_id: str,
+        *,
+        project_key: str = "",
+        bootstrapped: Optional[bool] = None,
+    ) -> None:
+        """Bind *session_id* to the runtime-owned *provider_session_id*.
+
+        Idempotent and last-writer-wins on the id: a runtime is allowed to
+        rotate its own session id (Claude does exactly this on a fork), and
+        the binding must follow it. ``recovery_count`` is deliberately NOT
+        reset here — it is the cap that stops a stale-session recovery from
+        looping, and a successful rebind is not evidence the loop ended.
+        """
+        if not session_id or not runtime or not provider_session_id:
+            return
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_runtime_sessions ("
+                "  session_id, runtime, provider_session_id, project_key,"
+                "  bootstrapped, created_at, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                "  provider_session_id = excluded.provider_session_id,"
+                "  project_key = excluded.project_key,"
+                "  bootstrapped = CASE WHEN ? IS NULL"
+                "    THEN provider_runtime_sessions.bootstrapped ELSE ? END,"
+                "  updated_at = excluded.updated_at",
+                (
+                    session_id,
+                    runtime,
+                    provider_session_id,
+                    project_key or "",
+                    1 if bootstrapped else 0,
+                    now,
+                    now,
+                    None if bootstrapped is None else 1,
+                    1 if bootstrapped else 0,
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "bind_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+
+    def get_provider_runtime_session(
+        self, session_id: str, runtime: str
+    ) -> Optional[Dict[str, Any]]:
+        """Return the binding row for (*session_id*, *runtime*), or None.
+
+        ``provider_session_id`` is an empty string when the binding has been
+        cleared by a stale-session recovery — the row survives so
+        ``recovery_count`` survives with it.
+        """
+        if not session_id or not runtime:
+            return None
+        try:
+            with self._read_ctx() as conn:
+                row = conn.execute(
+                    "SELECT session_id, runtime, provider_session_id, project_key,"
+                    "       bootstrapped, recovery_count, pending_rewind_ordinal,"
+                    "       pending_fork_source, created_at, updated_at "
+                    "FROM provider_runtime_sessions "
+                    "WHERE session_id = ? AND runtime = ?",
+                    (session_id, runtime),
+                ).fetchone()
+        except sqlite3.Error as exc:
+            logger.warning(
+                "get_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+            return None
+        if row is None:
+            return None
+        keys = (
+            "session_id",
+            "runtime",
+            "provider_session_id",
+            "project_key",
+            "bootstrapped",
+            "recovery_count",
+            "pending_rewind_ordinal",
+            "pending_fork_source",
+            "created_at",
+            "updated_at",
+        )
+        if isinstance(row, sqlite3.Row):
+            out = {k: row[k] for k in keys}
+        else:
+            out = dict(zip(keys, row))
+        out["bootstrapped"] = bool(out["bootstrapped"])
+        out["recovery_count"] = int(out["recovery_count"] or 0)
+        return out
+
+    def clear_provider_runtime_session(self, session_id: str, runtime: str) -> int:
+        """Drop the runtime session id and count the recovery. Returns the count.
+
+        Called when the runtime reports the bound session is gone. The row is
+        kept (with an empty id) rather than deleted so ``recovery_count``
+        accumulates across attempts — that counter is the only thing standing
+        between a permanently-broken binding and an infinite
+        bootstrap/retry loop.
+        """
+        if not session_id or not runtime:
+            return 0
+        now = time.time()
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_runtime_sessions ("
+                "  session_id, runtime, provider_session_id, project_key,"
+                "  bootstrapped, recovery_count, created_at, updated_at"
+                ") VALUES (?, ?, '', '', 0, 1, ?, ?) "
+                "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                "  provider_session_id = '',"
+                "  bootstrapped = 0,"
+                "  recovery_count = provider_runtime_sessions.recovery_count + 1,"
+                "  updated_at = excluded.updated_at",
+                (session_id, runtime, now, now),
+            )
+            row = conn.execute(
+                "SELECT recovery_count FROM provider_runtime_sessions "
+                "WHERE session_id = ? AND runtime = ?",
+                (session_id, runtime),
+            ).fetchone()
+            if row is None:
+                return 0
+            return int(row["recovery_count"] if isinstance(row, sqlite3.Row) else row[0])
+
+        try:
+            return int(self._execute_write(_do))
+        except sqlite3.Error as exc:
+            logger.warning(
+                "clear_provider_runtime_session(%s, %s) failed: %s",
+                session_id,
+                runtime,
+                exc,
+            )
+            return 0
+
+    # ── Transcript mirror ──
+
+    def append_provider_transcript_entries(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: str,
+        entries: List[Dict[str, Any]],
+        *,
+        summary_fold: Optional[Callable[[Optional[dict], list], dict]] = None,
+    ) -> None:
+        """Mirror a batch of opaque transcript entries.
+
+        Deduplicated on ``entry_uuid`` via a partial unique index, because a
+        failed batch is retried and a retry can re-deliver entries that
+        already landed. Entries with no uuid are appended unconditionally —
+        the runtime uses uuid-less lines (titles, tags, mode markers) that
+        legitimately repeat.
+
+        *summary_fold* is a PURE ``(previous_summary_or_None, entries) ->
+        summary`` callable owned by the caller (the runtime's SDK ships one).
+        It runs INSIDE this write transaction so concurrent appends for the
+        same session cannot interleave read-fold-write on the sidecar. It is
+        skipped for subagent keys: a subagent transcript must not contribute
+        to the main session's summary.
+        """
+        subpath = subpath or ""
+        now = time.time()
+        now_ms = self._provider_now_ms()
+
+        def _do(conn):
+            # Storage write time, forced strictly forward per key. Callers
+            # sort sessions on it and compare it against the summary sidecar's
+            # mtime, so a coarse clock must never make it go backwards.
+            row = conn.execute(
+                "SELECT mtime_ms FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchone()
+            prev_mtime = 0
+            if row is not None:
+                prev_mtime = int(row["mtime_ms"] if isinstance(row, sqlite3.Row) else row[0])
+            stamp = now_ms if now_ms > prev_mtime else prev_mtime + 1
+
+            conn.execute(
+                "INSERT INTO provider_transcript_keys ("
+                "  runtime, project_key, provider_session_id, subpath,"
+                "  mtime_ms, created_at"
+                ") VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(runtime, project_key, provider_session_id, subpath) "
+                "DO UPDATE SET mtime_ms = excluded.mtime_ms",
+                (runtime, project_key, provider_session_id, subpath, stamp, now),
+            )
+
+            for entry in entries:
+                entry_uuid = None
+                if isinstance(entry, dict):
+                    raw_uuid = entry.get("uuid")
+                    if isinstance(raw_uuid, str) and raw_uuid:
+                        entry_uuid = raw_uuid
+                conn.execute(
+                    "INSERT OR IGNORE INTO provider_transcript_entries ("
+                    "  runtime, project_key, provider_session_id, subpath,"
+                    "  entry_uuid, entry_json, created_at"
+                    ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        runtime,
+                        project_key,
+                        provider_session_id,
+                        subpath,
+                        entry_uuid,
+                        json.dumps(entry, ensure_ascii=False),
+                        now,
+                    ),
+                )
+
+            if summary_fold is None or subpath:
+                return
+
+            srow = conn.execute(
+                "SELECT summary_json FROM provider_transcript_summaries "
+                "WHERE runtime = ? AND project_key = ? AND provider_session_id = ?",
+                (runtime, project_key, provider_session_id),
+            ).fetchone()
+            previous = None
+            if srow is not None:
+                raw = srow["summary_json"] if isinstance(srow, sqlite3.Row) else srow[0]
+                try:
+                    previous = json.loads(raw)
+                except (TypeError, ValueError):
+                    previous = None
+            folded = summary_fold(previous, list(entries))
+            if not isinstance(folded, dict):
+                return
+            # The fold never sets mtime — it is storage write time and must
+            # share a clock with the key row stamped above.
+            folded = {**folded, "mtime": stamp}
+            conn.execute(
+                "INSERT INTO provider_transcript_summaries ("
+                "  runtime, project_key, provider_session_id, summary_json,"
+                "  mtime_ms, updated_at"
+                ") VALUES (?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(runtime, project_key, provider_session_id) "
+                "DO UPDATE SET summary_json = excluded.summary_json,"
+                "  mtime_ms = excluded.mtime_ms, updated_at = excluded.updated_at",
+                (
+                    runtime,
+                    project_key,
+                    provider_session_id,
+                    json.dumps(folded, ensure_ascii=False),
+                    stamp,
+                    now,
+                ),
+            )
+
+        self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
+
+    def load_provider_transcript_entries(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: str = "",
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Return every mirrored entry for a key in append order, or None.
+
+        None means "never written" — distinguishable from "written then
+        emptied" because the key row outlives its entries.
+        """
+        subpath = subpath or ""
+        with self._read_ctx() as conn:
+            key_row = conn.execute(
+                "SELECT 1 FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchone()
+            if key_row is None:
+                return None
+            rows = conn.execute(
+                "SELECT entry_json FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ? "
+                "ORDER BY id",
+                (runtime, project_key, provider_session_id, subpath),
+            ).fetchall()
+        out: List[Dict[str, Any]] = []
+        for row in rows:
+            raw = row["entry_json"] if isinstance(row, sqlite3.Row) else row[0]
+            try:
+                out.append(json.loads(raw))
+            except (TypeError, ValueError):
+                logger.warning(
+                    "provider transcript entry for %s/%s is not valid JSON; skipping",
+                    provider_session_id,
+                    subpath or "<main>",
+                )
+        return out
+
+    def list_provider_transcript_sessions(
+        self, runtime: str, project_key: str
+    ) -> List[Dict[str, Any]]:
+        """List main-transcript session ids + storage mtimes for a project key."""
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT provider_session_id, mtime_ms FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? AND subpath = '' "
+                "ORDER BY mtime_ms DESC",
+                (runtime, project_key),
+            ).fetchall()
+        return [
+            {
+                "session_id": r["provider_session_id"]
+                if isinstance(r, sqlite3.Row)
+                else r[0],
+                "mtime": int(r["mtime_ms"] if isinstance(r, sqlite3.Row) else r[1]),
+            }
+            for r in rows
+        ]
+
+    def list_provider_transcript_summaries(
+        self, runtime: str, project_key: str
+    ) -> List[Dict[str, Any]]:
+        """Return the folded summary sidecars for a project key.
+
+        ``summary_json`` is opaque runtime-owned state, returned verbatim with
+        the stored storage-write ``mtime`` re-applied.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT provider_session_id, summary_json, mtime_ms "
+                "FROM provider_transcript_summaries "
+                "WHERE runtime = ? AND project_key = ?",
+                (runtime, project_key),
+            ).fetchall()
+        out: List[Dict[str, Any]] = []
+        for r in rows:
+            if isinstance(r, sqlite3.Row):
+                sid, raw, mtime = r["provider_session_id"], r["summary_json"], r["mtime_ms"]
+            else:
+                sid, raw, mtime = r[0], r[1], r[2]
+            try:
+                summary = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(summary, dict):
+                continue
+            summary["session_id"] = sid
+            summary["mtime"] = int(mtime)
+            out.append(summary)
+        return out
+
+    def list_provider_transcript_subkeys(
+        self, runtime: str, project_key: str, provider_session_id: str
+    ) -> List[str]:
+        """List the subagent subpaths mirrored under a session.
+
+        Without this a resume rebuilds only the main transcript and every
+        subagent transcript is silently lost.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT subpath FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath != '' "
+                "ORDER BY subpath",
+                (runtime, project_key, provider_session_id),
+            ).fetchall()
+        return [r["subpath"] if isinstance(r, sqlite3.Row) else r[0] for r in rows]
+
+    def delete_provider_transcript(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        subpath: Optional[str] = None,
+    ) -> None:
+        """Delete a mirrored transcript.
+
+        Deleting the main key (``subpath is None``) cascades to every subkey
+        and drops the summary sidecar, so subagent transcripts are never
+        orphaned. A targeted delete with an explicit subpath removes only
+        that one.
+        """
+
+        def _do(conn):
+            if subpath is None:
+                conn.execute(
+                    "DELETE FROM provider_transcript_entries "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                conn.execute(
+                    "DELETE FROM provider_transcript_keys "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                conn.execute(
+                    "DELETE FROM provider_transcript_summaries "
+                    "WHERE runtime = ? AND project_key = ? "
+                    "AND provider_session_id = ?",
+                    (runtime, project_key, provider_session_id),
+                )
+                return
+            conn.execute(
+                "DELETE FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            )
+            conn.execute(
+                "DELETE FROM provider_transcript_keys "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ?",
+                (runtime, project_key, provider_session_id, subpath),
+            )
+
+        self._execute_write(_do)
+
+    # ── Visible user row ↔ runtime message UUID ──
+
+    def provider_transcript_watermark(
+        self, runtime: str, project_key: str, provider_session_id: str
+    ) -> int:
+        """Highest mirrored entry row id for a main transcript (0 when empty).
+
+        Recorded when a turn is submitted so the runtime UUID that opened the
+        turn can be resolved afterwards, once the mirror has caught up —
+        the mirror is asynchronous, so the id is not available at submit time.
+        """
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT MAX(id) FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = ''",
+                (runtime, project_key, provider_session_id),
+            ).fetchone()
+        value = row[0] if row is not None else None
+        return int(value or 0)
+
+    _VISIBLE_USER_ROW_CLAUSE = (
+        "role = 'user' AND active = 1 "
+        "AND (display_kind IS NULL OR display_kind = '')"
+    )
+
+    @classmethod
+    def _is_visible_user_message(cls, msg: Dict[str, Any]) -> bool:
+        """The one predicate every rewind path in Hermes agrees on.
+
+        A "visible user turn" is an active user row that is not display
+        bookkeeping (``display_kind`` marks model-switch notices, background
+        process notifications, and similar rows that /undo, session.undo,
+        rollback.restore and ``truncate_user_ordinal`` all skip).
+        """
+        return bool(
+            msg.get("role") == "user"
+            and not msg.get("display_kind")
+            and msg.get("active", 1)
+        )
+
+    def record_provider_message_binding(
+        self,
+        session_id: str,
+        user_ordinal: int,
+        runtime: str,
+        provider_session_id: str,
+        *,
+        message_id: int = 0,
+        project_key: str = "",
+        after_entry_id: int = 0,
+    ) -> None:
+        """Bind a visible Hermes user turn to the turn it opened in the runtime.
+
+        *user_ordinal* is 0-based over visible user rows — the same anchor
+        ``prompt.submit``'s ``truncate_user_ordinal`` uses, so the binding
+        survives both of Hermes' rewind mechanics (soft-delete and
+        delete-and-reinsert).
+        """
+        if not session_id or user_ordinal is None or not provider_session_id:
+            return
+
+        def _do(conn):
+            conn.execute(
+                "INSERT INTO provider_message_bindings ("
+                "  session_id, user_ordinal, message_id, runtime, project_key,"
+                "  provider_session_id, after_entry_id, created_at"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?) "
+                "ON CONFLICT(session_id, user_ordinal) DO UPDATE SET "
+                "  message_id = excluded.message_id,"
+                "  runtime = excluded.runtime,"
+                "  project_key = excluded.project_key,"
+                "  provider_session_id = excluded.provider_session_id,"
+                "  after_entry_id = excluded.after_entry_id",
+                (
+                    session_id,
+                    int(user_ordinal),
+                    int(message_id or 0),
+                    runtime,
+                    project_key or "",
+                    provider_session_id,
+                    int(after_entry_id or 0),
+                    time.time(),
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "record_provider_message_binding(%s, #%s) failed: %s",
+                session_id,
+                user_ordinal,
+                exc,
+            )
+
+    def get_provider_message_binding(
+        self, session_id: str, user_ordinal: int
+    ) -> Optional[Dict[str, Any]]:
+        """Return the binding row for a visible Hermes user turn, or None."""
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT session_id, user_ordinal, message_id, runtime, project_key,"
+                "       provider_session_id, after_entry_id,"
+                "       provider_message_uuid, fork_boundary_uuid "
+                "FROM provider_message_bindings "
+                "WHERE session_id = ? AND user_ordinal = ?",
+                (session_id, int(user_ordinal)),
+            ).fetchone()
+        if row is None:
+            return None
+        keys = (
+            "session_id",
+            "user_ordinal",
+            "message_id",
+            "runtime",
+            "project_key",
+            "provider_session_id",
+            "after_entry_id",
+            "provider_message_uuid",
+            "fork_boundary_uuid",
+        )
+        if isinstance(row, sqlite3.Row):
+            return {k: row[k] for k in keys}
+        return dict(zip(keys, row))
+
+    def set_provider_message_binding_uuids(
+        self,
+        session_id: str,
+        user_ordinal: int,
+        *,
+        provider_message_uuid: Optional[str],
+        fork_boundary_uuid: Optional[str],
+    ) -> None:
+        """Persist the resolved runtime UUIDs for a visible user turn."""
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE provider_message_bindings SET "
+                "  provider_message_uuid = ?, fork_boundary_uuid = ? "
+                "WHERE session_id = ? AND user_ordinal = ?",
+                (
+                    provider_message_uuid,
+                    fork_boundary_uuid,
+                    session_id,
+                    int(user_ordinal),
+                ),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.warning(
+                "set_provider_message_binding_uuids(%s, #%s) failed: %s",
+                session_id,
+                user_ordinal,
+                exc,
+            )
+
+    # ── Rewind / branch signalling ──
+    #
+    # Every durable rewind in Hermes funnels through exactly two SessionDB
+    # methods — rewind_to_message (CLI /undo, gateway /undo) and
+    # replace_messages (prompt.submit's truncate_user_ordinal, which is what
+    # Desktop's edit / regenerate / restore-checkpoint all submit, plus
+    # /retry and /compress). Signalling from there covers every surface at
+    # once instead of bolting a hook onto each one, and it cannot be bypassed
+    # by a surface that reaches the transcript another way.
+    #
+    # The signal is a boundary, not an action: a whole-turn runtime consumes
+    # it on its NEXT turn by forking its own session there. Doing the fork
+    # here would mean the state layer talking to a provider SDK, and would
+    # fork on every rewind even for sessions that never reach that runtime
+    # again.
+
+    def _note_provider_rewind_boundary(
+        self, conn, session_id: str, surviving_user_turns: int
+    ) -> None:
+        """Mark bound runtimes for a fork at *surviving_user_turns*.
+
+        Runs inside the caller's write transaction. The bindings for the
+        discarded turns are deliberately NOT dropped here: the binding at
+        ordinal ``surviving_user_turns`` is the first discarded turn, and its
+        ``fork_boundary_uuid`` is exactly the point the runtime forks at. The
+        runtime prunes them once it has consumed the boundary
+        (:meth:`prune_provider_message_bindings`).
+        """
+        if not session_id:
+            return
+        try:
+            conn.execute(
+                "UPDATE provider_runtime_sessions "
+                "SET pending_rewind_ordinal = ?, updated_at = ? "
+                "WHERE session_id = ? AND provider_session_id != ''",
+                (int(surviving_user_turns), time.time(), session_id),
+            )
+        except sqlite3.Error as exc:
+            # A missing table means a downgrade dropped it; the transcript
+            # rewrite itself must still commit.
+            logger.debug("provider rewind boundary not recorded: %s", exc)
+
+    def seed_provider_branch(
+        self, parent_session_id: str, new_session_id: str
+    ) -> None:
+        """Give a freshly-branched session its parent's runtime session to fork.
+
+        A branch is a fork, not a replay: the child starts from the parent's
+        runtime-native context so the provider's prompt cache stays warm and
+        no history is reconstructed. Marked pending here; the runtime performs
+        the fork on the branch's first turn.
+        """
+        if not parent_session_id or not new_session_id:
+            return
+
+        def _do(conn):
+            rows = conn.execute(
+                "SELECT runtime, provider_session_id, project_key "
+                "FROM provider_runtime_sessions "
+                "WHERE session_id = ? AND provider_session_id != ''",
+                (parent_session_id,),
+            ).fetchall()
+            now = time.time()
+            for row in rows:
+                if isinstance(row, sqlite3.Row):
+                    runtime, source, project_key = (
+                        row["runtime"],
+                        row["provider_session_id"],
+                        row["project_key"],
+                    )
+                else:
+                    runtime, source, project_key = row[0], row[1], row[2]
+                conn.execute(
+                    "INSERT INTO provider_runtime_sessions ("
+                    "  session_id, runtime, provider_session_id, project_key,"
+                    "  bootstrapped, pending_fork_source, created_at, updated_at"
+                    ") VALUES (?, ?, '', ?, 1, ?, ?, ?) "
+                    "ON CONFLICT(session_id, runtime) DO UPDATE SET "
+                    "  pending_fork_source = excluded.pending_fork_source,"
+                    "  project_key = excluded.project_key,"
+                    "  updated_at = excluded.updated_at",
+                    (new_session_id, runtime, project_key, source, now, now),
+                )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug("seed_provider_branch(%s) failed: %s", new_session_id, exc)
+
+    def prune_provider_message_bindings(
+        self, session_id: str, from_ordinal: int
+    ) -> None:
+        """Drop bindings for user turns at or past *from_ordinal*.
+
+        Called once the runtime has forked at that boundary — from then on
+        those UUIDs describe a branch the user abandoned.
+        """
+
+        def _do(conn):
+            conn.execute(
+                "DELETE FROM provider_message_bindings "
+                "WHERE session_id = ? AND user_ordinal >= ?",
+                (session_id, int(from_ordinal)),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug(
+                "prune_provider_message_bindings(%s) failed: %s", session_id, exc
+            )
+
+    def clear_provider_pending(self, session_id: str, runtime: str) -> None:
+        """Clear both pending markers once the runtime has acted on them."""
+
+        def _do(conn):
+            conn.execute(
+                "UPDATE provider_runtime_sessions SET pending_rewind_ordinal = NULL, "
+                "pending_fork_source = NULL, updated_at = ? "
+                "WHERE session_id = ? AND runtime = ?",
+                (time.time(), session_id, runtime),
+            )
+
+        try:
+            self._execute_write(_do)
+        except sqlite3.Error as exc:
+            logger.debug("clear_provider_pending(%s) failed: %s", session_id, exc)
+
+    def provider_transcript_entries_after(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        after_entry_id: int,
+        limit: int = 200,
+    ) -> List[Tuple[int, Optional[str], Dict[str, Any]]]:
+        """Return ``(row_id, entry_uuid, entry)`` triples past a watermark.
+
+        The caller decides which entry shape counts as "the visible user
+        turn" — that is runtime-specific knowledge and does not belong in the
+        state layer.
+        """
+        with self._read_ctx() as conn:
+            rows = conn.execute(
+                "SELECT id, entry_uuid, entry_json FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = '' AND id > ? "
+                "ORDER BY id LIMIT ?",
+                (
+                    runtime,
+                    project_key,
+                    provider_session_id,
+                    int(after_entry_id or 0),
+                    int(limit),
+                ),
+            ).fetchall()
+        out: List[Tuple[int, Optional[str], Dict[str, Any]]] = []
+        for row in rows:
+            if isinstance(row, sqlite3.Row):
+                rid, ruuid, raw = row["id"], row["entry_uuid"], row["entry_json"]
+            else:
+                rid, ruuid, raw = row[0], row[1], row[2]
+            try:
+                entry = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            out.append((int(rid), ruuid, entry))
+        return out
+
+    def provider_transcript_uuid_before(
+        self,
+        runtime: str,
+        project_key: str,
+        provider_session_id: str,
+        entry_row_id: int,
+    ) -> Optional[str]:
+        """The last entry UUID strictly before *entry_row_id* on the main key.
+
+        This is the fork boundary for a rewind: forking a session inclusive of
+        this UUID reproduces everything the user is keeping and nothing they
+        are replacing.
+        """
+        with self._read_ctx() as conn:
+            row = conn.execute(
+                "SELECT entry_uuid FROM provider_transcript_entries "
+                "WHERE runtime = ? AND project_key = ? "
+                "AND provider_session_id = ? AND subpath = '' "
+                "AND id < ? AND entry_uuid IS NOT NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (runtime, project_key, provider_session_id, int(entry_row_id)),
+            ).fetchone()
+        if row is None:
+            return None
+        return row["entry_uuid"] if isinstance(row, sqlite3.Row) else row[0]
 
 
 class AsyncSessionDB:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -529,6 +529,112 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+-- ── Whole-turn provider runtimes (claude_agent_sdk, codex_app_server, …) ──
+-- Some providers run the whole agentic turn themselves and own a session of
+-- their own: Claude's Agent SDK keeps the Claude-native context, the resume
+-- cursor, and the message UUIDs; Hermes keeps the visible transcript. The
+-- three tables below are the seam between the two halves.
+--
+-- They are deliberately provider-GENERIC (every row carries a ``runtime``
+-- discriminator) because Hermes already has two such runtimes, and
+-- deliberately FK-free: the mirror is written from the provider's own
+-- callback, which can fire before Hermes has created its ``sessions`` row,
+-- and a downgrade must be able to leave the mirror in place rather than
+-- delete transcript data (see docs/design/claude-subscription-via-agent-sdk.md
+-- § Rollback).
+
+-- Binds one Hermes session to the runtime-owned session id it resumes from.
+-- NOT sessions.thread_id: that column identifies a messaging origin (the
+-- chat/topic a gateway session was started in) and is load-bearing for
+-- gateway /resume IDOR scoping.
+CREATE TABLE IF NOT EXISTS provider_runtime_sessions (
+    session_id TEXT NOT NULL,
+    runtime TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    project_key TEXT NOT NULL DEFAULT '',
+    bootstrapped INTEGER NOT NULL DEFAULT 0,
+    recovery_count INTEGER NOT NULL DEFAULT 0,
+    -- Set by a rewind/edit/truncate to the number of visible user turns that
+    -- survive. The runtime consumes it on its next turn by FORKING its own
+    -- session at that boundary, so the parent transcript stays immutable and
+    -- the branch keeps a warm cache. NULL = nothing pending.
+    pending_rewind_ordinal INTEGER,
+    -- Set when a Hermes session is branched from one that had a binding: the
+    -- runtime session id to fork wholesale so the branch starts warm instead
+    -- of replaying history. NULL = nothing pending.
+    pending_fork_source TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (session_id, runtime)
+);
+
+-- One opaque JSONL transcript line as the runtime mirrored it to us. Entries
+-- are pass-through blobs: persisted in append order, returned in the same
+-- order, deep-equal on the way out. ``entry_uuid`` is the runtime's own id and
+-- is the idempotency key for a re-delivered batch; entries that carry no uuid
+-- (titles, tags, mode markers) are appended without dedup.
+CREATE TABLE IF NOT EXISTS provider_transcript_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    subpath TEXT NOT NULL DEFAULT '',
+    entry_uuid TEXT,
+    entry_json TEXT NOT NULL,
+    created_at REAL NOT NULL
+);
+
+-- One row per mirrored key (main transcript or subagent subpath). Carries the
+-- storage write time the runtime's session listing sorts on, and lets load()
+-- tell "never written" from "written then emptied".
+CREATE TABLE IF NOT EXISTS provider_transcript_keys (
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    subpath TEXT NOT NULL DEFAULT '',
+    mtime_ms INTEGER NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (runtime, project_key, provider_session_id, subpath)
+);
+
+-- Incrementally folded per-session summary sidecar. ``summary_json`` is opaque
+-- runtime-owned state — persisted verbatim, never interpreted here.
+CREATE TABLE IF NOT EXISTS provider_transcript_summaries (
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    summary_json TEXT NOT NULL,
+    mtime_ms INTEGER NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (runtime, project_key, provider_session_id)
+);
+
+-- Maps a VISIBLE Hermes user row (messages.id) to the runtime message UUID
+-- that turn opened with. This is what makes a rewind land on the right
+-- boundary instead of a guessed offset. ``after_entry_id`` is the mirror
+-- watermark taken when the turn was submitted, so the UUID can be resolved
+-- lazily once the mirror has caught up.
+-- ``user_ordinal`` is the primary anchor, not ``message_id``: Hermes has two
+-- durable rewind mechanics and one of them (replace_messages, behind
+-- prompt.submit's truncate) DELETEs and re-INSERTs rows, so autoincrement ids
+-- do not survive it. The ordinal — position among visible, non-bookkeeping
+-- user rows — is the same anchor prompt.submit's ``truncate_user_ordinal``
+-- already uses, so it survives both. ``message_id`` is kept alongside it for
+-- direct row lookups.
+CREATE TABLE IF NOT EXISTS provider_message_bindings (
+    session_id TEXT NOT NULL,
+    user_ordinal INTEGER NOT NULL,
+    message_id INTEGER NOT NULL DEFAULT 0,
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL DEFAULT '',
+    provider_session_id TEXT NOT NULL,
+    after_entry_id INTEGER NOT NULL DEFAULT 0,
+    provider_message_uuid TEXT,
+    fork_boundary_uuid TEXT,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (session_id, user_ordinal)
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -549,6 +655,25 @@ CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usag
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
+CREATE INDEX IF NOT EXISTS idx_provider_runtime_sessions_lookup
+    ON provider_runtime_sessions(runtime, provider_session_id);
+-- Ordered read path for load(): the AUTOINCREMENT id IS the append order.
+CREATE INDEX IF NOT EXISTS idx_provider_transcript_entries_key
+    ON provider_transcript_entries(
+        runtime, project_key, provider_session_id, subpath, id
+    );
+-- Idempotency for a re-delivered batch. Partial so the many legitimate
+-- uuid-less entries (titles, tags, mode markers) are never deduped against
+-- each other, and scoped per key because a fork rewrites every uuid.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_transcript_entries_uuid
+    ON provider_transcript_entries(
+        runtime, project_key, provider_session_id, subpath, entry_uuid
+    )
+    WHERE entry_uuid IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_provider_transcript_keys_project
+    ON provider_transcript_keys(runtime, project_key, mtime_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_provider_message_bindings_row
+    ON provider_message_bindings(session_id, message_id);
 """
 
 

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -278,6 +278,112 @@ CREATE TABLE IF NOT EXISTS async_delegations (
     delivery_claimed_at REAL
 );
 
+-- ── Whole-turn provider runtimes (claude_agent_sdk, codex_app_server, …) ──
+-- Some providers run the whole agentic turn themselves and own a session of
+-- their own: Claude's Agent SDK keeps the Claude-native context, the resume
+-- cursor, and the message UUIDs; Hermes keeps the visible transcript. The
+-- three tables below are the seam between the two halves.
+--
+-- They are deliberately provider-GENERIC (every row carries a ``runtime``
+-- discriminator) because Hermes already has two such runtimes, and
+-- deliberately FK-free: the mirror is written from the provider's own
+-- callback, which can fire before Hermes has created its ``sessions`` row,
+-- and a downgrade must be able to leave the mirror in place rather than
+-- delete transcript data (see docs/design/claude-subscription-via-agent-sdk.md
+-- § Rollback).
+
+-- Binds one Hermes session to the runtime-owned session id it resumes from.
+-- NOT sessions.thread_id: that column identifies a messaging origin (the
+-- chat/topic a gateway session was started in) and is load-bearing for
+-- gateway /resume IDOR scoping.
+CREATE TABLE IF NOT EXISTS provider_runtime_sessions (
+    session_id TEXT NOT NULL,
+    runtime TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    project_key TEXT NOT NULL DEFAULT '',
+    bootstrapped INTEGER NOT NULL DEFAULT 0,
+    recovery_count INTEGER NOT NULL DEFAULT 0,
+    -- Set by a rewind/edit/truncate to the number of visible user turns that
+    -- survive. The runtime consumes it on its next turn by FORKING its own
+    -- session at that boundary, so the parent transcript stays immutable and
+    -- the branch keeps a warm cache. NULL = nothing pending.
+    pending_rewind_ordinal INTEGER,
+    -- Set when a Hermes session is branched from one that had a binding: the
+    -- runtime session id to fork wholesale so the branch starts warm instead
+    -- of replaying history. NULL = nothing pending.
+    pending_fork_source TEXT,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (session_id, runtime)
+);
+
+-- One opaque JSONL transcript line as the runtime mirrored it to us. Entries
+-- are pass-through blobs: persisted in append order, returned in the same
+-- order, deep-equal on the way out. ``entry_uuid`` is the runtime's own id and
+-- is the idempotency key for a re-delivered batch; entries that carry no uuid
+-- (titles, tags, mode markers) are appended without dedup.
+CREATE TABLE IF NOT EXISTS provider_transcript_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    subpath TEXT NOT NULL DEFAULT '',
+    entry_uuid TEXT,
+    entry_json TEXT NOT NULL,
+    created_at REAL NOT NULL
+);
+
+-- One row per mirrored key (main transcript or subagent subpath). Carries the
+-- storage write time the runtime's session listing sorts on, and lets load()
+-- tell "never written" from "written then emptied".
+CREATE TABLE IF NOT EXISTS provider_transcript_keys (
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    subpath TEXT NOT NULL DEFAULT '',
+    mtime_ms INTEGER NOT NULL,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (runtime, project_key, provider_session_id, subpath)
+);
+
+-- Incrementally folded per-session summary sidecar. ``summary_json`` is opaque
+-- runtime-owned state — persisted verbatim, never interpreted here.
+CREATE TABLE IF NOT EXISTS provider_transcript_summaries (
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL,
+    provider_session_id TEXT NOT NULL,
+    summary_json TEXT NOT NULL,
+    mtime_ms INTEGER NOT NULL,
+    updated_at REAL NOT NULL,
+    PRIMARY KEY (runtime, project_key, provider_session_id)
+);
+
+-- Maps a VISIBLE Hermes user row (messages.id) to the runtime message UUID
+-- that turn opened with. This is what makes a rewind land on the right
+-- boundary instead of a guessed offset. ``after_entry_id`` is the mirror
+-- watermark taken when the turn was submitted, so the UUID can be resolved
+-- lazily once the mirror has caught up.
+-- ``user_ordinal`` is the primary anchor, not ``message_id``: Hermes has two
+-- durable rewind mechanics and one of them (replace_messages, behind
+-- prompt.submit's truncate) DELETEs and re-INSERTs rows, so autoincrement ids
+-- do not survive it. The ordinal — position among visible, non-bookkeeping
+-- user rows — is the same anchor prompt.submit's ``truncate_user_ordinal``
+-- already uses, so it survives both. ``message_id`` is kept alongside it for
+-- direct row lookups.
+CREATE TABLE IF NOT EXISTS provider_message_bindings (
+    session_id TEXT NOT NULL,
+    user_ordinal INTEGER NOT NULL,
+    message_id INTEGER NOT NULL DEFAULT 0,
+    runtime TEXT NOT NULL,
+    project_key TEXT NOT NULL DEFAULT '',
+    provider_session_id TEXT NOT NULL,
+    after_entry_id INTEGER NOT NULL DEFAULT 0,
+    provider_message_uuid TEXT,
+    fork_boundary_uuid TEXT,
+    created_at REAL NOT NULL,
+    PRIMARY KEY (session_id, user_ordinal)
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_source ON sessions(source);
 CREATE INDEX IF NOT EXISTS idx_sessions_source_id ON sessions(source, id);
 CREATE INDEX IF NOT EXISTS idx_sessions_parent ON sessions(parent_session_id);
@@ -288,6 +394,25 @@ CREATE INDEX IF NOT EXISTS idx_session_model_usage_session ON session_model_usag
 CREATE INDEX IF NOT EXISTS idx_session_model_usage_model ON session_model_usage(model);
 CREATE INDEX IF NOT EXISTS idx_async_delegations_delivery
     ON async_delegations(delivery_state, completed_at);
+CREATE INDEX IF NOT EXISTS idx_provider_runtime_sessions_lookup
+    ON provider_runtime_sessions(runtime, provider_session_id);
+-- Ordered read path for load(): the AUTOINCREMENT id IS the append order.
+CREATE INDEX IF NOT EXISTS idx_provider_transcript_entries_key
+    ON provider_transcript_entries(
+        runtime, project_key, provider_session_id, subpath, id
+    );
+-- Idempotency for a re-delivered batch. Partial so the many legitimate
+-- uuid-less entries (titles, tags, mode markers) are never deduped against
+-- each other, and scoped per key because a fork rewrites every uuid.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_provider_transcript_entries_uuid
+    ON provider_transcript_entries(
+        runtime, project_key, provider_session_id, subpath, entry_uuid
+    )
+    WHERE entry_uuid IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_provider_transcript_keys_project
+    ON provider_transcript_keys(runtime, project_key, mtime_ms DESC);
+CREATE INDEX IF NOT EXISTS idx_provider_message_bindings_row
+    ON provider_message_bindings(session_id, message_id);
 """
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,7 +1941,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1958,7 +1957,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1975,7 +1973,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1992,7 +1989,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2009,7 +2005,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2026,7 +2021,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2043,7 +2037,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2060,7 +2053,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2077,7 +2069,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2094,7 +2085,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2111,7 +2101,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2128,7 +2117,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2145,7 +2133,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2162,7 +2149,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2179,7 +2165,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2196,7 +2181,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2213,7 +2197,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2230,7 +2213,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2247,7 +2229,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2264,7 +2245,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2281,7 +2261,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2298,7 +2277,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2315,7 +2293,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2332,7 +2309,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2349,7 +2325,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2366,7 +2341,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10081,6 +10055,33 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
+    "node_modules/emojibase": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-17.0.0.tgz",
+      "integrity": "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      }
+    },
+    "node_modules/emojibase-data": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/emojibase-data/-/emojibase-data-16.0.3.tgz",
+      "integrity": "sha512-MopInVCDZeXvqBMPJxnvYUyKw9ImJZqIDr2sABo6acVSPev5IDYX+mf+0tsu96JJyc3INNvgIf06Eso7bdTX2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "ko-fi",
+        "url": "https://ko-fi.com/milesjohnson"
+      },
+      "peerDependencies": {
+        "emojibase": "*"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -11195,6 +11196,25 @@
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/frimousse": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/frimousse/-/frimousse-0.3.0.tgz",
+      "integrity": "sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site"
+      ],
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
           "optional": true
         }
       }
@@ -18371,7 +18391,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -19786,52 +19806,6 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/emojibase": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/emojibase/-/emojibase-17.0.0.tgz",
-      "integrity": "sha512-bXdpf4HPY3p41zK5swVKZdC/VynsMZ4LoLxdYDE+GucqkFwzcM1GVc4ODfYAlwoKaf2U2oNNUoOO78N96ovpBA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/milesjohnson"
-      }
-    },
-    "node_modules/emojibase-data": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/emojibase-data/-/emojibase-data-16.0.3.tgz",
-      "integrity": "sha512-MopInVCDZeXvqBMPJxnvYUyKw9ImJZqIDr2sABo6acVSPev5IDYX+mf+0tsu96JJyc3INNvgIf06Eso7bdTX2Q==",
-      "license": "MIT",
-      "funding": {
-        "type": "ko-fi",
-        "url": "https://ko-fi.com/milesjohnson"
-      },
-      "peerDependencies": {
-        "emojibase": "*"
-      }
-    },
-    "node_modules/frimousse": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/frimousse/-/frimousse-0.3.0.tgz",
-      "integrity": "sha512-kO6LMoKY/cLAYEhXXtqLRaLIE6L/DagpFPrUZaLv3LsUa1/8Iza3HhwZcgN8eZ+weXnhv69eoclNUPohcCa/IQ==",
-      "license": "MIT",
-      "workspaces": [
-        ".",
-        "site"
-      ],
-      "peerDependencies": {
-        "react": "^18 || ^19",
-        "typescript": ">=5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
     }
   }
 }

--- a/plugins/model-providers/anthropic/__init__.py
+++ b/plugins/model-providers/anthropic/__init__.py
@@ -43,9 +43,16 @@ class AnthropicProfile(ProviderProfile):
 
 anthropic = AnthropicProfile(
     name="anthropic",
-    aliases=("claude", "claude-oauth", "claude-code"),
+    # API-key only. The `claude-code` / `claude-oauth` aliases and the Claude
+    # subscription OAuth credential belong to the `claude-code` provider, which
+    # routes a Claude subscription through the official Claude Agent SDK
+    # instead of billing it as extra usage on this endpoint.
+    aliases=("claude",),
     api_mode="anthropic_messages",
-    env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"),
+    display_name="Anthropic API",
+    description="Anthropic API (Claude models, billed per token with an API key)",
+    signup_url="https://console.anthropic.com/settings/keys",
+    env_vars=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
     base_url="https://api.anthropic.com",
     auth_type="api_key",
     default_aux_model="claude-haiku-4-5-20251001",

--- a/plugins/model-providers/claude-code/__init__.py
+++ b/plugins/model-providers/claude-code/__init__.py
@@ -1,0 +1,56 @@
+"""Claude subscription provider profile — routed through the official Claude Agent SDK.
+
+Inference runs inside ``claude-agent-sdk`` (which wraps the Claude Code CLI),
+so ``api_mode="claude_agent_sdk"`` is handled separately from the HTTP
+transports; the profile only captures auth + identity metadata.
+
+Boundary: Hermes never reads, writes, refreshes, or deletes Claude
+credentials.  ``env_vars`` is empty on purpose — there is no credential for
+Hermes to hold.  The user runs ``claude auth login`` and the SDK resolves auth
+itself.  ``base_url`` is an internal scheme, not a reachable endpoint, so no
+code path can mistake this provider for a REST backend.
+"""
+
+from hermes_cli.claude_code import (
+    CLAUDE_CODE_API_MODE,
+    CLAUDE_CODE_BASE_URL,
+    CLAUDE_CODE_DESCRIPTION,
+    CLAUDE_CODE_DISPLAY_NAME,
+    CLAUDE_CODE_PROVIDER_ID,
+    CLAUDE_DOCS_URL,
+)
+from providers import register_provider
+from providers.base import ProviderProfile
+
+
+class ClaudeCodeProfile(ProviderProfile):
+    """Claude subscription via the Agent SDK — no REST models endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        """Model listing is owned by the Agent SDK, not a REST catalog."""
+        return None
+
+
+claude_code = ClaudeCodeProfile(
+    name=CLAUDE_CODE_PROVIDER_ID,
+    # `claude-oauth` used to be an anthropic alias meaning "Claude subscription".
+    # Once the gate is open the slug belongs here; while it is closed
+    # hermes_cli.claude_code.legacy_alias_target() keeps pointing it at anthropic.
+    aliases=("claude-subscription", "claude-agent-sdk", "claude-oauth"),
+    api_mode=CLAUDE_CODE_API_MODE,
+    display_name=CLAUDE_CODE_DISPLAY_NAME,
+    description=CLAUDE_CODE_DESCRIPTION,
+    signup_url=CLAUDE_DOCS_URL,
+    env_vars=(),  # No credential env var — the SDK resolves auth itself.
+    base_url=CLAUDE_CODE_BASE_URL,
+    auth_type="external_process",
+    supports_health_check=False,  # no HTTP endpoint to probe
+)
+
+register_provider(claude_code)

--- a/plugins/model-providers/claude-code/plugin.yaml
+++ b/plugins/model-providers/claude-code/plugin.yaml
@@ -1,0 +1,5 @@
+name: claude-code-provider
+kind: model-provider
+version: 1.0.0
+description: Claude subscription via the official Claude Agent SDK
+author: Nous Research

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,14 @@ dependencies = [
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
 anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+# Claude subscription via the official Agent SDK (provider "claude-code",
+# api_mode "claude_agent_sdk"). Range-pinned per the pre-1.0 rule in
+# AGENTS.md rather than exact-pinned like its neighbours, because the SDK
+# tracks the Claude CLI's release cadence and a floor+ceiling is what the
+# policy prescribes for 0.x. Deliberately NOT in [all]: the platform wheels
+# are ~72-82 MB each (they bundle the Claude executable), so every fresh
+# install would pay for a runtime that ships default-off.
+claude-code = ["claude-agent-sdk>=0.2.140,<0.4"]
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]
@@ -419,7 +427,10 @@ exclude-newer = "14 days"
 # cutoff can still brick installs. Exempting exact pins is pure brick-risk
 # removal at no supply-chain cost. Guarded by
 # tests/test_packaging_metadata.py::test_build_system_requires_exempt_from_exclude_newer.
-exclude-newer-package = { vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
+# claude-agent-sdk: dated exception so the lock can see 0.2.140 (uploaded
+# 2026-08-18), the first release whose `mcp` range admits the 2.x pinned above.
+# Remove once 0.2.140 is older than the 14-day window (after 2026-09-01).
+exclude-newer-package = { claude-agent-sdk = "2026-08-19T00:00:00Z", vercel = false, nemo-relay = false, huggingface_hub = false, h2 = false, aiohttp = false, cryptography = false, defusedxml = false, python-olm = false, unpaddedbase64 = false, setuptools = false, pillow = false, mcp = false }
 
 [tool.setuptools]
 # Top-level single-file modules (not packages). Without this, uv2nix's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,14 @@ dependencies = [
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).
 anthropic = ["anthropic==0.87.0"]  # CVE-2026-34450, CVE-2026-34452
+# Claude subscription via the official Agent SDK (provider "claude-code",
+# api_mode "claude_agent_sdk"). Range-pinned per the pre-1.0 rule in
+# AGENTS.md rather than exact-pinned like its neighbours, because the SDK
+# tracks the Claude CLI's release cadence and a floor+ceiling is what the
+# policy prescribes for 0.x. Deliberately NOT in [all]: the platform wheels
+# are ~72-82 MB each (they bundle the Claude executable), so every fresh
+# install would pay for a runtime that ships default-off.
+claude-code = ["claude-agent-sdk>=0.2.128,<0.4"]
 # Web search backends — each only loaded when the user picks it as their
 # search provider (configured via `hermes tools` or config.yaml).
 exa = ["exa-py==2.10.2"]

--- a/run_agent.py
+++ b/run_agent.py
@@ -3371,6 +3371,23 @@ class AIAgent:
                         exc_info=True,
                     )
 
+        # The Claude Agent SDK likewise owns its model/tool loop inside a CLI
+        # subprocess. Its interrupt is only half the sequence: the runtime
+        # keeps draining the interrupted response until the SDK's terminal
+        # ResultMessage lands, because issuing the next query() before that
+        # drain completes wedges the session.
+        if getattr(self, "api_mode", None) == "claude_agent_sdk":
+            _claude_session = getattr(self, "_claude_session", None)
+            _claude_interrupt = getattr(_claude_session, "request_interrupt", None)
+            if callable(_claude_interrupt):
+                try:
+                    _claude_interrupt()
+                except Exception:
+                    logger.debug(
+                        "Failed to interrupt Claude Agent SDK turn",
+                        exc_info=True,
+                    )
+
         # A cron turn performs its API request on the conversation thread to
         # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
         # path, its client is registered here so this cross-thread interrupt can
@@ -4605,6 +4622,32 @@ class AIAgent:
         except Exception:
             pass
 
+        # The Claude Agent SDK session holds an OS thread and a Claude Code
+        # subprocess, so it is released here too: an evicted agent that
+        # resumes is rebuilt and would spawn its own session anyway.
+        self._release_claude_agent_sdk_session()
+
+    def _release_claude_agent_sdk_session(self) -> None:
+        """Tear down the Claude Agent SDK session, if one was ever started.
+
+        Idempotent and never raises — called from both the soft eviction path
+        and the hard teardown.
+        """
+        session = getattr(self, "_claude_session", None)
+        if session is None:
+            return
+        # Mirror agent.claude_runtime._retire_session: the next session must
+        # re-prove its billing source, whichever teardown path retired this
+        # one. claude_runtime is already imported whenever a session existed.
+        from agent.claude_runtime import _UNSET as _billing_unset
+
+        self._claude_billing_refusal = _billing_unset
+        self._claude_session = None
+        try:
+            session.close()
+        except Exception:
+            logger.debug("Claude Agent SDK session close failed", exc_info=True)
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -4710,6 +4753,10 @@ class AIAgent:
                 codex_session.close()
         except Exception:
             pass
+
+        # 6c. Release the Claude Agent SDK session (loop thread + Claude Code
+        # subprocess) when the claude_agent_sdk runtime was in use.
+        self._release_claude_agent_sdk_session()
 
         # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
@@ -8995,6 +9042,43 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_agent_sdk_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.claude_runtime.run_claude_agent_sdk_turn``.
+
+        Normalises the prompt on the way through.  ``user_message`` is a plain
+        string on almost every turn, but a turn that carries an attachment hands
+        down OpenAI-style content parts, and the runtime passes whatever it gets
+        straight to the SDK — which accepts a string or an async iterable of
+        stream-json frames, and nothing in between.  Translating here keeps the
+        conversion out of the runtime while making an image either *arrive* or
+        *fail loudly*; the one outcome we refuse is dropping it silently.
+        """
+        from agent.claude_runtime import run_claude_agent_sdk_turn
+        from agent.claude_sdk_input import ClaudeImageInputUnsupported, prompt_for_content
+
+        try:
+            prompt = prompt_for_content(user_message)
+        except ClaudeImageInputUnsupported as exc:
+            return {
+                "final_response": str(exc),
+                "messages": messages,
+                "api_calls": 0,
+                "completed": False,
+                "partial": True,
+                "failed": True,
+                "interrupted": False,
+                "error": str(exc),
+            }
+        return run_claude_agent_sdk_turn(self, user_message=prompt, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -2985,6 +2985,23 @@ class AIAgent:
                         exc_info=True,
                     )
 
+        # The Claude Agent SDK likewise owns its model/tool loop inside a CLI
+        # subprocess. Its interrupt is only half the sequence: the runtime
+        # keeps draining the interrupted response until the SDK's terminal
+        # ResultMessage lands, because issuing the next query() before that
+        # drain completes wedges the session.
+        if getattr(self, "api_mode", None) == "claude_agent_sdk":
+            _claude_session = getattr(self, "_claude_session", None)
+            _claude_interrupt = getattr(_claude_session, "request_interrupt", None)
+            if callable(_claude_interrupt):
+                try:
+                    _claude_interrupt()
+                except Exception:
+                    logger.debug(
+                        "Failed to interrupt Claude Agent SDK turn",
+                        exc_info=True,
+                    )
+
         # A cron turn performs its API request on the conversation thread to
         # avoid the nested interrupt-worker deadlock.  Unlike the normal worker
         # path, its client is registered here so this cross-thread interrupt can
@@ -3950,6 +3967,32 @@ class AIAgent:
         except Exception:
             pass
 
+        # The Claude Agent SDK session holds an OS thread and a Claude Code
+        # subprocess, so it is released here too: an evicted agent that
+        # resumes is rebuilt and would spawn its own session anyway.
+        self._release_claude_agent_sdk_session()
+
+    def _release_claude_agent_sdk_session(self) -> None:
+        """Tear down the Claude Agent SDK session, if one was ever started.
+
+        Idempotent and never raises — called from both the soft eviction path
+        and the hard teardown.
+        """
+        session = getattr(self, "_claude_session", None)
+        if session is None:
+            return
+        # Mirror agent.claude_runtime._retire_session: the next session must
+        # re-prove its billing source, whichever teardown path retired this
+        # one. claude_runtime is already imported whenever a session existed.
+        from agent.claude_runtime import _UNSET as _billing_unset
+
+        self._claude_billing_refusal = _billing_unset
+        self._claude_session = None
+        try:
+            session.close()
+        except Exception:
+            logger.debug("Claude Agent SDK session close failed", exc_info=True)
+
     def close(self) -> None:
         """Release all resources held by this agent instance.
 
@@ -4025,6 +4068,10 @@ class AIAgent:
             self._close_cached_request_openai_client(reason="agent_close")
         except Exception:
             pass
+
+        # 6c. Release the Claude Agent SDK session (loop thread + Claude Code
+        # subprocess) when the claude_agent_sdk runtime was in use.
+        self._release_claude_agent_sdk_session()
 
         # 7. Free conversation history.  Mirrors _release_evicted_agent_soft's
         # soft-eviction clear — close() is the hard teardown for true session
@@ -7190,6 +7237,43 @@ class AIAgent:
         """Forwarder — see ``agent.codex_runtime.run_codex_app_server_turn``."""
         from agent.codex_runtime import run_codex_app_server_turn
         return run_codex_app_server_turn(self, user_message=user_message, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
+
+    def _run_claude_agent_sdk_turn(
+        self,
+        *,
+        user_message: str,
+        original_user_message: Any,
+        messages: List[Dict[str, Any]],
+        effective_task_id: str,
+        should_review_memory: bool = False,
+    ) -> Dict[str, Any]:
+        """Forwarder — see ``agent.claude_runtime.run_claude_agent_sdk_turn``.
+
+        Normalises the prompt on the way through.  ``user_message`` is a plain
+        string on almost every turn, but a turn that carries an attachment hands
+        down OpenAI-style content parts, and the runtime passes whatever it gets
+        straight to the SDK — which accepts a string or an async iterable of
+        stream-json frames, and nothing in between.  Translating here keeps the
+        conversion out of the runtime while making an image either *arrive* or
+        *fail loudly*; the one outcome we refuse is dropping it silently.
+        """
+        from agent.claude_runtime import run_claude_agent_sdk_turn
+        from agent.claude_sdk_input import ClaudeImageInputUnsupported, prompt_for_content
+
+        try:
+            prompt = prompt_for_content(user_message)
+        except ClaudeImageInputUnsupported as exc:
+            return {
+                "final_response": str(exc),
+                "messages": messages,
+                "api_calls": 0,
+                "completed": False,
+                "partial": True,
+                "failed": True,
+                "interrupted": False,
+                "error": str(exc),
+            }
+        return run_claude_agent_sdk_turn(self, user_message=prompt, original_user_message=original_user_message, messages=messages, effective_task_id=effective_task_id, should_review_memory=should_review_memory)
 
 def main(
     query: str = None,

--- a/scripts/check_claude_boundary.py
+++ b/scripts/check_claude_boundary.py
@@ -1,0 +1,492 @@
+#!/usr/bin/env python3
+"""
+Claude subscription boundary check.
+
+Hermes routes a Claude subscription through the official ``claude-agent-sdk``.
+The SDK owns the user's credentials; Hermes must not touch them, must not send
+a subscription token to Anthropic's API itself, and must not dress its requests
+up as Claude Code. This script makes those rules mechanical.
+
+Four rules, all fatal:
+
+  1. Credential access — no references to Claude/Anthropic credential stores
+     (``.credentials.json``, ``~/.claude.json``, ``.claude/.credentials``,
+     ``~/.anthropic/``).
+  2. Direct OAuth inference — no code path that sends a Claude
+     OAuth/subscription token to ``api.anthropic.com``. The API-key provider's
+     ``/v1/models`` and ``/v1/messages`` calls are legitimate and allowed; what
+     is forbidden is combining an Anthropic endpoint with
+     ``CLAUDE_CODE_OAUTH_TOKEN`` or a Claude-credential-derived token.
+  3. Identity spoofing — no ``claude-code/`` user-agent strings, no
+     ``x-app: cli`` header, no Claude Code beta flags, and no system-prompt or
+     tool-name rewriting that replaces "Hermes"/"Nous" to look like Claude Code.
+  4. ``CLAUDE_CODE_OAUTH_TOKEN`` reads outside the allow-list.
+
+Usage:
+    python scripts/check_claude_boundary.py            # scan the tree
+    python scripts/check_claude_boundary.py --verbose  # also list allow-list hits
+
+Exit status:
+    0 — no unallowed violations
+    1 — at least one violation
+
+Suppress a single intentional line with:
+    ...  # claude-boundary: ok — <why>
+
+ALLOW-LIST POLICY: every entry below names a file that still carries the
+pre-SDK direct-OAuth path, with a justification. Entries tagged
+``TODO(legacy-retirement)`` disappear when PR4 deletes that path — the check tightens
+automatically, without anyone remembering to tighten it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SUPPRESS_MARKER = re.compile(r"#\s*claude-boundary\s*:\s*ok\b", re.IGNORECASE)
+
+# Source roots that make up "Hermes source". Docs, the website, tests, and
+# vendored trees are out of scope: this guards shipped behavior, and tests
+# legitimately construct the very payloads the rules forbid in order to assert
+# on them.
+SOURCE_ROOTS = (
+    "acp_adapter",
+    "agent",
+    "apps",
+    "cron",
+    "gateway",
+    "hermes_cli",
+    "model_tools.py",
+    "plugins",
+    "providers",
+    "run_agent.py",
+    "tools",
+    "tui_gateway",
+    "utils.py",
+)
+
+SCANNED_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".mjs", ".cjs"}
+
+EXCLUDED_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    ".venv",
+    "venv",
+    ".pytest_cache",
+    ".mypy_cache",
+}
+
+
+@dataclass
+class Rule:
+    """One boundary rule."""
+
+    name: str
+    pattern: re.Pattern
+    message: str
+    # Repo-relative path prefixes whose matches are tolerated. Each entry MUST
+    # carry a justification in ALLOWLIST_REASONS.
+    allowlist: tuple[str, ...] = ()
+    # Optional second pattern that must ALSO be present for a match to count.
+    require_also: re.Pattern | None = None
+    # "line" — both patterns must be on the same line.
+    # "file" — ``require_also`` may appear anywhere in the file. Needed for the
+    #   direct-OAuth rule: a request's URL, headers, and token rarely share a
+    #   line, so co-location in one module is the honest signal.
+    scope: str = "line"
+    hits: list[tuple[str, int, str]] = field(default_factory=list)
+
+
+# ── Allow-list justifications ───────────────────────────────────────────────
+# Keyed by repo-relative path prefix. Anything listed here is a KNOWN, CURRENT
+# violation that PR4 removes; the entry is the audit trail for why the build is
+# still green today.
+ALLOWLIST_REASONS: dict[str, str] = {
+    "hermes_cli/inventory.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Names the Claude Code credential file in a docstring only: the "
+        "desktop explicit-provider filter mirrors list_authenticated_providers' "
+        "acceptance of the legacy Claude Code login so a provider the user "
+        "signed into is not silently dropped from inventory."
+    ),
+    "agent/anthropic_adapter.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Holds the entire pre-SDK Claude path: the claude.ai PKCE flow, the "
+        "keychain/credential-file readers and writer, the spoofed Claude Code "
+        "user-agent / x-app / beta headers, and the prompt+tool-name rewriting. "
+        "It must keep working until the Agent SDK runtime replaces it."
+    ),
+    "agent/account_usage.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Reads the Claude subscription usage endpoint with a Claude Code "
+        "user-agent to render remaining plan quota."
+    ),
+    "agent/credential_pool.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Seeds and refreshes pooled Anthropic credentials from the Claude Code "
+        "credential singleton."
+    ),
+    "agent/credential_sources.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Declares the claude_code credential source so users can suppress it."
+    ),
+    "agent/credential_persistence.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Names the Claude Code credential file among the persistence targets."
+    ),
+    "agent/agent_init.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Sets a Claude Code user-agent on the legacy Anthropic client."
+    ),
+    "agent/auxiliary_client.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Side-LLM clients inherit the legacy Anthropic OAuth headers and "
+        "credential resolution."
+    ),
+    "run_agent.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Sets the legacy Anthropic client user-agent."
+    ),
+    "hermes_cli/doctor.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Probes the legacy Anthropic OAuth endpoint during diagnostics."
+    ),
+    "hermes_cli/auth.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The anthropic registry entry still lists CLAUDE_CODE_OAUTH_TOKEN so "
+        "existing users keep resolving while the old path is live."
+    ),
+    "hermes_cli/config.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Documents CLAUDE_CODE_OAUTH_TOKEN in OPTIONAL_ENV_VARS and offers the "
+        "legacy 'use my Claude Code credentials' setup step."
+    ),
+    "hermes_cli/web_server.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Hosts the dashboard's Anthropic PKCE endpoints, which mint and store a "
+        "claude.ai OAuth token."
+    ),
+    "hermes_cli/main.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The `hermes model` Claude subscription flow shells out to the legacy "
+        "token-setup command."
+    ),
+    "hermes_cli/model_setup_flows.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Same legacy Claude subscription setup flow as hermes_cli/main.py."
+    ),
+    "hermes_cli/credential_lifecycle.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Enumerates the claude_code credential source for list/remove verbs."
+    ),
+    "hermes_cli/models.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Stats the Claude credential file's mtime to invalidate a provider "
+        "cache key; it reads no contents, but the reference goes with the path."
+    ),
+    "hermes_cli/setup.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The setup wizard skips prompting for CLAUDE_CODE_OAUTH_TOKEN because "
+        "Claude Code sets it."
+    ),
+    "hermes_cli/agent_import.py": (
+        "Not a boundary violation: `hermes import-agent claude-code` copies a "
+        "user's own agent config (skills, memory, settings) out of ~/.claude. "
+        "It reads no credential and performs no inference."
+    ),
+    "tools/environments/local.py": (
+        "Not a boundary violation: the terminal sandbox's env blocklist "
+        "deliberately does NOT strip CLAUDE_CODE_OAUTH_TOKEN, so an "
+        "agent-spawned `claude` CLI keeps using the user's own login instead "
+        "of falling through and clearing their credentials (#55878). This is "
+        "passthrough of the user's environment, not Hermes reading a token."
+    ),
+}
+
+# ── Rules ───────────────────────────────────────────────────────────────────
+
+_CREDENTIAL_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "hermes_cli/inventory.py",
+    "agent/credential_pool.py",
+    "agent/credential_sources.py",
+    "agent/credential_persistence.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/agent_import.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/config.py",
+    "hermes_cli/credential_lifecycle.py",
+    "hermes_cli/main.py",
+    "hermes_cli/models.py",
+    "hermes_cli/web_server.py",
+    "run_agent.py",
+    "tools/environments/local.py",
+)
+
+_OAUTH_INFERENCE_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/account_usage.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/web_server.py",
+)
+
+_SPOOF_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/account_usage.py",
+    "agent/agent_init.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/doctor.py",
+    "run_agent.py",
+)
+
+_OAUTH_ENV_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/credential_pool.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/config.py",
+    "hermes_cli/setup.py",
+    "hermes_cli/web_server.py",
+    "tools/environments/local.py",
+)
+
+RULES: list[Rule] = [
+    # ── Rule 1: credential access ───────────────────────────────────────────
+    Rule(
+        name="claude-credential-file",
+        pattern=re.compile(
+            r"\.credentials\.json"
+            r"|\.claude/\.credentials"
+            r"|~/\.claude\.json"
+            r"|\.anthropic/"
+        ),
+        message=(
+            "references a Claude/Anthropic credential store. The Agent SDK owns "
+            "those files — Hermes never reads, writes, or deletes them."
+        ),
+        allowlist=_CREDENTIAL_ALLOW,
+    ),
+    Rule(
+        name="claude-keychain-entry",
+        pattern=re.compile(r"Claude Code-credentials"),
+        message=(
+            "touches the Claude Code macOS keychain entry. Use `claude auth "
+            "login` / `claude auth logout` instead."
+        ),
+        allowlist=_CREDENTIAL_ALLOW,
+    ),
+    # ── Rule 2: direct OAuth inference ──────────────────────────────────────
+    # api.anthropic.com by itself is fine (the API-key provider's /v1/models
+    # and /v1/messages). The violation is an Anthropic endpoint on the same
+    # line as a Claude subscription token.
+    Rule(
+        name="anthropic-endpoint-with-claude-token",
+        pattern=re.compile(
+            r"api\.anthropic\.com|claude\.ai/oauth|platform\.claude\.com/v1/"
+        ),
+        # Symbols that denote a CLAUDE SUBSCRIPTION credential specifically —
+        # not "any Anthropic credential". Broader names (resolve_anthropic_token,
+        # generic *oauth_token*) also cover the legitimate API-key path and
+        # would flag every module that merely knows Anthropic's hostname.
+        require_also=re.compile(
+            r"CLAUDE_CODE_OAUTH_TOKEN"
+            r"|read_claude_code_credentials"
+            r"|_write_claude_code_credentials"
+            r"|refresh_anthropic_oauth"
+            r"|Claude Code-credentials"
+        ),
+        scope="file",
+        message=(
+            "sends a Claude OAuth/subscription token to an Anthropic endpoint. "
+            "Subscription inference must go through claude-agent-sdk. (An "
+            "Anthropic endpoint on its own is fine — the API-key provider's "
+            "/v1/models and /v1/messages calls are legitimate.)"
+        ),
+        allowlist=_OAUTH_INFERENCE_ALLOW,
+    ),
+    # ── Rule 3: identity spoofing ───────────────────────────────────────────
+    Rule(
+        name="claude-code-user-agent",
+        pattern=re.compile(r"""claude-code/(?:\d|\{|\$|"|')"""),
+        message=(
+            "sets a claude-code/<version> user-agent. Hermes must identify as "
+            "Hermes; the SDK sets its own identity."
+        ),
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-cli-app-header",
+        pattern=re.compile(r"""["']x-app["']\s*:\s*["']cli["']"""),
+        message="sets the Claude Code `x-app: cli` header.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-beta-flag",
+        pattern=re.compile(r"claude-code-\d{8}|oauth-\d{4}-\d{2}-\d{2}"),
+        message="sends a Claude Code OAuth-only beta flag.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-identity-rewrite",
+        pattern=re.compile(
+            r"""["'](?:Hermes(?:\s+Agent)?|Nous(?:\s+Research)?)["']\s*,\s*["']"""
+            r"""(?:Claude Code|Anthropic)["']"""
+        ),
+        message=(
+            "rewrites Hermes/Nous branding into Claude Code/Anthropic. Hermes "
+            "does not impersonate another client to change how it is billed."
+        ),
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-system-prompt",
+        pattern=re.compile(r"You are Claude Code"),
+        message="injects Claude Code's system-prompt identity.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    # ── Rule 4: CLAUDE_CODE_OAUTH_TOKEN reads ───────────────────────────────
+    Rule(
+        name="claude-oauth-token-env",
+        pattern=re.compile(r"CLAUDE_CODE_OAUTH_TOKEN"),
+        message=(
+            "reads CLAUDE_CODE_OAUTH_TOKEN. The Claude subscription provider "
+            "holds no credential — the SDK resolves auth itself."
+        ),
+        allowlist=_OAUTH_ENV_ALLOW,
+    ),
+]
+
+
+def _iter_source_files() -> Iterable[Path]:
+    """Yield every scannable Hermes source file."""
+    for root_name in SOURCE_ROOTS:
+        root = REPO_ROOT / root_name
+        if root.is_file():
+            if root.suffix in SCANNED_SUFFIXES:
+                yield root
+            continue
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.suffix not in SCANNED_SUFFIXES or not path.is_file():
+                continue
+            if any(part in EXCLUDED_DIR_NAMES for part in path.parts):
+                continue
+            yield path
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def scan(rules: list[Rule]) -> int:
+    """Populate ``rule.hits`` and return the number of unallowed violations."""
+    violations = 0
+    for path in _iter_source_files():
+        rel = _rel(path)
+        # This script names every pattern it forbids; scanning it would be a
+        # guaranteed self-hit.
+        if rel == "scripts/check_claude_boundary.py":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for rule in rules:
+            if not rule.pattern.search(text):
+                continue
+            if (
+                rule.scope == "file"
+                and rule.require_also is not None
+                and not rule.require_also.search(text)
+            ):
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if not rule.pattern.search(line):
+                    continue
+                if (
+                    rule.scope == "line"
+                    and rule.require_also is not None
+                    and not rule.require_also.search(line)
+                ):
+                    continue
+                if SUPPRESS_MARKER.search(line):
+                    continue
+                allowed = any(rel == a or rel.startswith(a) for a in rule.allowlist)
+                rule.hits.append((rel, lineno, line.strip()))
+                if not allowed:
+                    violations += 1
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="also print allow-listed hits (the PR4 removal backlog)",
+    )
+    args = parser.parse_args(argv)
+
+    rules = RULES
+    scan(rules)
+
+    failed = False
+    for rule in rules:
+        unallowed = [
+            (rel, lineno, line)
+            for rel, lineno, line in rule.hits
+            if not any(rel == a or rel.startswith(a) for a in rule.allowlist)
+        ]
+        if unallowed:
+            failed = True
+            print(f"FAIL [{rule.name}]: {rule.message}")
+            for rel, lineno, line in unallowed:
+                print(f"    {rel}:{lineno}: {line}")
+            print()
+
+    if args.verbose:
+        for rule in rules:
+            allowed = [
+                (rel, lineno, line)
+                for rel, lineno, line in rule.hits
+                if any(rel == a or rel.startswith(a) for a in rule.allowlist)
+            ]
+            if allowed:
+                print(f"allow-listed [{rule.name}]:")
+                for rel, lineno, line in allowed:
+                    print(f"    {rel}:{lineno}: {line}")
+                print()
+
+    if failed:
+        print(
+            "Claude boundary check FAILED.\n"
+            "Hermes must not read Claude credentials, send a subscription token "
+            "to Anthropic directly, or impersonate Claude Code. Route "
+            "subscription inference through claude-agent-sdk, or add a "
+            "justified allow-list entry to this script if the code is part of "
+            "the legacy path being retired."
+        )
+        return 1
+
+    print("Claude boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_claude_boundary.py
+++ b/scripts/check_claude_boundary.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+"""
+Claude subscription boundary check.
+
+Hermes routes a Claude subscription through the official ``claude-agent-sdk``.
+The SDK owns the user's credentials; Hermes must not touch them, must not send
+a subscription token to Anthropic's API itself, and must not dress its requests
+up as Claude Code. This script makes those rules mechanical.
+
+Four rules, all fatal:
+
+  1. Credential access — no references to Claude/Anthropic credential stores
+     (``.credentials.json``, ``~/.claude.json``, ``.claude/.credentials``,
+     ``~/.anthropic/``).
+  2. Direct OAuth inference — no code path that sends a Claude
+     OAuth/subscription token to ``api.anthropic.com``. The API-key provider's
+     ``/v1/models`` and ``/v1/messages`` calls are legitimate and allowed; what
+     is forbidden is combining an Anthropic endpoint with
+     ``CLAUDE_CODE_OAUTH_TOKEN`` or a Claude-credential-derived token.
+  3. Identity spoofing — no ``claude-code/`` user-agent strings, no
+     ``x-app: cli`` header, no Claude Code beta flags, and no system-prompt or
+     tool-name rewriting that replaces "Hermes"/"Nous" to look like Claude Code.
+  4. ``CLAUDE_CODE_OAUTH_TOKEN`` reads outside the allow-list.
+
+Usage:
+    python scripts/check_claude_boundary.py            # scan the tree
+    python scripts/check_claude_boundary.py --verbose  # also list allow-list hits
+
+Exit status:
+    0 — no unallowed violations
+    1 — at least one violation
+
+Suppress a single intentional line with:
+    ...  # claude-boundary: ok — <why>
+
+ALLOW-LIST POLICY: every entry below names a file that still carries the
+pre-SDK direct-OAuth path, with a justification. Entries tagged
+``TODO(legacy-retirement)`` disappear when PR4 deletes that path — the check tightens
+automatically, without anyone remembering to tighten it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SUPPRESS_MARKER = re.compile(r"#\s*claude-boundary\s*:\s*ok\b", re.IGNORECASE)
+
+# Source roots that make up "Hermes source". Docs, the website, tests, and
+# vendored trees are out of scope: this guards shipped behavior, and tests
+# legitimately construct the very payloads the rules forbid in order to assert
+# on them.
+SOURCE_ROOTS = (
+    "acp_adapter",
+    "agent",
+    "apps",
+    "cron",
+    "gateway",
+    "hermes_cli",
+    "model_tools.py",
+    "plugins",
+    "providers",
+    "run_agent.py",
+    "tools",
+    "tui_gateway",
+    "utils.py",
+)
+
+SCANNED_SUFFIXES = {".py", ".ts", ".tsx", ".js", ".mjs", ".cjs"}
+
+EXCLUDED_DIR_NAMES = {
+    ".git",
+    "__pycache__",
+    "node_modules",
+    "dist",
+    "build",
+    "out",
+    ".venv",
+    "venv",
+    ".pytest_cache",
+    ".mypy_cache",
+}
+
+
+@dataclass
+class Rule:
+    """One boundary rule."""
+
+    name: str
+    pattern: re.Pattern
+    message: str
+    # Repo-relative path prefixes whose matches are tolerated. Each entry MUST
+    # carry a justification in ALLOWLIST_REASONS.
+    allowlist: tuple[str, ...] = ()
+    # Optional second pattern that must ALSO be present for a match to count.
+    require_also: re.Pattern | None = None
+    # "line" — both patterns must be on the same line.
+    # "file" — ``require_also`` may appear anywhere in the file. Needed for the
+    #   direct-OAuth rule: a request's URL, headers, and token rarely share a
+    #   line, so co-location in one module is the honest signal.
+    scope: str = "line"
+    hits: list[tuple[str, int, str]] = field(default_factory=list)
+
+
+# ── Allow-list justifications ───────────────────────────────────────────────
+# Keyed by repo-relative path prefix. Anything listed here is a KNOWN, CURRENT
+# violation that PR4 removes; the entry is the audit trail for why the build is
+# still green today.
+ALLOWLIST_REASONS: dict[str, str] = {
+    "agent/anthropic_adapter.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Holds the entire pre-SDK Claude path: the claude.ai PKCE flow, the "
+        "keychain/credential-file readers and writer, the spoofed Claude Code "
+        "user-agent / x-app / beta headers, and the prompt+tool-name rewriting. "
+        "It must keep working until the Agent SDK runtime replaces it."
+    ),
+    "agent/account_usage.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Reads the Claude subscription usage endpoint with a Claude Code "
+        "user-agent to render remaining plan quota."
+    ),
+    "agent/credential_pool.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Seeds and refreshes pooled Anthropic credentials from the Claude Code "
+        "credential singleton."
+    ),
+    "agent/credential_sources.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Declares the claude_code credential source so users can suppress it."
+    ),
+    "agent/credential_persistence.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Names the Claude Code credential file among the persistence targets."
+    ),
+    "agent/agent_init.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Sets a Claude Code user-agent on the legacy Anthropic client."
+    ),
+    "agent/auxiliary_client.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Side-LLM clients inherit the legacy Anthropic OAuth headers and "
+        "credential resolution."
+    ),
+    "run_agent.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Sets the legacy Anthropic client user-agent."
+    ),
+    "hermes_cli/doctor.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Probes the legacy Anthropic OAuth endpoint during diagnostics."
+    ),
+    "hermes_cli/auth.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The anthropic registry entry still lists CLAUDE_CODE_OAUTH_TOKEN so "
+        "existing users keep resolving while the old path is live."
+    ),
+    "hermes_cli/config.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Documents CLAUDE_CODE_OAUTH_TOKEN in OPTIONAL_ENV_VARS and offers the "
+        "legacy 'use my Claude Code credentials' setup step."
+    ),
+    "hermes_cli/web_server.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Hosts the dashboard's Anthropic PKCE endpoints, which mint and store a "
+        "claude.ai OAuth token."
+    ),
+    "hermes_cli/main.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The `hermes model` Claude subscription flow shells out to the legacy "
+        "token-setup command."
+    ),
+    "hermes_cli/model_setup_flows.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Same legacy Claude subscription setup flow as hermes_cli/main.py."
+    ),
+    "hermes_cli/credential_lifecycle.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Enumerates the claude_code credential source for list/remove verbs."
+    ),
+    "hermes_cli/models.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "Stats the Claude credential file's mtime to invalidate a provider "
+        "cache key; it reads no contents, but the reference goes with the path."
+    ),
+    "hermes_cli/setup.py": (
+        "TODO(legacy-retirement): remove when the direct-OAuth path is deleted (after subscription enablement; see decision record §3). "
+        "The setup wizard skips prompting for CLAUDE_CODE_OAUTH_TOKEN because "
+        "Claude Code sets it."
+    ),
+    "hermes_cli/agent_import.py": (
+        "Not a boundary violation: `hermes import-agent claude-code` copies a "
+        "user's own agent config (skills, memory, settings) out of ~/.claude. "
+        "It reads no credential and performs no inference."
+    ),
+    "tools/environments/local.py": (
+        "Not a boundary violation: the terminal sandbox's env blocklist "
+        "deliberately does NOT strip CLAUDE_CODE_OAUTH_TOKEN, so an "
+        "agent-spawned `claude` CLI keeps using the user's own login instead "
+        "of falling through and clearing their credentials (#55878). This is "
+        "passthrough of the user's environment, not Hermes reading a token."
+    ),
+}
+
+# ── Rules ───────────────────────────────────────────────────────────────────
+
+_CREDENTIAL_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/credential_pool.py",
+    "agent/credential_sources.py",
+    "agent/credential_persistence.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/agent_import.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/config.py",
+    "hermes_cli/credential_lifecycle.py",
+    "hermes_cli/main.py",
+    "hermes_cli/models.py",
+    "hermes_cli/web_server.py",
+    "run_agent.py",
+    "tools/environments/local.py",
+)
+
+_OAUTH_INFERENCE_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/account_usage.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/doctor.py",
+    "hermes_cli/web_server.py",
+)
+
+_SPOOF_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/account_usage.py",
+    "agent/agent_init.py",
+    "agent/auxiliary_client.py",
+    "hermes_cli/doctor.py",
+    "run_agent.py",
+)
+
+_OAUTH_ENV_ALLOW = (
+    "agent/anthropic_adapter.py",
+    "agent/credential_pool.py",
+    "hermes_cli/auth.py",
+    "hermes_cli/config.py",
+    "hermes_cli/setup.py",
+    "hermes_cli/web_server.py",
+    "tools/environments/local.py",
+)
+
+RULES: list[Rule] = [
+    # ── Rule 1: credential access ───────────────────────────────────────────
+    Rule(
+        name="claude-credential-file",
+        pattern=re.compile(
+            r"\.credentials\.json"
+            r"|\.claude/\.credentials"
+            r"|~/\.claude\.json"
+            r"|\.anthropic/"
+        ),
+        message=(
+            "references a Claude/Anthropic credential store. The Agent SDK owns "
+            "those files — Hermes never reads, writes, or deletes them."
+        ),
+        allowlist=_CREDENTIAL_ALLOW,
+    ),
+    Rule(
+        name="claude-keychain-entry",
+        pattern=re.compile(r"Claude Code-credentials"),
+        message=(
+            "touches the Claude Code macOS keychain entry. Use `claude auth "
+            "login` / `claude auth logout` instead."
+        ),
+        allowlist=_CREDENTIAL_ALLOW,
+    ),
+    # ── Rule 2: direct OAuth inference ──────────────────────────────────────
+    # api.anthropic.com by itself is fine (the API-key provider's /v1/models
+    # and /v1/messages). The violation is an Anthropic endpoint on the same
+    # line as a Claude subscription token.
+    Rule(
+        name="anthropic-endpoint-with-claude-token",
+        pattern=re.compile(
+            r"api\.anthropic\.com|claude\.ai/oauth|platform\.claude\.com/v1/"
+        ),
+        # Symbols that denote a CLAUDE SUBSCRIPTION credential specifically —
+        # not "any Anthropic credential". Broader names (resolve_anthropic_token,
+        # generic *oauth_token*) also cover the legitimate API-key path and
+        # would flag every module that merely knows Anthropic's hostname.
+        require_also=re.compile(
+            r"CLAUDE_CODE_OAUTH_TOKEN"
+            r"|read_claude_code_credentials"
+            r"|_write_claude_code_credentials"
+            r"|refresh_anthropic_oauth"
+            r"|Claude Code-credentials"
+        ),
+        scope="file",
+        message=(
+            "sends a Claude OAuth/subscription token to an Anthropic endpoint. "
+            "Subscription inference must go through claude-agent-sdk. (An "
+            "Anthropic endpoint on its own is fine — the API-key provider's "
+            "/v1/models and /v1/messages calls are legitimate.)"
+        ),
+        allowlist=_OAUTH_INFERENCE_ALLOW,
+    ),
+    # ── Rule 3: identity spoofing ───────────────────────────────────────────
+    Rule(
+        name="claude-code-user-agent",
+        pattern=re.compile(r"""claude-code/(?:\d|\{|\$|"|')"""),
+        message=(
+            "sets a claude-code/<version> user-agent. Hermes must identify as "
+            "Hermes; the SDK sets its own identity."
+        ),
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-cli-app-header",
+        pattern=re.compile(r"""["']x-app["']\s*:\s*["']cli["']"""),
+        message="sets the Claude Code `x-app: cli` header.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-beta-flag",
+        pattern=re.compile(r"claude-code-\d{8}|oauth-\d{4}-\d{2}-\d{2}"),
+        message="sends a Claude Code OAuth-only beta flag.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-identity-rewrite",
+        pattern=re.compile(
+            r"""["'](?:Hermes(?:\s+Agent)?|Nous(?:\s+Research)?)["']\s*,\s*["']"""
+            r"""(?:Claude Code|Anthropic)["']"""
+        ),
+        message=(
+            "rewrites Hermes/Nous branding into Claude Code/Anthropic. Hermes "
+            "does not impersonate another client to change how it is billed."
+        ),
+        allowlist=_SPOOF_ALLOW,
+    ),
+    Rule(
+        name="claude-code-system-prompt",
+        pattern=re.compile(r"You are Claude Code"),
+        message="injects Claude Code's system-prompt identity.",
+        allowlist=_SPOOF_ALLOW,
+    ),
+    # ── Rule 4: CLAUDE_CODE_OAUTH_TOKEN reads ───────────────────────────────
+    Rule(
+        name="claude-oauth-token-env",
+        pattern=re.compile(r"CLAUDE_CODE_OAUTH_TOKEN"),
+        message=(
+            "reads CLAUDE_CODE_OAUTH_TOKEN. The Claude subscription provider "
+            "holds no credential — the SDK resolves auth itself."
+        ),
+        allowlist=_OAUTH_ENV_ALLOW,
+    ),
+]
+
+
+def _iter_source_files() -> Iterable[Path]:
+    """Yield every scannable Hermes source file."""
+    for root_name in SOURCE_ROOTS:
+        root = REPO_ROOT / root_name
+        if root.is_file():
+            if root.suffix in SCANNED_SUFFIXES:
+                yield root
+            continue
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.suffix not in SCANNED_SUFFIXES or not path.is_file():
+                continue
+            if any(part in EXCLUDED_DIR_NAMES for part in path.parts):
+                continue
+            yield path
+
+
+def _rel(path: Path) -> str:
+    try:
+        return path.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def scan(rules: list[Rule]) -> int:
+    """Populate ``rule.hits`` and return the number of unallowed violations."""
+    violations = 0
+    for path in _iter_source_files():
+        rel = _rel(path)
+        # This script names every pattern it forbids; scanning it would be a
+        # guaranteed self-hit.
+        if rel == "scripts/check_claude_boundary.py":
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for rule in rules:
+            if not rule.pattern.search(text):
+                continue
+            if (
+                rule.scope == "file"
+                and rule.require_also is not None
+                and not rule.require_also.search(text)
+            ):
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if not rule.pattern.search(line):
+                    continue
+                if (
+                    rule.scope == "line"
+                    and rule.require_also is not None
+                    and not rule.require_also.search(line)
+                ):
+                    continue
+                if SUPPRESS_MARKER.search(line):
+                    continue
+                allowed = any(rel == a or rel.startswith(a) for a in rule.allowlist)
+                rule.hits.append((rel, lineno, line.strip()))
+                if not allowed:
+                    violations += 1
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="also print allow-listed hits (the PR4 removal backlog)",
+    )
+    args = parser.parse_args(argv)
+
+    rules = RULES
+    scan(rules)
+
+    failed = False
+    for rule in rules:
+        unallowed = [
+            (rel, lineno, line)
+            for rel, lineno, line in rule.hits
+            if not any(rel == a or rel.startswith(a) for a in rule.allowlist)
+        ]
+        if unallowed:
+            failed = True
+            print(f"FAIL [{rule.name}]: {rule.message}")
+            for rel, lineno, line in unallowed:
+                print(f"    {rel}:{lineno}: {line}")
+            print()
+
+    if args.verbose:
+        for rule in rules:
+            allowed = [
+                (rel, lineno, line)
+                for rel, lineno, line in rule.hits
+                if any(rel == a or rel.startswith(a) for a in rule.allowlist)
+            ]
+            if allowed:
+                print(f"allow-listed [{rule.name}]:")
+                for rel, lineno, line in allowed:
+                    print(f"    {rel}:{lineno}: {line}")
+                print()
+
+    if failed:
+        print(
+            "Claude boundary check FAILED.\n"
+            "Hermes must not read Claude credentials, send a subscription token "
+            "to Anthropic directly, or impersonate Claude Code. Route "
+            "subscription inference through claude-agent-sdk, or add a "
+            "justified allow-list entry to this script if the code is part of "
+            "the legacy path being retired."
+        )
+        return 1
+
+    print("Claude boundary check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_claude_billing_source.py
+++ b/scripts/verify_claude_billing_source.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""Manual, opt-in check of which account a Claude subscription turn would bill.
+
+Nothing calls this. It exists so a maintainer can verify the billing source on
+a real machine, deliberately, and see exactly what each step costs.
+
+Two modes:
+
+``--probe`` (default, free)
+    Connects the Claude Agent SDK to the CLI through Hermes' sanitized-launch
+    transport, reads the CLI's own initialize response, and disconnects. No
+    user message is ever written to the child, so no model request is made:
+    it consumes no tokens and no plan quota. Prints the environment Hermes
+    would hand the child, which credentials were stripped, and how the CLI
+    classified the account.
+
+``--live-turn`` (COSTS QUOTA — never run this in CI or a test)
+    Sends one tiny real prompt so the turn appears in the account's usage.
+    This is the only way to prove the billing *bucket* end to end; a maintainer
+    then confirms it landed on the plan, not on the Console org, by checking
+    claude.ai usage and console.anthropic.com usage after the run.
+
+Usage::
+
+    python scripts/verify_claude_billing_source.py            # free probe
+    python scripts/verify_claude_billing_source.py --live-turn --yes
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from agent.claude_billing import (  # noqa: E402
+    BLOCKED_CHILD_ENV_VARS,
+    blocking_credentials,
+    classify_account,
+    sanitized_child_env,
+    static_billing_refusal,
+)
+
+LIVE_BANNER = """
+================================================================================
+  --live-turn sends ONE REAL PROMPT to Claude.
+
+  It consumes quota on whichever account the CLI resolves — your Claude plan
+  if everything below is configured correctly, your Anthropic Console org if
+  it is not. That is the thing being tested, so it cannot be avoided.
+
+  Re-run with --yes to proceed.
+================================================================================
+"""
+
+
+def report_environment() -> int:
+    print("== environment Hermes would hand the Claude CLI ==")
+    stripped = sorted(k for k in BLOCKED_CHILD_ENV_VARS if k in os.environ)
+    child = sanitized_child_env()
+    print(f"  parent variables:      {len(os.environ)}")
+    print(f"  child variables:       {len(child)}")
+    print(f"  stripped:              {', '.join(stripped) or '(none present)'}")
+    print(f"  CLAUDE_CONFIG_DIR:     {'passed through' if 'CLAUDE_CONFIG_DIR' in os.environ else 'not set'}")
+    print(f"  HOME:                  {'unchanged' if child.get('HOME') == os.environ.get('HOME') else 'CHANGED — bug'}")
+
+    print("\n== static precedence check ==")
+    slots = blocking_credentials()
+    if slots:
+        for slot in slots:
+            print(f"  BLOCKING  {slot.name} (precedence rank {slot.rank}) — {slot.fix}")
+    else:
+        print("  nothing outranks the subscription")
+
+    refusal = static_billing_refusal()
+    if refusal:
+        print("\n" + refusal)
+        return 1
+    return 0
+
+
+def run_probe() -> int:
+    from agent.transports.claude_sanitized_transport import build_sanitized_transport
+
+    try:
+        from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+    except ImportError:
+        print("claude-agent-sdk is not installed: pip install 'hermes-agent[claude-code]'")
+        return 2
+
+    options = ClaudeAgentOptions(tools=[], allowed_tools=[], setting_sources=[])
+
+    async def _go() -> dict:
+        client = ClaudeSDKClient(
+            options=options, transport=build_sanitized_transport(options)
+        )
+        await client.connect()
+        try:
+            info = await client.get_server_info()
+        finally:
+            await client.disconnect()
+        return (info or {}).get("account") or {}
+
+    print("\n== zero-cost init probe (no model request) ==")
+    account = asyncio.run(_go())
+    print("  CLI account payload:", json.dumps(account, default=str))
+    source = classify_account(account)
+    print(f"  classified as:       {source.kind}")
+    if source.plan:
+        print(f"  plan:                {source.plan}")
+    if source.account:
+        print(f"  account:             {source.account}")
+    if source.detail:
+        print(f"  decided by:          {source.detail}")
+    return 0 if source.is_subscription else 1
+
+
+def run_live_turn() -> int:
+    from agent.transports.claude_sanitized_transport import build_sanitized_transport
+
+    from claude_agent_sdk import ClaudeAgentOptions, ClaudeSDKClient
+
+    options = ClaudeAgentOptions(tools=[], allowed_tools=[], setting_sources=[])
+
+    async def _go() -> None:
+        client = ClaudeSDKClient(
+            options=options, transport=build_sanitized_transport(options)
+        )
+        await client.connect()
+        try:
+            await client.query("Reply with the single word: ok")
+            async for message in client.receive_response():
+                print("  ", type(message).__name__, getattr(message, "result", ""))
+        finally:
+            await client.disconnect()
+
+    print("\n== live turn (BILLED) ==")
+    asyncio.run(_go())
+    print(
+        "\nNow confirm the bucket by hand:\n"
+        "  • claude.ai → Settings → Usage should show this turn\n"
+        "  • console.anthropic.com → Usage should NOT show it"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--probe", action="store_true", help="free init probe (default)")
+    parser.add_argument(
+        "--live-turn", action="store_true", help="send one real, billed prompt"
+    )
+    parser.add_argument("--yes", action="store_true", help="confirm --live-turn")
+    args = parser.parse_args(argv)
+
+    status = report_environment()
+    if status:
+        return status
+
+    if args.live_turn:
+        if not args.yes:
+            print(LIVE_BANNER)
+            return 2
+        if run_probe():
+            print("Refusing --live-turn: the probe says this would not bill the plan.")
+            return 1
+        return run_live_turn()
+
+    return run_probe()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/agent/test_claude_agent_session.py
+++ b/tests/agent/test_claude_agent_session.py
@@ -1,0 +1,369 @@
+"""Contract for the synchronous facade over the async Claude Agent SDK.
+
+The facade owns one event-loop thread per session, so these tests care about
+threading behavior: messages must land on the caller's thread, the stream must
+be drained past ``ResultMessage``, an interrupt must leave the session usable,
+and teardown must leave no live thread.
+
+``claude-agent-sdk`` is an optional extra. Every test here injects a fake
+client through ``client_factory``, so the suite is green with or without the
+real package installed — the facade only imports the SDK when it has to build
+its own client.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+from agent.transports.claude_agent_session import (
+    ClaudeAgentSession,
+    ClaudeAgentSessionError,
+    is_result_message,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK client
+# ---------------------------------------------------------------------------
+
+
+class _Msg:
+    """Base for the fake message types; the facade dispatches on class name."""
+
+    def __init__(self, tag: str = "") -> None:
+        self.tag = tag
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"{type(self).__name__}({self.tag!r})"
+
+
+class AssistantMessage(_Msg):
+    pass
+
+
+class ResultMessage(_Msg):
+    pass
+
+
+class FakeClient:
+    """Scriptable stand-in for ``ClaudeSDKClient``.
+
+    ``scripts`` is a list of per-query message lists. Each entry may hold a
+    float, which the fake awaits before emitting the next message — that is how
+    a test makes trailing frames arrive *after* the ``ResultMessage``.
+    """
+
+    def __init__(self, *, options=None, scripts=None):
+        self.options = options
+        self._scripts = list(scripts or [])
+        self.queries = []
+        self.connected = False
+        self.disconnected = False
+        self.interrupts = 0
+        self.models = []
+        self.loops = set()
+        self._pending = []
+
+    async def connect(self, prompt=None):
+        self.connected = True
+        self.loops.add(asyncio.get_running_loop())
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def query(self, prompt, session_id="default"):
+        self.loops.add(asyncio.get_running_loop())
+        self.queries.append(prompt)
+        self._pending = list(self._scripts.pop(0)) if self._scripts else []
+
+    async def interrupt(self):
+        self.interrupts += 1
+        # A real interrupt still terminates the response with a result.
+        self._pending = [ResultMessage("interrupted")]
+
+    async def set_model(self, model=None):
+        self.models.append(model)
+
+    async def receive_messages(self):
+        while True:
+            if not self._pending:
+                # Idle forever, like the real stream between responses.
+                await asyncio.sleep(0.01)
+                continue
+            item = self._pending.pop(0)
+            if isinstance(item, float):
+                await asyncio.sleep(item)
+                continue
+            yield item
+
+
+def _session(scripts, **kwargs):
+    client = FakeClient(scripts=scripts)
+    kwargs.setdefault("trailing_drain_seconds", 0.2)
+    session = ClaudeAgentSession(
+        options_factory=lambda: {"marker": "opts"},
+        client_factory=lambda **kw: client,
+        **kwargs,
+    )
+    return session, client
+
+
+def _collect(session, prompt, **kwargs):
+    seen = []
+    session.run_turn(prompt, on_message=seen.append, **kwargs)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Startup
+# ---------------------------------------------------------------------------
+
+
+def test_result_message_is_recognised_by_class_name():
+    assert is_result_message(ResultMessage()) is True
+    assert is_result_message(AssistantMessage()) is False
+
+
+def test_start_is_idempotent_and_connects_exactly_once():
+    session, client = _session([[ResultMessage()]])
+    try:
+        session.ensure_started()
+        session.ensure_started()
+        assert client.connected is True
+        assert session.started is True
+    finally:
+        session.close()
+
+
+def test_client_lives_on_one_loop_that_the_session_created():
+    session, client = _session([[ResultMessage("a")], [ResultMessage("b")]])
+    try:
+        _collect(session, "one")
+        _collect(session, "two")
+        # Every await the client saw ran on the same, session-owned loop.
+        assert len(client.loops) == 1
+        assert asyncio.get_event_loop_policy() is not None
+    finally:
+        session.close()
+
+
+def test_module_imports_without_the_optional_sdk():
+    import agent.transports.claude_agent_session as mod
+
+    assert "claude_agent_sdk" not in mod.__dict__
+
+
+# ---------------------------------------------------------------------------
+# Turn semantics
+# ---------------------------------------------------------------------------
+
+
+def test_messages_are_delivered_in_order_on_the_calling_thread():
+    session, _client = _session(
+        [[AssistantMessage("1"), AssistantMessage("2"), ResultMessage("3")]]
+    )
+    threads = []
+
+    def _on_message(message):
+        threads.append(threading.current_thread())
+
+    try:
+        seen = []
+        session.run_turn(
+            "hi",
+            on_message=lambda m: (seen.append(m.tag), _on_message(m)),
+        )
+    finally:
+        session.close()
+
+    assert [m for m in seen] == ["1", "2", "3"]
+    assert set(threads) == {threading.current_thread()}
+
+
+def test_trailing_events_after_the_result_message_are_not_truncated():
+    """Stopping at ResultMessage drops frames the CLI flushes right after it."""
+    session, _client = _session(
+        [
+            [
+                AssistantMessage("body"),
+                ResultMessage("done"),
+                0.02,
+                AssistantMessage("trailing"),
+            ]
+        ]
+    )
+    try:
+        seen = _collect(session, "hi")
+    finally:
+        session.close()
+
+    assert [m.tag for m in seen] == ["body", "done", "trailing"]
+
+
+def test_the_turn_ends_once_the_stream_goes_quiet_after_the_result():
+    session, _client = _session([[ResultMessage("done")]])
+    try:
+        started = time.monotonic()
+        seen = _collect(session, "hi")
+        elapsed = time.monotonic() - started
+    finally:
+        session.close()
+
+    assert [m.tag for m in seen] == ["done"]
+    # Bounded by the trailing-drain grace, not by the turn deadline.
+    assert elapsed < 5.0
+
+
+def test_consecutive_turns_reuse_the_same_client():
+    session, client = _session([[ResultMessage("a")], [ResultMessage("b")]])
+    try:
+        _collect(session, "first")
+        _collect(session, "second")
+    finally:
+        session.close()
+
+    assert client.queries == ["first", "second"]
+    assert session.turn_count == 2
+
+
+def test_an_sdk_error_propagates_to_the_caller():
+    class Boom(FakeClient):
+        async def query(self, prompt, session_id="default"):
+            raise RuntimeError("cli exploded")
+
+    client = Boom()
+    session = ClaudeAgentSession(
+        options_factory=dict, client_factory=lambda **kw: client
+    )
+    try:
+        with pytest.raises(RuntimeError, match="cli exploded"):
+            _collect(session, "hi")
+    finally:
+        session.close()
+
+
+def test_a_turn_that_never_completes_raises_timeout_rather_than_hanging():
+    session, _client = _session([[AssistantMessage("partial")]])
+    try:
+        with pytest.raises(TimeoutError):
+            _collect(session, "hi", timeout=0.4)
+    finally:
+        session.close()
+
+
+# ---------------------------------------------------------------------------
+# Interrupt
+# ---------------------------------------------------------------------------
+
+
+def test_interrupt_then_drain_leaves_the_session_usable():
+    session, client = _session(
+        [
+            # First turn stalls; the interrupt below supplies its terminator.
+            [AssistantMessage("working"), 5.0, AssistantMessage("never")],
+            [ResultMessage("second-turn")],
+        ]
+    )
+    try:
+        session.ensure_started()
+
+        def _interrupt_soon():
+            time.sleep(0.15)
+            session.request_interrupt()
+
+        threading.Thread(target=_interrupt_soon, daemon=True).start()
+        first = _collect(session, "long task", timeout=10.0)
+
+        # The interrupted response was drained to its terminal result before
+        # the next query went out — skipping that drain wedges the session.
+        assert client.interrupts == 1
+        assert is_result_message(first[-1])
+
+        second = _collect(session, "follow-up", timeout=10.0)
+        assert [m.tag for m in second] == ["second-turn"]
+        assert client.queries == ["long task", "follow-up"]
+    finally:
+        session.close()
+
+
+def test_interrupt_before_start_is_a_no_op():
+    session, _client = _session([[ResultMessage()]])
+    assert session.request_interrupt() is False
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+
+def _session_threads():
+    return [t for t in threading.enumerate() if t.name == "hermes-claude-agent-sdk"]
+
+
+def test_close_is_idempotent_and_leaves_no_live_thread():
+    before = len(_session_threads())
+    session, client = _session([[ResultMessage()]])
+    _collect(session, "hi")
+    assert len(_session_threads()) == before + 1
+
+    session.close()
+    session.close()
+    session.close()
+
+    assert client.disconnected is True
+    assert session.closed is True
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and len(_session_threads()) > before:
+        time.sleep(0.02)
+    assert len(_session_threads()) == before
+
+
+def test_a_closed_session_refuses_to_restart():
+    session, _client = _session([[ResultMessage()]])
+    session.close()
+    with pytest.raises(ClaudeAgentSessionError):
+        session.ensure_started()
+
+
+def test_close_without_ever_starting_is_safe():
+    session, client = _session([[ResultMessage()]])
+    session.close()
+    assert client.connected is False
+    assert client.disconnected is False
+
+
+def test_context_manager_starts_and_closes():
+    session, client = _session([[ResultMessage("x")]])
+    with session as live:
+        assert live.started is True
+    assert client.disconnected is True
+    assert session.closed is True
+
+
+# ---------------------------------------------------------------------------
+# Session id (PR5 seam)
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_is_recorded_for_resume():
+    session, _client = _session([[ResultMessage()]])
+    try:
+        assert session.session_id is None
+        session.note_session_id("sdk-session-abc")
+        assert session.session_id == "sdk-session-abc"
+        session.note_session_id(None)
+        assert session.session_id == "sdk-session-abc"
+    finally:
+        session.close()
+
+
+def test_set_model_round_trips_to_the_client():
+    session, client = _session([[ResultMessage()]])
+    try:
+        session.ensure_started()
+        assert session.set_model("claude-opus-4-5") is True
+        assert client.models == ["claude-opus-4-5"]
+    finally:
+        session.close()

--- a/tests/agent/test_claude_auxiliary.py
+++ b/tests/agent/test_claude_auxiliary.py
@@ -1,0 +1,646 @@
+"""Contract for the one-shot Claude Agent SDK auxiliary adapter.
+
+Five things are pinned down here:
+
+1. An auxiliary call in subscription mode goes through the SDK and **never**
+   through the pre-SDK direct-OAuth HTTP adapter.
+2. The adapter exposes no tools and cannot touch the conversation's session.
+3. An explicit ``anthropic`` API-key auxiliary config is completely unaffected.
+4. The result is the same OpenAI-shaped object every other auxiliary transport
+   returns, so no call site in ``auxiliary_client.py`` has to special-case it.
+5. Image input either goes out on the SDK's streaming-input path or fails with
+   a message naming ``auxiliary.vision`` — never silently dropped.
+
+``claude-agent-sdk`` is an optional extra. Every test that makes a call installs
+a fake ``claude_agent_sdk`` module, so the suite behaves identically with and
+without the real package (and never touches the network either way). The two
+tests that inspect the *real* package's signature skip when it is absent.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent import claude_auxiliary, claude_sdk_input
+from agent.claude_auxiliary import (
+    ClaudeAuxiliaryError,
+    build_claude_auxiliary_client,
+    build_claude_auxiliary_options,
+    is_claude_subscription_provider,
+    split_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeClaudeAgentOptions:
+    system_prompt: Any = None
+    tools: Any = None
+    allowed_tools: list = field(default_factory=list)
+    mcp_servers: dict = field(default_factory=dict)
+    strict_mcp_config: bool = False
+    setting_sources: Any = None
+    max_turns: Any = None
+    model: Any = None
+    permission_mode: Any = None
+    include_partial_messages: bool = False
+    continue_conversation: bool = False
+    resume: Any = None
+    fork_session: bool = False
+    session_store: Any = None
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str = "claude-sonnet-5"
+
+
+@dataclass
+class ResultMessage:
+    result: str = ""
+    usage: dict | None = None
+    session_id: str = "sdk-throwaway-session"
+    is_error: bool = False
+
+
+class _Recorder:
+    """Captures what the adapter handed the SDK."""
+
+    def __init__(self) -> None:
+        self.prompts: list = []
+        self.options: list = []
+        self.calls = 0
+
+
+def _install_fake_sdk(monkeypatch, *, messages=None, recorder=None, delay=0.0):
+    """Install a fake ``claude_agent_sdk`` and return its recorder."""
+    recorder = recorder or _Recorder()
+    payload = list(
+        messages
+        if messages is not None
+        else [
+            AssistantMessage(content=[TextBlock("a title")]),
+            ResultMessage(result="a title", usage={"input_tokens": 11, "output_tokens": 3}),
+        ]
+    )
+
+    async def _query(*, prompt, options=None, transport=None):
+        recorder.calls += 1
+        # A streaming prompt is an async iterable; materialise it exactly as the
+        # real SDK does so the test sees the frames that would hit the CLI.
+        if isinstance(prompt, str):
+            recorder.prompts.append(prompt)
+        else:
+            frames = [frame async for frame in prompt]
+            recorder.prompts.append(frames)
+        recorder.options.append(options)
+        if delay:
+            import asyncio
+
+            await asyncio.sleep(delay)
+        for message in payload:
+            yield message
+
+    class _FakeSDKClient:
+        async def query(self, prompt, session_id="default"):  # pragma: no cover
+            raise AssertionError("the auxiliary path must not use ClaudeSDKClient")
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.ClaudeAgentOptions = FakeClaudeAgentOptions
+    module.query = _query
+    module.ClaudeSDKClient = _FakeSDKClient
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    return recorder
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    return _install_fake_sdk(monkeypatch)
+
+
+@pytest.fixture
+def sdk_absent(monkeypatch):
+    """Make ``import claude_agent_sdk`` fail, as it does without the extra."""
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+
+
+@pytest.fixture
+def streaming_input_supported(monkeypatch):
+    monkeypatch.setattr(claude_sdk_input, "sdk_supports_streaming_input", lambda: True)
+    monkeypatch.setattr(claude_auxiliary, "sdk_supports_streaming_input", lambda: True)
+
+
+@pytest.fixture
+def streaming_input_unsupported(monkeypatch):
+    monkeypatch.setattr(claude_sdk_input, "sdk_supports_streaming_input", lambda: False)
+    monkeypatch.setattr(claude_auxiliary, "sdk_supports_streaming_input", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# Options — no tools, no session state
+# ---------------------------------------------------------------------------
+
+
+class TestOptions:
+    def test_no_tools_of_any_kind(self, fake_sdk):
+        options = build_claude_auxiliary_options(
+            system_prompt="be terse", model="claude-sonnet-5"
+        )
+        assert options.tools == []
+        assert options.allowed_tools == []
+        assert options.mcp_servers == {}
+        # Without strict mode a project .mcp.json could reintroduce a toolset.
+        assert options.strict_mcp_config is True
+        # Without this the CLI loads settings, hooks, skills and plugins.
+        assert options.setting_sources == []
+
+    def test_bounded(self, fake_sdk):
+        options = build_claude_auxiliary_options(system_prompt=None, model=None)
+        assert options.max_turns == claude_auxiliary.CLAUDE_AUX_MAX_TURNS
+        assert options.max_turns >= 1
+
+    def test_carries_no_conversation_session_state(self, fake_sdk):
+        options = build_claude_auxiliary_options(system_prompt=None, model=None)
+        assert options.resume is None
+        assert options.continue_conversation is False
+        assert options.fork_session is False
+        assert options.session_store is None
+        assert getattr(options, "session_id", None) is None
+
+    def test_real_sdk_accepts_the_option_set(self):
+        """The locked-down option set must be constructible on the real SDK."""
+        pytest.importorskip("claude_agent_sdk")
+        options = build_claude_auxiliary_options(
+            system_prompt="hi", model="claude-sonnet-5"
+        )
+        assert options.tools == []
+        assert options.strict_mcp_config is True
+        assert options.setting_sources == []
+        assert options.resume is None
+
+
+class TestMissingExtra:
+    def test_actionable_import_error(self, sdk_absent):
+        with pytest.raises(ImportError) as excinfo:
+            build_claude_auxiliary_client("claude-sonnet-5")
+        message = str(excinfo.value)
+        assert "claude-code" in message
+        assert "pip install" in message
+
+    def test_options_also_report_the_missing_extra(self, sdk_absent):
+        with pytest.raises(ImportError):
+            build_claude_auxiliary_options(system_prompt=None, model=None)
+
+
+# ---------------------------------------------------------------------------
+# The call
+# ---------------------------------------------------------------------------
+
+
+class TestOneShotCall:
+    def test_returns_openai_shaped_response(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        response = client.chat.completions.create(
+            model="claude-sonnet-5",
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "title this"},
+            ],
+        )
+        assert response.choices[0].message.content == "a title"
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].finish_reason == "stop"
+        assert response.usage.prompt_tokens == 11
+        assert response.usage.completion_tokens == 3
+        assert response.usage.total_tokens == 14
+
+    def test_system_message_becomes_an_option_not_a_turn(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "title this"},
+            ]
+        )
+        assert fake_sdk.options[0].system_prompt == "be terse"
+        assert fake_sdk.prompts == ["title this"]
+
+    def test_uses_one_shot_query_not_a_client(self, fake_sdk):
+        """``ClaudeSDKClient`` would mean a second long-lived CLI subprocess."""
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert fake_sdk.calls == 1
+
+    def test_tools_are_refused_loudly(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "terminal"}}],
+            )
+        assert "no tools" in str(excinfo.value)
+        assert fake_sdk.calls == 0
+
+    def test_stream_request_degrades_to_a_complete_response(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        response = client.chat.completions.create(
+            messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+        assert response.choices[0].message.content == "a title"
+
+    def test_sdk_error_result_raises(self, monkeypatch):
+        _install_fake_sdk(
+            monkeypatch,
+            messages=[ResultMessage(result="rate limited", is_error=True)],
+        )
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert "rate limited" in str(excinfo.value)
+
+    def test_timeout_is_bounded_and_reported(self, monkeypatch):
+        _install_fake_sdk(monkeypatch, delay=5.0)
+        client = build_claude_auxiliary_client("claude-sonnet-5", timeout=0.2)
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert "timed out" in str(excinfo.value)
+
+    def test_no_worker_thread_survives_a_call(self, fake_sdk):
+        import threading
+
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert not [
+            t for t in threading.enumerate() if t.name == "hermes-claude-aux" and t.is_alive()
+        ]
+
+
+class TestSessionIsolation:
+    def test_does_not_mutate_the_conversation_session_id(self, fake_sdk):
+        """The SDK mints a throwaway session; the conversation keeps its own."""
+        agent = SimpleNamespace(_claude_sdk_session_id="conversation-session")
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert agent._claude_sdk_session_id == "conversation-session"
+        assert fake_sdk.options[0].resume is None
+        assert getattr(fake_sdk.options[0], "session_id", None) is None
+
+    def test_streaming_frame_carries_no_session_id(
+        self, monkeypatch, streaming_input_supported
+    ):
+        """A pinned session_id is exactly how an aux call would leak into chat."""
+        recorder = _install_fake_sdk(monkeypatch)
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,QUJD"},
+                        },
+                    ],
+                }
+            ]
+        )
+        frames = recorder.prompts[0]
+        assert isinstance(frames, list)
+        assert "session_id" not in frames[0]
+
+
+# ---------------------------------------------------------------------------
+# Message flattening
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMessages:
+    def test_single_user_turn_passes_through(self):
+        system, content = split_messages([{"role": "user", "content": "hi"}])
+        assert system is None
+        assert content == "hi"
+
+    def test_system_turns_are_hoisted(self):
+        system, content = split_messages(
+            [
+                {"role": "system", "content": "rule one"},
+                {"role": "system", "content": "rule two"},
+                {"role": "user", "content": "go"},
+            ]
+        )
+        assert system == "rule one\n\nrule two"
+        assert content == "go"
+
+    def test_multi_turn_examples_are_kept_not_dropped(self):
+        system, content = split_messages(
+            [
+                {"role": "user", "content": "example in"},
+                {"role": "assistant", "content": "example out"},
+                {"role": "user", "content": "real one"},
+            ]
+        )
+        assert system is None
+        assert "example in" in content
+        assert "example out" in content
+        assert "real one" in content
+
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+
+
+class TestImages:
+    def test_streaming_probe_matches_the_installed_sdk(self):
+        pytest.importorskip("claude_agent_sdk")
+        # 0.2.128 takes ``str | AsyncIterable[dict]`` on both entry points.
+        assert claude_sdk_input.sdk_supports_streaming_input() is True
+
+    def test_probe_is_false_without_the_extra(self, sdk_absent):
+        assert claude_sdk_input.sdk_supports_streaming_input() is False
+
+    def test_probe_is_false_for_a_string_only_build(self, monkeypatch):
+        async def _query(*, prompt: str, options=None, transport=None):  # noqa: ARG001
+            yield None
+
+        class _Client:
+            async def query(self, prompt: str, session_id="default"):
+                pass
+
+        module = types.ModuleType("claude_agent_sdk")
+        module.query = _query
+        module.ClaudeSDKClient = _Client
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+        assert claude_sdk_input.sdk_supports_streaming_input() is False
+
+    def test_image_goes_out_as_an_anthropic_block(
+        self, monkeypatch, streaming_input_supported
+    ):
+        recorder = _install_fake_sdk(monkeypatch)
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/jpeg;base64,QUJD"},
+                        },
+                    ],
+                }
+            ]
+        )
+        frames = recorder.prompts[0]
+        blocks = frames[0]["message"]["content"]
+        assert blocks[0] == {"type": "text", "text": "describe"}
+        assert blocks[1] == {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/jpeg", "data": "QUJD"},
+        }
+
+    def test_unsupported_build_names_the_vision_config(
+        self, fake_sdk, streaming_input_unsupported
+    ):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "data:image/png;base64,QUJD"},
+                            }
+                        ],
+                    }
+                ]
+            )
+        message = str(excinfo.value)
+        assert "auxiliary.vision" in message
+        assert "NOT sent" in message
+        assert fake_sdk.calls == 0
+
+    def test_text_only_content_never_uses_the_streaming_path(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        )
+        assert fake_sdk.prompts == ["hi"]
+
+    def test_unencodable_image_becomes_a_visible_note(self):
+        blocks = claude_sdk_input.content_to_sdk_blocks(
+            [{"type": "image_url", "image_url": {"url": "file:///tmp/x.png"}}]
+        )
+        assert blocks == [
+            {"type": "text", "text": "[an image was attached but could not be encoded]"}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Routing inside auxiliary_client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscription_gate_open(monkeypatch):
+    """Open the Claude subscription gate for provider normalisation.
+
+    Also pretends the ``claude`` CLI is installed: ``claude-code`` credential
+    resolution refuses without a resolvable binary, and the routing tests must
+    not depend on the developer's (or CI's) machine having one.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.claude_code.subscription_enabled", lambda config=None: True
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.get_external_process_provider_status",
+        lambda provider_id: {
+            "configured": True,
+            "provider": provider_id,
+            "resolved_command": "/opt/claude/bin/claude",
+            "logged_in": True,
+        },
+    )
+
+
+class TestAuxiliaryRouting:
+    def test_provider_slug_is_never_anthropic(self):
+        assert is_claude_subscription_provider("claude-code") is True
+        assert is_claude_subscription_provider("anthropic") is False
+        assert is_claude_subscription_provider("") is False
+
+    def test_subscription_task_never_touches_the_http_adapter(
+        self, fake_sdk, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+
+        with patch.object(auxiliary_client, "_try_anthropic") as http_path, patch.object(
+            auxiliary_client, "_create_openai_client"
+        ) as openai_path:
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+
+        assert isinstance(client, claude_auxiliary.ClaudeAuxiliaryClient)
+        assert model == "claude-sonnet-5"
+        http_path.assert_not_called()
+        openai_path.assert_not_called()
+
+    def test_resolved_client_holds_no_credential(self, fake_sdk, subscription_gate_open):
+        from agent import auxiliary_client
+
+        client, _ = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5"
+        )
+        assert client.api_key == ""
+        assert not client.base_url.startswith("http")
+
+    def test_async_mode_returns_the_async_facade(self, fake_sdk, subscription_gate_open):
+        from agent import auxiliary_client
+
+        client, _ = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5", async_mode=True
+        )
+        assert isinstance(client, claude_auxiliary.AsyncClaudeAuxiliaryClient)
+
+    def test_missing_extra_degrades_instead_of_raising(
+        self, sdk_absent, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+
+        client, model = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5"
+        )
+        assert client is None and model is None
+
+    def test_missing_claude_cli_degrades_instead_of_raising(
+        self, fake_sdk, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+        from hermes_cli.auth import AuthError
+
+        with patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            side_effect=AuthError("Could not find the `claude` CLI."),
+        ):
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+        assert client is None and model is None
+
+    def test_credential_material_is_refused(self, fake_sdk, subscription_gate_open):
+        """A non-empty key here would mean Hermes started holding Claude auth."""
+        from agent import auxiliary_client
+
+        with patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={"api_key": "sk-ant-oat01-leaked", "base_url": "x"},
+        ):
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+        assert client is None and model is None
+
+    def test_streaming_flag_is_not_sent_to_the_sdk_client(self, fake_sdk):
+        from agent import auxiliary_client
+
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        assert auxiliary_client._client_streams_internally(client) is True
+
+
+class TestAnthropicApiKeyConfigUnchanged:
+    """An explicit ``anthropic`` API-key auxiliary config must not shift."""
+
+    def test_api_key_provider_still_builds_the_http_adapter(self, monkeypatch):
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(
+            auxiliary_client, "_read_main_provider", lambda: "claude-code"
+        )
+        built = {}
+
+        def _fake_build(token, base_url, **kwargs):
+            built["token"] = token
+            return SimpleNamespace(base_url=base_url)
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client", _fake_build
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token", lambda: ""
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._is_oauth_token", lambda tok: False
+        )
+
+        client, model = auxiliary_client._try_anthropic(
+            explicit_api_key="sk-ant-api03-real-key"
+        )
+        assert client is not None
+        assert built["token"] == "sk-ant-api03-real-key"
+        assert model
+
+    def test_oauth_token_is_refused_when_the_subscription_runtime_is_active(
+        self, monkeypatch
+    ):
+        """Otherwise an aux fallback quietly resumes extra-usage billing."""
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(
+            auxiliary_client, "_read_main_provider", lambda: "claude-code"
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "sk-ant-oat01-subscription",
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._is_oauth_token", lambda tok: True
+        )
+
+        def _must_not_build(*args, **kwargs):  # pragma: no cover - guard
+            raise AssertionError("the legacy direct-OAuth path was reached")
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client", _must_not_build
+        )
+
+        client, model = auxiliary_client._try_anthropic()
+        assert client is None and model is None
+
+    def test_oauth_token_still_works_for_a_non_subscription_user(self, monkeypatch):
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(auxiliary_client, "_read_main_provider", lambda: "anthropic")
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "sk-ant-oat01-legacy",
+        )
+        monkeypatch.setattr("agent.anthropic_adapter._is_oauth_token", lambda tok: True)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda token, base_url, **kw: SimpleNamespace(base_url=base_url),
+        )
+
+        client, _ = auxiliary_client._try_anthropic()
+        assert client is not None

--- a/tests/agent/test_claude_auxiliary.py
+++ b/tests/agent/test_claude_auxiliary.py
@@ -1,0 +1,632 @@
+"""Contract for the one-shot Claude Agent SDK auxiliary adapter.
+
+Five things are pinned down here:
+
+1. An auxiliary call in subscription mode goes through the SDK and **never**
+   through the pre-SDK direct-OAuth HTTP adapter.
+2. The adapter exposes no tools and cannot touch the conversation's session.
+3. An explicit ``anthropic`` API-key auxiliary config is completely unaffected.
+4. The result is the same OpenAI-shaped object every other auxiliary transport
+   returns, so no call site in ``auxiliary_client.py`` has to special-case it.
+5. Image input either goes out on the SDK's streaming-input path or fails with
+   a message naming ``auxiliary.vision`` — never silently dropped.
+
+``claude-agent-sdk`` is an optional extra. Every test that makes a call installs
+a fake ``claude_agent_sdk`` module, so the suite behaves identically with and
+without the real package (and never touches the network either way). The two
+tests that inspect the *real* package's signature skip when it is absent.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from agent import claude_auxiliary, claude_sdk_input
+from agent.claude_auxiliary import (
+    ClaudeAuxiliaryError,
+    build_claude_auxiliary_client,
+    build_claude_auxiliary_options,
+    is_claude_subscription_provider,
+    split_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeClaudeAgentOptions:
+    system_prompt: Any = None
+    tools: Any = None
+    allowed_tools: list = field(default_factory=list)
+    mcp_servers: dict = field(default_factory=dict)
+    strict_mcp_config: bool = False
+    setting_sources: Any = None
+    max_turns: Any = None
+    model: Any = None
+    permission_mode: Any = None
+    include_partial_messages: bool = False
+    continue_conversation: bool = False
+    resume: Any = None
+    fork_session: bool = False
+    session_store: Any = None
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str = "claude-sonnet-5"
+
+
+@dataclass
+class ResultMessage:
+    result: str = ""
+    usage: dict | None = None
+    session_id: str = "sdk-throwaway-session"
+    is_error: bool = False
+
+
+class _Recorder:
+    """Captures what the adapter handed the SDK."""
+
+    def __init__(self) -> None:
+        self.prompts: list = []
+        self.options: list = []
+        self.calls = 0
+
+
+def _install_fake_sdk(monkeypatch, *, messages=None, recorder=None, delay=0.0):
+    """Install a fake ``claude_agent_sdk`` and return its recorder."""
+    recorder = recorder or _Recorder()
+    payload = list(
+        messages
+        if messages is not None
+        else [
+            AssistantMessage(content=[TextBlock("a title")]),
+            ResultMessage(result="a title", usage={"input_tokens": 11, "output_tokens": 3}),
+        ]
+    )
+
+    async def _query(*, prompt, options=None, transport=None):
+        recorder.calls += 1
+        # A streaming prompt is an async iterable; materialise it exactly as the
+        # real SDK does so the test sees the frames that would hit the CLI.
+        if isinstance(prompt, str):
+            recorder.prompts.append(prompt)
+        else:
+            frames = [frame async for frame in prompt]
+            recorder.prompts.append(frames)
+        recorder.options.append(options)
+        if delay:
+            import asyncio
+
+            await asyncio.sleep(delay)
+        for message in payload:
+            yield message
+
+    class _FakeSDKClient:
+        async def query(self, prompt, session_id="default"):  # pragma: no cover
+            raise AssertionError("the auxiliary path must not use ClaudeSDKClient")
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.ClaudeAgentOptions = FakeClaudeAgentOptions
+    module.query = _query
+    module.ClaudeSDKClient = _FakeSDKClient
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    return recorder
+
+
+@pytest.fixture
+def fake_sdk(monkeypatch):
+    return _install_fake_sdk(monkeypatch)
+
+
+@pytest.fixture
+def sdk_absent(monkeypatch):
+    """Make ``import claude_agent_sdk`` fail, as it does without the extra."""
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+
+
+@pytest.fixture
+def streaming_input_supported(monkeypatch):
+    monkeypatch.setattr(claude_sdk_input, "sdk_supports_streaming_input", lambda: True)
+    monkeypatch.setattr(claude_auxiliary, "sdk_supports_streaming_input", lambda: True)
+
+
+@pytest.fixture
+def streaming_input_unsupported(monkeypatch):
+    monkeypatch.setattr(claude_sdk_input, "sdk_supports_streaming_input", lambda: False)
+    monkeypatch.setattr(claude_auxiliary, "sdk_supports_streaming_input", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# Options — no tools, no session state
+# ---------------------------------------------------------------------------
+
+
+class TestOptions:
+    def test_no_tools_of_any_kind(self, fake_sdk):
+        options = build_claude_auxiliary_options(
+            system_prompt="be terse", model="claude-sonnet-5"
+        )
+        assert options.tools == []
+        assert options.allowed_tools == []
+        assert options.mcp_servers == {}
+        # Without strict mode a project .mcp.json could reintroduce a toolset.
+        assert options.strict_mcp_config is True
+        # Without this the CLI loads settings, hooks, skills and plugins.
+        assert options.setting_sources == []
+
+    def test_bounded(self, fake_sdk):
+        options = build_claude_auxiliary_options(system_prompt=None, model=None)
+        assert options.max_turns == claude_auxiliary.CLAUDE_AUX_MAX_TURNS
+        assert options.max_turns >= 1
+
+    def test_carries_no_conversation_session_state(self, fake_sdk):
+        options = build_claude_auxiliary_options(system_prompt=None, model=None)
+        assert options.resume is None
+        assert options.continue_conversation is False
+        assert options.fork_session is False
+        assert options.session_store is None
+        assert getattr(options, "session_id", None) is None
+
+    def test_real_sdk_accepts_the_option_set(self):
+        """The locked-down option set must be constructible on the real SDK."""
+        pytest.importorskip("claude_agent_sdk")
+        options = build_claude_auxiliary_options(
+            system_prompt="hi", model="claude-sonnet-5"
+        )
+        assert options.tools == []
+        assert options.strict_mcp_config is True
+        assert options.setting_sources == []
+        assert options.resume is None
+
+
+class TestMissingExtra:
+    def test_actionable_import_error(self, sdk_absent):
+        with pytest.raises(ImportError) as excinfo:
+            build_claude_auxiliary_client("claude-sonnet-5")
+        message = str(excinfo.value)
+        assert "claude-code" in message
+        assert "pip install" in message
+
+    def test_options_also_report_the_missing_extra(self, sdk_absent):
+        with pytest.raises(ImportError):
+            build_claude_auxiliary_options(system_prompt=None, model=None)
+
+
+# ---------------------------------------------------------------------------
+# The call
+# ---------------------------------------------------------------------------
+
+
+class TestOneShotCall:
+    def test_returns_openai_shaped_response(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        response = client.chat.completions.create(
+            model="claude-sonnet-5",
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "title this"},
+            ],
+        )
+        assert response.choices[0].message.content == "a title"
+        assert response.choices[0].message.tool_calls is None
+        assert response.choices[0].finish_reason == "stop"
+        assert response.usage.prompt_tokens == 11
+        assert response.usage.completion_tokens == 3
+        assert response.usage.total_tokens == 14
+
+    def test_system_message_becomes_an_option_not_a_turn(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": "title this"},
+            ]
+        )
+        assert fake_sdk.options[0].system_prompt == "be terse"
+        assert fake_sdk.prompts == ["title this"]
+
+    def test_uses_one_shot_query_not_a_client(self, fake_sdk):
+        """``ClaudeSDKClient`` would mean a second long-lived CLI subprocess."""
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert fake_sdk.calls == 1
+
+    def test_tools_are_refused_loudly(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"type": "function", "function": {"name": "terminal"}}],
+            )
+        assert "no tools" in str(excinfo.value)
+        assert fake_sdk.calls == 0
+
+    def test_stream_request_degrades_to_a_complete_response(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        response = client.chat.completions.create(
+            messages=[{"role": "user", "content": "hi"}], stream=True
+        )
+        assert response.choices[0].message.content == "a title"
+
+    def test_sdk_error_result_raises(self, monkeypatch):
+        _install_fake_sdk(
+            monkeypatch,
+            messages=[ResultMessage(result="rate limited", is_error=True)],
+        )
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert "rate limited" in str(excinfo.value)
+
+    def test_timeout_is_bounded_and_reported(self, monkeypatch):
+        _install_fake_sdk(monkeypatch, delay=5.0)
+        client = build_claude_auxiliary_client("claude-sonnet-5", timeout=0.2)
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert "timed out" in str(excinfo.value)
+
+    def test_no_worker_thread_survives_a_call(self, fake_sdk):
+        import threading
+
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert not [
+            t for t in threading.enumerate() if t.name == "hermes-claude-aux" and t.is_alive()
+        ]
+
+
+class TestSessionIsolation:
+    def test_does_not_mutate_the_conversation_session_id(self, fake_sdk):
+        """The SDK mints a throwaway session; the conversation keeps its own."""
+        agent = SimpleNamespace(_claude_sdk_session_id="conversation-session")
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(messages=[{"role": "user", "content": "hi"}])
+        assert agent._claude_sdk_session_id == "conversation-session"
+        assert fake_sdk.options[0].resume is None
+        assert getattr(fake_sdk.options[0], "session_id", None) is None
+
+    def test_streaming_frame_carries_no_session_id(
+        self, monkeypatch, streaming_input_supported
+    ):
+        """A pinned session_id is exactly how an aux call would leak into chat."""
+        recorder = _install_fake_sdk(monkeypatch)
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,QUJD"},
+                        },
+                    ],
+                }
+            ]
+        )
+        frames = recorder.prompts[0]
+        assert isinstance(frames, list)
+        assert "session_id" not in frames[0]
+
+
+# ---------------------------------------------------------------------------
+# Message flattening
+# ---------------------------------------------------------------------------
+
+
+class TestSplitMessages:
+    def test_single_user_turn_passes_through(self):
+        system, content = split_messages([{"role": "user", "content": "hi"}])
+        assert system is None
+        assert content == "hi"
+
+    def test_system_turns_are_hoisted(self):
+        system, content = split_messages(
+            [
+                {"role": "system", "content": "rule one"},
+                {"role": "system", "content": "rule two"},
+                {"role": "user", "content": "go"},
+            ]
+        )
+        assert system == "rule one\n\nrule two"
+        assert content == "go"
+
+    def test_multi_turn_examples_are_kept_not_dropped(self):
+        system, content = split_messages(
+            [
+                {"role": "user", "content": "example in"},
+                {"role": "assistant", "content": "example out"},
+                {"role": "user", "content": "real one"},
+            ]
+        )
+        assert system is None
+        assert "example in" in content
+        assert "example out" in content
+        assert "real one" in content
+
+
+# ---------------------------------------------------------------------------
+# Images
+# ---------------------------------------------------------------------------
+
+
+class TestImages:
+    def test_streaming_probe_matches_the_installed_sdk(self):
+        pytest.importorskip("claude_agent_sdk")
+        # 0.2.128 takes ``str | AsyncIterable[dict]`` on both entry points.
+        assert claude_sdk_input.sdk_supports_streaming_input() is True
+
+    def test_probe_is_false_without_the_extra(self, sdk_absent):
+        assert claude_sdk_input.sdk_supports_streaming_input() is False
+
+    def test_probe_is_false_for_a_string_only_build(self, monkeypatch):
+        async def _query(*, prompt: str, options=None, transport=None):  # noqa: ARG001
+            yield None
+
+        class _Client:
+            async def query(self, prompt: str, session_id="default"):
+                pass
+
+        module = types.ModuleType("claude_agent_sdk")
+        module.query = _query
+        module.ClaudeSDKClient = _Client
+        monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+        assert claude_sdk_input.sdk_supports_streaming_input() is False
+
+    def test_image_goes_out_as_an_anthropic_block(
+        self, monkeypatch, streaming_input_supported
+    ):
+        recorder = _install_fake_sdk(monkeypatch)
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "describe"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/jpeg;base64,QUJD"},
+                        },
+                    ],
+                }
+            ]
+        )
+        frames = recorder.prompts[0]
+        blocks = frames[0]["message"]["content"]
+        assert blocks[0] == {"type": "text", "text": "describe"}
+        assert blocks[1] == {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/jpeg", "data": "QUJD"},
+        }
+
+    def test_unsupported_build_names_the_vision_config(
+        self, fake_sdk, streaming_input_unsupported
+    ):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        with pytest.raises(ClaudeAuxiliaryError) as excinfo:
+            client.chat.completions.create(
+                messages=[
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "data:image/png;base64,QUJD"},
+                            }
+                        ],
+                    }
+                ]
+            )
+        message = str(excinfo.value)
+        assert "auxiliary.vision" in message
+        assert "NOT sent" in message
+        assert fake_sdk.calls == 0
+
+    def test_text_only_content_never_uses_the_streaming_path(self, fake_sdk):
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        client.chat.completions.create(
+            messages=[{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        )
+        assert fake_sdk.prompts == ["hi"]
+
+    def test_unencodable_image_becomes_a_visible_note(self):
+        blocks = claude_sdk_input.content_to_sdk_blocks(
+            [{"type": "image_url", "image_url": {"url": "file:///tmp/x.png"}}]
+        )
+        assert blocks == [
+            {"type": "text", "text": "[an image was attached but could not be encoded]"}
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Routing inside auxiliary_client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscription_gate_open(monkeypatch):
+    """Open the Claude subscription gate for provider normalisation."""
+    monkeypatch.setattr(
+        "hermes_cli.claude_code.subscription_enabled", lambda config=None: True
+    )
+
+
+class TestAuxiliaryRouting:
+    def test_provider_slug_is_never_anthropic(self):
+        assert is_claude_subscription_provider("claude-code") is True
+        assert is_claude_subscription_provider("anthropic") is False
+        assert is_claude_subscription_provider("") is False
+
+    def test_subscription_task_never_touches_the_http_adapter(
+        self, fake_sdk, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+
+        with patch.object(auxiliary_client, "_try_anthropic") as http_path, patch.object(
+            auxiliary_client, "_create_openai_client"
+        ) as openai_path:
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+
+        assert isinstance(client, claude_auxiliary.ClaudeAuxiliaryClient)
+        assert model == "claude-sonnet-5"
+        http_path.assert_not_called()
+        openai_path.assert_not_called()
+
+    def test_resolved_client_holds_no_credential(self, fake_sdk, subscription_gate_open):
+        from agent import auxiliary_client
+
+        client, _ = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5"
+        )
+        assert client.api_key == ""
+        assert not client.base_url.startswith("http")
+
+    def test_async_mode_returns_the_async_facade(self, fake_sdk, subscription_gate_open):
+        from agent import auxiliary_client
+
+        client, _ = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5", async_mode=True
+        )
+        assert isinstance(client, claude_auxiliary.AsyncClaudeAuxiliaryClient)
+
+    def test_missing_extra_degrades_instead_of_raising(
+        self, sdk_absent, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+
+        client, model = auxiliary_client.resolve_provider_client(
+            "claude-code", model="claude-sonnet-5"
+        )
+        assert client is None and model is None
+
+    def test_missing_claude_cli_degrades_instead_of_raising(
+        self, fake_sdk, subscription_gate_open
+    ):
+        from agent import auxiliary_client
+        from hermes_cli.auth import AuthError
+
+        with patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            side_effect=AuthError("Could not find the `claude` CLI."),
+        ):
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+        assert client is None and model is None
+
+    def test_credential_material_is_refused(self, fake_sdk, subscription_gate_open):
+        """A non-empty key here would mean Hermes started holding Claude auth."""
+        from agent import auxiliary_client
+
+        with patch(
+            "hermes_cli.auth.resolve_external_process_provider_credentials",
+            return_value={"api_key": "sk-ant-oat01-leaked", "base_url": "x"},
+        ):
+            client, model = auxiliary_client.resolve_provider_client(
+                "claude-code", model="claude-sonnet-5"
+            )
+        assert client is None and model is None
+
+    def test_streaming_flag_is_not_sent_to_the_sdk_client(self, fake_sdk):
+        from agent import auxiliary_client
+
+        client = build_claude_auxiliary_client("claude-sonnet-5")
+        assert auxiliary_client._client_streams_internally(client) is True
+
+
+class TestAnthropicApiKeyConfigUnchanged:
+    """An explicit ``anthropic`` API-key auxiliary config must not shift."""
+
+    def test_api_key_provider_still_builds_the_http_adapter(self, monkeypatch):
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(
+            auxiliary_client, "_read_main_provider", lambda: "claude-code"
+        )
+        built = {}
+
+        def _fake_build(token, base_url, **kwargs):
+            built["token"] = token
+            return SimpleNamespace(base_url=base_url)
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client", _fake_build
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token", lambda: ""
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._is_oauth_token", lambda tok: False
+        )
+
+        client, model = auxiliary_client._try_anthropic(
+            explicit_api_key="sk-ant-api03-real-key"
+        )
+        assert client is not None
+        assert built["token"] == "sk-ant-api03-real-key"
+        assert model
+
+    def test_oauth_token_is_refused_when_the_subscription_runtime_is_active(
+        self, monkeypatch
+    ):
+        """Otherwise an aux fallback quietly resumes extra-usage billing."""
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(
+            auxiliary_client, "_read_main_provider", lambda: "claude-code"
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "sk-ant-oat01-subscription",
+        )
+        monkeypatch.setattr(
+            "agent.anthropic_adapter._is_oauth_token", lambda tok: True
+        )
+
+        def _must_not_build(*args, **kwargs):  # pragma: no cover - guard
+            raise AssertionError("the legacy direct-OAuth path was reached")
+
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client", _must_not_build
+        )
+
+        client, model = auxiliary_client._try_anthropic()
+        assert client is None and model is None
+
+    def test_oauth_token_still_works_for_a_non_subscription_user(self, monkeypatch):
+        from agent import auxiliary_client
+
+        monkeypatch.setattr(auxiliary_client, "_read_main_provider", lambda: "anthropic")
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.resolve_anthropic_token",
+            lambda: "sk-ant-oat01-legacy",
+        )
+        monkeypatch.setattr("agent.anthropic_adapter._is_oauth_token", lambda tok: True)
+        monkeypatch.setattr(
+            "agent.anthropic_adapter.build_anthropic_client",
+            lambda token, base_url, **kw: SimpleNamespace(base_url=base_url),
+        )
+
+        client, _ = auxiliary_client._try_anthropic()
+        assert client is not None

--- a/tests/agent/test_claude_billing_source.py
+++ b/tests/agent/test_claude_billing_source.py
@@ -1,0 +1,795 @@
+"""Contract for "this turn bills the user's Claude plan, or it does not run".
+
+The Claude Code CLI resolves credentials in a fixed order and the user's
+subscription is last, so an exported ``ANTHROPIC_API_KEY`` silently redirects
+a "Claude subscription" turn onto a metered API account. Three guarantees are
+pinned down here:
+
+1. Every credential that outranks the subscription makes the runtime **refuse**,
+   with a message that names that specific variable (never its value).
+2. The environment the launcher builds for the CLI subprocess genuinely lacks
+   those variables — while ``os.environ`` itself is never mutated, because
+   Hermes is multi-threaded and other providers run concurrently.
+3. The billing probe reads the CLI's own account report without ever issuing a
+   model request.
+
+No test here spawns ``claude`` or touches the network: the SDK client and its
+transport are injected. The file runs with and without the optional
+``claude-agent-sdk`` extra — everything that needs the real package is skipped
+when it is absent, and the pure logic (precedence, sanitized env,
+classification) is exercised either way.
+"""
+
+from __future__ import annotations
+
+import os
+import types
+from dataclasses import dataclass, field
+from importlib.util import find_spec
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import claude_billing
+from agent.claude_billing import (
+    BLOCKED_CHILD_ENV_VARS,
+    CLAUDE_CREDENTIAL_PRECEDENCE,
+    BillingSource,
+    billing_source_refusal,
+    blocking_credentials,
+    classify_account,
+    sanitized_child_env,
+    static_billing_refusal,
+    verify_claude_billing_source,
+)
+from agent.transports import claude_sanitized_transport
+
+SDK_INSTALLED = find_spec("claude_agent_sdk") is not None
+requires_sdk = pytest.mark.skipif(
+    not SDK_INSTALLED, reason="claude-agent-sdk optional extra not installed"
+)
+
+# The env-var slots the CLI's documented precedence puts above the
+# subscription. Derived from the module rather than restated, so adding a slot
+# extends the coverage instead of silently leaving one untested.
+ENV_CREDENTIAL_NAMES = [
+    slot.name for slot in CLAUDE_CREDENTIAL_PRECEDENCE if slot.kind == "env"
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_credential_env(monkeypatch):
+    """No ambient credential decides the outcome of these tests."""
+    for name in BLOCKED_CHILD_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Refusal: every higher-precedence credential
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", ENV_CREDENTIAL_NAMES)
+def test_each_higher_precedence_credential_refuses_and_names_itself(name):
+    refusal = static_billing_refusal({name: "some-value"})
+    assert refusal is not None
+    assert name in refusal
+    # The user needs the action, not just the diagnosis.
+    assert "unset" in refusal.lower()
+
+
+@pytest.mark.parametrize("name", ENV_CREDENTIAL_NAMES)
+def test_refusal_never_prints_the_credential_value(name):
+    refusal = static_billing_refusal({name: "sk-ant-super-secret-value"})
+    assert refusal is not None
+    assert "sk-ant-super-secret-value" not in refusal
+
+
+def test_the_documented_precedence_list_is_covered():
+    """Every variable the decision record names has a slot."""
+    documented = {
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+        "CLAUDE_CODE_USE_FOUNDRY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH" + "_TOKEN",
+    }
+    assert documented <= set(ENV_CREDENTIAL_NAMES)
+    assert documented <= BLOCKED_CHILD_ENV_VARS
+
+
+def test_several_conflicting_credentials_are_all_named():
+    refusal = static_billing_refusal(
+        {"ANTHROPIC_API_KEY": "a", "CLAUDE_CODE_USE_BEDROCK": "1"}
+    )
+    assert refusal is not None
+    assert "ANTHROPIC_API_KEY" in refusal
+    assert "CLAUDE_CODE_USE_BEDROCK" in refusal
+
+
+def test_conflicts_are_reported_highest_precedence_first():
+    slots = blocking_credentials(
+        {"ANTHROPIC_API_KEY": "a", "CLAUDE_CODE_USE_VERTEX": "1"}
+    )
+    assert [slot.rank for slot in slots] == sorted(slot.rank for slot in slots)
+    assert slots[0].name == "CLAUDE_CODE_USE_VERTEX"
+
+
+def test_a_clean_environment_is_allowed():
+    assert static_billing_refusal({"PATH": "/usr/bin", "HOME": "/home/x"}) is None
+
+
+def test_a_blank_value_is_not_a_conflict():
+    assert static_billing_refusal({"ANTHROPIC_API_KEY": "   "}) is None
+
+
+def test_api_key_helper_is_a_setting_not_an_env_var():
+    """`apiKeyHelper` lives in settings.json, so an env sweep cannot see it."""
+    helper = next(
+        slot for slot in CLAUDE_CREDENTIAL_PRECEDENCE if slot.name == "apiKeyHelper"
+    )
+    assert helper.kind == "setting"
+    assert helper.name not in BLOCKED_CHILD_ENV_VARS
+    assert blocking_credentials({"apiKeyHelper": "/bin/true"}) == []
+    # It is still reachable when a caller can see the settings file.
+    found = blocking_credentials({}, settings_keys={"apiKeyHelper": "/bin/true"})
+    assert [slot.name for slot in found] == ["apiKeyHelper"]
+    assert "apiKeyHelper" in claude_billing.credential_refusal_message(found)
+
+
+# ---------------------------------------------------------------------------
+# The sanitized child environment
+# ---------------------------------------------------------------------------
+
+
+def _dirty_env() -> dict:
+    env = {name: f"value-for-{name}" for name in BLOCKED_CHILD_ENV_VARS}
+    env.update(
+        {
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/home/tester",
+            "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
+            "LANG": "C.UTF-8",
+        }
+    )
+    return env
+
+
+@pytest.mark.parametrize("name", sorted(BLOCKED_CHILD_ENV_VARS))
+def test_the_launcher_env_lacks_every_blocked_key(name):
+    child = sanitized_child_env(_dirty_env())
+    assert name not in child
+
+
+def test_the_launcher_env_keeps_everything_else():
+    base = _dirty_env()
+    child = sanitized_child_env(base)
+    for name in ("PATH", "HOME", "LANG"):
+        assert child[name] == base[name]
+
+
+def test_claude_config_dir_passes_through():
+    child = sanitized_child_env(_dirty_env())
+    assert child["CLAUDE_CONFIG_DIR"] == "/tmp/claude-config"
+
+
+def test_nothing_is_both_blocked_and_passed_through():
+    from agent.claude_billing import PASS_THROUGH_ENV_VARS
+
+    assert set(PASS_THROUGH_ENV_VARS) & BLOCKED_CHILD_ENV_VARS == set()
+
+
+def test_home_is_never_overridden():
+    """Rewriting HOME relocates the macOS keychain lookup and breaks login."""
+    base = _dirty_env()
+    child = sanitized_child_env(base)
+    assert child["HOME"] == base["HOME"]
+
+
+def test_building_the_child_env_does_not_mutate_os_environ(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+    before = dict(os.environ)
+    child = sanitized_child_env()
+    assert "ANTHROPIC_API_KEY" not in child
+    assert dict(os.environ) == before
+    # ...which is what leaves every other api_mode's credential resolution
+    # exactly as it was.
+    assert os.environ["ANTHROPIC_API_KEY"] == "sk-ant-live"
+
+
+# ---------------------------------------------------------------------------
+# The transport's env builder
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Options:
+    env: dict = field(default_factory=dict)
+    cwd: str | None = None
+    enable_file_checkpointing: bool = False
+    stderr: Any = None
+    user: Any = None
+
+
+def test_transport_env_strips_blocked_keys(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    child = claude_sanitized_transport.build_child_env(_Options(cwd="/work"))
+    assert "ANTHROPIC_API_KEY" not in child
+    assert "CLAUDE_CODE_USE_BEDROCK" not in child
+    assert child["PWD"] == "/work"
+    # The SDK's own required markers survive the rebuild.
+    assert child["CLAUDE_CODE_ENTRYPOINT"] == "sdk-py"
+
+
+def test_options_env_cannot_smuggle_a_credential_back_in(monkeypatch):
+    """`options.env` is applied, then re-filtered — it is not an escape hatch."""
+    child = claude_sanitized_transport.build_child_env(
+        _Options(env={"ANTHROPIC_API_KEY": "sk-ant-sneaky", "FOO": "bar"})
+    )
+    assert "ANTHROPIC_API_KEY" not in child
+    assert child["FOO"] == "bar"
+
+
+def test_transport_env_leaves_home_and_config_dir_alone(monkeypatch):
+    monkeypatch.setenv("HOME", "/home/tester")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/cfg")
+    child = claude_sanitized_transport.build_child_env(_Options())
+    assert child["HOME"] == "/home/tester"
+    assert child["CLAUDE_CONFIG_DIR"] == "/tmp/cfg"
+
+
+@requires_sdk
+def test_sanitized_transport_subclasses_the_sdk_transport():
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        SubprocessCLITransport,
+    )
+
+    assert issubclass(
+        claude_sanitized_transport.sanitized_transport_class(), SubprocessCLITransport
+    )
+
+
+@requires_sdk
+def test_sdk_options_env_alone_cannot_delete_an_inherited_key(monkeypatch):
+    """Why a transport is required at all.
+
+    The SDK merges ``options.env`` *over* a copy of ``os.environ``; there is no
+    value that means "remove". This pins the SDK behavior our transport exists
+    to work around.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+    inherited = {k: v for k, v in os.environ.items() if k != "CLAUDECODE"}
+    sdk_merge = {**inherited, "CLAUDE_CODE_ENTRYPOINT": "sdk-py", **{"ANTHROPIC_API_KEY": ""}}
+    assert "ANTHROPIC_API_KEY" in sdk_merge  # still present, merely blank
+
+    ours = claude_sanitized_transport.build_child_env(_Options())
+    assert "ANTHROPIC_API_KEY" not in ours
+
+
+# ---------------------------------------------------------------------------
+# Classifying the CLI's own account report
+# ---------------------------------------------------------------------------
+
+
+def test_a_plan_login_is_a_subscription():
+    source = classify_account(
+        {
+            "email": "user@example.com",
+            "organization": "Example",
+            "subscriptionType": "Claude Max",
+            "apiProvider": "firstParty",
+        }
+    )
+    assert source.is_subscription
+    assert source.plan == "Claude Max"
+    assert billing_source_refusal(source) is None
+
+
+@pytest.mark.parametrize(
+    "tier",
+    [
+        "Claude Max",
+        "claudeProSubscription",
+        "claudeMax20xSubscription",
+        "claudeTeamSubscription",
+        "claudeEnterpriseSubscription",
+    ],
+)
+def test_every_plan_tier_shape_is_a_subscription(tier):
+    source = classify_account({"subscriptionType": tier, "apiProvider": "firstParty"})
+    assert source.is_subscription
+
+
+def test_an_api_key_source_wins_over_a_claude_ai_token_source():
+    """Observed on Claude Code 2.1.220 with ANTHROPIC_API_KEY exported."""
+    source = classify_account(
+        {
+            "tokenSource": "claude.ai",
+            "apiKeySource": "ANTHROPIC_API_KEY",
+            "apiProvider": "firstParty",
+        }
+    )
+    assert source.kind == "api_key"
+    refusal = billing_source_refusal(source)
+    assert refusal is not None
+    assert "ANTHROPIC_API_KEY" in refusal
+
+
+@pytest.mark.parametrize(
+    "token_source", ["ANTHROPIC_AUTH_TOKEN", "anthropicApiKey", "apiKeyHelper"]
+)
+def test_api_shaped_token_sources_refuse_and_name_themselves(token_source):
+    source = classify_account({"tokenSource": token_source})
+    assert source.kind == "api_key"
+    refusal = billing_source_refusal(source)
+    assert refusal is not None
+    assert token_source in refusal
+
+
+def test_an_oauth_token_is_the_extra_usage_meter_not_the_plan():
+    name = "CLAUDE_CODE_OAUTH" + "_TOKEN"
+    source = classify_account({"tokenSource": name})
+    assert source.kind == "oauth_token"
+    refusal = billing_source_refusal(source)
+    assert refusal is not None
+    assert name in refusal
+
+
+def test_a_cloud_provider_refuses_and_names_the_provider():
+    source = classify_account({"apiProvider": "bedrock", "subscriptionType": "max"})
+    assert source.kind == "cloud"
+    refusal = billing_source_refusal(source)
+    assert refusal is not None
+    assert "bedrock" in refusal
+
+
+def test_no_signed_in_account_refuses_with_the_login_command():
+    source = classify_account({"tokenSource": "none"})
+    assert source.kind == "unauthenticated"
+    assert "claude auth login" in (billing_source_refusal(source) or "")
+
+
+def test_an_unreadable_payload_refuses_rather_than_assuming():
+    assert classify_account(None).kind == "unknown"
+    assert billing_source_refusal(BillingSource(kind="unknown")) is not None
+
+
+# ---------------------------------------------------------------------------
+# The zero-cost probe
+# ---------------------------------------------------------------------------
+
+
+class _FakeTransport:
+    """Records everything a real transport would be asked to do."""
+
+    def __init__(self, options) -> None:
+        self.options = options
+        self.writes: list[str] = []
+        self.connected = False
+
+    async def connect(self) -> None:
+        self.connected = True
+
+    async def write(self, data: str) -> None:  # pragma: no cover - must not run
+        self.writes.append(data)
+
+
+class _FakeClient:
+    """Fails loudly if the probe tries to run a turn."""
+
+    def __init__(self, *, options, transport) -> None:
+        self.options = options
+        self.transport = transport
+        self.calls: list[str] = []
+        self.account: dict = {
+            "email": "user@example.com",
+            "subscriptionType": "Claude Max",
+            "apiProvider": "firstParty",
+        }
+
+    async def connect(self, *_a, **_kw) -> None:
+        self.calls.append("connect")
+
+    async def get_server_info(self) -> dict:
+        self.calls.append("get_server_info")
+        return {"account": dict(self.account)}
+
+    async def disconnect(self) -> None:
+        self.calls.append("disconnect")
+
+    async def query(self, *_a, **_kw):  # pragma: no cover - must not run
+        raise AssertionError("the billing probe must not issue a model request")
+
+    def receive_response(self):  # pragma: no cover - must not run
+        raise AssertionError("the billing probe must not read a model response")
+
+
+def _probe(account: dict | None = None):
+    """Run the probe against injected fakes; return (source, client)."""
+    made: dict = {}
+
+    def _client_factory(*, options, transport):
+        client = _FakeClient(options=options, transport=transport)
+        if account is not None:
+            client.account = account
+        made["client"] = client
+        return client
+
+    source = claude_billing.probe_claude_billing_source(
+        timeout=5.0,
+        client_factory=_client_factory,
+        options_factory=lambda: types.SimpleNamespace(tools=[], setting_sources=[]),
+        transport_factory=_FakeTransport,
+    )
+    return source, made["client"]
+
+
+def test_the_probe_reads_the_account_without_issuing_a_model_request():
+    source, client = _probe()
+    assert source.is_subscription
+    assert source.plan == "Claude Max"
+    # Connect, read the init report, hang up. Nothing else.
+    assert client.calls == ["connect", "get_server_info", "disconnect"]
+    assert client.transport.writes == []
+
+
+@requires_sdk
+def test_the_probe_session_loads_no_settings_and_no_tools():
+    """`setting_sources=[]` is also what keeps an apiKeyHelper from running.
+
+    Verified against Claude Code 2.1.220: with ``["user"]`` the helper script
+    executes and the account reports ``tokenSource: apiKeyHelper``; with ``[]``
+    it never runs.
+    """
+    options = claude_billing.probe_options()
+    assert options.setting_sources == []
+    assert options.tools == []
+    assert options.allowed_tools == []
+
+
+def test_the_probe_refuses_when_the_cli_resolved_an_api_key():
+    source, _ = _probe({"apiKeySource": "ANTHROPIC_API_KEY", "tokenSource": "claude.ai"})
+    assert source.kind == "api_key"
+    assert "ANTHROPIC_API_KEY" in (billing_source_refusal(source) or "")
+
+
+def test_the_probe_falls_back_to_claude_auth_status_when_the_sdk_path_fails():
+    def _explode(**_kw):
+        raise RuntimeError("no sdk here")
+
+    with patch(
+        "hermes_cli.claude_code.probe_claude_auth",
+        return_value={
+            "logged_in": True,
+            "auth_method": "claude.ai",
+            "subscription_type": "max",
+            "account": "user@example.com",
+        },
+    ):
+        source = claude_billing.probe_claude_billing_source(
+            timeout=1.0,
+            client_factory=_explode,
+            options_factory=lambda: types.SimpleNamespace(),
+            transport_factory=_FakeTransport,
+        )
+    assert source.is_subscription
+    assert source.plan == "max"
+
+
+def test_the_fallback_refuses_when_claude_auth_status_says_api_key():
+    with patch(
+        "hermes_cli.claude_code.probe_claude_auth",
+        return_value={"logged_in": True, "auth_method": "api-key"},
+    ):
+        source = claude_billing.probe_claude_billing_source(
+            timeout=1.0,
+            client_factory=lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+            options_factory=lambda: types.SimpleNamespace(),
+            transport_factory=_FakeTransport,
+        )
+    assert source.kind == "api_key"
+    assert billing_source_refusal(source) is not None
+
+
+# ---------------------------------------------------------------------------
+# The combined gate
+# ---------------------------------------------------------------------------
+
+
+def test_the_static_check_short_circuits_before_spawning_anything():
+    def _never(**_kw):  # pragma: no cover - must not run
+        raise AssertionError("a refused environment must not spawn the CLI")
+
+    refusal = verify_claude_billing_source(
+        env={"ANTHROPIC_API_KEY": "sk-ant"}, client_factory=_never
+    )
+    assert refusal is not None
+    assert "ANTHROPIC_API_KEY" in refusal
+
+
+def test_a_clean_environment_and_a_plan_login_is_allowed():
+    with patch.object(
+        claude_billing,
+        "probe_claude_billing_source",
+        return_value=BillingSource(kind="subscription", plan="Claude Max"),
+    ):
+        assert verify_claude_billing_source(env={"PATH": "/usr/bin"}) is None
+
+
+# ---------------------------------------------------------------------------
+# The runtime seam
+# ---------------------------------------------------------------------------
+
+
+def _agent() -> Any:
+    """The bare surface `verify_claude_billing_for_agent` touches."""
+    return types.SimpleNamespace()
+
+
+def test_the_billing_verdict_is_cached_for_the_life_of_the_session():
+    from agent.claude_runtime import verify_claude_billing_for_agent
+
+    agent = _agent()
+    calls = []
+
+    def _verify(**_kw):
+        calls.append(1)
+        return None
+
+    with patch.object(claude_billing, "verify_claude_billing_source", _verify):
+        assert verify_claude_billing_for_agent(agent) is None
+        assert verify_claude_billing_for_agent(agent) is None
+    assert len(calls) == 1
+
+
+def test_retiring_a_session_forces_the_next_one_to_re_prove():
+    from agent import claude_runtime
+
+    closed = []
+    agent = types.SimpleNamespace(
+        _claude_session=types.SimpleNamespace(close=lambda: closed.append(1)),
+        _claude_billing_refusal="stale verdict",
+    )
+    claude_runtime._retire_session(agent)
+    assert closed == [1]
+    assert agent._claude_billing_refusal is claude_runtime._UNSET
+
+
+def test_a_refused_turn_returns_a_failure_that_names_the_variable(monkeypatch):
+    from agent import claude_runtime
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+
+    agent = types.SimpleNamespace(
+        _interrupt_requested=False,
+        _interrupt_message=None,
+        clear_interrupt=lambda: None,
+    )
+    messages: list = []
+
+    def _no_session(*_a, **_kw):  # pragma: no cover - must not run
+        raise AssertionError("a refused turn must not build a session")
+
+    with (
+        patch.object(claude_runtime, "claude_runtime_preflight", return_value=None),
+        patch.object(claude_runtime, "_ensure_session", _no_session),
+    ):
+        result = claude_runtime.run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert "ANTHROPIC_API_KEY" in result["final_response"]
+    assert "unset ANTHROPIC_API_KEY" in result["error"]
+
+
+def test_preflight_refuses_a_conflicting_credential_before_the_login_probe(monkeypatch):
+    from agent.claude_runtime import claude_runtime_preflight
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+
+    def _never():  # pragma: no cover - must not run
+        raise AssertionError("no subprocess before the free check has spoken")
+
+    with (
+        patch(
+            "hermes_cli.claude_subscription.claude_agent_sdk_available",
+            return_value=True,
+        ),
+        patch("hermes_cli.claude_code.probe_claude_auth", _never),
+    ):
+        message = claude_runtime_preflight({"claude_subscription": {"enabled": True}})
+    assert message is not None
+    assert "ANTHROPIC_API_KEY" in message
+
+
+# ---------------------------------------------------------------------------
+# Session start
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    def __init__(self, *, options, transport=None) -> None:
+        self.options = options
+        self.transport = transport
+
+    async def connect(self) -> None:
+        return None
+
+    async def disconnect(self) -> None:
+        return None
+
+
+def test_starting_a_session_does_not_mutate_os_environ(monkeypatch):
+    from agent.transports.claude_agent_session import ClaudeAgentSession
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/cfg")
+    before = dict(os.environ)
+
+    built: dict = {}
+
+    def _transport_factory(options):
+        built["env"] = claude_sanitized_transport.build_child_env(options)
+        return object()
+
+    session = ClaudeAgentSession(
+        options_factory=lambda: _Options(),
+        client_factory=_StubClient,
+        transport_factory=_transport_factory,
+    )
+    try:
+        session.ensure_started()
+    finally:
+        session.close()
+
+    assert dict(os.environ) == before
+    assert "ANTHROPIC_API_KEY" not in built["env"]
+    assert built["env"]["CLAUDE_CONFIG_DIR"] == "/tmp/cfg"
+
+
+def test_a_session_without_a_transport_factory_still_connects():
+    """Existing callers keep working; the transport is opt-in at the seam."""
+    from agent.transports.claude_agent_session import ClaudeAgentSession
+
+    seen: dict = {}
+
+    def _factory(**kwargs):
+        seen.update(kwargs)
+        return _StubClient(**kwargs)
+
+    session = ClaudeAgentSession(
+        options_factory=lambda: _Options(), client_factory=_factory
+    )
+    try:
+        session.ensure_started()
+    finally:
+        session.close()
+    assert "transport" not in seen
+
+
+# ---------------------------------------------------------------------------
+# stderr routing
+# ---------------------------------------------------------------------------
+
+
+def test_claude_stderr_goes_to_the_logs_not_the_users_screen(caplog):
+    from agent.claude_runtime import _make_stderr_logger
+
+    sink = _make_stderr_logger()
+    with caplog.at_level("DEBUG", logger="agent.claude_runtime.claude_stderr"):
+        sink("routine chatter")
+        sink("")
+        sink("Error: something broke")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("routine chatter" in m for m in messages)
+    # The blank line is dropped, not logged as an empty record.
+    assert not any(m.strip() == "claude:" for m in messages)
+    levels = {
+        record.levelname
+        for record in caplog.records
+        if "something broke" in record.getMessage()
+    }
+    assert "WARNING" in levels
+
+
+def test_error_shaped_stderr_escalation_is_capped(caplog):
+    from agent.claude_runtime import MAX_ESCALATED_STDERR_LINES, _make_stderr_logger
+
+    sink = _make_stderr_logger()
+    with caplog.at_level("DEBUG", logger="agent.claude_runtime.claude_stderr"):
+        for i in range(MAX_ESCALATED_STDERR_LINES * 3):
+            sink(f"error number {i}")
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == MAX_ESCALATED_STDERR_LINES
+
+
+@requires_sdk
+def test_the_runtime_registers_a_stderr_callback():
+    """Without one the SDK lets the child inherit the parent's stderr, which
+    under Electron can be a closed handle."""
+    from agent.claude_runtime import build_claude_agent_options
+
+    agent = MagicMock()
+    agent.model = "claude-sonnet-4-5"
+    with patch(
+        "agent.claude_runtime.build_hermes_sdk_mcp_server", return_value=MagicMock()
+    ), patch("agent.claude_runtime.bridged_allowed_tools", return_value=[]):
+        options = build_claude_agent_options(
+            agent, system_prompt="prompt", effective_task_id=lambda: "t", cwd="/work"
+        )
+    assert callable(options.stderr)
+    # The child env is built by the transport, not here.
+    assert options.env == {}
+
+
+# ---------------------------------------------------------------------------
+# The spawn itself
+# ---------------------------------------------------------------------------
+
+
+@requires_sdk
+def test_the_spawn_receives_a_sanitized_environment_and_a_stdin_pipe(monkeypatch):
+    """End-to-end at the launcher: what actually reaches ``open_process``.
+
+    Nothing is executed — ``anyio.open_process`` is replaced, so no ``claude``
+    process is created and no network call is possible.
+    """
+    import anyio
+    from subprocess import PIPE
+
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-live")
+    monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "bearer-live")
+    monkeypatch.setenv("CLAUDE_CODE_USE_BEDROCK", "1")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/tmp/cfg")
+    monkeypatch.setenv("HOME", "/home/tester")
+    # Skip the CLI version probe, which would spawn the real binary.
+    monkeypatch.setenv("CLAUDE_AGENT_SDK_SKIP_VERSION_CHECK", "1")
+
+    captured: dict = {}
+
+    class _FakeProcess:
+        stdout = stderr = stdin = None
+
+    async def _fake_open_process(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured.update(kwargs)
+        return _FakeProcess()
+
+    monkeypatch.setattr(anyio, "open_process", _fake_open_process)
+
+    options = ClaudeAgentOptions(
+        tools=[],
+        setting_sources=[],
+        cli_path="/usr/bin/claude-not-executed",
+        cwd="/work",
+        env={"ANTHROPIC_API_KEY": "sk-ant-sneaky"},
+    )
+    transport = claude_sanitized_transport.build_sanitized_transport(options)
+
+    import asyncio
+
+    asyncio.run(transport.connect())
+
+    env = captured["env"]
+    for name in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_USE_BEDROCK"):
+        assert name not in env
+    assert env["CLAUDE_CONFIG_DIR"] == "/tmp/cfg"
+    assert env["HOME"] == "/home/tester"
+    assert env["PWD"] == "/work"
+    # Claude Code probes stdin and blocks forever on an unusable inherited one.
+    assert captured["stdin"] is PIPE
+    assert dict(os.environ)["ANTHROPIC_API_KEY"] == "sk-ant-live"

--- a/tests/agent/test_claude_durable_sessions.py
+++ b/tests/agent/test_claude_durable_sessions.py
@@ -1,0 +1,871 @@
+"""Contract for durable Claude Agent SDK sessions: resume, rewind, recovery.
+
+The property under test throughout is the ownership boundary: Hermes remembers
+*which* Claude session belongs to a conversation and never rebuilds Claude's
+context.  Concretely —
+
+* a restart resumes the same SDK session rather than replaying history, and
+  the visible Hermes transcript gains exactly one user row per turn;
+* a rewind forks the SDK session at the message UUID that opened the turn
+  being replaced, and leaves the parent transcript untouched;
+* a branch forks too, so the child starts warm and isolated;
+* a stale binding recovers in exactly one bootstrap+retry and cannot loop;
+* a provider switch bootstraps once and resumes forever after — asserting
+  that history is NOT rebuilt on turn two is the prompt-cache guarantee.
+
+``claude-agent-sdk`` is an optional extra; a stand-in is installed when it is
+absent, and every assertion here is about Hermes' own behaviour so the suite
+means the same thing either way.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+import uuid
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import claude_runtime
+from agent.claude_runtime import (
+    MAX_SESSION_RECOVERIES,
+    ClaudeEventProjector,
+    build_claude_agent_options,
+    claude_bootstrap_prefix,
+    prepare_claude_sdk_session,
+    run_claude_agent_sdk_turn,
+)
+from agent.claude_session_store import RUNTIME
+from hermes_state import SessionDB
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# SDK stand-in (used only when the optional extra is not installed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeHookMatcher:
+    matcher: object = None
+    hooks: list = field(default_factory=list)
+    timeout: object = None
+
+
+@dataclass
+class _FakeClaudeAgentOptions:
+    system_prompt: object = None
+    tools: object = None
+    allowed_tools: list = field(default_factory=list)
+    mcp_servers: dict = field(default_factory=dict)
+    strict_mcp_config: bool = False
+    setting_sources: object = None
+    cwd: object = None
+    env: dict = field(default_factory=dict)
+    stderr: object = None
+    model: object = None
+    include_partial_messages: bool = False
+    resume: object = None
+    session_store: object = None
+    session_store_flush: str = "batched"
+    enable_file_checkpointing: bool = False
+    hooks: object = None
+
+
+@pytest.fixture(autouse=True)
+def sdk_module(monkeypatch):
+    """Yield an importable ``claude_agent_sdk``, faking it when absent."""
+    try:  # pragma: no cover - exercised only where the extra is installed
+        import claude_agent_sdk  # noqa: F401
+
+        yield sys.modules["claude_agent_sdk"]
+        return
+    except ImportError:
+        pass
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.ClaudeAgentOptions = _FakeClaudeAgentOptions
+    module.HookMatcher = _FakeHookMatcher
+    module.project_key_for_directory = lambda directory=None: f"key:{directory}"
+    module.fold_session_summary = _fake_fold
+    module.tool = lambda *a, **k: (lambda fn: fn)
+    module.create_sdk_mcp_server = lambda **kwargs: types.SimpleNamespace(**kwargs)
+    module.ToolAnnotations = type("ToolAnnotations", (), {})
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    yield module
+
+
+def _fake_fold(previous, key, entries):
+    data = dict((previous or {}).get("data") or {})
+    data["entries"] = int(data.get("entries", 0)) + len(entries)
+    return {"session_id": key["session_id"], "mtime": 0, "data": data}
+
+
+# ---------------------------------------------------------------------------
+# SDK message shapes (the runtime dispatches on class name)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    session_id: str | None = None
+
+
+@dataclass
+class ResultMessage:
+    subtype: str = "success"
+    session_id: str = "sdk-1"
+    result: str | None = None
+    usage: dict | None = None
+    total_cost_usd: float | None = None
+    terminal_reason: str | None = None
+    is_error: bool = False
+    errors: list | None = None
+
+
+@dataclass
+class SystemMessage:
+    subtype: str
+    data: dict = field(default_factory=dict)
+
+
+@dataclass
+class MirrorErrorMessage:
+    subtype: str = "mirror_error"
+    data: dict = field(default_factory=dict)
+    key: dict | None = None
+    error: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+HERMES_SESSION = "hermes-session-1"
+CWD = "/tmp/hermes-claude-test"
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session(HERMES_SESSION, "cli")
+    yield session_db
+    session_db.close()
+
+
+def _make_agent(db) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.api_mode = "claude_agent_sdk"
+    agent.client = MagicMock()
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.session_id = HERMES_SESSION
+    agent.session_cwd = CWD
+    agent._session_db = db
+    agent._session_db_created = True
+    # Persist visible rows the way the real flush does, without dragging the
+    # whole run_agent persistence stack into a runtime test.
+    agent._flush_messages_to_session_db = lambda messages, *a, **k: _flush(db, messages)
+    return agent
+
+
+_FLUSHED = "_test_flushed"
+
+
+def _flush(db, messages):
+    for message in messages:
+        if message.get(_FLUSHED):
+            continue
+        message[_FLUSHED] = True
+        content = message.get("content")
+        db.append_message(
+            HERMES_SESSION,
+            message.get("role", "user"),
+            content if isinstance(content, str) else "",
+            display_kind=message.get("display_kind"),
+        )
+    return True
+
+
+class _StubSession:
+    """Replays a scripted message list; optionally fails the first attempt."""
+
+    def __init__(self, script, *, fail_once=None):
+        self.script = script
+        self.fail_once = fail_once
+        self.closed = False
+        self.prompts: list[str] = []
+
+    def run_turn(self, prompt, *, on_message, timeout=None):
+        self.prompts.append(prompt)
+        if self.fail_once is not None:
+            failure, self.fail_once = self.fail_once, None
+            raise failure
+        for message in self.script:
+            on_message(message)
+        return len(self.script)
+
+    def note_session_id(self, session_id):
+        pass
+
+    def close(self):
+        self.closed = True
+
+
+def _script(sdk_session_id: str, text: str = "ok"):
+    return [
+        AssistantMessage(content=[TextBlock(text)], session_id=sdk_session_id),
+        ResultMessage(session_id=sdk_session_id, result=text),
+    ]
+
+
+def _turn(agent, session, messages, user_message="hello"):
+    """Drive one Claude turn with the preflight and session build stubbed."""
+    messages.append({"role": "user", "content": user_message})
+    with (
+        patch.object(claude_runtime, "claude_runtime_preflight", return_value=None),
+        patch.object(
+            claude_runtime, "verify_claude_billing_for_agent", return_value=None
+        ),
+        patch.object(claude_runtime, "_ensure_session", return_value=session),
+    ):
+        return run_claude_agent_sdk_turn(
+            agent,
+            user_message=user_message,
+            original_user_message=user_message,
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+
+def _mirror(db, agent, sdk_session_id, entries):
+    """Stand in for the SDK's transcript mirror landing a batch."""
+    db.append_provider_transcript_entries(
+        RUNTIME,
+        agent._claude_project_key,
+        sdk_session_id,
+        "",
+        entries,
+    )
+
+
+def _user_entry(text="hello"):
+    return {
+        "type": "user",
+        "uuid": str(uuid.uuid4()),
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "message": {"role": "user", "content": text},
+    }
+
+
+def _assistant_entry(text="ok"):
+    return {
+        "type": "assistant",
+        "uuid": str(uuid.uuid4()),
+        "timestamp": "2026-01-01T00:00:01.000Z",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Options
+# ---------------------------------------------------------------------------
+
+
+def test_options_carry_an_eager_mirror_and_never_the_sdks_own_checkpoints(db):
+    agent = _make_agent(db)
+    agent._claude_sdk_resume_id = None
+
+    options = build_claude_agent_options(
+        agent, system_prompt="sys", effective_task_id=lambda: "t", cwd=CWD
+    )
+
+    assert options.session_store is not None
+    # Eager, because Hermes' rewind boundary is a message UUID and a batched
+    # flush would leave the newest turn unmappable until the next one.
+    assert options.session_store_flush == "eager"
+    # The SDK rejects the pair, and Hermes owns checkpointing.
+    assert not getattr(options, "enable_file_checkpointing", False)
+    assert getattr(options, "resume", None) is None
+
+
+def test_options_resume_the_session_bound_to_this_conversation(db):
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-abc")
+
+    prepare_claude_sdk_session(agent, CWD)
+    options = build_claude_agent_options(
+        agent, system_prompt="sys", effective_task_id=lambda: "t", cwd=CWD
+    )
+
+    assert options.resume == "sdk-abc"
+
+
+def test_no_session_db_means_no_mirror_and_no_resume(db):
+    """A background-review fork or a persistence-disabled agent still runs."""
+    agent = _make_agent(db)
+    agent._session_db = None
+
+    state = prepare_claude_sdk_session(agent, CWD)
+    options = build_claude_agent_options(
+        agent, system_prompt="sys", effective_task_id=lambda: "t", cwd=CWD
+    )
+
+    assert state == {"resume": None, "bootstrap": False, "recoveries": 0}
+    assert options.session_store is None
+    assert getattr(options, "resume", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Restart → resume
+# ---------------------------------------------------------------------------
+
+
+def test_a_restart_resumes_the_same_sdk_session_without_duplicating_the_turn(db):
+    first = _make_agent(db)
+    messages: list[dict] = []
+    session = _StubSession(_script("sdk-1"))
+    _turn(first, session, messages, "first question")
+
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == "sdk-1"
+
+    # A new process: a new AIAgent over the same session id and the same DB,
+    # with the transcript reloaded rather than carried in memory.
+    restarted = _make_agent(db)
+    reloaded = [{"role": "user", "content": "first question", _FLUSHED: True},
+                {"role": "assistant", "content": "ok", _FLUSHED: True}]
+    second_session = _StubSession(_script("sdk-1"))
+    _turn(restarted, second_session, reloaded, "second question")
+
+    assert restarted._claude_sdk_resume_id == "sdk-1"
+    # The whole point: the prompt is the user's message, NOT a replay of
+    # history on top of a session that already has it.
+    assert second_session.prompts == ["second question"]
+    stored = [m for m in db.get_messages(HERMES_SESSION) if m["role"] == "user"]
+    assert [m["content"] for m in stored] == ["first question", "second question"]
+
+
+def test_the_binding_survives_in_the_db_not_just_on_the_agent(db):
+    agent = _make_agent(db)
+    _turn(agent, _StubSession(_script("sdk-77")), [], "hi")
+
+    binding = db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)
+
+    assert binding["provider_session_id"] == "sdk-77"
+    assert binding["bootstrapped"] is True
+    assert binding["project_key"] == agent._claude_project_key
+
+
+# ---------------------------------------------------------------------------
+# Provider switch → bootstrap once, then resume
+# ---------------------------------------------------------------------------
+
+
+def test_switching_into_claude_bootstraps_once_then_resumes(db):
+    """Rebuilding history every turn would destroy the upstream prompt cache."""
+    agent = _make_agent(db)
+    history = [
+        {"role": "user", "content": "what is a monad", _FLUSHED: True},
+        {"role": "assistant", "content": "a monoid in the category of endofunctors",
+         _FLUSHED: True},
+    ]
+    session_one = _StubSession(_script("sdk-boot"))
+    _turn(agent, session_one, history, "explain that again")
+
+    assert "prior_conversation" in session_one.prompts[0]
+    assert "monoid in the category of endofunctors" in session_one.prompts[0]
+    assert session_one.prompts[0].endswith("explain that again")
+
+    session_two = _StubSession(_script("sdk-boot"))
+    _turn(agent, session_two, history, "and again")
+
+    # Turn two resumes. History is NOT rebuilt.
+    assert session_two.prompts == ["and again"]
+    assert agent._claude_sdk_resume_id == "sdk-boot"
+
+
+def test_a_conversation_with_no_history_replays_no_prior_conversation(db):
+    agent = _make_agent(db)
+    session = _StubSession(_script("sdk-1"))
+
+    _turn(agent, session, [], "first message ever")
+
+    prompt = session.prompts[0]
+    # Hermes' own context always rides the first turn — in subscription mode
+    # it cannot go in the system prompt (decision record §11) — but with no
+    # prior history there is nothing to replay.
+    assert "<prior_conversation>" not in prompt
+    assert "<operating_instructions>" in prompt
+    assert prompt.endswith("first message ever")
+
+
+def test_the_bootstrap_prefix_is_deterministic_and_bounded():
+    history = [{"role": "user", "content": f"turn {i}"} for i in range(500)]
+
+    first = claude_bootstrap_prefix(history)
+    second = claude_bootstrap_prefix(history)
+
+    assert first == second
+    assert len(first) <= claude_runtime.BOOTSTRAP_MAX_CHARS + 1000
+    # Tool traffic is Claude's to own from here; replaying it would imply
+    # Claude issued calls it never made.
+    assert claude_bootstrap_prefix(
+        [{"role": "tool", "content": "result", "tool_call_id": "t1"}]
+    ) == ""
+
+
+# ---------------------------------------------------------------------------
+# Rewind / edit
+# ---------------------------------------------------------------------------
+
+
+def _prime_two_turns(db):
+    """Two mirrored turns with a binding, as if two Claude turns had run."""
+    agent = _make_agent(db)
+    agent._claude_project_key = claude_runtime.claude_project_key(CWD)
+    db.bind_provider_runtime_session(
+        HERMES_SESSION, RUNTIME, "sdk-parent", project_key=agent._claude_project_key
+    )
+
+    turn_one = [_user_entry("one"), _assistant_entry("answer one")]
+    _mirror(db, agent, "sdk-parent", turn_one)
+    row_one = db.append_message(HERMES_SESSION, "user", "one")
+    db.append_message(HERMES_SESSION, "assistant", "answer one")
+    db.record_provider_message_binding(
+        HERMES_SESSION, 0, RUNTIME, "sdk-parent",
+        message_id=row_one, project_key=agent._claude_project_key, after_entry_id=0,
+    )
+    db.set_provider_message_binding_uuids(
+        HERMES_SESSION, 0,
+        provider_message_uuid=turn_one[0]["uuid"], fork_boundary_uuid=None,
+    )
+
+    watermark = db.provider_transcript_watermark(
+        RUNTIME, agent._claude_project_key, "sdk-parent"
+    )
+    turn_two = [_user_entry("two"), _assistant_entry("answer two")]
+    _mirror(db, agent, "sdk-parent", turn_two)
+    row_two = db.append_message(HERMES_SESSION, "user", "two")
+    db.append_message(HERMES_SESSION, "assistant", "answer two")
+    db.record_provider_message_binding(
+        HERMES_SESSION, 1, RUNTIME, "sdk-parent",
+        message_id=row_two, project_key=agent._claude_project_key,
+        after_entry_id=watermark,
+    )
+    db.set_provider_message_binding_uuids(
+        HERMES_SESSION, 1,
+        provider_message_uuid=turn_two[0]["uuid"],
+        # Everything up to and including the end of turn one survives.
+        fork_boundary_uuid=turn_one[-1]["uuid"],
+    )
+    return agent, row_two, turn_one, turn_two
+
+
+def test_rewinding_forks_the_sdk_session_at_the_surviving_boundary(db):
+    agent, row_two, turn_one, _turn_two = _prime_two_turns(db)
+    forks: list[tuple] = []
+
+    def _fake_fork(store, source, cwd, up_to):
+        forks.append((source, up_to))
+        return "sdk-fork"
+
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(claude_runtime, "_fork_stored_session", _fake_fork):
+        state = prepare_claude_sdk_session(agent, CWD)
+
+    # Forked from the parent, inclusive of the last entry the user kept.
+    assert forks == [("sdk-parent", turn_one[-1]["uuid"])]
+    assert state["resume"] == "sdk-fork"
+    assert state["bootstrap"] is False
+    binding = db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)
+    assert binding["provider_session_id"] == "sdk-fork"
+    assert binding["pending_rewind_ordinal"] is None
+
+
+def test_rewinding_leaves_the_parent_transcript_untouched(db):
+    agent, row_two, _turn_one, _turn_two = _prime_two_turns(db)
+    before = db.load_provider_transcript_entries(
+        RUNTIME, agent._claude_project_key, "sdk-parent"
+    )
+
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(
+        claude_runtime, "_fork_stored_session", lambda *a, **k: "sdk-fork"
+    ):
+        prepare_claude_sdk_session(agent, CWD)
+
+    assert (
+        db.load_provider_transcript_entries(
+            RUNTIME, agent._claude_project_key, "sdk-parent"
+        )
+        == before
+    )
+
+
+def test_rewinding_drops_the_bindings_for_the_turns_being_replaced(db):
+    agent, row_two, _turn_one, _turn_two = _prime_two_turns(db)
+
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(
+        claude_runtime, "_fork_stored_session", lambda *a, **k: "sdk-fork"
+    ):
+        prepare_claude_sdk_session(agent, CWD)
+
+    assert db.get_provider_message_binding(HERMES_SESSION, 0) is not None
+    assert db.get_provider_message_binding(HERMES_SESSION, 1) is None
+
+
+def test_a_truncating_transcript_rewrite_signals_the_same_boundary(db):
+    """prompt.submit's truncate (Desktop edit/regenerate) goes through here."""
+    agent, _row_two, _turn_one, _turn_two = _prime_two_turns(db)
+
+    db.replace_messages(
+        HERMES_SESSION,
+        [{"role": "user", "content": "one"}, {"role": "assistant", "content": "answer one"}],
+    )
+
+    binding = db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)
+    assert binding["pending_rewind_ordinal"] == 1
+
+
+def test_rewinding_past_every_turn_starts_a_clean_session(db):
+    agent, _row_two, _turn_one, _turn_two = _prime_two_turns(db)
+    first_row = db.get_provider_message_binding(HERMES_SESSION, 0)["message_id"]
+    forks: list = []
+
+    db.rewind_to_message(HERMES_SESSION, first_row)
+    with patch.object(
+        claude_runtime, "_fork_stored_session", lambda *a, **k: forks.append(a) or "x"
+    ):
+        state = prepare_claude_sdk_session(agent, CWD)
+
+    # Nothing survives, so there is nothing to fork.
+    assert forks == []
+    assert state["resume"] is None
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == ""
+
+
+def test_a_failed_fork_degrades_to_a_clean_session_rather_than_a_wrong_resume(db):
+    agent, row_two, _turn_one, _turn_two = _prime_two_turns(db)
+
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(claude_runtime, "_fork_stored_session", lambda *a, **k: None):
+        state = prepare_claude_sdk_session(agent, CWD)
+
+    assert state["resume"] is None
+    # Never resume a cursor that points past discarded history.
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == ""
+
+
+# ---------------------------------------------------------------------------
+# Branch
+# ---------------------------------------------------------------------------
+
+
+def test_branching_a_session_forks_the_sdk_session_instead_of_replaying(db):
+    parent_agent, _row, _t1, _t2 = _prime_two_turns(db)
+    branch_id = "hermes-branch-1"
+
+    db.create_session(
+        branch_id, "cli", model_config={"_branched_from": HERMES_SESSION}
+    )
+
+    branch_agent = _make_agent(db)
+    branch_agent.session_id = branch_id
+    forks: list[tuple] = []
+    with patch.object(
+        claude_runtime,
+        "_fork_stored_session",
+        lambda store, source, cwd, up_to: forks.append((source, up_to)) or "sdk-branch",
+    ):
+        state = prepare_claude_sdk_session(branch_agent, CWD)
+
+    # A full fork (no boundary): the branch keeps the parent's whole context.
+    assert forks == [("sdk-parent", None)]
+    assert state["resume"] == "sdk-branch"
+    assert state["bootstrap"] is False
+    # The parent's own binding is untouched — the two sessions are isolated.
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == "sdk-parent"
+
+
+def test_an_ordinary_new_session_is_not_treated_as_a_branch(db):
+    _prime_two_turns(db)
+    db.create_session("hermes-plain", "cli")
+
+    assert db.get_provider_runtime_session("hermes-plain", RUNTIME) is None
+
+
+# ---------------------------------------------------------------------------
+# Stale / deleted SDK session
+# ---------------------------------------------------------------------------
+
+
+def test_a_stale_session_recovers_in_exactly_one_bootstrap_retry(db):
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-gone")
+    history = [{"role": "user", "content": "earlier", _FLUSHED: True},
+               {"role": "assistant", "content": "earlier answer", _FLUSHED: True}]
+    session = _StubSession(
+        _script("sdk-new"),
+        fail_once=RuntimeError("No conversation found with session ID sdk-gone"),
+    )
+
+    result = _turn(agent, session, history, "next")
+
+    assert result["completed"] is True
+    assert len(session.prompts) == 2, "the user's turn is submitted once, then retried"
+    assert session.prompts[0] == "next"
+    # The retry bootstraps canonical history into the fresh session.
+    assert "prior_conversation" in session.prompts[1]
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == "sdk-new"
+
+
+def test_recovery_does_not_loop_when_the_fresh_session_also_fails(db):
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-gone")
+
+    class _AlwaysFails(_StubSession):
+        def run_turn(self, prompt, *, on_message, timeout=None):
+            self.prompts.append(prompt)
+            raise RuntimeError("No conversation found")
+
+    session = _AlwaysFails([])
+    result = _turn(agent, session, [], "next")
+
+    # One recovery, then the failure is reported as a failure.
+    assert len(session.prompts) == 2
+    assert result["completed"] is False
+    assert result["error"]
+
+
+def test_the_recovery_cap_stops_a_permanently_broken_binding(db):
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-gone")
+    for _ in range(MAX_SESSION_RECOVERIES):
+        db.clear_provider_runtime_session(HERMES_SESSION, RUNTIME)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-gone")
+
+    session = _StubSession(_script("sdk-new"), fail_once=RuntimeError("session not found"))
+    result = _turn(agent, session, [], "next")
+
+    assert len(session.prompts) == 1, "the cap must stop the retry"
+    assert result["completed"] is False
+
+
+def test_a_connect_that_fails_while_resuming_is_treated_as_stale(db):
+    """The structural signal: the CLI could not open the transcript at all."""
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-gone")
+    good = _StubSession(_script("sdk-new"))
+    attempts = {"n": 0}
+
+    def _ensure(_agent, _task_id):
+        attempts["n"] += 1
+        if attempts["n"] == 1:
+            raise RuntimeError("Failed to start Claude Code")
+        return good
+
+    messages: list[dict] = [{"role": "user", "content": "hi"}]
+    with (
+        patch.object(claude_runtime, "claude_runtime_preflight", return_value=None),
+        patch.object(
+            claude_runtime, "verify_claude_billing_for_agent", return_value=None
+        ),
+        patch.object(claude_runtime, "_ensure_session", _ensure),
+    ):
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+    assert attempts["n"] == 2
+    assert result["completed"] is True
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == "sdk-new"
+
+
+def test_a_rewind_retires_the_live_session_so_the_fork_actually_takes_effect(db):
+    """A connected client still points at the parent transcript."""
+    agent, row_two, _t1, _t2 = _prime_two_turns(db)
+    live = _StubSession([])
+    agent._claude_session = live
+
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(
+        claude_runtime, "_fork_stored_session", lambda *a, **k: "sdk-fork"
+    ):
+        prepare_claude_sdk_session(agent, CWD)
+
+    assert live.closed is True
+    assert getattr(agent, "_claude_session", None) is None
+
+
+def test_an_unrelated_turn_failure_is_not_treated_as_a_stale_session(db):
+    agent = _make_agent(db)
+    db.bind_provider_runtime_session(HERMES_SESSION, RUNTIME, "sdk-live")
+
+    session = _StubSession(_script("sdk-live"), fail_once=RuntimeError("connection reset"))
+    result = _turn(agent, session, [], "next")
+
+    assert len(session.prompts) == 1
+    assert result["completed"] is False
+    # The binding is not thrown away over a network blip.
+    assert db.get_provider_runtime_session(HERMES_SESSION, RUNTIME)[
+        "provider_session_id"
+    ] == "sdk-live"
+
+
+def test_a_fresh_session_that_fails_is_a_failure_not_a_recovery(db):
+    agent = _make_agent(db)
+    session = _StubSession(_script("sdk-1"), fail_once=RuntimeError("session not found"))
+
+    result = _turn(agent, session, [], "next")
+
+    assert len(session.prompts) == 1
+    assert result["completed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Mirror errors
+# ---------------------------------------------------------------------------
+
+
+def test_a_mirror_error_warns_and_does_not_kill_the_turn(db, caplog):
+    agent = _make_agent(db)
+    statuses: list[str] = []
+    agent._emit_status = statuses.append
+    session = _StubSession(
+        [
+            AssistantMessage(content=[TextBlock("still here")], session_id="sdk-1"),
+            MirrorErrorMessage(
+                error="store append failed",
+                data={"error": "store append failed"},
+                key={"project_key": "p", "session_id": "sdk-1"},
+            ),
+            ResultMessage(session_id="sdk-1", result="still here"),
+        ]
+    )
+
+    with caplog.at_level("WARNING", logger="agent.claude_runtime"):
+        result = _turn(agent, session, [], "hi")
+
+    assert result["completed"] is True
+    assert result["final_response"] == "still here"
+    assert any("mirror" in record.message.lower() for record in caplog.records)
+    assert statuses, "the user is told durability degraded"
+
+
+def test_a_mirror_error_delivered_as_a_plain_system_message_still_warns(db, caplog):
+    agent = _make_agent(db)
+    projector = ClaudeEventProjector(agent)
+
+    with caplog.at_level("WARNING", logger="agent.claude_runtime"):
+        projector(SystemMessage("mirror_error", {"error": "boom"}))
+
+    assert projector.mirror_errors == ["boom"]
+
+
+# ---------------------------------------------------------------------------
+# Alternation
+# ---------------------------------------------------------------------------
+
+
+def _roles(messages):
+    return [m["role"] for m in messages]
+
+
+def _assert_alternating(messages):
+    """No two same-role messages in a row outside a tool round."""
+    previous = None
+    for message in messages:
+        role = message["role"]
+        if role in ("user", "assistant"):
+            assert not (
+                previous == role and not message.get("tool_calls")
+            ), f"role alternation broken: {_roles(messages)}"
+            previous = role
+        elif role == "tool":
+            previous = "tool"
+
+
+def test_alternation_holds_across_a_restart(db):
+    agent = _make_agent(db)
+    messages: list[dict] = []
+    _turn(agent, _StubSession(_script("sdk-1", "first answer")), messages, "one")
+
+    restarted = _make_agent(db)
+    _turn(restarted, _StubSession(_script("sdk-1", "second answer")), messages, "two")
+
+    _assert_alternating(messages)
+    assert _roles(messages) == ["user", "assistant", "user", "assistant"]
+
+
+def test_alternation_holds_across_a_rewind_and_re_ask(db):
+    agent, row_two, _t1, _t2 = _prime_two_turns(db)
+    db.rewind_to_message(HERMES_SESSION, row_two)
+    with patch.object(
+        claude_runtime, "_fork_stored_session", lambda *a, **k: "sdk-fork"
+    ):
+        prepare_claude_sdk_session(agent, CWD)
+
+    messages = [{"role": "user", "content": "one", _FLUSHED: True},
+                {"role": "assistant", "content": "answer one", _FLUSHED: True}]
+    _turn(agent, _StubSession(_script("sdk-fork", "edited answer")), messages, "two-edited")
+
+    _assert_alternating(messages)
+    assert _roles(messages) == ["user", "assistant", "user", "assistant"]
+
+
+def test_alternation_holds_across_a_native_compaction(db):
+    agent = _make_agent(db)
+    messages: list[dict] = []
+
+    session = _StubSession(
+        [
+            SystemMessage("compact_boundary", {"session_id": "sdk-1"}),
+            AssistantMessage(content=[TextBlock("after compaction")], session_id="sdk-1"),
+            ResultMessage(session_id="sdk-1", result="after compaction"),
+        ]
+    )
+    _turn(agent, session, messages, "long conversation")
+    _turn(agent, _StubSession(_script("sdk-1", "next")), messages, "and more")
+
+    _assert_alternating(messages)
+    # Compaction is Claude's; Hermes' visible transcript is not rewritten.
+    assert _roles(messages) == ["user", "assistant", "user", "assistant"]

--- a/tests/agent/test_claude_model_switch.py
+++ b/tests/agent/test_claude_model_switch.py
@@ -1,0 +1,247 @@
+"""Contract for switching models on a live Claude Agent SDK session.
+
+The SDK owns the conversation context, the message UUIDs, and the upstream
+prompt cache. Hermes cannot reconstruct any of them, so an in-session model
+switch has to go through the SDK's control plane rather than through a
+teardown-and-reconnect — a rebuild silently costs the user a cold cache and a
+lost context, and neither failure announces itself.
+
+Also pinned: an unknown model is rejected here, with the allowed set named,
+instead of being handed to the CLI's ``--model`` where it fails inside a spawned
+subprocess with nothing the user can act on.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent.agent_runtime_helpers import switch_claude_agent_sdk_model, switch_model
+from hermes_cli.models import (
+    claude_subscription_models,
+    is_valid_claude_subscription_model,
+    validate_requested_model,
+)
+
+
+def _make_session(*, accepted=True, closed=False):
+    session = MagicMock()
+    session.closed = closed
+    session.set_model.return_value = accepted
+    return session
+
+
+def _make_claude_agent(session=None):
+    """A duck-typed agent carrying the fields ``switch_model`` touches."""
+    agent = MagicMock()
+    agent.model = "claude-sonnet-5"
+    agent.provider = "claude-code"
+    agent.requested_provider = "claude-code"
+    agent.api_mode = "claude_agent_sdk"
+    agent.base_url = "claude-sdk://subscription"
+    agent.api_key = ""
+    agent.client = None
+    agent._client_kwargs = {}
+    agent._session_db = None
+    agent._claude_session = session
+    agent._anthropic_prompt_cache_policy.return_value = (True, False)
+    agent._effective_lmstudio_context_length.return_value = 200_000
+
+    def _release():
+        live = agent._claude_session
+        agent._claude_session = None
+        if live is not None:
+            live.close()
+
+    agent._release_claude_agent_sdk_session.side_effect = _release
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# The control-plane switch
+# ---------------------------------------------------------------------------
+
+
+class TestInPlaceSwitch:
+    def test_uses_set_model_and_keeps_the_session(self):
+        session = _make_session(accepted=True)
+        agent = _make_claude_agent(session)
+
+        outcome = switch_claude_agent_sdk_model(agent, "claude-opus-5")
+
+        assert outcome == "set_model"
+        session.set_model.assert_called_once_with("claude-opus-5")
+        # The whole point: no teardown, so Claude keeps context + prompt cache.
+        session.close.assert_not_called()
+        assert agent._claude_session is session
+
+    def test_a_refused_switch_retires_rather_than_lying(self):
+        """A session still pinned to the old model would answer as it silently."""
+        session = _make_session(accepted=False)
+        agent = _make_claude_agent(session)
+
+        outcome = switch_claude_agent_sdk_model(agent, "claude-opus-5")
+
+        assert outcome == "retired"
+        session.close.assert_called_once()
+        assert agent._claude_session is None
+
+    def test_a_raising_control_plane_also_retires(self):
+        session = _make_session()
+        session.set_model.side_effect = RuntimeError("transport wedged")
+        agent = _make_claude_agent(session)
+
+        assert switch_claude_agent_sdk_model(agent, "claude-opus-5") == "retired"
+        assert agent._claude_session is None
+
+    def test_no_live_session_is_a_no_op(self):
+        agent = _make_claude_agent(None)
+        assert switch_claude_agent_sdk_model(agent, "claude-opus-5") == "none"
+        agent._release_claude_agent_sdk_session.assert_not_called()
+
+    def test_closed_session_is_a_no_op(self):
+        session = _make_session(closed=True)
+        agent = _make_claude_agent(session)
+        assert switch_claude_agent_sdk_model(agent, "claude-opus-5") == "none"
+        session.set_model.assert_not_called()
+
+
+class TestSwitchModelIntegration:
+    def test_switch_model_retargets_instead_of_rebuilding(self):
+        session = _make_session(accepted=True)
+        agent = _make_claude_agent(session)
+
+        switch_model(
+            agent,
+            "claude-opus-5",
+            "claude-code",
+            api_key="",
+            base_url="claude-sdk://subscription",
+            api_mode="claude_agent_sdk",
+        )
+
+        assert agent.model == "claude-opus-5"
+        session.set_model.assert_called_once_with("claude-opus-5")
+        session.close.assert_not_called()
+        # No HTTP client is built: `claude-sdk://subscription` is not an endpoint.
+        agent._create_openai_client.assert_not_called()
+        assert agent.client is None
+        assert agent.api_key == ""
+
+    def test_leaving_the_runtime_releases_the_session(self):
+        session = _make_session()
+        agent = _make_claude_agent(session)
+
+        switch_model(
+            agent,
+            "gpt-5.5",
+            "openai-api",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+        )
+
+        agent._release_claude_agent_sdk_session.assert_called_once()
+        session.close.assert_called_once()
+        # And the model switch itself still happened.
+        assert agent.model == "gpt-5.5"
+        assert agent.provider == "openai-api"
+
+    def test_a_non_claude_agent_is_untouched_by_the_release_hook(self):
+        agent = _make_claude_agent(None)
+        agent.api_mode = "chat_completions"
+        agent.provider = "openai-api"
+        agent.base_url = "https://api.openai.com/v1"
+
+        switch_model(
+            agent,
+            "gpt-5.5",
+            "openai-api",
+            api_key="sk-test",
+            base_url="https://api.openai.com/v1",
+            api_mode="chat_completions",
+        )
+
+        agent._release_claude_agent_sdk_session.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The curated model set
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscription_gate_open(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.claude_code.subscription_enabled", lambda config=None: True
+    )
+
+
+class TestCuratedModelSet:
+    def test_derived_from_the_catalog_this_module_already_keeps(self):
+        """Not a second hand-maintained list: every entry traces to a source."""
+        from hermes_cli.models import (
+            CLAUDE_SUBSCRIPTION_MODEL_ALIASES,
+            OPENROUTER_MODELS,
+            _PROVIDER_MODELS,
+        )
+
+        models = claude_subscription_models()
+        assert models, "the curated set must not be empty"
+
+        known = {m.lower() for m in _PROVIDER_MODELS["anthropic"]}
+        known |= {
+            mid.split("/", 1)[1].replace(".", "-").lower()
+            for mid, _ in OPENROUTER_MODELS
+            if mid.startswith("anthropic/")
+        }
+        known |= {a.lower() for a in CLAUDE_SUBSCRIPTION_MODEL_ALIASES}
+        for model in models:
+            assert model.lower() in known
+
+    def test_registered_for_the_picker(self):
+        from hermes_cli.models import _PROVIDER_MODELS
+
+        assert _PROVIDER_MODELS["claude-code"] == claude_subscription_models()
+
+    def test_cli_short_aliases_are_accepted(self):
+        for alias in ("sonnet", "opus", "haiku", "default"):
+            assert is_valid_claude_subscription_model(alias)
+
+    def test_matching_is_case_insensitive(self):
+        first = claude_subscription_models()[0]
+        assert is_valid_claude_subscription_model(first.upper())
+
+    def test_unknown_model_is_rejected_with_the_allowed_set(
+        self, subscription_gate_open
+    ):
+        result = validate_requested_model("claude-imaginary-9", "claude-code")
+        assert result["accepted"] is False
+        assert result["persist"] is False
+        for model in claude_subscription_models():
+            assert model in result["message"]
+
+    def test_known_model_is_accepted_without_a_network_probe(
+        self, subscription_gate_open, monkeypatch
+    ):
+        def _no_probe(*args, **kwargs):  # pragma: no cover - guard
+            raise AssertionError("claude-sdk:// is not a reachable endpoint")
+
+        monkeypatch.setattr(
+            "hermes_cli.models._urlopen_model_catalog_request", _no_probe
+        )
+        result = validate_requested_model(
+            claude_subscription_models()[0], "claude-code"
+        )
+        assert result["accepted"] is True
+        assert result["recognized"] is True
+
+    def test_gate_closed_keeps_the_legacy_anthropic_behaviour(self, monkeypatch):
+        """While the gate is shut, `claude-code` still means `anthropic`."""
+        monkeypatch.setattr(
+            "hermes_cli.claude_code.subscription_enabled", lambda config=None: False
+        )
+        from hermes_cli.models import is_claude_subscription_slug
+
+        assert is_claude_subscription_slug("claude-code") is False

--- a/tests/agent/test_claude_runtime.py
+++ b/tests/agent/test_claude_runtime.py
@@ -1,0 +1,896 @@
+"""Contract for the ``claude_agent_sdk`` whole-turn runtime.
+
+Three things are being pinned down here:
+
+1. The turn refuses to start unless the gate is on, the optional extra is
+   installed, and the user is signed in — with an error that names the fix.
+2. The SDK options carry Hermes' ownership boundary: the exact Hermes system
+   prompt, no SDK built-ins, no second settings load, a pinned MCP toolset.
+3. A Claude turn fires the same canonical Hermes callbacks and produces the
+   same message shape as every other provider, exactly once.
+
+``claude-agent-sdk`` is an optional extra, so a stand-in module is installed
+when it is absent. The SDK message/block classes are re-declared locally
+because the runtime dispatches on class name — that is what lets the projector
+behave identically with and without the real package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import claude_runtime
+from agent.claude_runtime import (
+    ClaudeEventProjector,
+    build_claude_agent_options,
+    claude_runtime_preflight,
+    display_tool_name,
+    run_claude_agent_sdk_turn,
+)
+from agent.transports.claude_tool_bridge import MCP_SERVER_NAME, bridged_allowed_tools
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# SDK stand-in (used only when the optional extra is not installed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeToolAnnotations:
+    readOnlyHint: bool = False
+
+
+@dataclass
+class _FakeSdkTool:
+    name: str
+    description: str
+    input_schema: dict
+    handler: Any
+    annotations: Any = None
+
+
+def _fake_tool(name, description, input_schema, annotations=None):
+    def _decorate(handler):
+        return _FakeSdkTool(name, description, input_schema, handler, annotations)
+
+    return _decorate
+
+
+def _fake_create_sdk_mcp_server(*, name, version, tools):
+    return SimpleNamespace(name=name, version=version, tools=list(tools))
+
+
+@dataclass
+class _FakeClaudeAgentOptions:
+    system_prompt: Any = None
+    tools: Any = None
+    allowed_tools: list = field(default_factory=list)
+    disallowed_tools: list = field(default_factory=list)
+    mcp_servers: dict = field(default_factory=dict)
+    strict_mcp_config: bool = False
+    setting_sources: Any = None
+    cwd: Any = None
+    env: dict = field(default_factory=dict)
+    stderr: Any = None
+    model: Any = None
+    include_partial_messages: bool = False
+    resume: Any = None
+    session_store: Any = None
+    hooks: Any = None
+
+
+@dataclass
+class _FakeHookMatcher:
+    matcher: Any = None
+    hooks: list = field(default_factory=list)
+    timeout: Any = None
+
+
+@pytest.fixture
+def sdk_module(monkeypatch):
+    """Yield an importable ``claude_agent_sdk``, faking it when absent."""
+    try:  # pragma: no cover - exercised only where the extra is installed
+        import claude_agent_sdk  # noqa: F401
+
+        yield sys.modules["claude_agent_sdk"]
+        return
+    except ImportError:
+        pass
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.tool = _fake_tool
+    module.create_sdk_mcp_server = _fake_create_sdk_mcp_server
+    module.ToolAnnotations = _FakeToolAnnotations
+    module.ClaudeAgentOptions = _FakeClaudeAgentOptions
+    module.HookMatcher = _FakeHookMatcher
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    yield module
+
+
+# ---------------------------------------------------------------------------
+# SDK message shapes (dispatch is by class name)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class ThinkingBlock:
+    thinking: str
+    signature: str = ""
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    content: Any = None
+    is_error: bool | None = None
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str = "claude-sonnet-4-5"
+    stop_reason: str | None = None
+    session_id: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class UserMessage:
+    content: Any
+
+
+@dataclass
+class SystemMessage:
+    subtype: str
+    data: dict = field(default_factory=dict)
+
+
+@dataclass
+class StreamEvent:
+    event: dict
+    session_id: str = "sdk-session-1"
+    uuid: str = "u1"
+
+
+@dataclass
+class ResultMessage:
+    subtype: str = "success"
+    session_id: str = "sdk-session-1"
+    result: str | None = None
+    usage: dict | None = None
+    total_cost_usd: float | None = None
+    terminal_reason: str | None = None
+    is_error: bool = False
+    errors: list | None = None
+
+
+def _text_delta(text: str) -> StreamEvent:
+    return StreamEvent(
+        event={"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}}
+    )
+
+
+def _thinking_delta(text: str) -> StreamEvent:
+    return StreamEvent(
+        event={
+            "type": "content_block_delta",
+            "delta": {"type": "thinking_delta", "thinking": text},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str, api_mode: str = "claude_agent_sdk") -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.api_mode = api_mode
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+class _Recorder:
+    """Captures the canonical Hermes callbacks a runtime must fire."""
+
+    def __init__(self, agent) -> None:
+        self.text: list[str] = []
+        self.reasoning: list[str] = []
+        self.interim: list[dict] = []
+        self.progress: list[tuple] = []
+        self.tool_started: list[tuple] = []
+        self.tool_completed: list[tuple] = []
+        agent._fire_stream_delta = self.text.append
+        agent._fire_reasoning_delta = self.reasoning.append
+        agent._emit_interim_assistant_message = self.interim.append
+        agent.tool_progress_callback = self._progress
+        agent.tool_start_callback = lambda *a: self.tool_started.append(a)
+        agent.tool_complete_callback = lambda *a: self.tool_completed.append(a)
+
+    def _progress(self, phase, name, *rest, **kwargs):
+        self.progress.append((phase, name, kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_names_the_config_key_when_the_gate_is_off():
+    message = claude_runtime_preflight({"claude_subscription": {"enabled": False}})
+    assert message is not None
+    assert "claude_subscription.enabled" in message
+
+
+def test_preflight_names_the_extra_when_the_sdk_is_missing():
+    with patch(
+        "hermes_cli.claude_subscription.claude_agent_sdk_available", return_value=False
+    ):
+        message = claude_runtime_preflight({"claude_subscription": {"enabled": True}})
+    assert message is not None
+    assert "claude-code" in message
+
+
+def test_preflight_names_the_login_command_when_signed_out():
+    with (
+        patch(
+            "hermes_cli.claude_subscription.claude_agent_sdk_available",
+            return_value=True,
+        ),
+        patch(
+            "hermes_cli.claude_code.probe_claude_auth_cached",
+            return_value={"logged_in": False, "message": ""},
+        ),
+    ):
+        message = claude_runtime_preflight({"claude_subscription": {"enabled": True}})
+    assert message is not None
+    assert "claude auth login" in message
+
+
+def test_preflight_passes_when_all_three_gates_are_open():
+    with (
+        patch(
+            "hermes_cli.claude_subscription.claude_agent_sdk_available",
+            return_value=True,
+        ),
+        patch(
+            "hermes_cli.claude_code.probe_claude_auth_cached",
+            return_value={"logged_in": True, "message": "Signed in."},
+        ),
+    ):
+        assert claude_runtime_preflight({"claude_subscription": {"enabled": True}}) is None
+
+
+@pytest.mark.parametrize(
+    "config,patches",
+    [
+        ({"claude_subscription": {"enabled": False}}, {}),
+        ({"claude_subscription": {"enabled": True}}, {"sdk": False}),
+        ({"claude_subscription": {"enabled": True}}, {"sdk": True, "login": False}),
+    ],
+)
+def test_a_refused_turn_never_builds_a_session(config, patches):
+    agent = _make_agent("web_search")
+    messages: list[dict] = []
+    stack = [patch("hermes_cli.config.load_config_readonly", return_value=config)]
+    if "sdk" in patches:
+        stack.append(
+            patch(
+                "hermes_cli.claude_subscription.claude_agent_sdk_available",
+                return_value=patches["sdk"],
+            )
+        )
+    if "login" in patches:
+        stack.append(
+            patch(
+                "hermes_cli.claude_code.probe_claude_auth_cached",
+                return_value={"logged_in": patches["login"], "message": ""},
+            )
+        )
+    built = []
+    stack.append(
+        patch.object(
+            claude_runtime, "_ensure_session", lambda *a, **k: built.append(a)
+        )
+    )
+
+    from contextlib import ExitStack
+
+    with ExitStack() as es:
+        for ctx in stack:
+            es.enter_context(ctx)
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+    assert built == []
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["error"]
+    assert messages == []
+
+
+# ---------------------------------------------------------------------------
+# Options — the ownership boundary
+# ---------------------------------------------------------------------------
+
+
+def _options_for(agent, prompt="HERMES SYSTEM PROMPT"):
+    return build_claude_agent_options(
+        agent,
+        system_prompt=prompt,
+        effective_task_id=lambda: "task-1",
+        cwd="/tmp/workspace",
+    )
+
+
+def test_options_append_hermes_own_identity_and_author_nothing(sdk_module):
+    from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+    agent = _make_agent("web_search")
+    agent._cached_system_prompt = "SYSTEM PROMPT — byte stable"
+    options = _options_for(agent, agent._cached_system_prompt)
+
+    # The append is Hermes' own identity section verbatim — no text authored
+    # for this provider. The classifier bills a preset-replacing request, or
+    # one carrying the full prompt, to extra usage (decision record §11), so
+    # the rest of the prompt rides the first user turn instead.
+    assert options.system_prompt == {
+        "type": "preset",
+        "preset": "claude_code",
+        "append": claude_runtime.claude_subscription_append(agent),
+    }
+    append = options.system_prompt["append"]
+    assert append.startswith(DEFAULT_AGENT_IDENTITY.strip())
+    # The only non-Hermes text is the factual tool-routing note — no persona.
+    assert claude_runtime.CLAUDE_TOOL_ROUTING_NOTE in append
+    assert "mcp__hermes__" in append
+    # The full prompt must NOT be in the system slot.
+    assert agent._cached_system_prompt not in str(options.system_prompt)
+
+
+def test_identity_anchor_follows_a_customised_soul(sdk_module, monkeypatch):
+    # A user who customises SOUL.md gets their customisation in the anchor
+    # too, rather than a provider-specific persona overriding it.
+    monkeypatch.setattr(
+        "agent.prompt_builder.load_soul_md", lambda *a, **k: "You are Ares Agent."
+    )
+    assert claude_runtime.hermes_identity_anchor() == "You are Ares Agent."
+
+
+def test_options_keep_builtins_in_context_but_deny_them_via_hook(sdk_module):
+    agent = _make_agent("web_search", "terminal")
+    options = _options_for(agent)
+
+    # Built-ins stay context-visible (stripping them trips the billing
+    # classifier); execution is pinned to the bridge by the PreToolUse hook.
+    assert getattr(options, "tools", None) in (None, ()) or options.tools is None
+    hooks = options.hooks or {}
+    assert "PreToolUse" in hooks
+
+    matcher = hooks["PreToolUse"][0]
+    hook = matcher.hooks[0]
+
+    async def _run(name):
+        return await hook({"tool_name": name}, "toolu_1", None)
+
+    denied = asyncio.run(_run("Bash"))
+    decision = denied["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert "mcp__hermes__" in decision["permissionDecisionReason"]
+    # Read is auto-allowed by the CLI without a permission prompt, so the hook
+    # (not can_use_tool) must be the choke point for it too.
+    assert asyncio.run(_run("Read"))["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert asyncio.run(_run("mcp__hermes__web_search")) == {}
+
+
+def test_options_expose_only_the_hermes_bridge(sdk_module):
+    agent = _make_agent("web_search", "terminal")
+    options = _options_for(agent)
+
+    assert set(options.mcp_servers) == {MCP_SERVER_NAME}
+    assert sorted(options.allowed_tools) == sorted(bridged_allowed_tools(agent))
+    assert all(name.startswith("mcp__hermes__") for name in options.allowed_tools)
+    # Every allowed name is actually served by the bridge.
+    assert len(options.allowed_tools) == len(agent.tools)
+
+
+def test_options_pin_the_toolset_and_skip_a_second_settings_load(sdk_module):
+    agent = _make_agent("web_search")
+    options = _options_for(agent)
+
+    assert options.setting_sources == []
+    assert options.strict_mcp_config is True
+
+
+def test_options_carry_cwd_and_model_and_hold_no_credential(sdk_module):
+    agent = _make_agent("web_search")
+    agent.model = "claude-sonnet-4-5"
+    options = _options_for(agent)
+
+    assert options.cwd == "/tmp/workspace"
+    assert options.model == "claude-sonnet-4-5"
+    # PR7 owns the sanitized environment; PR4 must not smuggle credentials in.
+    assert options.env == {}
+
+
+def test_options_leave_the_pr5_resume_seam_unset(sdk_module):
+    agent = _make_agent("web_search")
+    options = _options_for(agent)
+
+    assert getattr(options, "resume", None) is None
+    assert getattr(options, "session_store", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Event projection
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_namespacing_is_stripped_for_display():
+    assert display_tool_name("mcp__hermes__web_search") == "web_search"
+    assert display_tool_name("Bash") == "Bash"
+
+
+def test_a_multi_tool_streaming_turn_fires_the_canonical_callbacks():
+    agent = _make_agent("web_search", "terminal")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    for message in [
+        SystemMessage("init", {"session_id": "sdk-session-1"}),
+        _thinking_delta("planning"),
+        _text_delta("Looking that up"),
+        AssistantMessage(
+            content=[
+                ThinkingBlock("planning"),
+                TextBlock("Looking that up"),
+                ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "hermes"}),
+                ToolUseBlock("t2", "mcp__hermes__terminal", {"command": "ls"}),
+            ],
+            session_id="sdk-session-1",
+        ),
+        UserMessage(content=[ToolResultBlock("t1", "search results")]),
+        UserMessage(content=[ToolResultBlock("t2", "file-a\nfile-b")]),
+        _text_delta("All done"),
+        AssistantMessage(content=[TextBlock("All done")]),
+        ResultMessage(result="All done", usage={"input_tokens": 10, "output_tokens": 4}),
+    ]:
+        projector(message)
+    projector.finalize()
+
+    assert rec.text == ["Looking that up", "All done"]
+    assert rec.reasoning == ["planning"]
+    started = [p for p in rec.progress if p[0] == "tool.started"]
+    completed = [p for p in rec.progress if p[0] == "tool.completed"]
+    assert [p[1] for p in started] == ["web_search", "terminal"]
+    assert [p[1] for p in completed] == ["web_search", "terminal"]
+    assert all(p[2]["is_error"] is False for p in completed)
+    assert [c[1] for c in rec.tool_started] == ["web_search", "terminal"]
+    assert [c[1] for c in rec.tool_completed] == ["web_search", "terminal"]
+    assert projector.tool_iterations == 2
+
+
+def test_streamed_text_is_not_replayed_when_the_block_completes():
+    agent = _make_agent("web_search")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    projector(_text_delta("hel"))
+    projector(_text_delta("lo"))
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert rec.text == ["hel", "lo"]
+
+
+def test_completed_blocks_still_stream_when_partial_events_are_absent():
+    agent = _make_agent("web_search")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert rec.text == ["hello"]
+
+
+def test_projected_messages_preserve_role_alternation():
+    agent = _make_agent("web_search", "terminal")
+    projector = ClaudeEventProjector(agent)
+
+    for message in [
+        AssistantMessage(
+            content=[
+                TextBlock("working"),
+                ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"}),
+                ToolUseBlock("t2", "mcp__hermes__terminal", {"command": "ls"}),
+            ]
+        ),
+        # Results land out of order; the transcript must still answer the
+        # tool_calls in the order they were issued.
+        UserMessage(content=[ToolResultBlock("t2", "listing")]),
+        UserMessage(content=[ToolResultBlock("t1", "results")]),
+        AssistantMessage(content=[TextBlock("done")]),
+        ResultMessage(result="done"),
+    ]:
+        projector(message)
+    projected = projector.finalize()
+
+    roles = [m["role"] for m in projected]
+    assert roles == ["assistant", "tool", "tool", "assistant"]
+    assert [m["tool_call_id"] for m in projected if m["role"] == "tool"] == ["t1", "t2"]
+    call_ids = [tc["id"] for tc in projected[0]["tool_calls"]]
+    assert call_ids == ["t1", "t2"]
+    assert [tc["function"]["name"] for tc in projected[0]["tool_calls"]] == [
+        "web_search",
+        "terminal",
+    ]
+    # Never two assistant messages in a row.
+    assert not any(
+        roles[i] == roles[i + 1] == "assistant" for i in range(len(roles) - 1)
+    )
+
+
+def test_consecutive_assistant_text_is_merged_rather_than_duplicated():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("part one")]))
+    projector(AssistantMessage(content=[TextBlock("part two")]))
+    projected = projector.finalize()
+
+    assert [m["role"] for m in projected] == ["assistant"]
+    assert "part one" in projected[0]["content"]
+    assert "part two" in projected[0]["content"]
+
+
+def test_an_unanswered_tool_call_still_gets_a_tool_message():
+    """An unanswered tool_call_id makes the next provider request fail."""
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        AssistantMessage(
+            content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+        )
+    )
+    projector(ResultMessage(result="gave up"))
+    projected = projector.finalize()
+
+    assert [m["role"] for m in projected] == ["assistant", "tool"]
+    assert projected[1]["tool_call_id"] == "t1"
+    assert projected[1]["content"]
+
+
+def test_the_sdk_session_id_is_captured_for_pr5():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(SystemMessage("init", {"session_id": "sdk-session-xyz"}))
+    projector(ResultMessage(session_id="sdk-session-xyz"))
+
+    assert projector.session_id == "sdk-session-xyz"
+    assert agent._claude_sdk_session_id == "sdk-session-xyz"
+
+
+def test_a_compaction_boundary_is_observed():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(SystemMessage("compact_boundary", {"session_id": "s"}))
+    assert projector.compacted is True
+
+
+def test_terminal_reason_and_error_are_surfaced():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        ResultMessage(
+            subtype="error_during_execution",
+            is_error=True,
+            errors=["upstream refused"],
+            terminal_reason="max_turns",
+        )
+    )
+
+    assert projector.is_error is True
+    assert "upstream refused" in projector.error
+    assert projector.terminal_reason == "max_turns"
+
+
+def test_image_tool_results_survive_projection():
+    agent = _make_agent("web_search")
+    agent._model_supports_vision = lambda *a, **k: True
+    agent._provider_supports_vision_tool_messages = lambda *a, **k: True
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        AssistantMessage(
+            content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+        )
+    )
+    projector(
+        UserMessage(
+            content=[
+                ToolResultBlock(
+                    "t1",
+                    [
+                        {"type": "text", "text": "a screenshot"},
+                        {"type": "image", "data": "QUJD", "mimeType": "image/png"},
+                    ],
+                )
+            ]
+        )
+    )
+    projected = projector.finalize()
+
+    content = projected[1]["content"]
+    assert isinstance(content, list)
+    assert any(part.get("type") == "image_url" for part in content)
+
+
+def test_a_buggy_display_callback_cannot_break_the_turn():
+    agent = _make_agent("web_search")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("display exploded")
+
+    agent._fire_stream_delta = _boom
+    agent.tool_progress_callback = _boom
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert projector.final_text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Whole turn
+# ---------------------------------------------------------------------------
+
+
+class _StubSession:
+    """Replays a scripted message list through the projector."""
+
+    def __init__(self, script, *, raises=None):
+        self.script = script
+        self.raises = raises
+        self.closed = False
+        self.prompts = []
+        self.session_ids = []
+
+    def run_turn(self, prompt, *, on_message, timeout=None):
+        self.prompts.append(prompt)
+        if self.raises is not None:
+            raise self.raises
+        for message in self.script:
+            on_message(message)
+        return len(self.script)
+
+    def note_session_id(self, session_id):
+        self.session_ids.append(session_id)
+
+    def close(self):
+        self.closed = True
+
+
+def _run_turn(agent, session, messages=None):
+    messages = messages if messages is not None else []
+    with (
+        patch.object(claude_runtime, "claude_runtime_preflight", return_value=None),
+        # The per-session billing proof spawns the real CLI; a turn-shape test
+        # must not depend on the developer's (or CI's) Claude login.
+        patch.object(claude_runtime, "verify_claude_billing_for_agent", return_value=None),
+        patch.object(claude_runtime, "_ensure_session", return_value=session),
+    ):
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+    return result, messages
+
+
+def test_a_completed_turn_returns_the_run_conversation_shape():
+    agent = _make_agent("web_search")
+    session = _StubSession(
+        [
+            AssistantMessage(content=[TextBlock("hello")]),
+            ResultMessage(
+                result="hello",
+                usage={"input_tokens": 12, "output_tokens": 3},
+                total_cost_usd=0.001,
+            ),
+        ]
+    )
+    result, messages = _run_turn(agent, session)
+
+    assert result["final_response"] == "hello"
+    assert result["messages"] is messages
+    assert result["completed"] is True
+    assert result["partial"] is False
+    assert result["interrupted"] is False
+    assert result["error"] is None
+    assert result["api_calls"] == 1
+    assert result["agent_persisted"] is True
+    assert result["claude_session_id"] == "sdk-session-1"
+    assert result["prompt_tokens"] >= 12
+
+
+def test_projected_messages_are_spliced_exactly_once_including_trailing_events():
+    """Events after ResultMessage must be projected, and only once."""
+    agent = _make_agent("web_search")
+    session = _StubSession(
+        [
+            AssistantMessage(
+                content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+            ),
+            UserMessage(content=[ToolResultBlock("t1", "results")]),
+            ResultMessage(result="done"),
+            # Trailing frame the CLI flushed after the result.
+            AssistantMessage(content=[TextBlock("done")]),
+        ]
+    )
+    result, messages = _run_turn(agent, session)
+
+    assert [m["role"] for m in messages] == ["assistant", "tool", "assistant"]
+    assert sum(1 for m in messages if m["role"] == "tool") == 1
+    assert messages[-1]["content"] == "done"
+    # A second finalize must not be able to duplicate anything.
+    assert result["messages"] == messages
+
+
+def test_a_wedged_turn_retires_the_session_so_the_next_one_respawns():
+    agent = _make_agent("web_search")
+    agent._claude_session = session = _StubSession([], raises=TimeoutError("stalled"))
+    result, _messages = _run_turn(agent, session)
+
+    assert session.closed is True
+    assert getattr(agent, "_claude_session", None) is None
+    assert result["completed"] is False
+    assert "stalled" in result["error"]
+
+
+def test_tool_iterations_feed_the_skill_nudge_counter():
+    agent = _make_agent("web_search")
+    agent._iters_since_skill = 0
+    session = _StubSession(
+        [
+            AssistantMessage(
+                content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+            ),
+            UserMessage(content=[ToolResultBlock("t1", "results")]),
+            ResultMessage(result="done"),
+        ]
+    )
+    _run_turn(agent, session)
+
+    assert agent._iters_since_skill == 1
+
+
+def test_a_turn_without_usage_still_counts_as_one_api_call():
+    agent = _make_agent("web_search")
+    before = agent.session_api_calls
+    session = _StubSession([ResultMessage(result="hi")])
+    result, _messages = _run_turn(agent, session)
+
+    assert agent.session_api_calls == before + 1
+    assert result["api_calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Every other api_mode is untouched
+# ---------------------------------------------------------------------------
+
+
+def _exhaust_budget(agent):
+    agent.max_iterations = 0
+    agent.iteration_budget._used = agent.iteration_budget.max_total
+
+
+@pytest.mark.parametrize(
+    "api_mode",
+    [
+        "chat_completions",
+        "anthropic_messages",
+        "codex_responses",
+        "codex_app_server",
+        "bedrock_converse",
+    ],
+)
+def test_the_early_branch_does_not_fire_for_other_api_modes(api_mode):
+    agent = _make_agent("web_search", api_mode=api_mode)
+    _exhaust_budget(agent)
+    fired = []
+    agent._run_claude_agent_sdk_turn = lambda **kw: fired.append(kw) or {}
+    agent._run_codex_app_server_turn = lambda **kw: {
+        "final_response": "codex",
+        "messages": [],
+        "api_calls": 0,
+    }
+
+    agent.run_conversation("hello")
+
+    assert fired == []
+
+
+def test_the_early_branch_fires_for_claude_agent_sdk():
+    agent = _make_agent("web_search", api_mode="claude_agent_sdk")
+    _exhaust_budget(agent)
+    fired = []
+
+    def _forward(**kwargs):
+        fired.append(kwargs)
+        return {"final_response": "claude", "messages": [], "api_calls": 1}
+
+    agent._run_claude_agent_sdk_turn = _forward
+    result = agent.run_conversation("hello")
+
+    assert len(fired) == 1
+    assert result["final_response"] == "claude"
+    # The default provider loop was bypassed entirely.
+    assert result["api_calls"] == 1

--- a/tests/agent/test_claude_runtime.py
+++ b/tests/agent/test_claude_runtime.py
@@ -1,0 +1,893 @@
+"""Contract for the ``claude_agent_sdk`` whole-turn runtime.
+
+Three things are being pinned down here:
+
+1. The turn refuses to start unless the gate is on, the optional extra is
+   installed, and the user is signed in — with an error that names the fix.
+2. The SDK options carry Hermes' ownership boundary: the exact Hermes system
+   prompt, no SDK built-ins, no second settings load, a pinned MCP toolset.
+3. A Claude turn fires the same canonical Hermes callbacks and produces the
+   same message shape as every other provider, exactly once.
+
+``claude-agent-sdk`` is an optional extra, so a stand-in module is installed
+when it is absent. The SDK message/block classes are re-declared locally
+because the runtime dispatches on class name — that is what lets the projector
+behave identically with and without the real package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent import claude_runtime
+from agent.claude_runtime import (
+    ClaudeEventProjector,
+    build_claude_agent_options,
+    claude_runtime_preflight,
+    display_tool_name,
+    run_claude_agent_sdk_turn,
+)
+from agent.transports.claude_tool_bridge import MCP_SERVER_NAME, bridged_allowed_tools
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# SDK stand-in (used only when the optional extra is not installed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeToolAnnotations:
+    readOnlyHint: bool = False
+
+
+@dataclass
+class _FakeSdkTool:
+    name: str
+    description: str
+    input_schema: dict
+    handler: Any
+    annotations: Any = None
+
+
+def _fake_tool(name, description, input_schema, annotations=None):
+    def _decorate(handler):
+        return _FakeSdkTool(name, description, input_schema, handler, annotations)
+
+    return _decorate
+
+
+def _fake_create_sdk_mcp_server(*, name, version, tools):
+    return SimpleNamespace(name=name, version=version, tools=list(tools))
+
+
+@dataclass
+class _FakeClaudeAgentOptions:
+    system_prompt: Any = None
+    tools: Any = None
+    allowed_tools: list = field(default_factory=list)
+    disallowed_tools: list = field(default_factory=list)
+    mcp_servers: dict = field(default_factory=dict)
+    strict_mcp_config: bool = False
+    setting_sources: Any = None
+    cwd: Any = None
+    env: dict = field(default_factory=dict)
+    stderr: Any = None
+    model: Any = None
+    include_partial_messages: bool = False
+    resume: Any = None
+    session_store: Any = None
+    hooks: Any = None
+
+
+@dataclass
+class _FakeHookMatcher:
+    matcher: Any = None
+    hooks: list = field(default_factory=list)
+    timeout: Any = None
+
+
+@pytest.fixture
+def sdk_module(monkeypatch):
+    """Yield an importable ``claude_agent_sdk``, faking it when absent."""
+    try:  # pragma: no cover - exercised only where the extra is installed
+        import claude_agent_sdk  # noqa: F401
+
+        yield sys.modules["claude_agent_sdk"]
+        return
+    except ImportError:
+        pass
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.tool = _fake_tool
+    module.create_sdk_mcp_server = _fake_create_sdk_mcp_server
+    module.ToolAnnotations = _FakeToolAnnotations
+    module.ClaudeAgentOptions = _FakeClaudeAgentOptions
+    module.HookMatcher = _FakeHookMatcher
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    yield module
+
+
+# ---------------------------------------------------------------------------
+# SDK message shapes (dispatch is by class name)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TextBlock:
+    text: str
+
+
+@dataclass
+class ThinkingBlock:
+    thinking: str
+    signature: str = ""
+
+
+@dataclass
+class ToolUseBlock:
+    id: str
+    name: str
+    input: dict
+
+
+@dataclass
+class ToolResultBlock:
+    tool_use_id: str
+    content: Any = None
+    is_error: bool | None = None
+
+
+@dataclass
+class AssistantMessage:
+    content: list
+    model: str = "claude-sonnet-4-5"
+    stop_reason: str | None = None
+    session_id: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class UserMessage:
+    content: Any
+
+
+@dataclass
+class SystemMessage:
+    subtype: str
+    data: dict = field(default_factory=dict)
+
+
+@dataclass
+class StreamEvent:
+    event: dict
+    session_id: str = "sdk-session-1"
+    uuid: str = "u1"
+
+
+@dataclass
+class ResultMessage:
+    subtype: str = "success"
+    session_id: str = "sdk-session-1"
+    result: str | None = None
+    usage: dict | None = None
+    total_cost_usd: float | None = None
+    terminal_reason: str | None = None
+    is_error: bool = False
+    errors: list | None = None
+
+
+def _text_delta(text: str) -> StreamEvent:
+    return StreamEvent(
+        event={"type": "content_block_delta", "delta": {"type": "text_delta", "text": text}}
+    )
+
+
+def _thinking_delta(text: str) -> StreamEvent:
+    return StreamEvent(
+        event={
+            "type": "content_block_delta",
+            "delta": {"type": "thinking_delta", "thinking": text},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                },
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str, api_mode: str = "claude_agent_sdk") -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.api_mode = api_mode
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+class _Recorder:
+    """Captures the canonical Hermes callbacks a runtime must fire."""
+
+    def __init__(self, agent) -> None:
+        self.text: list[str] = []
+        self.reasoning: list[str] = []
+        self.interim: list[dict] = []
+        self.progress: list[tuple] = []
+        self.tool_started: list[tuple] = []
+        self.tool_completed: list[tuple] = []
+        agent._fire_stream_delta = self.text.append
+        agent._fire_reasoning_delta = self.reasoning.append
+        agent._emit_interim_assistant_message = self.interim.append
+        agent.tool_progress_callback = self._progress
+        agent.tool_start_callback = lambda *a: self.tool_started.append(a)
+        agent.tool_complete_callback = lambda *a: self.tool_completed.append(a)
+
+    def _progress(self, phase, name, *rest, **kwargs):
+        self.progress.append((phase, name, kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Preflight
+# ---------------------------------------------------------------------------
+
+
+def test_preflight_names_the_config_key_when_the_gate_is_off():
+    message = claude_runtime_preflight({"claude_subscription": {"enabled": False}})
+    assert message is not None
+    assert "claude_subscription.enabled" in message
+
+
+def test_preflight_names_the_extra_when_the_sdk_is_missing():
+    with patch(
+        "hermes_cli.claude_subscription.claude_agent_sdk_available", return_value=False
+    ):
+        message = claude_runtime_preflight({"claude_subscription": {"enabled": True}})
+    assert message is not None
+    assert "claude-code" in message
+
+
+def test_preflight_names_the_login_command_when_signed_out():
+    with (
+        patch(
+            "hermes_cli.claude_subscription.claude_agent_sdk_available",
+            return_value=True,
+        ),
+        patch(
+            "hermes_cli.claude_code.probe_claude_auth_cached",
+            return_value={"logged_in": False, "message": ""},
+        ),
+    ):
+        message = claude_runtime_preflight({"claude_subscription": {"enabled": True}})
+    assert message is not None
+    assert "claude auth login" in message
+
+
+def test_preflight_passes_when_all_three_gates_are_open():
+    with (
+        patch(
+            "hermes_cli.claude_subscription.claude_agent_sdk_available",
+            return_value=True,
+        ),
+        patch(
+            "hermes_cli.claude_code.probe_claude_auth_cached",
+            return_value={"logged_in": True, "message": "Signed in."},
+        ),
+    ):
+        assert claude_runtime_preflight({"claude_subscription": {"enabled": True}}) is None
+
+
+@pytest.mark.parametrize(
+    "config,patches",
+    [
+        ({"claude_subscription": {"enabled": False}}, {}),
+        ({"claude_subscription": {"enabled": True}}, {"sdk": False}),
+        ({"claude_subscription": {"enabled": True}}, {"sdk": True, "login": False}),
+    ],
+)
+def test_a_refused_turn_never_builds_a_session(config, patches):
+    agent = _make_agent("web_search")
+    messages: list[dict] = []
+    stack = [patch("hermes_cli.config.load_config_readonly", return_value=config)]
+    if "sdk" in patches:
+        stack.append(
+            patch(
+                "hermes_cli.claude_subscription.claude_agent_sdk_available",
+                return_value=patches["sdk"],
+            )
+        )
+    if "login" in patches:
+        stack.append(
+            patch(
+                "hermes_cli.claude_code.probe_claude_auth_cached",
+                return_value={"logged_in": patches["login"], "message": ""},
+            )
+        )
+    built = []
+    stack.append(
+        patch.object(
+            claude_runtime, "_ensure_session", lambda *a, **k: built.append(a)
+        )
+    )
+
+    from contextlib import ExitStack
+
+    with ExitStack() as es:
+        for ctx in stack:
+            es.enter_context(ctx)
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+
+    assert built == []
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["error"]
+    assert messages == []
+
+
+# ---------------------------------------------------------------------------
+# Options — the ownership boundary
+# ---------------------------------------------------------------------------
+
+
+def _options_for(agent, prompt="HERMES SYSTEM PROMPT"):
+    return build_claude_agent_options(
+        agent,
+        system_prompt=prompt,
+        effective_task_id=lambda: "task-1",
+        cwd="/tmp/workspace",
+    )
+
+
+def test_options_append_hermes_own_identity_and_author_nothing(sdk_module):
+    from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+
+    agent = _make_agent("web_search")
+    agent._cached_system_prompt = "SYSTEM PROMPT — byte stable"
+    options = _options_for(agent, agent._cached_system_prompt)
+
+    # The append is Hermes' own identity section verbatim — no text authored
+    # for this provider. The classifier bills a preset-replacing request, or
+    # one carrying the full prompt, to extra usage (decision record §11), so
+    # the rest of the prompt rides the first user turn instead.
+    assert options.system_prompt == {
+        "type": "preset",
+        "preset": "claude_code",
+        "append": claude_runtime.claude_subscription_append(agent),
+    }
+    append = options.system_prompt["append"]
+    assert append.startswith(DEFAULT_AGENT_IDENTITY.strip())
+    # The only non-Hermes text is the factual tool-routing note — no persona.
+    assert claude_runtime.CLAUDE_TOOL_ROUTING_NOTE in append
+    assert "mcp__hermes__" in append
+    # The full prompt must NOT be in the system slot.
+    assert agent._cached_system_prompt not in str(options.system_prompt)
+
+
+def test_identity_anchor_follows_a_customised_soul(sdk_module, monkeypatch):
+    # A user who customises SOUL.md gets their customisation in the anchor
+    # too, rather than a provider-specific persona overriding it.
+    monkeypatch.setattr(
+        "agent.prompt_builder.load_soul_md", lambda *a, **k: "You are Ares Agent."
+    )
+    assert claude_runtime.hermes_identity_anchor() == "You are Ares Agent."
+
+
+def test_options_keep_builtins_in_context_but_deny_them_via_hook(sdk_module):
+    agent = _make_agent("web_search", "terminal")
+    options = _options_for(agent)
+
+    # Built-ins stay context-visible (stripping them trips the billing
+    # classifier); execution is pinned to the bridge by the PreToolUse hook.
+    assert getattr(options, "tools", None) in (None, ()) or options.tools is None
+    hooks = options.hooks or {}
+    assert "PreToolUse" in hooks
+
+    matcher = hooks["PreToolUse"][0]
+    hook = matcher.hooks[0]
+
+    async def _run(name):
+        return await hook({"tool_name": name}, "toolu_1", None)
+
+    denied = asyncio.run(_run("Bash"))
+    decision = denied["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert "mcp__hermes__" in decision["permissionDecisionReason"]
+    # Read is auto-allowed by the CLI without a permission prompt, so the hook
+    # (not can_use_tool) must be the choke point for it too.
+    assert asyncio.run(_run("Read"))["hookSpecificOutput"]["permissionDecision"] == "deny"
+    assert asyncio.run(_run("mcp__hermes__web_search")) == {}
+
+
+def test_options_expose_only_the_hermes_bridge(sdk_module):
+    agent = _make_agent("web_search", "terminal")
+    options = _options_for(agent)
+
+    assert set(options.mcp_servers) == {MCP_SERVER_NAME}
+    assert sorted(options.allowed_tools) == sorted(bridged_allowed_tools(agent))
+    assert all(name.startswith("mcp__hermes__") for name in options.allowed_tools)
+    # Every allowed name is actually served by the bridge.
+    assert len(options.allowed_tools) == len(agent.tools)
+
+
+def test_options_pin_the_toolset_and_skip_a_second_settings_load(sdk_module):
+    agent = _make_agent("web_search")
+    options = _options_for(agent)
+
+    assert options.setting_sources == []
+    assert options.strict_mcp_config is True
+
+
+def test_options_carry_cwd_and_model_and_hold_no_credential(sdk_module):
+    agent = _make_agent("web_search")
+    agent.model = "claude-sonnet-4-5"
+    options = _options_for(agent)
+
+    assert options.cwd == "/tmp/workspace"
+    assert options.model == "claude-sonnet-4-5"
+    # PR7 owns the sanitized environment; PR4 must not smuggle credentials in.
+    assert options.env == {}
+
+
+def test_options_leave_the_pr5_resume_seam_unset(sdk_module):
+    agent = _make_agent("web_search")
+    options = _options_for(agent)
+
+    assert getattr(options, "resume", None) is None
+    assert getattr(options, "session_store", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Event projection
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_namespacing_is_stripped_for_display():
+    assert display_tool_name("mcp__hermes__web_search") == "web_search"
+    assert display_tool_name("Bash") == "Bash"
+
+
+def test_a_multi_tool_streaming_turn_fires_the_canonical_callbacks():
+    agent = _make_agent("web_search", "terminal")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    for message in [
+        SystemMessage("init", {"session_id": "sdk-session-1"}),
+        _thinking_delta("planning"),
+        _text_delta("Looking that up"),
+        AssistantMessage(
+            content=[
+                ThinkingBlock("planning"),
+                TextBlock("Looking that up"),
+                ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "hermes"}),
+                ToolUseBlock("t2", "mcp__hermes__terminal", {"command": "ls"}),
+            ],
+            session_id="sdk-session-1",
+        ),
+        UserMessage(content=[ToolResultBlock("t1", "search results")]),
+        UserMessage(content=[ToolResultBlock("t2", "file-a\nfile-b")]),
+        _text_delta("All done"),
+        AssistantMessage(content=[TextBlock("All done")]),
+        ResultMessage(result="All done", usage={"input_tokens": 10, "output_tokens": 4}),
+    ]:
+        projector(message)
+    projector.finalize()
+
+    assert rec.text == ["Looking that up", "All done"]
+    assert rec.reasoning == ["planning"]
+    started = [p for p in rec.progress if p[0] == "tool.started"]
+    completed = [p for p in rec.progress if p[0] == "tool.completed"]
+    assert [p[1] for p in started] == ["web_search", "terminal"]
+    assert [p[1] for p in completed] == ["web_search", "terminal"]
+    assert all(p[2]["is_error"] is False for p in completed)
+    assert [c[1] for c in rec.tool_started] == ["web_search", "terminal"]
+    assert [c[1] for c in rec.tool_completed] == ["web_search", "terminal"]
+    assert projector.tool_iterations == 2
+
+
+def test_streamed_text_is_not_replayed_when_the_block_completes():
+    agent = _make_agent("web_search")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    projector(_text_delta("hel"))
+    projector(_text_delta("lo"))
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert rec.text == ["hel", "lo"]
+
+
+def test_completed_blocks_still_stream_when_partial_events_are_absent():
+    agent = _make_agent("web_search")
+    rec = _Recorder(agent)
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert rec.text == ["hello"]
+
+
+def test_projected_messages_preserve_role_alternation():
+    agent = _make_agent("web_search", "terminal")
+    projector = ClaudeEventProjector(agent)
+
+    for message in [
+        AssistantMessage(
+            content=[
+                TextBlock("working"),
+                ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"}),
+                ToolUseBlock("t2", "mcp__hermes__terminal", {"command": "ls"}),
+            ]
+        ),
+        # Results land out of order; the transcript must still answer the
+        # tool_calls in the order they were issued.
+        UserMessage(content=[ToolResultBlock("t2", "listing")]),
+        UserMessage(content=[ToolResultBlock("t1", "results")]),
+        AssistantMessage(content=[TextBlock("done")]),
+        ResultMessage(result="done"),
+    ]:
+        projector(message)
+    projected = projector.finalize()
+
+    roles = [m["role"] for m in projected]
+    assert roles == ["assistant", "tool", "tool", "assistant"]
+    assert [m["tool_call_id"] for m in projected if m["role"] == "tool"] == ["t1", "t2"]
+    call_ids = [tc["id"] for tc in projected[0]["tool_calls"]]
+    assert call_ids == ["t1", "t2"]
+    assert [tc["function"]["name"] for tc in projected[0]["tool_calls"]] == [
+        "web_search",
+        "terminal",
+    ]
+    # Never two assistant messages in a row.
+    assert not any(
+        roles[i] == roles[i + 1] == "assistant" for i in range(len(roles) - 1)
+    )
+
+
+def test_consecutive_assistant_text_is_merged_rather_than_duplicated():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("part one")]))
+    projector(AssistantMessage(content=[TextBlock("part two")]))
+    projected = projector.finalize()
+
+    assert [m["role"] for m in projected] == ["assistant"]
+    assert "part one" in projected[0]["content"]
+    assert "part two" in projected[0]["content"]
+
+
+def test_an_unanswered_tool_call_still_gets_a_tool_message():
+    """An unanswered tool_call_id makes the next provider request fail."""
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        AssistantMessage(
+            content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+        )
+    )
+    projector(ResultMessage(result="gave up"))
+    projected = projector.finalize()
+
+    assert [m["role"] for m in projected] == ["assistant", "tool"]
+    assert projected[1]["tool_call_id"] == "t1"
+    assert projected[1]["content"]
+
+
+def test_the_sdk_session_id_is_captured_for_pr5():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(SystemMessage("init", {"session_id": "sdk-session-xyz"}))
+    projector(ResultMessage(session_id="sdk-session-xyz"))
+
+    assert projector.session_id == "sdk-session-xyz"
+    assert agent._claude_sdk_session_id == "sdk-session-xyz"
+
+
+def test_a_compaction_boundary_is_observed():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(SystemMessage("compact_boundary", {"session_id": "s"}))
+    assert projector.compacted is True
+
+
+def test_terminal_reason_and_error_are_surfaced():
+    agent = _make_agent("web_search")
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        ResultMessage(
+            subtype="error_during_execution",
+            is_error=True,
+            errors=["upstream refused"],
+            terminal_reason="max_turns",
+        )
+    )
+
+    assert projector.is_error is True
+    assert "upstream refused" in projector.error
+    assert projector.terminal_reason == "max_turns"
+
+
+def test_image_tool_results_survive_projection():
+    agent = _make_agent("web_search")
+    agent._model_supports_vision = lambda *a, **k: True
+    agent._provider_supports_vision_tool_messages = lambda *a, **k: True
+    projector = ClaudeEventProjector(agent)
+
+    projector(
+        AssistantMessage(
+            content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+        )
+    )
+    projector(
+        UserMessage(
+            content=[
+                ToolResultBlock(
+                    "t1",
+                    [
+                        {"type": "text", "text": "a screenshot"},
+                        {"type": "image", "data": "QUJD", "mimeType": "image/png"},
+                    ],
+                )
+            ]
+        )
+    )
+    projected = projector.finalize()
+
+    content = projected[1]["content"]
+    assert isinstance(content, list)
+    assert any(part.get("type") == "image_url" for part in content)
+
+
+def test_a_buggy_display_callback_cannot_break_the_turn():
+    agent = _make_agent("web_search")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("display exploded")
+
+    agent._fire_stream_delta = _boom
+    agent.tool_progress_callback = _boom
+    projector = ClaudeEventProjector(agent)
+
+    projector(AssistantMessage(content=[TextBlock("hello")]))
+    projector(ResultMessage(result="hello"))
+
+    assert projector.final_text == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Whole turn
+# ---------------------------------------------------------------------------
+
+
+class _StubSession:
+    """Replays a scripted message list through the projector."""
+
+    def __init__(self, script, *, raises=None):
+        self.script = script
+        self.raises = raises
+        self.closed = False
+        self.prompts = []
+        self.session_ids = []
+
+    def run_turn(self, prompt, *, on_message, timeout=None):
+        self.prompts.append(prompt)
+        if self.raises is not None:
+            raise self.raises
+        for message in self.script:
+            on_message(message)
+        return len(self.script)
+
+    def note_session_id(self, session_id):
+        self.session_ids.append(session_id)
+
+    def close(self):
+        self.closed = True
+
+
+def _run_turn(agent, session, messages=None):
+    messages = messages if messages is not None else []
+    with (
+        patch.object(claude_runtime, "claude_runtime_preflight", return_value=None),
+        patch.object(claude_runtime, "_ensure_session", return_value=session),
+    ):
+        result = run_claude_agent_sdk_turn(
+            agent,
+            user_message="hi",
+            original_user_message="hi",
+            messages=messages,
+            effective_task_id="task-1",
+        )
+    return result, messages
+
+
+def test_a_completed_turn_returns_the_run_conversation_shape():
+    agent = _make_agent("web_search")
+    session = _StubSession(
+        [
+            AssistantMessage(content=[TextBlock("hello")]),
+            ResultMessage(
+                result="hello",
+                usage={"input_tokens": 12, "output_tokens": 3},
+                total_cost_usd=0.001,
+            ),
+        ]
+    )
+    result, messages = _run_turn(agent, session)
+
+    assert result["final_response"] == "hello"
+    assert result["messages"] is messages
+    assert result["completed"] is True
+    assert result["partial"] is False
+    assert result["interrupted"] is False
+    assert result["error"] is None
+    assert result["api_calls"] == 1
+    assert result["agent_persisted"] is True
+    assert result["claude_session_id"] == "sdk-session-1"
+    assert result["prompt_tokens"] >= 12
+
+
+def test_projected_messages_are_spliced_exactly_once_including_trailing_events():
+    """Events after ResultMessage must be projected, and only once."""
+    agent = _make_agent("web_search")
+    session = _StubSession(
+        [
+            AssistantMessage(
+                content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+            ),
+            UserMessage(content=[ToolResultBlock("t1", "results")]),
+            ResultMessage(result="done"),
+            # Trailing frame the CLI flushed after the result.
+            AssistantMessage(content=[TextBlock("done")]),
+        ]
+    )
+    result, messages = _run_turn(agent, session)
+
+    assert [m["role"] for m in messages] == ["assistant", "tool", "assistant"]
+    assert sum(1 for m in messages if m["role"] == "tool") == 1
+    assert messages[-1]["content"] == "done"
+    # A second finalize must not be able to duplicate anything.
+    assert result["messages"] == messages
+
+
+def test_a_wedged_turn_retires_the_session_so_the_next_one_respawns():
+    agent = _make_agent("web_search")
+    agent._claude_session = session = _StubSession([], raises=TimeoutError("stalled"))
+    result, _messages = _run_turn(agent, session)
+
+    assert session.closed is True
+    assert getattr(agent, "_claude_session", None) is None
+    assert result["completed"] is False
+    assert "stalled" in result["error"]
+
+
+def test_tool_iterations_feed_the_skill_nudge_counter():
+    agent = _make_agent("web_search")
+    agent._iters_since_skill = 0
+    session = _StubSession(
+        [
+            AssistantMessage(
+                content=[ToolUseBlock("t1", "mcp__hermes__web_search", {"query": "a"})]
+            ),
+            UserMessage(content=[ToolResultBlock("t1", "results")]),
+            ResultMessage(result="done"),
+        ]
+    )
+    _run_turn(agent, session)
+
+    assert agent._iters_since_skill == 1
+
+
+def test_a_turn_without_usage_still_counts_as_one_api_call():
+    agent = _make_agent("web_search")
+    before = agent.session_api_calls
+    session = _StubSession([ResultMessage(result="hi")])
+    result, _messages = _run_turn(agent, session)
+
+    assert agent.session_api_calls == before + 1
+    assert result["api_calls"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Every other api_mode is untouched
+# ---------------------------------------------------------------------------
+
+
+def _exhaust_budget(agent):
+    agent.max_iterations = 0
+    agent.iteration_budget._used = agent.iteration_budget.max_total
+
+
+@pytest.mark.parametrize(
+    "api_mode",
+    [
+        "chat_completions",
+        "anthropic_messages",
+        "codex_responses",
+        "codex_app_server",
+        "bedrock_converse",
+    ],
+)
+def test_the_early_branch_does_not_fire_for_other_api_modes(api_mode):
+    agent = _make_agent("web_search", api_mode=api_mode)
+    _exhaust_budget(agent)
+    fired = []
+    agent._run_claude_agent_sdk_turn = lambda **kw: fired.append(kw) or {}
+    agent._run_codex_app_server_turn = lambda **kw: {
+        "final_response": "codex",
+        "messages": [],
+        "api_calls": 0,
+    }
+
+    agent.run_conversation("hello")
+
+    assert fired == []
+
+
+def test_the_early_branch_fires_for_claude_agent_sdk():
+    agent = _make_agent("web_search", api_mode="claude_agent_sdk")
+    _exhaust_budget(agent)
+    fired = []
+
+    def _forward(**kwargs):
+        fired.append(kwargs)
+        return {"final_response": "claude", "messages": [], "api_calls": 1}
+
+    agent._run_claude_agent_sdk_turn = _forward
+    result = agent.run_conversation("hello")
+
+    assert len(fired) == 1
+    assert result["final_response"] == "claude"
+    # The default provider loop was bypassed entirely.
+    assert result["api_calls"] == 1

--- a/tests/agent/test_claude_session_store.py
+++ b/tests/agent/test_claude_session_store.py
@@ -1,0 +1,497 @@
+"""Contract for the durable ``SessionStore`` mirror behind the Claude runtime.
+
+Three layers are pinned down here:
+
+1. **The storage contracts the SDK depends on** — entries are opaque and come
+   back deep-equal in append order, a re-delivered batch is stored once,
+   deleting a session cascades to its subagent transcripts and drops the
+   summary. These run with or without the optional extra, because the
+   guarantees are Hermes' SQLite behaviour, not the SDK's.
+2. **The SDK's own conformance suite** run against the adapter, which is the
+   strongest available evidence the adapter is correct.
+3. **Resume through the sanitized transport** — the one thing the SDK does
+   *not* do for us, because supplying a custom transport makes it skip
+   ``materialize_resume_session()``.
+
+``claude-agent-sdk`` is an optional extra; layers 2 and 3 skip without it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+
+from agent.claude_session_store import (
+    RUNTIME,
+    HermesClaudeSessionStore,
+    build_claude_session_store,
+    is_visible_user_entry,
+)
+from hermes_state import SessionDB
+
+
+
+def _sdk_or_skip():
+    return pytest.importorskip(
+        "claude_agent_sdk", reason="claude-code extra not installed"
+    )
+
+
+@pytest.fixture()
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    yield session_db
+    session_db.close()
+
+
+@pytest.fixture()
+def store(db):
+    """Adapter with a stand-in fold, so the storage contracts run SDK-free."""
+    return HermesClaudeSessionStore(db, summary_fold=_counting_fold)
+
+
+def _counting_fold(previous, key, entries):
+    """A pure fold with the same shape as the SDK's, for SDK-free tests."""
+    data = dict((previous or {}).get("data") or {})
+    data["batches"] = int(data.get("batches", 0)) + 1
+    data["entries"] = int(data.get("entries", 0)) + len(entries)
+    return {"session_id": key["session_id"], "mtime": 0, "data": data}
+
+
+def _entry(**fields):
+    return {"type": "user", **fields}
+
+
+KEY = {"project_key": "proj", "session_id": "sess"}
+SUB = {"project_key": "proj", "session_id": "sess", "subpath": "subagents/agent-1"}
+
+
+# ---------------------------------------------------------------------------
+# Storage contracts (no SDK required)
+# ---------------------------------------------------------------------------
+
+
+def test_entries_come_back_in_append_order(store):
+    asyncio.run(store.append(KEY, [_entry(uuid="b", n=1), _entry(uuid="a", n=2)]))
+    asyncio.run(store.append(KEY, [_entry(uuid="c", n=3)]))
+
+    loaded = asyncio.run(store.load(KEY))
+
+    # Append order, not uuid order — the SDK replays these as JSONL lines.
+    assert [e["uuid"] for e in loaded] == ["b", "a", "c"]
+
+
+def test_entries_round_trip_deep_equal_including_nested_payloads(store):
+    original = _entry(
+        uuid="u1",
+        message={"role": "user", "content": [{"type": "text", "text": "héllo"}]},
+        nested={"a": [1, 2, {"b": None}], "z": True},
+    )
+    asyncio.run(store.append(KEY, [original]))
+
+    loaded = asyncio.run(store.load(KEY))
+
+    assert loaded == [original]
+
+
+def test_a_redelivered_batch_is_stored_once(store):
+    """A failed append is retried, and a retry can re-deliver what landed."""
+    first = [_entry(uuid="u1"), _entry(uuid="u2")]
+    asyncio.run(store.append(KEY, first))
+    # The retry overlaps the previous batch and adds one new entry.
+    asyncio.run(store.append(KEY, first + [_entry(uuid="u3")]))
+
+    loaded = asyncio.run(store.load(KEY))
+
+    assert [e["uuid"] for e in loaded] == ["u1", "u2", "u3"]
+
+
+def test_entries_without_a_uuid_are_never_deduplicated(store):
+    """Titles, tags and mode markers carry no uuid and legitimately repeat."""
+    asyncio.run(store.append(KEY, [{"type": "tag", "tag": "x"}]))
+    asyncio.run(store.append(KEY, [{"type": "tag", "tag": "x"}]))
+
+    assert len(asyncio.run(store.load(KEY))) == 2
+
+
+def test_dedup_is_scoped_per_key_because_a_fork_reuses_uuids(store):
+    other = {"project_key": "proj", "session_id": "other"}
+    asyncio.run(store.append(KEY, [_entry(uuid="shared", side="a")]))
+    asyncio.run(store.append(other, [_entry(uuid="shared", side="b")]))
+
+    assert asyncio.run(store.load(KEY))[0]["side"] == "a"
+    assert asyncio.run(store.load(other))[0]["side"] == "b"
+
+
+def test_load_distinguishes_never_written_from_emptied(store):
+    assert asyncio.run(store.load(KEY)) is None
+    asyncio.run(store.append(KEY, []))
+    assert asyncio.run(store.load(KEY)) == []
+
+
+def test_subagent_transcripts_are_stored_and_listed_separately(store):
+    asyncio.run(store.append(KEY, [_entry(uuid="main")]))
+    asyncio.run(store.append(SUB, [_entry(uuid="sub")]))
+
+    assert [e["uuid"] for e in asyncio.run(store.load(KEY))] == ["main"]
+    assert asyncio.run(store.list_subkeys(KEY)) == ["subagents/agent-1"]
+    # A subagent transcript is not a session in its own right.
+    assert [s["session_id"] for s in asyncio.run(store.list_sessions("proj"))] == [
+        "sess"
+    ]
+
+
+def test_deleting_a_session_cascades_to_subkeys_and_drops_the_summary(store):
+    sub2 = {**KEY, "subpath": "subagents/agent-2"}
+    survivor = {"project_key": "proj", "session_id": "survivor"}
+    asyncio.run(store.append(KEY, [_entry(uuid="m")]))
+    asyncio.run(store.append(SUB, [_entry(uuid="s1")]))
+    asyncio.run(store.append(sub2, [_entry(uuid="s2")]))
+    asyncio.run(store.append(survivor, [_entry(uuid="k")]))
+
+    asyncio.run(store.delete(KEY))
+
+    assert asyncio.run(store.load(KEY)) is None
+    assert asyncio.run(store.load(SUB)) is None
+    assert asyncio.run(store.load(sub2)) is None
+    assert asyncio.run(store.list_subkeys(KEY)) == []
+    assert asyncio.run(store.list_session_summaries("proj")) == [] or [
+        s["session_id"] for s in asyncio.run(store.list_session_summaries("proj"))
+    ] == ["survivor"]
+    # Untouched neighbours survive.
+    assert asyncio.run(store.load(survivor)) is not None
+
+
+def test_deleting_one_subpath_leaves_the_session_intact(store):
+    sub2 = {**KEY, "subpath": "subagents/agent-2"}
+    asyncio.run(store.append(KEY, [_entry(uuid="m")]))
+    asyncio.run(store.append(SUB, [_entry(uuid="s1")]))
+    asyncio.run(store.append(sub2, [_entry(uuid="s2")]))
+
+    asyncio.run(store.delete(SUB))
+
+    assert asyncio.run(store.load(SUB)) is None
+    assert asyncio.run(store.load(sub2)) is not None
+    assert asyncio.run(store.load(KEY)) is not None
+    assert asyncio.run(store.list_subkeys(KEY)) == ["subagents/agent-2"]
+
+
+def test_the_summary_fold_runs_once_per_main_batch_and_never_for_subagents(store):
+    asyncio.run(store.append(KEY, [_entry(uuid="a"), _entry(uuid="b")]))
+    asyncio.run(store.append(KEY, [_entry(uuid="c")]))
+    before = asyncio.run(store.list_session_summaries("proj"))[0]["data"]
+
+    asyncio.run(store.append(SUB, [_entry(uuid="s")]))
+    after = asyncio.run(store.list_session_summaries("proj"))[0]["data"]
+
+    assert before == {"batches": 2, "entries": 3}
+    # A subagent transcript must not contribute to the main session's summary.
+    assert after == before
+
+
+def test_summary_mtime_shares_a_clock_with_the_session_listing(store):
+    """The staleness fast-path compares these two directly."""
+    asyncio.run(store.append(KEY, [_entry(uuid="a", timestamp="2024-01-01T00:00:00Z")]))
+
+    listed = {s["session_id"]: s["mtime"] for s in asyncio.run(store.list_sessions("proj"))}
+    summary = asyncio.run(store.list_session_summaries("proj"))[0]
+
+    assert summary["mtime"] >= listed["sess"]
+    # Epoch milliseconds, not seconds — anything smaller would read as 1970.
+    assert summary["mtime"] > 1e12
+
+
+def test_project_keys_are_isolated(store):
+    asyncio.run(store.append({"project_key": "A", "session_id": "s"}, [_entry(k="A")]))
+    asyncio.run(store.append({"project_key": "B", "session_id": "s"}, [_entry(k="B")]))
+
+    # Same session_id under two project keys must not collide.
+    assert asyncio.run(store.load({"project_key": "A", "session_id": "s"}))[0]["k"] == "A"
+    assert asyncio.run(store.load({"project_key": "B", "session_id": "s"}))[0]["k"] == "B"
+    assert len(asyncio.run(store.list_sessions("A"))) == 1
+    assert len(asyncio.run(store.list_sessions("B"))) == 1
+    assert asyncio.run(store.list_sessions("never-used")) == []
+
+
+def test_a_concurrent_append_burst_folds_the_summary_exactly_once_per_batch(store):
+    """Read-fold-write on the sidecar must not interleave."""
+
+    async def _burst():
+        await asyncio.gather(
+            *(store.append(KEY, [_entry(uuid=f"u{i}")]) for i in range(12))
+        )
+
+    asyncio.run(_burst())
+
+    summary = asyncio.run(store.list_session_summaries("proj"))[0]
+    assert summary["data"] == {"batches": 12, "entries": 12}
+    assert len(asyncio.run(store.load(KEY))) == 12
+
+
+def test_the_store_is_unavailable_without_a_session_db():
+    """No DB (persistence off, a background-review fork) means no mirror."""
+    assert build_claude_session_store(None) is None
+
+
+def test_a_downgrade_can_leave_mirror_rows_in_place(db, store):
+    """The rollback contract: never require deleting SDK transcript data."""
+    asyncio.run(store.append(KEY, [_entry(uuid="a")]))
+    db.bind_provider_runtime_session("hermes-1", RUNTIME, "sess", project_key="proj")
+
+    # Dropping the binding is all a rollback needs; the transcript survives.
+    db.clear_provider_runtime_session("hermes-1", RUNTIME)
+
+    assert asyncio.run(store.load(KEY)) is not None
+
+
+# ---------------------------------------------------------------------------
+# Visible-user-turn boundary detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "entry,expected",
+    [
+        ({"type": "user", "message": {"role": "user", "content": "hi"}}, True),
+        (
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hi"}],
+                },
+            },
+            True,
+        ),
+        # A tool result is a type="user" entry too, but nothing the user sees.
+        (
+            {
+                "type": "user",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "tool_result", "content": "ok"}],
+                },
+            },
+            False,
+        ),
+        ({"type": "user", "isMeta": True, "message": {"role": "user"}}, False),
+        (
+            {"type": "user", "isCompactSummary": True, "message": {"role": "user"}},
+            False,
+        ),
+        ({"type": "user", "isSidechain": True, "message": {"role": "user"}}, False),
+        ({"type": "assistant", "message": {"role": "assistant"}}, False),
+        ("not a dict", False),
+    ],
+)
+def test_only_a_real_user_message_is_a_rewind_boundary(entry, expected):
+    assert is_visible_user_entry(entry) is expected
+
+
+# ---------------------------------------------------------------------------
+# The SDK's own conformance suite
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_passes_the_sdk_session_store_conformance_suite(tmp_path):
+    _sdk_or_skip()
+    from claude_agent_sdk.testing import run_session_store_conformance
+
+    opened: list[SessionDB] = []
+
+    def _make_store():
+        # Each contract gets EMPTY backing storage, as the suite requires.
+        session_db = SessionDB(db_path=tmp_path / f"conformance-{len(opened)}.db")
+        opened.append(session_db)
+        return build_claude_session_store(session_db)
+
+    try:
+        asyncio.run(run_session_store_conformance(_make_store))
+    finally:
+        for session_db in opened:
+            session_db.close()
+
+    assert len(opened) > 1, "the suite must build a fresh store per contract"
+
+
+# ---------------------------------------------------------------------------
+# Resume through the sanitized transport
+# ---------------------------------------------------------------------------
+
+
+def _seed_resumable_session(store, cwd):
+    """Write a main transcript plus a subagent transcript for *cwd*."""
+    from claude_agent_sdk import project_key_for_directory
+
+    project_key = project_key_for_directory(cwd)
+    session_id = str(uuid.uuid4())
+    key = {"project_key": project_key, "session_id": session_id}
+    asyncio.run(
+        store.append(
+            key,
+            [
+                {
+                    "type": "user",
+                    "uuid": str(uuid.uuid4()),
+                    "sessionId": session_id,
+                    "timestamp": "2026-01-01T00:00:00.000Z",
+                    "message": {"role": "user", "content": "hello"},
+                }
+            ],
+        )
+    )
+    asyncio.run(
+        store.append(
+            {**key, "subpath": "subagents/agent-1"},
+            [
+                {
+                    "type": "user",
+                    "uuid": str(uuid.uuid4()),
+                    "sessionId": session_id,
+                    "message": {"role": "user", "content": "sub"},
+                }
+            ],
+        )
+    )
+    return project_key, session_id
+
+
+def test_resume_materializes_the_stored_transcript_for_the_sanitized_transport(
+    db, tmp_path, monkeypatch
+):
+    """The blocker PR7 flagged: a custom transport skips materialization.
+
+    The session facade runs it explicitly instead, one step earlier, and hands
+    the repointed options to BOTH the transport and the client.
+    """
+    _sdk_or_skip()
+    from claude_agent_sdk import ClaudeAgentOptions
+    from claude_agent_sdk._internal.sessions import _get_projects_dir
+
+    from agent.transports.claude_agent_session import ClaudeAgentSession
+    from agent.transports.claude_sanitized_transport import (
+        build_child_env,
+        sanitized_transport_class,
+    )
+
+    # A credential that outranks the subscription. It must not survive into the
+    # child even on the resume path.
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-should-be-stripped")
+
+    cwd = str(tmp_path)
+    store = build_claude_session_store(db)
+    _project_key, session_id = _seed_resumable_session(store, cwd)
+
+    options = ClaudeAgentOptions(
+        cwd=cwd,
+        env={},
+        session_store=store,
+        session_store_flush="eager",
+        resume=session_id,
+        stderr=lambda line: None,
+    )
+    session = ClaudeAgentSession(options_factory=lambda: options)
+    resolved, materialized = asyncio.run(session._materialize(options))
+    assert materialized is not None
+    # What _connect() does; the facade owns the teardown because the SDK
+    # cleans up only what it materialized itself.
+    session._materialized = materialized
+    try:
+        config_dir = materialized.config_dir
+        # The CLI can only resume from a local file, so the stored transcript
+        # is written back out — including every subagent transcript, which is
+        # what list_subkeys() exists for.
+        written = {str(p.relative_to(config_dir)) for p in config_dir.rglob("*.jsonl")}
+        assert f"projects/{_project_key}/{session_id}.jsonl" in written
+        assert (
+            f"projects/{_project_key}/{session_id}/subagents/agent-1.jsonl" in written
+        )
+
+        transport = sanitized_transport_class()(
+            prompt=_empty_prompt(), options=resolved
+        )
+        transport._cli_path = "/usr/bin/claude"
+        command = transport._build_command()
+        assert f"--resume={session_id}" in command
+        assert "--session-mirror" in command
+
+        child_env = build_child_env(resolved, cwd=cwd)
+        assert child_env["CLAUDE_CONFIG_DIR"] == str(config_dir)
+        # PR7's guarantee is intact: sanitization still wins.
+        assert "ANTHROPIC_API_KEY" not in child_env
+        assert "HOME" not in resolved.env
+
+        # The mirror batcher resolves its projects_dir from options.env, so the
+        # repointed options must reach the client too or mirrored entries land
+        # under a key resume will never look in.
+        assert _get_projects_dir(resolved.env) == config_dir / "projects"
+    finally:
+        asyncio.run(session._cleanup_materialized())
+    assert not materialized.config_dir.exists()
+
+
+def test_a_fresh_session_does_not_redirect_the_config_dir(db, tmp_path):
+    """No resume, no temp dir — CLAUDE_CONFIG_DIR passes through as PR7 set it."""
+    _sdk_or_skip()
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    from agent.transports.claude_agent_session import ClaudeAgentSession
+
+    options = ClaudeAgentOptions(
+        cwd=str(tmp_path), env={}, session_store=build_claude_session_store(db)
+    )
+    session = ClaudeAgentSession(options_factory=lambda: options)
+
+    resolved, materialized = asyncio.run(session._materialize(options))
+
+    assert materialized is None
+    assert resolved is options
+    assert "CLAUDE_CONFIG_DIR" not in resolved.env
+
+
+def test_a_fork_rewrites_uuids_rather_than_copying_rows(db, tmp_path):
+    """``fork_session_via_store`` must transform, and must leave the source alone."""
+    _sdk_or_skip()
+    from claude_agent_sdk import fork_session_via_store
+
+    cwd = str(tmp_path)
+    store = build_claude_session_store(db)
+    project_key, session_id = _seed_resumable_session(store, cwd)
+    source_key = {"project_key": project_key, "session_id": session_id}
+    before = asyncio.run(store.load(source_key))
+
+    forked = asyncio.run(fork_session_via_store(store, session_id, directory=cwd))
+
+    assert forked.session_id != session_id
+    # The parent transcript is immutable across a fork.
+    assert asyncio.run(store.load(source_key)) == before
+    child = asyncio.run(
+        store.load({"project_key": project_key, "session_id": forked.session_id})
+    )
+    assert child
+    child_uuids = {e.get("uuid") for e in child if e.get("uuid")}
+    assert not (child_uuids & {e.get("uuid") for e in before})
+    assert all(
+        e.get("sessionId") in (None, forked.session_id) for e in child
+    ), "every entry's sessionId must be rewritten to the fork"
+
+
+async def _empty_prompt_impl():
+    return
+    yield {}
+
+
+def _empty_prompt():
+    return _empty_prompt_impl()
+
+
+def test_stored_entries_are_valid_json_documents(store, db):
+    """The store is a mirror, so what goes in must survive a JSONL rewrite."""
+    asyncio.run(store.append(KEY, [_entry(uuid="a", text="line\nbreak — dash")]))
+
+    loaded = asyncio.run(store.load(KEY))
+
+    assert json.loads(json.dumps(loaded)) == loaded

--- a/tests/agent/test_claude_surfaces.py
+++ b/tests/agent/test_claude_surfaces.py
@@ -1,0 +1,319 @@
+"""Surface contract for the Claude Agent SDK runtime.
+
+PR4's event projector already emits the canonical Hermes callbacks, so the
+interactive surfaces need no per-surface code. The non-interactive ones do, and
+these are the three properties they were missing:
+
+* **Reachability.** Every non-interactive surface builds its agent from
+  ``resolve_runtime_provider()``. Without a ``claude-code`` branch there, a
+  subscription-mode cron job / ACP session / batch run silently resolved to
+  ``anthropic`` and resumed the pre-SDK direct-OAuth billing path.
+* **Fail fast, not hang.** A missing login must surface as an actionable
+  message before work starts, never as a login prompt on a headless process.
+* **Teardown.** These surfaces run many agents; each SDK agent owns an OS
+  thread and a Claude Code subprocess.
+
+Image input is here too because it is a whole-turn property that every surface
+shares: an attachment either reaches the SDK or fails loudly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Reachability
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def subscription_gate_open(monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.claude_code.subscription_enabled", lambda config=None: True
+    )
+
+
+class TestRuntimeProviderResolution:
+    def test_resolves_to_the_sdk_runtime_and_not_to_anthropic(
+        self, subscription_gate_open
+    ):
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_external_process_provider_credentials",
+            return_value={
+                "provider": "claude-code",
+                "api_key": "",
+                "base_url": "claude-sdk://subscription",
+                "command": "/usr/bin/claude",
+                "credentials_owner": "claude-agent-sdk",
+                "source": "claude_agent_sdk",
+            },
+        ):
+            runtime = resolve_runtime_provider(requested="claude-code")
+
+        assert runtime["provider"] == "claude-code"
+        assert runtime["api_mode"] == "claude_agent_sdk"
+        assert runtime["api_key"] == ""
+        assert runtime["credentials_owner"] == "claude-agent-sdk"
+        # Not a reachable REST endpoint — nothing may treat it as one.
+        assert not runtime["base_url"].startswith("http")
+
+    def test_a_missing_claude_cli_propagates_its_actionable_error(
+        self, subscription_gate_open
+    ):
+        from hermes_cli.auth import AuthError
+        from hermes_cli.runtime_provider import resolve_runtime_provider
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_external_process_provider_credentials",
+            side_effect=AuthError(
+                "Could not find the `claude` CLI. Install Claude Code, then run "
+                "`claude auth login`."
+            ),
+        ):
+            with pytest.raises(AuthError) as excinfo:
+                resolve_runtime_provider(requested="claude-code")
+        assert "claude auth login" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# ACP
+# ---------------------------------------------------------------------------
+
+
+class TestAcpAuth:
+    def test_an_empty_api_key_is_not_an_unconfigured_provider(self):
+        from acp_adapter.auth import detect_provider
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "claude-code",
+                "api_key": "",
+                "api_mode": "claude_agent_sdk",
+                "credentials_owner": "claude-agent-sdk",
+            },
+        ):
+            assert detect_provider() == "claude-code"
+
+    def test_a_genuinely_unconfigured_provider_is_still_rejected(self):
+        from acp_adapter.auth import detect_provider
+
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            return_value={
+                "provider": "openrouter",
+                "api_key": "",
+                "api_mode": "chat_completions",
+            },
+        ):
+            assert detect_provider() is None
+
+
+class TestAcpSessionLifecycle:
+    def _manager(self):
+        from acp_adapter.session import SessionManager
+
+        return SessionManager(agent_factory=lambda: MagicMock())
+
+    def test_removing_a_session_closes_its_agent(self):
+        manager = self._manager()
+        state = manager.create_session(cwd=".")
+        agent = state.agent
+        assert manager.remove_session(state.session_id) is True
+        agent.close.assert_called_once()
+
+    def test_cleanup_closes_every_live_agent(self):
+        manager = self._manager()
+        agents = [manager.create_session(cwd=".").agent for _ in range(3)]
+        manager.cleanup()
+        for agent in agents:
+            agent.close.assert_called_once()
+
+    def test_replacing_an_agent_closes_the_one_it_replaces(self):
+        manager = self._manager()
+        state = manager.create_session(cwd=".")
+        previous = state.agent
+        replacement = MagicMock()
+        manager.replace_agent(state, replacement)
+        previous.close.assert_called_once()
+        assert state.agent is replacement
+
+    def test_replacing_an_agent_with_itself_does_not_close_it(self):
+        manager = self._manager()
+        state = manager.create_session(cwd=".")
+        manager.replace_agent(state, state.agent)
+        state.agent.close.assert_not_called()
+
+    def test_a_failing_close_never_breaks_teardown(self):
+        from acp_adapter.session import SessionManager
+
+        agent = MagicMock()
+        agent.close.side_effect = RuntimeError("wedged subprocess")
+        SessionManager.close_agent(agent)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Batch
+# ---------------------------------------------------------------------------
+
+
+class TestBatchRunner:
+    @pytest.fixture
+    def dataset(self, tmp_path):
+        path = tmp_path / "prompts.jsonl"
+        path.write_text('{"prompt": "hi"}\n', encoding="utf-8")
+        return str(path)
+
+    def _runner(self, dataset, **kwargs):
+        import batch_runner
+
+        return batch_runner.BatchRunner(
+            dataset_file=dataset,
+            batch_size=1,
+            run_name="preflight-test",
+            **kwargs,
+        )
+
+    def test_preflight_refuses_to_start_when_not_signed_in(self, dataset):
+        runner = self._runner(dataset, api_mode="claude_agent_sdk")
+        with patch(
+            "agent.claude_runtime.claude_runtime_preflight",
+            return_value="Not signed in to Claude — run `claude auth login`.",
+        ):
+            with pytest.raises(RuntimeError) as excinfo:
+                runner._preflight_runtime()
+        assert "claude auth login" in str(excinfo.value)
+
+    def test_preflight_is_a_no_op_for_every_other_runtime(self, dataset):
+        runner = self._runner(dataset, api_mode="chat_completions")
+        with patch(
+            "agent.claude_runtime.claude_runtime_preflight",
+            side_effect=AssertionError("must not be consulted"),
+        ):
+            runner._preflight_runtime()
+
+    def test_preflight_passes_when_signed_in(self, dataset):
+        runner = self._runner(dataset, api_mode="claude_agent_sdk")
+        with patch("agent.claude_runtime.claude_runtime_preflight", return_value=None):
+            runner._preflight_runtime()
+
+    def test_provider_and_api_mode_reach_the_agent(self):
+        import batch_runner
+
+        config = {
+            "distribution": "default",
+            "model": "claude-sonnet-5",
+            "max_iterations": 3,
+            "base_url": "claude-sdk://subscription",
+            "api_key": "",
+            "provider": "claude-code",
+            "api_mode": "claude_agent_sdk",
+            "verbose": False,
+        }
+        with patch("batch_runner.AIAgent") as MockAgent:
+            child = MagicMock()
+            child.run_conversation.return_value = {
+                "messages": [],
+                "completed": True,
+                "api_calls": 1,
+            }
+            MockAgent.return_value = child
+            batch_runner._process_single_prompt(0, {"prompt": "hi"}, 0, config)
+            _, kwargs = MockAgent.call_args
+
+        assert kwargs["provider"] == "claude-code"
+        assert kwargs["api_mode"] == "claude_agent_sdk"
+        # Every prompt closes its agent; the pool has no maxtasksperchild.
+        child.close.assert_called_once()
+
+    def test_the_agent_is_closed_even_when_the_turn_raises(self):
+        import batch_runner
+
+        config = {
+            "distribution": "default",
+            "model": "claude-sonnet-5",
+            "max_iterations": 3,
+            "base_url": "claude-sdk://subscription",
+            "api_key": "",
+            "provider": "claude-code",
+            "api_mode": "claude_agent_sdk",
+            "verbose": False,
+        }
+        with patch("batch_runner.AIAgent") as MockAgent:
+            child = MagicMock()
+            child.run_conversation.side_effect = RuntimeError("boom")
+            MockAgent.return_value = child
+            result = batch_runner._process_single_prompt(0, {"prompt": "hi"}, 0, config)
+
+        assert result["success"] is False
+        child.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Images (a whole-turn property, shared by every surface)
+# ---------------------------------------------------------------------------
+
+
+class TestImageTurns:
+    def _agent(self):
+        from run_agent import AIAgent
+
+        return AIAgent.__new__(AIAgent)
+
+    def test_a_text_turn_stays_a_plain_string(self):
+        agent = self._agent()
+        with patch("agent.claude_runtime.run_claude_agent_sdk_turn") as run_turn:
+            run_turn.return_value = {"final_response": "ok"}
+            agent._run_claude_agent_sdk_turn(
+                user_message="hello",
+                original_user_message="hello",
+                messages=[],
+                effective_task_id="t",
+            )
+        assert run_turn.call_args.kwargs["user_message"] == "hello"
+
+    def test_an_image_turn_becomes_a_stream_json_prompt(self, monkeypatch):
+        import agent.claude_sdk_input as sdk_input
+
+        monkeypatch.setattr(sdk_input, "sdk_supports_streaming_input", lambda: True)
+        agent = self._agent()
+        content = [
+            {"type": "text", "text": "what is this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUJD"}},
+        ]
+        with patch("agent.claude_runtime.run_claude_agent_sdk_turn") as run_turn:
+            run_turn.return_value = {"final_response": "ok"}
+            agent._run_claude_agent_sdk_turn(
+                user_message=content,
+                original_user_message=content,
+                messages=[],
+                effective_task_id="t",
+            )
+        prompt = run_turn.call_args.kwargs["user_message"]
+        # An async iterable, which is the only structured shape the SDK takes.
+        assert hasattr(prompt, "__aiter__")
+
+    def test_an_image_is_never_silently_dropped(self, monkeypatch):
+        import agent.claude_sdk_input as sdk_input
+
+        monkeypatch.setattr(sdk_input, "sdk_supports_streaming_input", lambda: False)
+        agent = self._agent()
+        content = [
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,QUJD"}}
+        ]
+        with patch("agent.claude_runtime.run_claude_agent_sdk_turn") as run_turn:
+            result = agent._run_claude_agent_sdk_turn(
+                user_message=content,
+                original_user_message=content,
+                messages=[],
+                effective_task_id="t",
+            )
+        run_turn.assert_not_called()
+        assert result["completed"] is False
+        assert "auxiliary.vision" in result["final_response"]
+        assert "NOT sent" in result["final_response"]

--- a/tests/agent/test_claude_tool_bridge.py
+++ b/tests/agent/test_claude_tool_bridge.py
@@ -1,0 +1,343 @@
+"""Contract for the in-process ``claude_agent_sdk`` MCP bridge.
+
+``claude-agent-sdk`` is an optional extra, so the tests stand up a minimal
+fake module when it is absent — importing ``agent.transports.claude_tool_bridge``
+and running this file must stay green on a machine without the SDK.
+"""
+
+import asyncio
+import base64
+import json
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.transports import claude_tool_bridge as bridge
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK (used only when the real optional extra is not installed)
+# ---------------------------------------------------------------------------
+
+
+class _FakeToolAnnotations:
+    """Mirror of the SDK's pydantic ``ToolAnnotations`` (0.2.140+).
+
+    It validates by the camelCase alias on input and exposes the snake_case
+    field on the model, so callers construct with ``readOnlyHint=`` and read
+    ``read_only_hint``.
+    """
+
+    def __init__(self, readOnlyHint: bool = False, **_ignored):
+        self.read_only_hint = readOnlyHint
+
+
+@dataclass
+class _FakeSdkTool:
+    name: str
+    description: str
+    input_schema: dict
+    handler: object
+    annotations: object = None
+
+
+def _fake_tool(name, description, input_schema, annotations=None):
+    def _decorate(handler):
+        return _FakeSdkTool(name, description, input_schema, handler, annotations)
+
+    return _decorate
+
+
+def _fake_create_sdk_mcp_server(*, name, version, tools):
+    return SimpleNamespace(name=name, version=version, tools=list(tools))
+
+
+@pytest.fixture
+def sdk_module(monkeypatch):
+    """Yield an importable ``claude_agent_sdk``, faking it when absent."""
+    try:  # pragma: no cover - exercised only where the extra is installed
+        import claude_agent_sdk  # noqa: F401
+
+        yield sys.modules["claude_agent_sdk"]
+        return
+    except ImportError:
+        pass
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.tool = _fake_tool
+    module.create_sdk_mcp_server = _fake_create_sdk_mcp_server
+    module.ToolAnnotations = _FakeToolAnnotations
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    yield module
+
+
+# ---------------------------------------------------------------------------
+# Agent helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _tools_by_name(tools) -> dict:
+    """Map tool name -> SdkMcpTool.
+
+    ``create_sdk_mcp_server`` returns an SDK-internal value — a stub object
+    carrying ``.tools`` here, a ``{"type", "name", "instance"}`` dict in the
+    real package — so tests that need the tool objects go through
+    ``build_bridged_sdk_tools`` and never unwrap either shape.
+    """
+    return {t.name: t for t in tools}
+
+
+# ---------------------------------------------------------------------------
+# Naming + surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_without_the_optional_sdk():
+    """Nothing at module scope may require claude-agent-sdk."""
+    assert "claude_agent_sdk" not in getattr(bridge, "__dict__", {})
+    assert bridge.mcp_tool_name("web_search") == "mcp__hermes__web_search"
+
+
+def test_missing_sdk_raises_an_actionable_import_error(monkeypatch):
+    agent = _make_agent("web_search")
+    # A None entry in sys.modules is the stdlib's "this import fails" marker.
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+
+    with pytest.raises(ImportError, match="claude-agent-sdk"):
+        bridge.build_hermes_sdk_mcp_server(agent, "task-1")
+
+
+def test_exposed_names_match_the_agents_enabled_tools_and_nothing_else(sdk_module):
+    agent = _make_agent("web_search", "write_file")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+
+    assert set(_tools_by_name(tools)) == {"web_search", "write_file"}
+    assert set(bridge.bridged_allowed_tools(agent)) == {
+        "mcp__hermes__web_search",
+        "mcp__hermes__write_file",
+    }
+    assert all(
+        name.startswith(bridge.MCP_TOOL_PREFIX)
+        for name in bridge.bridged_allowed_tools(agent)
+    )
+
+
+def test_json_schemas_are_forwarded_verbatim(sdk_module):
+    agent = _make_agent("web_search")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+
+    schema = _tools_by_name(tools)["web_search"].input_schema
+    assert schema == agent.tools[0]["function"]["parameters"]
+
+
+def test_read_only_annotation_matches_hermes_read_only_set(sdk_module):
+    from agent.tool_dispatch_helpers import _PARALLEL_SAFE_TOOLS
+
+    read_only_name = sorted(_PARALLEL_SAFE_TOOLS)[0]
+    agent = _make_agent(read_only_name, "write_file", "terminal")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+    tools = _tools_by_name(tools)
+
+    assert tools[read_only_name].annotations.read_only_hint is True
+    # Mutating tools must never be announced as read-only.
+    assert tools["write_file"].annotations.read_only_hint is False
+    assert tools["terminal"].annotations.read_only_hint is False
+
+
+def test_read_only_predicate_never_marks_a_mutating_tool_read_only():
+    for name in ("write_file", "patch", "terminal", "delegate_task", "memory"):
+        assert bridge.is_read_only_tool(name) is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routes through the Hermes lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_reaches_execute_one_tool_and_not_handle_function_call(sdk_module):
+    agent = _make_agent("web_search")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-routed")
+    handler = _tools_by_name(tools)["web_search"].handler
+
+    from agent.tool_executor import ToolExecutionOutcome
+
+    seen = {}
+
+    def _fake_execute_one_tool(bound_agent, tool_call, task_id, **kwargs):
+        seen["agent"] = bound_agent
+        seen["name"] = tool_call.function.name
+        seen["args"] = json.loads(tool_call.function.arguments)
+        seen["task_id"] = task_id
+        return ToolExecutionOutcome(
+            tool_call=tool_call,
+            tool_call_id=tool_call.id,
+            function_name=tool_call.function.name,
+            function_args={},
+            result=json.dumps({"ok": True}),
+            duration=0.0,
+            is_error=False,
+            blocked=False,
+            cancelled=False,
+            malformed=False,
+            middleware_trace=[],
+        )
+
+    with (
+        patch.object(bridge, "execute_one_tool", side_effect=_fake_execute_one_tool),
+        patch.object(bridge, "finalize_tool_outcome", side_effect=lambda a, o: o.result),
+        patch("run_agent.handle_function_call") as raw_dispatch,
+    ):
+        response = asyncio.run(handler({"query": "hermes"}))
+
+    raw_dispatch.assert_not_called()
+    assert seen["agent"] is agent
+    assert seen["name"] == "web_search"
+    assert seen["args"] == {"query": "hermes"}
+    assert seen["task_id"] == "task-routed"
+    assert response["content"] == [{"type": "text", "text": json.dumps({"ok": True})}]
+    assert "is_error" not in response
+
+
+def test_task_id_may_be_resolved_per_call(sdk_module):
+    agent = _make_agent("web_search")
+    current = {"id": "task-a"}
+    tools = bridge.build_bridged_sdk_tools(agent, lambda: current["id"])
+    handler = _tools_by_name(tools)["web_search"].handler
+
+    seen = []
+
+    def _fake_dispatch(name, args, task_id, **kwargs):
+        seen.append(task_id)
+        return json.dumps({"ok": True})
+
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", return_value=(None, None)),
+        patch("run_agent.handle_function_call", side_effect=_fake_dispatch),
+    ):
+        asyncio.run(handler({"query": "one"}))
+        current["id"] = "task-b"
+        asyncio.run(handler({"query": "two"}))
+
+    assert seen == ["task-a", "task-b"]
+
+
+def test_denied_tool_call_never_dispatches_and_reports_an_error(sdk_module):
+    agent = _make_agent("terminal")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-deny")
+    handler = _tools_by_name(tools)["terminal"].handler
+
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", return_value=("denied by policy", None)),
+        patch("run_agent.handle_function_call") as raw_dispatch,
+    ):
+        response = asyncio.run(handler({"command": "ls"}))
+
+    raw_dispatch.assert_not_called()
+    assert response["is_error"] is True
+    assert "denied by policy" in response["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Result conversion
+# ---------------------------------------------------------------------------
+
+
+def test_error_results_carry_is_error():
+    response = bridge.build_tool_response(
+        "web_search", json.dumps({"error": "upstream exploded"})
+    )
+    assert response["is_error"] is True
+    assert response["content"][0]["type"] == "text"
+
+
+def test_successful_results_omit_is_error():
+    response = bridge.build_tool_response("web_search", json.dumps({"results": []}))
+    assert "is_error" not in response
+
+
+def test_image_results_become_image_blocks_with_raw_base64():
+    payload = base64.b64encode(b"\x89PNG fake").decode()
+    multimodal = {
+        "_multimodal": True,
+        "text_summary": "a screenshot",
+        "content": [
+            {"type": "text", "text": "a screenshot"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            },
+        ],
+    }
+
+    blocks = bridge.tool_result_content_blocks(multimodal)
+
+    assert blocks[0] == {"type": "text", "text": "a screenshot"}
+    image = blocks[1]
+    assert image["type"] == "image"
+    assert image["mimeType"] == "image/png"
+    assert image["data"] == payload
+    assert not image["data"].startswith("data:")
+    assert base64.b64decode(image["data"]) == b"\x89PNG fake"
+
+
+def test_plain_string_results_become_a_single_text_block():
+    assert bridge.tool_result_content_blocks("hello") == [
+        {"type": "text", "text": "hello"}
+    ]
+
+
+def test_tool_specs_ignore_malformed_definitions():
+    agent = SimpleNamespace(
+        tools=[
+            {"type": "function", "function": {"name": "web_search"}},
+            {"type": "function"},
+            "not-a-dict",
+            {"type": "function", "function": {"name": "web_search"}},
+        ]
+    )
+    assert [spec["name"] for spec in bridge.agent_tool_specs(agent)] == ["web_search"]

--- a/tests/agent/test_claude_tool_bridge.py
+++ b/tests/agent/test_claude_tool_bridge.py
@@ -1,0 +1,336 @@
+"""Contract for the in-process ``claude_agent_sdk`` MCP bridge.
+
+``claude-agent-sdk`` is an optional extra, so the tests stand up a minimal
+fake module when it is absent — importing ``agent.transports.claude_tool_bridge``
+and running this file must stay green on a machine without the SDK.
+"""
+
+import asyncio
+import base64
+import json
+import sys
+import types
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.transports import claude_tool_bridge as bridge
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Fake SDK (used only when the real optional extra is not installed)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeToolAnnotations:
+    readOnlyHint: bool = False
+
+
+@dataclass
+class _FakeSdkTool:
+    name: str
+    description: str
+    input_schema: dict
+    handler: object
+    annotations: object = None
+
+
+def _fake_tool(name, description, input_schema, annotations=None):
+    def _decorate(handler):
+        return _FakeSdkTool(name, description, input_schema, handler, annotations)
+
+    return _decorate
+
+
+def _fake_create_sdk_mcp_server(*, name, version, tools):
+    return SimpleNamespace(name=name, version=version, tools=list(tools))
+
+
+@pytest.fixture
+def sdk_module(monkeypatch):
+    """Yield an importable ``claude_agent_sdk``, faking it when absent."""
+    try:  # pragma: no cover - exercised only where the extra is installed
+        import claude_agent_sdk  # noqa: F401
+
+        yield sys.modules["claude_agent_sdk"]
+        return
+    except ImportError:
+        pass
+
+    module = types.ModuleType("claude_agent_sdk")
+    module.tool = _fake_tool
+    module.create_sdk_mcp_server = _fake_create_sdk_mcp_server
+    module.ToolAnnotations = _FakeToolAnnotations
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", module)
+    yield module
+
+
+# ---------------------------------------------------------------------------
+# Agent helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                },
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value={}),
+        patch("hermes_cli.config.load_config_readonly", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _tools_by_name(tools) -> dict:
+    """Map tool name -> SdkMcpTool.
+
+    ``create_sdk_mcp_server`` returns an SDK-internal value — a stub object
+    carrying ``.tools`` here, a ``{"type", "name", "instance"}`` dict in the
+    real package — so tests that need the tool objects go through
+    ``build_bridged_sdk_tools`` and never unwrap either shape.
+    """
+    return {t.name: t for t in tools}
+
+
+# ---------------------------------------------------------------------------
+# Naming + surface
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports_without_the_optional_sdk():
+    """Nothing at module scope may require claude-agent-sdk."""
+    assert "claude_agent_sdk" not in getattr(bridge, "__dict__", {})
+    assert bridge.mcp_tool_name("web_search") == "mcp__hermes__web_search"
+
+
+def test_missing_sdk_raises_an_actionable_import_error(monkeypatch):
+    agent = _make_agent("web_search")
+    # A None entry in sys.modules is the stdlib's "this import fails" marker.
+    monkeypatch.setitem(sys.modules, "claude_agent_sdk", None)
+
+    with pytest.raises(ImportError, match="claude-agent-sdk"):
+        bridge.build_hermes_sdk_mcp_server(agent, "task-1")
+
+
+def test_exposed_names_match_the_agents_enabled_tools_and_nothing_else(sdk_module):
+    agent = _make_agent("web_search", "write_file")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+
+    assert set(_tools_by_name(tools)) == {"web_search", "write_file"}
+    assert set(bridge.bridged_allowed_tools(agent)) == {
+        "mcp__hermes__web_search",
+        "mcp__hermes__write_file",
+    }
+    assert all(
+        name.startswith(bridge.MCP_TOOL_PREFIX)
+        for name in bridge.bridged_allowed_tools(agent)
+    )
+
+
+def test_json_schemas_are_forwarded_verbatim(sdk_module):
+    agent = _make_agent("web_search")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+
+    schema = _tools_by_name(tools)["web_search"].input_schema
+    assert schema == agent.tools[0]["function"]["parameters"]
+
+
+def test_read_only_annotation_matches_hermes_read_only_set(sdk_module):
+    from agent.tool_dispatch_helpers import _PARALLEL_SAFE_TOOLS
+
+    read_only_name = sorted(_PARALLEL_SAFE_TOOLS)[0]
+    agent = _make_agent(read_only_name, "write_file", "terminal")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-1")
+    tools = _tools_by_name(tools)
+
+    assert tools[read_only_name].annotations.readOnlyHint is True
+    # Mutating tools must never be announced as read-only.
+    assert tools["write_file"].annotations.readOnlyHint is False
+    assert tools["terminal"].annotations.readOnlyHint is False
+
+
+def test_read_only_predicate_never_marks_a_mutating_tool_read_only():
+    for name in ("write_file", "patch", "terminal", "delegate_task", "memory"):
+        assert bridge.is_read_only_tool(name) is False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routes through the Hermes lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_reaches_execute_one_tool_and_not_handle_function_call(sdk_module):
+    agent = _make_agent("web_search")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-routed")
+    handler = _tools_by_name(tools)["web_search"].handler
+
+    from agent.tool_executor import ToolExecutionOutcome
+
+    seen = {}
+
+    def _fake_execute_one_tool(bound_agent, tool_call, task_id, **kwargs):
+        seen["agent"] = bound_agent
+        seen["name"] = tool_call.function.name
+        seen["args"] = json.loads(tool_call.function.arguments)
+        seen["task_id"] = task_id
+        return ToolExecutionOutcome(
+            tool_call=tool_call,
+            tool_call_id=tool_call.id,
+            function_name=tool_call.function.name,
+            function_args={},
+            result=json.dumps({"ok": True}),
+            duration=0.0,
+            is_error=False,
+            blocked=False,
+            cancelled=False,
+            malformed=False,
+            middleware_trace=[],
+        )
+
+    with (
+        patch.object(bridge, "execute_one_tool", side_effect=_fake_execute_one_tool),
+        patch.object(bridge, "finalize_tool_outcome", side_effect=lambda a, o: o.result),
+        patch("run_agent.handle_function_call") as raw_dispatch,
+    ):
+        response = asyncio.run(handler({"query": "hermes"}))
+
+    raw_dispatch.assert_not_called()
+    assert seen["agent"] is agent
+    assert seen["name"] == "web_search"
+    assert seen["args"] == {"query": "hermes"}
+    assert seen["task_id"] == "task-routed"
+    assert response["content"] == [{"type": "text", "text": json.dumps({"ok": True})}]
+    assert "is_error" not in response
+
+
+def test_task_id_may_be_resolved_per_call(sdk_module):
+    agent = _make_agent("web_search")
+    current = {"id": "task-a"}
+    tools = bridge.build_bridged_sdk_tools(agent, lambda: current["id"])
+    handler = _tools_by_name(tools)["web_search"].handler
+
+    seen = []
+
+    def _fake_dispatch(name, args, task_id, **kwargs):
+        seen.append(task_id)
+        return json.dumps({"ok": True})
+
+    with (
+        patch("hermes_cli.plugins.resolve_pre_tool_block", return_value=None),
+        patch("run_agent.handle_function_call", side_effect=_fake_dispatch),
+    ):
+        asyncio.run(handler({"query": "one"}))
+        current["id"] = "task-b"
+        asyncio.run(handler({"query": "two"}))
+
+    assert seen == ["task-a", "task-b"]
+
+
+def test_denied_tool_call_never_dispatches_and_reports_an_error(sdk_module):
+    agent = _make_agent("terminal")
+    tools = bridge.build_bridged_sdk_tools(agent, "task-deny")
+    handler = _tools_by_name(tools)["terminal"].handler
+
+    with (
+        patch("hermes_cli.plugins.resolve_pre_tool_block", return_value="denied by policy"),
+        patch("run_agent.handle_function_call") as raw_dispatch,
+    ):
+        response = asyncio.run(handler({"command": "ls"}))
+
+    raw_dispatch.assert_not_called()
+    assert response["is_error"] is True
+    assert "denied by policy" in response["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Result conversion
+# ---------------------------------------------------------------------------
+
+
+def test_error_results_carry_is_error():
+    response = bridge.build_tool_response(
+        "web_search", json.dumps({"error": "upstream exploded"})
+    )
+    assert response["is_error"] is True
+    assert response["content"][0]["type"] == "text"
+
+
+def test_successful_results_omit_is_error():
+    response = bridge.build_tool_response("web_search", json.dumps({"results": []}))
+    assert "is_error" not in response
+
+
+def test_image_results_become_image_blocks_with_raw_base64():
+    payload = base64.b64encode(b"\x89PNG fake").decode()
+    multimodal = {
+        "_multimodal": True,
+        "text_summary": "a screenshot",
+        "content": [
+            {"type": "text", "text": "a screenshot"},
+            {
+                "type": "image_url",
+                "image_url": {"url": f"data:image/png;base64,{payload}"},
+            },
+        ],
+    }
+
+    blocks = bridge.tool_result_content_blocks(multimodal)
+
+    assert blocks[0] == {"type": "text", "text": "a screenshot"}
+    image = blocks[1]
+    assert image["type"] == "image"
+    assert image["mimeType"] == "image/png"
+    assert image["data"] == payload
+    assert not image["data"].startswith("data:")
+    assert base64.b64decode(image["data"]) == b"\x89PNG fake"
+
+
+def test_plain_string_results_become_a_single_text_block():
+    assert bridge.tool_result_content_blocks("hello") == [
+        {"type": "text", "text": "hello"}
+    ]
+
+
+def test_tool_specs_ignore_malformed_definitions():
+    agent = SimpleNamespace(
+        tools=[
+            {"type": "function", "function": {"name": "web_search"}},
+            {"type": "function"},
+            "not-a-dict",
+            {"type": "function", "function": {"name": "web_search"}},
+        ]
+    )
+    assert [spec["name"] for spec in bridge.agent_tool_specs(agent)] == ["web_search"]

--- a/tests/agent/test_tool_executor_lifecycle.py
+++ b/tests/agent/test_tool_executor_lifecycle.py
@@ -1,0 +1,485 @@
+"""Behavior contract for the shared per-tool lifecycle in ``agent.tool_executor``.
+
+``execute_one_tool`` is the single funnel every runtime must use to run a
+model tool call — the sequential dispatcher, the concurrent dispatcher, and
+the ``claude_agent_sdk`` MCP bridge.  These tests pin the *invariants* of that
+funnel (a wrapper is consulted, a denial short-circuits, an interrupt cancels,
+the task id reaches the handler) rather than the current wording of any
+message or the internal call counts of private helpers, so the extraction can
+keep moving without the suite fighting it.
+"""
+
+import json
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tool_executor import (
+    ToolExecutionOutcome,
+    execute_one_tool,
+    execute_tool_calls_concurrent,
+    execute_tool_calls_sequential,
+    finalize_tool_outcome,
+)
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("hermes_cli.config.load_config_readonly", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _tool_call(name="web_search", args=None, call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(
+            name=name, arguments=json.dumps(args if args is not None else {})
+        ),
+    )
+
+
+def _assistant(*tool_calls):
+    return SimpleNamespace(content="", tool_calls=list(tool_calls))
+
+
+def _dispatch(mode):
+    return (
+        execute_tool_calls_sequential
+        if mode == "sequential"
+        else execute_tool_calls_concurrent
+    )
+
+
+BOTH_PATHS = pytest.mark.parametrize("mode", ["sequential", "concurrent"])
+
+
+def _assert_role_alternation(messages: list, baseline: int = 0) -> None:
+    """Alternation invariant for what tool execution appends.
+
+    A batch legitimately produces one ``tool`` message per tool_call, so a run
+    of ``tool`` rows is valid; two ``user`` or two ``assistant`` rows in a row
+    is not, and no ``user`` turn may be injected mid-loop.
+    """
+    for message in messages[baseline:]:
+        assert message.get("role") != "user", (
+            "tool execution must not inject a user message"
+        )
+    previous = None
+    for message in messages:
+        role = message.get("role")
+        if role in {"user", "assistant"}:
+            assert role != previous, (
+                f"consecutive {role!r} messages break alternation"
+            )
+        previous = role
+
+
+class _Observed:
+    """Records the observable effect of each wrapper around the handler."""
+
+    def __init__(self):
+        self.plugin_block = []
+        self.guardrail_before = []
+        self.approval = []
+        self.tool_started = []
+        self.tool_completed = []
+        self.tool_start_callback = []
+        self.checkpoints = []
+        self.post_hook = []
+        self.dispatched = []
+
+
+def _instrument(agent, observed: _Observed, *, handler=None, plugin_block=None):
+    """Patch every wrapper's observation point around one tool dispatch.
+
+    Dispatch is intercepted at ``registry.dispatch`` rather than at
+    ``handle_function_call`` so the real dispatcher — and therefore the real
+    approval layer and the real ``post_tool_call`` emission — still runs.
+    """
+
+    def _progress(event, name, preview, args, **kwargs):
+        if event == "tool.started":
+            observed.tool_started.append(name)
+        elif event == "tool.completed":
+            observed.tool_completed.append(name)
+
+    agent.tool_progress_callback = _progress
+    agent.tool_start_callback = lambda call_id, name, args: (
+        observed.tool_start_callback.append(name)
+    )
+    agent._checkpoint_mgr = SimpleNamespace(
+        enabled=True,
+        get_working_dir_for_path=lambda path: path,
+        ensure_checkpoint=lambda path, reason: observed.checkpoints.append(
+            (path, reason)
+        ),
+    )
+
+    original_before_call = agent._tool_guardrails.before_call
+
+    def _before_call(name, args):
+        observed.guardrail_before.append(name)
+        return original_before_call(name, args)
+
+    def _plugin(name, args, **kwargs):
+        observed.plugin_block.append(name)
+        return plugin_block, None
+
+    def _approval(name, args):
+        observed.approval.append(name)
+        return None
+
+    def _post_hook(**kwargs):
+        # Mirror the real emitter's first line: the sequential dispatcher
+        # suppresses the inner ``handle_function_call`` emission so the
+        # executor owns one terminal event per tool_call_id.
+        import model_tools
+
+        if model_tools._post_tool_call_hook_suppressed.get():
+            return
+        observed.post_hook.append(kwargs.get("function_name"))
+
+    def _dispatch_tool(name, args, **kwargs):
+        observed.dispatched.append((name, dict(args), kwargs.get("task_id")))
+        if handler is not None:
+            return handler(name, args, **kwargs)
+        return json.dumps({"ok": True})
+
+    patches = (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", side_effect=_plugin),
+        patch.object(agent._tool_guardrails, "before_call", side_effect=_before_call),
+        patch("model_tools._emit_post_tool_call_hook", side_effect=_post_hook),
+        patch("model_tools.registry.dispatch", side_effect=_dispatch_tool),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+        patch(
+            "acp_adapter.edit_approval.maybe_require_edit_approval",
+            side_effect=_approval,
+        ),
+    )
+
+    stack = ExitStack()
+    for one in patches:
+        stack.enter_context(one)
+    return stack
+
+
+def _hard_stop_config() -> dict:
+    return {
+        "tool_loop_guardrails": {
+            "warnings_enabled": True,
+            "hard_stop_enabled": True,
+            "hard_stop_after": {
+                "exact_failure": 2,
+                "same_tool_failure": 8,
+                "idempotent_no_progress": 5,
+            },
+        }
+    }
+
+
+def _seed_guardrail_block(agent, tool_name: str, args: dict) -> None:
+    for _ in range(2):
+        agent._tool_guardrails.after_call(
+            tool_name, args, json.dumps({"error": "boom"}), failed=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Every wrapper runs, exactly once, on both dispatchers
+# ---------------------------------------------------------------------------
+
+
+@BOTH_PATHS
+def test_tool_call_passes_through_every_wrapper_exactly_once(mode):
+    agent = _make_agent("write_file")
+    args = {"path": "/tmp/hermes-lifecycle.txt", "content": "hi"}
+    call = _tool_call("write_file", args, "c-1")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(agent, _assistant(call), messages, "task-lifecycle")
+
+    # Each wrapper is consulted for this call, and only once.
+    assert observed.plugin_block == ["write_file"]
+    assert observed.guardrail_before == ["write_file"]
+    assert observed.tool_started == ["write_file"]
+    assert observed.tool_completed == ["write_file"]
+    assert observed.tool_start_callback == ["write_file"]
+    assert observed.approval == ["write_file"]
+    assert observed.post_hook == ["write_file"]
+    assert len(observed.dispatched) == 1
+    # A file-mutating tool checkpoints the path it is about to touch.
+    assert [reason for _path, reason in observed.checkpoints] == [
+        "before write_file"
+    ]
+    # Exactly one tool result, matched to the model's tool_call_id.
+    assert [m["tool_call_id"] for m in messages] == ["c-1"]
+    _assert_role_alternation(messages)
+
+
+@BOTH_PATHS
+def test_effective_task_id_reaches_the_handler(mode):
+    """Environment routing (local/Docker/SSH/Modal/...) rides on the task id."""
+    agent = _make_agent("web_search")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("web_search", {"query": "x"})),
+            messages, "task-routed-env",
+        )
+
+    assert [task_id for _n, _a, task_id in observed.dispatched] == ["task-routed-env"]
+
+
+# ---------------------------------------------------------------------------
+# Denials short-circuit
+# ---------------------------------------------------------------------------
+
+
+@BOTH_PATHS
+def test_approval_denial_short_circuits_execution(mode):
+    agent = _make_agent("terminal")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed, plugin_block="denied by policy"):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("terminal", {"command": "ls"}, "c-deny")),
+            messages, "task-deny",
+        )
+
+    assert observed.dispatched == [], "a denied call must never reach the handler"
+    assert observed.tool_started == []
+    assert observed.checkpoints == []
+    # The denial is reported back to the model on the denied call's own id.
+    assert [m["tool_call_id"] for m in messages] == ["c-deny"]
+    assert "denied by policy" in messages[0]["content"]
+    _assert_role_alternation(messages)
+
+
+@BOTH_PATHS
+def test_guardrail_block_prevents_the_handler_from_running(mode):
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    args = {"query": "looping"}
+    _seed_guardrail_block(agent, "web_search", args)
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("web_search", args, "c-blocked")),
+            messages, "task-guardrail",
+        )
+
+    assert observed.guardrail_before == ["web_search"]
+    assert observed.dispatched == [], "a guardrail block must pre-empt dispatch"
+    assert [m["tool_call_id"] for m in messages] == ["c-blocked"]
+    _assert_role_alternation(messages)
+
+
+# ---------------------------------------------------------------------------
+# Interrupt semantics
+# ---------------------------------------------------------------------------
+
+
+def test_keyboard_interrupt_mid_execution_yields_a_cancelled_outcome():
+    agent = _make_agent("terminal")
+    agent.interrupt = MagicMock()
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    with (
+        patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", return_value=(None, None)),
+        patch("run_agent.handle_function_call", side_effect=_boom),
+    ):
+        outcome = execute_one_tool(
+            agent, _tool_call("terminal", {"command": "sleep 60"}), "task-int",
+        )
+
+    assert outcome.cancelled is True
+    assert outcome.is_error is True
+    assert json.loads(outcome.result)["status"] == "cancelled"
+    agent.interrupt.assert_called_once()
+
+
+@BOTH_PATHS
+def test_interrupt_mid_batch_keeps_one_result_per_call_and_valid_alternation(mode):
+    agent = _make_agent("web_search")
+    calls = [
+        _tool_call("web_search", {"query": "first"}, "c-a"),
+        _tool_call("web_search", {"query": "second"}, "c-b"),
+    ]
+    messages: list = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+    ]
+    observed = _Observed()
+
+    def _interrupting_handler(name, args, **kwargs):
+        agent._interrupt_requested = True
+        return json.dumps({"ok": True})
+
+    with _instrument(agent, observed, handler=_interrupting_handler):
+        _dispatch(mode)(agent, _assistant(*calls), messages, "task-int-batch")
+
+    tool_ids = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+    assert tool_ids == ["c-a", "c-b"], "every tool_call_id must be answered once"
+    _assert_role_alternation(messages, baseline=2)
+
+
+# ---------------------------------------------------------------------------
+# Output budgeting
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_result_is_budgeted_identically_through_both_callers():
+    oversized = "x" * 400_000
+    contents = {}
+
+    for mode in ("sequential", "concurrent"):
+        agent = _make_agent("web_search")
+        messages: list = []
+        with (
+            patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", return_value=(None, None)),
+            patch("run_agent.handle_function_call", return_value=oversized),
+        ):
+            _dispatch(mode)(
+                agent, _assistant(_tool_call("web_search", {"query": "big"}, "c-big")),
+                messages, "task-budget",
+            )
+        assert [m["tool_call_id"] for m in messages] == ["c-big"]
+        contents[mode] = messages[0]["content"]
+
+    assert len(contents["sequential"]) < len(oversized), (
+        "an oversized result must be budgeted, not passed through whole"
+    )
+    assert contents["sequential"] == contents["concurrent"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-path equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_both_callers_produce_equivalent_per_tool_observable_effects():
+    args = {"path": "/tmp/hermes-equivalence.txt", "content": "same"}
+    snapshots = {}
+
+    for mode in ("sequential", "concurrent"):
+        agent = _make_agent("write_file")
+        messages: list = []
+        observed = _Observed()
+        with _instrument(agent, observed):
+            _dispatch(mode)(
+                agent, _assistant(_tool_call("write_file", args, "c-eq")),
+                messages, "task-eq",
+            )
+        snapshots[mode] = {
+            "plugin_block": observed.plugin_block,
+            "guardrail_before": observed.guardrail_before,
+            "tool_started": observed.tool_started,
+            "tool_completed": observed.tool_completed,
+            "tool_start_callback": observed.tool_start_callback,
+            "post_hook": observed.post_hook,
+            "approval": observed.approval,
+            "dispatched": observed.dispatched,
+            "checkpoint_reasons": [r for _p, r in observed.checkpoints],
+            "tool_messages": [
+                (m["tool_call_id"], m["content"])
+                for m in messages
+                if m["role"] == "tool"
+            ],
+        }
+
+    assert snapshots["sequential"] == snapshots["concurrent"]
+
+
+# ---------------------------------------------------------------------------
+# The funnel is usable without a transcript (the SDK bridge's shape)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_one_tool_applies_wrappers_without_a_message_list():
+    """The claude_agent_sdk bridge owns no message list; wrappers still run."""
+    agent = _make_agent("web_search")
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        outcome = execute_one_tool(
+            agent, _tool_call("web_search", {"query": "x"}, "c-bridge"),
+            "task-bridge", messages=None,
+        )
+        result = finalize_tool_outcome(agent, outcome)
+
+    assert isinstance(outcome, ToolExecutionOutcome)
+    assert outcome.blocked is False and outcome.cancelled is False
+    assert observed.plugin_block == ["web_search"]
+    assert observed.guardrail_before == ["web_search"]
+    assert observed.tool_started == ["web_search"]
+    assert observed.post_hook == ["web_search"]
+    assert [task_id for _n, _a, task_id in observed.dispatched] == ["task-bridge"]
+    assert json.loads(result) == {"ok": True}
+
+
+def test_malformed_arguments_are_reported_without_dispatching():
+    agent = _make_agent("web_search")
+    bad_call = SimpleNamespace(
+        id="c-bad",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{not json"),
+    )
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        outcome = execute_one_tool(agent, bad_call, "task-bad")
+
+    assert outcome.malformed is True
+    assert observed.dispatched == []
+    assert observed.tool_started == []

--- a/tests/agent/test_tool_executor_lifecycle.py
+++ b/tests/agent/test_tool_executor_lifecycle.py
@@ -1,0 +1,478 @@
+"""Behavior contract for the shared per-tool lifecycle in ``agent.tool_executor``.
+
+``execute_one_tool`` is the single funnel every runtime must use to run a
+model tool call — the sequential dispatcher, the concurrent dispatcher, and
+the ``claude_agent_sdk`` MCP bridge.  These tests pin the *invariants* of that
+funnel (a wrapper is consulted, a denial short-circuits, an interrupt cancels,
+the task id reaches the handler) rather than the current wording of any
+message or the internal call counts of private helpers, so the extraction can
+keep moving without the suite fighting it.
+"""
+
+import json
+import uuid
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.tool_executor import (
+    ToolExecutionOutcome,
+    execute_one_tool,
+    execute_tool_calls_concurrent,
+    execute_tool_calls_sequential,
+    finalize_tool_outcome,
+)
+from run_agent import AIAgent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _make_agent(*tool_names: str, config: dict | None = None) -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs(*tool_names)),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("hermes_cli.config.load_config", return_value=config or {}),
+        patch("hermes_cli.config.load_config_readonly", return_value=config or {}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.client = MagicMock()
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _tool_call(name="web_search", args=None, call_id=None):
+    return SimpleNamespace(
+        id=call_id or f"call_{uuid.uuid4().hex[:8]}",
+        type="function",
+        function=SimpleNamespace(
+            name=name, arguments=json.dumps(args if args is not None else {})
+        ),
+    )
+
+
+def _assistant(*tool_calls):
+    return SimpleNamespace(content="", tool_calls=list(tool_calls))
+
+
+def _dispatch(mode):
+    return (
+        execute_tool_calls_sequential
+        if mode == "sequential"
+        else execute_tool_calls_concurrent
+    )
+
+
+BOTH_PATHS = pytest.mark.parametrize("mode", ["sequential", "concurrent"])
+
+
+def _assert_role_alternation(messages: list, baseline: int = 0) -> None:
+    """Alternation invariant for what tool execution appends.
+
+    A batch legitimately produces one ``tool`` message per tool_call, so a run
+    of ``tool`` rows is valid; two ``user`` or two ``assistant`` rows in a row
+    is not, and no ``user`` turn may be injected mid-loop.
+    """
+    for message in messages[baseline:]:
+        assert message.get("role") != "user", (
+            "tool execution must not inject a user message"
+        )
+    previous = None
+    for message in messages:
+        role = message.get("role")
+        if role in {"user", "assistant"}:
+            assert role != previous, (
+                f"consecutive {role!r} messages break alternation"
+            )
+        previous = role
+
+
+class _Observed:
+    """Records the observable effect of each wrapper around the handler."""
+
+    def __init__(self):
+        self.plugin_block = []
+        self.guardrail_before = []
+        self.approval = []
+        self.tool_started = []
+        self.tool_completed = []
+        self.tool_start_callback = []
+        self.checkpoints = []
+        self.post_hook = []
+        self.dispatched = []
+
+
+def _instrument(agent, observed: _Observed, *, handler=None, plugin_block=None):
+    """Patch every wrapper's observation point around one tool dispatch.
+
+    Dispatch is intercepted at ``registry.dispatch`` rather than at
+    ``handle_function_call`` so the real dispatcher — and therefore the real
+    approval layer and the real ``post_tool_call`` emission — still runs.
+    """
+
+    def _progress(event, name, preview, args, **kwargs):
+        if event == "tool.started":
+            observed.tool_started.append(name)
+        elif event == "tool.completed":
+            observed.tool_completed.append(name)
+
+    agent.tool_progress_callback = _progress
+    agent.tool_start_callback = lambda call_id, name, args: (
+        observed.tool_start_callback.append(name)
+    )
+    agent._checkpoint_mgr = SimpleNamespace(
+        enabled=True,
+        get_working_dir_for_path=lambda path: path,
+        ensure_checkpoint=lambda path, reason: observed.checkpoints.append(
+            (path, reason)
+        ),
+    )
+
+    original_before_call = agent._tool_guardrails.before_call
+
+    def _before_call(name, args):
+        observed.guardrail_before.append(name)
+        return original_before_call(name, args)
+
+    def _plugin(name, args, **kwargs):
+        observed.plugin_block.append(name)
+        return plugin_block
+
+    def _approval(name, args):
+        observed.approval.append(name)
+        return None
+
+    def _post_hook(**kwargs):
+        observed.post_hook.append(kwargs.get("function_name"))
+
+    def _dispatch_tool(name, args, **kwargs):
+        observed.dispatched.append((name, dict(args), kwargs.get("task_id")))
+        if handler is not None:
+            return handler(name, args, **kwargs)
+        return json.dumps({"ok": True})
+
+    patches = (
+        patch("hermes_cli.plugins.resolve_pre_tool_block", side_effect=_plugin),
+        patch.object(agent._tool_guardrails, "before_call", side_effect=_before_call),
+        patch("model_tools._emit_post_tool_call_hook", side_effect=_post_hook),
+        patch("model_tools.registry.dispatch", side_effect=_dispatch_tool),
+        patch(
+            "agent.tool_executor.maybe_persist_tool_result",
+            side_effect=lambda **kwargs: kwargs["content"],
+        ),
+        patch(
+            "acp_adapter.edit_approval.maybe_require_edit_approval",
+            side_effect=_approval,
+        ),
+    )
+
+    stack = ExitStack()
+    for one in patches:
+        stack.enter_context(one)
+    return stack
+
+
+def _hard_stop_config() -> dict:
+    return {
+        "tool_loop_guardrails": {
+            "warnings_enabled": True,
+            "hard_stop_enabled": True,
+            "hard_stop_after": {
+                "exact_failure": 2,
+                "same_tool_failure": 8,
+                "idempotent_no_progress": 5,
+            },
+        }
+    }
+
+
+def _seed_guardrail_block(agent, tool_name: str, args: dict) -> None:
+    for _ in range(2):
+        agent._tool_guardrails.after_call(
+            tool_name, args, json.dumps({"error": "boom"}), failed=True
+        )
+
+
+# ---------------------------------------------------------------------------
+# Every wrapper runs, exactly once, on both dispatchers
+# ---------------------------------------------------------------------------
+
+
+@BOTH_PATHS
+def test_tool_call_passes_through_every_wrapper_exactly_once(mode):
+    agent = _make_agent("write_file")
+    args = {"path": "/tmp/hermes-lifecycle.txt", "content": "hi"}
+    call = _tool_call("write_file", args, "c-1")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(agent, _assistant(call), messages, "task-lifecycle")
+
+    # Each wrapper is consulted for this call, and only once.
+    assert observed.plugin_block == ["write_file"]
+    assert observed.guardrail_before == ["write_file"]
+    assert observed.tool_started == ["write_file"]
+    assert observed.tool_completed == ["write_file"]
+    assert observed.tool_start_callback == ["write_file"]
+    assert observed.approval == ["write_file"]
+    assert observed.post_hook == ["write_file"]
+    assert len(observed.dispatched) == 1
+    # A file-mutating tool checkpoints the path it is about to touch.
+    assert [reason for _path, reason in observed.checkpoints] == [
+        "before write_file"
+    ]
+    # Exactly one tool result, matched to the model's tool_call_id.
+    assert [m["tool_call_id"] for m in messages] == ["c-1"]
+    _assert_role_alternation(messages)
+
+
+@BOTH_PATHS
+def test_effective_task_id_reaches_the_handler(mode):
+    """Environment routing (local/Docker/SSH/Modal/...) rides on the task id."""
+    agent = _make_agent("web_search")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("web_search", {"query": "x"})),
+            messages, "task-routed-env",
+        )
+
+    assert [task_id for _n, _a, task_id in observed.dispatched] == ["task-routed-env"]
+
+
+# ---------------------------------------------------------------------------
+# Denials short-circuit
+# ---------------------------------------------------------------------------
+
+
+@BOTH_PATHS
+def test_approval_denial_short_circuits_execution(mode):
+    agent = _make_agent("terminal")
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed, plugin_block="denied by policy"):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("terminal", {"command": "ls"}, "c-deny")),
+            messages, "task-deny",
+        )
+
+    assert observed.dispatched == [], "a denied call must never reach the handler"
+    assert observed.tool_started == []
+    assert observed.checkpoints == []
+    # The denial is reported back to the model on the denied call's own id.
+    assert [m["tool_call_id"] for m in messages] == ["c-deny"]
+    assert "denied by policy" in messages[0]["content"]
+    _assert_role_alternation(messages)
+
+
+@BOTH_PATHS
+def test_guardrail_block_prevents_the_handler_from_running(mode):
+    agent = _make_agent("web_search", config=_hard_stop_config())
+    args = {"query": "looping"}
+    _seed_guardrail_block(agent, "web_search", args)
+    messages: list = []
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        _dispatch(mode)(
+            agent, _assistant(_tool_call("web_search", args, "c-blocked")),
+            messages, "task-guardrail",
+        )
+
+    assert observed.guardrail_before == ["web_search"]
+    assert observed.dispatched == [], "a guardrail block must pre-empt dispatch"
+    assert [m["tool_call_id"] for m in messages] == ["c-blocked"]
+    _assert_role_alternation(messages)
+
+
+# ---------------------------------------------------------------------------
+# Interrupt semantics
+# ---------------------------------------------------------------------------
+
+
+def test_keyboard_interrupt_mid_execution_yields_a_cancelled_outcome():
+    agent = _make_agent("terminal")
+    agent.interrupt = MagicMock()
+
+    def _boom(*_args, **_kwargs):
+        raise KeyboardInterrupt
+
+    with (
+        patch("hermes_cli.plugins.resolve_pre_tool_block", return_value=None),
+        patch("run_agent.handle_function_call", side_effect=_boom),
+    ):
+        outcome = execute_one_tool(
+            agent, _tool_call("terminal", {"command": "sleep 60"}), "task-int",
+        )
+
+    assert outcome.cancelled is True
+    assert outcome.is_error is True
+    assert json.loads(outcome.result)["status"] == "cancelled"
+    agent.interrupt.assert_called_once()
+
+
+@BOTH_PATHS
+def test_interrupt_mid_batch_keeps_one_result_per_call_and_valid_alternation(mode):
+    agent = _make_agent("web_search")
+    calls = [
+        _tool_call("web_search", {"query": "first"}, "c-a"),
+        _tool_call("web_search", {"query": "second"}, "c-b"),
+    ]
+    messages: list = [
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": "", "tool_calls": []},
+    ]
+    observed = _Observed()
+
+    def _interrupting_handler(name, args, **kwargs):
+        agent._interrupt_requested = True
+        return json.dumps({"ok": True})
+
+    with _instrument(agent, observed, handler=_interrupting_handler):
+        _dispatch(mode)(agent, _assistant(*calls), messages, "task-int-batch")
+
+    tool_ids = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+    assert tool_ids == ["c-a", "c-b"], "every tool_call_id must be answered once"
+    _assert_role_alternation(messages, baseline=2)
+
+
+# ---------------------------------------------------------------------------
+# Output budgeting
+# ---------------------------------------------------------------------------
+
+
+def test_oversized_result_is_budgeted_identically_through_both_callers():
+    oversized = "x" * 400_000
+    contents = {}
+
+    for mode in ("sequential", "concurrent"):
+        agent = _make_agent("web_search")
+        messages: list = []
+        with (
+            patch("hermes_cli.plugins.resolve_pre_tool_block", return_value=None),
+            patch("run_agent.handle_function_call", return_value=oversized),
+        ):
+            _dispatch(mode)(
+                agent, _assistant(_tool_call("web_search", {"query": "big"}, "c-big")),
+                messages, "task-budget",
+            )
+        assert [m["tool_call_id"] for m in messages] == ["c-big"]
+        contents[mode] = messages[0]["content"]
+
+    assert len(contents["sequential"]) < len(oversized), (
+        "an oversized result must be budgeted, not passed through whole"
+    )
+    assert contents["sequential"] == contents["concurrent"]
+
+
+# ---------------------------------------------------------------------------
+# Cross-path equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_both_callers_produce_equivalent_per_tool_observable_effects():
+    args = {"path": "/tmp/hermes-equivalence.txt", "content": "same"}
+    snapshots = {}
+
+    for mode in ("sequential", "concurrent"):
+        agent = _make_agent("write_file")
+        messages: list = []
+        observed = _Observed()
+        with _instrument(agent, observed):
+            _dispatch(mode)(
+                agent, _assistant(_tool_call("write_file", args, "c-eq")),
+                messages, "task-eq",
+            )
+        snapshots[mode] = {
+            "plugin_block": observed.plugin_block,
+            "guardrail_before": observed.guardrail_before,
+            "tool_started": observed.tool_started,
+            "tool_completed": observed.tool_completed,
+            "tool_start_callback": observed.tool_start_callback,
+            "post_hook": observed.post_hook,
+            "approval": observed.approval,
+            "dispatched": observed.dispatched,
+            "checkpoint_reasons": [r for _p, r in observed.checkpoints],
+            "tool_messages": [
+                (m["tool_call_id"], m["content"])
+                for m in messages
+                if m["role"] == "tool"
+            ],
+        }
+
+    assert snapshots["sequential"] == snapshots["concurrent"]
+
+
+# ---------------------------------------------------------------------------
+# The funnel is usable without a transcript (the SDK bridge's shape)
+# ---------------------------------------------------------------------------
+
+
+def test_execute_one_tool_applies_wrappers_without_a_message_list():
+    """The claude_agent_sdk bridge owns no message list; wrappers still run."""
+    agent = _make_agent("web_search")
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        outcome = execute_one_tool(
+            agent, _tool_call("web_search", {"query": "x"}, "c-bridge"),
+            "task-bridge", messages=None,
+        )
+        result = finalize_tool_outcome(agent, outcome)
+
+    assert isinstance(outcome, ToolExecutionOutcome)
+    assert outcome.blocked is False and outcome.cancelled is False
+    assert observed.plugin_block == ["web_search"]
+    assert observed.guardrail_before == ["web_search"]
+    assert observed.tool_started == ["web_search"]
+    assert observed.post_hook == ["web_search"]
+    assert [task_id for _n, _a, task_id in observed.dispatched] == ["task-bridge"]
+    assert json.loads(result) == {"ok": True}
+
+
+def test_malformed_arguments_are_reported_without_dispatching():
+    agent = _make_agent("web_search")
+    bad_call = SimpleNamespace(
+        id="c-bad",
+        type="function",
+        function=SimpleNamespace(name="web_search", arguments="{not json"),
+    )
+    observed = _Observed()
+
+    with _instrument(agent, observed):
+        outcome = execute_one_tool(agent, bad_call, "task-bad")
+
+    assert outcome.malformed is True
+    assert observed.dispatched == []
+    assert observed.tool_started == []

--- a/tests/hermes_cli/test_api_key_providers.py
+++ b/tests/hermes_cli/test_api_key_providers.py
@@ -31,6 +31,7 @@ class TestProviderRegistry:
 
     @pytest.mark.parametrize("provider_id,name,auth_type", [
         ("copilot-acp", "GitHub Copilot ACP", "external_process"),
+        ("claude-code", "Claude subscription (Agent SDK)", "external_process"),
         ("copilot", "GitHub Copilot", "api_key"),
         ("huggingface", "Hugging Face", "api_key"),
         ("zai", "Z.AI / GLM", "api_key"),

--- a/tests/hermes_cli/test_claude_code_provider.py
+++ b/tests/hermes_cli/test_claude_code_provider.py
@@ -1,0 +1,457 @@
+"""Tests for the ``claude-code`` provider (Claude subscription via the Agent SDK).
+
+The contract under test is a boundary, not a feature list: Hermes holds no
+Claude credential, asks the official CLI for auth state instead of reading
+credential files, and never claims a Claude subscription under the API-key
+``anthropic`` provider.
+
+Every ``claude`` invocation is mocked. These tests never spawn the real binary
+and never touch the network.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hermes_cli import claude_code as cc
+
+
+@pytest.fixture(autouse=True)
+def _closed_gate(monkeypatch):
+    """Default to a deterministic, closed subscription gate.
+
+    The gate reads config.yaml; pinning it keeps these tests independent of
+    whatever the isolated HERMES_HOME happens to contain.
+    """
+    cc.reset_subscription_gate_cache()
+    monkeypatch.setattr(cc, "subscription_enabled", lambda config=None: False)
+    yield
+    cc.reset_subscription_gate_cache()
+
+
+# =============================================================================
+# Profile identity
+# =============================================================================
+
+class TestProfile:
+    def _profile(self):
+        from providers import get_provider_profile
+
+        prof = get_provider_profile("claude-code")
+        assert prof is not None, "claude-code provider profile is not registered"
+        return prof
+
+    def test_carries_no_credential_env_vars(self):
+        """Load-bearing: the SDK resolves auth, so Hermes declares no credential."""
+        assert self._profile().env_vars == ()
+
+    def test_api_mode_and_auth_type(self):
+        prof = self._profile()
+        assert prof.api_mode == "claude_agent_sdk"
+        assert prof.auth_type == "external_process"
+
+    def test_base_url_is_an_internal_scheme_not_http(self):
+        """Nothing may mistake this provider for a reachable REST endpoint."""
+        base = self._profile().base_url
+        assert base and not base.startswith(("http://", "https://"))
+
+    def test_no_rest_model_listing(self):
+        assert self._profile().fetch_models() is None
+
+    def test_display_metadata_names_the_login_step(self):
+        prof = self._profile()
+        assert prof.display_name
+        assert "claude auth login" in prof.description.lower()
+
+
+class TestAnthropicProfileNoLongerClaimsClaudeCode:
+    """The API-key provider must not present itself as the subscription path."""
+
+    def _anthropic(self):
+        from providers import get_provider_profile
+
+        prof = get_provider_profile("anthropic")
+        assert prof is not None
+        return prof
+
+    def test_claude_code_aliases_dropped(self):
+        aliases = set(self._anthropic().aliases)
+        assert "claude-code" not in aliases
+        assert "claude-oauth" not in aliases
+
+    def test_subscription_token_env_var_dropped(self):
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in set(self._anthropic().env_vars)
+
+    def test_overlay_drops_the_subscription_token(self):
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in set(
+            HERMES_OVERLAYS["anthropic"].extra_env_vars
+        )
+
+
+# =============================================================================
+# Catalog gating + parity
+# =============================================================================
+
+class TestCatalogGate:
+    """The catalog's parity contract must hold with the gate on OR off.
+
+    The gate is applied at CANONICAL_PROVIDERS (the shared universe), so both
+    desktop tabs always see the same provider set. These tests assert that
+    relationship rather than a provider count.
+    """
+
+    def _catalog_for(self, monkeypatch, enabled: bool):
+        import importlib
+
+        import hermes_cli.claude_code as claude_code_mod
+        import hermes_cli.models as models_mod
+        import hermes_cli.provider_catalog as catalog_mod
+
+        monkeypatch.setattr(
+            claude_code_mod, "subscription_enabled", lambda config=None: enabled
+        )
+        models_mod = importlib.reload(models_mod)
+        catalog_mod = importlib.reload(catalog_mod)
+        try:
+            return (
+                [e.slug for e in models_mod.CANONICAL_PROVIDERS],
+                catalog_mod.provider_catalog_by_slug(),
+            )
+        finally:
+            # Restore the real gate for anything importing these later.
+            monkeypatch.undo()
+            importlib.reload(models_mod)
+            importlib.reload(catalog_mod)
+
+    def test_absent_from_the_universe_when_the_gate_is_closed(self, monkeypatch):
+        slugs, by_slug = self._catalog_for(monkeypatch, enabled=False)
+        assert "claude-code" not in slugs
+        assert "claude-code" not in by_slug
+
+    def test_lands_on_the_accounts_tab_when_the_gate_is_open(self, monkeypatch):
+        slugs, by_slug = self._catalog_for(monkeypatch, enabled=True)
+        assert "claude-code" in slugs
+        assert by_slug["claude-code"].tab == "accounts"
+        assert by_slug["claude-code"].auth_type == "external_process"
+        # No credential env var to configure — that is the whole point.
+        assert by_slug["claude-code"].api_key_env_vars == ()
+
+    @pytest.mark.parametrize("enabled", [False, True])
+    def test_tab_union_still_equals_the_universe(self, monkeypatch, enabled):
+        """The locked parity contract, in both gate states."""
+        slugs, by_slug = self._catalog_for(monkeypatch, enabled=enabled)
+        union = {d.slug for d in by_slug.values() if d.tab in {"keys", "accounts"}}
+        assert union == set(slugs)
+
+
+# =============================================================================
+# Legacy alias back-compat
+# =============================================================================
+
+class TestLegacyAliases:
+    def test_legacy_slugs_still_reach_anthropic_while_the_gate_is_closed(self):
+        """An existing ``provider: claude-code`` config must not start erroring."""
+        assert cc.legacy_alias_target("claude-code") == "anthropic"
+        assert cc.legacy_alias_target("claude-oauth") == "anthropic"
+
+    def test_slug_belongs_to_the_new_provider_once_the_gate_is_open(self, monkeypatch):
+        monkeypatch.setattr(cc, "subscription_enabled", lambda config=None: True)
+        assert cc.legacy_alias_target("claude-code") is None
+        assert cc.legacy_alias_target("claude-oauth") is None
+
+    def test_unrelated_slugs_are_untouched(self):
+        assert cc.legacy_alias_target("anthropic") is None
+        assert cc.legacy_alias_target("openrouter") is None
+
+    @pytest.mark.parametrize("slug", ["claude-code", "claude-oauth"])
+    def test_every_legacy_slug_still_resolves_in_both_gate_states(
+        self, monkeypatch, slug
+    ):
+        """No gate state may leave a previously-valid provider slug unresolvable.
+
+        Regression guard: dropping ``claude-oauth`` from the anthropic profile
+        without re-homing it made ``provider: claude-oauth`` raise "Unknown
+        provider" the moment a user enabled the subscription gate.
+        """
+        from hermes_cli.auth import resolve_provider
+        from hermes_cli.providers import normalize_provider
+
+        for enabled in (False, True):
+            monkeypatch.setattr(cc, "subscription_enabled", lambda config=None: enabled)
+            expected = "claude-code" if enabled else "anthropic"
+            assert resolve_provider(slug) == expected
+            assert normalize_provider(slug) == expected
+
+    def test_gate_open_routes_legacy_slugs_to_a_real_provider_definition(
+        self, monkeypatch
+    ):
+        """The slug must land on a definition, not a dangling alias target."""
+        from hermes_cli.providers import get_provider
+
+        monkeypatch.setattr(cc, "subscription_enabled", lambda config=None: True)
+        pdef = get_provider("claude-oauth", allow_network=False)
+        assert pdef is not None and pdef.id == "claude-code"
+        assert pdef.auth_type == "external_process"
+        assert pdef.api_key_env_vars == ()
+
+
+class TestMigrationNotice:
+    def test_legacy_slug_gets_both_billing_options(self):
+        notice = cc.legacy_provider_notice("claude-code", env={})
+        assert "anthropic" in notice
+        assert "claude auth login" in notice
+        assert "billed" in notice.lower() or "billing" in notice.lower()
+
+    def test_anthropic_with_a_subscription_token_gets_the_notice(self):
+        notice = cc.legacy_provider_notice(
+            "anthropic", env={"CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-oat01-x"}
+        )
+        assert notice
+
+    def test_plain_api_key_setup_is_left_alone(self):
+        # An API key outranks any Claude login, so there is nothing to warn
+        # about and no reason to spawn the auth probe.
+        assert cc.legacy_provider_notice(
+            "anthropic", env={"ANTHROPIC_API_KEY": "sk-ant-api03-x"}
+        ) == ""
+        assert cc.legacy_provider_notice("openrouter", env={}) == ""
+
+    def test_anthropic_without_a_key_warns_when_a_claude_login_exists(
+        self, monkeypatch
+    ):
+        # The `anthropic` picker row reports itself authenticated off a Claude
+        # Code credential on disk; selecting it then bills extra usage. The
+        # probe is stubbed so the assertion does not depend on whether the
+        # machine running the suite happens to be signed in.
+        cc.reset_probe_cache()
+        monkeypatch.setattr(
+            cc, "probe_claude_auth_cached", lambda *a, **k: {"logged_in": True}
+        )
+        assert cc.legacy_provider_notice("anthropic", env={})
+
+    def test_anthropic_without_a_key_is_silent_when_not_signed_in(self, monkeypatch):
+        cc.reset_probe_cache()
+        monkeypatch.setattr(
+            cc, "probe_claude_auth_cached", lambda *a, **k: {"logged_in": False}
+        )
+        assert cc.legacy_provider_notice("anthropic", env={}) == ""
+
+    def test_notice_states_that_nothing_changed_automatically(self):
+        """AGENTS.md: never silently switch a user's billing source."""
+        notice = cc.legacy_provider_notice("claude-code", env={})
+        assert "automatically" in notice
+
+
+# =============================================================================
+# Status probe — the `claude` subprocess is always mocked
+# =============================================================================
+
+def _fake_run(results):
+    """Build a subprocess.run stub driven by ``{argv_tail: outcome}``.
+
+    An outcome is a ``(returncode, stdout)`` pair, or an exception instance to
+    raise. Asserts stdin is muzzled on every call: Claude Code blocks forever
+    on an unusable inherited stdin.
+    """
+    def _run(cmd, **kwargs):
+        assert kwargs.get("stdin") is subprocess.DEVNULL, (
+            "claude must be spawned with stdin=DEVNULL or it can block forever"
+        )
+        assert kwargs.get("timeout"), "every claude probe must be time-bounded"
+        key = tuple(cmd[1:])
+        outcome = results[key]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        returncode, stdout = outcome
+        return subprocess.CompletedProcess(cmd, returncode, stdout, "")
+
+    return _run
+
+
+AUTH_ARGS = ("auth", "status")
+VERSION_ARGS = ("--version",)
+
+
+@pytest.fixture
+def claude_installed(monkeypatch):
+    monkeypatch.setattr(cc, "resolve_claude_binary", lambda: "/usr/bin/claude")
+
+
+class TestProbeClaudeAuth:
+    def test_logged_in_via_claude_ai_is_a_subscription(self, monkeypatch, claude_installed):
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "claude.ai", '
+                           '"email": "u@example.com", "subscriptionType": "max"}'),
+            VERSION_ARGS: (0, "2.1.220 (Claude Code)\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["logged_in"] is True
+        assert info["subscription"] is True
+        assert info["auth_method"] == "claude.ai"
+        assert info["subscription_type"] == "max"
+        assert info["cli_version"].startswith("2.1.220")
+
+    def test_logged_in_via_api_key_is_not_a_subscription(self, monkeypatch, claude_installed):
+        """A user on an API key is billed as API usage and must be told so."""
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "api-key"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["logged_in"] is True
+        assert info["subscription"] is False
+        assert info["auth_method"] == "api-key"
+        assert "api" in info["message"].lower()
+
+    def test_not_logged_in_exits_one(self, monkeypatch, claude_installed):
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (1, '{"loggedIn": false}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["logged_in"] is False
+        assert info["status"] == "logged_out"
+        assert "claude auth login" in info["message"]
+
+    def test_binary_missing_is_actionable_not_fatal(self, monkeypatch):
+        monkeypatch.setattr(cc, "resolve_claude_binary", lambda: None)
+        info = cc.probe_claude_auth()
+        assert info["status"] == "cli_missing"
+        assert info["logged_in"] is False
+        assert "install" in info["message"].lower()
+
+    def test_timeout_degrades_to_unknown(self, monkeypatch, claude_installed):
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: subprocess.TimeoutExpired(cmd="claude", timeout=5),
+            VERSION_ARGS: subprocess.TimeoutExpired(cmd="claude", timeout=5),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["status"] == "unknown"
+        assert info["logged_in"] is False
+        assert info["message"]
+
+    def test_malformed_json_falls_back_to_the_exit_code(self, monkeypatch, claude_installed):
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, "Logged in as u@example.com"),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["logged_in"] is True
+        assert info["status"] == "logged_in"
+
+    def test_malformed_json_with_failure_exit_is_logged_out(self, monkeypatch, claude_installed):
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (1, "Not logged in"),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert info["logged_in"] is False
+
+    def test_probe_never_returns_credential_material(self, monkeypatch, claude_installed):
+        """The probe reports state, never a token."""
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "claude.ai"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        info = cc.probe_claude_auth()
+        assert not any(
+            k in info for k in ("token", "access_token", "accessToken", "refresh_token")
+        )
+
+
+class TestAuthIntegration:
+    """The shared external-process entry points must route claude-code correctly."""
+
+    def test_status_matches_the_external_process_shape(self, monkeypatch, claude_installed):
+        from hermes_cli.auth import (
+            get_external_process_provider_status,
+            get_auth_status,
+        )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "claude.ai"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        status = get_external_process_provider_status("claude-code")
+        for key in (
+            "configured", "provider", "name", "command", "args",
+            "resolved_command", "base_url", "logged_in",
+        ):
+            assert key in status, f"{key} missing from the external-process shape"
+        assert status["provider"] == "claude-code"
+        assert status["logged_in"] is True
+        # Same dict must come back through the generic dispatcher.
+        assert get_auth_status("claude-code")["provider"] == "claude-code"
+
+    def test_status_survives_a_broken_cli(self, monkeypatch, claude_installed):
+        from hermes_cli.auth import get_external_process_provider_status
+
+        def _boom(*a, **kw):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(subprocess, "run", _boom)
+        status = get_external_process_provider_status("claude-code")
+        assert status["logged_in"] is False
+        assert status["message"]
+
+    def test_credentials_carry_no_secret(self, monkeypatch, claude_installed):
+        from hermes_cli.auth import resolve_external_process_provider_credentials
+
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "claude.ai"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        creds = resolve_external_process_provider_credentials("claude-code")
+        assert creds["provider"] == "claude-code"
+        assert creds["api_key"] == "", "Hermes must not hand out Claude credential material"
+        assert not creds["base_url"].startswith(("http://", "https://"))
+
+    def test_missing_cli_raises_an_actionable_auth_error(self, monkeypatch):
+        from hermes_cli.auth import (
+            AuthError,
+            resolve_external_process_provider_credentials,
+        )
+
+        monkeypatch.setattr(cc, "resolve_claude_binary", lambda: None)
+        with pytest.raises(AuthError) as exc:
+            resolve_external_process_provider_credentials("claude-code")
+        assert "claude auth login" in str(exc.value)
+
+
+class TestDashboardCard:
+    def test_logout_never_deletes_a_credential_file(self):
+        """Regression guard: the dashboard used to rm the credential store."""
+        from hermes_cli.web_server import _oauth_provider_disconnect_command
+
+        cmd = _oauth_provider_disconnect_command(
+            {"id": "claude-code", "flow": "external"}
+        )
+        assert cmd == "claude auth logout"
+
+    def test_card_status_exposes_no_token_preview(self, monkeypatch, claude_installed):
+        from hermes_cli.web_server import _claude_code_only_status
+
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "claude.ai"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        status = _claude_code_only_status()
+        assert status["logged_in"] is True
+        assert status["token_preview"] is None
+
+    def test_api_key_login_is_not_reported_as_a_subscription(self, monkeypatch, claude_installed):
+        from hermes_cli.web_server import _claude_code_only_status
+
+        monkeypatch.setattr(subprocess, "run", _fake_run({
+            AUTH_ARGS: (0, '{"loggedIn": true, "authMethod": "api-key"}'),
+            VERSION_ARGS: (0, "2.1.220\n"),
+        }))
+        status = _claude_code_only_status()
+        assert status["subscription"] is False
+        assert status["logged_in"] is False, (
+            "an API-key login is not subscription mode; the card must not claim it is"
+        )

--- a/tests/hermes_cli/test_claude_subscription_gate.py
+++ b/tests/hermes_cli/test_claude_subscription_gate.py
@@ -1,0 +1,78 @@
+"""Behavior contract for the Claude-subscription release gate.
+
+The gate is imported by the provider catalog and the dashboard web server, so
+the invariants that matter are: it is off unless someone explicitly turned it
+on, it never raises on a malformed config, and the SDK probe answers even when
+the optional `claude-code` extra is not installed.
+"""
+
+from hermes_cli import claude_subscription
+from hermes_cli.claude_subscription import (
+    CLAUDE_AGENT_SDK_MIN_VERSION,
+    CLAUDE_CLI_MIN_VERSION,
+    claude_agent_sdk_available,
+    claude_subscription_enabled,
+)
+from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+
+def test_shipped_default_is_off():
+    """The runtime ships default-off pending Anthropic policy clearance."""
+    assert claude_subscription_enabled(DEFAULT_CONFIG) is False
+
+
+def test_off_for_absent_empty_and_none_config():
+    assert claude_subscription_enabled(None) is False
+    assert claude_subscription_enabled({}) is False
+    assert claude_subscription_enabled({"model": "", "agent": {}}) is False
+    assert claude_subscription_enabled({"claude_subscription": {}}) is False
+
+
+def test_on_only_when_explicitly_enabled():
+    assert claude_subscription_enabled({"claude_subscription": {"enabled": True}}) is True
+    assert claude_subscription_enabled({"claude_subscription": {"enabled": False}}) is False
+
+
+def test_malformed_config_reads_as_off_without_raising():
+    """A hand-edited config.yaml can put anything under the key; the gate must
+    fail closed rather than blow up a startup path."""
+    for section in ("yes", 1, [], ["enabled"], None):
+        assert claude_subscription_enabled({"claude_subscription": section}) is False
+    for config in ("not-a-dict", [], 0):
+        assert claude_subscription_enabled(config) is False
+
+
+def test_availability_probe_returns_bool_and_never_raises():
+    assert isinstance(claude_agent_sdk_available(), bool)
+
+
+def test_availability_probe_is_false_without_the_optional_extra(monkeypatch):
+    claude_agent_sdk_available.cache_clear()
+    monkeypatch.setattr(claude_subscription.importlib.util, "find_spec", lambda name: None)
+    try:
+        assert claude_agent_sdk_available() is False
+    finally:
+        claude_agent_sdk_available.cache_clear()
+
+
+def test_availability_probe_swallows_a_broken_import_system(monkeypatch):
+    """A shadowed/half-installed `claude_agent_sdk` makes find_spec raise. The
+    probe runs on startup paths, so it must answer False, not propagate."""
+    def _boom(name):
+        raise ImportError(name)
+
+    claude_agent_sdk_available.cache_clear()
+    monkeypatch.setattr(claude_subscription.importlib.util, "find_spec", _boom)
+    try:
+        assert claude_agent_sdk_available() is False
+    finally:
+        claude_agent_sdk_available.cache_clear()
+
+
+def test_pinned_versions_are_orderable_version_strings():
+    """Downstream PRs compare an installed version against these floors, so
+    both constants must parse as dotted numeric versions."""
+    for pin in (CLAUDE_AGENT_SDK_MIN_VERSION, CLAUDE_CLI_MIN_VERSION):
+        parts = pin.split(".")
+        assert len(parts) >= 3
+        assert all(part.isdigit() for part in parts)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -89,7 +89,9 @@ class TestNormalizeProvider:
 
 class TestProviderLabel:
     def test_known_labels_and_auto(self):
-        assert provider_label("anthropic") == "Anthropic"
+        # "Anthropic API", not bare "Anthropic": the label must not read as the
+        # Claude subscription path, which is now its own provider.
+        assert provider_label("anthropic") == "Anthropic API"
         assert provider_label("kimi") == "Kimi / Kimi Coding Plan"
         assert provider_label("stepfun") == "StepFun Step Plan"
         assert provider_label("copilot") == "GitHub Copilot"

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -524,14 +524,16 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert "provider's CLI" in providers["qwen-oauth"]["disconnect_hint"]
     assert providers["qwen-oauth"]["disconnect_command"] is None
 
-    # Claude Code: still not API-disconnectable, but we hand the GUI a runnable
-    # command (clears the keychain entry / credentials file) so it can offer a
-    # one-click "run in terminal" disconnect.
+    # Claude subscription: still not API-disconnectable, but we hand the GUI a
+    # runnable command so it can offer a one-click "run in terminal" disconnect.
+    # That command must be the CLI's own logout — Hermes never deletes or
+    # rewrites Anthropic's credential store on the user's behalf.
     assert providers["claude-code"]["flow"] == "external"
     assert providers["claude-code"]["disconnectable"] is False
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
-    assert cmd and ".claude/.credentials.json" in cmd
+    assert cmd == "claude auth logout"
+    assert "credentials" not in cmd and "rm " not in cmd and "delete" not in cmd
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):

--- a/tests/hermes_cli/test_web_oauth_dispatch.py
+++ b/tests/hermes_cli/test_web_oauth_dispatch.py
@@ -273,14 +273,16 @@ def test_oauth_catalog_marks_external_providers_not_disconnectable():
     assert "provider's CLI" in providers["qwen-oauth"]["disconnect_hint"]
     assert providers["qwen-oauth"]["disconnect_command"] is None
 
-    # Claude Code: still not API-disconnectable, but we hand the GUI a runnable
-    # command (clears the keychain entry / credentials file) so it can offer a
-    # one-click "run in terminal" disconnect.
+    # Claude subscription: still not API-disconnectable, but we hand the GUI a
+    # runnable command so it can offer a one-click "run in terminal" disconnect.
+    # That command must be the CLI's own logout — Hermes never deletes or
+    # rewrites Anthropic's credential store on the user's behalf.
     assert providers["claude-code"]["flow"] == "external"
     assert providers["claude-code"]["disconnectable"] is False
     assert providers["claude-code"]["disconnect_hint"]
     cmd = providers["claude-code"]["disconnect_command"]
-    assert cmd and ".claude/.credentials.json" in cmd
+    assert cmd == "claude auth logout"
+    assert "credentials" not in cmd and "rm " not in cmd and "delete" not in cmd
 
 
 def test_external_oauth_disconnect_rejected_before_auth_mutation(monkeypatch):

--- a/tests/scripts/test_claude_boundary.py
+++ b/tests/scripts/test_claude_boundary.py
@@ -1,0 +1,113 @@
+"""Pytest wrapper for scripts/check_claude_boundary.py.
+
+Runs the boundary checker as part of the suite so a regression is caught even
+when the dedicated CI job is not what a contributor is looking at.
+"""
+
+import importlib.util
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "check_claude_boundary.py"
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("_claude_boundary", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec: @dataclass resolves annotations via
+    # sys.modules[cls.__module__], which fails for an unregistered module.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_boundary_check_passes_on_the_current_tree():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        stdin=subprocess.DEVNULL,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, (
+        f"Claude boundary check failed:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_every_allowlisted_path_has_a_justification():
+    """An allow-list entry without a reason is an untracked exemption."""
+    checker = _load_checker()
+    listed = {p for rule in checker.RULES for p in rule.allowlist}
+    missing = sorted(p for p in listed if not checker.ALLOWLIST_REASONS.get(p))
+    assert not missing, f"allow-listed with no justification: {missing}"
+
+
+def test_legacy_path_exemptions_are_tagged_for_removal():
+    """Exemptions covering the pre-SDK path must name the PR that deletes them.
+
+    Without the tag the allow-list silently becomes permanent; with it, the
+    check tightens on its own as the legacy path is removed.
+    """
+    checker = _load_checker()
+    legacy_prefixes = ("agent/anthropic_adapter.py", "agent/account_usage.py")
+    for prefix in legacy_prefixes:
+        reason = checker.ALLOWLIST_REASONS[prefix]
+        assert "TODO(legacy-retirement)" in reason, f"{prefix} exemption is not tagged for removal"
+
+
+def test_rules_cover_each_documented_category():
+    """All four documented rule categories must actually be enforced."""
+    checker = _load_checker()
+    names = {rule.name for rule in checker.RULES}
+    for expected in (
+        "claude-credential-file",           # 1. credential access
+        "anthropic-endpoint-with-claude-token",  # 2. direct OAuth inference
+        "claude-code-user-agent",           # 3. identity spoofing
+        "claude-oauth-token-env",           # 4. token env reads
+    ):
+        assert expected in names, f"boundary rule '{expected}' is missing"
+
+
+def test_legitimate_anthropic_api_usage_is_not_flagged():
+    """The API-key provider's own endpoint calls must stay allowed."""
+    checker = _load_checker()
+    rule = next(
+        r for r in checker.RULES if r.name == "anthropic-endpoint-with-claude-token"
+    )
+    benign = 'req = urllib.request.Request("https://api.anthropic.com/v1/models")'
+    assert rule.pattern.search(benign)
+    assert rule.require_also is not None
+    assert not rule.require_also.search(benign), (
+        "a plain Anthropic API call must not trip the direct-OAuth rule"
+    )
+
+
+def test_spoofed_identity_patterns_are_detected():
+    """The spoofing rules must match the shapes they exist to forbid."""
+    checker = _load_checker()
+    by_name = {r.name: r for r in checker.RULES}
+    samples = {
+        "claude-code-user-agent": '"user-agent": f"claude-code/{ver} (external, cli)"',
+        "claude-code-cli-app-header": '"x-app": "cli",',
+        "claude-code-beta-flag": '"anthropic-beta": "claude-code-20250219"',
+        "claude-code-system-prompt": 'P = "You are Claude Code, Anthropic\'s official CLI."',
+        "claude-code-identity-rewrite": 'text = text.replace("Hermes Agent", "Claude Code")',
+    }
+    for name, sample in samples.items():
+        assert by_name[name].pattern.search(sample), f"{name} failed to match its own shape"
+
+
+def test_inline_suppression_marker_is_honored():
+    checker = _load_checker()
+    assert checker.SUPPRESS_MARKER.search("x = 1  # claude-boundary: ok — why")
+    assert not checker.SUPPRESS_MARKER.search("x = 1  # ok")
+
+
+def test_docstring_documents_the_allowlist_policy():
+    """The script is the audit trail; it must say so."""
+    checker = _load_checker()
+    assert re.search(r"ALLOW-LIST POLICY", checker.__doc__ or "")

--- a/tests/tools/test_delegate_claude_sdk.py
+++ b/tests/tools/test_delegate_claude_sdk.py
@@ -1,0 +1,247 @@
+"""Delegation contract for the Claude Agent SDK runtime.
+
+Three properties, none of which hold by accident:
+
+1. A child inherits the parent's provider mode **without an API key** —
+   ``claude-code`` has none by design, and the guards that demand one had to
+   learn the difference between "missing" and "none exists".
+2. Every child gets its **own** ``ClaudeAgentSession``. ``ClaudeSDKClient`` is
+   bound to the event-loop thread that created it, so a shared session across
+   parent and children (or across siblings) corrupts the transport.
+3. Those sessions are torn down when the child finishes. N children in parallel
+   must leave N *fewer* live loop threads than they started, i.e. zero.
+
+No real SDK is involved: the session facade takes a ``client_factory``, which is
+the seam these tests use.
+"""
+
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agent.transports.claude_agent_session import ClaudeAgentSession
+from run_agent import AIAgent
+from tools.delegate_tool import (
+    _build_child_agent,
+    _provider_owns_its_own_credentials,
+    _resolve_delegation_credentials,
+    delegate_task,
+)
+
+SESSION_THREAD_NAME = "hermes-claude-agent-sdk"
+
+
+class _FakeSDKClient:
+    """Minimal stand-in for ``ClaudeSDKClient`` (connect/disconnect only)."""
+
+    def __init__(self, options=None):
+        self.options = options
+        self.connected = False
+        self.disconnected = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def _live_session_threads() -> list[threading.Thread]:
+    return [
+        t for t in threading.enumerate() if t.name == SESSION_THREAD_NAME and t.is_alive()
+    ]
+
+
+def _make_claude_parent(depth: int = 0):
+    parent = MagicMock()
+    parent.base_url = "claude-sdk://subscription"
+    parent.api_key = ""
+    parent.provider = "claude-code"
+    parent.api_mode = "claude_agent_sdk"
+    parent.model = "claude-sonnet-5"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.client = None
+    parent._client_kwargs = {}
+    return parent
+
+
+class TestChildInheritsSubscriptionMode(unittest.TestCase):
+    def test_child_gets_the_runtime_without_an_api_key(self):
+        parent = _make_claude_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="inherit the subscription runtime",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+            _, kwargs = MockAgent.call_args
+
+        self.assertEqual(kwargs["provider"], "claude-code")
+        self.assertEqual(kwargs["api_mode"], "claude_agent_sdk")
+        self.assertEqual(kwargs["base_url"], "claude-sdk://subscription")
+        # The point of the provider: there is no credential to inherit.
+        self.assertFalse(kwargs["api_key"])
+
+    def test_a_credential_less_runtime_is_not_a_missing_credential(self):
+        self.assertTrue(
+            _provider_owns_its_own_credentials({"api_mode": "claude_agent_sdk"})
+        )
+        self.assertTrue(
+            _provider_owns_its_own_credentials(
+                {"credentials_owner": "claude-agent-sdk"}
+            )
+        )
+        # Every other provider keeps failing loudly on an empty key.
+        self.assertFalse(_provider_owns_its_own_credentials({"api_mode": "chat_completions"}))
+        self.assertFalse(_provider_owns_its_own_credentials({}))
+
+    def test_delegation_provider_claude_code_does_not_require_a_key(self):
+        runtime = {
+            "provider": "claude-code",
+            "api_mode": "claude_agent_sdk",
+            "base_url": "claude-sdk://subscription",
+            "api_key": "",
+            "credentials_owner": "claude-agent-sdk",
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+        ):
+            creds = _resolve_delegation_credentials(
+                {"provider": "claude-code", "model": "claude-sonnet-5"}, None
+            )
+        self.assertEqual(creds["provider"], "claude-code")
+        self.assertEqual(creds["api_mode"], "claude_agent_sdk")
+        self.assertEqual(creds["api_key"], "")
+
+    def test_a_genuinely_missing_key_still_raises(self):
+        runtime = {
+            "provider": "minimax",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.minimax.io/v1",
+            "api_key": "",
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+        ):
+            with self.assertRaises(ValueError):
+                _resolve_delegation_credentials({"provider": "minimax"}, None)
+
+
+class TestChildSessionIsolation(unittest.TestCase):
+    """Each child owns one session; none of them survive the delegation."""
+
+    def _run_parallel_children(self, count: int):
+        parent = _make_claude_parent()
+        created: list[ClaudeAgentSession] = []
+        created_lock = threading.Lock()
+
+        def _make_child(**_kwargs):
+            child = MagicMock()
+            child._claude_session = None
+            child.provider = "claude-code"
+            child.api_mode = "claude_agent_sdk"
+            child.model = "claude-sonnet-5"
+            child.session_prompt_tokens = 0
+            child.session_completion_tokens = 0
+            child.session_estimated_cost_usd = 0.0
+            child._delegate_role = "leaf"
+
+            def _run_conversation(user_message, task_id=None, stream_callback=None):
+                # Exactly what agent.claude_runtime does on a child's first
+                # turn: build this agent's own session and connect it.
+                session = ClaudeAgentSession(
+                    options_factory=lambda: None,
+                    client_factory=_FakeSDKClient,
+                )
+                session.ensure_started()
+                child._claude_session = session
+                with created_lock:
+                    created.append(session)
+                return {
+                    "final_response": "done",
+                    "completed": True,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            child.run_conversation.side_effect = _run_conversation
+            # The real teardown path, run against a duck-typed child.
+            child.close.side_effect = lambda: AIAgent._release_claude_agent_sdk_session(
+                child
+            )
+            return child
+
+        before = len(_live_session_threads())
+        with patch("run_agent.AIAgent", side_effect=_make_child):
+            delegate_task(
+                tasks=[
+                    {
+                        # Descriptive on purpose: delegate_task rejects
+                        # placeholder goals before any child is built.
+                        "goal": (
+                            f"Read chapter {i + 1} of docs/design/"
+                            "claude-subscription-via-agent-sdk.md and list "
+                            "every decision it records, quoting each verbatim."
+                        )
+                    }
+                    for i in range(count)
+                ],
+                parent_agent=parent,
+            )
+        return created, before
+
+    def test_each_child_gets_its_own_session(self):
+        # 3 is delegation.max_concurrent_children's default, which is also the
+        # hard cap on a single batch — the widest fan-out one call can produce.
+        created, _ = self._run_parallel_children(3)
+        self.assertEqual(len(created), 3)
+        # Identity, not equality: a shared ClaudeSDKClient across sibling
+        # threads corrupts the anyio streams it was created with.
+        self.assertEqual(len({id(session) for session in created}), 3)
+
+    def test_no_loop_thread_survives_the_delegation(self):
+        created, before = self._run_parallel_children(3)
+        for session in created:
+            self.assertTrue(session.closed)
+        # join() inside close() is synchronous, so this is not a race.
+        self.assertEqual(len(_live_session_threads()), before)
+
+    def test_children_do_not_share_the_parents_session(self):
+        parent = _make_claude_parent()
+        parent_session = ClaudeAgentSession(
+            options_factory=lambda: None, client_factory=_FakeSDKClient
+        )
+        parent_session.ensure_started()
+        parent._claude_session = parent_session
+        try:
+            created, _ = self._run_parallel_children(2)
+            for session in created:
+                self.assertIsNot(session, parent_session)
+            # A child's teardown must not close the parent out from under it.
+            self.assertFalse(parent_session.closed)
+        finally:
+            parent_session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_claude_sdk.py
+++ b/tests/tools/test_delegate_claude_sdk.py
@@ -1,0 +1,236 @@
+"""Delegation contract for the Claude Agent SDK runtime.
+
+Three properties, none of which hold by accident:
+
+1. A child inherits the parent's provider mode **without an API key** —
+   ``claude-code`` has none by design, and the guards that demand one had to
+   learn the difference between "missing" and "none exists".
+2. Every child gets its **own** ``ClaudeAgentSession``. ``ClaudeSDKClient`` is
+   bound to the event-loop thread that created it, so a shared session across
+   parent and children (or across siblings) corrupts the transport.
+3. Those sessions are torn down when the child finishes. N children in parallel
+   must leave N *fewer* live loop threads than they started, i.e. zero.
+
+No real SDK is involved: the session facade takes a ``client_factory``, which is
+the seam these tests use.
+"""
+
+from __future__ import annotations
+
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agent.transports.claude_agent_session import ClaudeAgentSession
+from run_agent import AIAgent
+from tools.delegate_tool import (
+    _build_child_agent,
+    _provider_owns_its_own_credentials,
+    _resolve_delegation_credentials,
+    delegate_task,
+)
+
+SESSION_THREAD_NAME = "hermes-claude-agent-sdk"
+
+
+class _FakeSDKClient:
+    """Minimal stand-in for ``ClaudeSDKClient`` (connect/disconnect only)."""
+
+    def __init__(self, options=None):
+        self.options = options
+        self.connected = False
+        self.disconnected = False
+
+    async def connect(self):
+        self.connected = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def _live_session_threads() -> list[threading.Thread]:
+    return [
+        t for t in threading.enumerate() if t.name == SESSION_THREAD_NAME and t.is_alive()
+    ]
+
+
+def _make_claude_parent(depth: int = 0):
+    parent = MagicMock()
+    parent.base_url = "claude-sdk://subscription"
+    parent.api_key = ""
+    parent.provider = "claude-code"
+    parent.api_mode = "claude_agent_sdk"
+    parent.model = "claude-sonnet-5"
+    parent.platform = "cli"
+    parent.providers_allowed = None
+    parent.providers_ignored = None
+    parent.providers_order = None
+    parent.provider_sort = None
+    parent._session_db = None
+    parent._delegate_depth = depth
+    parent._active_children = []
+    parent._active_children_lock = threading.Lock()
+    parent._print_fn = None
+    parent.tool_progress_callback = None
+    parent.thinking_callback = None
+    parent.client = None
+    parent._client_kwargs = {}
+    return parent
+
+
+class TestChildInheritsSubscriptionMode(unittest.TestCase):
+    def test_child_gets_the_runtime_without_an_api_key(self):
+        parent = _make_claude_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="inherit the subscription runtime",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+            _, kwargs = MockAgent.call_args
+
+        self.assertEqual(kwargs["provider"], "claude-code")
+        self.assertEqual(kwargs["api_mode"], "claude_agent_sdk")
+        self.assertEqual(kwargs["base_url"], "claude-sdk://subscription")
+        # The point of the provider: there is no credential to inherit.
+        self.assertFalse(kwargs["api_key"])
+
+    def test_a_credential_less_runtime_is_not_a_missing_credential(self):
+        self.assertTrue(
+            _provider_owns_its_own_credentials({"api_mode": "claude_agent_sdk"})
+        )
+        self.assertTrue(
+            _provider_owns_its_own_credentials(
+                {"credentials_owner": "claude-agent-sdk"}
+            )
+        )
+        # Every other provider keeps failing loudly on an empty key.
+        self.assertFalse(_provider_owns_its_own_credentials({"api_mode": "chat_completions"}))
+        self.assertFalse(_provider_owns_its_own_credentials({}))
+
+    def test_delegation_provider_claude_code_does_not_require_a_key(self):
+        runtime = {
+            "provider": "claude-code",
+            "api_mode": "claude_agent_sdk",
+            "base_url": "claude-sdk://subscription",
+            "api_key": "",
+            "credentials_owner": "claude-agent-sdk",
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+        ):
+            creds = _resolve_delegation_credentials(
+                {"provider": "claude-code", "model": "claude-sonnet-5"}, None
+            )
+        self.assertEqual(creds["provider"], "claude-code")
+        self.assertEqual(creds["api_mode"], "claude_agent_sdk")
+        self.assertEqual(creds["api_key"], "")
+
+    def test_a_genuinely_missing_key_still_raises(self):
+        runtime = {
+            "provider": "minimax",
+            "api_mode": "chat_completions",
+            "base_url": "https://api.minimax.io/v1",
+            "api_key": "",
+        }
+        with patch(
+            "hermes_cli.runtime_provider.resolve_runtime_provider", return_value=runtime
+        ):
+            with self.assertRaises(ValueError):
+                _resolve_delegation_credentials({"provider": "minimax"}, None)
+
+
+class TestChildSessionIsolation(unittest.TestCase):
+    """Each child owns one session; none of them survive the delegation."""
+
+    def _run_parallel_children(self, count: int):
+        parent = _make_claude_parent()
+        created: list[ClaudeAgentSession] = []
+        created_lock = threading.Lock()
+
+        def _make_child(**_kwargs):
+            child = MagicMock()
+            child._claude_session = None
+            child.provider = "claude-code"
+            child.api_mode = "claude_agent_sdk"
+            child.model = "claude-sonnet-5"
+            child.session_prompt_tokens = 0
+            child.session_completion_tokens = 0
+            child.session_estimated_cost_usd = 0.0
+            child._delegate_role = "leaf"
+
+            def _run_conversation(user_message, task_id=None, stream_callback=None):
+                # Exactly what agent.claude_runtime does on a child's first
+                # turn: build this agent's own session and connect it.
+                session = ClaudeAgentSession(
+                    options_factory=lambda: None,
+                    client_factory=_FakeSDKClient,
+                )
+                session.ensure_started()
+                child._claude_session = session
+                with created_lock:
+                    created.append(session)
+                return {
+                    "final_response": "done",
+                    "completed": True,
+                    "api_calls": 1,
+                    "messages": [],
+                }
+
+            child.run_conversation.side_effect = _run_conversation
+            # The real teardown path, run against a duck-typed child.
+            child.close.side_effect = lambda: AIAgent._release_claude_agent_sdk_session(
+                child
+            )
+            return child
+
+        before = len(_live_session_threads())
+        with patch("run_agent.AIAgent", side_effect=_make_child):
+            delegate_task(
+                tasks=[{"goal": f"task {i}"} for i in range(count)],
+                parent_agent=parent,
+            )
+        return created, before
+
+    def test_each_child_gets_its_own_session(self):
+        # 3 is delegation.max_concurrent_children's default, which is also the
+        # hard cap on a single batch — the widest fan-out one call can produce.
+        created, _ = self._run_parallel_children(3)
+        self.assertEqual(len(created), 3)
+        # Identity, not equality: a shared ClaudeSDKClient across sibling
+        # threads corrupts the anyio streams it was created with.
+        self.assertEqual(len({id(session) for session in created}), 3)
+
+    def test_no_loop_thread_survives_the_delegation(self):
+        created, before = self._run_parallel_children(3)
+        for session in created:
+            self.assertTrue(session.closed)
+        # join() inside close() is synchronous, so this is not a race.
+        self.assertEqual(len(_live_session_threads()), before)
+
+    def test_children_do_not_share_the_parents_session(self):
+        parent = _make_claude_parent()
+        parent_session = ClaudeAgentSession(
+            options_factory=lambda: None, client_factory=_FakeSDKClient
+        )
+        parent_session.ensure_started()
+        parent._claude_session = parent_session
+        try:
+            created, _ = self._run_parallel_children(2)
+            for session in created:
+                self.assertIsNot(session, parent_session)
+            # A child's teardown must not close the parent out from under it.
+            self.assertFalse(parent_session.closed)
+        finally:
+            parent_session.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4451,6 +4451,25 @@ def _resolve_child_credential_pool(
     return None
 
 
+# api_mode values whose provider holds no credential Hermes could check for.
+_CREDENTIAL_LESS_API_MODES = frozenset({"claude_agent_sdk"})
+
+
+def _provider_owns_its_own_credentials(runtime: Dict[str, Any]) -> bool:
+    """True when a resolved runtime has no API key *by design*.
+
+    The Claude subscription provider is the case that matters: the Agent SDK
+    resolves the user's own ``claude`` login and Hermes holds nothing. An empty
+    ``api_key`` there is the contract (``hermes_cli/auth.py`` —
+    ``credentials_owner: "claude-agent-sdk"``), not a misconfiguration, so the
+    "no API key" guard below must not reject it. Every other provider keeps
+    failing loudly on a missing key.
+    """
+    if str(runtime.get("credentials_owner") or "").strip() == "claude-agent-sdk":
+        return True
+    return str(runtime.get("api_mode") or "").strip() in _CREDENTIAL_LESS_API_MODES
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -4560,7 +4579,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         ) from exc
 
     api_key = runtime.get("api_key", "")
-    if not api_key:
+    if not api_key and not _provider_owns_its_own_credentials(runtime):
         raise ValueError(
             f"Delegation provider '{configured_provider}' resolved but has no API key. "
             f"Set the appropriate environment variable or run 'hermes auth'."

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3476,6 +3476,25 @@ def _resolve_child_credential_pool(
     return None
 
 
+# api_mode values whose provider holds no credential Hermes could check for.
+_CREDENTIAL_LESS_API_MODES = frozenset({"claude_agent_sdk"})
+
+
+def _provider_owns_its_own_credentials(runtime: Dict[str, Any]) -> bool:
+    """True when a resolved runtime has no API key *by design*.
+
+    The Claude subscription provider is the case that matters: the Agent SDK
+    resolves the user's own ``claude`` login and Hermes holds nothing. An empty
+    ``api_key`` there is the contract (``hermes_cli/auth.py`` —
+    ``credentials_owner: "claude-agent-sdk"``), not a misconfiguration, so the
+    "no API key" guard below must not reject it. Every other provider keeps
+    failing loudly on a missing key.
+    """
+    if str(runtime.get("credentials_owner") or "").strip() == "claude-agent-sdk":
+        return True
+    return str(runtime.get("api_mode") or "").strip() in _CREDENTIAL_LESS_API_MODES
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -3585,7 +3604,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         ) from exc
 
     api_key = runtime.get("api_key", "")
-    if not api_key:
+    if not api_key and not _provider_owns_its_own_credentials(runtime):
         raise ValueError(
             f"Delegation provider '{configured_provider}' resolved but has no API key. "
             f"Set the appropriate environment variable or run 'hermes auth'."

--- a/uv.lock
+++ b/uv.lock
@@ -16,10 +16,11 @@ setuptools = false
 h2 = false
 vercel = false
 pillow = false
+claude-agent-sdk = "2026-08-19T00:00:00Z"
 unpaddedbase64 = false
 defusedxml = false
-aiohttp = false
 cryptography = false
+aiohttp = false
 mcp = false
 python-olm = false
 nemo-relay = false
@@ -724,6 +725,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/26/b9924fa27db384bdcd97ab83b4f0a8058d96ad9626ead570674d5e737d90/charset_normalizer-3.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:b435cba5f4f750aa6c0a0d92c541fb79f69a387c91e61f1795227e4ed9cece14", size = 107092, upload-time = "2025-10-14T04:41:31.188Z" },
     { url = "https://files.pythonhosted.org/packages/af/8f/3ed4bfa0c0c72a7ca17f0380cd9e4dd842b09f664e780c13cff1dcf2ef1b/charset_normalizer-3.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:542d2cee80be6f80247095cc36c418f7bddd14f4a6de45af91dfad36d817bba2", size = 100408, upload-time = "2025-10-14T04:41:32.624Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
+]
+
+[[package]]
+name = "claude-agent-sdk"
+version = "0.2.140"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "jsonschema" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/7e/8157c0fdb982f865c4ce1cb1fc1eeb2ad8fba427fe5f3df78e3498ff6d2f/claude_agent_sdk-0.2.140.tar.gz", hash = "sha256:93b646e34bb39e37c868d67dc736de29a655529a4c986857e83a9d5bcf1f4e2b", size = 344707, upload-time = "2026-08-18T20:56:47.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/9d/012976d8e3836dabb75212c46473cb2ae650fcd6faa3040c0c18810e21b2/claude_agent_sdk-0.2.140-py3-none-macosx_11_0_arm64.whl", hash = "sha256:1eb420b70b431351b7f807e28f635754367e9509d7b57878016b6a88efbbbf1d", size = 89856476, upload-time = "2026-08-18T20:56:52.27Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b9/51bd78ac29b4df81a310c5fa5cd2f1205d149497034a61ffb2f273ecada2/claude_agent_sdk-0.2.140-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:da83b7657728f4a12f90b147743c7b3bd292adbadfd11b6b235789b68b5e3058", size = 94764368, upload-time = "2026-08-18T20:56:57.352Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c0/c278fcab903587798976a29fbcc67aab6d1dc4b2b4023107e1f9f13a26ed/claude_agent_sdk-0.2.140-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:b55ed0333ba235e992455f990ec5cea557736fb9207c73878b96876a4cdb1c15", size = 99183268, upload-time = "2026-08-18T20:57:02.422Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/4b/0a6a80d00f01168957daf5ed3c32323839b5ee21e953ccf7b8db37a0525c/claude_agent_sdk-0.2.140-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:a873fd3f7378a6320b73193a1502115979567f9b52ea1f25dc225e69cd4a2920", size = 100180869, upload-time = "2026-08-18T20:57:07.985Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/abbdffb94dcc7b8a741621fbdfbd2ffc90e5e7f976e1cc9735ae8ae851ad/claude_agent_sdk-0.2.140-py3-none-win_amd64.whl", hash = "sha256:c3feb45d7dc7564b66e161fcb9ea976e39faae40a64d429137cb0d85fb955e1f", size = 102371936, upload-time = "2026-08-18T20:57:13.222Z" },
 ]
 
 [[package]]
@@ -1637,6 +1657,9 @@ azure-identity = [
 bedrock = [
     { name = "boto3" },
 ]
+claude-code = [
+    { name = "claude-agent-sdk" },
+]
 computer-use = [
     { name = "httpx2" },
     { name = "mcp" },
@@ -1828,6 +1851,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude-code'", specifier = ">=0.2.140,<0.4" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==50.0.0" },
@@ -1948,7 +1972,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "claude-code", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -4052,7 +4076,7 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -4107,7 +4131,7 @@ resolution-markers = [
     "python_full_version == '3.12.*'",
 ]
 dependencies = [
-    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -4755,11 +4779,11 @@ name = "vercel-workers"
 version = "0.0.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio", marker = "python_full_version >= '3.12'" },
-    { name = "httpx", marker = "python_full_version >= '3.12'" },
-    { name = "pydantic", marker = "python_full_version >= '3.12'" },
-    { name = "python-dotenv", marker = "python_full_version >= '3.12'" },
-    { name = "vercel", marker = "python_full_version >= '3.12'" },
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "vercel" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/df/04d37021ad7ca53b7599c313e411d91623c7a005c741f491d1eefb7a9f0c/vercel_workers-0.0.25.tar.gz", hash = "sha256:212ded01400b524be51d251df49f801caf115ad7d48cca7eb168cbeceda3def3", size = 64149, upload-time = "2026-06-20T19:26:27.177Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -703,6 +703,24 @@ wheels = [
 ]
 
 [[package]]
+name = "claude-agent-sdk"
+version = "0.2.128"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "mcp" },
+    { name = "sniffio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e8/3a9622b31f9ee22274e13a620e5e75ac38454d14538391b2fe3bc7eb76dc/claude_agent_sdk-0.2.128.tar.gz", hash = "sha256:2ac7b2b3bc56ae9037fd284c8690d3dafab9493ecd28d8974bba79a418e1b800", size = 309369, upload-time = "2026-07-25T01:48:25.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/ff/03613a38a84285cd85f114fc26d4431f545d2b3b344eb8f69f9b0f18f3c6/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_arm64.whl", hash = "sha256:2e47ee95be68cb07612fd5288a40f3307763da5a5adf66d6e03ea49dc0495c9c", size = 75183825, upload-time = "2026-07-25T01:48:30.45Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/df/2adbd3077f1a1cada39cd1508990d4008a8ac9ec74c801b24b1b302348b0/claude_agent_sdk-0.2.128-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:55e8fa28918af5620f391692efe80527ad9f2294cec14dadeea93c5161dbefc4", size = 80305667, upload-time = "2026-07-25T01:48:35.091Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/776a41af67a53d794b420dcd2f1075b585ed3725faa9827164f4a2e945dd/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:6c10cc1c5403b2b0b3d8deb79ad5271a8e49b9db6460193599b91f49f16b4cf7", size = 84617823, upload-time = "2026-07-25T01:48:39.297Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1c/37044abbddf2141c4eeb6cc8e15a486491549a27283029d73db2c4f3c3b7/claude_agent_sdk-0.2.128-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cc4a0f20337e227fe16f00edf7cbe109349707adb440fe51ca6c44f9f8d7d21a", size = 85663462, upload-time = "2026-07-25T01:48:43.982Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c9/ffbd8113080f87a4cd7bbfc8b00a974ea7189e3f666b5d7a2903dec7b74f/claude_agent_sdk-0.2.128-py3-none-win_amd64.whl", hash = "sha256:37b87c8e75daa2a6dc74da6d788e0981a2e5e3a6be80cfa4c287abce2bf70e0b", size = 85566882, upload-time = "2026-07-25T01:48:48.635Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1611,6 +1629,9 @@ azure-identity = [
 bedrock = [
     { name = "boto3" },
 ]
+claude-code = [
+    { name = "claude-agent-sdk" },
+]
 cli = [
     { name = "simple-term-menu" },
 ]
@@ -1796,6 +1817,7 @@ requires-dist = [
     { name = "boto3", marker = "extra == 'bedrock'", specifier = "==1.42.89" },
     { name = "brotlicffi", marker = "extra == 'messaging'", specifier = "==1.2.0.1" },
     { name = "certifi", specifier = "==2026.5.20" },
+    { name = "claude-agent-sdk", marker = "extra == 'claude-code'", specifier = ">=0.2.128,<0.4" },
     { name = "concurrent-log-handler", marker = "sys_platform == 'win32'", specifier = "==0.9.29" },
     { name = "croniter", specifier = "==6.0.0" },
     { name = "cryptography", specifier = "==48.0.1" },
@@ -1912,7 +1934,7 @@ requires-dist = [
     { name = "websockets", specifier = "==15.0.1" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
-provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+provides-extras = ["anthropic", "claude-code", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "cli", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
 
 [[package]]
 name = "hf-xet"
@@ -2673,6 +2695,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/25/65/d320016505457cc30971f575e8dadffb923b7cfc780ab8bb25a4ce9d305c/nemo_relay-0.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:ad5dae6febf6532d7b113abc2a404679c8feffc499df3034b93d9a078185d2bb", size = 9917779, upload-time = "2026-07-22T20:07:48.961Z" },
     { url = "https://files.pythonhosted.org/packages/ae/c0/f33250e71c4206da1b339072893f9a1e39295fe1aceb9a2fef4b8620a0f2/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c0cd9570f64c6956fe3bfb82af1cdb3ee70cb50b51098cdb0de831c3f9b4e904", size = 8888375, upload-time = "2026-07-22T20:07:51.049Z" },
     { url = "https://files.pythonhosted.org/packages/a3/f4/d1dfaed022da0f6f14765a122867f976a69cc520fe1faaf99757f5719d1f/nemo_relay-0.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:849daa9e45158ac581e54506e0fcc7a24f557d1ed06dbdc074f5de7a00393cbc", size = 9336372, upload-time = "2026-07-22T20:07:53.224Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9e/f8b80509eef5e05702b940a3d1e2f60c962548d87dec2d712fd3804e6cd4/nemo_relay-0.6.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8c80e534b76bb0455cfc222aaf5c10fa064c088b3c0d5e137eb3c97db46dbc47", size = 10578834, upload-time = "2026-07-30T15:44:44.726Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a0/84ee49d45a1a874457f2f9260d30fd573af30c9be360d9d97b8bb7835ad9/nemo_relay-0.6.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c8bc4a792a2f8c35ddef1b900cc43be2b2bbbfcd5e7cf65aa0829c04d25eb77f", size = 10849651, upload-time = "2026-07-30T15:44:40.48Z" },
     { url = "https://files.pythonhosted.org/packages/3a/b0/908d77f75b9054e1e403da78f7d9430249a45939070d4298abbb41a04b5b/nemo_relay-0.6.0-cp311-abi3-win_amd64.whl", hash = "sha256:bfbbedfd130fa95c9b8c04643c30910df850e0ed3500beeab82b00ca2d94e7ea", size = 9613425, upload-time = "2026-07-22T20:07:55.175Z" },
     { url = "https://files.pythonhosted.org/packages/cd/71/c438b9d746303ff7f270d99f13b250bf947cdac3e52de2a83fd132cbca0b/nemo_relay-0.6.0-cp311-abi3-win_arm64.whl", hash = "sha256:82fe132943399d89e6ec34dc28df0be7bbe41b84f6698c545928b8816b6010f6", size = 9034810, upload-time = "2026-07-22T20:07:57.467Z" },
 ]

--- a/website/docs/user-guide/features/claude-agent-sdk-runtime.md
+++ b/website/docs/user-guide/features/claude-agent-sdk-runtime.md
@@ -1,0 +1,150 @@
+---
+title: Claude Agent SDK Runtime (optional)
+sidebar_label: Claude Agent SDK Runtime
+---
+
+# Claude Agent SDK Runtime
+
+Hermes can optionally hand a whole turn to Anthropic's official
+[Claude Agent SDK](https://code.claude.com/docs/en/agent-sdk/overview), which wraps the Claude Code CLI as a subprocess. When enabled, your Claude Pro / Max / Team / Enterprise plan drives inference: Claude runs its own model loop, and Hermes becomes the shell around it (sessions DB, tools, approvals, environments, slash commands, gateway, memory and skill review).
+
+This is **opt-in and default-off**. Nothing changes unless you flip the flag, and Hermes never auto-routes you onto this runtime.
+
+:::caution Default-off pending a policy answer
+Anthropic's Agent SDK overview says third-party developers may not *offer* claude.ai login for their products without prior approval, while Anthropic's Help Center says SDK usage still draws from your subscription's limits. Those two statements are not reconcilable by reading harder, and the risk of guessing wrong lands on your account. Hermes therefore ships the runtime turned off; enable it only for your own account, knowingly. See `docs/design/claude-subscription-via-agent-sdk.md` for the full record.
+:::
+
+## Why
+
+- Run Claude turns against your **Claude subscription** instead of a metered API key.
+- Hermes holds **no Claude credential at all** — no token reading, no credential files, no OAuth flow. You sign in with `claude auth login` and the SDK resolves credentials itself.
+- The traffic **is** Claude Code's, rather than Hermes' traffic dressed up to look like it. That is the entire point of the change.
+- **Claude owns its own context and compaction**, so prompt-cache continuity and message alternation are handled by the side that actually knows the exact bytes.
+
+## Two Claude providers, and how billing differs
+
+`claude-code` and `anthropic` are separate providers on purpose. Blurring them is how a subscription silently becomes an API bill.
+
+|  | **Anthropic API** (`anthropic`) | **Claude subscription** (`claude-code`) |
+|---|---|---|
+| Auth | `ANTHROPIC_API_KEY` you pasted | `claude auth login`, handled by the SDK |
+| Billed to | your Anthropic Console org, metered per token | your Claude plan's usage limits |
+| Request shape | Hermes builds `/v1/messages` | the Claude Code CLI, via the SDK |
+| Runs the loop | Hermes | Claude |
+| Credential held by Hermes | yes | none |
+
+Hermes still records token counts for a subscription turn so `/status`, session accounting, and the dashboard keep working — but a subscription turn is reported as `subscription_included`, not as a dollar charge. The SDK also reports what the same turn *would* have cost on the API; that number is surfaced for comparison only and is never added to your API spend.
+
+### Why Hermes refuses to run when `ANTHROPIC_API_KEY` is set
+
+The two things above are different accounts, and it is easy to end up on the wrong one without noticing.
+
+- **Anthropic API** is a pay-as-you-go Console account. Every token is a charge on a card.
+- **Claude subscription** is your Pro / Max / Team / Enterprise plan. Usage draws on the limits you already pay a flat fee for.
+
+The Claude Code CLI decides which one to use by looking at your environment, and it prefers a key over your plan. Its order is:
+
+1. Cloud provider credentials (`CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_FOUNDRY`)
+2. `ANTHROPIC_AUTH_TOKEN`
+3. `ANTHROPIC_API_KEY`
+4. an `apiKeyHelper` script in your Claude settings
+5. `CLAUDE_CODE_OAUTH_TOKEN`
+6. **your subscription login — last**
+
+So if you have `ANTHROPIC_API_KEY` exported (Hermes' setup wizard encourages one, so most people do), a "Claude subscription" turn would quietly be billed to your Console account instead.
+
+Hermes does not let that happen. Before a subscription turn starts it checks which credential would win, and if anything outranks your plan it **refuses the turn** and tells you exactly what to unset:
+
+```
+Refusing to start the Claude subscription runtime: this turn would not be billed to your Claude plan.
+  • ANTHROPIC_API_KEY is set, and the Claude Code CLI prefers it over your subscription —
+    requests would bill your Anthropic Console account, as metered API usage.
+    Fix: unset ANTHROPIC_API_KEY
+  Check what the CLI would use with: claude auth status
+```
+
+**To check it yourself:**
+
+```bash
+claude auth status
+```
+
+`"authMethod": "claude.ai"` with a `subscriptionType` means your plan pays. `"authMethod": "api-key"` means a key pays — run `claude auth login`, and unset the variable the refusal named.
+
+**To fix it:** unset the variable in the shell you start Hermes from (`unset ANTHROPIC_API_KEY`), or remove it from `~/.hermes/.env` if that is where it comes from. If you need the key for the `anthropic` provider as well, keep them in separate shells or profiles — Hermes will not silently pick one for you.
+
+Belt and braces: even once the check passes, Hermes launches the Claude CLI from an environment it builds explicitly, with every one of those variables removed, so nothing that appears later can redirect the bill. Your own environment is never modified — other providers keep seeing their keys exactly as before.
+
+## Who owns what
+
+The runtime is only tractable because each side owns its half completely and neither reconstructs the other's state.
+
+**Hermes owns** — and these behave identically to every other provider:
+
+- The **system prompt**. Hermes sends its own, byte-for-byte the string it already built for your conversation. Not the SDK's `claude_code` preset. Your SOUL.md identity, memory instructions, context files, and skills all still apply.
+- **Every tool.** The SDK's built-in Bash / Read / Edit / Glob / Grep tools are switched off entirely. Claude calls Hermes' tools instead, through an in-process bridge, and each call runs the normal Hermes lifecycle: approvals, guardrails, checkpoints, plugin hooks, progress events.
+- **Execution environments.** Tools run wherever your session runs — local, Docker, SSH, Modal, Daytona, or Singularity — because the bridge follows the turn's task id.
+- **Permissions and approvals**, plugins, memory, skills, the session picker, transcripts, and the UI.
+- The **toolset is pinned** for the conversation. A project or user `.mcp.json` cannot widen it mid-session, and the CLI is told not to load a second copy of `CLAUDE.md`, settings, hooks, or skills that would compete with Hermes' context assembly.
+
+**Claude owns:**
+
+- Claude-native context and its opaque frames.
+- **Prompt-cache continuity** across turns.
+- **Automatic compaction.** When Claude compacts, Hermes records the boundary and shows the usual compression status, but does not rewrite your visible transcript.
+- Assistant/tool-result alternation, message UUIDs, the resume cursor, turn usage, and the terminal reason.
+
+## What it looks like while running
+
+Claude's stream is projected into the same callbacks every other Hermes runtime fires, so nothing renders differently:
+
+- Live assistant text and thinking deltas in the CLI, TUI, desktop app, and messaging gateways.
+- Tool start/completion cards with stable ids, using the plain Hermes tool name (`terminal`, `web_search`) rather than the bridge's internal MCP naming.
+- Interim commentary, honoring `display.show_commentary`.
+- Compaction status, token/usage accounting, and the memory + skill review nudges.
+
+Interrupting works too: `/stop` asks Claude to abort, the runtime drains the interrupted response to completion, and the session stays usable for the next turn.
+
+## Prerequisites
+
+1. **Claude Code installed and signed in.**
+   ```bash
+   claude auth login
+   claude auth status    # should report a plan login, not "api-key"
+   ```
+   If `claude auth status` says you are signed in with an API key, that is metered API billing, not your plan.
+
+2. **The optional `claude-code` extra.** The SDK's platform wheels bundle the Claude executable and are ~80 MB, so it is never a base dependency and is not part of `[all]`.
+   ```bash
+   pip install 'hermes-agent[claude-code]'
+   ```
+
+3. **Turn the gate on** in `~/.hermes/config.yaml`:
+   ```yaml
+   claude_subscription:
+     enabled: true
+   ```
+
+If any of the three is missing, the turn refuses to start and tells you which one — it does not fail with a stack trace or silently fall back to a different billing source.
+
+## Enabling
+
+With the three prerequisites met, select the provider the same way as any other:
+
+```yaml
+model: claude-sonnet-4-5
+provider: claude-code
+```
+
+While `claude_subscription.enabled` is `false`, the legacy `claude-code` and `claude-oauth` slugs keep resolving to the `anthropic` provider, so an existing config is never silently repointed at a different billing source.
+
+## Rolling back
+
+Set `claude_subscription.enabled: false`. Nothing else is required: the runtime is purely additive, and it never alters or deletes Hermes transcripts, provider bindings, or Claude's own credentials. Every other provider stays available and unchanged, so a rolled-back setup is exactly the one you had before.
+
+## Known limitations
+
+- **Session resume is not wired up yet.** Each Hermes session starts a fresh Claude session; the SDK session id is captured but not yet used to resume or fork.
+- **Auxiliary/side-LLM tasks** (title generation, the curator, vision fallbacks, the goal judge) do not route through this runtime. They keep using whatever `auxiliary.*` provider you have configured.
+- **Subagents** (`delegate_task`) run on the normal provider path, not on the SDK.
+- **A conflicting credential blocks the runtime rather than being worked around.** Hermes refuses instead of quietly stripping the variable, because which account pays is your decision to make, not ours. See the billing section above.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -99,6 +99,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/delegation',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
+            'user-guide/features/claude-agent-sdk-runtime',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/kanban-worker-lanes',
             'user-guide/features/goals',

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -96,6 +96,7 @@ const sidebars: SidebarsConfig = {
             'user-guide/features/delegation',
             'user-guide/features/kanban',
             'user-guide/features/codex-app-server-runtime',
+            'user-guide/features/claude-agent-sdk-runtime',
             'user-guide/features/kanban-tutorial',
             'user-guide/features/kanban-worker-lanes',
             'user-guide/features/goals',


### PR DESCRIPTION
## What

Adds a new **Claude subscription (Agent SDK)** provider (`claude-code`, `api_mode=claude_agent_sdk`) that runs whole turns through Anthropic's official `claude-agent-sdk`. Users sign in with `claude auth login`; turns draw on their Claude Pro/Max/Team plan instead of the extra-usage pool.

**The existing `anthropic` API-key provider is unchanged, and the current direct-OAuth path keeps working.** Nothing is migrated automatically — users on the old path get a one-time notice explaining the two options.

## Why

Today's `claude-code` alias reads Claude Code's credential store and hand-builds `/v1/messages` requests with Claude Code identity headers. Anthropic's billing classifier routes that to the plan's **extra-usage** pool (empty by default), which is the recurring "out of extra usage" complaint. Routing turns through the official SDK — the same integration shape as T3 Code and Codemux — bills the plan itself.

## Design

- Hermes keeps tools, approvals, guardrails, checkpoints, environments, memory, skills, and session history; the SDK keeps Claude's context, prompt cache, and compaction. Claude's tool calls come back over an in-process MCP bridge into `execute_one_tool()`, which mirrors the per-tool lifecycle of Hermes' own dispatchers (approvals, guardrails, checkpoints, environment routing, hooks).
- **Billing safety:** a sanitized subprocess transport strips every higher-precedence credential (`options.env` can override but never delete), preflight refuses any turn that would not bill the plan (naming the offending variable), and a zero-cost init probe verifies the billing source per session. Auxiliary/side-LLM calls use the same transport and guard.
- **Durable sessions:** DB-backed SessionStore mirror (the SDK's own conformance suite passes), restart resume, rewind/branch as SDK forks, stale-session recovery.
- **Ships default-off** behind `claude_subscription.enabled` — Anthropic's Agent SDK docs and Help Center currently disagree on third-party subscription use, so enablement is an explicit user choice. Full decision record in `docs/design/claude-subscription-via-agent-sdk.md`.
- New CI: a boundary checker forbidding Claude-credential access and Claude Code impersonation (legacy path allow-listed until retirement), and an integration job that installs the real SDK.

## Testing

- ~600 targeted tests, green with and without the optional `claude-agent-sdk` extra installed; full suites unaffected.
- Live verification in unprivileged containers (`--cap-drop=ALL`, non-root) on a consenting maintainer account: billing proven by falsification — with a deliberately **invalid** `ANTHROPIC_API_KEY` in the environment, a turn through this runtime succeeds (plan credential) while the same turn without sanitization fails; the CLI does not fall back from a bad key.
- Clean-container E2E of a fresh `pip install -e '.[claude-code]'`: chat, tool calls through the bridge, terminal, context continuity, and **restart resume** (same SDK session id after a new process). Also exercised against SDK 0.2.131 to confirm the range pin at the time; after the rebase the floor is 0.2.140, the first release whose `mcp` range admits the `mcp==2.0.0` main pins.
- Interactive TUI testing on a real Max subscription: multi-turn, model switching via `set_model` (context preserved), tool execution, session persistence.

## Notes for review

- The legacy path's spoofing/credential code is deliberately **not** removed — it is what current users run, and it is allow-listed in the boundary checker under `TODO(legacy-retirement)` markers for removal after enablement and migration.
- `pyproject.toml` adds `claude-code` as an opt-in extra (the SDK wheels are ~80 MB; deliberately not in `[all]`). `uv.lock` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)