### PR TITLE
feat(delegation): durable retained subagents — registry, follow-up messaging, persisted usage attribution

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -642,6 +642,25 @@ class CLIAgentSetupMixin:
             )
             self._restore_session_cwd(session_meta)
             self._restore_session_yolo(session_meta)
+            # Reapply persisted subagent-usage attribution (#79686 P1): the
+            # in-memory child cost rollup died with the previous process, so
+            # re-seed this session's aggregate from the durable ledger.
+            try:
+                from tools.async_delegation import load_child_usage_totals
+
+                _child_totals = load_child_usage_totals(self.session_id)
+                _child_cost = float(_child_totals.get("cost_usd") or 0.0)
+                if _child_cost > 0.0:
+                    self.session_estimated_cost_usd = (
+                        float(getattr(self, "session_estimated_cost_usd", 0.0) or 0.0)
+                        + _child_cost
+                    )
+                    if getattr(self, "session_cost_source", "none") in {None, "", "none"}:
+                        self.session_cost_source = "subagent"
+                    if getattr(self, "session_cost_status", "unknown") in {None, "", "unknown"}:
+                        self.session_cost_status = "estimated"
+            except Exception:
+                pass
         else:
             accent_color = _accent_hex()
             self._console_print(

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1725,6 +1725,12 @@ DEFAULT_CONFIG = {
         # Flip to true only if you trust delegated work to run dangerous cmds
         # without human review (cron pipelines, batch automation, etc.).
         "subagent_auto_approve": False,
+        # Retained-subagent registry (delegate_task follow_up mode). Completed
+        # children stay addressable for follow-up messaging until tombstoned,
+        # TTL-expired, or pushed out by the cap. Tombstoning only removes
+        # addressability — transcripts/artifacts are never erased.
+        "max_retained": 10,        # max follow-up-addressable completed children
+        "retained_ttl_hours": 72,  # hours a completed child stays addressable
     },
 
     # Ephemeral prefill messages file — JSON list of {role, content} dicts

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5982,6 +5982,82 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             current = child_id
         return current
 
+    def get_compression_lineage_root(self, session_id: str) -> Optional[str]:
+        """Return a proven compression-only ancestor, or ``None`` on doubt.
+
+        Authority primitive for retained-subagent follow-ups (tracker
+        #79686 P1; design credit @0xbWy, #76512). Deliberately narrower than
+        :meth:`get_conversation_root`: delegate, branch, and tool children
+        share the same parent column, so a generic lineage walk would make
+        them co-owners of a parent's retained delegation. Each backwards hop
+        proves a real compression edge: a compression-ended parent, exactly
+        one eligible child, no explicit branch/delegate marker, and no tool
+        source. Any ambiguity (cycle, missing row, foreign marker, sibling
+        fan-out) returns ``None`` so callers fail closed.
+        """
+        if not isinstance(session_id, str) or not session_id.strip():
+            return None
+
+        current = session_id.strip()
+        seen: set[str] = set()
+        conn = self._conn
+        if conn is None:
+            return None
+        try:
+            with self._lock:
+                for _ in range(100):
+                    if current in seen:
+                        return None
+                    seen.add(current)
+                    child = conn.execute(
+                        """SELECT id, parent_session_id, source, model_config
+                           FROM sessions WHERE id = ?""",
+                        (current,),
+                    ).fetchone()
+                    if child is None:
+                        return None
+                    source = str(child["source"] or "").strip().lower()
+                    if source in {"delegate", "subagent", "tool"}:
+                        return None
+                    try:
+                        config = json.loads(child["model_config"] or "{}")
+                    except (TypeError, ValueError):
+                        return None
+                    if not isinstance(config, dict) or any(
+                        marker in config
+                        for marker in ("_branched_from", "_delegate_from")
+                    ):
+                        return None
+                    parent_id = child["parent_session_id"]
+                    if not parent_id:
+                        return current
+                    parent = conn.execute(
+                        """SELECT ended_at, end_reason FROM sessions
+                           WHERE id = ?""",
+                        (parent_id,),
+                    ).fetchone()
+                    if (
+                        parent is None
+                        or parent["ended_at"] is None
+                        or parent["end_reason"] != "compression"
+                    ):
+                        return None
+                    siblings = conn.execute(
+                        """SELECT id FROM sessions
+                           WHERE parent_session_id = ?
+                             AND json_extract(COALESCE(model_config, '{}'), '$._branched_from') IS NULL
+                             AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL
+                             AND COALESCE(source, '') != 'tool'
+                           LIMIT 2""",
+                        (parent_id,),
+                    ).fetchall()
+                    if len(siblings) != 1 or siblings[0]["id"] != current:
+                        return None
+                    current = str(parent_id)
+        except Exception:
+            return None
+        return None
+
     # Columns excluded from compact_rows projections: only the payload-heavy
     # blob no list consumer renders. Everything else — including gateway
     # routing fields and desktop sidebar fields like git_branch — stays, and

--- a/run_agent.py
+++ b/run_agent.py
@@ -7663,6 +7663,7 @@ class AIAgent:
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),
+            follow_up=function_args.get("follow_up"),
             parent_agent=self,
         )
 

--- a/tests/tools/test_retained_subagents.py
+++ b/tests/tools/test_retained_subagents.py
@@ -1,0 +1,591 @@
+"""Tests for the durable retained-subagent registry (tracker #79686 P1).
+
+Covers: schema additions on async_delegations + the delegation_child_usage
+ledger, child-manifest persistence, retention on completion, tombstoning
+(addressability removed, transcript untouched), TTL/cap pruning, restart
+rehydration through recover_abandoned_delegations, the compression-lineage
+follow-up authority model (design credit @0xbWy, #76512), persisted
+child-usage attribution with reapply-on-load totals, and the budget-exempt
+delegate_task(follow_up=...) paths.
+"""
+
+import json
+import sqlite3
+import time
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from tools import async_delegation as ad
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    ad._reset_for_tests()
+    yield
+    ad._reset_for_tests()
+
+
+def _db_conn(tmp_path) -> sqlite3.Connection:
+    return sqlite3.connect(tmp_path / "state.db")
+
+
+def _insert_delegation(delegation_id, *, parent_session_id="parent-1", state="running"):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            """INSERT OR REPLACE INTO async_delegations
+               (delegation_id, origin_session, origin_ui_session_id,
+                parent_session_id, state, dispatched_at, updated_at,
+                delivery_state, delivery_attempts, origin_session_id)
+               VALUES (?, '', '', ?, ?, ?, ?, 'pending', 0, '')""",
+            (delegation_id, parent_session_id, state, time.time(), time.time()),
+        )
+
+
+def _dispatch_and_retain(
+    delegation_id="deleg_test0001",
+    *,
+    parent_session_id="parent-1",
+    children=None,
+):
+    _insert_delegation(delegation_id, parent_session_id=parent_session_id)
+    ad.record_dispatched_children(
+        delegation_id,
+        children
+        or [
+            {
+                "subagent_id": "sa-0-abc12345",
+                "session_id": "child-sess-1",
+                "model": "test/model",
+                "goal": "do the thing",
+            }
+        ],
+    )
+    ad.retain_completed_delegation(delegation_id, usage={"cost_usd": 0.5})
+    return delegation_id
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+
+def test_schema_adds_retained_columns_and_usage_table(tmp_path):
+    conn = ad._connect()
+    conn.close()
+    raw = _db_conn(tmp_path)
+    try:
+        cols = {r[1] for r in raw.execute("PRAGMA table_info(async_delegations)")}
+        for expected in (
+            "retained", "retained_at", "tombstoned_at", "child_session_id",
+            "children_json", "owner_profile", "usage_json",
+        ):
+            assert expected in cols
+        tables = {
+            r[0]
+            for r in raw.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        assert "delegation_child_usage" in tables
+    finally:
+        raw.close()
+
+
+def test_schema_upgrade_is_backwards_compatible(tmp_path):
+    """A legacy DB without the new columns gains them on connect."""
+    raw = _db_conn(tmp_path)
+    raw.execute(
+        """CREATE TABLE async_delegations (
+            delegation_id TEXT PRIMARY KEY,
+            origin_session TEXT NOT NULL,
+            origin_ui_session_id TEXT NOT NULL DEFAULT '',
+            parent_session_id TEXT,
+            state TEXT NOT NULL,
+            dispatched_at REAL NOT NULL,
+            completed_at REAL,
+            updated_at REAL NOT NULL,
+            event_json TEXT,
+            result_json TEXT,
+            delivery_state TEXT NOT NULL DEFAULT 'pending',
+            delivery_attempts INTEGER NOT NULL DEFAULT 0,
+            delivered_at REAL
+        )"""
+    )
+    raw.commit()
+    raw.close()
+    conn = ad._connect()
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(async_delegations)")}
+        assert "retained" in cols and "children_json" in cols
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Retained registry lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_retain_and_list_children():
+    _dispatch_and_retain()
+    entries = ad.list_retained_children()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["child_id"] == "sa-0-abc12345"
+    assert entry["child_session_id"] == "child-sess-1"
+    assert entry["model"] == "test/model"
+    assert entry["delegation_id"] == "deleg_test0001"
+
+
+def test_find_retained_child_by_any_id():
+    _dispatch_and_retain()
+    for key in ("sa-0-abc12345", "child-sess-1", "deleg_test0001"):
+        assert ad.find_retained_child(key) is not None
+    assert ad.find_retained_child("nope") is None
+
+
+def test_tombstone_removes_addressability_only(tmp_path):
+    _dispatch_and_retain()
+    assert ad.tombstone_retained_child("sa-0-abc12345") is True
+    assert ad.find_retained_child("sa-0-abc12345") is None
+    # Second tombstone is a no-op (already de-registered).
+    assert ad.tombstone_retained_child("sa-0-abc12345") is False
+    # The durable row (and thus everything pointing at the transcript)
+    # still exists — tombstoning never deletes.
+    raw = _db_conn(tmp_path)
+    try:
+        row = raw.execute(
+            "SELECT tombstoned_at, children_json FROM async_delegations "
+            "WHERE delegation_id='deleg_test0001'"
+        ).fetchone()
+    finally:
+        raw.close()
+    assert row is not None
+    assert row[0] is not None
+    assert "child-sess-1" in (row[1] or "")
+
+
+def test_ttl_prune_tombstones_expired_rows(tmp_path):
+    _dispatch_and_retain()
+    # Backdate retained_at past the TTL.
+    raw = _db_conn(tmp_path)
+    raw.execute(
+        "UPDATE async_delegations SET retained_at=? WHERE delegation_id=?",
+        (time.time() - 100 * 3600, "deleg_test0001"),
+    )
+    raw.commit()
+    raw.close()
+    pruned = ad.prune_retained_children(ttl_hours=72)
+    assert pruned == 1
+    assert ad.list_retained_children() == []
+
+
+def test_cap_prune_keeps_newest():
+    for i in range(4):
+        _dispatch_and_retain(
+            f"deleg_cap{i:05d}",
+            children=[{"subagent_id": f"sa-{i}", "session_id": f"cs-{i}"}],
+        )
+        time.sleep(0.01)
+    ad.prune_retained_children(max_retained=2, ttl_hours=9999)
+    remaining = {e["delegation_id"] for e in ad.list_retained_children()}
+    assert remaining == {"deleg_cap00002", "deleg_cap00003"}
+
+
+def test_completion_persist_retains_only_success():
+    _insert_delegation("deleg_ok000001")
+    _insert_delegation("deleg_err00001")
+    ad.record_dispatched_children(
+        "deleg_ok000001", [{"subagent_id": "sa-ok", "session_id": "cs-ok"}]
+    )
+    ad.record_dispatched_children(
+        "deleg_err00001", [{"subagent_id": "sa-err", "session_id": "cs-err"}]
+    )
+    ad._persist_completion(
+        {"delegation_id": "deleg_ok000001", "status": "completed"},
+        {"status": "completed", "summary": "done"},
+    )
+    ad._persist_completion(
+        {"delegation_id": "deleg_err00001", "status": "error"},
+        {"status": "error", "summary": None},
+    )
+    ids = {e["delegation_id"] for e in ad.list_retained_children()}
+    assert ids == {"deleg_ok000001"}
+
+
+def test_recover_abandoned_delegations_rehydrates_retained(tmp_path):
+    """Restart path: retained rows survive and are validated during recovery."""
+    _dispatch_and_retain()
+    # Simulate restart: in-memory registry gone, durable rows remain.
+    ad._reset_for_tests()
+    ad.recover_abandoned_delegations()
+    entries = ad.list_retained_children()
+    assert [e["child_session_id"] for e in entries] == ["child-sess-1"]
+
+
+# ---------------------------------------------------------------------------
+# Follow-up authority (compression lineage; design credit @0xbWy #76512)
+# ---------------------------------------------------------------------------
+
+
+def _session_db(tmp_path):
+    from hermes_state import SessionDB
+
+    return SessionDB(Path(tmp_path) / "state.db")
+
+
+def test_lineage_authority_allows_compression_continuation(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+        db.end_session("A", "compression")
+        db.create_session("B", source="cli", parent_session_id="A")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+    entry = ad.find_retained_child("sa-0-abc12345")
+    # The compression continuation B shares A's lineage root → allowed.
+    assert ad.check_follow_up_authority(entry, "B") is None
+    # A itself is also allowed.
+    assert ad.check_follow_up_authority(entry, "A") is None
+
+
+def test_lineage_authority_rejects_siblings_and_foreigners(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+        db.end_session("A", "compression")
+        db.create_session("B", source="cli", parent_session_id="A")
+        db.create_session(
+            "branch", source="cli", parent_session_id="A",
+            model_config={"_branched_from": "A"},
+        )
+        db.create_session(
+            "delegatechild", source="delegate", parent_session_id="A",
+            model_config={"_delegate_from": "A"},
+        )
+        db.create_session("stranger", source="cli")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+    entry = ad.find_retained_child("sa-0-abc12345")
+    for foreign in ("branch", "delegatechild", "stranger", None, ""):
+        assert ad.check_follow_up_authority(entry, foreign) is not None
+
+
+def test_lineage_authority_rejects_child_self_follow_up(tmp_path):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+    entry = ad.find_retained_child("sa-0-abc12345")
+    err = ad.check_follow_up_authority(entry, "child-sess-1")
+    assert err is not None and "itself" in err
+
+
+def test_foreign_profile_is_rejected(tmp_path, monkeypatch):
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+    entry = dict(ad.find_retained_child("sa-0-abc12345"))
+    entry["owner_profile"] = "someone-else"
+    monkeypatch.setattr(ad, "_current_owner_profile", lambda: "me")
+    err = ad.check_follow_up_authority(entry, "A")
+    assert err is not None and "profile" in err
+
+
+# ---------------------------------------------------------------------------
+# Persisted usage attribution
+# ---------------------------------------------------------------------------
+
+
+def test_usage_attribution_roundtrip_and_totals():
+    ad._connect().close()  # ensure schema
+    ad.record_child_usage_attribution(
+        parent_session_id="p1",
+        parent_turn_id="turn-1",
+        child_session_id="c1",
+        usage={"cost_usd": 0.25, "tokens": {"input": 100, "output": 50}},
+        aggregate={"session_estimated_cost_usd": 1.25},
+    )
+    ad.record_child_usage_attribution(
+        parent_session_id="p1",
+        child_session_id="c2",
+        usage={"cost_usd": 0.75, "tokens": {"input": 10, "output": 5}},
+    )
+    ad.record_child_usage_attribution(
+        parent_session_id="other",
+        usage={"cost_usd": 99.0},
+    )
+    records = ad.load_child_usage_attributions("p1")
+    assert len(records) == 2
+    assert records[0]["parent_turn_id"] == "turn-1"
+    assert records[0]["aggregate"]["session_estimated_cost_usd"] == 1.25
+    totals = ad.load_child_usage_totals("p1")
+    assert totals["cost_usd"] == pytest.approx(1.0)
+    assert totals["input_tokens"] == pytest.approx(110)
+    assert totals["output_tokens"] == pytest.approx(55)
+    assert ad.load_child_usage_totals("missing") == {
+        "cost_usd": 0.0, "input_tokens": 0.0, "output_tokens": 0.0,
+    }
+
+
+def test_finalize_child_results_persists_attribution(tmp_path):
+    import tools.delegate_tool as dt
+
+    ad._connect().close()
+    parent = MagicMock()
+    parent.session_id = "parent-durable"
+    parent._current_turn_id = "turn-9"
+    parent._memory_manager = None
+    parent.session_estimated_cost_usd = 0.0
+    parent.session_cost_source = "none"
+    parent.session_cost_status = "unknown"
+    child = MagicMock()
+    child.session_id = "child-durable"
+    results = [
+        {
+            "task_index": 0,
+            "status": "completed",
+            "summary": "ok",
+            "tokens": {"input": 7, "output": 3},
+            "api_calls": 2,
+            "_child_role": "leaf",
+            "_child_cost_usd": 0.42,
+            "duration_seconds": 1.0,
+        }
+    ]
+    dt._finalize_child_results(results, [{"goal": "g"}], [(0, {"goal": "g"}, child)], parent)
+    assert parent.session_estimated_cost_usd == pytest.approx(0.42)
+    totals = ad.load_child_usage_totals("parent-durable")
+    assert totals["cost_usd"] == pytest.approx(0.42)
+    recs = ad.load_child_usage_attributions("parent-durable")
+    assert recs[0]["child_session_id"] == "child-durable"
+    assert recs[0]["usage"]["tokens"] == {"input": 7, "output": 3}
+
+
+# ---------------------------------------------------------------------------
+# delegate_task(follow_up=...)
+# ---------------------------------------------------------------------------
+
+
+def _parent_agent(depth=0):
+    parent = MagicMock()
+    parent._delegate_depth = depth
+    parent.session_id = "A"
+    parent._session_db = None
+    return parent
+
+
+def test_follow_up_steers_running_child(monkeypatch):
+    import tools.delegate_tool as dt
+
+    agent = MagicMock()
+    agent.session_id = "live-child-sess"
+    agent.steer.return_value = True
+    dt._register_subagent(
+        {"subagent_id": "sa-live-1", "agent": agent, "accepting_steer": True}
+    )
+    try:
+        out = json.loads(
+            dt.delegate_task(
+                goal="please also check X",
+                follow_up="sa-live-1",
+                parent_agent=_parent_agent(),
+            )
+        )
+        assert out["status"] == "queued"
+        assert out["child_id"] == "sa-live-1"
+        agent.steer.assert_called_once()
+        # Addressing by the child's session id works too.
+        agent.steer.reset_mock()
+        out2 = json.loads(
+            dt.delegate_task(
+                goal="more", follow_up="live-child-sess",
+                parent_agent=_parent_agent(),
+            )
+        )
+        assert out2["status"] == "queued"
+    finally:
+        dt._unregister_subagent("sa-live-1")
+
+
+def test_follow_up_is_budget_exempt(monkeypatch):
+    """A follow-up succeeds even when the spawn depth budget is exhausted."""
+    import tools.delegate_tool as dt
+
+    agent = MagicMock()
+    agent.steer.return_value = True
+    dt._register_subagent(
+        {"subagent_id": "sa-deep-1", "agent": agent, "accepting_steer": True}
+    )
+    try:
+        parent = _parent_agent(depth=99)  # far beyond max_spawn_depth
+        out = json.loads(
+            dt.delegate_task(goal="msg", follow_up="sa-deep-1", parent_agent=parent)
+        )
+        assert out["status"] == "queued"
+        # And it bypasses the spawn-pause kill switch as well.
+        dt.set_spawn_paused(True)
+        try:
+            out2 = json.loads(
+                dt.delegate_task(goal="msg2", follow_up="sa-deep-1", parent_agent=parent)
+            )
+            assert out2["status"] == "queued"
+        finally:
+            dt.set_spawn_paused(False)
+    finally:
+        dt._unregister_subagent("sa-deep-1")
+
+
+def test_follow_up_unknown_target_errors():
+    import tools.delegate_tool as dt
+
+    out = json.loads(
+        dt.delegate_task(goal="hi", follow_up="sa-ghost", parent_agent=_parent_agent())
+    )
+    assert "error" in out
+    assert "not a running subagent" in out["error"]
+
+
+def test_follow_up_requires_goal():
+    import tools.delegate_tool as dt
+
+    out = json.loads(
+        dt.delegate_task(follow_up="sa-anything", parent_agent=_parent_agent())
+    )
+    assert "error" in out
+
+
+def test_follow_up_tombstoned_child_errors(tmp_path):
+    import tools.delegate_tool as dt
+
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+    assert ad.tombstone_retained_child("sa-0-abc12345")
+    out = json.loads(
+        dt.delegate_task(
+            goal="hi", follow_up="sa-0-abc12345", parent_agent=_parent_agent()
+        )
+    )
+    assert "error" in out
+
+
+def test_follow_up_resumes_completed_child(tmp_path, monkeypatch):
+    """Completed retained child: transcript re-opens; follow-up is a NEW user
+    turn on the child's own session and the new summary is returned."""
+    import tools.delegate_tool as dt
+
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+        db.create_session("child-sess-1", source="delegate", parent_session_id="A")
+        db.append_message("child-sess-1", "user", "original goal")
+        db.append_message("child-sess-1", "assistant", "original answer")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+
+    captured = {}
+
+    def fake_build(**kwargs):
+        captured["build"] = kwargs
+        child = MagicMock()
+        child.session_id = kwargs.get("resume_session_id") or "child-sess-1"
+        return child
+
+    def fake_run(task_index, goal, child, parent_agent, **kw):
+        captured["run_goal"] = goal
+        captured["resume_history"] = getattr(child, "_delegate_resume_history", None)
+        return {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": "follow-up answer",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+        }
+
+    monkeypatch.setattr(dt, "_build_child_preserving_parent_tools", fake_build)
+    monkeypatch.setattr(dt, "_run_single_child", fake_run)
+    monkeypatch.setattr(dt, "_finalize_child_results", lambda *a, **k: None)
+
+    parent = _parent_agent()
+    from hermes_state import SessionDB
+
+    parent._session_db = SessionDB(Path(tmp_path) / "state.db")
+    try:
+        out = json.loads(
+            dt.delegate_task(
+                goal="one more thing",
+                follow_up="sa-0-abc12345",
+                parent_agent=parent,
+            )
+        )
+    finally:
+        parent._session_db.close()
+
+    assert out["mode"] == "follow_up"
+    assert out["results"][0]["summary"] == "follow-up answer"
+    # The child was rebuilt ON its own persisted session id.
+    assert captured["build"]["resume_session_id"] == "child-sess-1"
+    # The persisted transcript rides in as the resume history (system rows
+    # stripped; dialogue preserved in order).
+    roles = [m["role"] for m in captured["resume_history"]]
+    assert roles == ["user", "assistant"]
+    assert captured["run_goal"].startswith("one more thing")
+
+
+def test_follow_up_foreign_lineage_rejected(tmp_path, monkeypatch):
+    import tools.delegate_tool as dt
+
+    db = _session_db(tmp_path)
+    try:
+        db.create_session("A", source="cli")
+        db.create_session("stranger", source="cli")
+        db.create_session("child-sess-1", source="delegate", parent_session_id="A")
+        db.append_message("child-sess-1", "user", "g")
+        db.append_message("child-sess-1", "assistant", "a")
+    finally:
+        db.close()
+    _dispatch_and_retain(parent_session_id="A")
+
+    parent = _parent_agent()
+    parent.session_id = "stranger"
+    out = json.loads(
+        dt.delegate_task(
+            goal="hi", follow_up="sa-0-abc12345", parent_agent=parent
+        )
+    )
+    assert "error" in out
+    assert "lineage" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# Schema surface
+# ---------------------------------------------------------------------------
+
+
+def test_delegate_schema_exposes_follow_up():
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+    props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+    assert "follow_up" in props
+    assert props["follow_up"]["type"] == "string"
+
+
+def test_config_defaults_include_retention_knobs():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    deleg = DEFAULT_CONFIG["delegation"]
+    assert deleg["max_retained"] == 10
+    assert deleg["retained_ttl_hours"] == 72

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -173,9 +173,46 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        # ── Durable retained-subagent registry (tracker #79686 P1) ──
+        # child_session_id: durable state.db session id of a SINGLE child
+        # (nullable; batches use children_json). children_json: JSON list of
+        # {subagent_id, session_id, model, goal} for every child in the unit.
+        # retained/retained_at: the completed child is addressable for
+        # delegate_task(follow_up=...) resume. tombstoned_at: de-registered
+        # from follow-up messaging (transcript/artifacts are NEVER erased).
+        # owner_profile: profile key that dispatched the unit — foreign-
+        # profile follow-ups are rejected. usage_json: last known child usage
+        # rollup for observability.
+        ("child_session_id", "TEXT"),
+        ("children_json", "TEXT"),
+        ("retained", "INTEGER"),
+        ("retained_at", "REAL"),
+        ("tombstoned_at", "REAL"),
+        ("owner_profile", "TEXT"),
+        ("usage_json", "TEXT"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
+    # Persisted child-usage attribution (tracker #79686 P1): each row records
+    # one child's usage rolled into a parent session's aggregate so the
+    # parent's subagent cost rollup survives process restarts and session
+    # reloads (reapply-on-load — see load_child_usage_totals). PR #62206
+    # attempted a one-shot additive write; this is the durable reapply design.
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS delegation_child_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            parent_session_id TEXT NOT NULL,
+            parent_turn_id TEXT NOT NULL DEFAULT '',
+            child_session_id TEXT NOT NULL DEFAULT '',
+            usage_json TEXT NOT NULL,
+            aggregate_json TEXT,
+            created_at REAL NOT NULL
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_delegation_child_usage_parent "
+        "ON delegation_child_usage(parent_session_id)"
+    )
 
 
 @contextmanager
@@ -280,6 +317,16 @@ def _persist_completion(event: Dict[str, Any], result: Dict[str, Any]) -> None:
             (event.get("status", "completed"), event.get("completed_at", now), now,
              json.dumps(event), json.dumps(result), event["delegation_id"]),
         )
+    # Retained-subagent registry (#79686 P1): a successfully completed unit's
+    # children stay follow-up addressable until tombstoned or TTL-pruned.
+    if event.get("status") == "completed":
+        try:
+            retain_completed_delegation(
+                str(event["delegation_id"]),
+                usage=result.get("usage") if isinstance(result, dict) else None,
+            )
+        except Exception:
+            logger.debug("retain_completed_delegation failed", exc_info=True)
 
 
 def _note_delivery_attempt(delegation_id: str) -> None:
@@ -338,6 +385,12 @@ def recover_abandoned_delegations() -> int:
                 (now, now, json.dumps(event), json.dumps(result), delegation_id),
             )
             recovered += 1
+    # Retained children survive restarts by construction (durable rows);
+    # validate + TTL-prune the reconnectable set as part of recovery.
+    try:
+        rehydrate_retained_children()
+    except Exception:
+        logger.debug("retained-children rehydration failed", exc_info=True)
     return recovered
 
 
@@ -1495,6 +1548,382 @@ def interrupt_for_session(
             count, reason,
         )
     return count
+
+
+# ---------------------------------------------------------------------------
+# Durable retained-subagent registry (tracker #79686 P1)
+# ---------------------------------------------------------------------------
+# A completed child whose delegation unit is RETAINED stays addressable for
+# delegate_task(follow_up=<child_id>): its persisted transcript can be
+# re-opened as a continued conversation. Rows live in the same durable
+# async_delegations table (retained/retained_at/tombstoned_at/children_json
+# columns), so restart rehydration is inherent — recover_abandoned_delegations
+# proves the restart path and rehydrate_retained_children() reports the
+# reconnectable set after boot. Tombstoning de-registers a child from
+# follow-up messaging but NEVER erases its transcript or artifacts.
+
+_DEFAULT_MAX_RETAINED = 10
+_DEFAULT_RETAINED_TTL_HOURS = 72.0
+
+
+def _retention_limits() -> tuple[int, float]:
+    """(max_retained, ttl_hours) from delegation config, with safe floors."""
+    max_retained = _DEFAULT_MAX_RETAINED
+    ttl_hours = _DEFAULT_RETAINED_TTL_HOURS
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = (load_config_readonly().get("delegation") or {})
+        if isinstance(cfg, dict):
+            max_retained = max(1, int(cfg.get("max_retained", max_retained)))
+            ttl_hours = max(1.0, float(cfg.get("retained_ttl_hours", ttl_hours)))
+    except Exception:
+        pass
+    return max_retained, ttl_hours
+
+
+def _current_owner_profile() -> str:
+    try:
+        from agent.relay_runtime import current_profile_key
+
+        profile = current_profile_key()
+        return profile.strip() if isinstance(profile, str) else ""
+    except Exception:
+        return ""
+
+
+def _open_session_db_readonly():
+    from hermes_state import SessionDB
+
+    return SessionDB(get_hermes_home() / "state.db", read_only=True)
+
+
+def _lineage_root(session_id: Optional[str]) -> Optional[str]:
+    """Compression-only ownership root for ``session_id``, or None on doubt.
+
+    Authority model from #76512 (@0xbWy): only the compression-continuation
+    lineage of the spawning session owns a retained child. Branch, delegate,
+    and tool sessions resolve to None so sibling/cycle/foreign follow-ups
+    fail closed.
+    """
+    if not isinstance(session_id, str) or not session_id.strip():
+        return None
+    try:
+        db = _open_session_db_readonly()
+        try:
+            return db.get_compression_lineage_root(session_id.strip())
+        finally:
+            db.close()
+    except Exception:
+        return None
+
+
+def record_dispatched_children(
+    delegation_id: str, children: List[Dict[str, Any]]
+) -> None:
+    """Persist the child identity manifest for a dispatched unit.
+
+    ``children``: list of {subagent_id, session_id, model, goal} dicts,
+    captured at spawn so the immediate delegate_task return payload and the
+    durable registry agree on child identities.
+    """
+    if not delegation_id:
+        return
+    single_sid = (
+        str(children[0].get("session_id") or "") if len(children) == 1 else None
+    )
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """UPDATE async_delegations
+               SET children_json=?, child_session_id=?, owner_profile=?,
+                   updated_at=?
+               WHERE delegation_id=?""",
+            (
+                json.dumps(children, ensure_ascii=False),
+                single_sid,
+                _current_owner_profile(),
+                time.time(),
+                delegation_id,
+            ),
+        )
+
+
+def retain_completed_delegation(
+    delegation_id: str, usage: Optional[Dict[str, Any]] = None
+) -> None:
+    """Mark a completed unit's children as retained (follow-up addressable)."""
+    if not delegation_id:
+        return
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """UPDATE async_delegations
+               SET retained=1, retained_at=?, usage_json=?, updated_at=?
+               WHERE delegation_id=? AND tombstoned_at IS NULL""",
+            (
+                now,
+                json.dumps(usage, ensure_ascii=False) if usage else None,
+                now,
+                delegation_id,
+            ),
+        )
+    prune_retained_children()
+
+
+def _retained_rows(conn) -> List[Any]:
+    return conn.execute(
+        """SELECT delegation_id, parent_session_id, owner_profile, state,
+                  retained_at, children_json, child_session_id, usage_json,
+                  task_json, completed_at
+           FROM async_delegations
+           WHERE retained=1 AND tombstoned_at IS NULL
+           ORDER BY retained_at DESC"""
+    ).fetchall()
+
+
+def _row_children(row) -> List[Dict[str, Any]]:
+    try:
+        children = json.loads(row[5] or "[]")
+    except (TypeError, ValueError):
+        children = []
+    if not children and row[6]:
+        children = [{"session_id": row[6]}]
+    return [c for c in children if isinstance(c, dict)]
+
+
+def list_retained_children() -> List[Dict[str, Any]]:
+    """Snapshot of every follow-up-addressable retained child."""
+    prune_retained_children()
+    out: List[Dict[str, Any]] = []
+    with _DB_LOCK, _transaction() as conn:
+        rows = _retained_rows(conn)
+    for row in rows:
+        for child in _row_children(row):
+            out.append(
+                {
+                    "delegation_id": row[0],
+                    "parent_session_id": row[1],
+                    "owner_profile": row[2] or "",
+                    "state": row[3],
+                    "retained_at": row[4],
+                    "completed_at": row[9],
+                    "child_id": child.get("subagent_id")
+                    or child.get("session_id") or "",
+                    "child_session_id": child.get("session_id") or "",
+                    "model": child.get("model"),
+                    "goal": child.get("goal"),
+                }
+            )
+    return out
+
+
+def find_retained_child(child_id: str) -> Optional[Dict[str, Any]]:
+    """Resolve a retained child by subagent id, session id, or delegation id."""
+    if not child_id or not isinstance(child_id, str):
+        return None
+    child_id = child_id.strip()
+    for entry in list_retained_children():
+        if child_id in (
+            entry.get("child_id"),
+            entry.get("child_session_id"),
+            entry.get("delegation_id"),
+        ):
+            return entry
+    return None
+
+
+def tombstone_retained_child(child_id: str) -> bool:
+    """De-register a retained child from follow-up messaging.
+
+    The tombstone removes ADDRESSABILITY only: the child's transcript rows in
+    state.db and any files it produced are never touched. Returns True when a
+    matching retained row was tombstoned.
+    """
+    entry = find_retained_child(child_id)
+    if entry is None:
+        return False
+    now = time.time()
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegations SET tombstoned_at=?, updated_at=?
+               WHERE delegation_id=? AND retained=1 AND tombstoned_at IS NULL""",
+            (now, now, entry["delegation_id"]),
+        )
+        return cur.rowcount == 1
+
+
+def prune_retained_children(
+    max_retained: Optional[int] = None, ttl_hours: Optional[float] = None
+) -> int:
+    """TTL + cap pruning: tombstone (never delete) expired/excess retained rows."""
+    cfg_max, cfg_ttl = _retention_limits()
+    max_retained = cfg_max if max_retained is None else max(1, int(max_retained))
+    ttl_hours = cfg_ttl if ttl_hours is None else max(0.0, float(ttl_hours))
+    now = time.time()
+    cutoff = now - ttl_hours * 3600.0
+    pruned = 0
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegations SET tombstoned_at=?, updated_at=?
+               WHERE retained=1 AND tombstoned_at IS NULL AND retained_at < ?""",
+            (now, now, cutoff),
+        )
+        pruned += cur.rowcount
+        live = conn.execute(
+            """SELECT delegation_id FROM async_delegations
+               WHERE retained=1 AND tombstoned_at IS NULL
+               ORDER BY retained_at DESC"""
+        ).fetchall()
+        for (stale_id,) in live[max_retained:]:
+            cur = conn.execute(
+                """UPDATE async_delegations SET tombstoned_at=?, updated_at=?
+                   WHERE delegation_id=? AND tombstoned_at IS NULL""",
+                (now, now, stale_id),
+            )
+            pruned += cur.rowcount
+    return pruned
+
+
+def rehydrate_retained_children() -> int:
+    """Restart-rehydration hook: prune expired rows, count reconnectables.
+
+    Called from recover_abandoned_delegations() so a process restart proves
+    the retained registry is still addressable (rows are durable; nothing to
+    rebuild in memory — this validates and reports the reconnectable set).
+    """
+    prune_retained_children()
+    count = len(list_retained_children())
+    if count:
+        logger.info("Rehydrated %d retained subagent record(s) after restart", count)
+    return count
+
+
+def check_follow_up_authority(
+    entry: Dict[str, Any], requester_session_id: Optional[str]
+) -> Optional[str]:
+    """Return an error string when the requester may NOT follow up, else None.
+
+    Ownership model (design credit @0xbWy, #76512): the requester must be in
+    the same profile AND share the retained delegation's compression-only
+    lineage root with the spawning session. Branch/delegate/tool sessions
+    have no lineage root, so sibling children, cycles (a child following up
+    itself or its parent chain), and foreign sessions all fail closed.
+    """
+    owner_profile = str(entry.get("owner_profile") or "")
+    profile = _current_owner_profile()
+    if owner_profile and profile and owner_profile != profile:
+        return (
+            "follow_up rejected: retained subagent belongs to profile "
+            f"'{owner_profile}', not '{profile}'."
+        )
+    child_session_id = str(entry.get("child_session_id") or "")
+    if (
+        requester_session_id
+        and child_session_id
+        and requester_session_id.strip() == child_session_id
+    ):
+        return "follow_up rejected: a subagent cannot follow up on itself."
+    owner_root = _lineage_root(entry.get("parent_session_id"))
+    requester_root = _lineage_root(requester_session_id)
+    if owner_root is None or requester_root is None or owner_root != requester_root:
+        return (
+            "follow_up rejected: only the session lineage that spawned this "
+            "subagent may message it (compression-rotation continuations "
+            "included; branches, siblings, and foreign sessions are not owners)."
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Persisted child-usage attribution (tracker #79686 P1)
+# ---------------------------------------------------------------------------
+
+
+def record_child_usage_attribution(
+    *,
+    parent_session_id: str,
+    parent_turn_id: str = "",
+    child_session_id: str = "",
+    usage: Dict[str, Any],
+    aggregate: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Persist one child's usage rollup into the parent's durable ledger."""
+    if not parent_session_id:
+        return
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """INSERT INTO delegation_child_usage
+               (parent_session_id, parent_turn_id, child_session_id,
+                usage_json, aggregate_json, created_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                parent_session_id,
+                parent_turn_id or "",
+                child_session_id or "",
+                json.dumps(usage, ensure_ascii=False),
+                json.dumps(aggregate, ensure_ascii=False) if aggregate else None,
+                time.time(),
+            ),
+        )
+
+
+def load_child_usage_attributions(
+    parent_session_id: str,
+) -> List[Dict[str, Any]]:
+    """All persisted child-usage records for one parent session, oldest first."""
+    if not parent_session_id:
+        return []
+    with _DB_LOCK, _transaction() as conn:
+        rows = conn.execute(
+            """SELECT parent_turn_id, child_session_id, usage_json,
+                      aggregate_json, created_at
+               FROM delegation_child_usage
+               WHERE parent_session_id=? ORDER BY id""",
+            (parent_session_id,),
+        ).fetchall()
+    out = []
+    for turn_id, child_sid, usage_json, aggregate_json, created_at in rows:
+        try:
+            usage = json.loads(usage_json)
+        except (TypeError, ValueError):
+            usage = {}
+        try:
+            aggregate = json.loads(aggregate_json) if aggregate_json else None
+        except (TypeError, ValueError):
+            aggregate = None
+        out.append(
+            {
+                "parent_turn_id": turn_id,
+                "child_session_id": child_sid,
+                "usage": usage,
+                "aggregate": aggregate,
+                "created_at": created_at,
+            }
+        )
+    return out
+
+
+def load_child_usage_totals(parent_session_id: str) -> Dict[str, float]:
+    """Summed child usage for reapply-on-load (cost/tokens attribution).
+
+    Session-load paths call this to re-seed the parent agent's in-memory
+    subagent cost aggregate so it survives process restarts — the reapply
+    design that replaces #62206's lost one-shot additive write.
+    """
+    totals = {"cost_usd": 0.0, "input_tokens": 0.0, "output_tokens": 0.0}
+    for rec in load_child_usage_attributions(parent_session_id):
+        usage = rec.get("usage") or {}
+        try:
+            totals["cost_usd"] += float(usage.get("cost_usd") or 0.0)
+        except (TypeError, ValueError):
+            pass
+        tokens = usage.get("tokens") or {}
+        for src, dst in (("input", "input_tokens"), ("output", "output_tokens")):
+            try:
+                totals[dst] += float(tokens.get(src) or 0.0)
+            except (TypeError, ValueError):
+                pass
+    return totals
 
 
 def _reset_for_tests() -> None:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1324,6 +1324,10 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    # Retained-subagent follow-up (#79686 P1): reuse a completed child's
+    # durable session id so the follow-up turn appends to ITS OWN session,
+    # preserving the transcript (and the provider prompt-cache prefix).
+    resume_session_id: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1622,6 +1626,7 @@ def _build_child_agent(
             acp_command=effective_acp_command,
             acp_args=effective_acp_args,
             max_iterations=max_iterations,
+            session_id=resume_session_id,
 
             reasoning_config=child_reasoning,
             prefill_messages=getattr(parent_agent, "prefill_messages", None),
@@ -2323,11 +2328,23 @@ def _run_single_child(
             _worker_thread_holder["t"] = threading.current_thread()
             from agent.delegation_context import delegated_child_context
 
+            # Retained-child follow-up (#79686 P1): the resumed transcript is
+            # stashed on the child at build time. Passing it as
+            # conversation_history appends the follow-up as the NEXT user
+            # turn of the child's own session — alternation stays legal and
+            # the cached prefix is preserved verbatim.
+            _resume_history = getattr(child, "_delegate_resume_history", None)
+            _extra_kwargs = (
+                {"conversation_history": _resume_history}
+                if isinstance(_resume_history, list) and _resume_history
+                else {}
+            )
             with delegated_child_context(str(getattr(child, "session_id", "") or "")):
                 return child.run_conversation(
                     user_message=goal,
                     task_id=child_task_id,
                     stream_callback=_relay_child_text,
+                    **_extra_kwargs,
                 )
 
         _child_context = contextvars.copy_context()
@@ -2562,6 +2579,10 @@ def _run_single_child(
             "duration_seconds": duration,
             "model": _model if isinstance(_model, str) else None,
             "exit_reason": exit_reason,
+            # Durable child identity (#79686 P1): lets the parent address this
+            # child later via delegate_task(follow_up=...) once retained.
+            "child_session_id": str(getattr(child, "session_id", "") or "") or None,
+            "subagent_id": _subagent_id,
             "tokens": {
                 "input": (
                     _input_tokens if isinstance(_input_tokens, (int, float)) else 0
@@ -2881,12 +2902,34 @@ def _finalize_child_results(
             invoke_hook = None
 
         children_cost_total = 0.0
+        _usage_records: List[tuple] = []
         for entry in results:
             child_role = entry.pop("_child_role", None)
             child_cost = entry.pop("_child_cost_usd", 0.0)
             try:
                 if child_cost:
                     children_cost_total += float(child_cost)
+            except (TypeError, ValueError):
+                pass
+            # Capture per-child usage for the durable attribution ledger
+            # (#79686 P1) — persisted below once the aggregate is known.
+            try:
+                _entry_child = child_by_index.get(entry.get("task_index", -1))
+                _usage_records.append(
+                    (
+                        str(getattr(_entry_child, "session_id", "") or ""),
+                        {
+                            "cost_usd": float(child_cost or 0.0),
+                            "tokens": (
+                                entry.get("tokens")
+                                if isinstance(entry.get("tokens"), dict)
+                                else {}
+                            ),
+                            "api_calls": entry.get("api_calls", 0),
+                            "status": entry.get("status"),
+                        },
+                    )
+                )
             except (TypeError, ValueError):
                 pass
             if invoke_hook is None:
@@ -2931,6 +2974,39 @@ def _finalize_child_results(
             except Exception:
                 logger.debug("Subagent cost rollup failed", exc_info=True)
 
+        # Persist the child-usage attribution ledger (#79686 P1): the
+        # in-memory rollup above dies with the process, so each child's usage
+        # plus the resulting aggregate is written durably keyed on the parent
+        # session + turn. Session-load paths reapply via
+        # async_delegation.load_child_usage_totals so parent aggregates
+        # survive reload (the reapply-on-load design; #62206's one-shot
+        # additive write was lost in production).
+        _parent_sid_raw = getattr(parent_agent, "session_id", None)
+        if isinstance(_parent_sid_raw, str) and _parent_sid_raw and _usage_records:
+            try:
+                from tools.async_delegation import record_child_usage_attribution
+
+                _aggregate = {
+                    "session_estimated_cost_usd": float(
+                        getattr(parent_agent, "session_estimated_cost_usd", 0.0)
+                        or 0.0
+                    ),
+                    "children_cost_total": children_cost_total,
+                }
+                _turn_id = getattr(parent_agent, "_current_turn_id", "") or ""
+                for _child_sid, _usage in _usage_records:
+                    record_child_usage_attribution(
+                        parent_session_id=_parent_sid_raw,
+                        parent_turn_id=_turn_id if isinstance(_turn_id, str) else "",
+                        child_session_id=_child_sid,
+                        usage=_usage,
+                        aggregate=_aggregate,
+                    )
+            except Exception:
+                logger.debug(
+                    "Persisting child usage attribution failed", exc_info=True
+                )
+
 
 def _run_child_lifecycle(
     task_index: int,
@@ -2974,6 +3050,185 @@ def _recover_tasks_from_json_string(
     return parsed, None
 
 
+def _resolve_running_child_for_follow_up(child_id: str) -> Optional[str]:
+    """Map a follow_up target onto a LIVE registered subagent id, if any.
+
+    Accepts either the public subagent id (``sa-...``) or the child's durable
+    session id; returns the registry subagent_id to steer, or None.
+    """
+    if not child_id:
+        return None
+    with _active_subagents_lock:
+        for sid, record in _active_subagents.items():
+            if sid == child_id:
+                return sid
+            agent = record.get("agent")
+            if agent is not None and str(
+                getattr(agent, "session_id", "") or ""
+            ) == child_id:
+                return sid
+    return None
+
+
+def _handle_follow_up(
+    follow_up: str,
+    goal: Optional[str],
+    context: Optional[str],
+    parent_agent,
+) -> str:
+    """delegate_task(follow_up=...): message a running or retained child.
+
+    Budget-exempt by design (#79686 P1): a follow-up is NOT a spawn, so it
+    consumes neither max_spawn_depth nor the async concurrency budget.
+
+    - RUNNING child → deliver via the steer primitive; receipt is
+      'delivered'/'queued' (the child folds the text in at its next
+      iteration boundary).
+    - COMPLETED retained child → re-open its persisted transcript as a
+      continued conversation (same lineage resolution as gateway /resume),
+      run the follow-up as the child's next user turn — a NEW user turn in
+      ITS OWN session, so alternation and the cached prefix stay intact —
+      and return the child's new summary.
+    """
+    text = (goal or "").strip()
+    if context and str(context).strip():
+        text = f"{text}\n\nContext: {str(context).strip()}" if text else str(context).strip()
+    if not text:
+        return tool_error(
+            "follow_up requires 'goal' (the message to deliver to the child)."
+        )
+
+    # 1) Running child → steer receipt.
+    live_sid = _resolve_running_child_for_follow_up(follow_up)
+    if live_sid is not None:
+        queued = steer_subagent(live_sid, text)
+        if queued:
+            return json.dumps(
+                {
+                    "status": "queued",
+                    "mode": "follow_up",
+                    "child_id": live_sid,
+                    "receipt": (
+                        "Message queued for the running subagent; it folds in "
+                        "at the child's next iteration boundary (the current "
+                        "tool call is never cut)."
+                    ),
+                },
+                ensure_ascii=False,
+            )
+        # Fall through: the child may have just completed and been retained.
+
+    # 2) Completed retained child → resume its transcript.
+    from tools.async_delegation import (
+        check_follow_up_authority,
+        find_retained_child,
+    )
+
+    entry = find_retained_child(follow_up)
+    if entry is None:
+        return tool_error(
+            f"follow_up target '{follow_up}' is not a running subagent or a "
+            "retained completed child. It may have been tombstoned (removed "
+            "from follow-up messaging), pruned by delegation.retained_ttl_hours, "
+            "or never retained. Its transcript, if any, is still in state.db."
+        )
+
+    requester_sid = getattr(parent_agent, "session_id", None)
+    auth_error = check_follow_up_authority(
+        entry, requester_sid if isinstance(requester_sid, str) else None
+    )
+    if auth_error:
+        return tool_error(auth_error)
+
+    child_session_id = str(entry.get("child_session_id") or "")
+    if not child_session_id:
+        return tool_error(
+            "Retained record has no child session id; cannot resume the "
+            "child's transcript."
+        )
+
+    session_db = getattr(parent_agent, "_session_db", None)
+    if session_db is None:
+        return tool_error(
+            "follow_up on a completed child requires a session database "
+            "(parent agent has none in this runtime)."
+        )
+
+    # Same lineage walk gateway /resume uses: if the child's own session was
+    # compression-rotated, follow the chain to the tip that holds messages.
+    try:
+        resume_sid = session_db.resolve_resume_session_id(child_session_id)
+    except Exception:
+        resume_sid = child_session_id
+    try:
+        history = session_db.get_messages_as_conversation(
+            resume_sid, repair_alternation=True
+        )
+    except Exception as exc:
+        return tool_error(
+            f"Could not load the retained child's transcript ({resume_sid}): {exc}"
+        )
+    if not history:
+        return tool_error(
+            f"Retained child transcript ({resume_sid}) is empty; nothing to resume."
+        )
+    # The stored system prompt is restored from the session row by
+    # run_conversation; keep only the dialogue so it isn't double-injected.
+    history = [m for m in history if m.get("role") != "system"]
+
+    cfg = _load_config()
+    try:
+        creds = _resolve_delegation_credentials(cfg, parent_agent)
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    overall_start = time.monotonic()
+    child = _build_child_preserving_parent_tools(
+        task_index=0,
+        goal=text,
+        context=None,
+        toolsets=None,
+        model=entry.get("model") or creds["model"],
+        max_iterations=cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS),
+        task_count=1,
+        parent_agent=parent_agent,
+        override_provider=creds["provider"],
+        override_base_url=creds["base_url"],
+        override_api_key=creds["api_key"],
+        override_api_mode=creds["api_mode"],
+        override_request_overrides=creds.get("request_overrides"),
+        override_max_tokens=creds.get("max_output_tokens"),
+        override_acp_command=creds.get("command"),
+        override_acp_args=creds.get("args"),
+        role="leaf",
+        resume_session_id=resume_sid,
+    )
+    # Hand the persisted transcript to the run wrapper: run_conversation
+    # receives it as conversation_history, and the follow-up lands as the
+    # session's next user turn.
+    setattr(child, "_delegate_resume_history", history)
+
+    result = _run_single_child(0, text, child, parent_agent)
+    result.setdefault("task_index", 0)
+    _finalize_child_results(
+        [result], [{"goal": text}], [(0, {"goal": text}, child)], parent_agent
+    )
+    payload = {
+        "mode": "follow_up",
+        "child_id": entry.get("child_id") or child_session_id,
+        "child_session_id": str(getattr(child, "session_id", "") or resume_sid),
+        "delegation_id": entry.get("delegation_id"),
+        "results": [result],
+        "total_duration_seconds": round(time.monotonic() - overall_start, 2),
+        "note": (
+            "Follow-up ran as the retained child's next user turn on its own "
+            "persisted session (budget-exempt: no spawn depth or concurrency "
+            "consumed)."
+        ),
+    }
+    return json.dumps(payload, ensure_ascii=False)
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -2981,6 +3236,7 @@ def delegate_task(
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
     background: Optional[bool] = None,
+    follow_up: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
@@ -2995,10 +3251,22 @@ def delegate_task(
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
 
+    ``follow_up=<child_id>`` switches to follow-up mode (#79686 P1): deliver
+    'goal' to a RUNNING child via steering, or resume a COMPLETED retained
+    child's transcript as its next user turn. Follow-ups are budget-exempt —
+    they are messages, not spawns — so neither the depth limit nor the
+    concurrency budget applies.
+
     Returns JSON with results array, one entry per task.
     """
     if parent_agent is None:
         return tool_error("delegate_task requires a parent agent context.")
+
+    # Follow-up mode short-circuits BEFORE the spawn-pause kill switch, the
+    # depth limit, and capacity checks: messaging an existing child must
+    # never be blocked by spawn budgets (it is not a spawn).
+    if follow_up is not None and str(follow_up).strip():
+        return _handle_follow_up(str(follow_up).strip(), goal, context, parent_agent)
 
     # Operator-controlled kill switch — lets the TUI freeze new fan-out
     # when a runaway tree is detected, without interrupting already-running
@@ -3559,6 +3827,39 @@ def delegate_task(
 
         if dispatch.get("status") == "dispatched":
             n = len(_goals)
+            # Admission-handle info (#79686 P1): child ids, durable session
+            # ids (transcript paths), and model in the IMMEDIATE return so
+            # the parent can address each child (steer/follow_up) without
+            # waiting for completion.
+            _children_manifest = [
+                {
+                    "subagent_id": (
+                        getattr(c, "_subagent_id", None)
+                        if isinstance(getattr(c, "_subagent_id", None), str)
+                        else None
+                    ),
+                    "session_id": (
+                        getattr(c, "session_id", "")
+                        if isinstance(getattr(c, "session_id", ""), str)
+                        else ""
+                    ),
+                    "model": (
+                        getattr(c, "model", None)
+                        if isinstance(getattr(c, "model", None), str)
+                        else None
+                    ),
+                    "goal": t["goal"][:200],
+                }
+                for (_i, t, c) in children
+            ]
+            try:
+                from tools.async_delegation import record_dispatched_children
+
+                record_dispatched_children(
+                    dispatch["delegation_id"], _children_manifest
+                )
+            except Exception:
+                logger.debug("record_dispatched_children failed", exc_info=True)
             note = (
                 "Subagent is running in the background. You and the user can "
                 "keep working; its full result re-enters the conversation as a "
@@ -3577,6 +3878,7 @@ def delegate_task(
                 "count": n,
                 "delegation_id": dispatch["delegation_id"],
                 "goals": _goals,
+                "children": _children_manifest,
                 "note": note,
             }
             if live_paths:
@@ -4065,6 +4367,22 @@ DELEGATE_TASK_SCHEMA = {
                     "backward compatibility."
                 ),
             },
+            "follow_up": {
+                "type": "string",
+                "description": (
+                    "Follow-up mode: the id of an existing subagent to message "
+                    "instead of spawning a new one. Pass the subagent_id or "
+                    "child session_id from a previous delegate_task dispatch or "
+                    "result, with 'goal' as the message. A RUNNING child "
+                    "receives it as steering at its next iteration boundary "
+                    "(receipt: queued); a COMPLETED retained child is resumed — "
+                    "its saved conversation continues with your message as the "
+                    "next turn and its new summary is returned. Follow-ups are "
+                    "not spawns: they never consume the delegation depth or "
+                    "concurrency budget. When follow_up is set, tasks/role are "
+                    "ignored."
+                ),
+            },
         },
         "required": [],
     },
@@ -4125,6 +4443,7 @@ registry.register(
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),
+        follow_up=args.get("follow_up"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
Makes delegated subagents durable, addressable teammates: completed children are retained in a state.db registry, can be messaged again via `delegate_task(follow_up=...)` (running → steer receipt; completed → transcript resumed as its next user turn), and their usage is persisted so parent cost aggregates survive restarts.

## Changes

- **Durable retained-child registry** (`tools/async_delegation.py`): `async_delegations` gains `retained`, `retained_at`, `tombstoned_at`, `child_session_id`, `children_json`, `owner_profile`, `usage_json` via the existing backwards-compatible column-reconciliation pattern (no migration required; legacy DBs upgrade on connect). Successfully completed delegations auto-retain their children; `recover_abandoned_delegations()` now rehydrates/validates the reconnectable retained set on restart.
- **Admission handle on spawn**: background dispatch returns `children` — per-child `subagent_id`, durable `session_id`, and `model` — in the immediate `delegate_task` payload (persisted as the `children_json` manifest), and per-task results carry `child_session_id` + `subagent_id`, so the parent can address children without waiting for completion.
- **`delegate_task(follow_up=<child_id>)`**: a RUNNING child receives the message through the merged steering primitive (receipt `queued`, folds in at the child's next iteration boundary); a COMPLETED retained child is re-opened via `resolve_resume_session_id` lineage, its persisted transcript rides in as `conversation_history`, and the follow-up runs as the child's next user turn on its own session — message-role alternation and the provider prompt-cache prefix stay intact. Follow-ups are **budget-exempt**: they consume neither `max_spawn_depth` nor a concurrency slot, and they bypass the spawn-pause kill switch (they are messages, not spawns).
- **Persisted usage attribution**: new `delegation_child_usage` ledger records each child's usage plus the resulting aggregate keyed on parent session + turn; the CLI resume path reapplies `load_child_usage_totals()` on session load so the parent's subagent cost rollup survives process restarts (reapply-on-load design; #62206's one-shot additive write was lost in production).
- **Tombstone deletes**: `tombstone_retained_child()` removes follow-up addressability only — the child's transcript rows and artifacts are never erased.
- **Ownership/authority**: new `SessionDB.get_compression_lineage_root()` proves a compression-only ancestry; `check_follow_up_authority()` rejects foreign-profile, sibling, branch/delegate/tool-session, self-cycle, and foreign-lineage follow-ups, failing closed on any ambiguity.
- **Config knobs**: `delegation.max_retained` (default 10) and `delegation.retained_ttl_hours` (default 72) with TTL + cap pruning (pruning tombstones, never deletes).
- No new model-facing tool: `follow_up` is a parameter on the existing `delegate_task` schema, wired through the registry handler and `run_agent._dispatch_delegate_task`.

## Validation

| Check | Result |
| --- | --- |
| `tests/tools/test_retained_subagents.py` (new, 24 tests) | ✅ 24 passed |
| `tests/tools/test_delegate.py` + 5 sibling delegate suites | ✅ all passed |
| `tests/tools/test_async_delegation.py` | ✅ 20 passed |
| `tests/hermes_state/` (incl. `resolve_resume_session_id`) | ✅ 61 passed |
| `tests/test_hermes_state.py` | ✅ 187 passed |
| Full `tests/tools/` (410 files, 5566 tests) | ✅ 5565 passed, 1 failed — `test_managed_browserbase_and_modal.py` failure reproduced on pristine `origin/main` (pre-existing, unrelated) |
| `ruff check` | ✅ All checks passed |
| `scripts/check-windows-footguns.py --all` | ✅ No footguns |

## Infographic

![Retained subagents infographic](https://v3b.fal.media/files/b/0aa5467e/GBKw29jhRoDQVW2bTVVL0_ExNJrZ9I.png)

Closes #76508. Part of #79686 (P1). Authority model design credit: @0xbWy (#76512).
