### PR TITLE
fix(file-ops): tolerate truncated UTF-8 sample boundary

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -673,3 +673,16 @@ class TestReadNonUtf8IsBinary:
         ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
         # Proper UTF-8 (including non-ASCII) must still read as text.
         assert ops._is_likely_binary("notes.txt", "café résumé\nsecond\n") is False
+
+    def test_trailing_replacement_from_truncated_sample_not_flagged(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        sample = "中文内容\n" + ("这是合法 UTF-8 文本。" * 80) + "\ufffd"
+        assert ops._is_likely_binary(
+            "notes.txt", sample, sample_truncated=True
+        ) is False
+
+    def test_trailing_replacement_in_untruncated_sample_still_flagged(self, tmp_path):
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        assert ops._is_likely_binary(
+            "notes.txt", "合法文本\ufffd", sample_truncated=False
+        ) is True

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -882,16 +882,17 @@ class ShellFileOperations(FileOperations):
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
     
-    def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
+    def _is_likely_binary(self, path: str, content_sample: str = None,
+                          sample_truncated: bool = False) -> bool:
         """
         Check if a file is likely binary.
-        
+
         Uses extension check (fast) + content analysis (fallback).
         """
         ext = os.path.splitext(path)[1].lower()
         if ext in BINARY_EXTENSIONS:
             return True
-        
+
         # Content analysis: >30% non-printable chars = binary
         if content_sample:
             # Undecodable bytes: the terminal env decodes stdout with
@@ -903,12 +904,25 @@ class ShellFileOperations(FileOperations):
             # sample carries the replacement char as binary (read-only) so the
             # agent can't corrupt it. Legitimate UTF-8 text effectively never
             # contains U+FFFD.
-            if "\ufffd" in content_sample[:1000]:
+            #
+            # `head -c 1000` slices bytes, while the terminal environment
+            # decodes stdout with errors="replace". If this sample is known
+            # to be cut from a larger file, one trailing U+FFFD can be the
+            # synthetic result of splitting a valid multi-byte UTF-8 code
+            # point at that byte boundary (common for CJK/emoji). Ignore only
+            # that narrow case; U+FFFD in the middle, or in an untruncated
+            # sample, remains binary evidence.
+            boundary_sample = (
+                content_sample[:-1]
+                if sample_truncated and content_sample.endswith("\ufffd")
+                else content_sample
+            )
+            if "\ufffd" in boundary_sample[:1000]:
                 return True
-            non_printable = sum(1 for c in content_sample[:1000]
+            non_printable = sum(1 for c in boundary_sample[:1000]
                                if ord(c) < 32 and c not in '\n\r\t')
-            return non_printable / min(len(content_sample), 1000) > 0.30
-        
+            return non_printable / min(len(boundary_sample), 1000) > 0.30
+
         return False
     
     def _is_image(self, path: str) -> bool:
@@ -1193,13 +1207,15 @@ class ShellFileOperations(FileOperations):
         sample_result = self._exec(sample_cmd)
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
         
-        if self._is_likely_binary(path, sample_output):
+        if self._is_likely_binary(
+            path, sample_output, sample_truncated=file_size > 1000
+        ):
             return ReadResult(
                 is_binary=True,
                 file_size=file_size,
                 error="Binary file - cannot display as text. Use appropriate tools to handle this file type."
             )
-        
+
         # Read with pagination using sed
         end_line = offset + limit - 1
         read_cmd = f"sed -n '{offset},{end_line}p' {self._escape_shell_arg(path)}"
@@ -1309,7 +1325,9 @@ class ShellFileOperations(FileOperations):
             return ReadResult(is_image=True, is_binary=True, file_size=file_size)
         sample_result = self._exec(f"head -c 1000 {self._escape_shell_arg(path)} 2>/dev/null")
         sample_output = _strip_terminal_fence_leaks(sample_result.stdout)
-        if self._is_likely_binary(path, sample_output):
+        if self._is_likely_binary(
+            path, sample_output, sample_truncated=file_size > 1000
+        ):
             return ReadResult(
                 is_binary=True, file_size=file_size,
                 error="Binary file — cannot display as text."


### PR DESCRIPTION
# Fix truncated UTF-8 sample boundary in file operations

## Bug Description

`read_file` can misclassify valid UTF-8 text as binary when its binary-detection sample is produced with `head -c 1000` and the 1000-byte boundary falls inside a multi-byte UTF-8 code point. The terminal output layer decodes the truncated sample with `errors="replace"`, producing a synthetic trailing `U+FFFD`; the detector then treats that replacement character as proof of binary content.

This is especially visible with long CJK Markdown files. The path encoding is not the cause: a Chinese path containing long ASCII content does not reproduce the failure.

Related upstream issue/PRs previously observed during investigation (their
current state should be rechecked by maintainers; this change is a potentially
overlapping alternative, not a claim that the upstream maintainers have
accepted this particular implementation):

- https://github.com/NousResearch/hermes-agent/issues/76886
- https://github.com/NousResearch/hermes-agent/issues/77842
- https://github.com/NousResearch/hermes-agent/pull/80250
- https://github.com/NousResearch/hermes-agent/pull/80188

These reports and PRs appear to concern the same broad sample-boundary/U+FFFD
failure mode. Their proposed implementations differ from this commit: this
draft keeps the existing non-UTF-8 safety guard and makes the sample-truncated
condition explicit before ignoring a single trailing replacement character.
The commit should therefore be evaluated as a potentially complementary or
alternative implementation, not as an unrelated new bug or a claim that the
other proposals are insufficient.

## Root Cause

`ShellFileOperations.read_file()` and `read_file_raw()` sample the first 1000 bytes before reading the requested content. The terminal environment decodes command output as UTF-8 with `errors="replace"`. A byte-truncated multi-byte character therefore becomes a trailing `U+FFFD`, and `_is_likely_binary()` previously rejected any sample containing that character.

## Fix

- Pass an explicit `sample_truncated` fact to `_is_likely_binary()` based on the measured file size.
- When the file is larger than the 1000-byte sample and the replacement character occurs only at the sample end, treat that one character as a possible UTF-8 boundary artifact.
- Continue treating `U+FFFD` in the middle of the sample, or in an untruncated sample, as binary evidence. This preserves the existing protection against lossy reads of non-UTF-8 files.
- Apply the same logic to both paginated `read_file()` and full-content `read_file_raw()`.

## How to Verify

1. Create or use a UTF-8 Markdown file larger than 1000 bytes whose first 1000 bytes end inside a CJK or other multi-byte character.
2. Call `read_file` and confirm it returns text rather than `is_binary=true`.
3. Call `read_file_raw` on the same file and confirm it returns text.
4. Confirm a sample with `U+FFFD` in the middle remains classified as binary.
5. Confirm a known `.bin` file containing NUL bytes remains classified as binary; this exercises the known-binary-extension guard as well as the real-file path, not a universal claim about every binary format.

## Test Plan

- [x] Added regression tests for truncated-sample trailing `U+FFFD`.
- [x] Added regression test that an untruncated trailing `U+FFFD` remains binary.
- [x] Existing `tests/tools/test_file_operations.py` passes: `48 passed` (run on the clean contribution worktree).
- [x] `python3 -m py_compile tools/file_operations.py tests/tools/test_file_operations.py` passes (clean contribution worktree).
- [x] `git diff --check` passes (clean contribution worktree).
- [x] Manual verification against two real long Chinese Markdown files through `read_file` and `read_file_raw` passes; the files were copied from the Hermes repository/docs into Chinese-named paths before testing.
- [x] Re-ran the final verification on the exact PR head immediately before preparing this draft for submission; see the commands and results recorded below.

Final exact-HEAD verification (`a1fd18985`, clean contribution worktree):

- `pytest -q tests/tools/test_file_operations.py` → `48 passed`.
- `python3 -m py_compile tools/file_operations.py tests/tools/test_file_operations.py` → exit 0.
- `git diff --check origin/main...HEAD` → exit 0.
- Real long Chinese Markdown files copied from the Hermes repository/docs into Chinese-named paths: both `read_file` and `read_file_raw` returned text; the negative `U+FFFD` and known `.bin` checks retained binary classification.

## Risk Assessment

Low to medium — the change is limited to binary-sample classification in the two file-reading paths. The main trade-off is a narrow residual ambiguity for a genuinely invalid byte sequence that appears only as the final replacement character of a truncated sample. Replacement characters in the sample body remain binary evidence, and the change does not remove extension-based binary detection or the existing non-printable-byte heuristic.

## Notes for Maintainers

This draft uses a small local fix rather than changing all terminal backends or redesigning sampling around raw bytes/base64. If maintainers prefer the more rigorous raw-byte approach, this commit can be adapted or superseded by that design.
