### PR TITLE
fix(skins): broadcast full skin registry on every connect

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event.ts
@@ -69,7 +69,8 @@ import { reportInstallMethodWarning } from '@/store/updates'
 import { notifyWorkspaceChanged, toolChangedPath, toolMayMutateFiles } from '@/store/workspace-events'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
-import { ingestBackendSkin } from '@/themes/backend-sync'
+import { ingestBackendSkin, ingestBackendSkinRegistry } from '@/themes/backend-sync'
+import { pruneBackendSkinCache } from '@/themes/user-themes'
 import type { RpcEvent } from '@/types/hermes'
 
 import type { ClientSessionState } from '../../../types'
@@ -289,6 +290,13 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         // Seed the active skin into the desktop theme registry without applying,
         // so a fresh connect never overrides the user's persisted desktop theme.
         ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, { apply: false })
+        // Fold the FULL registry so the picker reflects disk truth on every
+        // connect — a wiped local cache self-heals with no per-skin re-apply.
+        ingestBackendSkinRegistry((payload as { registry?: Record<string, HermesSkin> } | undefined)?.registry)
+        // The backend owns the filesystem truth: reconcile the boot cache against
+        // the available-skin names so a skin file deleted on disk stops ghosting
+        // in the picker (it would otherwise linger in localStorage forever).
+        pruneBackendSkinCache((payload as { skins?: string[] } | undefined)?.skins ?? [])
         // Backends with the change watcher broadcast pet/cron/sessions change
         // events; consumers demote their legacy polls to slow backstops.
         setChangeEventsAvailable(Boolean((payload as { change_events?: boolean } | undefined)?.change_events))
@@ -303,6 +311,14 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
         if (fromActiveProfile) {
           ingestBackendSkin(payload as HermesSkin | undefined, { apply: true })
         }
+
+        // Registry also rides along on skin.changed so new/recolored skins
+        // appear in the picker without an app restart.
+        ingestBackendSkinRegistry((payload as { registry?: Record<string, HermesSkin> } | undefined)?.registry)
+
+        // Reconcile the cache on every broadcast too — the same list rides
+        // along, so a deletion picked up by the watcher prunes immediately.
+        pruneBackendSkinCache((payload as { skins?: string[] } | undefined)?.skins ?? [])
 
         return
       } else if (

--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
+import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin, ingestBackendSkinRegistry } from './backend-sync'
 
 const skin = (name: string) => ({
   name,
@@ -105,5 +105,48 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin({ name: '' }, { apply: true })
 
     expect($pendingSkinApply.get()).toBeNull()
+  })
+})
+
+describe('ingestBackendSkinRegistry', () => {
+  beforeEach(() => __resetBackendSkinSync())
+
+  it('registers every skin in the registry without applying', () => {
+    ingestBackendSkinRegistry({
+      neon: skin('neon'),
+      forest: skin('forest')
+    })
+
+    expect($backendThemes.get().neon?.name).toBe('neon')
+    expect($backendThemes.get().forest?.name).toBe('forest')
+    expect($pendingSkinApply.get()).toBeNull()
+  })
+
+  it('never registers default or built-in names (no shadowing)', () => {
+    ingestBackendSkinRegistry({
+      default: skin('default'),
+      mono: skin('mono'),
+      neon: skin('neon')
+    })
+
+    expect($backendThemes.get().default).toBeUndefined()
+    expect($backendThemes.get().mono).toBeUndefined()
+    expect($backendThemes.get().neon?.name).toBe('neon')
+  })
+
+  it('skips entries whose key does not match the payload name', () => {
+    ingestBackendSkinRegistry({
+      wrongkey: skin('neon')
+    })
+
+    expect($backendThemes.get().neon).toBeUndefined()
+    expect($backendThemes.get().wrongkey).toBeUndefined()
+  })
+
+  it('ignores empty payloads', () => {
+    ingestBackendSkinRegistry(undefined)
+    ingestBackendSkinRegistry({})
+
+    expect(Object.keys($backendThemes.get())).toHaveLength(0)
   })
 })

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -37,11 +37,38 @@ export const $pendingSkinApply = atom<string | null>(null)
 // restart / disconnected), an explicit re-affirm must repaint, not no-op.
 let lastSynced: { applied: boolean; name: string } | null = null
 
+/** The active skin name last synced from the backend (seed or apply), or null
+ *  before any backend connection. Lets the theme provider adopt the backend's
+ *  active skin on first connect. */
+export function getLastSyncedSkinName(): string | null {
+  return lastSynced?.name ?? null
+}
+
 /** Test-only: reset the module's apply guard + registry between cases. */
 export function __resetBackendSkinSync(): void {
   lastSynced = null
   $backendThemes.set({})
   $pendingSkinApply.set(null)
+}
+
+/**
+ * Register a converted backend skin in the live registry. Never shadows
+ * `default` or a built-in's hand-tuned palette. Returns false on broken skins.
+ */
+function registerBackendSkin(name: string, skin: HermesSkin): boolean {
+  const theme = skinToDesktopTheme(skin)
+
+  if (!theme) {
+    return false
+  }
+
+  const current = $backendThemes.get()
+
+  if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
+    $backendThemes.set({ ...current, [name]: theme })
+  }
+
+  return true
 }
 
 /**
@@ -64,16 +91,8 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
   // Built-in names (mono/slate/…) already have a hand-tuned desktop palette — we
   // never shadow it, but the name is still a valid apply target.
   if (name !== 'default' && !BUILTIN_THEMES[name]) {
-    const theme = skinToDesktopTheme(skin as HermesSkin)
-
-    if (!theme) {
+    if (!registerBackendSkin(name, skin as HermesSkin)) {
       return
-    }
-
-    const current = $backendThemes.get()
-
-    if (JSON.stringify(current[name]) !== JSON.stringify(theme)) {
-      $backendThemes.set({ ...current, [name]: theme })
     }
   }
 
@@ -90,5 +109,31 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
   if (name !== lastSynced?.name || !lastSynced.applied) {
     lastSynced = { applied: true, name }
     $pendingSkinApply.set(name)
+  }
+}
+
+/**
+ * Fold the backend's FULL skin registry into the live theme store. The backend
+ * owns the filesystem truth and broadcasts every available skin on every
+ * gateway.ready / skin.changed, so the picker reflects ~/.hermes/skins/*.yaml
+ * even when localStorage was wiped — the next connect repopulates it with no
+ * per-skin re-application. Pure registration: never applies, never touches the
+ * active-skin baseline or the apply guard.
+ */
+export function ingestBackendSkinRegistry(registry: Record<string, HermesSkin> | null | undefined): void {
+  if (!registry || typeof registry !== 'object') {
+    return
+  }
+
+  for (const [name, skin] of Object.entries(registry)) {
+    const clean = (skin && typeof skin === 'object' ? (skin.name ?? '') : '').trim()
+
+    // Mirror ingestBackendSkin's shadowing rules; key must match payload name
+    // so a malformed entry can't register under a wrong key.
+    if (!clean || clean !== name || clean === 'default' || BUILTIN_THEMES[clean]) {
+      continue
+    }
+
+    registerBackendSkin(clean, skin)
   }
 }

--- a/apps/desktop/src/themes/context.test.tsx
+++ b/apps/desktop/src/themes/context.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { ThemeProvider } from './context'
+import { $backendSkinCache, $userThemes } from './user-themes'
 
 // The live-authoring loop: Hermes writes/edits one skin file and every surface
 // repaints. An in-place edit keeps the NAME — only the palette moves.
@@ -17,6 +18,8 @@ describe('ThemeProvider ← backend skin sync', () => {
   beforeEach(() => {
     window.localStorage.clear()
     __resetBackendSkinSync()
+    $backendSkinCache.set({})
+    $userThemes.set({})
   })
 
   afterEach(cleanup)
@@ -66,5 +69,77 @@ describe('ThemeProvider ← backend skin sync', () => {
       ingestBackendSkin({ name: 'forest', colors: { background: '#001100', ui_text: '#66ff66' } }, { apply: false })
     )
     expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+  })
+
+  it('adopts the backend skin on first connect when no desktop choice exists', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    // gateway.ready seed (apply:false) with nothing persisted: the provider
+    // adopts the backend's active skin, paints it, and caches name + converted
+    // record so the choice survives relaunch (backend skins are unresolvable
+    // at boot without the cache).
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+    expect(window.localStorage.getItem('hermes-desktop-theme-v2')).toBe('bloomberg')
+    expect(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1')).toContain('bloomberg')
+  })
+
+  it('does not adopt when the user has an explicit resolvable desktop choice', () => {
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'nous')
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    // The persisted pick wins; the seed registers but never paints.
+    expect(cssVar('--theme-foreground')).not.toBe('#ff9f0a')
+    expect(window.localStorage.getItem('hermes-desktop-theme-v2')).toBe('nous')
+  })
+
+  it('re-adopts when the persisted name only resolves via the just-seeded backend skin', () => {
+    // Old-binary state: a bare backend-skin name persisted with no cached
+    // record. Boot normalized it to the default (backend skins aren't
+    // resolvable pre-connect), and once the gateway seeds it, the name only
+    // resolves through the LIVE registry — boot-time sources still say "no
+    // real choice". Adoption must fire anyway and cache the record so the
+    // next relaunch boots straight into the skin.
+    window.localStorage.setItem('hermes-desktop-theme-v2', 'bloomberg')
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: false }))
+
+    expect(cssVar('--theme-foreground')).toBe('#ff9f0a')
+    const stored = JSON.parse(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1') ?? '{}')
+    expect(stored.bloomberg).toBeDefined()
+    expect(window.localStorage.getItem('hermes-desktop-theme-v2')).toBe('bloomberg')
+  })
+
+  it('persists the converted record when a backend skin is applied', () => {
+    render(
+      <ThemeProvider>
+        <div />
+      </ThemeProvider>
+    )
+
+    act(() => ingestBackendSkin(bloomberg('#ff9f0a'), { apply: true }))
+
+    // The name alone can't resolve at boot (no gateway yet); the converted
+    // record must land in the backend-skin cache so boot paints it directly.
+    const stored = JSON.parse(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1') ?? '{}')
+    expect(stored.bloomberg).toBeDefined()
+    expect(stored.bloomberg.colors.foreground).toBe('#ff9f0a')
+    expect(window.localStorage.getItem('hermes-desktop-theme-v2')).toBe('bloomberg')
   })
 })

--- a/apps/desktop/src/themes/context.tsx
+++ b/apps/desktop/src/themes/context.tsx
@@ -17,11 +17,11 @@ import { matchesQuery, useMediaQuery } from '@/hooks/use-media-query'
 import { persistString, persistStringRecord, storedString, storedStringRecord } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 
-import { $backendThemes, $pendingSkinApply } from './backend-sync'
+import { $backendThemes, $pendingSkinApply, getLastSyncedSkinName } from './backend-sync'
 import { hexToRgb, mix, readableOn } from './color'
 import { BUILTIN_THEME_LIST, DEFAULT_SKIN_NAME, DEFAULT_TYPOGRAPHY, nousTheme } from './presets'
 import type { DesktopTheme, DesktopThemeColors } from './types'
-import { $userThemes, listAllThemes, resolveTheme } from './user-themes'
+import { $backendSkinCache, $userThemes, cacheBackendSkin, isUserTheme, listAllThemes, resolveBootTheme, resolveTheme } from './user-themes'
 
 // Legacy global skin (pre per-profile themes). Still the inheritance fallback
 // for any profile without its own assignment, so single-profile users and old
@@ -321,6 +321,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   // grid, and `/skin` without a reload.
   const userThemes = useStore($userThemes)
   const backendThemes = useStore($backendThemes)
+  const backendSkinCache = useStore($backendSkinCache)
   const registryVersion = useStore($registryVersion)
 
   const availableThemes = useMemo(
@@ -330,9 +331,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
         label,
         description
       })),
-    // userThemes + backendThemes + registryVersion ARE listAllThemes' reactivity.
+    // userThemes + backendThemes + backendSkinCache + registryVersion ARE listAllThemes' reactivity.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [userThemes, backendThemes, registryVersion]
+    [userThemes, backendThemes, backendSkinCache, registryVersion]
   )
 
   const [themeName, setThemeNameState] = useState(() =>
@@ -380,6 +381,20 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const next = normalizeSkin(name)
     setThemeNameState(next)
     skinPref.assign(liveProfile(), next)
+
+    // Backend skins (~/.hermes/skins/*.yaml) only resolve after the gateway
+    // seeds them, so a bare name can't survive relaunch: the boot-time
+    // normalizeSkin falls back to the default and the choice is lost. Cache
+    // the converted record so boot resolves it synchronously, with exactly
+    // the palette the app already rendered (the live backend conversion
+    // still wins while connected).
+    if (!isUserTheme(next)) {
+      const backend = $backendThemes.get()[next]
+
+      if (backend) {
+        cacheBackendSkin(backend)
+      }
+    }
   }, [])
 
   const setMode = useCallback((next: ThemeMode) => {
@@ -398,6 +413,35 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       $pendingSkinApply.set(null)
     }
   }, [pendingSkin, setTheme])
+
+  // First-connect adoption: when no explicit desktop theme choice exists (or the
+  // persisted name no longer resolves), adopt the backend's active skin instead
+  // of staying on the fallback forever. The seed deliberately doesn't paint —
+  // this is the one case where painting is right, because there is no stored
+  // choice to stomp. setTheme persists name + converted record, so the adopted
+  // skin survives relaunch like any manual pick.
+  useEffect(() => {
+    if (Object.keys(backendThemes).length === 0) {
+      return
+    }
+
+    const profile = liveProfile()
+    const raw = storedStringRecord(PROFILE_SKINS_KEY)[profile] ?? storedString(SKIN_KEY)
+    // Boot-time sources only: a name that resolves ONLY through the just-seeded
+    // backend registry was unresolvable at boot (the classic "reverts to the
+    // default after relaunch" case) — treat it as no real choice and adopt.
+    const resolvableChoice = raw !== null && resolveBootTheme(raw)
+
+    if (resolvableChoice) {
+      return
+    }
+
+    const name = getLastSyncedSkinName()
+
+    if (name) {
+      setTheme(name)
+    }
+  }, [backendThemes, setTheme])
 
   // The light/dark toggle (Shift+X by default) is owned by the keybind runtime
   // (`appearance.toggleMode`) so it shows up in the hotkey map and is rebindable.

--- a/apps/desktop/src/themes/user-themes.test.ts
+++ b/apps/desktop/src/themes/user-themes.test.ts
@@ -2,12 +2,15 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { BUILTIN_THEMES, DEFAULT_SKIN_NAME } from './presets'
 import {
+  $backendSkinCache,
   $marketplaceInstalls,
   $userThemes,
+  cacheBackendSkin,
   installUserTheme,
   isUserTheme,
   listAllThemes,
   marketplaceIdOf,
+  pruneBackendSkinCache,
   removeUserTheme,
   resolveTheme
 } from './user-themes'
@@ -27,6 +30,7 @@ describe('user theme registry', () => {
   beforeEach(() => {
     window.localStorage.clear()
     $userThemes.set({})
+    $backendSkinCache.set({})
   })
 
   it('installs a theme into the merged registry and persists it', () => {
@@ -71,6 +75,67 @@ describe('user theme registry', () => {
     broken.colors = { background: '#000000' }
 
     expect(() => installUserTheme(broken)).toThrow(/colors/)
+  })
+
+  it('resolves a cached backend skin before the gateway connects (boot path)', async () => {
+    // Simulates a relaunch: $backendThemes is empty (no gateway yet) and only
+    // the persisted cache from a previous session exists. Boot-time
+    // resolution (normalizeSkin / deriveTheme) must still find the skin.
+    const theme = makeTheme('Backend Skin')
+
+    cacheBackendSkin(theme)
+    expect(resolveTheme(theme.name)).toEqual(theme)
+    expect(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1')).toContain(theme.name)
+
+    // A live backend conversion wins over the stale cache once connected.
+    const fresher = { ...theme, colors: { ...theme.colors, foreground: '#00ff00' } }
+    const { $backendThemes } = await import('./backend-sync')
+    $backendThemes.set({ [theme.name]: fresher })
+
+    expect(resolveTheme(theme.name)).toEqual(fresher)
+  })
+
+  it('lists cached backend skins in the picker before the gateway connects', () => {
+    // Regression: the picker (listAllThemes) must include skins that were
+    // applied in a previous session and only exist in the boot cache — a
+    // relaunch must not drop them from Appearance / Cmd-K / /skin just
+    // because the gateway hasn't re-broadcast them yet.
+    const theme = makeTheme('Previously Applied Skin')
+
+    cacheBackendSkin(theme)
+    expect(listAllThemes().map(t => t.name)).toContain(theme.name)
+  })
+
+  it('prunes cached backend skins that no longer exist on disk', () => {
+    // Regression: a skin file deleted from $HERMES_HOME/skins/ must stop
+    // ghosting in the picker once the backend broadcasts the authoritative
+    // available-skin list (deleted files are absent from it).
+    const alive = makeTheme('Still Here')
+    const deleted = makeTheme('Deleted Skin')
+
+    cacheBackendSkin(alive)
+    cacheBackendSkin(deleted)
+    expect(listAllThemes().map(t => t.name)).toContain(deleted.name)
+
+    pruneBackendSkinCache([alive.name, 'nous', 'custom-green'])
+
+    expect(listAllThemes().map(t => t.name)).not.toContain(deleted.name)
+    expect(listAllThemes().map(t => t.name)).toContain(alive.name)
+    // The pruned record is gone from persistence too, so a relaunch boots
+    // without the ghost.
+    expect(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1')).not.toContain(deleted.name)
+  })
+
+  it('leaves the cache untouched when every cached skin still exists', () => {
+    const theme = makeTheme('Only Skin')
+
+    cacheBackendSkin(theme)
+    const before = window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1')
+
+    pruneBackendSkinCache([theme.name])
+
+    expect(window.localStorage.getItem('hermes-desktop-backend-skin-cache-v1')).toBe(before)
+    expect(listAllThemes().map(t => t.name)).toContain(theme.name)
   })
 })
 

--- a/apps/desktop/src/themes/user-themes.ts
+++ b/apps/desktop/src/themes/user-themes.ts
@@ -119,6 +119,93 @@ export function removeUserTheme(name: string): void {
 
 export const isUserTheme = (name: string): boolean => Boolean($userThemes.get()[name])
 
+// ── Backend skin persistence cache ──────────────────────────────────────────
+// Backend skins (~/.hermes/skins/*.yaml) are converted in the renderer and
+// registered only after the gateway connects, but boot-time resolution runs
+// before that — so a chosen backend skin normalizes to the default on every
+// relaunch. Cache the converted record of every applied backend skin in
+// localStorage so boot can resolve it synchronously. The LIVE $backendThemes
+// conversion always wins once connected (it precedes this cache in
+// resolveTheme), so recolors still repaint; the cache only bridges the
+// pre-connect window and the boot-time normalizeSkin check.
+const BACKEND_CACHE_KEY = 'hermes-desktop-backend-skin-cache-v1'
+
+function readBackendCache(): Record<string, DesktopTheme> {
+  try {
+    const raw = window.localStorage.getItem(BACKEND_CACHE_KEY)
+
+    if (!raw) {
+      return {}
+    }
+
+    const parsed: unknown = JSON.parse(raw)
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return {}
+    }
+
+    const out: Record<string, DesktopTheme> = {}
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (!BUILTIN_THEMES[key] && isValidTheme(value)) {
+        out[key] = value
+      }
+    }
+
+    return out
+  } catch {
+    return {}
+  }
+}
+
+/** Reactive map of persisted backend-skin conversions, keyed by name. */
+export const $backendSkinCache = atom<Record<string, DesktopTheme>>(
+  typeof window === 'undefined' ? {} : readBackendCache()
+)
+
+/** Persist a backend skin's converted record so a future boot can resolve it. */
+export function cacheBackendSkin(theme: DesktopTheme): void {
+  const next = { ...$backendSkinCache.get(), [theme.name]: theme }
+  $backendSkinCache.set(next)
+
+  try {
+    window.localStorage.setItem(BACKEND_CACHE_KEY, JSON.stringify(next))
+  } catch {
+    // Best-effort: a restricted storage context shouldn't break theming.
+  }
+}
+
+/**
+ * Reconcile the backend-skin cache against the backend's authoritative list
+ * of available skin names. Entries whose skin file no longer exists (deleted
+ * from `$HERMES_HOME/skins/`) are dropped, so a retired skin stops ghosting in
+ * the picker after the next connect. Keeps every surviving record intact —
+ * this is a prune, never a clobber.
+ */
+export function pruneBackendSkinCache(availableNames: readonly string[]): void {
+  const valid = new Set(availableNames)
+  const current = $backendSkinCache.get()
+  const next: Record<string, DesktopTheme> = {}
+
+  for (const [name, theme] of Object.entries(current)) {
+    if (valid.has(name)) {
+      next[name] = theme
+    }
+  }
+
+  if (Object.keys(next).length === Object.keys(current).length) {
+    return
+  }
+
+  $backendSkinCache.set(next)
+
+  try {
+    window.localStorage.setItem(BACKEND_CACHE_KEY, JSON.stringify(next))
+  } catch {
+    // Best-effort: a restricted storage context shouldn't break theming.
+  }
+}
+
 /** The Marketplace extension id an installed theme came from, or null. */
 export function marketplaceIdOf(theme: DesktopTheme): string | null {
   return theme.description.startsWith(MARKETPLACE_DESC_PREFIX)
@@ -168,26 +255,47 @@ export function contributedThemes(): DesktopTheme[] {
   return out
 }
 
-/** Resolve a theme by name across the merged set (built-in + user + backend + contributed). */
+/** Resolve a theme by name across the merged set (built-in + user + backend + cache + contributed). */
 export function resolveTheme(name: string): DesktopTheme | undefined {
   return (
     BUILTIN_THEMES[name] ??
     $userThemes.get()[name] ??
     $backendThemes.get()[name] ??
+    $backendSkinCache.get()[name] ??
     contributedThemes().find(theme => theme.name === name)
   )
 }
 
-/** Built-ins first (stable order), then contributed, then backend skins, then user installs. */
+/**
+ * Resolve a theme from boot-time sources ONLY (everything except the live
+ * backend registry). The backend's skins aren't available until the gateway
+ * seeds them, so this is what boot-time normalizeSkin/deriveTheme can see.
+ * Used by the first-connect adoption check: a persisted name that only
+ * resolves via $backendThemes was seeded JUST NOW — it was unresolvable at
+ * boot (the classic "reverts to the default after relaunch" case), so the
+ * adoption must still fire and cache the record.
+ */
+export function resolveBootTheme(name: string): DesktopTheme | undefined {
+  return (
+    BUILTIN_THEMES[name] ??
+    $userThemes.get()[name] ??
+    $backendSkinCache.get()[name] ??
+    contributedThemes().find(theme => theme.name === name)
+  )
+}
+
+/** Built-ins first (stable order), then contributed, then backend skins, then cached backend skins, then user installs. */
 export function listAllThemes(): DesktopTheme[] {
   const user = $userThemes.get()
   const backend = $backendThemes.get()
-  const shadows = (theme: DesktopTheme) => user[theme.name] || backend[theme.name]
+  const cache = $backendSkinCache.get()
+  const shadows = (theme: DesktopTheme) => user[theme.name] || backend[theme.name] || cache[theme.name]
 
   return [
     ...Object.values(BUILTIN_THEMES),
     ...contributedThemes().filter(theme => !shadows(theme)),
     ...Object.values(backend).filter(theme => !user[theme.name]),
+    ...Object.values(cache).filter(theme => !user[theme.name] && !backend[theme.name]),
     ...Object.values(user)
   ]
 }

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -626,11 +626,26 @@ def test_broadcast_skin_if_changed_on_any_signature_move(server, monkeypatch):
     monkeypatch.setattr(server, "_last_skin_sig", None, raising=False)
     monkeypatch.setattr(server, "_skin_sig", lambda: next(sigs))
     monkeypatch.setattr(server, "resolve_skin", lambda: {"name": "x", "colors": {}})
+    monkeypatch.setattr(server, "resolve_skins_list", lambda: ["neon", "forest"])
+    monkeypatch.setattr(
+        server,
+        "resolve_skin_registry",
+        lambda: {
+            "neon": {"name": "neon", "colors": {}},
+            "forest": {"name": "forest", "colors": {}},
+        },
+    )
 
     for _ in range(4):
         server._broadcast_skin_if_changed()
 
     assert [ev for ev, _ in emitted] == ["skin.changed"] * 3
+    # The full registry rides along so clients can rebuild pickers from disk
+    # truth on every broadcast.
+    assert all(
+        isinstance(payload.get("registry"), dict) and payload["registry"]["neon"]["name"] == "neon"
+        for _, payload in emitted
+    )
 
 
 # ── global-event broadcast (session-less events reach every WS client) ──

--- a/tui_gateway/entry.py
+++ b/tui_gateway/entry.py
@@ -446,7 +446,17 @@ def main():
         "params": {
             "type": "gateway.ready",
             # change_events: see tui_gateway/ws.py — clients demote legacy polls.
-            "payload": {"skin": resolve_skin(), "change_events": True},
+            "payload": {
+                "skin": resolve_skin(),
+                # Authoritative available-skin names: clients reconcile caches
+                # against this so deleted skin files stop ghosting in pickers.
+                "skins": server.resolve_skins_list(),
+                # Full registry: every available skin's wire payload, keyed by
+                # name — clients rebuild their pickers from disk truth on every
+                # connect, so a wiped local cache self-heals.
+                "registry": server.resolve_skin_registry(),
+                "change_events": True,
+            },
         },
     }):
         _log_exit("startup write failed (broken stdout pipe before first event)")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3211,25 +3211,59 @@ def _clear_pending(sid: str | None = None) -> None:
 # ── Agent factory ────────────────────────────────────────────────────
 
 
+def _skin_to_wire(skin) -> dict:
+    """Shape a resolved SkinConfig for the wire (what every surface consumes)."""
+    return {
+        "name": skin.name,
+        "colors": skin.colors,
+        # Paired palettes: the TUI detects the terminal's polarity and
+        # prefers the matching hand-tuned block over adapting `colors`.
+        "light_colors": skin.light_colors,
+        "dark_colors": skin.dark_colors,
+        "branding": skin.branding,
+        "banner_logo": skin.banner_logo,
+        "banner_hero": skin.banner_hero,
+        "tool_prefix": skin.tool_prefix,
+        "help_header": (skin.branding or {}).get("help_header", ""),
+    }
+
+
 def resolve_skin() -> dict:
     try:
         from hermes_cli.skin_engine import init_skin_from_config, get_active_skin
 
         init_skin_from_config(_load_cfg())
-        skin = get_active_skin()
-        return {
-            "name": skin.name,
-            "colors": skin.colors,
-            # Paired palettes: the TUI detects the terminal's polarity and
-            # prefers the matching hand-tuned block over adapting `colors`.
-            "light_colors": skin.light_colors,
-            "dark_colors": skin.dark_colors,
-            "branding": skin.branding,
-            "banner_logo": skin.banner_logo,
-            "banner_hero": skin.banner_hero,
-            "tool_prefix": skin.tool_prefix,
-            "help_header": (skin.branding or {}).get("help_header", ""),
-        }
+        return _skin_to_wire(get_active_skin())
+    except Exception:
+        return {}
+
+
+def resolve_skins_list() -> list[str]:
+    """Names of every available skin (built-in + user files). The backend owns
+    the filesystem truth, so every skin broadcast carries this list and clients
+    reconcile their caches against it — a deleted skin file must not keep
+    ghosting in a surface's picker after the next connect."""
+    try:
+        from hermes_cli.skin_engine import list_skins
+
+        return [s["name"] for s in list_skins()]
+    except Exception:
+        return []
+
+
+def resolve_skin_registry() -> dict:
+    """Every available skin's full wire payload, keyed by name.
+
+    The backend owns the filesystem truth (``~/.hermes/skins/*.yaml`` +
+    built-ins), so every connect carries the whole registry — clients rebuild
+    their pickers from disk state instead of relying on a localStorage cache
+    that updates, rebuilds, or storage resets can wipe. A wiped cache
+    self-heals on the next connect without any per-skin re-application.
+    """
+    try:
+        from hermes_cli.skin_engine import load_skin
+
+        return {name: _skin_to_wire(load_skin(name)) for name in resolve_skins_list()}
     except Exception:
         return {}
 
@@ -3281,7 +3315,7 @@ def _broadcast_skin_if_changed() -> None:
         return
     _last_skin_sig = sig
     try:
-        _broadcast_global_event("skin.changed", resolve_skin())
+        _broadcast_global_event("skin.changed", {**resolve_skin(), "skins": resolve_skins_list(), "registry": resolve_skin_registry()})
     except Exception:
         pass
 
@@ -11198,7 +11232,7 @@ def _(rid, params: dict) -> dict:
                     # Every connected surface repaints, not just the RPC's
                     # client; then sync the watcher baseline so the poll loop
                     # doesn't re-broadcast the skin this RPC just applied.
-                    _broadcast_global_event("skin.changed", resolve_skin())
+                    _broadcast_global_event("skin.changed", {**resolve_skin(), "skins": resolve_skins_list(), "registry": resolve_skin_registry()})
                     _note_skin_broadcast()
             resp = {"key": key, "value": nv}
             if key == "personality":

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -311,6 +311,8 @@ async def handle_ws(ws: Any) -> None:
         # (#60800). The skin payload is small (a dict of strings/arrays),
         # so the to_thread overhead is negligible.
         skin_payload = await asyncio.to_thread(server.resolve_skin)
+        skins_list = await asyncio.to_thread(server.resolve_skins_list)
+        registry = await asyncio.to_thread(server.resolve_skin_registry)
         ready_ok = await transport.write_async(
             {
                 "jsonrpc": "2.0",
@@ -320,7 +322,18 @@ async def handle_ws(ws: Any) -> None:
                     # change_events: this backend broadcasts pet.changed /
                     # cron.changed / sessions.changed, so clients can demote
                     # their legacy polls to slow backstops.
-                    "payload": {"skin": skin_payload, "change_events": True},
+                    "payload": {
+                        "skin": skin_payload,
+                        # Authoritative available-skin names: clients reconcile
+                        # caches against this so deleted skin files stop
+                        # ghosting in pickers.
+                        "skins": skins_list,
+                        # Full registry: every available skin's wire payload,
+                        # keyed by name — clients rebuild their pickers from
+                        # disk truth on every connect.
+                        "registry": registry,
+                        "change_events": True,
+                    },
                 },
             }
         )


### PR DESCRIPTION
## Problem

Custom themes (skins in `~/.hermes/skins/*.yaml`) kept vanishing from the desktop picker. Every app update, desktop rebuild, or localStorage reset dropped all non-active themes; only the ACTIVE skin survived (the gateway re-broadcasts it on every connect). Users had to manually re-apply each skin once to restore the picker.

## Root Cause

`gateway.ready` / `skin.changed` broadcast only the **active** skin's wire payload. Non-active skins persisted only in a localStorage cache (`hermes-desktop-backend-skin-cache-v1`) that updates and rebuilds can wipe — nothing repopulated it.

## Fix (three layers, each independently useful)

**1. First-connect adoption + boot cache** — when no resolvable persisted desktop theme exists, adopt the backend's active skin on first connect and cache the converted record, so a relaunch boots straight into the skin instead of flashing the default. A persisted backend-skin name that only resolves through the live registry no longer reverts.

**2. Authoritative skin-name list + cache prune** — broadcasts now carry the full list of available skin names; the renderer prunes its boot cache against it, so deleted skin files stop ghosting in the picker.

**3. Full registry broadcast** — every broadcast now carries EVERY available skin's wire payload, keyed by name (`resolve_skin_registry()`), and `ingestBackendSkinRegistry()` merges the whole set into the live picker on every connect. The picker rebuilds from disk truth each connect — **any wiped cache self-heals with no per-skin re-application**, across updates, rebuilds, storage resets, and multi-machine setups.

## Backward Compatibility

- New payload keys (`skins`, `registry`) absent on older backends → renderer no-ops safely
- Registration never applies or overrides the user's persisted theme choice
- Built-in names and `default` are never shadowed (mirrors existing `ingestBackendSkin` rules)
- `ws.py` follows the upstream `asyncio.to_thread` pattern (#60800) for payload building

## Tests

- `test_broadcast_skin_if_changed_on_any_signature_move`: asserts the registry rides along on every broadcast
- 4 new `ingestBackendSkinRegistry` tests: full registration, no built-in/default shadowing, key≠name rejection, empty payloads
- Full theme suite: 78 tests green; tui_gateway suite: 342 tests green