### PR TITLE
test(fault_lab): deterministic real-fault injection primitives

### DIFF
--- a/tests/fault_lab/__init__.py
+++ b/tests/fault_lab/__init__.py
@@ -1,0 +1,12 @@
+"""Deterministic fault injection for reliability-critical paths.
+
+Companion to #54964 ("Enforce E2E Testing over Isolated Unit Mocks in Core
+Agent Tests"): provides REAL primitives (a real local HTTP socket for
+provider faults, a real separate process for SQLite lock contention)
+instead of mocking the client/transport, so tests exercise the actual
+error-surfacing code instead of a MagicMock standing in for it.
+
+Scope of this first cut: provider HTTP faults (429, truncated stream) and
+SQLite write-lock contention. MCP-disconnect and gateway-reconnect fault
+scenarios are natural follow-ups once these primitives are in use.
+"""

--- a/tests/fault_lab/fake_provider_server.py
+++ b/tests/fault_lab/fake_provider_server.py
@@ -1,0 +1,124 @@
+"""Scriptable fake OpenAI-compatible HTTP server — a REAL local socket.
+
+Drives genuine HTTP failure modes (429, 5xx, connection-reset mid-stream)
+through the REAL ``openai`` SDK client construction path
+(``agent.auxiliary_client.resolve_provider_client``), so fault-injection
+tests exercise the actual error-surfacing code instead of a ``MagicMock``
+standing in for the transport.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any, Dict, List, Optional
+
+__all__ = ["FakeProviderServer"]
+
+
+class FakeProviderServer:
+    """A real ``HTTPServer`` bound to 127.0.0.1:0, serving a scripted queue.
+
+    Each POST to ``/v1/chat/completions`` pops the next scripted response.
+    Use :meth:`script` for a plain JSON response (any status code) or
+    :meth:`script_truncated_stream` for an SSE stream that closes mid-way
+    without a terminating ``[DONE]`` — the real shape of a server crash.
+    """
+
+    def __init__(self) -> None:
+        self._responses: List[tuple] = []
+        self._requests: List[Dict[str, Any]] = []
+        self._lock = threading.Lock()
+        handler = self._make_handler()
+        self._httpd = HTTPServer(("127.0.0.1", 0), handler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    @property
+    def base_url(self) -> str:
+        host, port = self._httpd.server_address
+        return f"http://{host}:{port}/v1"
+
+    @property
+    def requests(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return list(self._requests)
+
+    def script(self, status: int, body: Optional[Dict[str, Any]] = None) -> None:
+        """Queue a plain JSON response."""
+        with self._lock:
+            self._responses.append(("json", status, body or {}))
+
+    def script_truncated_stream(self, chunks: List[str]) -> None:
+        """Queue an SSE stream that sends ``chunks`` then closes without [DONE]."""
+        with self._lock:
+            self._responses.append(("truncated_stream", 200, chunks))
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+    def __enter__(self) -> "FakeProviderServer":
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.stop()
+
+    def _make_handler(self):
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # silence stdlib access log
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802 — stdlib handler contract
+                length = int(self.headers.get("Content-Length", 0))
+                raw = self.rfile.read(length) if length else b"{}"
+                try:
+                    payload = json.loads(raw.decode("utf-8"))
+                except Exception:
+                    payload = {}
+                with server._lock:
+                    server._requests.append({"path": self.path, "body": payload})
+                    if not server._responses:
+                        kind, status, data = (
+                            "json", 500,
+                            {"error": {"message": "fault_lab: no scripted response left"}},
+                        )
+                    else:
+                        kind, status, data = server._responses.pop(0)
+
+                if kind == "json":
+                    body = json.dumps(data).encode("utf-8")
+                    self.send_response(status)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("Content-Length", str(len(body)))
+                    self.end_headers()
+                    self.wfile.write(body)
+                    return
+
+                # truncated_stream: real SSE framing, then the connection
+                # closes mid-stream — no [DONE], no final chunk. This is the
+                # real shape of a provider crash, not a simulated one.
+                self.send_response(status)
+                self.send_header("Content-Type", "text/event-stream")
+                self.end_headers()
+                for chunk_text in data:
+                    event = {
+                        "id": "fault-lab",
+                        "object": "chat.completion.chunk",
+                        "model": "fault-lab-model",
+                        "choices": [
+                            {"delta": {"content": chunk_text}, "index": 0,
+                             "finish_reason": None}
+                        ],
+                    }
+                    self.wfile.write(f"data: {json.dumps(event)}\n\n".encode("utf-8"))
+                    self.wfile.flush()
+                self.close_connection = True
+
+        return Handler

--- a/tests/fault_lab/sqlite_faults.py
+++ b/tests/fault_lab/sqlite_faults.py
@@ -1,0 +1,60 @@
+"""Real cross-process SQLite write-lock contention.
+
+Spawns a REAL separate process that opens the target database file,
+takes an exclusive write lock, and holds it — so a write attempt in the
+test process hits a genuine ``sqlite3.OperationalError: database is
+locked`` from actual OS-level file locking, not a mocked connection.
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import sqlite3
+import time
+from pathlib import Path
+from typing import Optional
+
+__all__ = ["LockHolder"]
+
+
+def _hold_exclusive_lock(db_path: str, ready: "multiprocessing.synchronize.Event",
+                          release: "multiprocessing.synchronize.Event") -> None:
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("BEGIN EXCLUSIVE")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS fault_lab_lock_holder (id INTEGER)"
+    )
+    ready.set()
+    release.wait(timeout=30)
+    conn.rollback()
+    conn.close()
+
+
+class LockHolder:
+    """Context manager: a real subprocess holds an exclusive lock on ``db_path``."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = str(db_path)
+        self._ctx = multiprocessing.get_context("spawn")
+        self._ready = self._ctx.Event()
+        self._release = self._ctx.Event()
+        self._proc: Optional[multiprocessing.process.BaseProcess] = None
+
+    def __enter__(self) -> "LockHolder":
+        self._proc = self._ctx.Process(
+            target=_hold_exclusive_lock,
+            args=(self._db_path, self._ready, self._release),
+            daemon=True,
+        )
+        self._proc.start()
+        if not self._ready.wait(timeout=10):
+            raise RuntimeError("fault_lab: lock-holder subprocess never acquired the lock")
+        # Small buffer so the exclusive transaction is fully committed
+        # from SQLite's perspective before the caller attempts a write.
+        time.sleep(0.05)
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self._release.set()
+        if self._proc is not None:
+            self._proc.join(timeout=10)

--- a/tests/fault_lab/test_provider_faults.py
+++ b/tests/fault_lab/test_provider_faults.py
@@ -1,0 +1,98 @@
+"""Fault-injection tests for provider HTTP failure modes.
+
+Companion to #54964: these tests drive REAL sockets through the REAL
+``openai`` SDK client construction path
+(``agent.auxiliary_client.resolve_provider_client``) — no client mock, no
+patched transport. Each test proves how a genuine failure mode actually
+surfaces, which is the primitive Hermes' own retry/fallback code depends
+on getting right.
+"""
+
+from __future__ import annotations
+
+import openai
+import pytest
+
+from agent.auxiliary_client import resolve_provider_client
+from tests.fault_lab.fake_provider_server import FakeProviderServer
+
+
+def test_429_surfaces_real_rate_limit_error_with_reason_intact():
+    """A real 429 must raise with the original reason, not a swallowed generic one."""
+    with FakeProviderServer() as server:
+        server.script(
+            429,
+            {"error": {"message": "Rate limit exceeded: 10 req/min",
+                       "type": "rate_limit_error"}},
+        )
+        client, _ = resolve_provider_client(
+            "custom", explicit_base_url=server.base_url, explicit_api_key="fake-key"
+        )
+        with pytest.raises(openai.RateLimitError) as exc_info:
+            client.chat.completions.create(
+                model="fault-lab-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        assert "Rate limit exceeded: 10 req/min" in str(exc_info.value)
+        assert len(server.requests) == 1
+
+
+def test_5xx_surfaces_real_internal_server_error():
+    with FakeProviderServer() as server:
+        server.script(500, {"error": {"message": "upstream exploded", "type": "server_error"}})
+        client, _ = resolve_provider_client(
+            "custom", explicit_base_url=server.base_url, explicit_api_key="fake-key"
+        )
+        with pytest.raises(openai.InternalServerError) as exc_info:
+            client.chat.completions.create(
+                model="fault-lab-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        assert "upstream exploded" in str(exc_info.value)
+
+
+def test_truncated_stream_ends_silently_without_finish_reason_stop():
+    """A mid-stream connection close ends the SDK's iteration WITHOUT raising.
+
+    This is the real fault: silent truncation is indistinguishable from a
+    normal end-of-stream at the SDK level unless the caller explicitly
+    checks that a ``finish_reason`` of ``"stop"`` was actually observed.
+    Any Hermes streaming path that assumes "loop ended => complete" is
+    exposed to exactly this failure mode.
+    """
+    with FakeProviderServer() as server:
+        server.script_truncated_stream(["Hello", " world", " this is"])
+        client, _ = resolve_provider_client(
+            "custom", explicit_base_url=server.base_url, explicit_api_key="fake-key"
+        )
+        stream = client.chat.completions.create(
+            model="fault-lab-model",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )
+        collected = ""
+        saw_stop = False
+        for event in stream:
+            choice = event.choices[0]
+            collected += choice.delta.content or ""
+            if choice.finish_reason == "stop":
+                saw_stop = True
+
+        # The stream ended (no exception), content arrived, but the
+        # completion was never actually signaled — this is the fault.
+        assert collected == "Hello world this is"
+        assert saw_stop is False
+
+
+def test_no_scripted_response_left_returns_fault_lab_marker_not_a_hang():
+    """An un-scripted call gets a deterministic 500, never a silent hang."""
+    with FakeProviderServer() as server:
+        client, _ = resolve_provider_client(
+            "custom", explicit_base_url=server.base_url, explicit_api_key="fake-key"
+        )
+        with pytest.raises(openai.InternalServerError) as exc_info:
+            client.chat.completions.create(
+                model="fault-lab-model",
+                messages=[{"role": "user", "content": "hi"}],
+            )
+        assert "fault_lab: no scripted response left" in str(exc_info.value)

--- a/tests/fault_lab/test_sqlite_faults.py
+++ b/tests/fault_lab/test_sqlite_faults.py
@@ -1,0 +1,41 @@
+"""Fault-injection test for real cross-process SQLite write-lock contention.
+
+Companion to #54964: a REAL separate process holds the exclusive lock —
+no mocked connection, no monkeypatched cursor — so this proves the actual
+``sqlite3.OperationalError`` shape a concurrent writer hits, which is what
+retry/backoff code in ``hermes_state.py`` (``SessionDB``) must handle.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from tests.fault_lab.sqlite_faults import LockHolder
+
+
+def test_write_during_exclusive_lock_raises_real_operational_error(tmp_path):
+    db_path = tmp_path / "fault_lab.db"
+    setup_conn = sqlite3.connect(db_path)
+    setup_conn.execute("CREATE TABLE t (id INTEGER)")
+    setup_conn.commit()
+    setup_conn.close()
+
+    with LockHolder(db_path):
+        writer = sqlite3.connect(db_path, timeout=0.5)
+        try:
+            with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+                writer.execute("INSERT INTO t VALUES (1)")
+                writer.commit()
+        finally:
+            writer.close()
+
+    # After the holder releases, a normal write must succeed — the fault
+    # was transient contention, not a corrupted database.
+    recovered = sqlite3.connect(db_path)
+    recovered.execute("INSERT INTO t VALUES (2)")
+    recovered.commit()
+    row_count = recovered.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+    recovered.close()
+    assert row_count == 1


### PR DESCRIPTION
## Summary

Adds `tests/fault_lab/` — reusable, real (never mocked) fault-injection primitives for provider HTTP failures and SQLite lock contention, directly addressing the mocks-vs-real-E2E gap #54964 documents.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Real openai.OpenAI Client] -->|POST /v1/chat/completions| B[Real Local HTTP Socket]
    B -->|Scripted 429| C[Real RateLimitError, Reason Intact]
    B -->|Scripted 5xx| D[Real InternalServerError]
    B -->|Mid-Stream Close| E[Silent Truncation: No finish_reason=stop]
    F[Real Subprocess] -->|BEGIN EXCLUSIVE| G[Real SQLite File Lock]
    G -->|Concurrent Write| H[Real OperationalError: database is locked]
```

## Infographic :

<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/7e359fb4-d55d-427b-a694-a03b33a59d84" />

Closes #80484

## The concrete gap this closes

`tests/agent/test_auxiliary_client.py::test_429_rate_limit_triggers_fallback` mocks the entire client (`MagicMock`, `patch("_get_cached_client", ...)`). That proves Hermes' *fallback selection logic* runs when told a 429 happened — it can't catch a change in how the real SDK actually surfaces a 429 (message shape, exception type), because nothing real ever produces one. `tests/fault_lab/test_provider_faults.py` does: a real local HTTP server returns a genuine 429, driven through the real `agent.auxiliary_client.resolve_provider_client("custom", explicit_base_url=...)` → real `openai.OpenAI` client → real `openai.RateLimitError` with the original message intact.

## What each primitive proves

- **429 / 5xx**: the real SDK raises the correctly-typed exception with the original reason string intact — the precondition for "fallback without hiding the reason."
- **Mid-stream truncation**: a closed connection ends the SDK's stream iteration *without raising* — content arrives, but `finish_reason` never becomes `"stop"`. This is the actual fault: silent truncation is indistinguishable from normal completion unless the caller checks for the `stop` signal explicitly. Any Hermes streaming path assuming "loop ended ⇒ complete" is exposed to this.
- **SQLite exclusive lock**: a real separate `multiprocessing` process holds a genuine `BEGIN EXCLUSIVE` transaction on the db file; a concurrent writer gets a real `sqlite3.OperationalError: database is locked` — and the database is provably uncorrupted (a write after release succeeds, row count is correct) once the contention clears.

## Scope for this first cut

Provider HTTP faults + SQLite lock contention only. MCP-disconnect and gateway-reconnect fault scenarios (also in the original proposal) are natural follow-ups once these two primitives see real use — scoped out here to keep the PR reviewable. Test-only infra: no production code touched, no new config, no CI wiring changes.

## Test plan

- [x] `pytest tests/fault_lab/ -q` — 5 passing (real socket for provider faults, real subprocess for SQLite contention — no `MagicMock`/`patch` anywhere in this package)
- [x] `ruff check tests/fault_lab/` — clean
- [x] Manually verified each fault primitive in isolation before writing assertions (429 → `RateLimitError` with exact message; truncated stream → silent end, no `stop`; lock contention → real `OperationalError`, then a clean recovery write)