### PR TITLE
fix(memory): entry-point + project-dir discovery parity for out-of-tree providers (salvage of #18842, #40644, #76567)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -828,6 +828,14 @@ Separate discovery system for pluggable memory backends. Current built-in
 providers include **honcho, mem0, supermemory, byterover, hindsight,
 holographic, openviking, retaindb**.
 
+Discovery covers the same four sources as the general `PluginManager` —
+bundled, `$HERMES_HOME/plugins/`, `./.hermes/plugins/` (opt-in via
+`HERMES_ENABLE_PROJECT_PLUGINS`), and `hermes_agent.memory_providers` entry
+points — but with **bundled-first** precedence, the reverse of the general
+system's later-wins order: a memory provider is activated by name, so a
+dropped-in directory must not be able to shadow a shipped one. Discovery
+enumerates without importing; nothing runs until `memory.provider` names it.
+
 Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
 and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
 `sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -764,6 +764,14 @@ Separate discovery system for pluggable memory backends. Current built-in
 providers include **honcho, mem0, supermemory, byterover, hindsight,
 holographic, openviking, retaindb**.
 
+Discovery covers the same four sources as the general `PluginManager` —
+bundled, `$HERMES_HOME/plugins/`, `./.hermes/plugins/` (opt-in via
+`HERMES_ENABLE_PROJECT_PLUGINS`), and `hermes_agent.memory_providers` entry
+points — but with **bundled-first** precedence, the reverse of the general
+system's later-wins order: a memory provider is activated by name, so a
+dropped-in directory must not be able to shadow a shipped one. Discovery
+enumerates without importing; nothing runs until `memory.provider` names it.
+
 Each provider implements the `MemoryProvider` ABC (see `agent/memory_provider.py`)
 and is orchestrated by `agent/memory_manager.py`. Lifecycle hooks include
 `sync_turn(turn_messages)`, `prefetch(query)`, `shutdown()`, and optional

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1774,6 +1774,21 @@ class PluginManager:
         of its parent packages (see ``_resolve_module_source``); only
         the first 8192 chars are scanned, mirroring the directory-plugin
         heuristic. Unresolvable or non-Python modules stay ``standalone``.
+
+        Activation contract: this method only decides whether the general
+        manager imports the module — it does not activate anything.
+        Memory and model providers activate through their own systems
+        (``memory.provider`` config via ``plugins/memory`` directory
+        discovery; ``providers/`` lazy directory discovery). Both are
+        directory-based today, so a pip-only provider is recorded for
+        introspection but not activatable until those systems gain
+        entry-point discovery (tracked for memory: #40644). That is not
+        a regression: pre-change such a provider was equally
+        unactivatable — it was merely imported first, at full cost
+        (e.g. fastembed -> onnxruntime), and logged
+        ``no register() function``. Classification removes the cost
+        without changing the activation surface, and is the prerequisite
+        that prevents double-import once entry-point activation lands.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -280,6 +280,25 @@ def _get_enabled_plugins() -> Optional[set]:
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
 
 
+def _detect_kind_from_source(source_text: str) -> Optional[str]:
+    """Return the plugin kind implied by source markers, or ``None``.
+
+    Mirrors ``plugins/memory/__init__.py:_is_memory_provider_dir``: a
+    module that registers a memory provider (``register_memory_provider``
+    or ``MemoryProvider``) belongs to the memory-provider discovery
+    system (``exclusive``); a module that registers a model provider
+    (``register_provider`` + ``ProviderProfile``) belongs to the
+    providers discovery (``model-provider``). Applied to both directory
+    plugins and pip entry-point plugins so neither is eagerly imported
+    by the general PluginManager.
+    """
+    if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
+        return "exclusive"
+    if "register_provider" in source_text and "ProviderProfile" in source_text:
+        return "model-provider"
+    return None
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -1623,29 +1642,16 @@ class PluginManager:
                 init_file = plugin_dir / "__init__.py"
                 if init_file.exists():
                     try:
-                        source_text = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
-                        if (
-                            "register_memory_provider" in source_text
-                            or "MemoryProvider" in source_text
-                        ):
-                            kind = "exclusive"
+                        detected = _detect_kind_from_source(
+                            init_file.read_text(
+                                errors="replace", encoding="utf-8"
+                            )[:8192]
+                        )
+                        if detected:
+                            kind = detected
                             logger.debug(
-                                "Plugin %s: detected memory provider, "
-                                "treating as kind='exclusive'",
-                                key,
-                            )
-                        elif (
-                            "register_provider" in source_text
-                            and "ProviderProfile" in source_text
-                        ):
-                            # Model provider plugin (calls register_provider()
-                            # from ``providers`` with a ProviderProfile). Route
-                            # to providers/__init__.py discovery.
-                            kind = "model-provider"
-                            logger.debug(
-                                "Plugin %s: detected model provider, "
-                                "treating as kind='model-provider'",
-                                key,
+                                "Plugin %s: detected %s, treating as kind='%s'",
+                                key, detected, detected,
                             )
                     except Exception:
                         pass
@@ -1677,6 +1683,37 @@ class PluginManager:
     # Entry-point scanning
     # -----------------------------------------------------------------------
 
+    def _classify_entrypoint_kind(self, ep) -> str:
+        """Classify a pip entry-point plugin by scanning its module source.
+
+        The ``kind`` semantics are the same for pip entry points as for
+        directory plugins: memory providers (``exclusive``) and model
+        providers (``model-provider``) have their own discovery systems,
+        so importing them here registers nothing and only pays the
+        module's import cost in every Hermes process (e.g. a pip
+        memory-provider plugin pulling in onnxruntime via fastembed —
+        ~60 MB RSS on startup).
+
+        The module is resolved with ``importlib.util.find_spec`` — no
+        import for top-level module names (for dotted names only the
+        parent package may be imported). Only the first 8192 chars of
+        source are scanned, mirroring the directory-plugin heuristic.
+        Unresolvable or non-Python modules stay ``standalone``.
+        """
+        try:
+            module_name = ep.value.split(":", 1)[0].strip()
+            if not module_name:
+                return "standalone"
+            spec = importlib.util.find_spec(module_name)
+            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
+                return "standalone"
+            source_text = Path(spec.origin).read_text(
+                errors="replace", encoding="utf-8"
+            )[:8192]
+            return _detect_kind_from_source(source_text) or "standalone"
+        except Exception:
+            return "standalone"
+
     def _scan_entry_points(self) -> List[PluginManifest]:
         """Check ``importlib.metadata`` for pip-installed plugins."""
         manifests: List[PluginManifest] = []
@@ -1697,6 +1734,7 @@ class PluginManager:
                     path=ep.value,
                     key=ep.name,
                 )
+                manifest.kind = self._classify_entrypoint_kind(ep)
                 manifests.append(manifest)
         except Exception as exc:
             logger.debug("Entry-point scan failed: %s", exc)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -299,6 +299,82 @@ def _detect_kind_from_source(source_text: str) -> Optional[str]:
     return None
 
 
+def _read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
+    """Read the first ``limit`` chars of a module's source file.
+
+    Returns ``""`` on any failure (callers fall back to ``standalone``).
+    ``.pyc``/``.pyo`` origins are mapped back to their source path so
+    source is still scanned when only the bytecode cache is present.
+    """
+    if not origin:
+        return ""
+    if origin.endswith((".pyc", ".pyo")):
+        try:
+            origin = importlib.util.source_from_cache(origin)
+        except Exception:
+            return ""
+    if not origin.endswith(".py"):
+        return ""
+    try:
+        return Path(origin).read_text(encoding="utf-8", errors="replace")[:limit]
+    except Exception:
+        return ""
+
+
+def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """Return the first ``limit`` chars of a module's source WITHOUT importing it.
+
+    ``importlib.util.find_spec`` on a dotted name imports the parent
+    package first (executing its ``__init__.py``), which would run
+    arbitrary package initialization during discovery and pay the very
+    import cost this classification exists to avoid — a provider whose
+    heavy imports live in ``package/__init__.py`` would still pay them.
+
+    Only the top-level name is resolved with ``find_spec`` (import-free
+    for top-level names); the remaining dotted segments are walked
+    through ``submodule_search_locations`` by hand, mirroring the file
+    layout conventions of the default PathFinder (``part.py`` module or
+    ``part/__init__.py`` package). Namespace packages, zipped modules,
+    extension modules, and anything else unexpected fall back to ``""``
+    (→ ``standalone``, the safe default).
+    """
+    parts = [p for p in module_name.split(".") if p]
+    if not parts:
+        return ""
+    try:
+        spec = importlib.util.find_spec(parts[0])
+        if spec is None or not spec.origin:
+            return ""
+        if len(parts) == 1:
+            return _read_source_from_origin(spec.origin, limit)
+
+        search_paths = spec.submodule_search_locations
+        if not search_paths:
+            return ""
+        for i, part in enumerate(parts[1:], start=2):
+            found_origin = None
+            next_paths = None
+            for base in search_paths:
+                base = Path(base)
+                pkg_init = base / part / "__init__.py"
+                if pkg_init.is_file():
+                    found_origin = str(pkg_init)
+                    next_paths = [base / part]
+                    break
+                mod_file = base / (part + ".py")
+                if mod_file.is_file():
+                    found_origin = str(mod_file)
+                    break
+            if found_origin is None:
+                return ""
+            if i == len(parts) or next_paths is None:
+                return _read_source_from_origin(found_origin, limit)
+            search_paths = next_paths
+        return ""
+    except Exception:
+        return ""
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -1694,22 +1770,16 @@ class PluginManager:
         memory-provider plugin pulling in onnxruntime via fastembed —
         ~60 MB RSS on startup).
 
-        The module is resolved with ``importlib.util.find_spec`` — no
-        import for top-level module names (for dotted names only the
-        parent package may be imported). Only the first 8192 chars of
-        source are scanned, mirroring the directory-plugin heuristic.
-        Unresolvable or non-Python modules stay ``standalone``.
+        The module source is read without importing the module or any
+        of its parent packages (see ``_resolve_module_source``); only
+        the first 8192 chars are scanned, mirroring the directory-plugin
+        heuristic. Unresolvable or non-Python modules stay ``standalone``.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()
             if not module_name:
                 return "standalone"
-            spec = importlib.util.find_spec(module_name)
-            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
-                return "standalone"
-            source_text = Path(spec.origin).read_text(
-                errors="replace", encoding="utf-8"
-            )[:8192]
+            source_text = _resolve_module_source(module_name)
             return _detect_kind_from_source(source_text) or "standalone"
         except Exception:
             return "standalone"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -321,36 +321,40 @@ def _read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
         return ""
 
 
-def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
-    """Return the first ``limit`` chars of a module's source WITHOUT importing it.
+def resolve_module_origin(module_name: str) -> Optional[str]:
+    """Return a module's source path WITHOUT importing it, or ``None``.
 
     ``importlib.util.find_spec`` on a dotted name imports the parent
     package first (executing its ``__init__.py``), which would run
     arbitrary package initialization during discovery and pay the very
-    import cost this classification exists to avoid — a provider whose
-    heavy imports live in ``package/__init__.py`` would still pay them.
+    import cost this exists to avoid — a provider whose heavy imports
+    live in ``package/__init__.py`` would still pay them.
 
     Only the top-level name is resolved with ``find_spec`` (import-free
     for top-level names); the remaining dotted segments are walked
     through ``submodule_search_locations`` by hand, mirroring the file
     layout conventions of the default PathFinder (``part.py`` module or
     ``part/__init__.py`` package). Namespace packages, zipped modules,
-    extension modules, and anything else unexpected fall back to ``""``
-    (→ ``standalone``, the safe default).
+    extension modules, and anything else unexpected return ``None``.
+
+    Shared with ``plugins/memory/__init__.py``, which needs the directory
+    of a pip-installed provider to find its ``config_schema.py`` and
+    ``cli.py`` — both of which are loaded by path precisely so the
+    provider module never has to be imported.
     """
     parts = [p for p in module_name.split(".") if p]
     if not parts:
-        return ""
+        return None
     try:
         spec = importlib.util.find_spec(parts[0])
         if spec is None or not spec.origin:
-            return ""
+            return None
         if len(parts) == 1:
-            return _read_source_from_origin(spec.origin, limit)
+            return spec.origin
 
         search_paths = spec.submodule_search_locations
         if not search_paths:
-            return ""
+            return None
         for i, part in enumerate(parts[1:], start=2):
             found_origin = None
             next_paths = None
@@ -366,13 +370,22 @@ def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
                     found_origin = str(mod_file)
                     break
             if found_origin is None:
-                return ""
+                return None
             if i == len(parts) or next_paths is None:
-                return _read_source_from_origin(found_origin, limit)
+                return found_origin
             search_paths = next_paths
-        return ""
+        return None
     except Exception:
-        return ""
+        return None
+
+
+def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """First ``limit`` chars of a module's source, without importing it.
+
+    Empty string when the module cannot be resolved or read, which
+    callers treat as ``standalone`` — the safe default.
+    """
+    return _read_source_from_origin(resolve_module_origin(module_name), limit)
 
 
 @dataclass
@@ -758,6 +771,38 @@ class PluginContext:
         logger.info(
             "Plugin '%s' registered context engine: %s",
             self.manifest.name, engine.name,
+        )
+
+    # -- memory provider registration ---------------------------------------
+
+    def register_memory_provider(self, provider) -> None:
+        """Register a memory provider.
+
+        Memory providers are activated exclusively, by name, through
+        ``memory.provider`` in config.yaml, and ``plugins/memory/__init__.py``
+        owns that path with its own collector. A provider reaching *this*
+        implementation is therefore one the general PluginManager loaded — it
+        was not classified ``exclusive`` — so the call is recorded and
+        otherwise inert. Without it, such a plugin's ``register()`` dies on a
+        missing attribute and the plugin fails to load at all.
+
+        Memory was the only provider category with no ``register_*`` here,
+        which is what made that failure mode possible. The provider must be an
+        instance of ``agent.memory_provider.MemoryProvider``.
+        """
+        from agent.memory_provider import MemoryProvider
+
+        if not isinstance(provider, MemoryProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a memory provider that does not "
+                "inherit from MemoryProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        self._memory_provider = provider
+        logger.debug(
+            "Plugin '%s' registered memory provider: %s",
+            self.manifest.name, getattr(provider, "name", "?"),
         )
 
     # -- image gen provider registration ------------------------------------

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -4117,6 +4117,21 @@ class PluginManager:
         of its parent packages (see ``_resolve_module_source``); only
         the first 8192 chars are scanned, mirroring the directory-plugin
         heuristic. Unresolvable or non-Python modules stay ``standalone``.
+
+        Activation contract: this method only decides whether the general
+        manager imports the module — it does not activate anything.
+        Memory and model providers activate through their own systems
+        (``memory.provider`` config via ``plugins/memory`` directory
+        discovery; ``providers/`` lazy directory discovery). Both are
+        directory-based today, so a pip-only provider is recorded for
+        introspection but not activatable until those systems gain
+        entry-point discovery (tracked for memory: #40644). That is not
+        a regression: pre-change such a provider was equally
+        unactivatable — it was merely imported first, at full cost
+        (e.g. fastembed -> onnxruntime), and logged
+        ``no register() function``. Classification removes the cost
+        without changing the activation surface, and is the prerequisite
+        that prevents double-import once entry-point activation lands.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -761,36 +761,40 @@ def _read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
         return ""
 
 
-def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
-    """Return the first ``limit`` chars of a module's source WITHOUT importing it.
+def resolve_module_origin(module_name: str) -> Optional[str]:
+    """Return a module's source path WITHOUT importing it, or ``None``.
 
     ``importlib.util.find_spec`` on a dotted name imports the parent
     package first (executing its ``__init__.py``), which would run
     arbitrary package initialization during discovery and pay the very
-    import cost this classification exists to avoid — a provider whose
-    heavy imports live in ``package/__init__.py`` would still pay them.
+    import cost this exists to avoid — a provider whose heavy imports
+    live in ``package/__init__.py`` would still pay them.
 
     Only the top-level name is resolved with ``find_spec`` (import-free
     for top-level names); the remaining dotted segments are walked
     through ``submodule_search_locations`` by hand, mirroring the file
     layout conventions of the default PathFinder (``part.py`` module or
     ``part/__init__.py`` package). Namespace packages, zipped modules,
-    extension modules, and anything else unexpected fall back to ``""``
-    (→ ``standalone``, the safe default).
+    extension modules, and anything else unexpected return ``None``.
+
+    Shared with ``plugins/memory/__init__.py``, which needs the directory
+    of a pip-installed provider to find its ``config_schema.py`` and
+    ``cli.py`` — both of which are loaded by path precisely so the
+    provider module never has to be imported.
     """
     parts = [p for p in module_name.split(".") if p]
     if not parts:
-        return ""
+        return None
     try:
         spec = importlib.util.find_spec(parts[0])
         if spec is None or not spec.origin:
-            return ""
+            return None
         if len(parts) == 1:
-            return _read_source_from_origin(spec.origin, limit)
+            return spec.origin
 
         search_paths = spec.submodule_search_locations
         if not search_paths:
-            return ""
+            return None
         for i, part in enumerate(parts[1:], start=2):
             found_origin = None
             next_paths = None
@@ -806,13 +810,22 @@ def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
                     found_origin = str(mod_file)
                     break
             if found_origin is None:
-                return ""
+                return None
             if i == len(parts) or next_paths is None:
-                return _read_source_from_origin(found_origin, limit)
+                return found_origin
             search_paths = next_paths
-        return ""
+        return None
     except Exception:
-        return ""
+        return None
+
+
+def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """First ``limit`` chars of a module's source, without importing it.
+
+    Empty string when the module cannot be resolved or read, which
+    callers treat as ``standalone`` — the safe default.
+    """
+    return _read_source_from_origin(resolve_module_origin(module_name), limit)
 
 
 @dataclass
@@ -2066,6 +2079,38 @@ class PluginContext:
         logger.info(
             "Plugin '%s' registered context reference: @%s:",
             self.manifest.name, provider.prefix,
+        )
+
+    # -- memory provider registration ---------------------------------------
+
+    def register_memory_provider(self, provider) -> None:
+        """Register a memory provider.
+
+        Memory providers are activated exclusively, by name, through
+        ``memory.provider`` in config.yaml, and ``plugins/memory/__init__.py``
+        owns that path with its own collector. A provider reaching *this*
+        implementation is therefore one the general PluginManager loaded — it
+        was not classified ``exclusive`` — so the call is recorded and
+        otherwise inert. Without it, such a plugin's ``register()`` dies on a
+        missing attribute and the plugin fails to load at all.
+
+        Memory was the only provider category with no ``register_*`` here,
+        which is what made that failure mode possible. The provider must be an
+        instance of ``agent.memory_provider.MemoryProvider``.
+        """
+        from agent.memory_provider import MemoryProvider
+
+        if not isinstance(provider, MemoryProvider):
+            logger.warning(
+                "Plugin '%s' tried to register a memory provider that does not "
+                "inherit from MemoryProvider. Ignoring.",
+                self.manifest.name,
+            )
+            return
+        self._memory_provider = provider
+        logger.debug(
+            "Plugin '%s' registered memory provider: %s",
+            self.manifest.name, getattr(provider, "name", "?"),
         )
 
     # -- image gen provider registration ------------------------------------
@@ -4046,9 +4091,10 @@ class PluginManager:
 
             # Auto-coerce user-installed memory providers to kind="exclusive"
             # so they're routed to plugins/memory discovery instead of being
-            # loaded by the general PluginManager (which has no
-            # register_memory_provider on PluginContext). Mirrors the
-            # heuristic in plugins/memory/__init__.py:_is_memory_provider_dir.
+            # loaded by the general PluginManager (whose PluginContext
+            # register_memory_provider is a recorded no-op, not an
+            # activation path). Mirrors the heuristic in
+            # plugins/memory/__init__.py:_is_memory_provider_dir.
             # Bundled memory providers are already skipped via skip_names.
             if kind == "standalone" and "kind" not in data:
                 init_file = plugin_dir / "__init__.py"

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -720,6 +720,25 @@ def resolve_plugin_load_order(
     return ordered
 
 
+def _detect_kind_from_source(source_text: str) -> Optional[str]:
+    """Return the plugin kind implied by source markers, or ``None``.
+
+    Mirrors ``plugins/memory/__init__.py:_is_memory_provider_dir``: a
+    module that registers a memory provider (``register_memory_provider``
+    or ``MemoryProvider``) belongs to the memory-provider discovery
+    system (``exclusive``); a module that registers a model provider
+    (``register_provider`` + ``ProviderProfile``) belongs to the
+    providers discovery (``model-provider``). Applied to both directory
+    plugins and pip entry-point plugins so neither is eagerly imported
+    by the general PluginManager.
+    """
+    if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
+        return "exclusive"
+    if "register_provider" in source_text and "ProviderProfile" in source_text:
+        return "model-provider"
+    return None
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -3959,29 +3978,16 @@ class PluginManager:
                 init_file = plugin_dir / "__init__.py"
                 if init_file.exists():
                     try:
-                        source_text = init_file.read_text(errors="replace", encoding="utf-8")[:8192]
-                        if (
-                            "register_memory_provider" in source_text
-                            or "MemoryProvider" in source_text
-                        ):
-                            kind = "exclusive"
+                        detected = _detect_kind_from_source(
+                            init_file.read_text(
+                                errors="replace", encoding="utf-8"
+                            )[:8192]
+                        )
+                        if detected:
+                            kind = detected
                             logger.debug(
-                                "Plugin %s: detected memory provider, "
-                                "treating as kind='exclusive'",
-                                key,
-                            )
-                        elif (
-                            "register_provider" in source_text
-                            and "ProviderProfile" in source_text
-                        ):
-                            # Model provider plugin (calls register_provider()
-                            # from ``providers`` with a ProviderProfile). Route
-                            # to providers/__init__.py discovery.
-                            kind = "model-provider"
-                            logger.debug(
-                                "Plugin %s: detected model provider, "
-                                "treating as kind='model-provider'",
-                                key,
+                                "Plugin %s: detected %s, treating as kind='%s'",
+                                key, detected, detected,
                             )
                     except Exception:
                         pass
@@ -4020,6 +4026,37 @@ class PluginManager:
     # Entry-point scanning
     # -----------------------------------------------------------------------
 
+    def _classify_entrypoint_kind(self, ep) -> str:
+        """Classify a pip entry-point plugin by scanning its module source.
+
+        The ``kind`` semantics are the same for pip entry points as for
+        directory plugins: memory providers (``exclusive``) and model
+        providers (``model-provider``) have their own discovery systems,
+        so importing them here registers nothing and only pays the
+        module's import cost in every Hermes process (e.g. a pip
+        memory-provider plugin pulling in onnxruntime via fastembed —
+        ~60 MB RSS on startup).
+
+        The module is resolved with ``importlib.util.find_spec`` — no
+        import for top-level module names (for dotted names only the
+        parent package may be imported). Only the first 8192 chars of
+        source are scanned, mirroring the directory-plugin heuristic.
+        Unresolvable or non-Python modules stay ``standalone``.
+        """
+        try:
+            module_name = ep.value.split(":", 1)[0].strip()
+            if not module_name:
+                return "standalone"
+            spec = importlib.util.find_spec(module_name)
+            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
+                return "standalone"
+            source_text = Path(spec.origin).read_text(
+                errors="replace", encoding="utf-8"
+            )[:8192]
+            return _detect_kind_from_source(source_text) or "standalone"
+        except Exception:
+            return "standalone"
+
     def _scan_entry_points(self) -> List[PluginManifest]:
         """Check ``importlib.metadata`` for pip-installed plugins."""
         manifests: List[PluginManifest] = []
@@ -4040,6 +4077,7 @@ class PluginManager:
                     path=ep.value,
                     key=ep.name,
                 )
+                manifest.kind = self._classify_entrypoint_kind(ep)
                 manifests.append(manifest)
         except Exception as exc:
             logger.debug("Entry-point scan failed: %s", exc)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -739,6 +739,82 @@ def _detect_kind_from_source(source_text: str) -> Optional[str]:
     return None
 
 
+def _read_source_from_origin(origin: Optional[str], limit: int = 8192) -> str:
+    """Read the first ``limit`` chars of a module's source file.
+
+    Returns ``""`` on any failure (callers fall back to ``standalone``).
+    ``.pyc``/``.pyo`` origins are mapped back to their source path so
+    source is still scanned when only the bytecode cache is present.
+    """
+    if not origin:
+        return ""
+    if origin.endswith((".pyc", ".pyo")):
+        try:
+            origin = importlib.util.source_from_cache(origin)
+        except Exception:
+            return ""
+    if not origin.endswith(".py"):
+        return ""
+    try:
+        return Path(origin).read_text(encoding="utf-8", errors="replace")[:limit]
+    except Exception:
+        return ""
+
+
+def _resolve_module_source(module_name: str, limit: int = 8192) -> str:
+    """Return the first ``limit`` chars of a module's source WITHOUT importing it.
+
+    ``importlib.util.find_spec`` on a dotted name imports the parent
+    package first (executing its ``__init__.py``), which would run
+    arbitrary package initialization during discovery and pay the very
+    import cost this classification exists to avoid — a provider whose
+    heavy imports live in ``package/__init__.py`` would still pay them.
+
+    Only the top-level name is resolved with ``find_spec`` (import-free
+    for top-level names); the remaining dotted segments are walked
+    through ``submodule_search_locations`` by hand, mirroring the file
+    layout conventions of the default PathFinder (``part.py`` module or
+    ``part/__init__.py`` package). Namespace packages, zipped modules,
+    extension modules, and anything else unexpected fall back to ``""``
+    (→ ``standalone``, the safe default).
+    """
+    parts = [p for p in module_name.split(".") if p]
+    if not parts:
+        return ""
+    try:
+        spec = importlib.util.find_spec(parts[0])
+        if spec is None or not spec.origin:
+            return ""
+        if len(parts) == 1:
+            return _read_source_from_origin(spec.origin, limit)
+
+        search_paths = spec.submodule_search_locations
+        if not search_paths:
+            return ""
+        for i, part in enumerate(parts[1:], start=2):
+            found_origin = None
+            next_paths = None
+            for base in search_paths:
+                base = Path(base)
+                pkg_init = base / part / "__init__.py"
+                if pkg_init.is_file():
+                    found_origin = str(pkg_init)
+                    next_paths = [base / part]
+                    break
+                mod_file = base / (part + ".py")
+                if mod_file.is_file():
+                    found_origin = str(mod_file)
+                    break
+            if found_origin is None:
+                return ""
+            if i == len(parts) or next_paths is None:
+                return _read_source_from_origin(found_origin, limit)
+            search_paths = next_paths
+        return ""
+    except Exception:
+        return ""
+
+
 @dataclass
 class PluginManifest:
     """Parsed representation of a plugin.yaml manifest."""
@@ -4037,22 +4113,16 @@ class PluginManager:
         memory-provider plugin pulling in onnxruntime via fastembed —
         ~60 MB RSS on startup).
 
-        The module is resolved with ``importlib.util.find_spec`` — no
-        import for top-level module names (for dotted names only the
-        parent package may be imported). Only the first 8192 chars of
-        source are scanned, mirroring the directory-plugin heuristic.
-        Unresolvable or non-Python modules stay ``standalone``.
+        The module source is read without importing the module or any
+        of its parent packages (see ``_resolve_module_source``); only
+        the first 8192 chars are scanned, mirroring the directory-plugin
+        heuristic. Unresolvable or non-Python modules stay ``standalone``.
         """
         try:
             module_name = ep.value.split(":", 1)[0].strip()
             if not module_name:
                 return "standalone"
-            spec = importlib.util.find_spec(module_name)
-            if spec is None or not spec.origin or not spec.origin.endswith(".py"):
-                return "standalone"
-            source_text = Path(spec.origin).read_text(
-                errors="replace", encoding="utf-8"
-            )[:8192]
+            source_text = _resolve_module_source(module_name)
             return _detect_kind_from_source(source_text) or "standalone"
         except Exception:
             return "standalone"

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -1,13 +1,15 @@
 """Memory provider plugin discovery.
 
-Scans two directories for memory provider plugins:
+Scans three sources for memory provider plugins:
 
 1. Bundled providers: ``plugins/memory/<name>/`` (shipped with hermes-agent)
 2. User-installed providers: ``$HERMES_HOME/plugins/<name>/``
+3. Pip-installed providers: ``hermes_agent.memory_providers`` entry points
 
-Each subdirectory must contain ``__init__.py`` with a class implementing
-the MemoryProvider ABC.  On name collisions, bundled providers take
-precedence.
+Directory providers must contain ``__init__.py`` with a class implementing
+the MemoryProvider ABC. Pip packages expose a provider or ``register(ctx)``
+callback through the entry-point group. On name collisions, bundled providers
+take precedence, followed by user-installed directories, then entry points.
 
 Only ONE provider can be active at a time, selected via
 ``memory.provider`` in config.yaml.
@@ -23,16 +25,22 @@ from __future__ import annotations
 
 import importlib
 import importlib.machinery
+import importlib.metadata
 import importlib.util
 import logging
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, TYPE_CHECKING
 from hermes_cli.config import cfg_get
+
+if TYPE_CHECKING:
+    from agent.memory_provider import MemoryProvider
 
 logger = logging.getLogger(__name__)
 
 _MEMORY_PLUGINS_DIR = Path(__file__).parent
+ENTRY_POINTS_GROUP = "hermes_agent.memory_providers"
+_REGISTERED_MEMORY_PROVIDER_SKILLS: dict[str, Path] = {}
 
 # Synthetic parent package for user-installed providers, so they don't
 # collide with bundled providers in sys.modules.
@@ -121,6 +129,20 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     return dirs
 
 
+def _iter_entry_points():
+    """Yield pip-installed memory provider entry points."""
+    try:
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            return list(eps.select(group=ENTRY_POINTS_GROUP))
+        if isinstance(eps, dict):
+            return list(eps.get(ENTRY_POINTS_GROUP, []))
+        return [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+    except Exception as exc:
+        logger.debug("Memory provider entry-point scan failed: %s", exc)
+        return []
+
+
 def find_provider_dir(name: str) -> Optional[Path]:
     """Resolve a provider name to its directory.
 
@@ -136,6 +158,14 @@ def find_provider_dir(name: str) -> Optional[Path]:
         user = user_dir / name
         if user.is_dir() and _is_memory_provider_dir(user):
             return user
+    return None
+
+
+def find_provider_entry_point(name: str):
+    """Resolve a provider name to a pip entry point, if installed."""
+    for entry_point in _iter_entry_points():
+        if entry_point.name == name:
+            return entry_point
     return None
 
 
@@ -155,12 +185,14 @@ def list_memory_provider_names() -> List[str]:
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
-    """Scan bundled and user-installed directories for available providers.
+    """Scan directory and pip entry-point memory providers.
 
     Returns list of (name, description, is_available) tuples.
-    Bundled providers take precedence on name collisions.
+    Bundled providers take precedence on name collisions, followed by
+    user-installed directory providers, then pip entry-point providers.
     """
     results = []
+    seen: set[str] = set()
 
     for name, child in _iter_provider_dirs():
         # Read description from plugin.yaml if available
@@ -178,7 +210,7 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
         # Quick availability check — try loading and calling is_available()
         available = True
         try:
-            provider = _load_provider_from_dir(child)
+            provider = _load_provider_from_dir(child, register_skills=False)
             if provider:
                 available = provider.is_available()
             else:
@@ -187,26 +219,70 @@ def discover_memory_providers() -> List[Tuple[str, str, bool]]:
             available = False
 
         results.append((name, desc, available))
+        seen.add(name)
+
+    for entry_point in _iter_entry_points():
+        name = entry_point.name
+        if name in seen:
+            continue
+        desc = ""
+        available = True
+        try:
+            provider = _load_provider_from_entry_point(
+                entry_point,
+                register_skills=False,
+            )
+            if provider:
+                available = provider.is_available()
+            else:
+                available = False
+        except Exception:
+            available = False
+
+        results.append((name, desc, available))
+        seen.add(name)
 
     return results
 
 
-def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
+def load_memory_provider(
+    name: str,
+    *,
+    register_skills: Optional[bool] = None,
+) -> Optional["MemoryProvider"]:
     """Load and return a MemoryProvider instance by name.
 
-    Checks both bundled (``plugins/memory/<name>/``) and user-installed
-    (``$HERMES_HOME/plugins/<name>/``) directories.  Bundled takes
-    precedence on name collisions.
+    Checks bundled (``plugins/memory/<name>/``), user-installed
+    (``$HERMES_HOME/plugins/<name>/``), and pip entry-point providers.
+    Bundled providers take precedence on name collisions.
+
+    Skills register only when *name* is the configured active provider unless
+    ``register_skills`` is passed explicitly. This keeps status and setup
+    inspection of inactive providers free of registry side effects.
 
     Returns None if the provider is not found or fails to load.
     """
+    if register_skills is None:
+        register_skills = name == _get_active_memory_provider()
+
     provider_dir = find_provider_dir(name)
-    if not provider_dir:
-        logger.debug("Memory provider '%s' not found in bundled or user plugins", name)
+    entry_point = None if provider_dir else find_provider_entry_point(name)
+    if not provider_dir and entry_point is None:
+        logger.debug(
+            "Memory provider '%s' not found in bundled, user plugins, or entry points",
+            name,
+        )
         return None
 
     try:
-        provider = _load_provider_from_dir(provider_dir)
+        provider = (
+            _load_provider_from_dir(provider_dir, register_skills=register_skills)
+            if provider_dir
+            else _load_provider_from_entry_point(
+                entry_point,
+                register_skills=register_skills,
+            )
+        )
         if provider:
             return provider
         logger.warning("Memory provider '%s' loaded but no provider instance found", name)
@@ -216,7 +292,61 @@ def load_memory_provider(name: str) -> Optional["MemoryProvider"]:
         return None
 
 
-def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
+def _load_provider_from_entry_point(
+    entry_point,
+    *,
+    register_skills: bool = True,
+) -> Optional["MemoryProvider"]:
+    """Import a provider entry point and extract the MemoryProvider instance."""
+    from agent.memory_provider import MemoryProvider
+
+    loaded = entry_point.load()
+
+    if isinstance(loaded, MemoryProvider):
+        return loaded
+
+    if isinstance(loaded, type) and issubclass(loaded, MemoryProvider):
+        try:
+            return loaded()
+        except Exception:
+            pass
+
+    if hasattr(loaded, "register"):
+        collector = _ProviderCollector(entry_point.name, register_skills=register_skills)
+        loaded.register(collector)
+        if collector.provider:
+            return collector.provider
+
+    if callable(loaded):
+        try:
+            provider = loaded()
+            if isinstance(provider, MemoryProvider):
+                return provider
+        except TypeError:
+            pass
+
+        collector = _ProviderCollector(entry_point.name, register_skills=register_skills)
+        loaded(collector)
+        return collector.provider
+
+    for attr_name in dir(loaded):
+        attr = getattr(loaded, attr_name, None)
+        if (isinstance(attr, type) and issubclass(attr, MemoryProvider)
+                and attr is not MemoryProvider):
+            try:
+                return attr()
+            except Exception:
+                pass
+
+    logger.debug("Memory provider entry point '%s' loaded no provider", entry_point.name)
+    return None
+
+
+def _load_provider_from_dir(
+    provider_dir: Path,
+    *,
+    register_skills: bool = True,
+) -> Optional["MemoryProvider"]:
     """Import a provider module and extract the MemoryProvider instance.
 
     The module must have either:
@@ -305,7 +435,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 
     # Try register(ctx) pattern first (how our plugins are written)
     if hasattr(mod, "register"):
-        collector = _ProviderCollector()
+        collector = _ProviderCollector(name, register_skills=register_skills)
         try:
             mod.register(collector)
             if collector.provider:
@@ -330,11 +460,37 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 class _ProviderCollector:
     """Fake plugin context that captures register_memory_provider calls."""
 
-    def __init__(self):
+    def __init__(self, name: str, *, register_skills: bool = True):
+        self.name = name
         self.provider = None
+        self._register_skills = register_skills
 
     def register_memory_provider(self, provider):
         self.provider = provider
+
+    def register_skill(self, *args, **kwargs):
+        """Forward plugin-provided skills to the general plugin registry.
+
+        Memory provider discovery uses this lightweight collector instead of
+        the general PluginContext. Forwarding keeps skills registered by memory
+        provider shims visible to skill_view() while preserving the exclusive
+        memory-provider activation path.
+        """
+        if not self._register_skills:
+            return
+        try:
+            from hermes_cli.plugins import PluginManifest, PluginContext, get_plugin_manager
+
+            manager = get_plugin_manager()
+            manifest = PluginManifest(name=self.name, key=self.name)
+            PluginContext(manifest, manager).register_skill(*args, **kwargs)
+            skill_name = args[0] if args else kwargs.get("name")
+            qualified_name = f"{self.name}:{skill_name}"
+            registered_path = manager.find_plugin_skill(qualified_name)
+            if registered_path is not None:
+                _REGISTERED_MEMORY_PROVIDER_SKILLS[qualified_name] = registered_path
+        except Exception as exc:
+            logger.debug("Memory provider '%s' failed to register skill: %s", self.name, exc)
 
     # No-op for other registration methods
     def register_tool(self, *args, **kwargs):
@@ -360,6 +516,27 @@ def _get_active_memory_provider() -> Optional[str]:
         return cfg_get(config, "memory", "provider") or None
     except Exception:
         return None
+
+
+def _prune_inactive_memory_provider_skills(
+    active_provider: Optional[str] = None,
+) -> None:
+    """Remove tracked skills that no longer belong to the active provider."""
+    if active_provider is None:
+        active_provider = _get_active_memory_provider()
+
+    from hermes_cli.plugins import get_plugin_manager
+
+    manager = get_plugin_manager()
+    for qualified_name, registered_path in list(
+        _REGISTERED_MEMORY_PROVIDER_SKILLS.items()
+    ):
+        namespace, _, _ = qualified_name.partition(":")
+        if namespace == active_provider:
+            continue
+        if manager.find_plugin_skill(qualified_name) == registered_path:
+            manager.remove_plugin_skill(qualified_name)
+        _REGISTERED_MEMORY_PROVIDER_SKILLS.pop(qualified_name, None)
 
 
 def discover_plugin_cli_commands() -> List[dict]:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -1,15 +1,23 @@
 """Memory provider plugin discovery.
 
-Scans three sources for memory provider plugins:
+Scans four sources for memory provider plugins:
 
 1. Bundled providers: ``plugins/memory/<name>/`` (shipped with hermes-agent)
 2. User-installed providers: ``$HERMES_HOME/plugins/<name>/``
-3. Pip-installed providers: ``hermes_agent.memory_providers`` entry points
+3. Project-local providers: ``./.hermes/plugins/<name>/``, opt-in via
+   ``HERMES_ENABLE_PROJECT_PLUGINS``
+4. Pip-installed providers: ``hermes_agent.memory_providers`` entry points
 
 Directory providers must contain ``__init__.py`` with a class implementing
 the MemoryProvider ABC. Pip packages expose a provider or ``register(ctx)``
-callback through the entry-point group. On name collisions, bundled providers
-take precedence, followed by user-installed directories, then entry points.
+callback through the entry-point group.
+
+These are the same four sources the general ``PluginManager`` scans, but the
+precedence is deliberately the reverse of its later-source-wins order: here
+**bundled wins**, then user, then project, then entry point. A memory provider
+is activated by name, so letting a directory dropped into the working tree
+shadow a shipped provider would silently redirect the agent's memory. Changing
+this order is a breaking change, not a cleanup.
 
 Only ONE provider can be active at a time, selected via
 ``memory.provider`` in config.yaml.
@@ -79,6 +87,24 @@ def _get_user_plugins_dir() -> Optional[Path]:
         return None
 
 
+def _get_project_plugins_dir() -> Optional[Path]:
+    """Return ``./.hermes/plugins/`` or None if unavailable or not opted in.
+
+    Gated on ``HERMES_ENABLE_PROJECT_PLUGINS`` exactly as the general
+    ``PluginManager`` gates its own project scan — a repository you merely
+    ``cd`` into must not be able to offer the agent a memory backend.
+    """
+    try:
+        from hermes_cli.plugins import _env_enabled
+
+        if not _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS"):
+            return None
+        d = Path.cwd() / ".hermes" / "plugins"
+        return d if d.is_dir() else None
+    except Exception:
+        return None
+
+
 def _is_memory_provider_dir(path: Path) -> bool:
     """Heuristic: does *path* look like a memory provider plugin?
 
@@ -98,8 +124,8 @@ def _is_memory_provider_dir(path: Path) -> bool:
 def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     """Yield ``(name, path)`` for all discovered provider directories.
 
-    Scans bundled first, then user-installed.  Bundled takes precedence
-    on name collisions (first-seen wins via ``seen`` set).
+    Scans bundled, then user-installed, then project-local.  Bundled takes
+    precedence on name collisions (first-seen wins via ``seen`` set).
     """
     seen: set = set()
     dirs: List[Tuple[str, Path]] = []
@@ -115,15 +141,18 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
             dirs.append((child.name, child))
 
     # 2. User-installed providers ($HERMES_HOME/plugins/<name>/)
-    user_dir = _get_user_plugins_dir()
-    if user_dir:
-        for child in sorted(user_dir.iterdir()):
+    # 3. Project-local providers (./.hermes/plugins/<name>/), opt-in
+    for source_dir in (_get_user_plugins_dir(), _get_project_plugins_dir()):
+        if not source_dir:
+            continue
+        for child in sorted(source_dir.iterdir()):
             if not child.is_dir() or child.name.startswith(("_", ".")):
                 continue
             if child.name in seen:
-                continue  # bundled takes precedence
+                continue  # earlier source wins
             if not _is_memory_provider_dir(child):
                 continue  # skip non-memory plugins
+            seen.add(child.name)
             dirs.append((child.name, child))
 
     return dirs
@@ -144,21 +173,63 @@ def _iter_entry_points():
 
 
 def find_provider_dir(name: str) -> Optional[Path]:
-    """Resolve a provider name to its directory.
+    """Resolve a provider name to the directory holding its files.
 
-    Checks bundled first, then user-installed.
+    Checks bundled, then user-installed, then project-local, then the package
+    directory of a pip entry-point provider.
+
+    The entry-point case matters because two of a provider's files are read
+    from disk rather than imported: ``config_schema.py`` (loaded by path so the
+    web server never pulls in the agent runtime — see
+    ``plugins/memory/config_schema.py``) and ``cli.py`` (loaded by
+    ``discover_plugin_cli_commands`` at argparse time). Without a directory, a
+    pip-installed provider silently loses its dashboard config panel and its
+    ``hermes <provider>`` subcommands — working, but a second-class citizen next
+    to a directory install.
     """
     # Bundled
     bundled = _MEMORY_PLUGINS_DIR / name
     if bundled.is_dir() and (bundled / "__init__.py").exists():
         return bundled
-    # User-installed
-    user_dir = _get_user_plugins_dir()
-    if user_dir:
-        user = user_dir / name
-        if user.is_dir() and _is_memory_provider_dir(user):
-            return user
-    return None
+    # User-installed, then project-local
+    for source_dir in (_get_user_plugins_dir(), _get_project_plugins_dir()):
+        if not source_dir:
+            continue
+        candidate = source_dir / name
+        if candidate.is_dir() and _is_memory_provider_dir(candidate):
+            return candidate
+    # Pip entry point
+    return _entry_point_package_dir(find_provider_entry_point(name))
+
+
+def _entry_point_package_dir(entry_point) -> Optional[Path]:
+    """The directory of an entry point's module, resolved WITHOUT importing it.
+
+    Discovery must stay free of third-party imports: ``find_provider_dir`` is
+    called from the dashboard and from argparse setup, long before the operator
+    has selected a provider, so importing every installed candidate would run
+    arbitrary code on the strength of a package merely being present.
+    ``resolve_module_origin`` walks the module's file layout instead.
+
+    Only package entry points (``pkg/__init__.py``) yield a directory — a
+    provider pointed at a bare ``module.py`` has nowhere to put a sibling
+    ``config_schema.py``, so it correctly resolves to None.
+    """
+    if entry_point is None:
+        return None
+    try:
+        from hermes_cli.plugins import resolve_module_origin
+
+        module_name = (entry_point.value or "").split(":")[0].strip()
+        origin = resolve_module_origin(module_name)
+        if not origin:
+            return None
+        path = Path(origin)
+        return path.parent if path.name == "__init__.py" else None
+    except Exception as exc:
+        logger.debug("Could not resolve directory for entry point '%s': %s",
+                     getattr(entry_point, "name", "?"), exc)
+        return None
 
 
 def find_provider_entry_point(name: str):
@@ -177,11 +248,14 @@ def list_memory_provider_names() -> List[str]:
     """Cheap name-only listing of discoverable memory providers.
 
     Unlike :func:`discover_memory_providers`, this does NOT import provider
-    modules or run availability checks — it's a directory scan only, safe to
-    call at module-import time (e.g. when building the dashboard config
-    schema).
+    modules or run availability checks — a directory scan plus entry-point
+    *enumeration*, which reads distribution metadata without executing any of
+    it. Safe to call at module-import time (e.g. when building the dashboard
+    config schema, where it fills the ``memory.provider`` dropdown).
     """
-    return sorted({name for name, _ in _iter_provider_dirs()})
+    names = {name for name, _ in _iter_provider_dirs()}
+    names.update(ep.name for ep in _iter_entry_points())
+    return sorted(names)
 
 
 def discover_memory_providers() -> List[Tuple[str, str, bool]]:
@@ -438,10 +512,21 @@ def _load_provider_from_dir(
         collector = _ProviderCollector(name, register_skills=register_skills)
         try:
             mod.register(collector)
-            if collector.provider:
-                return collector.provider
         except Exception as e:
-            logger.debug("register() failed for %s: %s", name, e)
+            # A raise AFTER register_memory_provider() must not cost us the
+            # provider. Falling through to the subclass scan below would
+            # discard the instance the plugin configured and hand back a bare
+            # second one — a silent downgrade that looks like success.
+            if collector.provider is None:
+                logger.debug("register() failed for %s: %s", name, e)
+            else:
+                logger.warning(
+                    "Memory provider '%s' raised after registering (%s) — "
+                    "using the registered provider; later registrations were skipped",
+                    name, e,
+                )
+        if collector.provider:
+            return collector.provider
 
     # Fallback: find a MemoryProvider subclass and instantiate it
     from agent.memory_provider import MemoryProvider
@@ -458,12 +543,19 @@ def _load_provider_from_dir(
 
 
 class _ProviderCollector:
-    """Fake plugin context that captures register_memory_provider calls."""
+    """Plugin context for memory providers.
+
+    Captures ``register_memory_provider`` directly — that is the one call the
+    exclusive activation path owns — and delegates everything else to a real
+    ``PluginContext`` (see ``__getattr__``), so a memory provider has the same
+    registration surface as any other plugin.
+    """
 
     def __init__(self, name: str, *, register_skills: bool = True):
         self.name = name
         self.provider = None
         self._register_skills = register_skills
+        self._context = None
 
     def register_memory_provider(self, provider):
         self.provider = provider
@@ -471,36 +563,84 @@ class _ProviderCollector:
     def register_skill(self, *args, **kwargs):
         """Forward plugin-provided skills to the general plugin registry.
 
-        Memory provider discovery uses this lightweight collector instead of
-        the general PluginContext. Forwarding keeps skills registered by memory
-        provider shims visible to skill_view() while preserving the exclusive
-        memory-provider activation path.
+        Handled explicitly rather than through ``__getattr__`` because skills
+        are tracked for pruning: switching the active provider has to retract
+        the skills the previous one registered, which needs the qualified name
+        and resolved path recorded here.
+
+        Gated on ``register_skills`` so merely *inspecting* an inactive
+        provider — ``hermes memory status``, the setup picker — leaves no
+        registry side effects behind.
         """
         if not self._register_skills:
             return
         try:
-            from hermes_cli.plugins import PluginManifest, PluginContext, get_plugin_manager
-
-            manager = get_plugin_manager()
-            manifest = PluginManifest(name=self.name, key=self.name)
-            PluginContext(manifest, manager).register_skill(*args, **kwargs)
+            manager_context = self._plugin_context()
+            manager_context.register_skill(*args, **kwargs)
             skill_name = args[0] if args else kwargs.get("name")
             qualified_name = f"{self.name}:{skill_name}"
-            registered_path = manager.find_plugin_skill(qualified_name)
+
+            from hermes_cli.plugins import get_plugin_manager
+
+            registered_path = get_plugin_manager().find_plugin_skill(qualified_name)
             if registered_path is not None:
                 _REGISTERED_MEMORY_PROVIDER_SKILLS[qualified_name] = registered_path
         except Exception as exc:
             logger.debug("Memory provider '%s' failed to register skill: %s", self.name, exc)
 
-    # No-op for other registration methods
-    def register_tool(self, *args, **kwargs):
-        pass
-
-    def register_hook(self, *args, **kwargs):
-        pass
-
     def register_cli_command(self, *args, **kwargs):
         pass  # CLI registration happens via discover_plugin_cli_commands()
+
+    def __getattr__(self, attr: str):
+        """Delegate any other ``register_*`` call to a real ``PluginContext``.
+
+        Memory providers used to get a hand-maintained stub of three no-ops
+        here, which had two failure modes. Calls it *did* know about
+        (``register_tool``, ``register_hook``) were silently dropped, so a
+        provider's tools simply never appeared. Calls it did *not* know about
+        raised ``AttributeError`` — and ``register_auxiliary_task`` is one of
+        them, despite ``PluginContext.register_auxiliary_task`` documenting a
+        memory provider (hindsight's pre-retain dedup) as its worked example.
+        That exception surfaces as "register() failed" and costs the provider.
+
+        Delegating instead of enumerating means this can never drift behind
+        ``PluginContext`` again: a capability added there works for memory
+        providers on the same commit, which is what the "widen the generic
+        plugin surface" rule in AGENTS.md asks for.
+
+        Only ``register_*`` is forwarded. Everything else raises normally, so a
+        typo still fails loudly rather than being absorbed.
+        """
+        if not attr.startswith("register_"):
+            raise AttributeError(attr)
+
+        def _forward(*args, **kwargs):
+            try:
+                return self._plugin_context().__getattribute__(attr)(*args, **kwargs)
+            except Exception as exc:
+                # A secondary registration must not cost the provider itself —
+                # by the time these run, register_memory_provider has usually
+                # already handed us the instance the agent needs.
+                logger.warning(
+                    "Memory provider '%s' failed to %s: %s", self.name, attr, exc
+                )
+                return None
+
+        return _forward
+
+    def _plugin_context(self):
+        """A real ``PluginContext`` for this provider, built once on demand.
+
+        Lazy because the common case — a provider that only calls
+        ``register_memory_provider`` — must not pay for importing the general
+        plugin manager, which discovery touches on every hermes startup.
+        """
+        if self._context is None:
+            from hermes_cli.plugins import PluginContext, PluginManifest, get_plugin_manager
+
+            manifest = PluginManifest(name=self.name, key=self.name)
+            self._context = PluginContext(manifest, get_plugin_manager())
+        return self._context
 
 
 def _get_active_memory_provider() -> Optional[str]:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -487,6 +487,208 @@ class TestUserInstalledProviderCli:
         assert p.name == "extcliload"
 
 
+class TestEntryPointMemoryProviderDiscovery:
+    """Memory providers installed as Python packages should be discoverable."""
+
+    class FakeEntryPoint:
+        def __init__(self, name, module, exposure="register"):
+            self.name = name
+            self.value = f"{module}:{exposure}"
+            self.group = "hermes_agent.memory_providers"
+            self._module = module
+            self._exposure = exposure
+
+        def load(self):
+            import importlib
+
+            return getattr(importlib.import_module(self._module), self._exposure)
+
+    class FakeEntryPoints(list):
+        def select(self, *, group):
+            return [ep for ep in self if ep.group == group]
+
+    def _make_entrypoint_module(
+        self,
+        tmp_path,
+        module_name="ep_memory_provider",
+        exposure="register",
+        include_skill=False,
+    ):
+        module_file = tmp_path / f"{module_name}.py"
+        register_skill = ""
+        if include_skill:
+            skill_md = tmp_path / "skills" / "maintenance" / "SKILL.md"
+            skill_md.parent.mkdir(parents=True)
+            skill_md.write_text(
+                "---\nname: maintenance\ndescription: Memory maintenance\n---\n\n"
+                "Packaged provider maintenance body.\n"
+            )
+            register_skill = (
+                "    ctx.register_skill(\n"
+                "        'maintenance',\n"
+                "        Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md',\n"
+                "    )\n"
+            )
+        module_file.write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'entrymem'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            f"{register_skill}"
+            "def make_provider():\n"
+            "    return Provider()\n"
+        )
+        return module_name, exposure
+
+    def test_discover_finds_entry_point_provider(self, tmp_path, monkeypatch):
+        from plugins.memory import discover_memory_providers
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        providers = discover_memory_providers()
+
+        assert ("entrymem", "", True) in providers
+
+    @pytest.mark.parametrize("exposure", ["register", "Provider", "make_provider"])
+    def test_load_entry_point_provider(self, tmp_path, monkeypatch, exposure):
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path, exposure=exposure)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert provider.name == "entrymem"
+        assert provider.is_available()
+
+    def test_active_entry_point_provider_registers_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "entrymem",
+        )
+
+        result = json.loads(skill_view("entrymem:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "entrymem:maintenance"
+        assert "Packaged provider maintenance body." in result["content"]
+
+    def test_inactive_entry_point_load_does_not_register_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_inactive_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "other-provider",
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+    def test_switching_provider_prunes_registered_entry_point_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_switched_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        active = {"name": "entrymem"}
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: active["name"],
+        )
+
+        loaded = json.loads(skill_view("entrymem:maintenance"))
+        active["name"] = "other-provider"
+        switched = json.loads(skill_view("entrymem:maintenance"))
+
+        assert loaded["success"] is True
+        assert switched["success"] is False
+        assert "not found" in switched["error"].lower()
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+
 # ---------------------------------------------------------------------------
 # Sequential dispatch routing tests
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -465,6 +465,208 @@ class TestUserInstalledProviderCli:
         assert p.name == "extcliload"
 
 
+class TestEntryPointMemoryProviderDiscovery:
+    """Memory providers installed as Python packages should be discoverable."""
+
+    class FakeEntryPoint:
+        def __init__(self, name, module, exposure="register"):
+            self.name = name
+            self.value = f"{module}:{exposure}"
+            self.group = "hermes_agent.memory_providers"
+            self._module = module
+            self._exposure = exposure
+
+        def load(self):
+            import importlib
+
+            return getattr(importlib.import_module(self._module), self._exposure)
+
+    class FakeEntryPoints(list):
+        def select(self, *, group):
+            return [ep for ep in self if ep.group == group]
+
+    def _make_entrypoint_module(
+        self,
+        tmp_path,
+        module_name="ep_memory_provider",
+        exposure="register",
+        include_skill=False,
+    ):
+        module_file = tmp_path / f"{module_name}.py"
+        register_skill = ""
+        if include_skill:
+            skill_md = tmp_path / "skills" / "maintenance" / "SKILL.md"
+            skill_md.parent.mkdir(parents=True)
+            skill_md.write_text(
+                "---\nname: maintenance\ndescription: Memory maintenance\n---\n\n"
+                "Packaged provider maintenance body.\n"
+            )
+            register_skill = (
+                "    ctx.register_skill(\n"
+                "        'maintenance',\n"
+                "        Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md',\n"
+                "    )\n"
+            )
+        module_file.write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'entrymem'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            f"{register_skill}"
+            "def make_provider():\n"
+            "    return Provider()\n"
+        )
+        return module_name, exposure
+
+    def test_discover_finds_entry_point_provider(self, tmp_path, monkeypatch):
+        from plugins.memory import discover_memory_providers
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        providers = discover_memory_providers()
+
+        assert ("entrymem", "", True) in providers
+
+    @pytest.mark.parametrize("exposure", ["register", "Provider", "make_provider"])
+    def test_load_entry_point_provider(self, tmp_path, monkeypatch, exposure):
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(tmp_path, exposure=exposure)
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert provider.name == "entrymem"
+        assert provider.is_available()
+
+    def test_active_entry_point_provider_registers_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "entrymem",
+        )
+
+        result = json.loads(skill_view("entrymem:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "entrymem:maintenance"
+        assert "Packaged provider maintenance body." in result["content"]
+
+    def test_inactive_entry_point_load_does_not_register_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from plugins.memory import load_memory_provider
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_inactive_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: "other-provider",
+        )
+
+        provider = load_memory_provider("entrymem")
+
+        assert provider is not None
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+    def test_switching_provider_prunes_registered_entry_point_skill(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli.plugins import get_plugin_manager
+        from tools.skills_tool import skill_view
+        import plugins.memory as memory_plugins
+
+        module_name, exposure = self._make_entrypoint_module(
+            tmp_path,
+            module_name="ep_switched_memory_provider_with_skill",
+            include_skill=True,
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: None)
+        monkeypatch.setattr(
+            memory_plugins.importlib.metadata,
+            "entry_points",
+            lambda: self.FakeEntryPoints([
+                self.FakeEntryPoint("entrymem", module_name, exposure)
+            ]),
+        )
+        active = {"name": "entrymem"}
+        monkeypatch.setattr(
+            memory_plugins,
+            "_get_active_memory_provider",
+            lambda: active["name"],
+        )
+
+        loaded = json.loads(skill_view("entrymem:maintenance"))
+        active["name"] = "other-provider"
+        switched = json.loads(skill_view("entrymem:maintenance"))
+
+        assert loaded["success"] is True
+        assert switched["success"] is False
+        assert "not found" in switched["error"].lower()
+        assert get_plugin_manager().find_plugin_skill("entrymem:maintenance") is None
+
+
 # ---------------------------------------------------------------------------
 # Sequential dispatch routing tests
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -576,6 +576,100 @@ class TestPluginLoading:
         )
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
+        # Routing contract: classification records the manifest but does
+        # not fabricate activation. providers/ discovery is directory-based
+        # today, so a pip-only provider is not activatable via
+        # get_provider_profile() — and it must not leak into sys.modules
+        # through the providers path either (no double import).
+        from providers import get_provider_profile
+
+        assert get_provider_profile("fakeprovider") is None
+        assert "fakeprovider" not in sys.modules
+
+    def test_entrypoint_duplicate_does_not_block_directory_provider_activation(
+        self, tmp_path, monkeypatch
+    ):
+        """The mnemosyne shape: a pip entry point duplicating a same-name
+        directory provider.
+
+        The pip copy is classified ``exclusive`` (recorded, never
+        imported); the directory copy must still activate through
+        memory-provider discovery, exactly once. Classification must not
+        interfere with the real activation path.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        # Same-name pip entry point (the duplicate).
+        ep_dir = tmp_path / "ep_modules"
+        ep_dir.mkdir()
+        (ep_dir / "mempalace_dup.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(ep_dir))
+        ep = EntryPoint(
+            name="mempalace_dup",
+            value="mempalace_dup:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Same-name directory provider under $HERMES_HOME/plugins/.
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        provider_dir = plugins_dir / "mempalace_dup"
+        provider_dir.mkdir(parents=True)
+        (provider_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class MyProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'mempalace_dup'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+        )
+        (provider_dir / "plugin.yaml").write_text(
+            "name: mempalace_dup\ndescription: dup\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dup"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir", lambda: plugins_dir
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        # Pip duplicate: classified exclusive, recorded, never imported.
+        entry = mgr._plugins["mempalace_dup"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "mempalace_dup" not in sys.modules
+
+        # Directory copy still activates through memory-provider discovery,
+        # exactly once.
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        names = [n for n, _, _ in discover_memory_providers()]
+        assert names.count("mempalace_dup") == 1
+        p = load_memory_provider("mempalace_dup")
+        assert p is not None
+        assert p.name == "mempalace_dup"
+        assert p.is_available()
 
     def test_entrypoint_dotted_name_never_imports_parent_package(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -467,6 +467,116 @@ class TestPluginLoading:
         assert entry.module is None
         assert "exclusive" in (entry.error or "").lower()
 
+    def test_entrypoint_memory_provider_auto_coerced_to_exclusive(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point memory-provider plugins must NOT be imported by
+        the general PluginManager.
+
+        Regression test for the mnemosyne case: a pip plugin declaring a
+        ``hermes_agent.plugins`` entry point but exposing
+        ``register_memory_provider`` (not ``register()``) used to be
+        eagerly imported in every process, pulling heavy deps (fastembed
+        → onnxruntime, ~60 MB RSS) even though the import registered
+        nothing. Entry-point manifests now get the same source-scan
+        classification as directory plugins: recorded, never imported.
+        Activation stays with plugins/memory discovery via
+        ``memory.provider`` config.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "mempalace_ep.py"
+        module_path.write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_ep",
+            value="mempalace_ep:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Even if the user explicitly enables it, the loader must treat it
+        # as exclusive and skip the import (the bug: eager import of a
+        # module with no register() function).
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_ep"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "mempalace_ep" in mgr._plugins
+        entry = mgr._plugins["mempalace_ep"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "exclusive" in (entry.error or "").lower()
+        # The whole point: the module was never imported.
+        assert "mempalace_ep" not in sys.modules
+
+    def test_entrypoint_model_provider_auto_coerced_to_model_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point model-provider plugins are routed to the
+        providers/ discovery system instead of being imported by the
+        general manager (which would double-instantiate ProviderProfile)."""
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "fakeprovider.py"
+        module_path.write_text(
+            "class ProviderProfile:\n"
+            "    pass\n"
+            "def register_provider(profile):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="fakeprovider",
+            value="fakeprovider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["fakeprovider"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["fakeprovider"]
+        assert entry.manifest.kind == "model-provider", (
+            f"Expected auto-coerced kind='model-provider', "
+            f"got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "fakeprovider" not in sys.modules
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -577,6 +577,70 @@ class TestPluginLoading:
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
 
+    def test_entrypoint_dotted_name_never_imports_parent_package(
+        self, tmp_path, monkeypatch
+    ):
+        """A dotted entry point (pkg.mod:register) must NOT import the
+        parent package during classification.
+
+        ``importlib.util.find_spec`` on a dotted name imports the parent
+        first — executing its ``__init__.py``, which is where a provider's
+        heavy imports typically live. The classifier must resolve the
+        module path by hand so the parent's initialization code never
+        runs and neither the parent nor the child enters ``sys.modules``.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        marker = tmp_path / "parent_executed"
+        pkg_dir = tmp_path / "mempalace_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "# If this ever executes, the no-import property is broken.\n"
+            f"from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('executed')\n"
+            "from .provider import register_memory_provider\n"
+        )
+        (pkg_dir / "provider.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_dotted",
+            value="mempalace_pkg.provider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dotted"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["mempalace_dotted"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        # Neither the parent package nor the child module was imported.
+        assert "mempalace_pkg" not in sys.modules
+        assert "mempalace_pkg.provider" not in sys.modules
+        # And the parent's __init__.py never executed.
+        assert not marker.exists()
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -408,6 +408,100 @@ class TestPluginLoading:
         )
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
+        # Routing contract: classification records the manifest but does
+        # not fabricate activation. providers/ discovery is directory-based
+        # today, so a pip-only provider is not activatable via
+        # get_provider_profile() — and it must not leak into sys.modules
+        # through the providers path either (no double import).
+        from providers import get_provider_profile
+
+        assert get_provider_profile("fakeprovider") is None
+        assert "fakeprovider" not in sys.modules
+
+    def test_entrypoint_duplicate_does_not_block_directory_provider_activation(
+        self, tmp_path, monkeypatch
+    ):
+        """The mnemosyne shape: a pip entry point duplicating a same-name
+        directory provider.
+
+        The pip copy is classified ``exclusive`` (recorded, never
+        imported); the directory copy must still activate through
+        memory-provider discovery, exactly once. Classification must not
+        interfere with the real activation path.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        # Same-name pip entry point (the duplicate).
+        ep_dir = tmp_path / "ep_modules"
+        ep_dir.mkdir()
+        (ep_dir / "mempalace_dup.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(ep_dir))
+        ep = EntryPoint(
+            name="mempalace_dup",
+            value="mempalace_dup:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Same-name directory provider under $HERMES_HOME/plugins/.
+        hermes_home = tmp_path / "hermes_test"
+        plugins_dir = hermes_home / "plugins"
+        provider_dir = plugins_dir / "mempalace_dup"
+        provider_dir.mkdir(parents=True)
+        (provider_dir / "__init__.py").write_text(
+            "from agent.memory_provider import MemoryProvider\n"
+            "class MyProvider(MemoryProvider):\n"
+            "    @property\n"
+            "    def name(self): return 'mempalace_dup'\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+        )
+        (provider_dir / "plugin.yaml").write_text(
+            "name: mempalace_dup\ndescription: dup\n"
+        )
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dup"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir", lambda: plugins_dir
+        )
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        # Pip duplicate: classified exclusive, recorded, never imported.
+        entry = mgr._plugins["mempalace_dup"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "mempalace_dup" not in sys.modules
+
+        # Directory copy still activates through memory-provider discovery,
+        # exactly once.
+        from plugins.memory import discover_memory_providers, load_memory_provider
+
+        names = [n for n, _, _ in discover_memory_providers()]
+        assert names.count("mempalace_dup") == 1
+        p = load_memory_provider("mempalace_dup")
+        assert p is not None
+        assert p.name == "mempalace_dup"
+        assert p.is_available()
 
     def test_entrypoint_dotted_name_never_imports_parent_package(
         self, tmp_path, monkeypatch

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -409,6 +409,70 @@ class TestPluginLoading:
         assert entry.module is None
         assert "fakeprovider" not in sys.modules
 
+    def test_entrypoint_dotted_name_never_imports_parent_package(
+        self, tmp_path, monkeypatch
+    ):
+        """A dotted entry point (pkg.mod:register) must NOT import the
+        parent package during classification.
+
+        ``importlib.util.find_spec`` on a dotted name imports the parent
+        first — executing its ``__init__.py``, which is where a provider's
+        heavy imports typically live. The classifier must resolve the
+        module path by hand so the parent's initialization code never
+        runs and neither the parent nor the child enters ``sys.modules``.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        marker = tmp_path / "parent_executed"
+        pkg_dir = tmp_path / "mempalace_pkg"
+        pkg_dir.mkdir()
+        (pkg_dir / "__init__.py").write_text(
+            "# If this ever executes, the no-import property is broken.\n"
+            f"from pathlib import Path\n"
+            f"Path({str(marker)!r}).write_text('executed')\n"
+            "from .provider import register_memory_provider\n"
+        )
+        (pkg_dir / "provider.py").write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_dotted",
+            value="mempalace_pkg.provider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_dotted"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["mempalace_dotted"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        # Neither the parent package nor the child module was imported.
+        assert "mempalace_pkg" not in sys.modules
+        assert "mempalace_pkg.provider" not in sys.modules
+        # And the parent's __init__.py never executed.
+        assert not marker.exists()
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -299,6 +299,116 @@ class TestPluginLoading:
         assert entry.module is None
         assert "exclusive" in (entry.error or "").lower()
 
+    def test_entrypoint_memory_provider_auto_coerced_to_exclusive(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point memory-provider plugins must NOT be imported by
+        the general PluginManager.
+
+        Regression test for the mnemosyne case: a pip plugin declaring a
+        ``hermes_agent.plugins`` entry point but exposing
+        ``register_memory_provider`` (not ``register()``) used to be
+        eagerly imported in every process, pulling heavy deps (fastembed
+        → onnxruntime, ~60 MB RSS) even though the import registered
+        nothing. Entry-point manifests now get the same source-scan
+        classification as directory plugins: recorded, never imported.
+        Activation stays with plugins/memory discovery via
+        ``memory.provider`` config.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "mempalace_ep.py"
+        module_path.write_text(
+            "class MemPalaceProvider:\n"
+            "    pass\n"
+            "def register_memory_provider(name, cls):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="mempalace_ep",
+            value="mempalace_ep:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        # Even if the user explicitly enables it, the loader must treat it
+        # as exclusive and skip the import (the bug: eager import of a
+        # module with no register() function).
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["mempalace_ep"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        assert "mempalace_ep" in mgr._plugins
+        entry = mgr._plugins["mempalace_ep"]
+        assert entry.manifest.kind == "exclusive", (
+            f"Expected auto-coerced kind='exclusive', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "exclusive" in (entry.error or "").lower()
+        # The whole point: the module was never imported.
+        assert "mempalace_ep" not in sys.modules
+
+    def test_entrypoint_model_provider_auto_coerced_to_model_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point model-provider plugins are routed to the
+        providers/ discovery system instead of being imported by the
+        general manager (which would double-instantiate ProviderProfile)."""
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "fakeprovider.py"
+        module_path.write_text(
+            "class ProviderProfile:\n"
+            "    pass\n"
+            "def register_provider(profile):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="fakeprovider",
+            value="fakeprovider:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["fakeprovider"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = mgr._plugins["fakeprovider"]
+        assert entry.manifest.kind == "model-provider", (
+            f"Expected auto-coerced kind='model-provider', "
+            f"got {entry.manifest.kind}"
+        )
+        assert entry.module is None
+        assert "fakeprovider" not in sys.modules
+
 
 # ── TestPluginHooks ────────────────────────────────────────────────────────
 

--- a/tests/plugins/memory/test_discovery_sources.py
+++ b/tests/plugins/memory/test_discovery_sources.py
@@ -1,0 +1,221 @@
+"""Discovery parity for out-of-tree memory providers.
+
+Upstream policy closed ``plugins/memory/`` to new providers, so every new
+memory backend now lives outside this tree. These tests cover the two sources
+that reach it — project-local directories and pip entry points — and the
+integration points a directory install gets for free but a pip install
+historically did not: the dashboard config panel, the provider's CLI
+subcommands, and the ``memory.provider`` dropdown.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+import plugins.memory as memory_plugins
+
+PROVIDER_SOURCE = """\
+from agent.memory_provider import MemoryProvider
+
+
+class Provider(MemoryProvider):
+    @property
+    def name(self):
+        return "{name}"
+
+    def is_available(self):
+        return True
+
+    def initialize(self, *a, **kw):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+
+def register(ctx):
+    ctx.register_memory_provider(Provider())
+"""
+
+
+class FakeEntryPoint:
+    """Mirrors the importlib.metadata EntryPoint surface discovery uses."""
+
+    group = "hermes_agent.memory_providers"
+
+    def __init__(self, name, value):
+        self.name = name
+        self.value = value
+
+    def load(self):
+        import importlib
+
+        module_name, _, attr = self.value.partition(":")
+        module = importlib.import_module(module_name)
+        return getattr(module, attr) if attr else module
+
+
+class FakeEntryPoints(list):
+    def select(self, *, group):
+        return [ep for ep in self if ep.group == group]
+
+
+@pytest.fixture
+def entry_points(monkeypatch):
+    """Install a replaceable entry-point set for the memory group."""
+    registry = FakeEntryPoints()
+    monkeypatch.setattr(importlib.metadata, "entry_points", lambda: registry)
+    return registry
+
+
+def _write_provider_dir(root: Path, name: str) -> Path:
+    provider = root / name
+    provider.mkdir(parents=True)
+    (provider / "__init__.py").write_text(PROVIDER_SOURCE.format(name=name), encoding="utf-8")
+    return provider
+
+
+# ---------------------------------------------------------------------------
+# Project-local providers
+# ---------------------------------------------------------------------------
+
+
+def test_project_dir_is_ignored_without_opt_in(tmp_path, monkeypatch):
+    """A repo you merely cd into must not be able to offer a memory backend."""
+    _write_provider_dir(tmp_path / ".hermes" / "plugins", "projectmem")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("HERMES_ENABLE_PROJECT_PLUGINS", raising=False)
+
+    assert "projectmem" not in memory_plugins.list_memory_provider_names()
+    assert memory_plugins.find_provider_dir("projectmem") is None
+
+
+def test_project_dir_is_discovered_when_opted_in(tmp_path, monkeypatch):
+    provider = _write_provider_dir(tmp_path / ".hermes" / "plugins", "projectmem")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+
+    assert "projectmem" in memory_plugins.list_memory_provider_names()
+    assert memory_plugins.find_provider_dir("projectmem") == provider
+
+
+def test_bundled_still_wins_over_project(tmp_path, monkeypatch):
+    """Precedence here is bundled-first, the reverse of the general
+    PluginManager's later-wins order. A provider is activated by name, so a
+    directory dropped into the working tree must not be able to shadow a
+    shipped one and silently redirect the agent's memory."""
+    _write_provider_dir(tmp_path / ".hermes" / "plugins", "honcho")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HERMES_ENABLE_PROJECT_PLUGINS", "1")
+
+    resolved = memory_plugins.find_provider_dir("honcho")
+    assert resolved == Path(memory_plugins.__file__).parent / "honcho"
+
+
+# ---------------------------------------------------------------------------
+# Pip entry-point providers
+# ---------------------------------------------------------------------------
+
+
+def test_entry_point_provider_is_listed(entry_points, tmp_path, monkeypatch):
+    """list_memory_provider_names() fills the dashboard's memory.provider
+    dropdown. Enumerating entry points reads distribution metadata without
+    executing any of it, so this stays safe to call at import time."""
+    entry_points.append(FakeEntryPoint("pipmem", "pipmem_pkg"))
+    assert "pipmem" in memory_plugins.list_memory_provider_names()
+
+
+def test_find_provider_dir_resolves_a_package_entry_point(entry_points, tmp_path, monkeypatch):
+    """Without a directory, a pip-installed provider silently loses its
+    dashboard config panel and its `hermes <provider>` subcommands — both are
+    read from disk rather than imported."""
+    package = tmp_path / "pipmem_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(PROVIDER_SOURCE.format(name="pipmem"), encoding="utf-8")
+    (package / "config_schema.py").write_text("CONFIG_SCHEMA = None\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    entry_points.append(FakeEntryPoint("pipmem", "pipmem_pkg:register"))
+
+    assert memory_plugins.find_provider_dir("pipmem") == package
+
+
+def test_resolving_an_entry_point_does_not_import_it(entry_points, tmp_path, monkeypatch):
+    """Discovery runs before the operator has chosen a provider. Importing
+    every installed candidate would execute third-party code on the strength of
+    a package merely being present."""
+    package = tmp_path / "sideeffect_pkg"
+    package.mkdir()
+    (package / "__init__.py").write_text(
+        textwrap.dedent(
+            """\
+            import pathlib
+            pathlib.Path(__file__).with_name("IMPORTED").write_text("x")
+            """
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    entry_points.append(FakeEntryPoint("sideeffect", "sideeffect_pkg"))
+
+    assert memory_plugins.find_provider_dir("sideeffect") == package
+    assert not (package / "IMPORTED").exists()
+    assert "sideeffect_pkg" not in sys.modules
+
+
+def test_bare_module_entry_point_has_no_directory(entry_points, tmp_path, monkeypatch):
+    """A single-file provider has nowhere to put a sibling config_schema.py, so
+    it resolves to None rather than handing back the whole site-packages root."""
+    (tmp_path / "flatmem.py").write_text(PROVIDER_SOURCE.format(name="flatmem"), encoding="utf-8")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    entry_points.append(FakeEntryPoint("flatmem", "flatmem"))
+
+    assert memory_plugins.find_provider_dir("flatmem") is None
+
+
+# ---------------------------------------------------------------------------
+# Registration surface
+# ---------------------------------------------------------------------------
+
+
+def test_a_secondary_registration_cannot_cost_the_provider(tmp_path, monkeypatch):
+    """register_auxiliary_task used to raise AttributeError on the collector —
+    which the loader caught, discarded the registered provider, and replaced
+    with a bare second instance built by the subclass scan. A silent downgrade
+    that looked like success."""
+    plugins_root = tmp_path / "plugins"
+    provider = _write_provider_dir(plugins_root, "auxmem")
+    (provider / "__init__.py").write_text(
+        PROVIDER_SOURCE.format(name="auxmem").replace(
+            "    ctx.register_memory_provider(Provider())\n",
+            "    instance = Provider()\n"
+            "    instance.marked = True\n"
+            "    ctx.register_memory_provider(instance)\n"
+            "    ctx.register_auxiliary_task(\n"
+            "        'auxmem_filter', display_name='Aux', description='d'\n"
+            "    )\n",
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    loaded = memory_plugins.load_memory_provider("auxmem")
+    assert loaded is not None
+    assert loaded.name == "auxmem"
+    # The instance register() handed over, not a replacement.
+    assert getattr(loaded, "marked", False)
+
+
+def test_activation_is_not_gated_on_plugins_enabled(tmp_path, monkeypatch):
+    """Memory providers are activated by naming them in memory.provider. Using
+    a real PluginContext for secondary registrations must not start also
+    requiring the plugin in plugins.enabled — that would break every existing
+    user-installed provider."""
+    _write_provider_dir(tmp_path / "plugins", "gatedmem")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert memory_plugins.load_memory_provider("gatedmem") is not None

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -300,6 +300,91 @@ class TestSkillViewQualifiedName:
 
 
 
+    def test_does_not_lazy_load_inactive_memory_provider_skill(self, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        def fail_if_loaded(name):
+            raise AssertionError(f"unexpected provider load: {name}")
+
+        monkeypatch.setattr("plugins.memory._get_active_memory_provider", lambda: "active")
+        monkeypatch.setattr("plugins.memory.load_memory_provider", fail_if_loaded)
+
+        result = json.loads(skill_view("inactive:maintenance"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def _make_memory_provider_with_skill(self, tmp_path, name, body="Provider skill body."):
+        plugin_dir = tmp_path / ".hermes" / "plugins" / name
+        skill_dir = plugin_dir / "skills" / "maintenance"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: maintenance\ndescription: Memory maintenance\n---\n\n{body}\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            f"    def name(self): return {name!r}\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            "    ctx.register_skill('maintenance', Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md')\n"
+        )
+        return plugin_dir
+
+    def test_lazily_loads_memory_provider_registered_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memtest")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memtest",
+        )
+
+        result = json.loads(skill_view("memtest:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "memtest:maintenance"
+        assert "Provider skill body." in result["content"]
+
+    def test_discovery_does_not_pre_register_inactive_memory_provider_skills(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.memory import discover_memory_providers
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memactive", "Active body.")
+        self._make_memory_provider_with_skill(tmp_path, "meminactive", "Inactive body.")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memactive",
+        )
+
+        discover_memory_providers()
+
+        inactive = json.loads(skill_view("meminactive:maintenance"))
+        assert inactive["success"] is False
+        assert "not found" in inactive["error"].lower()
+
+        active = json.loads(skill_view("memactive:maintenance"))
+        assert active["success"] is True
+        assert active["name"] == "memactive:maintenance"
+        assert "Active body." in active["content"]
+
     def test_stale_entry_self_heals(self, tmp_path):
         from tools.skills_tool import skill_view
 
@@ -409,7 +494,7 @@ class TestBundleContextBanner:
         content = result["content"]
 
         sibling_line = next(
-            (l for l in content.split("\n") if "Sibling skills:" in l), None
+            (line for line in content.split("\n") if "Sibling skills:" in line), None
         )
         assert sibling_line is not None
         assert "bar" in sibling_line

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -228,6 +228,91 @@ class TestSkillViewQualifiedName:
 
 
 
+    def test_does_not_lazy_load_inactive_memory_provider_skill(self, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        def fail_if_loaded(name):
+            raise AssertionError(f"unexpected provider load: {name}")
+
+        monkeypatch.setattr("plugins.memory._get_active_memory_provider", lambda: "active")
+        monkeypatch.setattr("plugins.memory.load_memory_provider", fail_if_loaded)
+
+        result = json.loads(skill_view("inactive:maintenance"))
+
+        assert result["success"] is False
+        assert "not found" in result["error"].lower()
+
+    def _make_memory_provider_with_skill(self, tmp_path, name, body="Provider skill body."):
+        plugin_dir = tmp_path / ".hermes" / "plugins" / name
+        skill_dir = plugin_dir / "skills" / "maintenance"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: maintenance\ndescription: Memory maintenance\n---\n\n{body}\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "from pathlib import Path\n"
+            "from agent.memory_provider import MemoryProvider\n"
+            "class Provider(MemoryProvider):\n"
+            "    @property\n"
+            f"    def name(self): return {name!r}\n"
+            "    def is_available(self): return True\n"
+            "    def initialize(self, **kw): pass\n"
+            "    def sync_turn(self, *a, **kw): pass\n"
+            "    def get_tool_schemas(self): return []\n"
+            "    def handle_tool_call(self, *a, **kw): return '{}'\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider(Provider())\n"
+            "    ctx.register_skill('maintenance', Path(__file__).parent / 'skills' / 'maintenance' / 'SKILL.md')\n"
+        )
+        return plugin_dir
+
+    def test_lazily_loads_memory_provider_registered_skill(self, tmp_path, monkeypatch):
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memtest")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memtest",
+        )
+
+        result = json.loads(skill_view("memtest:maintenance"))
+
+        assert result["success"] is True
+        assert result["name"] == "memtest:maintenance"
+        assert "Provider skill body." in result["content"]
+
+    def test_discovery_does_not_pre_register_inactive_memory_provider_skills(
+        self, tmp_path, monkeypatch
+    ):
+        from plugins.memory import discover_memory_providers
+        from tools.skills_tool import skill_view
+
+        self._make_memory_provider_with_skill(tmp_path, "memactive", "Active body.")
+        self._make_memory_provider_with_skill(tmp_path, "meminactive", "Inactive body.")
+        monkeypatch.setattr(
+            "plugins.memory._get_user_plugins_dir",
+            lambda: tmp_path / ".hermes" / "plugins",
+        )
+        monkeypatch.setattr(
+            "plugins.memory._get_active_memory_provider",
+            lambda: "memactive",
+        )
+
+        discover_memory_providers()
+
+        inactive = json.loads(skill_view("meminactive:maintenance"))
+        assert inactive["success"] is False
+        assert "not found" in inactive["error"].lower()
+
+        active = json.loads(skill_view("memactive:maintenance"))
+        assert active["success"] is True
+        assert active["name"] == "memactive:maintenance"
+        assert "Active body." in active["content"]
+
     def test_stale_entry_self_heals(self, tmp_path):
         from tools.skills_tool import skill_view
 
@@ -337,7 +422,7 @@ class TestBundleContextBanner:
         content = result["content"]
 
         sibling_line = next(
-            (l for l in content.split("\n") if "Sibling skills:" in l), None
+            (line for line in content.split("\n") if "Sibling skills:" in line), None
         )
         assert sibling_line is not None
         assert "bar" in sibling_line

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1114,7 +1114,41 @@ def skill_view(
 
             discover_plugins()  # idempotent
             pm = get_plugin_manager()
+            active_memory_provider = None
+            try:
+                from plugins.memory import (
+                    _get_active_memory_provider,
+                    _prune_inactive_memory_provider_skills,
+                )
+
+                active_memory_provider = _get_active_memory_provider()
+                _prune_inactive_memory_provider_skills(active_memory_provider)
+            except Exception as exc:
+                logger.debug(
+                    "Failed pruning inactive memory-provider skills: %s",
+                    exc,
+                )
+
             plugin_skill_md = pm.find_plugin_skill(name)
+
+            # Memory provider plugins are loaded through plugins.memory rather
+            # than the general PluginManager. If a memory provider shim also
+            # registers skills, load the namespaced provider once so its
+            # collector can forward those skills into the plugin skill registry
+            # before declaring the qualified skill missing.
+            if plugin_skill_md is None:
+                try:
+                    from plugins.memory import load_memory_provider
+
+                    if namespace == active_memory_provider:
+                        load_memory_provider(namespace)
+                        plugin_skill_md = pm.find_plugin_skill(name)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed lazy memory-provider skill load for %s: %s",
+                        namespace,
+                        exc,
+                    )
 
             if plugin_skill_md is not None:
                 if not plugin_skill_md.exists():

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1019,7 +1019,41 @@ def skill_view(
 
             discover_plugins()  # idempotent
             pm = get_plugin_manager()
+            active_memory_provider = None
+            try:
+                from plugins.memory import (
+                    _get_active_memory_provider,
+                    _prune_inactive_memory_provider_skills,
+                )
+
+                active_memory_provider = _get_active_memory_provider()
+                _prune_inactive_memory_provider_skills(active_memory_provider)
+            except Exception as exc:
+                logger.debug(
+                    "Failed pruning inactive memory-provider skills: %s",
+                    exc,
+                )
+
             plugin_skill_md = pm.find_plugin_skill(name)
+
+            # Memory provider plugins are loaded through plugins.memory rather
+            # than the general PluginManager. If a memory provider shim also
+            # registers skills, load the namespaced provider once so its
+            # collector can forward those skills into the plugin skill registry
+            # before declaring the qualified skill missing.
+            if plugin_skill_md is None:
+                try:
+                    from plugins.memory import load_memory_provider
+
+                    if namespace == active_memory_provider:
+                        load_memory_provider(namespace)
+                        plugin_skill_md = pm.find_plugin_skill(name)
+                except Exception as exc:
+                    logger.debug(
+                        "Failed lazy memory-provider skill load for %s: %s",
+                        namespace,
+                        exc,
+                    )
 
             if plugin_skill_md is not None:
                 if not plugin_skill_md.exists():

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -12,9 +12,17 @@ Memory provider plugins give Hermes Agent persistent, cross-session knowledge be
 Memory providers are one of two **provider plugin** types. The other is [Context Engine Plugins](/developer-guide/context-engine-plugin), which replace the built-in context compressor. Both follow the same pattern: single-select, config-driven, managed via `hermes plugins`.
 :::
 
-## Directory Structure
+## Installation Layouts
 
-Each memory provider lives in `plugins/memory/<name>/`:
+Hermes discovers memory providers from bundled directories, user-installed
+directories, and installed Python package entry points. Bundled providers take
+precedence over a user directory with the same name, which takes precedence
+over a package entry point.
+
+### Directory Provider
+
+A directory provider lives in `plugins/memory/<name>/` when bundled with
+Hermes, or in `$HERMES_HOME/plugins/<name>/` when installed by a user:
 
 ```
 plugins/memory/my-provider/
@@ -22,6 +30,22 @@ plugins/memory/my-provider/
 ├── plugin.yaml      # Metadata (name, description, hooks)
 └── README.md        # Setup instructions, config reference, tools
 ```
+
+### Packaged Provider
+
+A pip-installed provider publishes an entry point in the
+`hermes_agent.memory_providers` group. The entry-point name is the provider
+name users select in `memory.provider`; its value points to the provider's
+`register(ctx)` function:
+
+```toml title="pyproject.toml"
+[project.entry-points."hermes_agent.memory_providers"]
+my-provider = "my_provider:register"
+```
+
+The package can keep its provider implementation, skills, and other resources
+inside its normal Python package layout. No copy under
+`$HERMES_HOME/plugins/` is required.
 
 ## The MemoryProvider ABC
 
@@ -138,6 +162,27 @@ def register(ctx) -> None:
     """Called by the memory plugin discovery system."""
     ctx.register_memory_provider(MyMemoryProvider())
 ```
+
+A provider may also expose read-only skills from the same callback. Skills are
+qualified by the entry-point name and are loaded only when that memory provider
+is active:
+
+```python
+from pathlib import Path
+
+SKILLS_DIR = Path(__file__).parent / "skills"
+
+def register(ctx) -> None:
+    ctx.register_memory_provider(MyMemoryProvider())
+    ctx.register_skill(
+        "maintenance",
+        SKILLS_DIR / "maintenance" / "SKILL.md",
+        "Maintain the provider's memory store",
+    )
+```
+
+With the `my-provider` entry point active, the skill is available as
+`my-provider:maintenance` through `skill_view()`.
 
 ## plugin.yaml
 

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -14,15 +14,32 @@ Memory providers are one of two **provider plugin** types. The other is [Context
 
 ## Installation Layouts
 
-Hermes discovers memory providers from bundled directories, user-installed
-directories, and installed Python package entry points. Bundled providers take
-precedence over a user directory with the same name, which takes precedence
-over a package entry point.
+Hermes discovers memory providers from four sources, in this precedence order:
+
+| Source | Location | Notes |
+|---|---|---|
+| Bundled | `plugins/memory/<name>/` | Ships with Hermes. Closed to new providers — see [CONTRIBUTING](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md). |
+| User | `$HERMES_HOME/plugins/<name>/` | Dropped in by the user, per profile. |
+| Project | `./.hermes/plugins/<name>/` | Opt-in via `HERMES_ENABLE_PROJECT_PLUGINS=1`. |
+| Package | `hermes_agent.memory_providers` entry point | `pip install`, nothing to copy. |
+
+Earlier sources win on a name collision, so a directory dropped into a working
+tree can never shadow a shipped provider.
+
+:::note
+This is the reverse of the general plugin system's later-wins order. A memory
+provider is activated by *name* (`memory.provider`), so shadowing would
+silently redirect the agent's memory rather than merely override a tool.
+:::
+
+Discovery only *enumerates* — it never imports a provider. Nothing runs until
+`memory.provider` names it.
 
 ### Directory Provider
 
 A directory provider lives in `plugins/memory/<name>/` when bundled with
-Hermes, or in `$HERMES_HOME/plugins/<name>/` when installed by a user:
+Hermes, in `$HERMES_HOME/plugins/<name>/` when installed by a user, or in
+`./.hermes/plugins/<name>/` for a project-local one:
 
 ```
 plugins/memory/my-provider/
@@ -43,9 +60,15 @@ name users select in `memory.provider`; its value points to the provider's
 my-provider = "my_provider:register"
 ```
 
-The package can keep its provider implementation, skills, and other resources
-inside its normal Python package layout. No copy under
-`$HERMES_HOME/plugins/` is required.
+Point the entry point at the **package**, or at a `register(ctx)` inside it, and
+keep your implementation, skills, and other resources in the normal Python
+package layout. No copy under `$HERMES_HOME/plugins/` is required.
+
+A package entry point gets everything a directory install does, including the
+two files Hermes reads from disk rather than importing — `config_schema.py`
+(the dashboard config panel) and `cli.py` (your `hermes <provider>`
+subcommands). Both are found next to your package's `__init__.py`, so point the
+entry point at a package rather than a single module if you ship either.
 
 ## The MemoryProvider ABC
 


### PR DESCRIPTION
Closes #40101.

## Problem

`plugins/memory/` is closed to new providers, so every new memory backend now ships out of tree. But the out-of-tree path is measurably weaker than the in-tree one, and the docs already promise otherwise.

`plugins/memory/__init__.py:_iter_provider_dirs()` walks **directories only** — bundled and `$HERMES_HOME/plugins/`. The general `PluginManager` (`hermes_cli/plugins.py:1371-1391`) scans four sources including pip entry points. `CONTRIBUTING.md:78` and `AGENTS.md` both state memory discovery "picks them up from user/project plugin directories and pip entry points". It does not.

The user-visible symptom is #40101: a correctly-registered pip-installed provider reports `Plugin: NOT installed`. The workaround in the wild is a bespoke second install step — note that Memori, documented in `memory-providers.md`, ships `pip install hermes-memori` **plus** `hermes-memori install` for exactly this reason.

## This is a salvage, not a fourth attempt

Three PRs already address parts of this and none have merged. Rather than add another competing implementation, this rebases them onto current `main` with authorship preserved and adds what none of them cover — the same approach as #79239.

| PR | Author | Taken |
|---|---|---|
| #18842 | @smarzola | Entry-point discovery via `hermes_agent.memory_providers`, `ctx.register_skill()` forwarding, tests, developer-guide docs |
| #76567 | @mlsmith | Classify entry-point provider plugins without importing them, including the dotted-name parent-import fix |
| #40644 | @AxDSan | Not taken — its discovery half duplicates #18842, and its pipx switch was correctly rejected in review (pipx venvs are invisible to both `importlib.metadata` and the agent runtime) and reverted by the author. Its Mnemosyne docs belong in a docs PR. |

#18842 and #76567 are complementary rather than competing: one adds memory entry-point discovery, the other stops the general PluginManager from eagerly importing such packages in every hermes process.

## What this adds on top

**Project-local providers** (`./.hermes/plugins/<name>/`), gated on `HERMES_ENABLE_PROJECT_PLUGINS` exactly as `PluginManager` gates its own project scan. Completes the four sources.

**`find_provider_dir()` resolves package entry points.** This is load-bearing rather than cosmetic: `config_schema.py` (the dashboard config panel) and `cli.py` (the `hermes <provider>` subcommands) are read **from disk**, not imported — `plugins/memory/config_schema.py:14-17` does this deliberately so the web server never pulls in the agent runtime. Without a directory, a pip-installed provider silently loses both.

**`list_memory_provider_names()` includes entry-point providers**, so they appear in the dashboard's `memory.provider` dropdown.

**Resolution stays import-free.** `resolve_module_origin()` is extracted from #76567's `_resolve_module_source()` and shared, so discovery walks a module's file layout instead of importing it. `find_provider_dir()` is called from the dashboard and from argparse setup — long before the operator has chosen a provider — so importing every installed candidate would execute third-party code on the strength of a package merely being present. A test asserts resolution leaves no side effect and no `sys.modules` entry.

**`PluginContext.register_memory_provider()`.** Memory was the only provider category without one — context engine, image gen, video gen, web search, browser, TTS, transcription, secret source, dashboard auth and platform all have one.

**`_ProviderCollector` delegates unknown `register_*` calls to a real `PluginContext`** instead of carrying three hand-written no-ops. It silently dropped `register_tool` / `register_hook`, and had **no `register_auxiliary_task` at all** — despite `PluginContext.register_auxiliary_task`'s own docstring using a memory provider (hindsight's pre-retain dedup) as its worked example. It can no longer drift behind `PluginContext`.

**A raise after `register_memory_provider()` no longer costs the provider.** The loader caught it into a `logger.debug`, discarded the registered instance, and fell through to "instantiate any `MemoryProvider` subclass" — returning a *different, unconfigured* provider. A silent downgrade that looked like success, and the exact outcome of calling `register_auxiliary_task`.

## Precedence

**bundled > user > project > entrypoint** — deliberately the reverse of the general PluginManager's later-wins order, and documented in the module docstring. A memory provider is activated by *name*, so letting a directory dropped into a working tree shadow a shipped provider would silently redirect the agent's memory. Existing behaviour is unchanged; the new sources sit below it.

## Safety

Activation is still gated on `memory.provider` naming the plugin. Discovery **enumerates**; it does not load. Using a real `PluginContext` must not start also requiring the plugin in `plugins.enabled` — that would break every existing user-installed provider — and there is a test pinning it.

## Testing

`406 passed` across `tests/plugins/memory/`, `tests/agent/test_memory_provider.py`, `tests/hermes_cli/test_plugins.py`, `tests/test_plugin_skills.py`, `tests/hermes_cli/test_web_server.py`. Six failures in `test_hindsight_provider.py` are a missing optional dependency (`hindsight_client_api`) and fail identically on `main`.

New coverage in `tests/plugins/memory/test_discovery_sources.py`: project-dir discovery on and off, entry-point discovery, precedence, import-free resolution, bare-module entry points, the secondary-registration fix, and the `plugins.enabled` invariant.

Verified end to end against a real third-party provider ([kainappsinc/elephant](https://github.com/kainappsinc/elephant)) installed by pip alone with no directory copy — it appears in the dropdown, resolves its directory, loads with its 34 tools, and renders its dashboard config panel.

## Follow-ups, deliberately not bundled

- `hermes_cli/config_defaults.py:3792` hardcodes env-var metadata per bundled provider; external plugins cannot join. Largely served already by `get_config_schema()` / `config_schema.py`, and a much larger refactor.
- `hermes_cli/main.py:9210` still hardcodes `"honcho"` in `_SUBCOMMANDS`. Cosmetic — it only affects unquoted multi-word session names — but it is the same class of thing PR #5295 removed.