### PR TITLE
fix(timeouts): apply reasoning floor to Codex event-idle watchdog

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -159,6 +159,53 @@ def openai_codex_stale_timeout_floor(est_tokens: int) -> float:
     return 0.0
 
 
+
+def resolve_codex_event_idle_timeout(
+    *,
+    base_timeout: float,
+    model: object = None,
+    provider: object = None,
+) -> float:
+    """Resolve post-first-byte Codex SSE idle patience.
+
+    The Codex event-idle watchdog (``HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS``)
+    is separate from the wall-clock stale detector. Reasoning models on
+    ``codex_responses`` paths — including OpenAI Codex and xAI OAuth/Grok —
+    can emit an opening SSE frame and then sit silent for several minutes
+    while thinking. The tiered default tops out at 180s for large tool-heavy
+    payloads, which kills healthy thinking streams and surfaces as
+    ``BrokenPipeError`` / errno 32 even when conversation fill is small.
+
+    This resolver keeps ``base_timeout <= 0`` as an explicit disable, then
+    raises patience via:
+
+    1. ``providers.<id>.stale_timeout_seconds`` / per-model override
+    2. the reasoning-model floor (``get_reasoning_stale_timeout_floor``)
+
+    Both are floors only — never lower an explicit higher base.
+    """
+    try:
+        timeout = float(base_timeout)
+    except (TypeError, ValueError):
+        return base_timeout
+    if timeout <= 0:
+        return timeout
+
+    provider_id = str(provider or "").strip()
+    model_id = model if isinstance(model, str) else (str(model) if model else None)
+    if provider_id:
+        cfg = get_provider_stale_timeout(provider_id, model_id)
+        if cfg is not None:
+            timeout = max(timeout, float(cfg))
+
+    from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+    floor = get_reasoning_stale_timeout_floor(model_id)
+    if floor is not None:
+        timeout = max(timeout, float(floor))
+    return timeout
+
+
 def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
     """Return a normalized OpenRouter provider.sort value or None."""
     if not isinstance(raw_sort, str):
@@ -918,6 +965,26 @@ def interruptible_api_call(agent, api_kwargs: dict):
     )
     if _codex_idle_timeout <= 0:
         _codex_idle_enabled = False
+    elif _codex_idle_enabled:
+        # Apply provider config + reasoning-model floor. Without this, the
+        # event-idle kill stays at the tiered default (often 180s) while the
+        # wall-clock stale path already respects reasoning floors — so Grok /
+        # o-series / DeepSeek thinking on codex_responses dies mid-think as
+        # errno 32 even on small chats (tool schemas inflate the estimate).
+        _raised = resolve_codex_event_idle_timeout(
+            base_timeout=_codex_idle_timeout,
+            model=api_kwargs.get("model") or getattr(agent, "model", None),
+            provider=getattr(agent, "provider", None),
+        )
+        if _raised > _codex_idle_timeout:
+            logger.debug(
+                "Raised Codex event-idle timeout %.0fs → %.0fs (model=%s provider=%s)",
+                _codex_idle_timeout,
+                _raised,
+                api_kwargs.get("model") or getattr(agent, "model", None),
+                getattr(agent, "provider", None),
+            )
+            _codex_idle_timeout = _raised
 
     if _codex_watchdog_enabled:
         # Reset before the worker starts so a marker left over from a previous

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -116,12 +116,18 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("claude-fable", 600),
     # xAI Grok reasoning variants.  Explicit reasoning-only keys
     # plus one for the ``non-reasoning`` variant so users picking
-    # the fast variant don't get the 300s floor.  Bare ``grok-3``,
-    # ``grok-4`` etc. don't match — only the explicit reasoning /
-    # non-reasoning pairs.
-    ("grok-4-fast-reasoning", 300),
-    ("grok-4.20-reasoning", 300),
-    ("grok-4.5", 300),
+    # the fast variant don't get the deep-reasoning floor.  Bare
+    # ``grok-3``, ``grok-4`` etc. don't match — only the explicit
+    # reasoning / non-reasoning pairs.
+    #
+    # 600s matches o1 / DeepSeek R1: xAI OAuth uses the codex_responses
+    # stream path, and production Desktop sessions observed healthy
+    # grok-4.5 thinks exceeding the prior 300s floor (and the 180s
+    # Codex event-idle default) before the first content token, dying
+    # as errno 32 / Broken pipe with small conversation fill.
+    ("grok-4-fast-reasoning", 600),
+    ("grok-4.20-reasoning", 600),
+    ("grok-4.5", 600),
     ("grok-4-fast-non-reasoning", 180),
 )
 

--- a/tests/agent/test_codex_event_idle_reasoning_floor.py
+++ b/tests/agent/test_codex_event_idle_reasoning_floor.py
@@ -1,0 +1,197 @@
+"""Codex event-idle watchdog must respect reasoning-model floors.
+
+Regression for Desktop + xAI OAuth (grok-4.5) and other codex_responses
+reasoning paths: the post-first-byte SSE idle kill used a tiered default
+(capped at 180s for large tool payloads) and never consulted
+``get_reasoning_stale_timeout_floor``. Healthy multi-minute thinking after
+the opening SSE frame was killed as errno 32 / Broken pipe even when the
+UI context meter showed small conversation fill (tool schemas inflate the
+request estimate used only for tier selection).
+
+Wall-clock stale already applied the reasoning floor; event-idle did not.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+
+@pytest.fixture(autouse=True)
+def _isolate_provider_stale_config(tmp_path, monkeypatch):
+    """Pure floor math must not see the developer's ~/.hermes config."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(config_mod, "load_config_readonly", lambda: {})
+
+
+@pytest.mark.parametrize(
+    "base,model,provider,expected",
+    [
+        (180.0, "gpt-4o", "openai", 180.0),
+        (12.0, "gpt-5.5", "openai-codex", 12.0),
+        (180.0, "grok-4.5", "xai-oauth", 600.0),
+        (180.0, "x-ai/grok-4.5", "xai-oauth", 600.0),
+        (60.0, "openai/o3", "openai-codex", 600.0),
+        (120.0, "deepseek/deepseek-r1", "deepseek", 600.0),
+        (0.0, "grok-4.5", "xai-oauth", 0.0),
+        (-1.0, "grok-4.5", "xai-oauth", -1.0),
+        (180.0, "grok-4-fast-non-reasoning", "xai-oauth", 180.0),
+        (900.0, "grok-4.5", "xai-oauth", 900.0),
+    ],
+)
+def test_resolve_codex_event_idle_timeout_floors(base, model, provider, expected):
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    got = resolve_codex_event_idle_timeout(
+        base_timeout=base, model=model, provider=provider
+    )
+    assert got == expected
+
+
+def test_resolve_respects_provider_stale_config(monkeypatch):
+    """providers.<id>.stale_timeout_seconds raises event-idle without env."""
+    import hermes_cli.config as config_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config_readonly",
+        lambda: {
+            "providers": {
+                "xai-oauth": {
+                    "stale_timeout_seconds": 900,
+                    "models": {"grok-4.5": {"stale_timeout_seconds": 900}},
+                }
+            }
+        },
+    )
+
+    from agent.chat_completion_helpers import resolve_codex_event_idle_timeout
+
+    got = resolve_codex_event_idle_timeout(
+        base_timeout=180.0, model="grok-4.5", provider="xai-oauth"
+    )
+    assert got == 900.0
+
+
+def _make_xai_agent(tmp_path, monkeypatch, model="grok-4.5"):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / ".env").write_text("", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text("{}\n", encoding="utf-8")
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        model=model,
+        provider="xai-oauth",
+        api_key="sk-dummy",
+        base_url="https://api.x.ai/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        platform="desktop",
+    )
+    agent.api_mode = "codex_responses"
+    monkeypatch.setattr(agent, "_emit_status", lambda *a, **k: None)
+    monkeypatch.setattr(
+        agent, "_compute_non_stream_stale_timeout", lambda *a, **k: 120.0
+    )
+    return agent
+
+
+def test_event_idle_does_not_kill_reasoning_think_under_floor(tmp_path, monkeypatch):
+    """After first SSE byte, a grok think shorter than the floor must complete."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_xai_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.5")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "0")
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    sentinel = SimpleNamespace(ok=True)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        agent._codex_stream_last_event_ts = time.time()
+        if on_first_delta:
+            on_first_delta()
+        time.sleep(1.2)  # > 0.5s base, << 600s floor
+        return sentinel
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    large = "x" * 44_000
+    resp = h.interruptible_api_call(
+        agent, {"model": "grok-4.5", "input": large, "tools": [{"x": "y" * 1000}]}
+    )
+    assert resp is sentinel
+    assert "codex_stream_idle_kill" not in closes
+
+
+def test_event_idle_still_kills_non_reasoning_at_base(tmp_path, monkeypatch):
+    """Non-reasoning models keep the short base idle (no reasoning floor)."""
+    from agent import chat_completion_helpers as h
+
+    agent = _make_xai_agent(tmp_path, monkeypatch, model="gpt-4o")
+    agent.model = "gpt-4o"
+    agent.provider = "openai"
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.4")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "30")
+    monkeypatch.setenv("HERMES_CODEX_HARD_TIMEOUT_SECONDS", "0")
+
+    closes: list = []
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+    monkeypatch.setattr(
+        agent,
+        "_close_request_openai_client",
+        lambda c, reason=None: closes.append(reason),
+    )
+
+    stop = {"flag": False}
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        agent._codex_stream_last_event_ts = time.time()
+        if on_first_delta:
+            on_first_delta()
+        deadline = time.time() + 30
+        while time.time() < deadline and not stop["flag"]:
+            time.sleep(0.02)
+        raise RuntimeError("connection closed")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+    try:
+        with pytest.raises(TimeoutError) as excinfo:
+            h.interruptible_api_call(agent, {"model": "gpt-4o", "input": "hi"})
+        msg = str(excinfo.value).lower()
+        assert "no sse events" in msg or "threshold" in msg
+        assert "codex_stream_idle_kill" in closes
+    finally:
+        stop["flag"] = True

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -79,9 +79,9 @@ import pytest
     ("claude-fable-5", 600.0),
     ("claude-fable", 600.0),
     # xAI Grok reasoning variants — explicit, not bare `grok`.
-    ("x-ai/grok-4-fast-reasoning", 300.0),
-    ("x-ai/grok-4.20-reasoning", 300.0),
-    ("x-ai/grok-4.5", 300.0),
+    ("x-ai/grok-4-fast-reasoning", 600.0),
+    ("x-ai/grok-4.20-reasoning", 600.0),
+    ("x-ai/grok-4.5", 600.0),
     ("x-ai/grok-4-fast-non-reasoning", 180.0),
 ])
 def test_reasoning_stale_timeout_floor_positive_cases(model, expected):


### PR DESCRIPTION
## Summary

Reasoning models on the `codex_responses` stream path (notably **xAI OAuth `grok-4.5`** on Desktop) were being killed mid-think with:

```
Codex stream produced no SSE events for 180s after first byte
[Errno 32] Broken pipe
```

even when the UI context meter showed **~14%** conversation fill.

### Root cause

Two separate patience budgets exist:

1. **Wall-clock stale** — already applies `get_reasoning_stale_timeout_floor`
2. **Codex post-first-byte event idle** (`HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS`) — tiered default capped at **180s** for large *request* estimates, and **never** consulted the reasoning floor

Tool schemas inflate `estimate_request_context_tokens` into the 100k+ tier while chat history stays small, so the idle kill fires during healthy multi-minute Grok thinking and surfaces as errno 32 after 3 retries.

### Fix

- Add `resolve_codex_event_idle_timeout()` that raises the idle budget via:
  - `providers.<id>.stale_timeout_seconds` / per-model override
  - `get_reasoning_stale_timeout_floor(model)`
  - keeps `<= 0` as explicit disable
- Wire it into `interruptible_api_call` after env base resolution
- Raise Grok reasoning floors **300 → 600s** (`grok-4.5`, `grok-4.20-reasoning`, `grok-4-fast-reasoning`) to match o1 / DeepSeek R1 depth (production Desktop multi-minute thinks observed past 300s)

Non-reasoning models and explicit `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=0` are unchanged.

## Test plan

- [x] `pytest tests/agent/test_codex_event_idle_reasoning_floor.py tests/agent/test_reasoning_stale_timeout_floor.py -o addopts=` → **46 passed**
- [ ] Desktop + xAI OAuth `grok-4.5`: long think no longer dies at 180s with small `/context` %
- [ ] Non-reasoning codex path still idle-kills at short base
- [ ] `HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=0` still disables idle kill

## Notes for reviewers

- This is the default-path fix for the class of “errno 32 on Grok with low context %” reports; local workarounds (`HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS=900` / `providers.xai-oauth.stale_timeout_seconds`) remain valid and now also feed the event-idle path via provider config.
- No new user-facing env vars; config.yaml provider stale already preferred over env for behavioral knobs.