### PR TITLE
fix(mattermost): remove unsafe substring auth-error fallback in WS reconnect loop

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -751,12 +751,8 @@ class MattermostAdapter(BasePlatformAdapter):
                 # Detect permanent auth/permission failures that will never
                 # succeed on retry — stop reconnecting instead of looping forever.
                 import aiohttp
-                err_str = str(exc).lower()
                 if isinstance(exc, aiohttp.WSServerHandshakeError) and exc.status in {401, 403}:
                     logger.error("Mattermost WS auth failed (HTTP %d) — stopping reconnect", exc.status)
-                    return
-                if "401" in err_str or "403" in err_str or "unauthorized" in err_str:
-                    logger.error("Mattermost WS permanent error: %s — stopping reconnect", exc)
                     return
                 logger.warning("Mattermost WS error: %s — reconnecting in %.0fs", exc, delay)
 

--- a/tests/gateway/test_ws_auth_retry.py
+++ b/tests/gateway/test_ws_auth_retry.py
@@ -14,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 # Mattermost: _ws_loop auth-aware retry
 # ---------------------------------------------------------------------------
 
+
 class TestMattermostWSAuthRetry:
     """gateway/platforms/mattermost.py — _ws_loop()"""
 
@@ -30,6 +31,7 @@ class TestMattermostWSAuthRetry:
         )
 
         from plugins.platforms.mattermost.adapter import MattermostAdapter
+
         adapter = MattermostAdapter.__new__(MattermostAdapter)
         adapter._closing = False
 
@@ -47,10 +49,64 @@ class TestMattermostWSAuthRetry:
         # Should have attempted once and stopped, not retried
         assert call_count == 1
 
+    def test_transient_401_substring_does_not_stop_reconnect(self):
+        """A transient exception whose stringified message merely contains
+        "401" (e.g. a proxy error body with digits) must not be mistaken
+        for a genuine auth rejection. The loop should log a warning and
+        retry, not return."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        adapter = MattermostAdapter.__new__(MattermostAdapter)
+        adapter._closing = False
+
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                # Stop the loop once we've proven a retry happened.
+                adapter._closing = True
+            raise RuntimeError(
+                "proxy returned HTTP/1.1 401 in body but connection reset"
+            )
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        # The substring fallback is gone, so this must retry past the
+        # first attempt instead of returning immediately.
+        assert call_count == 2
+
+    def test_closing_flag_prevents_further_connect_attempts(self):
+        """Existing self._closing early-return behavior is unaffected by
+        the substring-fallback removal: once _closing is set, the loop
+        must not attempt to connect at all."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        adapter = MattermostAdapter.__new__(MattermostAdapter)
+        adapter._closing = True
+
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("should never be called")
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        asyncio.run(adapter._ws_loop())
+
+        assert call_count == 0
+
 
 # ---------------------------------------------------------------------------
 # Matrix: _sync_loop auth-aware retry
 # ---------------------------------------------------------------------------
+
 
 class TestMatrixSyncAuthRetry:
     """gateway/platforms/matrix.py — _sync_loop()"""
@@ -58,6 +114,7 @@ class TestMatrixSyncAuthRetry:
     def test_unknown_token_sync_error_stops_loop(self):
         """A SyncError with M_UNKNOWN_TOKEN should stop syncing."""
         import types
+
         nio_mock = types.ModuleType("nio")
 
         class SyncError:
@@ -67,6 +124,7 @@ class TestMatrixSyncAuthRetry:
         nio_mock.SyncError = SyncError
 
         from plugins.platforms.matrix.adapter import MatrixAdapter
+
         adapter = MatrixAdapter.__new__(MatrixAdapter)
         adapter._closing = False
 
@@ -86,6 +144,7 @@ class TestMatrixSyncAuthRetry:
 
         async def run():
             import sys
+
             sys.modules["nio"] = nio_mock
             try:
                 await adapter._sync_loop()
@@ -94,5 +153,3 @@ class TestMatrixSyncAuthRetry:
 
         asyncio.run(run())
         assert sync_count == 1
-
-

--- a/tests/gateway/test_ws_auth_retry_verifier_probe.py
+++ b/tests/gateway/test_ws_auth_retry_verifier_probe.py
@@ -1,0 +1,142 @@
+"""Adversarial verifier probes for the mattermost-ws-401-classify fix
+(commit fdd1a11ac5).
+
+The implementer's test_ws_auth_retry.py covers:
+  - WSServerHandshakeError(status=401) stops the loop
+  - a transient RuntimeError whose message contains "401" now retries
+  - the pre-existing _closing early-return path is untouched
+
+This file probes boundary/edge cases the implementer's tests did NOT
+cover, per the independent-verifier mandate to go beyond what the
+implementer thought to test:
+
+  1. WSServerHandshakeError(status=403) — the other structured-check
+     status value — must still stop the loop (only 401 was tested).
+  2. WSServerHandshakeError with a non-auth status (e.g. 500) must NOT
+     stop the loop — the structured check must not over-match.
+  3. A transient exception containing "unauthorized" (not "401"/"403")
+     must retry now that the substring fallback is fully removed —
+     the implementer only exercised the "401" substring variant.
+  4. Multiple consecutive transient errors must all retry (not just
+     one) — proves the removed code path isn't silently reintroduced
+     via some other mechanism after N attempts.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+
+from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+
+def _make_adapter(closing: bool = False) -> MattermostAdapter:
+    adapter = MattermostAdapter.__new__(MattermostAdapter)
+    adapter._closing = closing
+    return adapter
+
+
+class TestMattermostWSAuthRetryBoundaryProbes:
+    def test_403_handshake_stops_reconnect(self):
+        """status=403 (the other half of the structured check's {401, 403}
+        set) must also stop the loop. The implementer only tested 401."""
+        exc = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(),
+            history=(),
+            status=403,
+            message="Forbidden",
+            headers=MagicMock(),
+        )
+
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            raise exc
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        asyncio.run(adapter._ws_loop())
+
+        assert call_count == 1
+
+    def test_non_auth_handshake_status_does_not_stop_reconnect(self):
+        """A WSServerHandshakeError with a non-auth status (500) is a
+        structured exception of the RIGHT TYPE but the WRONG status —
+        it must NOT be classified as a permanent auth failure. This
+        guards against an overly broad isinstance-only check that
+        forgets to gate on .status."""
+        exc = aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(),
+            history=(),
+            status=500,
+            message="Internal Server Error",
+            headers=MagicMock(),
+        )
+
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                adapter._closing = True
+            raise exc
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == 2
+
+    def test_unauthorized_substring_no_longer_stops_reconnect(self):
+        """Before the fix, a transient error whose message contained the
+        word 'unauthorized' (not digits) would ALSO trip the removed
+        substring fallback. The implementer's regression test only
+        covered the '401' digit-substring case; this proves the
+        'unauthorized' word variant is equally fixed."""
+        adapter = _make_adapter()
+        call_count = 0
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                adapter._closing = True
+            raise RuntimeError(
+                "upstream proxy replied: request unauthorized by WAF rule, retry"
+            )
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == 2
+
+    def test_repeated_transient_errors_all_retry(self):
+        """Guards against a fix that only relaxes classification for the
+        FIRST occurrence (e.g. some hidden retry-budget/counter that
+        starts rejecting after N attempts). Runs 5 consecutive
+        transient errors and confirms every one retries."""
+        adapter = _make_adapter()
+        call_count = 0
+        target_attempts = 5
+
+        async def fake_connect():
+            nonlocal call_count
+            call_count += 1
+            if call_count >= target_attempts:
+                adapter._closing = True
+            raise RuntimeError("403 seen in unrelated proxy diagnostic body")
+
+        adapter._ws_connect_and_listen = fake_connect
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            asyncio.run(adapter._ws_loop())
+
+        assert call_count == target_attempts


### PR DESCRIPTION
## Summary

The Mattermost WebSocket reconnect loop in `_ws_loop()` misclassifies transient
errors as permanent auth failures. A substring fallback sits below the correct
`WSServerHandshakeError`/`.status` check. Any exception whose stringified message
happens to contain "401", "403", or "unauthorized" kills the reconnect loop
forever, even when the underlying cause is temporary.

## Root cause

The exception handler in `plugins/platforms/mattermost/adapter.py` first checks
`isinstance(exc, aiohttp.WSServerHandshakeError) and exc.status in {401, 403}`,
which correctly catches the one case where the server explicitly rejects auth.
Below that, a catch-all substring check on `str(exc).lower()` treats any
coincidental mention of "401", "403", or "unauthorized" as a permanent failure:

```python
err_str = str(exc).lower()
if "401" in err_str or "403" in err_str or "unauthorized" in err_str:
    logger.error("Mattermost WS permanent error: %s", exc)
    return
```

A proxy returning a 401 in its response body but then resetting the connection,
or an unrelated error whose message happens to contain the word "unauthorized",
both get classified as permanent auth failures and stop the retry loop
permanently.

## Fix

Delete the redundant substring fallback. The structured `WSServerHandshakeError`
check already catches the one legitimate permanent-auth case (HTTP 401/403 from
the Mattermost server). No other exception in the aiohttp exception hierarchy
simultaneously signals permanent auth failure and evades the structured check.

## Regression tests

Added in `tests/gateway/test_ws_auth_retry.py`:

- `test_transient_401_substring_does_not_stop_reconnect`: a `RuntimeError`
  whose message contains "401" now retries instead of returning.
- `test_closing_flag_prevents_further_connect_attempts`: the existing
  `_closing` early-return path is untouched.

Added in `tests/gateway/test_ws_auth_retry_verifier_probe.py` (independent
verifier, adversarial edge cases):

- `test_403_handshake_stops_reconnect`: status=403 still stops the loop.
- `test_non_auth_handshake_status_does_not_stop_reconnect`: status=500
  does not stop the loop.
- `test_unauthorized_substring_no_longer_stops_reconnect`: the word
  "unauthorized" no longer trips a false permanent-fatal.
- `test_repeated_transient_errors_all_retry`: five consecutive transient
  errors all retry (not just the first one).

## Files changed

- `plugins/platforms/mattermost/adapter.py`: removed 4 lines (substring fallback)
- `tests/gateway/test_ws_auth_retry.py`: added 2 new tests (+57 lines)
- `tests/gateway/test_ws_auth_retry_verifier_probe.py`: new file, 4 boundary-case probes (+142 lines)

## Refs #35645

This PR conflicts with #35645 (open). Both change the same `_ws_loop()` exception
handler in opposite directions, and an earlier version of this description
incorrectly claimed zero line overlap. Verified with a three-way merge against
`main` (`b3aa561f`), merging this PR's `bd674b78` with #35645's `c94baf52`:
exactly one conflict in `plugins/platforms/mattermost/adapter.py`, on the
substring branch.

#35645 keeps the substring-detected branch and escalates it through a new
`_escalate_ws_fatal` with `retryable=False`. This PR deletes the branch so the
same exceptions fall through to the reconnect path. The escalation in #35645 is
correct for the structured `WSServerHandshakeError` case and fixes a real zombie
adapter bug. The disagreement is only about the substring fallback underneath it.

These are two different error classes, which is the reason for the split:
`WSServerHandshakeError` with `exc.status in {401, 403}` is a structured auth
rejection from the server, and both PRs keep that branch untouched. A
`RuntimeError` whose message merely contains "401" is a transient network failure
that happens to include three digits.

Ordering hazard for whoever resolves the conflict: this PR also removes the
`err_str = str(exc).lower()` assignment, which becomes unused once the branch is
gone. Keeping #35645's side of the hunk without restoring that assignment raises
`NameError` on the first WebSocket exception. It fails on the error path, so
happy-path tests will not catch it.

Proposed reconciliation: convert the branch to a structured attribute check
rather than deleting it, then escalate through `_escalate_ws_fatal` when it
genuinely fires. That preserves #35645's escalation contract while preventing
transient errors from being classified as permanent.

The Matrix adapter has the same substring bug on `main` today. #57375
(`fix(matrix): stop classifying auth errors by substring match`) proposes the
attribute-check approach there, switching to `http_status` and `errcode` on the
exception object. That PR is still open and not merged; an earlier version of
this description described it as a fix Matrix had already received, which was
wrong.
