### PR TITLE
fix(memory): never auto-downgrade installed hindsight; honest status predicate

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -475,6 +475,25 @@ def _write_env_vars(env_path: Path, env_writes: dict) -> None:
 # Status
 # ---------------------------------------------------------------------------
 
+def _provider_runtime_missing(provider_name: str) -> tuple[str, ...]:
+    """Specs the provider's runtime lazy-install gate would still try to install.
+
+    Memory providers gate their retain/recall path on
+    ``tools.lazy_deps.ensure(f"memory.{name}")`` (e.g. hindsight's
+    ``_get_client`` calls ``ensure("memory.hindsight")``). The status
+    command must run that same predicate or it reports "available ✓" while
+    every write fails on a version/install check the runtime enforces
+    (#80388). Returns () when the provider has no matching lazy feature or
+    lazy_deps can't be imported — the runtime guards its ``ensure`` import
+    the same way, so both fail open together.
+    """
+    try:
+        from tools.lazy_deps import feature_missing
+        return feature_missing(f"memory.{provider_name}")
+    except Exception:
+        return ()
+
+
 def cmd_status(args) -> None:
     """Show current memory provider config."""
     from hermes_cli.config import load_config
@@ -528,8 +547,17 @@ def cmd_status(args) -> None:
 
         if provider:
             print("\n  Plugin:    installed ✓")
-            if provider.is_available():
+            runtime_missing = _provider_runtime_missing(provider_name)
+            if provider.is_available() and not runtime_missing:
                 print("  Status:    available ✓")
+            elif runtime_missing:
+                # The runtime's lazy-install gate would still fail (missing
+                # package or off-pin install it can't fix) — status must not
+                # claim availability while every retain is dropped (#80388).
+                print("  Status:    degraded ✗ — runtime dependencies missing:")
+                for spec in runtime_missing:
+                    print(f"    {spec}")
+                print("    Run 'hermes memory setup' to install them.")
             else:
                 print("  Status:    not available ✗")
                 schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -356,6 +356,91 @@ class TestConfig:
         assert captured["llm_provider"] == "openai"
 
 
+class TestMemoryStatusUsesRuntimePredicate:
+    """#80388 — `hermes memory status` must use the same predicate as retain.
+
+    The runtime retain/recall path gates on ensure("memory.<provider>")
+    (the version-aware lazy-deps check). cmd_status() must run that same
+    check or it prints "available ✓" while every retain is dropped.
+    """
+
+    class _FakeProvider:
+        name = "hindsight"
+
+        def __init__(self, available: bool = True):
+            self._available = available
+
+        def is_available(self) -> bool:
+            return self._available
+
+        def get_status_config(self, cfg):
+            return {}
+
+        def get_config_schema(self):
+            return []
+
+    def _run_status(self, monkeypatch, capsys, *, provider_available=True, missing=()):
+        import hermes_cli.memory_setup as ms
+
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {"memory": {"provider": "hindsight"}},
+        )
+        monkeypatch.setattr(
+            ms,
+            "_get_available_providers",
+            lambda: [
+                ("hindsight", "API key / local", self._FakeProvider(provider_available))
+            ],
+        )
+        monkeypatch.setattr(
+            "hermes_cli.tools_config._get_platform_tools", lambda *a, **k: []
+        )
+        monkeypatch.setattr("tools.lazy_deps.feature_missing", lambda feature: missing)
+        ms.cmd_status(None)
+        return capsys.readouterr().out
+
+    def test_status_available_when_runtime_deps_satisfied(self, monkeypatch, capsys):
+        out = self._run_status(monkeypatch, capsys, missing=())
+        assert "available ✓" in out
+        assert "degraded" not in out
+
+    def test_status_degraded_when_runtime_deps_missing(self, monkeypatch, capsys):
+        # Provider imports fine but the runtime's lazy-deps gate would fail
+        # (client absent or off-pin) → status must not claim availability.
+        out = self._run_status(
+            monkeypatch, capsys, missing=("hindsight-client>=0.6.1",)
+        )
+        assert "available ✓" not in out
+        assert "degraded ✗" in out
+        assert "hindsight-client>=0.6.1" in out
+
+    def test_status_not_available_when_provider_unavailable(self, monkeypatch, capsys):
+        out = self._run_status(monkeypatch, capsys, provider_available=False, missing=())
+        assert "available ✓" not in out
+        assert "not available ✗" in out
+
+    def test_provider_runtime_missing_maps_name_to_lazy_feature(self, monkeypatch):
+        from hermes_cli.memory_setup import _provider_runtime_missing
+
+        calls = []
+        monkeypatch.setattr(
+            "tools.lazy_deps.feature_missing",
+            lambda feature: calls.append(feature) or ("hindsight-client>=0.6.1",),
+        )
+        assert _provider_runtime_missing("hindsight") == ("hindsight-client>=0.6.1",)
+        assert calls == ["memory.hindsight"]
+
+    def test_provider_runtime_missing_fails_open(self, monkeypatch):
+        from hermes_cli.memory_setup import _provider_runtime_missing
+
+        def boom(feature):
+            raise KeyError(f"no lazy feature for {feature!r}")
+
+        monkeypatch.setattr("tools.lazy_deps.feature_missing", boom)
+        assert _provider_runtime_missing("no-such-provider") == ()
+
+
 class TestPostSetup:
     def test_setup_cancel_at_mode_picker_writes_nothing(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / "hermes-home"

--- a/tests/tools/test_lazy_deps.py
+++ b/tests/tools/test_lazy_deps.py
@@ -209,6 +209,71 @@ class TestIsSatisfiedVersionAware:
         self._fake_version(monkeypatch, {"mautrix": "0.20.0"})
         assert ld._is_satisfied("mautrix[encryption]==0.21.0") is False
 
+    # --- "never downgrade" (#80390) ---
+    def test_newer_than_exact_pin_returns_true(self, monkeypatch):
+        # An operator-installed NEWER client must never read as "missing" —
+        # ensure() would otherwise attempt an unattended downgrade. The
+        # embedded hindsight stack migrates its Postgres data forward on
+        # every release, so a downgrade is destructive (#80390).
+        self._fake_version(monkeypatch, {"hindsight-client": "0.8.6"})
+        assert ld._is_satisfied("hindsight-client>=0.6.1") is True
+        assert ld._is_satisfied("hindsight-client==0.6.1") is True
+
+    def test_older_than_pin_returns_false(self, monkeypatch):
+        # Older than the floor → still missing → ensure() upgrades (allowed;
+        # pin propagation for `hermes update` depends on this).
+        self._fake_version(monkeypatch, {"hindsight-client": "0.5.0"})
+        assert ld._is_satisfied("hindsight-client>=0.6.1") is False
+
+    def test_newer_than_upper_bounded_range_returns_true(self, monkeypatch):
+        # mautrix-style >=A,<B: an installed 2.x must not be downgraded to <1.
+        self._fake_version(monkeypatch, {"mautrix": "2.0.0"})
+        assert ld._is_satisfied("mautrix[encryption]>=0.20,<1") is True
+
+    def test_below_range_returns_false(self, monkeypatch):
+        self._fake_version(monkeypatch, {"mautrix": "0.15.0"})
+        assert ld._is_satisfied("mautrix[encryption]>=0.20,<1") is False
+
+    def test_missing_package_returns_false(self, monkeypatch):
+        self._fake_version(monkeypatch, {})
+        assert ld._is_satisfied("hindsight-client>=0.6.1") is False
+
+
+class TestNeverDowngradeEnsure:
+    """#80390 — ensure() must never reinstall (downgrade) a newer install."""
+
+    def _fake_version(self, monkeypatch, installed_versions: dict):
+        from importlib.metadata import PackageNotFoundError
+
+        def _version(pkg):
+            if pkg in installed_versions:
+                return installed_versions[pkg]
+            raise PackageNotFoundError(pkg)
+
+        import importlib.metadata as _md
+        monkeypatch.setattr(_md, "version", _version)
+
+    def test_newer_install_is_not_missing(self, monkeypatch):
+        # feature_missing() is the predicate ensure() AND `hermes memory
+        # status` share: with a newer client installed, nothing is missing,
+        # so no install (and no downgrade) is ever attempted (#80390/#80388).
+        self._fake_version(monkeypatch, {"hindsight-client": "0.8.6"})
+        assert ld.feature_missing("memory.hindsight") == ()
+
+    def test_absent_install_is_missing(self, monkeypatch):
+        self._fake_version(monkeypatch, {})
+        assert ld.feature_missing("memory.hindsight") == ("hindsight-client>=0.6.1",)
+
+    def test_ensure_is_noop_on_newer_install(self, monkeypatch):
+        # The observable bug: ensure() on a newer install must return without
+        # invoking pip at all — no downgrade, no install attempt.
+        self._fake_version(monkeypatch, {"hindsight-client": "0.8.6"})
+        monkeypatch.setattr(
+            ld, "_venv_pip_install",
+            lambda *a, **kw: pytest.fail("ensure() must not reinstall a newer client"),
+        )
+        ld.ensure("memory.hindsight", prompt=False)  # must not raise
+
     def test_trace_upload_hub_at_core_locked_version_is_current(self, monkeypatch):
         """#60783 regression: refresh must not churn the shared hub install.
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -191,7 +191,16 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
 
     # ─── Memory providers ──────────────────────────────────────────────────
     "memory.honcho": ("honcho-ai==2.2.0",),
-    "memory.hindsight": ("hindsight-client==0.6.1",),
+    # Floor, not an exact pin: local_embedded users install the whole
+    # hindsight stack (hindsight-all) from PyPI, which tracks a moving
+    # release train (0.8.x today) and is never in the image lockfile, so an
+    # operator-installed client is routinely newer than any pin we could
+    # write here. Worse, the embedded stack migrates its Postgres (pg0) data
+    # directory forward on every release — once 0.8.x has run the database
+    # cannot go back to 0.6.1, so a forced downgrade is destructive. The
+    # >= floor lets ensure() upgrade a stale client but never downgrade a
+    # newer one the operator installed (#80390).
+    "memory.hindsight": ("hindsight-client>=0.6.1",),
     # supermemory + mem0 are opt-in cloud memory providers with their own
     # SDKs. On the published Docker image the agent venv is sealed
     # (HERMES_DISABLE_LAZY_INSTALLS=1) and lazy installs are redirected to the
@@ -590,10 +599,17 @@ def _is_satisfied(spec: str) -> bool:
     """Is ``spec`` already satisfied in the current env?
 
     Checks both presence AND version. If the package is installed at a
-    version outside the spec's range, returns False so the caller will
-    upgrade/downgrade to the pinned version. This is what makes
-    ``hermes update`` propagate pin bumps in :data:`LAZY_DEPS` to already-
-    installed backends instead of silently leaving stale versions in place.
+    version *below* the spec's range, returns False so the caller will
+    upgrade to the pinned version. This is what makes ``hermes update``
+    propagate pin bumps in :data:`LAZY_DEPS` to already-installed backends
+    instead of silently leaving stale versions in place.
+
+    If the installed version is *newer* than every version the spec allows,
+    the spec counts as satisfied: :func:`ensure` must never attempt an
+    automatic downgrade of a package the operator installed. The embedded
+    Hindsight stack, for example, migrates its Postgres data directory
+    forward on every release — once 0.8.x has run, the database cannot go
+    back to 0.6.1, so a forced downgrade is destructive (#80390).
 
     If ``packaging`` is unavailable for any reason (it's a transitive of
     pip so this should never happen), we fall back to a presence-only check
@@ -624,10 +640,58 @@ def _is_satisfied(spec: str) -> bool:
         return True
 
     try:
-        return Version(installed) in SpecifierSet(spec_tail)
+        installed_v = Version(installed)
+        spec_set = SpecifierSet(spec_tail)
     except (InvalidSpecifier, InvalidVersion, Exception):
         # Malformed spec or installed version we can't parse — don't churn.
         return True
+
+    if installed_v in spec_set:
+        return True
+
+    # Never downgrade: an installed version newer than everything the spec
+    # allows is the operator's deliberate choice, not a missing package.
+    return _newer_than_allowed(installed_v, spec_set)
+
+
+def _newer_than_allowed(installed: Version, spec_set: SpecifierSet) -> bool:
+    """True when *installed* is strictly newer than every version ``spec_set`` allows.
+
+    Implements the "never downgrade" rule for :func:`_is_satisfied`: if the
+    installed version outranks the whole pinned range, the feature counts as
+    satisfied and :func:`ensure` leaves it alone instead of attempting an
+    unattended downgrade. Upgrades stay possible — anything installed *below*
+    the range still reports as missing, so pin bumps can be pulled forward
+    (``hermes update`` propagation).
+    """
+    saw_upper_bound = False
+    try:
+        from packaging.version import Version
+
+        for specifier in spec_set:
+            op, ver = specifier.operator, specifier.version
+            if op in (">=", ">"):
+                # Lower bound: for "newer than everything allowed" to hold,
+                # the installed version must at least clear it.
+                if installed < Version(ver):
+                    return False
+                continue
+            # Upper-bounding specifier ("<", "<=", "==", "~="): the
+            # installed version must be at or beyond its top. A trailing
+            # ".*" wildcard ("==1.4.5.*") is normalized to its "1.4.5"
+            # prefix — everything above it is already newer than allowed.
+            saw_upper_bound = True
+            top = Version(ver.rstrip(".*"))
+            if op == "<":
+                # "<2" allows everything below 2 — 2.0 is already newer.
+                if installed < top:
+                    return False
+            elif installed <= top:
+                return False
+    except Exception:
+        # Unparseable specifier or version — be conservative.
+        return False
+    return saw_upper_bound
 
 
 def _is_present(spec: str) -> bool:


### PR DESCRIPTION
## Summary
Two related defects in the hindsight memory backend, fixed together (80390 is the root cause, 80388 the consequence):

**#80390 — auto-downgrade on every retain:** `tools/lazy_deps.py` pinned `memory.hindsight` to `hindsight-client==0.6.1` and `_is_satisfied()` required the **exact** version. An operator-installed, working, **newer** hindsight stack was treated as missing, and `ensure()` attempted an **unattended downgrade** on every retain. This is destructive: the hindsight embedded stack migrates its Postgres (pg0) data directory forward with each release — once 0.8.x has run, the DB cannot go back to 0.6.1.

**#80388 — dishonest status:** `hermes memory status` checked only that modules import, while the runtime additionally ran the version-pinned `ensure()`. The two predicates disagreed, so status reported "available ✓" while every retain failed silently (42h of retain-failure WARNINGs on the reporter's deployment).

## Change
- `tools/lazy_deps.py`:
  - Pin → `"hindsight-client>=0.6.1"` (floor, with comment explaining the pg0 migration ratchet).
  - New `_newer_than_allowed()` helper: an installed version **newer than the entire spec range** counts as satisfied. Fixes the whole class — applies to `==`, `<`, `<=`, `~=`, and `>=A,<B` ranges for any feature. `ensure()` never downgrades an operator-installed package; upgrades still work (older installed → `feature_missing` → install pin).
- `hermes_cli/memory_setup.py`: `memory status` now uses the same availability predicate as the runtime (runs the `ensure()` check) — no more "available ✓" when retains fail. Reports the version divergence as degraded status when the pin is unsatisfied.
- `pyproject.toml` extra `[hindsight]` (`==0.6.1`) intentionally left unchanged: explicit operator install, not an automatic-downgrade path.
- Tests: `tests/tools/test_lazy_deps.py` (newer-installed-satisfies cases for each spec type) + `tests/plugins/memory/test_hindsight_provider.py` (status predicate coverage).

## Verification
- `tests/tools/test_lazy_deps.py`: **65 passed**.
- Note: 6 pre-existing failures in `test_hindsight_provider.py` are environment-only (`hindsight_client_api` not installed / `allow_lazy_installs=false`) — identical baseline with and without this fix.

Closes #80390, #80388