### PR TITLE
fix(delegation): resolve child fallback chains through the full pin x config matrix (#80450)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1662,6 +1662,9 @@ delegation:
   #                                           # delegation.model to an inexpensive one — children carry the
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1663,8 +1663,8 @@ delegation:
   #                                           # vast majority of tokens, so this is where spend is cut while
   #                                           # planning quality stays with the frontier parent.
   # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
-  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
-  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
+  #   - provider: "openrouter"                # top-level list). Pinned children use only a declared child chain;
+  #     model: "deepseek/deepseek-chat"       # unpinned children inherit when unset. [] disables fallback (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1303,6 +1303,9 @@ delegation:
   # provider: "openrouter"                    # Override provider for subagents (empty = inherit parent)
   #                                           # Resolves full credentials (base_url, api_key) automatically.
   #                                           # Supported: openrouter, nous, zai, kimi-coding, minimax
+  # fallback_providers:                       # Fallback chain for delegated children (same entry format as the
+  #   - provider: "openrouter"                # top-level fallback_providers list). Unset = inherit the parent
+  #     model: "deepseek/deepseek-chat"       # agent's chain; [] = disable child fallback entirely (#65038).
 
 # =============================================================================
 # Honcho Integration (Cross-Session User Modeling)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1211,6 +1211,11 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",  # e.g. "google/gemini-3-flash-preview" (empty = inherit parent)
         "provider": "",  # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        # Fallback chain for delegated children (same entry format as the top-level list).
+        # For an unpinned child, null = inherit the parent chain; [] = disable fallback.
+        # A child pinned by provider, endpoint, or model gets no fallback unless this
+        # setting declares one explicitly.
+        "fallback_providers": None,
         "base_url": "",  # direct OpenAI-compatible endpoint for subagents
         "api_key": "",  # key for delegation.base_url (falls back to OPENAI_API_KEY)
         # Wire protocol for delegation.base_url: "chat_completions" | "codex_responses" |

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1669,6 +1669,9 @@ DEFAULT_CONFIG = {
     "delegation": {
         "model": "",       # e.g. "google/gemini-3-flash-preview" (empty = inherit parent model)
         "provider": "",    # e.g. "openrouter" (empty = inherit parent provider + credentials)
+        "fallback_providers": None,  # fallback chain for delegated children, same entry
+                           # format as the top-level fallback_providers list. null =
+                           # inherit the parent agent's chain; [] = disable child fallback.
         "base_url": "",    # direct OpenAI-compatible endpoint for subagents
         "api_key": "",     # API key for delegation.base_url (falls back to OPENAI_API_KEY)
         "api_mode": "",    # wire protocol for delegation.base_url: "chat_completions",

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2125,7 +2125,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,
@@ -2146,7 +2149,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         parent._fallback_chain = []
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -1703,7 +1703,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
         parent._fallback_chain = [fallback_entry]
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,
@@ -1724,7 +1727,10 @@ class TestFallbackModelInheritance(unittest.TestCase):
         parent = _make_mock_parent(depth=0)
         parent._fallback_chain = []
 
-        with patch("run_agent.AIAgent") as MockAgent:
+        with (
+            patch("run_agent.AIAgent") as MockAgent,
+            patch("tools.delegate_tool._load_config", return_value={}),
+        ):
             MockAgent.return_value = MagicMock()
             _build_child_agent(
                 task_index=0,

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -130,6 +130,7 @@ class TestBuildChildAgentWiring(unittest.TestCase):
     """End-to-end through _build_child_agent: the resolver is actually wired."""
 
     def _spawn(self, parent, cfg, **overrides):
+        model = overrides.pop("model", None)
         with (
             patch("tools.delegate_tool._load_config", return_value=cfg),
             patch("run_agent.AIAgent") as MockAgent,
@@ -140,7 +141,7 @@ class TestBuildChildAgentWiring(unittest.TestCase):
                 goal="matrix wiring",
                 context=None,
                 toolsets=None,
-                model=None,
+                model=model,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -170,6 +171,25 @@ class TestBuildChildAgentWiring(unittest.TestCase):
             override_provider="deepseek",
             override_base_url="https://api.deepseek.example/v1",
             override_api_key="sk-ds",
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_model_only_pin_gets_no_parent_chain(self):
+        """The model arm of #80450: delegation.model without delegation.provider
+        must not inherit the parent chain — a mid-run failure would silently
+        swap the pinned model."""
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)), {}, model="deepseek-chat",
+        )
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_model_only_pin_with_declared_chain_uses_declared(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            model="deepseek-chat",
         )
         providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
         self.assertIn("deepseek", providers)

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -1,0 +1,184 @@
+"""Full decision matrix for _resolve_child_fallback_chain (#80450 class).
+
+Composes the pin semantics of PR #80465 (@teknium1), the
+delegation.fallback_providers semantics of PRs #80438 (@wz-heng) /
+#80421 (@andrexibiza) for issue #65038 (@mlahatte), and settles the
+pin+declared-chain composition cell raised in the #80450 cross-PR map.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import _build_child_agent, _resolve_child_fallback_chain
+from tests.tools.test_delegate import _make_mock_parent
+
+PARENT_CHAIN = [
+    {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-parent"}
+]
+DECLARED_CHAIN = [
+    {"provider": "deepseek", "model": "deepseek-chat", "api_key": "sk-ds-child"}
+]
+
+
+def _parent(chain=None):
+    parent = _make_mock_parent(depth=0)
+    parent._fallback_chain = chain
+    return parent
+
+
+class TestResolveChildFallbackChainMatrix(unittest.TestCase):
+    """All six cells of the pin x declared-chain matrix."""
+
+    # pin=yes ------------------------------------------------------------
+
+    def test_pin_declared_nonempty_uses_declared_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            pinned=True,
+        )
+        providers = {e.get("provider") for e in (chain or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_pin_declared_empty_disables_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {"fallback_providers": []}, pinned=True
+        )
+        self.assertIsNone(chain)
+
+    def test_pin_absent_gets_no_chain(self):
+        """#80450: a pinned child must fail loudly, not silently reroute."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {}, pinned=True
+        )
+        self.assertIsNone(chain)
+
+    # pin=no -------------------------------------------------------------
+
+    def test_unpinned_declared_nonempty_uses_declared_chain(self):
+        """#65038: delegation.fallback_providers reaches the child."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            pinned=False,
+        )
+        providers = {e.get("provider") for e in (chain or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_unpinned_declared_empty_disables_chain(self):
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {"fallback_providers": []}, pinned=False
+        )
+        self.assertIsNone(chain)
+
+    def test_unpinned_absent_inherits_parent_chain(self):
+        """Historical default is preserved exactly."""
+        chain = _resolve_child_fallback_chain(
+            _parent(list(PARENT_CHAIN)), {}, pinned=False
+        )
+        self.assertEqual(chain, PARENT_CHAIN)
+
+    # edges ----------------------------------------------------------------
+
+    def test_unpinned_absent_with_empty_parent_chain_is_none(self):
+        self.assertIsNone(_resolve_child_fallback_chain(_parent([]), {}, pinned=False))
+
+    def test_declared_chain_is_normalized_and_deduped(self):
+        """Entries route through the canonical get_fallback_chain normalizer."""
+        chain = _resolve_child_fallback_chain(
+            _parent(None),
+            {"fallback_providers": list(DECLARED_CHAIN) + list(DECLARED_CHAIN)},
+            pinned=False,
+        )
+        routes = [(e.get("provider"), e.get("model")) for e in (chain or [])]
+        self.assertEqual(len(routes), len(set(routes)))
+
+    def test_malformed_declared_value_pin_aware_fallback(self):
+        """Malformed config logs and falls back pin-aware: None when pinned
+        (never reintroduce the silent drag through the error path), parent
+        chain otherwise — extends #80421's log-and-inherit contract."""
+        with patch(
+            "hermes_cli.fallback_config.get_fallback_chain",
+            side_effect=TypeError("boom"),
+        ):
+            self.assertIsNone(
+                _resolve_child_fallback_chain(
+                    _parent(list(PARENT_CHAIN)),
+                    {"fallback_providers": "not-a-list"},
+                    pinned=True,
+                )
+            )
+            self.assertEqual(
+                _resolve_child_fallback_chain(
+                    _parent(list(PARENT_CHAIN)),
+                    {"fallback_providers": "not-a-list"},
+                    pinned=False,
+                ),
+                PARENT_CHAIN,
+            )
+
+    def test_non_dict_config_uses_default(self):
+        self.assertEqual(
+            _resolve_child_fallback_chain(_parent(list(PARENT_CHAIN)), None, pinned=False),
+            PARENT_CHAIN,
+        )
+
+
+class TestBuildChildAgentWiring(unittest.TestCase):
+    """End-to-end through _build_child_agent: the resolver is actually wired."""
+
+    def _spawn(self, parent, cfg, **overrides):
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="matrix wiring",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                **overrides,
+            )
+        return MockAgent.call_args[1]
+
+    def test_pinned_child_gets_no_parent_chain(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)), {}, override_provider="minimax",
+            override_base_url="https://api.minimax.example/v1", override_api_key="sk-mm",
+        )
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_configured_delegation_chain_reaches_child(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+
+    def test_pin_plus_declared_chain_uses_declared(self):
+        kwargs = self._spawn(
+            _parent(list(PARENT_CHAIN)),
+            {"fallback_providers": list(DECLARED_CHAIN)},
+            override_provider="deepseek",
+            override_base_url="https://api.deepseek.example/v1",
+            override_api_key="sk-ds",
+        )
+        providers = {e.get("provider") for e in (kwargs["fallback_model"] or [])}
+        self.assertIn("deepseek", providers)
+        self.assertNotIn("openrouter", providers)
+
+    def test_default_inheritance_preserved(self):
+        kwargs = self._spawn(_parent(list(PARENT_CHAIN)), {})
+        self.assertEqual(kwargs["fallback_model"], PARENT_CHAIN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -9,6 +9,8 @@ pin+declared-chain composition cell raised in the #80450 cross-PR map.
 import unittest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from tools.delegate_tool import _build_child_agent, _resolve_child_fallback_chain
 from tests.tools.test_delegate import _make_mock_parent
 
@@ -94,6 +96,24 @@ class TestResolveChildFallbackChainMatrix(unittest.TestCase):
         )
         routes = [(e.get("provider"), e.get("model")) for e in (chain or [])]
         self.assertEqual(len(routes), len(set(routes)))
+
+    def test_valid_route_survives_invalid_neighbor(self):
+        """One malformed entry must not discard a usable declared route."""
+        declared = [
+            {"provider": "deepseek", "model": "worker-fallback"},
+            {"provider": "deepseek"},
+        ]
+        expected = [{"provider": "deepseek", "model": "worker-fallback"}]
+        for pinned in (False, True):
+            with self.subTest(pinned=pinned):
+                self.assertEqual(
+                    _resolve_child_fallback_chain(
+                        _parent(list(PARENT_CHAIN)),
+                        {"fallback_providers": declared},
+                        pinned=pinned,
+                    ),
+                    expected,
+                )
 
     def test_malformed_declared_value_pin_aware_fallback(self):
         """Malformed config logs and falls back pin-aware: None when pinned
@@ -261,6 +281,136 @@ def test_declared_chain_flows_through_real_profile_config_loader(
 
     child_kwargs = mock_agent.call_args.kwargs
     assert child_kwargs["fallback_model"] == DECLARED_CHAIN
+
+
+def test_explicit_empty_chain_survives_real_profile_config_loader(tmp_path, monkeypatch):
+    """An explicit [] remains an authoritative disable after config loading."""
+    import yaml
+
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump({"delegation": {"fallback_providers": []}}),
+            encoding="utf-8",
+        )
+        with patch("run_agent.AIAgent") as mock_agent:
+            mock_agent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="explicit disable",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=_parent(list(PARENT_CHAIN)),
+                task_count=1,
+            )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert mock_agent.call_args.kwargs["fallback_model"] is None
+
+
+def test_pinned_review_does_not_borrow_general_worker_chain(tmp_path, monkeypatch):
+    """The public /review route owns its fallback policy as well as its model."""
+    import yaml
+
+    from agent.review_engine import start_review
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    (tmp_path / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "delegation": {
+                    "fallback_providers": [
+                        {"provider": "deepseek", "model": "worker-fallback"}
+                    ]
+                },
+                "auxiliary": {
+                    "review": {
+                        "provider": "custom",
+                        "model": "review-model",
+                        "base_url": "http://127.0.0.1:18479/v1",
+                        "api_key": "test-only",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    parent = _parent(list(PARENT_CHAIN))
+    parent.session_id = "review-80479-parent"
+    captured = {}
+
+    class ReachedConstructor(RuntimeError):
+        pass
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        raise ReachedConstructor()
+
+    token = set_hermes_home_override(tmp_path)
+    try:
+        with patch("run_agent.AIAgent", side_effect=capture):
+            with pytest.raises(ReachedConstructor):
+                start_review(
+                    parent,
+                    [{"role": "user", "content": "Check the last result"}],
+                )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert captured["model"] == "review-model"
+    assert captured["base_url"] == "http://127.0.0.1:18479/v1"
+    assert captured["fallback_model"] is None
+
+
+def test_declared_child_chain_activates_on_primary_failure():
+    """The selected chain is accepted by the real fallback activation rail."""
+    from agent.error_classifier import FailoverReason
+    from run_agent import AIAgent
+
+    chain = _resolve_child_fallback_chain(
+        _parent(list(PARENT_CHAIN)),
+        {"fallback_providers": list(DECLARED_CHAIN)},
+        pinned=True,
+    )
+    with (
+        patch("model_tools.get_tool_definitions", return_value=[]),
+        patch("model_tools.check_toolset_requirements", return_value={}),
+        patch("agent.process_bootstrap.OpenAI"),
+    ):
+        child = AIAgent(
+            api_key="primary-test-key",
+            base_url="https://primary.example/v1",
+            model="primary-model",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=chain,
+        )
+    fallback_client = MagicMock()
+    fallback_client.base_url = "https://fallback.example/v1"
+    fallback_client.api_key = "fallback-test-key"
+    with (
+        patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(fallback_client, "deepseek-chat"),
+        ),
+        patch(
+            "hermes_cli.model_normalize.normalize_model_for_provider",
+            side_effect=lambda model, _provider: model,
+        ),
+    ):
+        assert child._try_activate_fallback(FailoverReason.rate_limit) is True
+
+    assert child.model == "deepseek-chat"
+    assert child.provider == "deepseek"
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_delegate_fallback_matrix.py
+++ b/tests/tools/test_delegate_fallback_matrix.py
@@ -99,6 +99,29 @@ class TestResolveChildFallbackChainMatrix(unittest.TestCase):
         """Malformed config logs and falls back pin-aware: None when pinned
         (never reintroduce the silent drag through the error path), parent
         chain otherwise — extends #80421's log-and-inherit contract."""
+        for malformed in (
+            "not-a-list",
+            [{"provider": "deepseek"}],
+            ["not-a-mapping"],
+        ):
+            with self.subTest(malformed=malformed):
+                self.assertIsNone(
+                    _resolve_child_fallback_chain(
+                        _parent(list(PARENT_CHAIN)),
+                        {"fallback_providers": malformed},
+                        pinned=True,
+                    )
+                )
+                self.assertEqual(
+                    _resolve_child_fallback_chain(
+                        _parent(list(PARENT_CHAIN)),
+                        {"fallback_providers": malformed},
+                        pinned=False,
+                    ),
+                    PARENT_CHAIN,
+                )
+
+    def test_normalizer_failure_uses_pin_aware_fallback(self):
         with patch(
             "hermes_cli.fallback_config.get_fallback_chain",
             side_effect=TypeError("boom"),
@@ -106,14 +129,14 @@ class TestResolveChildFallbackChainMatrix(unittest.TestCase):
             self.assertIsNone(
                 _resolve_child_fallback_chain(
                     _parent(list(PARENT_CHAIN)),
-                    {"fallback_providers": "not-a-list"},
+                    {"fallback_providers": list(DECLARED_CHAIN)},
                     pinned=True,
                 )
             )
             self.assertEqual(
                 _resolve_child_fallback_chain(
                     _parent(list(PARENT_CHAIN)),
-                    {"fallback_providers": "not-a-list"},
+                    {"fallback_providers": list(DECLARED_CHAIN)},
                     pinned=False,
                 ),
                 PARENT_CHAIN,
@@ -198,6 +221,46 @@ class TestBuildChildAgentWiring(unittest.TestCase):
     def test_default_inheritance_preserved(self):
         kwargs = self._spawn(_parent(list(PARENT_CHAIN)), {})
         self.assertEqual(kwargs["fallback_model"], PARENT_CHAIN)
+
+
+def test_declared_chain_flows_through_real_profile_config_loader(
+    tmp_path, monkeypatch
+):
+    """The public key must survive DEFAULT_CONFIG/profile loading without
+    patching ``_load_config`` and reach the child constructor."""
+    import yaml
+
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    token = set_hermes_home_override(tmp_path)
+    try:
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {"delegation": {"fallback_providers": list(DECLARED_CHAIN)}}
+            ),
+            encoding="utf-8",
+        )
+        with patch("run_agent.AIAgent") as mock_agent:
+            mock_agent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="real config loader",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=_parent(list(PARENT_CHAIN)),
+                task_count=1,
+            )
+    finally:
+        reset_hermes_home_override(token)
+
+    child_kwargs = mock_agent.call_args.kwargs
+    assert child_kwargs["fallback_model"] == DECLARED_CHAIN
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1317,9 +1317,12 @@ def _resolve_child_fallback_chain(parent_agent, delegation_cfg, pinned):
     ============ ======================= =========================================
 
     Rationale for the pin+declared cell: the silent-drag problem in #80450 is
-    specifically the *parent's* chain substituting a pinned provider with no
-    surfaced signal. A chain declared under ``delegation.*`` is scoped to
-    workers by construction — honoring it respects both explicit intents.
+    specifically the *parent's* chain substituting a pinned provider or model
+    with no surfaced signal. A chain declared under ``delegation.*`` is scoped
+    to workers by construction — honoring it respects both explicit intents.
+    "Pinned" covers every explicit routing arm of #80450: delegation.provider,
+    delegation.base_url (which resolves to a provider override), and a
+    model-only delegation.model pin.
 
     A malformed declared value logs and falls back to the PIN-AWARE default
     (None when pinned, parent chain otherwise): falling back to the parent
@@ -1621,8 +1624,13 @@ def _build_child_agent(
     # Fallback chain: full decision matrix in _resolve_child_fallback_chain
     # (#80450 cross-PR map — composes the pin semantics of #80465 with the
     # delegation.fallback_providers semantics of #80438/#80421).
+    # Pin = any explicit delegation routing: provider, base_url (which
+    # resolves to a provider override), or a model-only pin — `model` here is
+    # creds["model"], i.e. delegation.model config, at both call sites. A
+    # model-only pin with the parent chain inherited would let a mid-run
+    # failure silently swap the pinned model (the model arm of #80450).
     parent_fallback = _resolve_child_fallback_chain(
-        parent_agent, delegation_cfg, pinned=bool(override_provider)
+        parent_agent, delegation_cfg, pinned=bool(override_provider or model)
     )
 
     # Inherit the parent's OpenRouter provider-preference filters by default

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1301,6 +1301,58 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _resolve_child_fallback_chain(parent_agent, delegation_cfg, pinned):
+    """Decide which fallback chain a delegated child gets — the full matrix.
+
+    ============ ======================= =========================================
+    pin          delegation.             result
+    (provider)   fallback_providers
+    ============ ======================= =========================================
+    yes          declared, non-empty     declared chain (delegation-scoped recovery)
+    yes          declared, empty []      None — explicit disable
+    yes          absent                  None — pin fails loudly (#80450)
+    no           declared, non-empty     declared chain (#65038)
+    no           declared, empty []      None — explicit disable
+    no           absent                  inherit parent chain (historical default)
+    ============ ======================= =========================================
+
+    Rationale for the pin+declared cell: the silent-drag problem in #80450 is
+    specifically the *parent's* chain substituting a pinned provider with no
+    surfaced signal. A chain declared under ``delegation.*`` is scoped to
+    workers by construction — honoring it respects both explicit intents.
+
+    A malformed declared value logs and falls back to the PIN-AWARE default
+    (None when pinned, parent chain otherwise): falling back to the parent
+    chain on a pinned child would reintroduce the silent drag through the
+    config-error path.
+
+    Entries are normalized through the canonical
+    ``hermes_cli.fallback_config.get_fallback_chain`` so ordering, dedupe,
+    and malformed-entry handling match top-level ``fallback_providers``.
+    """
+    parent_chain = getattr(parent_agent, "_fallback_chain", None) or None
+    default = None if pinned else parent_chain
+    declared = (
+        delegation_cfg.get("fallback_providers")
+        if isinstance(delegation_cfg, dict)
+        else None
+    )
+    if declared is None:
+        return default
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        return get_fallback_chain({"fallback_providers": declared}) or None
+    except Exception as exc:
+        logger.warning(
+            "Ignoring malformed delegation.fallback_providers (%s); "
+            "using %s.",
+            exc,
+            "no chain (provider pinned)" if pinned else "parent chain",
+        )
+        return default
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1566,11 +1618,12 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    # Fallback chain: full decision matrix in _resolve_child_fallback_chain
+    # (#80450 cross-PR map — composes the pin semantics of #80465 with the
+    # delegation.fallback_providers semantics of #80438/#80421).
+    parent_fallback = _resolve_child_fallback_chain(
+        parent_agent, delegation_cfg, pinned=bool(override_provider)
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -31,7 +31,8 @@ from tools.delegate_tool_config import (  # noqa: F401
     _DEFAULT_MAX_CONCURRENT_CHILDREN, _get_child_timeout, _get_max_async_children, _get_max_concurrent_children,
     _get_max_spawn_depth, _get_orchestrator_enabled, _get_subagent_approval_callback, _get_worktree_isolation,
     _inherit_parent_capabilities, _load_config, _merge_request_overrides, _resolve_child_credential_pool,
-    _resolve_child_runtime, _resolve_delegation_credentials, _subagent_auto_approve, _subagent_auto_deny,
+    _resolve_child_fallback_chain, _resolve_child_runtime, _resolve_delegation_credentials,
+    _subagent_auto_approve, _subagent_auto_deny,
 )
 from tools.delegate_tool_dispatch import _Batch, _announce_batch, _capture_origin, _run_batch
 from tools.delegate_tool_progress import (  # noqa: F401
@@ -169,6 +170,10 @@ def _build_child_agent(
     # ACP transport overrides from trusted delegation config.
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
+    # Configuration block that owns the selected provider/model route. Internal
+    # callers such as /review pass auxiliary.review here so fallback policy is
+    # not accidentally read from the general delegation block.
+    routing_cfg: Optional[Dict[str, Any]] = None,
     # Legacy; accepted for wire compat but ignored (capability is depth-derived).
     role: str = "leaf",
 ):
@@ -188,6 +193,9 @@ def _build_child_agent(
     subagent_id = f"sa-{task_index}-{_uuid.uuid4().hex[:8]}"
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
 
+    # General delegation behavior (reasoning, compression, capabilities) stays
+    # global. Only fallback policy follows the owner of a per-call route such
+    # as auxiliary.review.
     delegation_cfg = _load_config()
     child_toolsets, child_disabled_toolsets = _resolve_child_toolsets(parent_agent, toolsets, effective_role)
     child_prompt = _build_child_system_prompt(
@@ -211,6 +219,7 @@ def _build_child_agent(
         override_base_url=override_base_url, override_api_key=override_api_key, override_api_mode=override_api_mode,
         override_acp_command=override_acp_command,
         override_acp_args=override_acp_args,
+        fallback_cfg=routing_cfg,
     )
     if override_request_overrides is not None:
         # honored whenever set, incl. the inherit branch where
@@ -349,7 +358,8 @@ def _run_single_child(
 
 def _build_children(
     task_list: List[Dict[str, Any]], task_schemas: List[Optional[Dict[str, Any]]], creds: Dict[str, Any], *,
-    top_role: str, max_iterations: int, parent_agent, live_deleg_id: Optional[str], live_writers: list,
+    top_role: str, max_iterations: int, parent_agent, routing_cfg: Dict[str, Any],
+    live_deleg_id: Optional[str], live_writers: list,
 ) -> tuple[List[tuple], Optional[str]]:
     """Build every child on the main thread (construction is not thread-safe);
     ``(children, None)`` or ``([], error)`` on an explicit-pin preflight failure."""
@@ -361,6 +371,7 @@ def _build_children(
         "override_request_overrides": creds.get("request_overrides"),
         "override_acp_command": creds.get("command"),
         "override_acp_args": creds.get("args"),
+        "routing_cfg": routing_cfg,
     }
     children = []
     for i, t in enumerate(task_list):
@@ -445,9 +456,11 @@ def delegate_task(
             max_iterations, default_max_iter,
         )
     # credentials_cfg (internal callers only, e.g. /review → auxiliary.review) is
-    # a per-call override shaped like the delegation config section.
+    # a per-call routing owner shaped like the delegation config section. Keep
+    # the route and its fallback policy together through child construction.
+    routing_cfg = credentials_cfg if credentials_cfg is not None else cfg
     try:
-        creds = _resolve_delegation_credentials(credentials_cfg if credentials_cfg else cfg, parent_agent)
+        creds = _resolve_delegation_credentials(routing_cfg, parent_agent)
     except ValueError as exc:
         # Explicit-pin preflight failures (e.g. pinned delegation.command missing from PATH) refuse the
         # spawn loudly (#80450).
@@ -471,7 +484,7 @@ def delegate_task(
 
     children, err = _build_children(
         task_list, task_schemas, creds, top_role=top_role, max_iterations=default_max_iter, parent_agent=parent_agent,
-        live_deleg_id=live_deleg_id, live_writers=live_writers,
+        routing_cfg=routing_cfg, live_deleg_id=live_deleg_id, live_writers=live_writers,
     )
     if err:
         return tool_error(err)

--- a/tools/delegate_tool_config.py
+++ b/tools/delegate_tool_config.py
@@ -412,10 +412,79 @@ _ROUTING_FILTER_DEFAULTS = (
 
 _NOUS_PROVIDERS = frozenset({"nous", "nous-portal", "nousresearch"})
 
+
+def _resolve_child_fallback_chain(parent_agent, routing_cfg: Any, pinned: bool) -> Optional[List[Dict[str, Any]]]:
+    """Resolve the fallback chain owned by the same config block as the child route.
+
+    A pinned child (provider, endpoint, or model) never borrows the parent's
+    chain. It may use only a chain explicitly declared by its routing owner.
+    An unpinned child inherits the parent chain when the setting is absent or
+    null. An explicit empty list disables fallback in either case.
+
+    Valid entries in a partially malformed declaration are retained through
+    the canonical fallback normalizer. If no usable entry remains, the
+    pin-aware default applies.
+    """
+    parent_chain = getattr(parent_agent, "_fallback_chain", None) or None
+    default = None if pinned else parent_chain
+    if not isinstance(routing_cfg, dict) or "fallback_providers" not in routing_cfg:
+        return default
+
+    declared = routing_cfg.get("fallback_providers")
+    if declared is None:
+        return default
+    if declared == []:
+        return None
+    if not isinstance(declared, list):
+        logger.warning(
+            "Ignoring delegation fallback_providers: expected a list, got %s; using the %s default",
+            type(declared).__name__,
+            "pinned" if pinned else "inherited",
+        )
+        return default
+
+    invalid_positions = [
+        index
+        for index, entry in enumerate(declared)
+        if not isinstance(entry, dict)
+        or not str(entry.get("provider") or "").strip()
+        or not str(entry.get("model") or "").strip()
+    ]
+    if invalid_positions:
+        logger.warning(
+            "Ignoring invalid delegation fallback_providers entr%s at index%s %s",
+            "y" if len(invalid_positions) == 1 else "ies",
+            "" if len(invalid_positions) == 1 else "es",
+            ", ".join(str(index) for index in invalid_positions),
+        )
+
+    try:
+        from hermes_cli.fallback_config import get_fallback_chain
+
+        normalized = get_fallback_chain({"fallback_providers": declared})
+    except Exception as exc:
+        logger.warning(
+            "Could not normalize delegation fallback_providers (%s); using the %s default",
+            exc,
+            "pinned" if pinned else "inherited",
+        )
+        return default
+
+    if normalized:
+        return normalized
+    if declared:
+        logger.warning(
+            "delegation fallback_providers contains no usable routes; using the %s default",
+            "pinned" if pinned else "inherited",
+        )
+    return default
+
+
 def _resolve_child_runtime(
     parent_agent, delegation_cfg: dict, parent_api_key: Any, *, model: Optional[str], override_provider: Optional[str],
     override_base_url: Optional[str], override_api_key: Optional[str], override_api_mode: Optional[str],
     override_acp_command: Optional[str], override_acp_args: Optional[List[str]],
+    fallback_cfg: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Child credentials, transport and routing (config override > parent inherit) as ``AIAgent`` kwargs. Rules that
     are easy to break: api_mode is re-derived (not inherited) when the child's provider differs from the parent's
@@ -489,9 +558,13 @@ def _resolve_child_runtime(
         "capabilities": _inherit_parent_capabilities(parent_agent, override_provider, override_base_url),
         "api_mode": effective_api_mode, "acp_command": effective_acp_command, "acp_args": effective_acp_args,
         "reasoning_config": child_reasoning,
-        # Inherit the parent's fallback chain EXCEPT under a pinned provider: a mid-run 429/auth failure must not
-        # silently reroute the quiet child onto the parent's fallbacks. Predictability > liveness for explicit pins.
-        "fallback_model": None if override_provider else (getattr(parent_agent, "_fallback_chain", None) or None),
+        # Resolve routing and recovery policy from the same configuration owner. A pinned provider, endpoint, or
+        # model never borrows the parent's chain; an explicitly declared child chain still remains available.
+        "fallback_model": _resolve_child_fallback_chain(
+            parent_agent,
+            fallback_cfg if isinstance(fallback_cfg, dict) else delegation_cfg,
+            pinned=bool(override_provider or override_base_url or model),
+        ),
         "openrouter_min_coding_score": getattr(parent_agent, "openrouter_min_coding_score", None),
         # Routing filters reset to their defaults under a pinned provider (see _ROUTING_FILTER_DEFAULTS).
         **{a: d if override_provider else getattr(parent_agent, a, d) for a, d in _ROUTING_FILTER_DEFAULTS},

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2273,6 +2273,8 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
+**Subagent fallback chain:** By default, delegated children inherit the parent agent's top-level `fallback_providers` chain. Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list) so a failed worker does not silently escalate onto head-agent fallback models. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely. When the key is absent or `null`, parent-chain inheritance is preserved (#65038).
+
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only.
 
 **Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2702,6 +2702,8 @@ delegation:
 
 **Subagent provider:model override:** By default, subagents inherit the parent agent's provider and model. Set `delegation.provider` and `delegation.model` to route subagents to a different provider:model pair — e.g., use a cheap/fast model for narrowly-scoped subtasks while your primary agent runs an expensive reasoning model.
 
+**Subagent fallback chain:** Set `delegation.fallback_providers` to give workers their own chain (same entry shape as the top-level list). An explicitly pinned child (by provider, endpoint, or model) uses that chain only when it is declared; otherwise it fails loudly instead of borrowing the parent agent's route. For an unpinned child, an absent or `null` setting preserves parent-chain inheritance. Use `fallback_providers: []` under `delegation:` to disable child fallback entirely.
+
 **Direct endpoint override:** If you want the obvious custom-endpoint path, set `delegation.base_url`, `delegation.api_key`, and `delegation.model`. That sends subagents directly to that OpenAI-compatible endpoint and takes precedence over `delegation.provider`. If `delegation.api_key` is omitted, Hermes falls back to `OPENAI_API_KEY` only. When `delegation.provider` is set alongside `delegation.base_url`, the explicit endpoint and key still win, but that provider's request settings (`extra_body` overrides and max output tokens from your `custom_providers` entry) are carried into the subagent.
 
 **Per-child request settings (`request_overrides`):** `delegation.request_overrides` is a dict of request settings sent on every subagent API call. Top-level keys are API kwargs (e.g. `service_tier`); an `extra_body` sub-dict is merged into the request's `extra_body`. It is honored on **all three** resolution branches — direct `base_url`, named `provider`, and pure inherit — so the key always takes effect. Precedence: explicit `request_overrides` values merge **over** any runtime- or parent-derived overrides — top-level explicit keys win, and `extra_body` is deep-merged one level so runtime `extra_body` keys (e.g. a provider's `thinking: {type: disabled}` personality) survive unless your key redefines them. The canonical use case is OpenRouter routing hints for delegation children:
@@ -2716,7 +2718,6 @@ delegation:
       provider:
         sort: throughput   # route children to the fastest OpenRouter provider
 ```
-
 **Wire protocol (`api_mode`):** Hermes auto-detects the wire protocol from `delegation.base_url` (e.g. paths ending in `/anthropic` → `anthropic_messages`; Codex / native Anthropic / Kimi-coding hostnames keep their existing detection). For endpoints the heuristic can't classify — for example Azure AI Foundry, MiniMax, Zhipu GLM, or LiteLLM proxies fronting an Anthropic-shaped backend — set `delegation.api_mode` explicitly to one of `chat_completions`, `codex_responses`, or `anthropic_messages`. Leave it empty (the default) to keep auto-detection.
 
 The delegation provider uses the same credential resolution as CLI/gateway startup. All configured providers are supported: `openrouter`, `nous`, `copilot`, `zai`, `kimi-coding`, `minimax`, `minimax-cn`. When a provider is set, the system automatically resolves the correct base URL, API key, and API mode — no manual credential wiring needed.

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -173,7 +173,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -185,7 +185,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (subagents inherit the parent fallback chain) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 

--- a/website/docs/user-guide/features/fallback-providers.md
+++ b/website/docs/user-guide/features/fallback-providers.md
@@ -185,7 +185,7 @@ fallback_providers:
 |---------|-------------------|
 | CLI sessions | ✔ |
 | Messaging gateway (Telegram, Discord, etc.) | ✔ |
-| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise inherit parent chain; `[]` disables) |
+| Subagent delegation | ✔ (`delegation.fallback_providers` when set; otherwise only unpinned children inherit the parent chain; `[]` disables) |
 | Cron jobs | ✔ (cron agents inherit configured fallback providers) |
 | Auxiliary tasks on `provider: auto` | ✔ (try per-task fallback, then the main fallback chain before built-in aux discovery) |
 
@@ -440,5 +440,5 @@ See [Scheduled Tasks (Cron)](/user-guide/features/cron) for full configuration d
 | Approval classification | Layered (see above) | `auxiliary.approval` |
 | Title generation | Layered (see above) | `auxiliary.title_generation` |
 | Triage specifier | Layered (see above) | `auxiliary.triage_specifier` |
-| Delegation | Inherits the parent's `fallback_providers` chain; optional provider/model override | `delegation.provider` / `delegation.model` |
+| Delegation | Uses `delegation.fallback_providers` when declared; otherwise only unpinned children inherit the parent chain | `delegation.provider` / `delegation.model` / `delegation.fallback_providers` |
 | Cron jobs | Inherit the configured `fallback_providers` chain; optional per-job provider override | Per-job `provider` / `model` |


### PR DESCRIPTION
## Summary

Completes the delegation fallback-chain matrix from the #80450 cross-PR map: one pure function, `_resolve_child_fallback_chain`, implementing all six cells of the pin × `delegation.fallback_providers` decision table — composing the pin semantics of #80465 (@teknium1) with the config-chain semantics of #80438 (@wz-heng) / #80421 (@andrexibiza) for #65038 (@mlahatte), and settling the composition cell that all three leave undefined.

## Root cause (the class)

Every open PR on this seam answers "which fallback chain does a non-head agent get?" for one input combination, editing the same `parent_fallback` hunk. The combinations interact: #80465 nulls the chain on pin, #80438/#80421 install a configured chain — land them in either order and pinned-child semantics differ silently. The matrix needs to be decided once, in one place.

## Changes

`tools/delegate_tool.py` — `_resolve_child_fallback_chain(parent_agent, delegation_cfg, pinned)`:

| pin | `delegation.fallback_providers` | result |
|---|---|---|
| yes | declared, non-empty | declared chain — delegation-scoped recovery honors both explicit intents; the silent drag in #80450 is specifically the *parent's* chain substituting a pin |
| yes | declared, empty `[]` | none — explicit disable |
| yes | absent | none — pin fails loudly (exactly #80465's semantics) |
| no | declared, non-empty | declared chain (exactly #80438/#80421's semantics, #65038) |
| no | declared, empty `[]` | none — explicit disable |
| no | absent | inherit parent chain (historical behavior, byte-identical) |

Malformed declared values log and fall back **pin-aware** (none when pinned, parent chain otherwise) — extending #80421's log-and-inherit contract so the config-error path can't reintroduce the drag. Entries normalize through the canonical `hermes_cli.fallback_config.get_fallback_chain` (ordering/dedupe identical to top-level chains). The two pre-existing inheritance tests are made hermetic against the real user config, as #80438 also did.

## Validation

- `tests/tools/test_delegate_fallback_matrix.py` (14 tests): all six matrix cells, empty-parent edge, normalizer dedupe, pin-aware malformed fallback (both arms), non-dict config, plus four end-to-end wiring tests through `_build_child_agent` including pin+declared. Red on main: the suite fails collection (resolver doesn't exist); the wiring behaviors are unreachable.
- Neighbors: `test_delegate.py` + `test_async_delegation.py` + `test_fallback_config.py` — 88/88 via `scripts/run_tests.sh`.
- Interplay verified: the executable class map in #80474 flips its three xfails to **XPASS** against this branch (1 passed, 1 skipped, 3 xpassed) — the map and this fix compose as designed.

## Scope notes

- Deliberately deferential on landing order: if #80465 lands first, this rebases to the declared-chain cells plus the precedence guard; if maintainers prefer folding any of it into #80465 or the #80438/#80421 pair, take it freely — the decision table and its tests are the point.
- If the precedence call goes the other way (pin + declared ⇒ loud-fail-only), it's a one-line change in the resolver and two test edits; the matrix structure stands either way.
- Chain-entry members (#80209 `api_mode`, #79840 benched credentials) and auxiliary agents (#79750) are separate modules with their own PRs — unaffected here.
