### PR TITLE
fix(sessions): recover orphaned compression parents without continuations (#80337)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1310,6 +1310,27 @@ def recover_rotated_compression_session(
                 return recovered
             holder = holder_getter(session_id) if callable(holder_getter) else None
             if not holder or attempt == 20:
+                if not holder:
+                    orphan_reopener = getattr(
+                        type(session_db),
+                        "reopen_orphaned_compression_session",
+                        None,
+                    )
+                    if callable(orphan_reopener):
+                        try:
+                            if orphan_reopener(session_db, session_id):
+                                logger.warning(
+                                    "compression recovery: reopened orphaned "
+                                    "session=%s with no continuation",
+                                    session_id,
+                                )
+                        except Exception as exc:
+                            logger.debug(
+                                "orphaned compression session reopen failed "
+                                "for %s: %s",
+                                session_id,
+                                exc,
+                            )
                 return None
             time.sleep(0.05)
         return None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1325,7 +1325,7 @@ def recover_rotated_compression_session(
                                     session_id,
                                 )
                         except Exception as exc:
-                            logger.debug(
+                            logger.warning(
                                 "orphaned compression session reopen failed "
                                 "for %s: %s",
                                 session_id,

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3715,18 +3715,6 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ):
                 return False
 
-            # An expired row is harmless: a publisher must revalidate its lease
-            # before committing, while an active row indicates a handoff may
-            # still be in flight.
-            active_lock = conn.execute(
-                "SELECT 1 FROM compression_locks "
-                "WHERE session_id = ? "
-                "AND (expires_at IS NULL OR expires_at >= ?) LIMIT 1",
-                (session_id, time.time()),
-            ).fetchone()
-            if active_lock is not None:
-                return False
-
             # Treat any direct non-branch/non-delegate/non-tool child as a
             # continuation, regardless of its current ended state. Reopening
             # in that case could create a second live head for one lineage.
@@ -3744,6 +3732,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             if child is not None:
                 return False
+
+            # refresh_compression_lock() deliberately lets an owner revive its
+            # own expired row. Reclaim that row inside this write transaction
+            # before reopening: refresh-first makes the lease active and aborts
+            # recovery; recovery-first deletes the holder identity so a later
+            # refresh cannot resurrect it.
+            now = time.time()
+            lock_row = conn.execute(
+                "SELECT holder, expires_at FROM compression_locks "
+                "WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()
+            if lock_row is not None:
+                expires_at = lock_row["expires_at"]
+                if expires_at is None or float(expires_at) >= now:
+                    return False
+                deleted = conn.execute(
+                    "DELETE FROM compression_locks "
+                    "WHERE session_id = ? AND holder = ? AND expires_at = ?",
+                    (session_id, lock_row["holder"], expires_at),
+                )
+                if deleted.rowcount != 1:
+                    return False
 
             updated = conn.execute(
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3648,6 +3648,24 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
         return self._session_row_dict(row) if row else None
 
+    # Children that carry a ``parent_session_id`` but are NOT compression
+    # continuations: branches, delegate/subagent runs, and tool sessions.
+    # A marker only disqualifies a child when it points at the parent being
+    # queried — compression continuations inherit the rotated agent's
+    # ``model_config`` verbatim (``publish_compression_child`` callers pass
+    # ``agent._session_init_model_config``), so a delegate subagent's
+    # continuation carries ``_delegate_from=<the delegate's own parent>``.
+    # Matching markers by mere presence misclassified those real
+    # continuations as delegate children (fail-open for orphan reopen,
+    # fail-closed for adoption). Bind the parent id for both markers.
+    _NON_CONTINUATION_CHILD_FILTER_SQL = (
+        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
+        " '$._branched_from'), '') != ?\n"
+        "  AND COALESCE(json_extract(COALESCE({alias}model_config, '{{}}'),"
+        " '$._delegate_from'), '') != ?\n"
+        "  AND COALESCE({alias}source, '') != 'tool'\n"
+    )
+
     def find_live_compression_child(
         self, parent_session_id: str
     ) -> Optional[Dict[str, Any]]:
@@ -3681,13 +3699,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash
                 WHERE s.parent_session_id = ?
                   AND s.ended_at IS NULL
-                  AND json_extract(COALESCE(s.model_config, '{}'), '$._branched_from') IS NULL
-                  AND json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from') IS NULL
-                  AND COALESCE(s.source, '') != 'tool'
+                """
+                + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="s.")
+                + """
                 ORDER BY s.started_at ASC
                 LIMIT 2
                 """,
-                (parent_session_id,),
+                (parent_session_id, parent_session_id, parent_session_id),
             ).fetchall()
         return self._session_row_dict(rows[0]) if len(rows) == 1 else None
 
@@ -3723,12 +3741,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 SELECT 1
                 FROM sessions
                 WHERE parent_session_id = ?
-                  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL
-                  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL
-                  AND COALESCE(source, '') != 'tool'
+                """
+                + self._NON_CONTINUATION_CHILD_FILTER_SQL.format(alias="")
+                + """
                 LIMIT 1
                 """,
-                (session_id,),
+                (session_id, session_id, session_id),
             ).fetchone()
             if child is not None:
                 return False
@@ -3762,6 +3780,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "AND end_reason = 'compression'",
                 (session_id,),
             )
+            # rowcount==1 is guaranteed by the parent SELECT at the top of
+            # this same BEGIN IMMEDIATE transaction. If this is ever edited
+            # to return False past this point, note that the lease DELETE
+            # above will still COMMIT (_execute_write commits unless _do
+            # raises) — raise instead of returning False to roll back.
             return updated.rowcount == 1
 
         return bool(self._execute_write(_do))

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3691,6 +3691,70 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchall()
         return self._session_row_dict(rows[0]) if len(rows) == 1 else None
 
+    def reopen_orphaned_compression_session(self, session_id: str) -> bool:
+        """Reopen a compression parent only when no continuation was published.
+
+        Compression publication is atomic in current builds, but older builds
+        could leave a closed parent behind after an interrupted handoff.  This
+        recovery is deliberately conservative: an active compression lease or
+        any canonical child means the lineage is still owned by another path,
+        so the caller must fail closed instead of reopening the parent.
+        """
+        if not session_id:
+            return False
+
+        def _do(conn):
+            parent = conn.execute(
+                "SELECT ended_at, end_reason FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if (
+                parent is None
+                or parent["ended_at"] is None
+                or parent["end_reason"] != "compression"
+            ):
+                return False
+
+            # An expired row is harmless: a publisher must revalidate its lease
+            # before committing, while an active row indicates a handoff may
+            # still be in flight.
+            active_lock = conn.execute(
+                "SELECT 1 FROM compression_locks "
+                "WHERE session_id = ? "
+                "AND (expires_at IS NULL OR expires_at >= ?) LIMIT 1",
+                (session_id, time.time()),
+            ).fetchone()
+            if active_lock is not None:
+                return False
+
+            # Treat any direct non-branch/non-delegate/non-tool child as a
+            # continuation, regardless of its current ended state. Reopening
+            # in that case could create a second live head for one lineage.
+            child = conn.execute(
+                """
+                SELECT 1
+                FROM sessions
+                WHERE parent_session_id = ?
+                  AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL
+                  AND COALESCE(source, '') != 'tool'
+                LIMIT 1
+                """,
+                (session_id,),
+            ).fetchone()
+            if child is not None:
+                return False
+
+            updated = conn.execute(
+                "UPDATE sessions SET ended_at = NULL, end_reason = NULL "
+                "WHERE id = ? AND ended_at IS NOT NULL "
+                "AND end_reason = 'compression'",
+                (session_id,),
+            )
+            return updated.rowcount == 1
+
+        return bool(self._execute_write(_do))
+
     def publish_compression_child(
         self,
         *,

--- a/tests/agent/test_compression_orphan_recovery.py
+++ b/tests/agent/test_compression_orphan_recovery.py
@@ -1,0 +1,42 @@
+"""Recovery for legacy compression parents with no continuation child."""
+
+from types import SimpleNamespace
+
+from agent.conversation_compression import recover_rotated_compression_session
+from hermes_state import CompressionSessionClosedError, SessionDB
+
+
+def test_recover_rotated_compression_session_reopens_legacy_orphan(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("orphan", source="cli")
+        db.append_message("orphan", "user", "before compression")
+        db.end_session("orphan", "compression")
+        agent = SimpleNamespace(_session_db=db, session_id="orphan")
+
+        assert recover_rotated_compression_session(agent) is None
+        db.append_message("orphan", "user", "after recovery")
+    finally:
+        db.close()
+
+
+def test_recover_rotated_compression_session_keeps_parent_closed_with_child(
+    tmp_path,
+):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("parent", source="cli")
+        db.append_message("parent", "user", "before compression")
+        db.end_session("parent", "compression")
+        db.create_session("child", source="cli", parent_session_id="parent")
+        agent = SimpleNamespace(_session_db=db, session_id="parent")
+
+        assert recover_rotated_compression_session(agent) is None
+        try:
+            db.append_message("parent", "user", "must stay closed")
+        except CompressionSessionClosedError:
+            pass
+        else:
+            raise AssertionError("compression parent with child was reopened")
+    finally:
+        db.close()

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from hermes_state import SessionDB
@@ -100,6 +102,44 @@ def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
 
     assert db.reopen_orphaned_compression_session("leased-parent") is False
     assert db.get_session("leased-parent")["end_reason"] == "compression"
+
+
+def test_reopen_orphaned_compression_session_reclaims_expired_lease(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "expired-lease-parent")
+    now = time.time()
+    db._conn.execute(
+        "INSERT INTO compression_locks "
+        "(session_id, holder, acquired_at, expires_at) VALUES (?, ?, ?, ?)",
+        ("expired-lease-parent", "old-compressor", now - 60, now - 30),
+    )
+    db._conn.commit()
+
+    assert db.reopen_orphaned_compression_session("expired-lease-parent") is True
+    assert db.refresh_compression_lock(
+        "expired-lease-parent", "old-compressor"
+    ) is False
+    assert db.get_compression_lock_holder("expired-lease-parent") is None
+
+
+def test_reopen_orphaned_compression_session_loses_to_expired_lease_refresh(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "refreshed-lease-parent")
+    now = time.time()
+    db._conn.execute(
+        "INSERT INTO compression_locks "
+        "(session_id, holder, acquired_at, expires_at) VALUES (?, ?, ?, ?)",
+        ("refreshed-lease-parent", "live-compressor", now - 60, now - 30),
+    )
+    db._conn.commit()
+
+    assert db.refresh_compression_lock(
+        "refreshed-lease-parent", "live-compressor"
+    ) is True
+    assert db.reopen_orphaned_compression_session("refreshed-lease-parent") is False
+    assert db.get_session("refreshed-lease-parent")["end_reason"] == "compression"
 
 
 

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -42,6 +42,66 @@ def test_find_live_compression_child_fails_closed_when_ambiguous(db: SessionDB) 
     assert db.find_live_compression_child("parent") is None
 
 
+def test_reopen_orphaned_compression_session_reopens_parent_without_child(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "orphan")
+
+    assert db.reopen_orphaned_compression_session("orphan") is True
+    assert db.get_session("orphan")["ended_at"] is None
+    assert db.get_session("orphan")["end_reason"] is None
+
+    db.append_message("orphan", "user", "recovered turn")
+    assert [m["content"] for m in db.get_messages("orphan")] == [
+        "before split",
+        "recovered turn",
+    ]
+
+
+def test_reopen_orphaned_compression_session_fails_closed_with_child(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "parent-with-child")
+    db.create_session("child", source="webui", parent_session_id="parent-with-child")
+
+    assert db.reopen_orphaned_compression_session("parent-with-child") is False
+    parent = db.get_session("parent-with-child")
+    assert parent["end_reason"] == "compression"
+    assert parent["ended_at"] is not None
+
+
+def test_reopen_orphaned_compression_session_ignores_non_continuation_children(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "parent-with-non-continuation-children")
+    db.create_session(
+        "branch",
+        source="webui",
+        parent_session_id="parent-with-non-continuation-children",
+        model_config={"_branched_from": "parent-with-non-continuation-children"},
+    )
+    db.create_session(
+        "delegate",
+        source="tool",
+        parent_session_id="parent-with-non-continuation-children",
+        model_config={"_delegate_from": "parent-with-non-continuation-children"},
+    )
+
+    assert db.reopen_orphaned_compression_session(
+        "parent-with-non-continuation-children"
+    ) is True
+
+
+def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
+    db: SessionDB,
+) -> None:
+    _compression_parent(db, "leased-parent")
+    assert db.try_acquire_compression_lock("leased-parent", "compressor")
+
+    assert db.reopen_orphaned_compression_session("leased-parent") is False
+    assert db.get_session("leased-parent")["end_reason"] == "compression"
+
+
 
 
 def test_find_live_compression_child_ignores_non_continuation_children(

--- a/tests/state/test_compression_lineage_guard.py
+++ b/tests/state/test_compression_lineage_guard.py
@@ -94,6 +94,48 @@ def test_reopen_orphaned_compression_session_ignores_non_continuation_children(
     ) is True
 
 
+def test_reopen_fails_closed_when_continuation_inherits_foreign_markers(
+    db: SessionDB,
+) -> None:
+    """A REAL continuation can carry ``_delegate_from``/``_branched_from``
+    pointing at some OTHER session: ``publish_compression_child`` callers
+    pass the rotated agent's ``_session_init_model_config`` verbatim, so a
+    delegate subagent's continuation inherits ``_delegate_from=<the
+    delegate's own parent>``. Marker-presence matching misclassified it as
+    a delegate child — reopen returned True with a live continuation
+    present, forking the lineage. Markers only disqualify a child when
+    they point at the queried parent."""
+    _compression_parent(db, "delegate-session")
+    db.create_session(
+        "delegate-continuation",
+        source="subagent",
+        parent_session_id="delegate-session",
+        model_config={"_delegate_from": "some-original-parent"},
+    )
+
+    assert db.reopen_orphaned_compression_session("delegate-session") is False
+    parent = db.get_session("delegate-session")
+    assert parent["end_reason"] == "compression"
+
+
+def test_find_live_child_returns_continuation_with_foreign_markers(
+    db: SessionDB,
+) -> None:
+    """Adoption-side twin of the reopen test above: the continuation that
+    inherited a foreign ``_delegate_from`` must still be adoptable."""
+    _compression_parent(db, "delegate-session-2")
+    db.create_session(
+        "inherited-continuation",
+        source="subagent",
+        parent_session_id="delegate-session-2",
+        model_config={"_delegate_from": "some-original-parent"},
+    )
+
+    child = db.find_live_compression_child("delegate-session-2")
+    assert child is not None
+    assert child["id"] == "inherited-continuation"
+
+
 def test_reopen_orphaned_compression_session_fails_closed_with_active_lease(
     db: SessionDB,
 ) -> None:
@@ -142,8 +184,6 @@ def test_reopen_orphaned_compression_session_loses_to_expired_lease_refresh(
     assert db.get_session("refreshed-lease-parent")["end_reason"] == "compression"
 
 
-
-
 def test_find_live_compression_child_ignores_non_continuation_children(
     db: SessionDB,
 ) -> None:
@@ -167,12 +207,6 @@ def test_find_live_compression_child_ignores_non_continuation_children(
 
     assert child is not None
     assert child["id"] == "canonical"
-
-
-
-
-
-
 
 
 def test_publish_compression_child_is_atomic_on_handoff_failure(


### PR DESCRIPTION
## Summary

Recovers compression-parent sessions whose continuation was never persisted — the "orphan" state from #80337 where every write raises `CompressionSessionClosedError`, every turn ends `session_persistence_failed`, and the only fix was manual SQL on `state.db`. Salvages @izumi0uu's #80380 (2 commits, authorship preserved) plus one follow-up fixing a reachable fail-open found in adversarial review.

## Changes

- `hermes_state.py`: `SessionDB.reopen_orphaned_compression_session()` — reopens a compression-ended parent only when, inside one `BEGIN IMMEDIATE` write txn: no canonical continuation child exists (ended or live), and no active compression lease exists (expired leases are reclaimed holder-identity-and-all, so a stale compressor's refresh can't resurrect them). Fails closed on any ambiguity. (@izumi0uu)
- `agent/conversation_compression.py`: `recover_rotated_compression_session()` invokes the reopener only after child adoption finds nothing and no live lease remains — recovery happens transparently at turn start. (@izumi0uu)
- **Follow-up (fail-open fix):** compression continuations inherit the rotated agent's `model_config` verbatim, so a delegate subagent's continuation carries `_delegate_from=<the delegate's own parent>`. The original marker-*presence* filters misclassified such a real continuation as a delegate child — reopen returned True with a live continuation present, forking the lineage (verified with a live repro). Markers now only disqualify a child when they point at the queried parent, via a shared `_NON_CONTINUATION_CHILD_FILTER_SQL` fragment used by both `find_live_compression_child` (adoption) and the reopener — also removing the duplicated-SQL drift risk. Reopen-failure log raised debug→warning (the failure hard-fails the turn moments later).

The three read-only projection walks (`get_compression_tip`, `list_sessions_rich` chain, resume walk) keep marker-presence semantics: they can only under-follow (fail closed → resume shows the parent), and the fixed adoption path self-heals at first turn.

## Validation

| Scenario | Before | After |
|---|---|---|
| True orphan (compression-ended, no child) | every write raises, session bricked | reopened at turn start, writes proceed |
| Mid-chain parent P→C(ended)→G(live) | — | reopen refused (fail closed) |
| Continuation with inherited `_delegate_from` | **reopen forked the lineage** (pre-follow-up) | reopen refused; adoption finds the continuation |
| Active/expired compression lease | — | active: refused; expired: reclaimed with holder identity, refresh-after loses |

- 3-agent review + adversarial probe batch: TOCTOU (reopen vs `publish_compression_child`) serializes via `BEGIN IMMEDIATE` — no window; `model_config` shape probes all fail closed except the inherited-marker case fixed here; archived-rows/idempotency/lease races all pass
- Perf: `find_live_compression_child` +0.005 ms vs before (identical query plan); reopener runs once per recovery attempt, never inside the retry loop
- Tests: 102 passed across `tests/state/`, `tests/agent/test_compression_orphan_recovery.py`, `tests/hermes_state/`; 69 passed in `tests/gateway/test_session.py` + `tests/agent/test_turn_context.py`; regression pair added for the inherited-marker case (reopen fails closed / adoption succeeds)

## Credit

- @izumi0uu — the salvaged implementation (#80380): transactional lineage+lease guards, the refresh-vs-reclaim fencing, and 8 regression tests
- @RelaxJonh — competing fix #80399 (same issue, simpler check; closed with explanation — its live-child-only test reopened mid-chain parents)
- Reporter of #80337 for the detailed orphan diagnosis

Fixes #80337. Supersedes #80380 (salvage), #80399.
