### PR TITLE
fix(mcp): treat null args config as empty list in stdio bridge

### DIFF
--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -754,6 +754,70 @@ class TestMCPServerTask:
         asyncio.run(_test())
 
 
+    @pytest.mark.parametrize(
+        ("config_args", "expected_args"),
+        [
+            (None, []),  # explicit YAML ``args:`` null -> empty list (#80437)
+            ("__missing__", []),  # key absent -> current behavior
+            (["-y", "test"], ["-y", "test"]),  # real list -> preserved
+        ],
+    )
+    def test_start_stdio_args_null_treated_as_empty_list(self, config_args, expected_args):
+        """Regression test for #80437.
+
+        ``config.get("args", [])`` only defaults when the key is *missing*;
+        an explicit YAML null (``args:``) came through as ``None`` and then
+        crashed the watchdog wrapper's ``*args`` splat with ``TypeError:
+        Value after * must be an iterable, not NoneType``. A null ``args``
+        must behave like an omitted one: the stdio spawn sees an empty
+        argument list, and real lists pass through unchanged.
+        """
+        from tools.mcp_tool import MCPServerTask
+
+        mock_tools = [_make_mcp_tool("echo")]
+        mock_session = MagicMock()
+        mock_session.initialize = AsyncMock()
+        mock_session.list_tools = AsyncMock(
+            return_value=SimpleNamespace(tools=mock_tools)
+        )
+
+        spawned_args = {}
+
+        def _fake_ssp(command=None, args=None, env=None, **kwargs):
+            spawned_args["args"] = args
+            return MagicMock()
+
+        config = {"command": "npx"}
+        if config_args != "__missing__":
+            config["args"] = config_args
+
+        p_stdio, p_cs, _, _ = self._mock_stdio_and_session(mock_session)
+
+        async def _test():
+            with patch(
+                "tools.mcp_tool.StdioServerParameters", side_effect=_fake_ssp
+            ), patch(
+                # Isolate the fix: bypass the watchdog argv rewrite so the
+                # args observed by StdioServerParameters are exactly the
+                # config-derived ones.
+                "tools.mcp_tool._wrap_command_with_watchdog",
+                side_effect=lambda command, args: (command, args),
+            ), patch(
+                "tools.osv_check.check_package_for_malware", return_value=None
+            ), p_stdio, p_cs:
+                server = MCPServerTask("null_args_srv")
+                # args: null previously raised TypeError here; now connects.
+                await server.start(config)
+
+                assert server.session is mock_session
+                assert len(server._tools) == 1
+
+                await server.shutdown()
+
+        asyncio.run(_test())
+        assert spawned_args["args"] == expected_args
+
+
     def test_stdio_recycle_deadline_pauses_while_rpc_active(self):
         from tools.mcp_tool import MCPServerTask
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -2384,7 +2384,12 @@ class MCPServerTask:
             )
 
         command = config.get("command")
-        args = config.get("args", [])
+        # ``args:`` with an explicit YAML null yields None -- the .get()
+        # default only fires for a *missing* key. None then explodes in the
+        # watchdog wrapper's ``*args`` splat with "Value after * must be an
+        # iterable, not NoneType" (#80437). Treat null as an empty list,
+        # matching mcp_schema_cache.
+        args = config.get("args") or []
         user_env = config.get("env")
 
         if not command:


### PR DESCRIPTION
## Summary
An MCP server config entry with `args: null` (YAML `args:` or `args: null`) crashed the stdio bridge with `TypeError: Value after * must be an iterable, not NoneType`, putting the server into a connecting→parked loop every 5 minutes.

## Root Cause
`tools/mcp_tool.py:2387` used `args = config.get("args", [])` — the default `[]` only applies when the key is **absent**. When the key exists with value `None`, `.get()` returns `None`, which then breaks `*args` unpacking in `_wrap_command_with_watchdog` and `StdioServerParameters(args=None)`.

## Change
- `tools/mcp_tool.py`: `args = config.get("args") or []` — `null` → `[]`, absent → `[]`, real list → preserved. Matches the existing idiom at `tools/mcp_schema_cache.py:35`.
- `tests/tools/test_mcp_tool.py`: parametrized regression — `args: null` → `[]`, absent → `[]`, real list preserved; exercises `_run_stdio` end-to-end via `server.start()` with mocks.
- Regression proof: reverting the fix makes the test fail (`assert None == []`); restored → passes.

## Verification
- `tests/tools/test_mcp_tool.py` + `test_mcp_tool_issue_948.py`: **97 passed**.

Closes #80437