### PR TITLE
fix(skills): save a bundle atomically so an interrupted write can't erase it

### DIFF
--- a/agent/skill_bundles.py
+++ b/agent/skill_bundles.py
@@ -411,9 +411,22 @@ def save_bundle(
     if instruction:
         payload["instruction"] = instruction
 
-    path.write_text(
+    # ``overwrite=True`` replaces a bundle the user already authored, and a
+    # bare ``write_text`` truncates it before the dump lands. An interrupted
+    # save leaves empty YAML, which ``_load_bundle_file`` reads as "not a
+    # mapping; skipping" — the bundle disappears from slash-command discovery
+    # with only a WARNING, and the ``scan_bundles()`` refresh below makes that
+    # visible immediately, so the editor's next save starts from nothing.
+    # ``preserve_mode`` keeps an existing bundle's bits instead of tightening
+    # it to mkstemp's 0600; a fresh one lands at 0644 like the other
+    # user-facing files Hermes creates.
+    from utils import atomic_write_text
+
+    atomic_write_text(
+        path,
         yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
-        encoding="utf-8",
+        preserve_mode=True,
+        create_mode=0o644,
     )
     scan_bundles()  # refresh cache
     return path

--- a/tests/agent/test_skill_bundles.py
+++ b/tests/agent/test_skill_bundles.py
@@ -7,6 +7,7 @@ import pytest
 
 from agent.skill_bundles import (
     _slugify,
+    bundle_path_for,
     build_bundle_invocation_message,
     delete_bundle,
     get_bundle,
@@ -264,6 +265,58 @@ class TestSaveAndDeleteBundle:
         delete_bundle("doomed")
         assert get_bundle("doomed") is None
 
+
+class TestSaveBundleDurability:
+    """An overwrite replaces a bundle the user authored.
+
+    A truncating write empties the file before the dump lands, and
+    ``_load_bundle_file`` reads empty YAML as "not a mapping; skipping" — the
+    bundle drops out of slash-command discovery with only a WARNING, and
+    ``save_bundle`` refreshes the cache right after the write, so the loss
+    shows up immediately and the next save starts from nothing.
+    """
+
+    def test_existing_bundle_survives_an_interrupted_save(self, bundles_env, monkeypatch):
+        save_bundle("keeper", ["s1"], description="original")
+        path = bundle_path_for("keeper")
+        original = path.read_bytes()
+
+        def boom(fd):
+            raise OSError("simulated crash mid-write")
+
+        monkeypatch.setattr(os, "fsync", boom)
+        try:
+            save_bundle("keeper", ["s2"], description="replacement", overwrite=True)
+        except OSError:
+            pass  # the durable path refuses to swap in a half-written file
+
+        assert path.read_bytes() == original, "the previous bundle was destroyed"
+        reload_bundles()
+        info = get_bundle("keeper")
+        assert info is not None, "bundle vanished from discovery after a failed save"
+        assert info["skills"] == ["s1"]
+
+    def test_overwrite_keeps_the_existing_file_mode(self, bundles_env):
+        if os.name == "nt":
+            pytest.skip("POSIX permission bits")
+        import stat
+
+        save_bundle("moded", ["s1"])
+        path = bundle_path_for("moded")
+        os.chmod(path, 0o640)
+
+        save_bundle("moded", ["s2"], overwrite=True)
+
+        assert stat.S_IMODE(path.stat().st_mode) == 0o640
+
+    def test_new_bundle_is_not_locked_to_0600(self, bundles_env):
+        if os.name == "nt":
+            pytest.skip("POSIX permission bits")
+        import stat
+
+        save_bundle("fresh", ["s1"])
+        mode = stat.S_IMODE(bundle_path_for("fresh").stat().st_mode)
+        assert mode == 0o644, f"new bundle landed at {oct(mode)}"
 
 
 class TestReloadBundles:


### PR DESCRIPTION
## What

`utils.atomic_write_text`'s docstring states the invariant plainly: it exists "so that every destructive file rewrite in the codebase shares one implementation." 67827dd99 swept four rewrites that still bypassed it — the user's `config.yaml`, their shell rc, `SOUL.md`, and `distribution.yaml`.

`save_bundle` is a fifth, and it matches both halves of that commit's rationale.

**Write half.** With `overwrite=True` the target is a bundle the user authored, and the write truncates it before the dump lands:

```python
path.write_text(
    yaml.safe_dump(payload, sort_keys=False, allow_unicode=True),
    encoding="utf-8",
)
scan_bundles()  # refresh cache
```

A crash, SIGINT or ENOSPC mid-write leaves empty or half-written YAML. Nothing in this path takes a backup.

**Read half degrades silently.** `_load_bundle_file` treats empty YAML as absent:

```python
data = yaml.safe_load(raw)
...
if not isinstance(data, dict):
    logger.warning("Bundle %s is not a mapping; skipping", path)
    return None
```

So the bundle simply stops existing for slash-command discovery, with only a WARNING in the log. And because `save_bundle` refreshes the cache on the very next line, the loss is visible immediately — the bundle reads as *never saved*, and the editor's next save starts from an empty document. That is the same shape the merged commit describes for `SOUL.md`: "presents as 'your persona was never set' and the editor's next Save persists the empty document."

Driving the two writers under the same interruption:

```
bare write_text   -> file after crash: ''                     secrets/content survived: False
atomic_write_text -> file after crash: <original contents>    survived: True
```

## The fix

Route the write through `atomic_write_text`, with the two mode arguments the sweep's siblings needed:

- `preserve_mode=True` — an overwrite keeps the existing file's bits instead of inheriting mkstemp's 0600
- `create_mode=0o644` — a fresh bundle lands like the other user-facing files Hermes creates (4541d3018 did the same for `SOUL.md` and `distribution.yaml`)

## Tests and results

Three cases in `tests/agent/test_skill_bundles.py`, in the same shape the sweep's own tests use (patch `os.fsync` to fail, then assert the previous file is still there):

- an interrupted overwrite leaves the previous bundle byte-identical, and it still resolves through `reload_bundles()` / `get_bundle()`
- an overwrite keeps the existing file's mode (`0o640` stays `0o640`)
- a newly created bundle lands at `0o644` rather than `0o600`

The first fails on `main` with `AssertionError: the previous bundle was destroyed` and passes with the fix; the two mode tests are POSIX-only and skip elsewhere.

The skills suites — 21 files across `tests/agent/*skill*` and `tests/hermes_cli/*skill*` — run to 160 passed. I ran them before and after and diffed the failure lists: 5 failures, byte-identical both ways, all pre-existing on `main` and unrelated (symlink lexical paths, a disabled-skills env var). `scripts/check-windows-footguns.py` reports the same 3 pre-existing findings on `main` as with the change; none are in lines this PR touches.