### PR TITLE
feat(desktop): live on-device caption preview during voice conversations

### DIFF
--- a/apps/desktop/electron/api-backend-routing.test.ts
+++ b/apps/desktop/electron/api-backend-routing.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { assertLocalBackendForRequest, resolveLocalitySensitiveBackend } from './api-backend-routing'
+
+interface TestConnection {
+  baseUrl: string
+  mode: string
+  token?: string
+}
+
+test('local-only request validates and transmits through the same pinned connection', async () => {
+  const local: TestConnection = { baseUrl: 'http://127.0.0.1:9001', mode: 'local', token: 'local-token' }
+  const remote: TestConnection = { baseUrl: 'https://remote.example', mode: 'remote', token: 'remote-token' }
+  let configuredConnection = local
+  let resolveCalls = 0
+
+  const ensureBackend = async () => {
+    resolveCalls += 1
+
+    return configuredConnection
+  }
+
+  // This mirrors the locality-sensitive branch in main.ts: resolve once,
+  // survive intervening awaits/config changes, validate that object, use it.
+  const request = { profile: 'work', requireLocalBackend: true }
+  const pinnedConnection = await resolveLocalitySensitiveBackend(request, ensureBackend)
+  await Promise.resolve()
+  configuredConnection = remote
+  assertLocalBackendForRequest(request, pinnedConnection)
+  const transmittedTo = pinnedConnection?.baseUrl
+
+  assert.equal(resolveCalls, 1)
+  assert.equal(transmittedTo, local.baseUrl)
+  assert.notEqual(transmittedTo, configuredConnection.baseUrl)
+})
+
+test('local-only request fails closed when its exact pinned connection is remote', () => {
+  assert.throws(
+    () =>
+      assertLocalBackendForRequest({ requireLocalBackend: true }, { baseUrl: 'https://remote.example', mode: 'remote' }),
+    /requires a local Hermes backend/
+  )
+})
+
+test('ordinary requests keep normal routing and never pin a backend', async () => {
+  let resolveCalls = 0
+
+  const ensureBackend = async () => {
+    resolveCalls += 1
+
+    return { baseUrl: 'https://remote.example', mode: 'remote' }
+  }
+
+  assert.equal(await resolveLocalitySensitiveBackend({ profile: 'work' }, ensureBackend), null)
+  assert.equal(await resolveLocalitySensitiveBackend(undefined, ensureBackend), null)
+  assert.equal(resolveCalls, 0)
+  // A remote connection is fine when locality was never demanded.
+  assertLocalBackendForRequest({ profile: 'work' }, { baseUrl: 'https://remote.example', mode: 'remote' })
+})

--- a/apps/desktop/electron/api-backend-routing.ts
+++ b/apps/desktop/electron/api-backend-routing.ts
@@ -1,0 +1,44 @@
+export const LOCAL_BACKEND_REQUIRED_ERROR = 'This request requires a local Hermes backend'
+
+export interface LocalitySensitiveRequest {
+  /** Set by callers whose payload must never leave the machine (live voice
+   *  preview transcription). Forces the request onto a local backend and fails
+   *  closed if one cannot be used. */
+  requireLocalBackend?: boolean
+  profile?: string
+}
+
+/** Only `mode` is inspected; callers pass their full connection descriptor. */
+export interface LocalityCheckedConnection {
+  mode?: string
+}
+
+/**
+ * Resolve the backend for a request that demands locality, bypassing the
+ * remote-interception path entirely. Returns null for ordinary requests so the
+ * caller keeps its normal routing.
+ */
+export async function resolveLocalitySensitiveBackend<TConnection>(
+  request: LocalitySensitiveRequest | null | undefined,
+  ensureBackend: (profile?: string) => Promise<TConnection>
+): Promise<TConnection | null> {
+  if (!request?.requireLocalBackend) {
+    return null
+  }
+
+  return ensureBackend(request?.profile)
+}
+
+/**
+ * Fail closed if a locality-sensitive request ended up on a non-local backend.
+ * Called immediately before transmission — after any config change that could
+ * have swapped the descriptor out from under the earlier resolution.
+ */
+export function assertLocalBackendForRequest<TConnection extends LocalityCheckedConnection>(
+  request: LocalitySensitiveRequest | null | undefined,
+  connection: TConnection | null | undefined
+): void {
+  if (request?.requireLocalBackend && connection?.mode !== 'local') {
+    throw new Error(LOCAL_BACKEND_REQUIRED_ERROR)
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -32,6 +32,7 @@ import {
 import nodePty from 'node-pty'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { assertLocalBackendForRequest, resolveLocalitySensitiveBackend } from './api-backend-routing'
 import { stopBackendChild as stopBackendChildImpl } from './backend-child'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -10248,11 +10249,19 @@ async function mergeRemoteProfileSessions(searchParams, remoteProfiles) {
 }
 
 ipcMain.handle('hermes:api', async (_event, request) => {
+  // Pin privacy-sensitive audio to one concrete connection descriptor. Config
+  // may change while the handler awaits interception/preparation work; never
+  // re-resolve and accidentally transmit the body through a different backend.
+  const localitySensitiveConnection = await resolveLocalitySensitiveBackend(request, ensureBackend)
+  assertLocalBackendForRequest(request, localitySensitiveConnection)
+
   // Remote-profile session requests would otherwise hit the local primary off
   // each profile's on-disk state.db — fine for local profiles, but a remote
   // profile's sessions live on its remote host, so the UI's IDs 404 (or mutations
   // no-op) the moment they run there. Route reads + mutations to the remote.
-  const rerouted = await interceptSessionRequestForRemote(request)
+  // A locality-pinned request is never rerouted to a remote host — that is the
+  // whole point of the pin, and reroute would hand its body to a remote backend.
+  const rerouted = request?.requireLocalBackend ? undefined : await interceptSessionRequestForRemote(request)
 
   if (rerouted !== undefined) {
     return rerouted
@@ -10266,7 +10275,13 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   // backend calls ensure_hermes_home() which recreates the profile directory,
   // defeating the deletion and leaving a zombie process.
   const routeProfile = resolveRouteProfile(tornDownProfile, profile)
-  const connection = await ensureBackend(routeProfile)
+  // Reuse the backend pinned above for locality-sensitive requests instead of
+  // re-resolving — an intervening config change must not swap in a remote one.
+  const connection = localitySensitiveConnection || (await ensureBackend(routeProfile))
+  // Validate the exact descriptor used below, immediately before transmission.
+  // This preserves normal local/token/OAuth routing while failing closed for a
+  // remote descriptor that was selected before an intervening config change.
+  assertLocalBackendForRequest(request, connection)
   const timeoutMs = resolveTimeoutMs(request?.timeoutMs, DEFAULT_FETCH_TIMEOUT_MS)
 
   const requestPath = pathWithGlobalRemoteProfile(request.path, profile, profileRouteOptions(profile))

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -137,3 +137,40 @@ describe('wake-word ear visibility', () => {
     expect((ear as HTMLButtonElement).disabled).toBe(true)
   })
 })
+
+describe('ComposerControls voice caption', () => {
+  it('shows the current partial transcript during a voice conversation', () => {
+    renderControls({
+      conversation: {
+        active: true,
+        level: 0.4,
+        muted: false,
+        onEnd: vi.fn(),
+        onStart: vi.fn(),
+        onStopTurn: vi.fn(),
+        onToggleMute: vi.fn(),
+        status: 'listening',
+        transcript: '지금 화면에 보이는 자막입니다'
+      }
+    })
+
+    expect(screen.getByText('지금 화면에 보이는 자막입니다')).toBeTruthy()
+  })
+
+  it('renders no caption element before any transcript arrives', () => {
+    const { container } = renderControls({
+      conversation: {
+        active: true,
+        level: 0.4,
+        muted: false,
+        onEnd: vi.fn(),
+        onStart: vi.fn(),
+        onStopTurn: vi.fn(),
+        onToggleMute: vi.fn(),
+        status: 'listening'
+      }
+    })
+
+    expect(container.querySelector('[aria-live="polite"]')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -44,6 +44,9 @@ interface ConversationProps {
   level: number
   muted: boolean
   status: ConversationStatus
+  /** Live caption for the utterance in progress; absent until a preview or
+   *  final transcription lands. */
+  transcript?: string
   onEnd: () => void
   onStart: () => void
   onStopTurn: () => void
@@ -176,7 +179,8 @@ function ConversationPill({
   onEnd,
   onStopTurn,
   onToggleMute,
-  status
+  status,
+  transcript
 }: ConversationProps & { disabled: boolean }) {
   const { t } = useI18n()
   const c = t.composer
@@ -196,6 +200,18 @@ function ConversationPill({
 
   return (
     <div className="ml-auto flex shrink-0 items-center gap-(--composer-control-gap)">
+      {/* Live preview of what the mic is picking up, ahead of the final
+          (authoritative) transcription. Sits left of the controls so a long
+          transcript truncates instead of pushing the buttons off-row. */}
+      {transcript && (
+        <span
+          aria-live="polite"
+          className="max-w-[min(28rem,42vw)] truncate rounded-lg bg-accent/45 px-2.5 py-1 text-sm text-foreground"
+          title={transcript}
+        >
+          {transcript}
+        </span>
+      )}
       {/* Keep the ear visible during voice chat — shown paused, since the
           conversation holds the mic (the one time wake must not listen). */}
       <WakeWordButton disabled={disabled} pausedForVoice />

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -1,0 +1,186 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type MicRecorderErrorCopy, useMicRecorder } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: 'access denied',
+  microphoneConstraintsUnsupported: 'constraints unsupported',
+  microphoneInUse: 'in use',
+  microphonePermissionDenied: 'permission denied',
+  microphoneStartFailed: 'start failed',
+  microphoneUnsupported: 'unsupported',
+  noMicrophone: 'no microphone'
+}
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static isTypeSupported = () => true
+
+  mimeType: string
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onstop: (() => void) | null = null
+  startTimeslice: number | undefined
+  state: RecordingState = 'inactive'
+
+  constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+    this.mimeType = options?.mimeType ?? 'audio/webm'
+    FakeMediaRecorder.instances.push(this)
+  }
+
+  emit(data: Blob) {
+    this.ondataavailable?.({ data })
+  }
+
+  start(timeslice?: number) {
+    this.startTimeslice = timeslice
+    this.state = 'recording'
+  }
+
+  stop() {
+    this.state = 'inactive'
+    this.onstop?.()
+  }
+}
+
+describe('useMicRecorder partial audio', () => {
+  beforeEach(() => {
+    FakeMediaRecorder.instances = []
+    vi.stubGlobal('MediaRecorder', FakeMediaRecorder)
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: vi.fn(async () => ({ getTracks: () => [{ stop: vi.fn() }] }))
+      }
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('emits the accumulated recording at the requested caption interval', async () => {
+    const onPartialAudio = vi.fn()
+    const { result, unmount } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start({ onPartialAudio, partialAudioMs: 2_500 })
+    })
+
+    const recorder = FakeMediaRecorder.instances[0]!
+    expect(recorder.startTimeslice).toBe(2_500)
+
+    const firstChunk = new Blob(['first'], { type: 'audio/webm' })
+    const secondChunk = new Blob(['second'], { type: 'audio/webm' })
+
+    act(() => recorder.emit(firstChunk))
+    act(() => recorder.emit(secondChunk))
+
+    expect(onPartialAudio).toHaveBeenCalledTimes(2)
+    expect(onPartialAudio.mock.calls[1]?.[0]).toBeInstanceOf(Blob)
+    expect(onPartialAudio.mock.calls[1]?.[0].size).toBe(firstChunk.size + secondChunk.size)
+
+    unmount()
+  })
+
+  it('stops emitting accumulated partial audio after the configured preview limit', async () => {
+    const now = vi.spyOn(Date, 'now').mockReturnValue(0)
+    const onPartialAudio = vi.fn()
+    const { result, unmount } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start({
+        onPartialAudio,
+        partialAudioMaxMs: 10_000,
+        partialAudioMs: 2_500
+      })
+    })
+
+    const recorder = FakeMediaRecorder.instances[0]!
+
+    act(() => recorder.emit(new Blob(['first'], { type: 'audio/webm' })))
+    now.mockReturnValue(10_001)
+    act(() => recorder.emit(new Blob(['second'], { type: 'audio/webm' })))
+
+    expect(onPartialAudio).toHaveBeenCalledTimes(1)
+
+    unmount()
+    now.mockRestore()
+  })
+
+  it.each(['cancel', 'unmount'] as const)(
+    'stops a stream that arrives after %s while microphone startup is pending',
+    async action => {
+      let resolveStream!: (stream: MediaStream) => void
+
+      const stopTrack = vi.fn()
+      const stream = { getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream
+
+      const getUserMedia = vi.fn(
+        () =>
+          new Promise<MediaStream>(resolve => {
+            resolveStream = resolve
+          })
+      )
+
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: { getUserMedia }
+      })
+
+      const { result, unmount } = renderHook(() => useMicRecorder(copy))
+      let startRequest!: Promise<void>
+
+      act(() => {
+        startRequest = result.current.handle.start()
+      })
+
+      await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledTimes(1))
+
+      if (action === 'cancel') {
+        act(() => result.current.handle.cancel())
+      } else {
+        unmount()
+      }
+
+      resolveStream(stream)
+      await startRequest
+
+      expect(stopTrack).toHaveBeenCalledTimes(1)
+      expect(FakeMediaRecorder.instances).toHaveLength(0)
+
+      if (action === 'cancel') {
+        unmount()
+      }
+    }
+  )
+
+  it('detaches an active recorder before unmount so late data cannot upload', async () => {
+    const stopTrack = vi.fn()
+    const onPartialAudio = vi.fn()
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia: vi.fn(async () => ({ getTracks: () => [{ stop: stopTrack }] })) }
+    })
+
+    const { result, unmount } = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => {
+      await result.current.handle.start({ onPartialAudio, partialAudioMs: 2_500 })
+    })
+
+    const recorder = FakeMediaRecorder.instances[0]!
+    const lateDataHandler = recorder.ondataavailable
+
+    unmount()
+
+    expect(recorder.state).toBe('inactive')
+    expect(recorder.ondataavailable).toBeNull()
+    expect(stopTrack).toHaveBeenCalledTimes(1)
+
+    lateDataHandler?.({ data: new Blob(['late'], { type: 'audio/webm' }) })
+    expect(onPartialAudio).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -1,11 +1,14 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 type BrowserAudioContext = typeof AudioContext
 
 export interface MicRecorderOptions {
   onLevel?: (level: number) => void
   onError?: (error: Error) => void
+  onPartialAudio?: (audio: Blob) => Promise<void> | void
   onSilence?: () => void
+  partialAudioMaxMs?: number
+  partialAudioMs?: number
   silenceLevel?: number
   silenceMs?: number
   idleSilenceMs?: number
@@ -77,8 +80,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const startGenerationRef = useRef(0)
+  const mountedRef = useRef(true)
 
-  const cleanup = () => {
+  const cleanup = useCallback(() => {
     if (animationRef.current) {
       window.cancelAnimationFrame(animationRef.current)
       animationRef.current = null
@@ -89,12 +94,51 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     streamRef.current?.getTracks().forEach(track => track.stop())
     streamRef.current = null
     recorderRef.current = null
-    setLevel(0)
-    setRecording(false)
-    silenceTriggeredRef.current = false
-  }
 
-  useEffect(() => () => cleanup(), [])
+    if (mountedRef.current) {
+      setLevel(0)
+      setRecording(false)
+    }
+
+    silenceTriggeredRef.current = false
+  }, [])
+
+  const abortRecording = useCallback(() => {
+    const recorder = recorderRef.current
+    const resolver = stopResolverRef.current
+
+    stopResolverRef.current = null
+
+    if (recorder) {
+      recorder.ondataavailable = null
+      recorder.onerror = null
+      recorder.onstop = null
+
+      if (recorder.state !== 'inactive') {
+        try {
+          recorder.stop()
+        } catch {
+          // The stream tracks are still stopped by cleanup below.
+        }
+      }
+    }
+
+    cleanup()
+    resolver?.(null)
+  }, [cleanup])
+
+  useEffect(
+    () => {
+      mountedRef.current = true
+
+      return () => {
+        mountedRef.current = false
+        startGenerationRef.current += 1
+        abortRecording()
+      }
+    },
+    [abortRecording]
+  )
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -116,6 +160,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       audioContextRef.current = audioContext
 
       const tick = () => {
+        if (!mountedRef.current || streamRef.current !== stream) {
+          return
+        }
+
         analyser.getByteTimeDomainData(data)
 
         let sum = 0
@@ -171,11 +219,17 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       return
     }
 
+    const startGeneration = ++startGenerationRef.current
+
     if (!navigator.mediaDevices?.getUserMedia || typeof MediaRecorder === 'undefined') {
       throw new Error(copy.microphoneUnsupported)
     }
 
     const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+
+    if (startGeneration !== startGenerationRef.current || !mountedRef.current) {
+      return
+    }
 
     if (permitted === false) {
       throw new Error(copy.microphoneAccessDenied)
@@ -188,7 +242,17 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
         audio: { echoCancellation: true, noiseSuppression: true }
       })
     } catch (error) {
+      if (startGeneration !== startGenerationRef.current || !mountedRef.current) {
+        return
+      }
+
       throw micError(error, copy)
+    }
+
+    if (startGeneration !== startGenerationRef.current || !mountedRef.current) {
+      stream.getTracks().forEach(track => track.stop())
+
+      return
     }
 
     const mimeType =
@@ -214,12 +278,28 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     startedAtRef.current = Date.now()
 
     recorder.ondataavailable = event => {
+      if (!mountedRef.current || recorderRef.current !== recorder) {
+        return
+      }
+
       if (event.data.size > 0) {
         chunksRef.current.push(event.data)
+
+        const withinPartialAudioLimit =
+          !options.partialAudioMaxMs || Date.now() - startedAtRef.current <= options.partialAudioMaxMs
+
+        if (options.onPartialAudio && options.partialAudioMs && options.partialAudioMs > 0 && withinPartialAudioLimit) {
+          const recordingType = recorder.mimeType || mimeType || 'audio/webm'
+          void options.onPartialAudio(new Blob(chunksRef.current, { type: recordingType }))
+        }
       }
     }
 
     recorder.onstop = () => {
+      if (!mountedRef.current || recorderRef.current !== recorder) {
+        return
+      }
+
       const chunks = chunksRef.current
       const recordingType = recorder.mimeType || mimeType || 'audio/webm'
       const durationMs = Date.now() - startedAtRef.current
@@ -245,6 +325,10 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     }
 
     recorder.onerror = event => {
+      if (!mountedRef.current || recorderRef.current !== recorder) {
+        return
+      }
+
       const error = micError((event as Event & { error?: unknown }).error, copy)
       const resolver = stopResolverRef.current
       stopResolverRef.current = null
@@ -253,13 +337,28 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       resolver?.(null)
     }
 
-    recorder.start()
+    try {
+      if (options.onPartialAudio && options.partialAudioMs && options.partialAudioMs > 0) {
+        recorder.start(options.partialAudioMs)
+      } else {
+        recorder.start()
+      }
+    } catch (error) {
+      recorder.ondataavailable = null
+      recorder.onerror = null
+      recorder.onstop = null
+      cleanup()
+
+      throw micError(error, copy)
+    }
+
     setRecording(true)
     startMeter(stream, options)
   }
 
   const stop: MicRecorderHandle['stop'] = () =>
     new Promise<MicRecording | null>(resolve => {
+      startGenerationRef.current += 1
       const recorder = recorderRef.current
 
       if (!recorder || recorder.state === 'inactive') {
@@ -274,19 +373,8 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     })
 
   const cancel: MicRecorderHandle['cancel'] = () => {
-    const recorder = recorderRef.current
-    const resolver = stopResolverRef.current
-    stopResolverRef.current = null
-
-    if (recorder && recorder.state !== 'inactive') {
-      recorder.ondataavailable = null
-      recorder.onerror = null
-      recorder.onstop = null
-      recorder.stop()
-    }
-
-    cleanup()
-    resolver?.(null)
+    startGenerationRef.current += 1
+    abortRecording()
   }
 
   const handle: MicRecorderHandle = { start, stop, cancel }

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.test.tsx
@@ -3,7 +3,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BargeMonitorCallbacks } from '@/lib/voice-barge-in'
 
-import type { MicRecording } from './use-mic-recorder'
+import type { AudioTranscriptionOptions } from '../types'
+
+import type { MicRecorderOptions, MicRecording } from './use-mic-recorder'
 import { useVoiceConversation } from './use-voice-conversation'
 
 // The full-duplex contract: the barge monitor is live across the WHOLE agent
@@ -262,5 +264,147 @@ describe('useVoiceConversation full-duplex barge-in', () => {
     hook.rerender({ busy: true })
 
     expect(monitorCalls.length).toBe(armed)
+  })
+})
+
+// Live captions: while the user is still speaking, short slices of audio are
+// transcribed on-device as a *preview*. They must never leave the machine, and
+// never outrank the final transcription of the same utterance.
+describe('useVoiceConversation live caption previews', () => {
+  beforeEach(() => {
+    monitorCalls.length = 0
+    vi.clearAllMocks()
+    micHandle.start.mockResolvedValue(undefined)
+    micHandle.stop.mockResolvedValue(null)
+  })
+
+  afterEach(cleanup)
+
+  type TranscribeFn = (audio: Blob, options?: AudioTranscriptionOptions) => Promise<string>
+
+  function renderForPreview(onTranscribeAudio: TranscribeFn) {
+    // Mirrors the real app: submitting a turn makes the agent busy, so the
+    // hook stays in 'thinking' instead of immediately re-opening the mic.
+    const onBusyChange: { current: (busy: boolean) => void } = { current: () => undefined }
+
+    const hook = renderHook(
+      ({ busy }: HookProps) =>
+        useVoiceConversation({
+          busy,
+          consumePendingResponse: vi.fn(),
+          enabled: true,
+          onStopWord: vi.fn(),
+          onSubmit: vi.fn(async () => {
+            onBusyChange.current(true)
+          }),
+          onTranscribeAudio,
+          pendingResponse: () => null
+        }),
+      { initialProps: { busy: false } }
+    )
+
+    onBusyChange.current = busy => hook.rerender({ busy })
+
+    return hook
+  }
+
+  /** Options handed to the recorder on the most recent open. The shared mock is
+   *  declared argument-less, so recover the real call signature here. */
+  function lastStartOptions(): MicRecorderOptions | undefined {
+    const calls = micHandle.start.mock.calls as unknown as Array<[MicRecorderOptions | undefined]>
+
+    return calls.at(-1)?.[0]
+  }
+
+  async function startListening(hook: ReturnType<typeof renderForPreview>) {
+    await act(async () => {
+      await hook.result.current.start()
+    })
+    await waitFor(() => expect(hook.result.current.status).toBe('listening'))
+  }
+
+  it('opens the mic with partial-audio slicing wired to the preview pass', async () => {
+    const hook = renderForPreview(vi.fn(async () => 'final'))
+    await startListening(hook)
+
+    const options = lastStartOptions()
+
+    expect(typeof options?.onPartialAudio).toBe('function')
+
+    const sliceMs = options?.partialAudioMs ?? 0
+    expect(sliceMs).toBeGreaterThan(0)
+    // Bounded: past this much audio, previewing stops paying for itself.
+    expect(options?.partialAudioMaxMs).toBeGreaterThan(sliceMs)
+  })
+
+  it('requests previews on-device only and shows the result as the caption', async () => {
+    const onTranscribeAudio = vi.fn(async () => 'partial caption')
+    const hook = renderForPreview(onTranscribeAudio)
+    await startListening(hook)
+
+    await act(async () => {
+      await lastStartOptions()?.onPartialAudio?.(new Blob(['p'], { type: 'audio/webm' }))
+    })
+
+    // localOnly keeps preview audio off any cloud STT provider; previewOnly
+    // marks it droppable so the final pass can pre-empt it.
+    expect(onTranscribeAudio).toHaveBeenCalledWith(expect.any(Blob), { localOnly: true, previewOnly: true })
+    await waitFor(() => expect(hook.result.current.transcript).toBe('partial caption'))
+  })
+
+  it('drops a preview that resolves after its turn already ended', async () => {
+    let releasePreview: (value: string) => void = () => undefined
+
+    const onTranscribeAudio = vi.fn(
+      (_audio: Blob, options?: { previewOnly?: boolean }) =>
+        options?.previewOnly
+          ? new Promise<string>(resolve => {
+              releasePreview = resolve
+            })
+          : Promise.resolve('final transcript')
+    )
+
+    const hook = renderForPreview(onTranscribeAudio)
+    await startListening(hook)
+
+    const partial = lastStartOptions()?.onPartialAudio?.(new Blob(['p'], { type: 'audio/webm' }))
+
+    // The user stops talking and the turn closes while the preview is in flight.
+    await act(async () => {
+      await hook.result.current.end()
+    })
+
+    await act(async () => {
+      releasePreview('stale caption')
+      await partial
+    })
+
+    expect(hook.result.current.transcript).toBe('')
+  })
+
+  it('replaces the caption with the authoritative final transcription', async () => {
+    const onTranscribeAudio = vi.fn(async (_audio: Blob, options?: { previewOnly?: boolean }) =>
+      options?.previewOnly ? 'rough guess' : 'the real transcript'
+    )
+
+    const hook = renderForPreview(onTranscribeAudio)
+    await startListening(hook)
+
+    await act(async () => {
+      await lastStartOptions()?.onPartialAudio?.(new Blob(['p'], { type: 'audio/webm' }))
+    })
+    await waitFor(() => expect(hook.result.current.transcript).toBe('rough guess'))
+
+    micHandle.stop.mockResolvedValueOnce({
+      audio: new Blob(['q'], { type: 'audio/webm' }),
+      durationMs: 900,
+      heardSpeech: true
+    })
+
+    await act(async () => {
+      hook.result.current.stopTurn()
+    })
+
+    await waitFor(() => expect(hook.result.current.transcript).toBe('the real transcript'))
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -14,9 +14,17 @@ import { isVoiceStopCommand } from '@/lib/voice-stop-word'
 import { notify, notifyError } from '@/store/notifications'
 import { $voicePlayback } from '@/store/voice-playback'
 
+import type { AudioTranscriptionOptions } from '../types'
+
 import { useMicRecorder } from './use-mic-recorder'
 
 export type ConversationStatus = 'idle' | 'listening' | 'transcribing' | 'thinking' | 'speaking'
+
+/** How much speech accumulates before a live-caption preview is attempted. */
+const PARTIAL_AUDIO_MS = 2_500
+/** Stop previewing past this much audio — long clips make local STT too slow
+ *  to be a *preview*, and the final transcription is what actually matters. */
+const PARTIAL_AUDIO_MAX_MS = 10_000
 
 interface PendingVoiceResponse {
   id: string
@@ -33,7 +41,7 @@ interface VoiceConversationOptions {
   onInterrupt?: () => Promise<void> | void
   onStopWord?: () => void
   onSubmit: (text: string) => Promise<void> | void
-  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  onTranscribeAudio?: (audio: Blob, options?: AudioTranscriptionOptions) => Promise<string>
   pendingResponse: () => PendingVoiceResponse | null
   consumePendingResponse: () => void
   /** Awaited right before the mic is opened. Used to let the wake-word listener
@@ -62,6 +70,15 @@ export function useVoiceConversation({
   const { handle, level } = useMicRecorder(voiceCopy)
   const [status, setStatus] = useState<ConversationStatus>('idle')
   const [muted, setMuted] = useState(false)
+  // Live caption of the current utterance, filled by best-effort local preview
+  // passes and then replaced by the authoritative final transcription.
+  const [transcript, setTranscript] = useState('')
+  // Bumped at every turn boundary. A preview that resolves after its turn ended
+  // carries a stale generation and is dropped instead of repainting the caption.
+  const transcriptGenerationRef = useRef(0)
+  // Holds the generation of the in-flight preview, so previews (which fire
+  // every PARTIAL_AUDIO_MS of speech) never stack on top of each other.
+  const partialTranscriptionGenerationRef = useRef<number | null>(null)
   const turnTimeoutRef = useRef<number | null>(null)
   const pendingStartRef = useRef(false)
   const turnClosingRef = useRef(false)
@@ -135,6 +152,65 @@ export function useVoiceConversation({
     spokenSourceLengthRef.current = 0
   }
 
+  /** Close the current caption generation: clears the text and invalidates any
+   *  preview still in flight for the turn that just ended. */
+  const resetTranscript = () => {
+    transcriptGenerationRef.current += 1
+    partialTranscriptionGenerationRef.current = null
+    setTranscript('')
+  }
+
+  /**
+   * Best-effort live caption for the utterance being spoken.
+   *
+   * Runs strictly on-device (`localOnly`) so partial audio never reaches a
+   * cloud provider, and `previewOnly` marks it droppable: the backend caps it,
+   * runs it in a killable process, and lets the authoritative final
+   * transcription pre-empt it. Failures are swallowed on purpose — a caption
+   * that doesn't show is a cosmetic loss, and the final transcript still
+   * surfaces its own errors.
+   */
+  const transcribePartialAudio = useCallback(
+    (audio: Blob) => {
+      const generation = transcriptGenerationRef.current
+
+      if (
+        !onTranscribeAudio ||
+        !enabledRef.current ||
+        partialTranscriptionGenerationRef.current === generation ||
+        turnClosingRef.current ||
+        statusRef.current !== 'listening'
+      ) {
+        return Promise.resolve()
+      }
+
+      partialTranscriptionGenerationRef.current = generation
+
+      return (async () => {
+        try {
+          const partial = (await onTranscribeAudio(audio, { localOnly: true, previewOnly: true })).trim()
+
+          if (
+            partial &&
+            generation === transcriptGenerationRef.current &&
+            !turnClosingRef.current &&
+            statusRef.current === 'listening'
+          ) {
+            setTranscript(partial)
+          }
+        } catch {
+          // Partial captions are best-effort. The final turn transcription
+          // remains authoritative and surfaces its own error if it fails.
+        } finally {
+          if (partialTranscriptionGenerationRef.current === generation) {
+            partialTranscriptionGenerationRef.current = null
+          }
+        }
+      })()
+    },
+    [onTranscribeAudio]
+  )
+
   const handleTurn = useCallback(
     async (forceTranscribe = false) => {
       if (turnClosingRef.current) {
@@ -153,19 +229,21 @@ export function useVoiceConversation({
             pendingStartRef.current = true
           }
 
+          resetTranscript()
           setStatus('idle')
 
           return
         }
 
         try {
-          const transcript = (await onTranscribeAudio(result.audio)).trim()
+          const finalTranscript = (await onTranscribeAudio(result.audio)).trim()
 
-          if (!transcript) {
+          if (!finalTranscript) {
             if (enabledRef.current) {
               pendingStartRef.current = true
             }
 
+            resetTranscript()
             setStatus('idle')
 
             return
@@ -175,8 +253,9 @@ export function useVoiceConversation({
           // conversation instead of being submitted as a turn. Only whole-
           // utterance stop commands match, so "stop the container" still goes
           // through as a real request.
-          if (isVoiceStopCommand(transcript)) {
+          if (isVoiceStopCommand(finalTranscript)) {
             dropSpeechSession()
+            resetTranscript()
             setStatus('idle')
             onStopWordRef.current?.()
 
@@ -185,7 +264,12 @@ export function useVoiceConversation({
 
           awaitingSpokenResponseRef.current = true
           dropSpeechSession()
-          await onSubmit(transcript)
+          // Replace any preview caption with the authoritative text. It stays
+          // on screen through 'thinking' and is cleared when listening resumes.
+          transcriptGenerationRef.current += 1
+          partialTranscriptionGenerationRef.current = null
+          setTranscript(finalTranscript)
+          await onSubmit(finalTranscript)
           setStatus('thinking')
         } catch (error) {
           notifyError(error, voiceCopy.transcriptionFailed)
@@ -234,15 +318,19 @@ export function useVoiceConversation({
 
     try {
       // VAD tuning mirrors `tools.voice_mode` defaults so the browser loop matches the CLI.
+      resetTranscript()
       await handle.start({
         silenceLevel: 0.075,
         silenceMs: 1_250,
         idleSilenceMs: 12_000,
+        partialAudioMaxMs: PARTIAL_AUDIO_MAX_MS,
+        partialAudioMs: PARTIAL_AUDIO_MS,
         onError: error => {
           notifyError(error, voiceCopy.microphoneFailed)
           pendingStartRef.current = false
           onFatalError?.()
         },
+        onPartialAudio: transcribePartialAudio,
         onSilence: () => void handleTurn()
       })
       setStatus('listening')
@@ -259,7 +347,14 @@ export function useVoiceConversation({
       setStatus('idle')
       onFatalError?.()
     }
-  }, [handle, handleTurn, onFatalError, voiceCopy.couldNotStartSession, voiceCopy.microphoneFailed])
+  }, [
+    handle,
+    handleTurn,
+    onFatalError,
+    transcribePartialAudio,
+    voiceCopy.couldNotStartSession,
+    voiceCopy.microphoneFailed
+  ])
 
   const settleAfterSpeech = useCallback(
     (barged: boolean, stoppedDuringSetup = false) => {
@@ -324,9 +419,10 @@ export function useVoiceConversation({
       setStatus('transcribing')
 
       try {
-        const transcript = (await onTranscribeAudio(audio)).trim()
+        const finalTranscript = (await onTranscribeAudio(audio)).trim()
 
-        if (!transcript) {
+        if (!finalTranscript) {
+          resetTranscript()
           resumeListening()
 
           return
@@ -335,8 +431,9 @@ export function useVoiceConversation({
         // A spoken stop command while barging means "stop everything" — the
         // turn/playback was already cut at trip time; now end the conversation
         // instead of submitting "stop" as a new prompt.
-        if (isVoiceStopCommand(transcript)) {
+        if (isVoiceStopCommand(finalTranscript)) {
           dropSpeechSession()
+          resetTranscript()
           setStatus('idle')
           onStopWordRef.current?.()
 
@@ -354,10 +451,14 @@ export function useVoiceConversation({
         awaitingSpokenResponseRef.current = true
         dropSpeechSession()
         consumePendingResponse()
-        await onSubmit(transcript)
+        transcriptGenerationRef.current += 1
+        partialTranscriptionGenerationRef.current = null
+        setTranscript(finalTranscript)
+        await onSubmit(finalTranscript)
         setStatus('thinking')
       } catch (error) {
         notifyError(error, voiceCopy.transcriptionFailed)
+        resetTranscript()
         resumeListening()
       }
     },
@@ -608,6 +709,7 @@ export function useVoiceConversation({
     awaitingSpokenResponseRef.current = false
     dropSpeechSession()
     consumePendingResponse()
+    resetTranscript()
     setMuted(false)
     setStatus('idle')
   }, [consumePendingResponse, handle])
@@ -732,5 +834,5 @@ export function useVoiceConversation({
     wasEnabledRef.current = enabled
   }, [enabled, end, start])
 
-  return { end, level, muted, start, status, stopTurn, toggleMute }
+  return { end, level, muted, start, status, stopTurn, toggleMute, transcript }
 }

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -925,7 +925,8 @@ export function ChatBar({
         onStart: startConversation,
         onStopTurn: conversation.stopTurn,
         onToggleMute: conversation.toggleMute,
-        status: conversation.status
+        status: conversation.status,
+        transcript: conversation.transcript
       }}
       disabled={disabled}
       hasComposerPayload={hasComposerPayload}

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -17,6 +17,11 @@ export interface QuickModelOption {
   model: string
 }
 
+export interface AudioTranscriptionOptions {
+  localOnly?: boolean
+  previewOnly?: boolean
+}
+
 export interface ChatBarState {
   model: {
     model: string
@@ -53,7 +58,7 @@ export interface ChatBarProps {
   onRemoveAttachment?: (id: string) => void
   onSteer?: (text: string) => Promise<boolean> | boolean
   onSubmit: (value: string, options?: SubmitTextOptions) => Promise<boolean> | boolean
-  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  onTranscribeAudio?: (audio: Blob, options?: AudioTranscriptionOptions) => Promise<string>
 }
 
 export type VoiceStatus = 'idle' | 'recording' | 'transcribing'

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -55,7 +55,7 @@ import { ChatBar, ChatBarFallback } from './composer'
 import { requestComposerInsert } from './composer/focus'
 import { droppedFileInlineRefs } from './composer/inline-refs'
 import { useComposerScope } from './composer/scope'
-import type { ChatBarState } from './composer/types'
+import type { AudioTranscriptionOptions, ChatBarState } from './composer/types'
 import { type DroppedFile, partitionDroppedFiles } from './hooks/use-composer-actions'
 import { type DragKind, useFileDropZone } from './hooks/use-file-drop-zone'
 import { ProfileTag } from './profile-tag'
@@ -90,7 +90,7 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onReload: (parentId: string | null) => Promise<void>
   onRestoreToMessage?: (messageId: string, target?: { text?: string; userOrdinal?: number | null }) => Promise<void>
   onRetryResume: (sessionId: string) => void
-  onTranscribeAudio?: (audio: Blob) => Promise<string>
+  onTranscribeAudio?: (audio: Blob, options?: AudioTranscriptionOptions) => Promise<string>
   onDismissError?: (messageId: string) => void
 }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -2,6 +2,7 @@ import type { AppendMessage, ThreadMessage } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
+import type { AudioTranscriptionOptions } from '@/app/chat/composer/types'
 import { PROMPT_SUBMIT_REQUEST_TIMEOUT_MS, transcribeAudio } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { stripAnsi } from '@/lib/ansi'
@@ -558,13 +559,13 @@ export function usePromptActions({
   )
 
   const transcribeVoiceAudio = useCallback(
-    async (audio: Blob) => {
+    async (audio: Blob, options?: AudioTranscriptionOptions) => {
       if (!sttEnabled) {
         throw new Error(copy.sttDisabled)
       }
 
       const dataUrl = await blobToDataUrl(audio)
-      const result = await transcribeAudio(dataUrl, audio.type)
+      const result = await transcribeAudio(dataUrl, audio.type, options)
 
       return result.transcript
     },

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -764,6 +764,7 @@ export interface HermesApiRequest {
   // ArrayBuffer. Token-mode backends only.
   upload?: { filename: string; contentType?: string; bytes: ArrayBuffer }
   timeoutMs?: number
+  requireLocalBackend?: boolean
   // Route this REST call to a specific profile's backend. Omit for the primary
   // (window) backend. Read-only cross-profile data is served by the primary, so
   // this is only needed for profile-scoped live/settings calls.

--- a/apps/desktop/src/hermes-transcription.test.ts
+++ b/apps/desktop/src/hermes-transcription.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setApiRequestProfile, transcribeAudio } from './hermes'
+
+describe('transcribeAudio preview routing', () => {
+  const api = vi.fn()
+  const getConnectionConfig = vi.fn()
+
+  beforeEach(() => {
+    api.mockReset()
+    getConnectionConfig.mockReset()
+
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { api, getConnectionConfig }
+    })
+  })
+
+  afterEach(() => {
+    setApiRequestProfile(null)
+  })
+
+  it('fails closed without sending preview audio when the backend is remote', async () => {
+    getConnectionConfig.mockResolvedValue({ mode: 'remote' })
+
+    await expect(
+      transcribeAudio('data:audio/webm;base64,cHJpdmF0ZQ==', 'audio/webm', {
+        localOnly: true,
+        previewOnly: true
+      })
+    ).rejects.toThrow('local Hermes backend')
+
+    expect(api).not.toHaveBeenCalled()
+  })
+
+  it('validates and sends preview audio through the same local profile', async () => {
+    setApiRequestProfile('work')
+    getConnectionConfig.mockResolvedValue({ mode: 'local' })
+    api.mockResolvedValue({ text: '부분 문장' })
+
+    await expect(
+      transcribeAudio('data:audio/webm;base64,bG9jYWw=', 'audio/webm', {
+        localOnly: true,
+        previewOnly: true
+      })
+    ).resolves.toEqual({ text: '부분 문장' })
+
+    expect(getConnectionConfig).toHaveBeenCalledWith('work')
+    expect(api).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body: expect.objectContaining({ local_only: true, preview_only: true }),
+        path: '/api/audio/transcribe',
+        profile: 'work',
+        requireLocalBackend: true
+      })
+    )
+  })
+})

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -384,9 +384,15 @@ describe('Hermes REST helpers', () => {
     })
 
     expect(api).toHaveBeenCalledWith({
-      body: { data_url: 'data:audio/webm;base64,AA==', mime_type: 'audio/webm' },
+      body: {
+        data_url: 'data:audio/webm;base64,AA==',
+        local_only: false,
+        mime_type: 'audio/webm',
+        preview_only: false
+      },
       method: 'POST',
       path: '/api/audio/transcribe',
+      requireLocalBackend: false,
       timeoutMs: AUDIO_TRANSCRIBE_MIN_REQUEST_TIMEOUT_MS
     })
   })

--- a/apps/desktop/src/hermes.ts
+++ b/apps/desktop/src/hermes.ts
@@ -1594,19 +1594,35 @@ export function getActionStatus(name: string, lines = 200): Promise<ActionStatus
   })
 }
 
-export function transcribeAudio(dataUrl: string, mimeType?: string): Promise<AudioTranscriptionResponse> {
+export async function transcribeAudio(
+  dataUrl: string,
+  mimeType?: string,
+  options?: { localOnly?: boolean; previewOnly?: boolean }
+): Promise<AudioTranscriptionResponse> {
+  if (options?.previewOnly) {
+    const connection = await window.hermesDesktop.getConnectionConfig(_apiProfile)
+
+    if (connection.mode !== 'local') {
+      throw new Error('Live transcription previews require a local Hermes backend')
+    }
+  }
+
   return window.hermesDesktop.api<AudioTranscriptionResponse>({
+    ...profileScoped(),
     path: '/api/audio/transcribe',
     method: 'POST',
-    ...profileScoped(),
+    requireLocalBackend: options?.previewOnly ?? false,
     body: {
       data_url: dataUrl,
-      mime_type: mimeType
+      mime_type: mimeType,
+      local_only: options?.localOnly ?? false,
+      preview_only: options?.previewOnly ?? false
     },
     // Transcription blocks until provider STT, file handling, and response
     // encoding finish. Remote providers and long clips regularly exceed the
-    // default 15s Electron backend timeout.
-    timeoutMs: audioTranscribeRequestTimeoutMs(dataUrl)
+    // default 15s Electron backend timeout. Previews are capped short on
+    // purpose — a slow preview is discarded, never awaited.
+    timeoutMs: options?.previewOnly ? 15_000 : audioTranscribeRequestTimeoutMs(dataUrl)
   })
 }
 

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -95,6 +95,10 @@ class WhatsAppOnboardingApply(BaseModel):
 class AudioTranscriptionRequest(BaseModel):
     data_url: str
     mime_type: Optional[str] = None
+    # Desktop voice composer: force on-device STT, and run a bounded
+    # best-effort preview pass whose result never overrides the final one.
+    local_only: bool = False
+    preview_only: bool = False
 
 
 class ManagedFileUpload(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -29,6 +29,7 @@ import json
 import logging
 import math
 import mimetypes
+import multiprocessing
 import os
 import queue
 import re
@@ -1413,6 +1414,172 @@ _AUDIO_MIME_EXTENSIONS: Dict[str, str] = {
     "video/webm": ".webm",
 }
 _MAX_TRANSCRIPTION_UPLOAD_BYTES = 25 * 1024 * 1024
+_PARTIAL_TRANSCRIPTION_TIMEOUT_SECONDS = 12.0
+_PARTIAL_TRANSCRIPTION_LOCK = threading.Lock()
+_ACTIVE_PREVIEW_PROCESS_LOCK = threading.Lock()
+_ACTIVE_PREVIEW_PROCESS = None
+_ACTIVE_FINAL_TRANSCRIPTIONS = 0
+
+
+def _local_preview_process_worker(file_path: str, result_connection) -> None:
+    """Run best-effort local preview STT in a process that can be terminated."""
+    try:
+        from tools.transcription_tools import transcribe_audio
+
+        result_connection.send(
+            ("result", transcribe_audio(file_path, provider_override="local"))
+        )
+    except BaseException as exc:
+        result_connection.send(("error", f"{type(exc).__name__}: {exc}"))
+    finally:
+        result_connection.close()
+
+
+def _stop_preview_process(process, join_timeout: float = 1.0) -> None:
+    if process is None or not process.is_alive():
+        return
+    process.terminate()
+    process.join(join_timeout)
+    if process.is_alive() and hasattr(process, "kill"):
+        process.kill()
+        process.join(join_timeout)
+
+
+def _cleanup_preview_process(process) -> None:
+    """Best-effort cleanup, including a Process whose start partially failed."""
+    if process is None:
+        return
+    try:
+        _stop_preview_process(process)
+    except (AssertionError, OSError, ValueError):
+        pass
+    try:
+        process.join(1.0)
+    except (AssertionError, OSError, ValueError):
+        # multiprocessing raises AssertionError when start failed before the
+        # child was created. There is nothing to join in that case.
+        pass
+    try:
+        process.close()
+    except (AttributeError, OSError, ValueError):
+        pass
+
+
+def _cancel_active_preview_process() -> None:
+    """Cancel and detach the active preview without waiting under its lock."""
+    global _ACTIVE_PREVIEW_PROCESS
+
+    with _ACTIVE_PREVIEW_PROCESS_LOCK:
+        process = _ACTIVE_PREVIEW_PROCESS
+        _ACTIVE_PREVIEW_PROCESS = None
+    _cleanup_preview_process(process)
+
+
+def _begin_final_transcription_priority() -> None:
+    """Atomically block new previews and detach the currently active one."""
+    global _ACTIVE_FINAL_TRANSCRIPTIONS, _ACTIVE_PREVIEW_PROCESS
+
+    with _ACTIVE_PREVIEW_PROCESS_LOCK:
+        _ACTIVE_FINAL_TRANSCRIPTIONS += 1
+        process = _ACTIVE_PREVIEW_PROCESS
+        _ACTIVE_PREVIEW_PROCESS = None
+    # Never wait for a child while holding the state lock. Its preview thread
+    # needs that lock in its own cleanup path.
+    try:
+        _cleanup_preview_process(process)
+    except BaseException:
+        _end_final_transcription_priority()
+        raise
+
+
+def _end_final_transcription_priority() -> None:
+    global _ACTIVE_FINAL_TRANSCRIPTIONS
+
+    with _ACTIVE_PREVIEW_PROCESS_LOCK:
+        _ACTIVE_FINAL_TRANSCRIPTIONS -= 1
+
+
+def _release_final_priority_after_acquisition(future) -> None:
+    """Release priority once a cancelled request's acquisition really finishes."""
+    try:
+        future.result()
+    except BaseException:
+        # A failed acquisition never transferred ownership to the request.
+        return
+    _end_final_transcription_priority()
+
+
+def _finish_cancelled_final_transcription(future, temp_path: str) -> None:
+    """Keep final priority and its input alive until executor work really ends."""
+    try:
+        future.exception()
+    except BaseException:
+        # The request is already gone; retrieve the result/exception only to
+        # avoid an unobserved-future warning. Endpoint behavior is unchanged.
+        pass
+    finally:
+        _end_final_transcription_priority()
+        try:
+            os.unlink(temp_path)
+        except OSError:
+            pass
+
+
+def _run_local_preview_isolated(
+    file_path: str,
+    timeout_seconds: float,
+    worker_target=None,
+) -> Dict[str, Any]:
+    """Run preview STT in bounded process isolation.
+
+    Python threads cannot cancel a hung faster-whisper call, so a timed-out
+    thread could retain the singleton model lock forever. A dedicated spawned
+    process owns its own model instance and is forcibly reaped on timeout or
+    when a final request arrives; the authoritative in-process model is never
+    locked by preview work.
+    """
+    global _ACTIVE_PREVIEW_PROCESS
+
+    receive_connection = None
+    send_connection = None
+    process = None
+    try:
+        context = multiprocessing.get_context("spawn")
+        receive_connection, send_connection = context.Pipe(duplex=False)
+        process = context.Process(
+            target=worker_target or _local_preview_process_worker,
+            args=(file_path, send_connection),
+            daemon=True,
+        )
+
+        # Launch and registration are one state transition with final-priority
+        # claiming. If a final request wins the lock, this preview never starts;
+        # if launch wins, the final request sees and reaps the registered child.
+        with _ACTIVE_PREVIEW_PROCESS_LOCK:
+            if _ACTIVE_FINAL_TRANSCRIPTIONS:
+                raise TimeoutError("Local preview transcription was cancelled")
+            process.start()
+            _ACTIVE_PREVIEW_PROCESS = process
+
+        send_connection.close()
+        if not receive_connection.poll(timeout_seconds):
+            raise TimeoutError("Local preview transcription timed out")
+        try:
+            kind, value = receive_connection.recv()
+        except EOFError as exc:
+            raise TimeoutError("Local preview transcription was cancelled") from exc
+        if kind == "error":
+            raise RuntimeError(value)
+        return value
+    finally:
+        with _ACTIVE_PREVIEW_PROCESS_LOCK:
+            if _ACTIVE_PREVIEW_PROCESS is process:
+                _ACTIVE_PREVIEW_PROCESS = None
+        _cleanup_preview_process(process)
+        if send_connection is not None:
+            send_connection.close()
+        if receive_connection is not None:
+            receive_connection.close()
 
 
 def _audio_extension_for_mime(mime_type: str) -> str:
@@ -4305,6 +4472,12 @@ async def check_hermes_update(force: bool = False):
 async def transcribe_audio_upload(
     payload: AudioTranscriptionRequest, profile: Optional[str] = None
 ):
+    if payload.preview_only and not payload.local_only:
+        raise HTTPException(
+            status_code=400,
+            detail="Preview transcription must use the local provider",
+        )
+
     data_url = (payload.data_url or "").strip()
     if not data_url.startswith("data:") or "," not in data_url:
         raise HTTPException(status_code=400, detail="Invalid audio payload")
@@ -4337,8 +4510,19 @@ async def transcribe_audio_upload(
     if len(audio_bytes) > _MAX_TRANSCRIPTION_UPLOAD_BYTES:
         raise HTTPException(status_code=413, detail="Audio recording is too large")
 
+    preview_lock_acquired = False
+    final_priority_acquired = False
     temp_path = ""
+    result: Dict[str, Any] = {}
     try:
+        if payload.preview_only:
+            preview_lock_acquired = _PARTIAL_TRANSCRIPTION_LOCK.acquire(blocking=False)
+            if not preview_lock_acquired:
+                raise HTTPException(
+                    status_code=429,
+                    detail="A local preview transcription is already running",
+                )
+
         suffix = _audio_extension_for_mime(mime_type)
         with tempfile.NamedTemporaryFile(
             prefix="hermes-desktop-voice-",
@@ -4361,16 +4545,65 @@ async def transcribe_audio_upload(
             # probe above). STT only needs config/.env resolution, which the
             # contextvar override provides inside this worker thread.
             with _config_profile_scope(profile):
+                # Pass provider_override only when the caller actually demands
+                # locality, so the ordinary path stays byte-identical to the
+                # plain transcribe_recording(path) call it has always been.
+                if payload.local_only:
+                    return transcribe_recording(temp_path, provider_override="local")
+
                 return transcribe_recording(temp_path)
 
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, _transcribe_scoped)
+        if payload.preview_only:
+            try:
+                result = await asyncio.to_thread(
+                    _run_local_preview_isolated,
+                    temp_path,
+                    _PARTIAL_TRANSCRIPTION_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                raise HTTPException(
+                    status_code=504,
+                    detail="Local preview transcription timed out",
+                )
+        else:
+            # Final transcription is authoritative. Claim priority before
+            # entering any provider/model path, then hold it until the final
+            # call completes so no new preview can overlap it.
+            priority_acquisition = asyncio.create_task(
+                asyncio.to_thread(_begin_final_transcription_priority)
+            )
+            try:
+                await asyncio.shield(priority_acquisition)
+            except asyncio.CancelledError:
+                priority_acquisition.add_done_callback(
+                    _release_final_priority_after_acquisition
+                )
+                raise
+            final_priority_acquired = True
+
+            final_transcription = loop.run_in_executor(None, _transcribe_scoped)
+            try:
+                result = await asyncio.shield(final_transcription)
+            except asyncio.CancelledError:
+                final_priority_acquired = False
+                cancelled_temp_path, temp_path = temp_path, ""
+                final_transcription.add_done_callback(
+                    lambda future, path=cancelled_temp_path: (
+                        _finish_cancelled_final_transcription(future, path)
+                    )
+                )
+                raise
     except HTTPException:
         raise
     except Exception as exc:
         _log.exception("Desktop voice transcription failed")
         raise HTTPException(status_code=500, detail=f"Transcription failed: {exc}")
     finally:
+        if final_priority_acquired:
+            _end_final_transcription_priority()
+        if preview_lock_acquired:
+            _PARTIAL_TRANSCRIPTION_LOCK.release()
         if temp_path:
             try:
                 os.unlink(temp_path)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -14,6 +14,54 @@ from unittest.mock import patch, MagicMock
 import pytest
 import yaml
 
+
+def _hang_preview_process_forever(_file_path, _result_connection):
+    """Picklable spawn target for preview-cancellation regression coverage."""
+    import time
+
+    while True:
+        time.sleep(60)
+
+
+def _assert_preview_launch_is_blocked(web_server, monkeypatch):
+    """Prove final priority rejects a preview before its process can start."""
+    started = False
+
+    class FakeConnection:
+        def close(self):
+            pass
+
+    class FakeProcess:
+        def start(self):
+            nonlocal started
+            started = True
+
+        def is_alive(self):
+            return False
+
+        def join(self, _timeout=None):
+            pass
+
+        def close(self):
+            pass
+
+    class FakeContext:
+        def Pipe(self, *, duplex):
+            assert duplex is False
+            return FakeConnection(), FakeConnection()
+
+        def Process(self, **_kwargs):
+            return FakeProcess()
+
+    monkeypatch.setattr(
+        web_server.multiprocessing, "get_context", lambda _method: FakeContext()
+    )
+
+    with pytest.raises(TimeoutError, match="cancelled"):
+        web_server._run_local_preview_isolated("preview.webm", 0.1)
+    assert started is False
+
+
 from hermes_cli.config import (
     reload_env,
     redact_key,
@@ -919,16 +967,467 @@ class TestWebServerEndpoints:
         ]
 
 
+    def test_audio_transcription_can_force_local_provider(self, monkeypatch):
+        """local_only must survive the whole endpoint → transcribe_recording →
+        transcribe_audio chain and land as provider_override='local'."""
+        import tools.transcription_tools as transcription_tools
 
+        captured = {}
 
+        def fake_transcribe_audio(path, model=None, *, provider_override=None):
+            captured["provider_override"] = provider_override
+            return {
+                "success": True,
+                "transcript": "local caption",
+                "provider": "local",
+            }
 
+        monkeypatch.setattr(transcription_tools, "transcribe_audio", fake_transcribe_audio)
 
+        resp = self.client.post(
+            "/api/audio/transcribe",
+            json={
+                "data_url": "data:audio/webm;base64,aGVsbG8=",
+                "mime_type": "audio/webm",
+                "local_only": True,
+            },
+        )
 
+        assert resp.status_code == 200
+        assert captured["provider_override"] == "local"
 
+    def test_audio_preview_transcription_requires_local_provider(self):
+        resp = self.client.post(
+            "/api/audio/transcribe",
+            json={
+                "data_url": "data:audio/webm;base64,aGVsbG8=",
+                "mime_type": "audio/webm",
+                "preview_only": True,
+            },
+        )
 
+        assert resp.status_code == 400
+        assert "local provider" in resp.json()["detail"]
 
+    def test_audio_preview_timeout_removes_temp_file(self, monkeypatch):
+        import hermes_cli.web_server as web_server
 
+        captured = {"path": ""}
 
+        def fake_isolated_preview(path, _timeout):
+            captured["path"] = path
+            raise TimeoutError("hung preview")
+
+        monkeypatch.setattr(web_server, "_run_local_preview_isolated", fake_isolated_preview)
+
+        payload = {
+            "data_url": "data:audio/webm;base64,aGVsbG8=",
+            "mime_type": "audio/webm",
+            "local_only": True,
+            "preview_only": True,
+        }
+
+        timed_out = self.client.post("/api/audio/transcribe", json=payload)
+
+        assert timed_out.status_code == 504
+        assert captured["path"]
+        assert not Path(captured["path"]).exists()
+        assert not web_server._PARTIAL_TRANSCRIPTION_LOCK.locked()
+
+    def test_audio_preview_rejects_when_worker_lock_is_held(self):
+        import hermes_cli.web_server as web_server
+
+        acquired = web_server._PARTIAL_TRANSCRIPTION_LOCK.acquire(blocking=False)
+        assert acquired
+
+        try:
+            resp = self.client.post(
+                "/api/audio/transcribe",
+                json={
+                    "data_url": "data:audio/webm;base64,aGVsbG8=",
+                    "mime_type": "audio/webm",
+                    "local_only": True,
+                    "preview_only": True,
+                },
+            )
+        finally:
+            web_server._PARTIAL_TRANSCRIPTION_LOCK.release()
+
+        assert resp.status_code == 429
+
+    def test_permanently_hung_preview_cannot_starve_final_transcription(self, monkeypatch, tmp_path):
+        import time
+        from concurrent.futures import ThreadPoolExecutor
+
+        import hermes_cli.web_server as web_server
+        import tools.transcription_tools as transcription_tools
+
+        monkeypatch.setattr(
+            transcription_tools,
+            "transcribe_audio",
+            lambda _path, **_kwargs: {
+                "success": True,
+                "transcript": "authoritative final",
+                "provider": "local",
+            },
+        )
+
+        preview_file = tmp_path / "preview.webm"
+        preview_file.write_bytes(b"preview")
+        final_payload = {
+            "data_url": "data:audio/webm;base64,aGVsbG8=",
+            "mime_type": "audio/webm",
+            "local_only": True,
+        }
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            preview = executor.submit(
+                web_server._run_local_preview_isolated,
+                str(preview_file),
+                60.0,
+                _hang_preview_process_forever,
+            )
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                with web_server._ACTIVE_PREVIEW_PROCESS_LOCK:
+                    process = web_server._ACTIVE_PREVIEW_PROCESS
+                if process is not None and process.is_alive():
+                    break
+                time.sleep(0.01)
+            else:
+                pytest.fail("hung preview process did not start")
+
+            started = time.monotonic()
+            final_response = self.client.post("/api/audio/transcribe", json=final_payload)
+            elapsed = time.monotonic() - started
+
+            with pytest.raises(TimeoutError, match="cancelled"):
+                preview.result(timeout=3)
+
+        assert final_response.status_code == 200
+        assert final_response.json()["transcript"] == "authoritative final"
+        assert elapsed < 3.0
+
+    def test_final_priority_serializes_paused_preview_launch(self, monkeypatch):
+        import threading
+        from concurrent.futures import ThreadPoolExecutor
+
+        import hermes_cli.web_server as web_server
+
+        launch_entered = threading.Event()
+        allow_launch = threading.Event()
+        final_attempted = threading.Event()
+        final_started = threading.Event()
+        allow_final_finish = threading.Event()
+
+        class FakeConnection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+            def poll(self, timeout):
+                assert process.terminated.wait(timeout)
+                return True
+
+            def recv(self):
+                raise EOFError
+
+        receive_connection = FakeConnection()
+        send_connection = FakeConnection()
+
+        class PausedStartProcess:
+            def __init__(self):
+                self.alive = False
+                self.terminated = threading.Event()
+                self.joined = False
+                self.closed = False
+
+            def start(self):
+                launch_entered.set()
+                assert allow_launch.wait(2)
+                self.alive = True
+
+            def is_alive(self):
+                return self.alive
+
+            def terminate(self):
+                self.alive = False
+                self.terminated.set()
+
+            def join(self, _timeout=None):
+                self.joined = True
+
+            def close(self):
+                self.closed = True
+
+        process = PausedStartProcess()
+
+        class FakeContext:
+            def Pipe(self, *, duplex):
+                assert duplex is False
+                return receive_connection, send_connection
+
+            def Process(self, **_kwargs):
+                return process
+
+        monkeypatch.setattr(
+            web_server.multiprocessing, "get_context", lambda method: FakeContext()
+        )
+
+        def run_final_transcription():
+            final_attempted.set()
+            web_server._begin_final_transcription_priority()
+            try:
+                # This represents the authoritative STT call. It must not begin
+                # until the paused launch is registered and then terminated.
+                assert not process.is_alive()
+                final_started.set()
+                assert allow_final_finish.wait(2)
+            finally:
+                web_server._end_final_transcription_priority()
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            preview = executor.submit(
+                web_server._run_local_preview_isolated, "preview.webm", 2.0
+            )
+            assert launch_entered.wait(2)
+
+            final = executor.submit(run_final_transcription)
+            assert final_attempted.wait(2)
+            assert not final_started.wait(0.1)
+
+            allow_launch.set()
+            assert final_started.wait(2)
+            assert process.terminated.is_set()
+            assert not process.is_alive()
+            allow_final_finish.set()
+
+            final.result(timeout=2)
+            with pytest.raises(TimeoutError, match="cancelled"):
+                preview.result(timeout=2)
+
+        assert web_server._ACTIVE_PREVIEW_PROCESS is None
+        assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0
+        assert not web_server._ACTIVE_PREVIEW_PROCESS_LOCK.locked()
+        assert receive_connection.closed
+        assert send_connection.closed
+
+    def test_cancel_during_final_priority_acquisition_releases_after_preview_cleanup(
+        self, monkeypatch
+    ):
+        import threading
+
+        import hermes_cli.web_server as web_server
+        import tools.transcription_tools as transcription_tools
+
+        cleanup_started = threading.Event()
+        allow_cleanup = threading.Event()
+        active_preview = object()
+        original_cleanup = web_server._cleanup_preview_process
+
+        def blocking_cleanup(process):
+            if process is active_preview:
+                cleanup_started.set()
+                assert allow_cleanup.wait(2)
+                return
+            original_cleanup(process)
+
+        monkeypatch.setattr(web_server, "_cleanup_preview_process", blocking_cleanup)
+        monkeypatch.setattr(
+            transcription_tools,
+            "transcribe_audio",
+            lambda *_args, **_kwargs: pytest.fail(
+                "cancelled acquisition must not start final transcription"
+            ),
+        )
+        with web_server._ACTIVE_PREVIEW_PROCESS_LOCK:
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0
+            web_server._ACTIVE_PREVIEW_PROCESS = active_preview
+
+        async def scenario():
+            request = asyncio.create_task(
+                web_server.transcribe_audio_upload(
+                    web_server.AudioTranscriptionRequest(
+                        data_url="data:audio/webm;base64,aGVsbG8=",
+                        mime_type="audio/webm",
+                        local_only=True,
+                    )
+                )
+            )
+            assert await asyncio.to_thread(cleanup_started.wait, 2)
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 1
+
+            request.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await request
+
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 1
+            _assert_preview_launch_is_blocked(web_server, monkeypatch)
+
+            allow_cleanup.set()
+            for _ in range(100):
+                if web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            allow_cleanup.set()
+            with web_server._ACTIVE_PREVIEW_PROCESS_LOCK:
+                web_server._ACTIVE_PREVIEW_PROCESS = None
+
+    def test_cancel_during_final_executor_holds_priority_and_temp_file_until_done(
+        self, monkeypatch
+    ):
+        import threading
+
+        import hermes_cli.web_server as web_server
+        import tools.transcription_tools as transcription_tools
+
+        transcription_started = threading.Event()
+        allow_transcription = threading.Event()
+        captured = {"path": ""}
+
+        def blocking_transcription(path, **_kwargs):
+            captured["path"] = path
+            transcription_started.set()
+            assert allow_transcription.wait(2)
+            return {
+                "success": True,
+                "transcript": "cancelled final",
+                "provider": "local",
+            }
+
+        monkeypatch.setattr(
+            transcription_tools, "transcribe_audio", blocking_transcription
+        )
+
+        async def scenario():
+            request = asyncio.create_task(
+                web_server.transcribe_audio_upload(
+                    web_server.AudioTranscriptionRequest(
+                        data_url="data:audio/webm;base64,aGVsbG8=",
+                        mime_type="audio/webm",
+                        local_only=True,
+                    )
+                )
+            )
+            assert await asyncio.to_thread(transcription_started.wait, 2)
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 1
+
+            request.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await request
+
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 1
+            assert Path(captured["path"]).exists()
+            _assert_preview_launch_is_blocked(web_server, monkeypatch)
+
+            allow_transcription.set()
+            for _ in range(100):
+                if web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0:
+                    break
+                await asyncio.sleep(0.01)
+            assert web_server._ACTIVE_FINAL_TRANSCRIPTIONS == 0
+            assert not Path(captured["path"]).exists()
+
+        try:
+            asyncio.run(scenario())
+        finally:
+            allow_transcription.set()
+
+    def test_preview_start_failure_cleans_resources_and_endpoint_lock(
+        self, monkeypatch
+    ):
+        import hermes_cli.web_server as web_server
+
+        class FakeConnection:
+            def __init__(self):
+                self.closed = False
+
+            def close(self):
+                self.closed = True
+
+        receive_connection = FakeConnection()
+        send_connection = FakeConnection()
+
+        class PartiallyStartedProcess:
+            def __init__(self):
+                self.alive = False
+                self.terminated = False
+                self.joined = False
+                self.closed = False
+
+            def start(self):
+                self.alive = True
+                raise RuntimeError("simulated process.start failure")
+
+            def is_alive(self):
+                return self.alive
+
+            def terminate(self):
+                self.terminated = True
+                self.alive = False
+
+            def join(self, _timeout=None):
+                self.joined = True
+
+            def close(self):
+                self.closed = True
+
+        process = PartiallyStartedProcess()
+
+        class FakeContext:
+            def Pipe(self, *, duplex):
+                assert duplex is False
+                return receive_connection, send_connection
+
+            def Process(self, **_kwargs):
+                return process
+
+        monkeypatch.setattr(
+            web_server.multiprocessing, "get_context", lambda method: FakeContext()
+        )
+
+        response = self.client.post(
+            "/api/audio/transcribe",
+            json={
+                "data_url": "data:audio/webm;base64,aGVsbG8=",
+                "mime_type": "audio/webm",
+                "local_only": True,
+                "preview_only": True,
+            },
+        )
+
+        assert response.status_code == 500
+        assert "simulated process.start failure" in response.json()["detail"]
+        assert receive_connection.closed
+        assert send_connection.closed
+        assert process.terminated
+        assert process.joined
+        assert process.closed
+        assert web_server._ACTIVE_PREVIEW_PROCESS is None
+        assert not web_server._ACTIVE_PREVIEW_PROCESS_LOCK.locked()
+        assert not web_server._PARTIAL_TRANSCRIPTION_LOCK.locked()
+
+    def test_desktop_audio_routes_registered(self):
+        """All three desktop voice endpoints must exist.
+
+        The renderer (apps/desktop) calls /api/audio/transcribe, /speak, and
+        /elevenlabs/voices. /speak + /voices were silently dropped in a merge
+        once; this guards the contract so a future merge can't lose them
+        without failing CI.
+        """
+        from hermes_cli.web_server import app
+
+        paths = {getattr(r, "path", None) for r in app.routes}
+        assert "/api/audio/transcribe" in paths
+        assert "/api/audio/speak" in paths
+        assert "/api/audio/elevenlabs/voices" in paths
 
     def test_latest_descendant_survives_parent_cycle(self):
         """Regression for the #39140 CTE salvage: a corrupted parent chain

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -506,6 +506,25 @@ class TestValidateAudioFileEdgeCases:
 # ============================================================================
 
 class TestTranscribeAudioDispatch:
+    def test_provider_override_forces_local_without_cloud_fallback(self, sample_ogg):
+        """A local-pinned call must never reach the configured cloud provider."""
+        local_result = {"success": True, "transcript": "local", "provider": "local"}
+
+        with patch(
+            "tools.transcription_tools._load_stt_config",
+            return_value={"provider": "groq", "local": {"model": "small"}},
+        ), patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), patch(
+            "tools.transcription_tools._transcribe_local",
+            return_value=local_result,
+        ) as mock_local, patch("tools.transcription_tools._transcribe_groq") as mock_groq:
+            from tools.transcription_tools import transcribe_audio
+
+            result = transcribe_audio(sample_ogg, provider_override="local")
+
+        assert result == local_result
+        mock_local.assert_called_once_with(sample_ogg, "small")
+        mock_groq.assert_not_called()
+
     def test_oversized_local_file_reaches_dispatcher(self, oversized_wav):
         with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "local"}), \
              patch("tools.transcription_tools._get_provider", return_value="local"), \

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -1619,7 +1619,13 @@ def _join_confident_segments(segments: Any, local_cfg: Dict[str, Any]) -> str:
 
 
 def _transcribe_local(file_path: str, model_name: str) -> Dict[str, Any]:
-    """Transcribe using faster-whisper (local, free)."""
+    """Transcribe using the process-wide faster-whisper singleton.
+
+    Only the model *load* is serialized (see `_local_model_lock`), not the
+    transcription itself — desktop preview passes run in their own spawned
+    process (`_run_local_preview_isolated`), so they never contend for this
+    in-process model and must not be able to hold it hostage.
+    """
     global _local_model, _local_model_name
 
     if not _HAS_FASTER_WHISPER:
@@ -2351,7 +2357,12 @@ def _transcribe_deepinfra(file_path: str, model_name: str) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def _transcribe_prepared_audio(
+    file_path: str,
+    model: Optional[str] = None,
+    *,
+    provider_override: Optional[str] = None,
+) -> Dict[str, Any]:
     """
     Transcribe an audio file using the configured STT provider.
 
@@ -2362,6 +2373,7 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
     Args:
         file_path: Absolute path to the audio file to transcribe.
         model:     Override the model. If None, uses config or provider default.
+        provider_override: Force a provider for privacy-sensitive call sites.
 
     Returns:
         dict with keys:
@@ -2395,7 +2407,11 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
             "error": "STT is disabled in config.yaml (stt.enabled: false).",
         }
 
-    provider = _get_provider(stt_config)
+    provider = _get_provider(
+        {**stt_config, "provider": provider_override}
+        if provider_override
+        else stt_config
+    )
     if not _is_local_stt_provider(provider, stt_config):
         error = _validate_audio_file_size(Path(file_path))
         if error:
@@ -2521,8 +2537,18 @@ def _transcribe_prepared_audio(file_path: str, model: Optional[str] = None) -> D
     }
 
 
-def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, Any]:
-    """Safely validate, preprocess supported inputs, and dispatch transcription."""
+def transcribe_audio(
+    file_path: str,
+    model: Optional[str] = None,
+    *,
+    provider_override: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Safely validate, preprocess supported inputs, and dispatch transcription.
+
+    ``provider_override`` forces a specific STT provider for privacy-sensitive
+    call sites (desktop voice preview passes ``"local"`` so audio never leaves
+    the machine), bypassing config/auto-detect provider selection.
+    """
     # Refuse to feed a credential / secret store (auth.json, .env, OAuth
     # tokens, mcp-tokens/, ...) to an STT provider — before ANY validation or
     # preprocessing, so the refusal names the real reason rather than a
@@ -2554,7 +2580,9 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         prepared_error = _validate_audio_file(prepared_path, enforce_size_limit=False)
         if prepared_error:
             return prepared_error
-        return _transcribe_prepared_audio(prepared_path, model)
+        return _transcribe_prepared_audio(
+            prepared_path, model, provider_override=provider_override
+        )
     finally:
         if cleanup_dir:
             shutil.rmtree(cleanup_dir, ignore_errors=True)

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -1328,7 +1328,12 @@ def voice_stop_hint() -> str:
 # ============================================================================
 # STT dispatch
 # ============================================================================
-def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str, Any]:
+def transcribe_recording(
+    wav_path: str,
+    model: Optional[str] = None,
+    *,
+    provider_override: Optional[str] = None,
+) -> Dict[str, Any]:
     """Transcribe a WAV recording using the existing Whisper pipeline.
 
     Delegates to ``tools.transcription_tools.transcribe_audio()``.
@@ -1337,13 +1342,15 @@ def transcribe_recording(wav_path: str, model: Optional[str] = None) -> Dict[str
     Args:
         wav_path: Path to the WAV file.
         model: Whisper model name (default: from config or ``whisper-1``).
+        provider_override: Force an STT provider (``"local"`` keeps audio on
+            the machine for the desktop composer's local-only voice mode).
 
     Returns:
         Dict with ``success``, ``transcript``, and optionally ``error``.
     """
     from tools.transcription_tools import MAX_FILE_SIZE, transcribe_audio
 
-    result = transcribe_audio(wav_path, model=model)
+    result = transcribe_audio(wav_path, model=model, provider_override=provider_override)
 
     # Only chunk when the provider itself reports "File too large" —
     # local providers (faster-whisper, whisper.cpp, etc.) have no upload


### PR DESCRIPTION
## What does this PR do?

During a voice conversation the composer shows nothing while the user is still speaking — the first feedback arrives only after the whole utterance has been transcribed. On a slow provider that is several seconds of a blank screen with no signal that the mic is even hearing anything.

This adds a **live caption**: short slices of the in-progress recording are transcribed on-device and shown next to the voice controls, then replaced by the authoritative final transcription.

The design treats previews as strictly second-class, because a naive implementation of this feature is a privacy and reliability hazard:

- **Previews never leave the machine.** `transcribe_audio()` and `transcribe_recording()` accept a `provider_override`, and the desktop request carries `local_only`, so partial audio of a half-finished sentence is never shipped to a cloud STT provider. `preview_only` without `local_only` is rejected with a 400 rather than silently downgraded.
- **The IPC layer fails closed.** `requireLocalBackend` pins one concrete connection descriptor, skips remote session rerouting, and re-validates *that exact descriptor* immediately before transmission — so a config change while the handler awaits cannot land preview audio on a remote backend.
- **Previews cannot wedge the model.** A hung `faster-whisper` call can't be cancelled from a thread, so an in-process preview could hold the model singleton forever. Previews run in a spawned process with a 12s cap that is reaped on timeout or when a final request arrives; the in-process model is never held by preview work.
- **Final transcription always wins.** It claims priority before entering any provider path, which cancels the active preview and blocks new ones for the duration of the call.
- **Stale previews can't repaint.** Every turn boundary bumps a generation counter; a preview that resolves after its turn ended is dropped. Failed or timed-out previews are swallowed — a missing caption is cosmetic, and the final transcription still surfaces its own errors.

## Related Issue

No existing issue — I searched open and merged PRs and issues (`partial transcription`, `live caption`, `preview transcription`, `local_only transcribe`) and found nothing covering the desktop voice composer. The `live caption` hits are all `google-meet` plugin work, which is unrelated.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**Backend**

- `tools/transcription_tools.py` — `transcribe_audio()` / `_transcribe_prepared_audio()` take a keyword-only `provider_override` to pin a provider for privacy-sensitive call sites.
- `tools/voice_mode.py` — `transcribe_recording()` forwards `provider_override`, so the desktop path keeps hallucination filtering while pinning local STT.
- `hermes_cli/web_models.py` — `AudioTranscriptionRequest` gains `local_only` and `preview_only`.
- `hermes_cli/web_server.py` — process-isolated preview runner (`_run_local_preview_isolated`), final-transcription priority claim/release, single-preview lock, and cancellation-safe cleanup of the temp upload.

**Desktop**

- `apps/desktop/electron/api-backend-routing.ts` *(new)* — `resolveLocalitySensitiveBackend()` + `assertLocalBackendForRequest()`.
- `apps/desktop/electron/main.ts` — pins the backend for locality-sensitive requests, skips remote rerouting for them, and re-validates immediately before transmission.
- `apps/desktop/src/hermes.ts` — `transcribeAudio()` accepts `{ localOnly, previewOnly }`, sets `requireLocalBackend`, and caps preview requests at 15s.
- `apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts` — emits partial audio slices via `onPartialAudio` / `partialAudioMs` / `partialAudioMaxMs`.
- `apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts` — generation-guarded caption state and the preview pass.
- `apps/desktop/src/app/chat/composer/controls.tsx` — renders the caption (`aria-live="polite"`, truncated so long text can't push the controls off-row).
- `apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts`, `composer/types.ts`, `composer/index.tsx`, `chat/index.tsx`, `global.d.ts` — plumb the options through.

**Tests** — `api-backend-routing.test.ts`, `use-mic-recorder.test.tsx`, `hermes-transcription.test.ts`, plus new cases in `test_web_server.py`, `test_transcription_tools.py`, `use-voice-conversation.test.tsx`, `controls.test.tsx`.

## How to Test

1. Configure a local STT provider (`stt.provider: local`, or any config with `faster-whisper` installed) and start the desktop app.
2. Start a voice conversation and speak for more than ~3 seconds. A caption appears beside the voice controls while you are still talking, and is replaced by the final transcript when you stop.
3. Verify previews stay on-device — with a cloud provider configured (e.g. `stt.provider: groq`), previews still go to local whisper while the final transcription uses the configured provider:
   ```bash
   pytest tests/tools/test_transcription_tools.py -k provider_override -q
   pytest tests/hermes_cli/test_web_server.py -k "audio_transcription or preview" -q
   ```
4. Verify the endpoint refuses a cloud preview:
   ```bash
   curl -X POST localhost:8100/api/audio/transcribe \
     -H 'Content-Type: application/json' \
     -d '{"data_url":"data:audio/webm;base64,aGVsbG8=","preview_only":true}'
   # → 400 "Preview transcription must use the local provider"
   ```
5. Desktop suites:
   ```bash
   cd apps/desktop
   npm run typecheck
   npx vitest run --project electron   # 941 passed
   npx vitest run --project ui         # 3502 passed
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — **no regressions**, but see the note below: I could not get a fully green baseline locally, so I verified by differential comparison against an unmodified checkout instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Tahoe), Apple Silicon, Python 3.11.15, Node 26.7.0

**On the Python suite:** `pytest tests/ -q` is not green on my machine even on an unmodified checkout — an untouched worktree at the same base reports **1181 failed / 24906 passed**, mostly missing API keys, absent optional extras (e.g. `terminal.daytona`), and environment-path assumptions. Rather than claim a green run I can't produce, I diffed failure sets between my branch and a clean worktree at the same commit, running `tests/tools tests/hermes_cli` (the suites that exercise every module I touched) with `-p no:randomly` on both:

| | failed | passed |
|---|---|---|
| clean worktree @ `6e9cae6a` | 215 | 9680 |
| this branch | 215 | 9691 |

The failing sets are **identical** — `comm` reports no test failing here that doesn't already fail there, and none fixed. The +11 passed are the tests this PR adds.

That comparison caught one genuine regression, which is fixed in this branch: passing `provider_override=None` to `transcribe_recording()` on the ordinary path broke `TestProfileScopedAudio::test_transcribe_runs_inside_target_profile_home`, whose fake has a narrower signature. The call site now passes the kwarg only when `local_only` is set, so the default path is byte-identical to before.

Desktop suites are fully green: typecheck (app + electron + e2e) clean, `vitest --project electron` 941 passed, `vitest --project ui` 3502 passed.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on all new/changed functions; no user-facing docs describe this surface yet
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys; `local_only`/`preview_only` are per-request fields)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the preview worker uses `multiprocessing.get_context("spawn")`, which is the default on both macOS and Windows, so the child never inherits fork-unsafe state. Verified on macOS only; Windows/Linux testing would be welcome.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (`provider_override` is keyword-only and internal; the model-facing `transcribe_audio` tool schema is unchanged)

## Notes for reviewers

- `provider_override` is additive and keyword-only, so every existing caller of `transcribe_audio()` / `transcribe_recording()` is unaffected.
- The preview worker resolves config in a spawned process, so it uses the default profile rather than a request-scoped one. That is harmless today because previews are pinned to local STT (no per-profile credentials involved), but it is worth knowing if profile-scoped local model settings ever matter.
- Happy to split the `requireLocalBackend` IPC guard into its own PR if you'd prefer to review the privacy boundary separately from the UI feature.
