### PR TITLE
fix(kanban): recover cards guarded by stale PR evidence

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2500,6 +2500,10 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
                 for (tid, who, current) in res.skipped_per_profile_capped
             ],
             "auto_assigned_default": res.auto_assigned_default,
+            "respawn_guarded": [
+                {"task_id": tid, "reason": reason}
+                for (tid, reason) in res.respawn_guarded
+            ],
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -2537,6 +2541,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
         )
+    if res.respawn_guarded:
+        guarded = ", ".join(
+            f"{task_id} ({reason})" for task_id, reason in res.respawn_guarded
+        )
+        print(f"Deferred (respawn guard): {guarded}")
     return 0
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8051,6 +8051,8 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
         opened a PR; re-spawning risks a duplicate PR on the same task.
+        The guard does not apply before the task's first run, and a later
+        explicit re-queue supersedes older PR evidence.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -8133,12 +8135,39 @@ def check_respawn_guard(conn: sqlite3.Connection, task_id: str) -> Optional[str]
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    A task with no run history cannot have produced that PR; review and
+    #    merge tasks often cite an existing PR before their first claim.
+    prior_run = conn.execute(
+        "SELECT 1 FROM task_runs WHERE task_id = ? LIMIT 1",
+        (task_id,),
+    ).fetchone()
+    if not prior_run:
+        return None
+
+    #    As with recent_success, an explicit re-queue after the latest PR
+    #    comment is a deliberate request to continue the existing work.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
+    latest_pr_comment_at = None
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            latest_pr_comment_at = int(c["created_at"])
+            break
+
+    if latest_pr_comment_at is not None:
+        requeued_after = conn.execute(
+            "SELECT 1 FROM task_events "
+            "WHERE task_id = ? AND created_at > ? "
+            "AND kind IN ("
+            "'status', 'promoted', 'promoted_manual', 'unblocked', 'reclaimed'"
+            ") LIMIT 1",
+            (task_id, latest_pr_comment_at),
+        ).fetchone()
+        if not requeued_after:
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_active_pr_recovery.py
+++ b/tests/hermes_cli/test_kanban_active_pr_recovery.py
@@ -1,0 +1,132 @@
+"""Regression coverage for recoverable active-PR respawn guards."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _add_pr_comment(conn, task_id: str, created_at: int) -> None:
+    conn.execute(
+        "INSERT INTO task_comments (task_id, author, body, created_at) "
+        "VALUES (?, 'worker', ?, ?)",
+        (task_id, "Opened https://github.com/example/project/pull/42", created_at),
+    )
+
+
+def _add_blocked_run(conn, task_id: str, started_at: int) -> None:
+    conn.execute(
+        "INSERT INTO task_runs "
+        "(task_id, profile, status, started_at, ended_at, outcome) "
+        "VALUES (?, 'worker', 'blocked', ?, ?, 'blocked')",
+        (task_id, started_at, started_at + 1),
+    )
+
+
+def test_active_pr_does_not_guard_a_task_that_has_never_run(kanban_home):
+    """A first-run review/merge task can legitimately cite an existing PR."""
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Review PR", assignee="default")
+        _add_pr_comment(conn, task_id, now - 10)
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_active_pr_still_guards_prior_worker_output_without_requeue(kanban_home):
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Implement fix", assignee="default")
+        _add_blocked_run(conn, task_id, now - 30)
+        _add_pr_comment(conn, task_id, now - 10)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+@pytest.mark.parametrize(
+    "event_kind",
+    ["status", "promoted", "promoted_manual", "unblocked", "reclaimed"],
+)
+def test_active_pr_yields_to_a_later_explicit_requeue(kanban_home, event_kind):
+    """An explicit requeue after the PR handoff asks the task to continue."""
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Continue PR", assignee="default")
+        _add_blocked_run(conn, task_id, now - 40)
+        _add_pr_comment(conn, task_id, now - 20)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) VALUES (?, ?, ?)",
+            (task_id, event_kind, now - 10),
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_active_pr_keeps_same_second_requeue_guarded(kanban_home):
+    """Second-resolution ties fail closed because causality is ambiguous."""
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Continue PR", assignee="default")
+        _add_blocked_run(conn, task_id, now - 40)
+        _add_pr_comment(conn, task_id, now - 10)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'unblocked', ?)",
+            (task_id, now - 10),
+        )
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_active_pr_uses_latest_pr_comment_for_requeue_order(kanban_home):
+    """A requeue between two PR comments does not supersede newer evidence."""
+    now = int(time.time())
+    with kb.connect_closing() as conn:
+        task_id = kb.create_task(conn, title="Continue PR", assignee="default")
+        _add_blocked_run(conn, task_id, now - 50)
+        _add_pr_comment(conn, task_id, now - 30)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, created_at) "
+            "VALUES (?, 'unblocked', ?)",
+            (task_id, now - 20),
+        )
+        _add_pr_comment(conn, task_id, now - 10)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+
+def test_dispatch_json_exposes_respawn_guarded(kanban_home, monkeypatch, capsys):
+    """Deterministic supervisors must be able to reconcile guarded cards."""
+    from hermes_cli import kanban as kb_cli
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr(
+        kb,
+        "dispatch_once",
+        lambda conn, **kwargs: kb.DispatchResult(
+            respawn_guarded=[("t_guarded", "active_pr")]
+        ),
+    )
+    args = argparse.Namespace(dry_run=True, max=None, failure_limit=2, json=True)
+
+    assert kb_cli._cmd_dispatch(args) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["respawn_guarded"] == [
+        {"task_id": "t_guarded", "reason": "active_pr"}
+    ]


### PR DESCRIPTION
## Summary

Fix Kanban cards that remain in Ready with no worker because the active-PR respawn guard treats every recent PR URL as proof that the card already ran.

- require prior run history before `active_pr` can guard a card
- let a strictly later explicit requeue supersede the latest PR comment
- include the real `promoted_manual` event in that requeue path
- expose `respawn_guarded` cards and reasons in `hermes kanban dispatch --json` and text output

## Root cause

`check_respawn_guard()` previously returned `active_pr` for any recent PR URL in task comments. That incorrectly guarded first-run review/merge cards, and it ignored later unblock/promote/reclaim requests after a prior worker handed off a PR.

The dispatcher did retain `(task_id, reason)` in `DispatchResult.respawn_guarded`, but `_cmd_dispatch` omitted it from JSON and text output. Supervisors therefore saw a ready card with no worker but no machine-readable reason, which surfaced as `stranded_in_ready` and required manual diagnosis.

## Tests

- `tests/hermes_cli/test_kanban_active_pr_recovery.py`: 10 passed
- `tests/hermes_cli/test_kanban_cli_dispatch_passthrough.py`: 2 passed
- `tests/hermes_cli/test_kanban_db.py`: 30 passed
- `ruff check` on changed files: passed
- `py_compile` on changed Python files: passed
- `git diff --check`: passed

The new regressions cover first-run PR references, prior-worker guarding, all explicit requeue event kinds, same-second fail-closed ordering, latest-comment precedence, and dispatch JSON observability.

Closes #80231.

Related active-PR guard work: #74432, #65996. This PR combines the first-run case with requeue recovery and the CLI observability needed by deterministic supervisors.
