### PR TITLE
fix(desktop): run npm/npx shims via node.exe so Unicode-whitespace profile paths work

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5502,14 +5502,19 @@ def _run_npm_install_deterministic(
         )
 
     def _attempt(npm_exe: str) -> subprocess.CompletedProcess:
+        from hermes_constants import node_cli_launch_for_shim
+
+        # Windows: run npm via node.exe + npm-cli.js, never the .cmd shim —
+        # cmd.exe truncates shim paths containing Unicode whitespace (U+00A0).
+        launch = node_cli_launch_for_shim(npm_exe)
         lockfile = cwd / "package-lock.json"
         if lockfile.exists():
-            ci_result = _run([npm_exe, "ci", "--include=dev", *extra_args])
+            ci_result = _run([*launch, "ci", "--include=dev", *extra_args])
             if ci_result.returncode == 0:
                 return ci_result
             # Fall through to `npm install` — lockfile may be out of sync on a
             # WIP fork/branch, or `npm ci` may not be available on very old npm.
-        return _run([npm_exe, "install", "--no-save", "--include=dev", *extra_args])
+        return _run([*launch, "install", "--no-save", "--include=dev", *extra_args])
 
     result = _attempt(npm)
     if result.returncode == 0:
@@ -7012,7 +7017,7 @@ def cmd_gui(args: argparse.Namespace):
     except Exception:
         pass
 
-    from hermes_constants import with_hermes_node_path
+    from hermes_constants import node_cli_launch_for_shim, with_hermes_node_path
 
     # with_hermes_node_path() copies os.environ when called with no arg.
     env = with_hermes_node_path()
@@ -7121,7 +7126,12 @@ def cmd_gui(args: argparse.Namespace):
                 stopped = _stop_desktop_processes_locking_build(desktop_dir)
                 if stopped:
                     print(f"  ⚠ Stopped running desktop app to free the build output (pid {', '.join(map(str, stopped))})")
-            build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+            build_result = subprocess.run(
+                [*node_cli_launch_for_shim(npm), "run", build_script],
+                cwd=desktop_dir,
+                env=env,
+                check=False,
+            )
             if (
                 build_result.returncode != 0
                 and not source_mode
@@ -7148,7 +7158,12 @@ def cmd_gui(args: argparse.Namespace):
                     # The purge can't remove a win-unpacked tree whose Hermes.exe
                     # is still locked by a running instance; stop it before retry.
                     _stop_desktop_processes_locking_build(desktop_dir)
-                    build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=env, check=False)
+                    build_result = subprocess.run(
+                        [*node_cli_launch_for_shim(npm), "run", build_script],
+                        cwd=desktop_dir,
+                        env=env,
+                        check=False,
+                    )
             if (
                 build_result.returncode != 0
                 and not source_mode
@@ -7164,7 +7179,12 @@ def cmd_gui(args: argparse.Namespace):
                 if not _electron_dist_ok(PROJECT_ROOT):
                     _redownload_electron_dist(PROJECT_ROOT, env, mirror=mirror)
                 _stop_desktop_processes_locking_build(desktop_dir)
-                build_result = subprocess.run([npm, "run", build_script], cwd=desktop_dir, env=mirror_env, check=False)
+                build_result = subprocess.run(
+                    [*node_cli_launch_for_shim(npm), "run", build_script],
+                    cwd=desktop_dir,
+                    env=mirror_env,
+                    check=False,
+                )
             if build_result.returncode != 0:
                 print("✗ Desktop GUI build failed")
                 print(f"  Run manually:  cd apps/desktop && npm run {build_script}")
@@ -7227,7 +7247,12 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_result = subprocess.run([npm, "exec", "--", "electron", "."], cwd=desktop_dir, env=env, check=False)
+        launch_result = subprocess.run(
+            [*node_cli_launch_for_shim(npm), "exec", "--", "electron", "."],
+            cwd=desktop_dir,
+            env=env,
+            check=False,
+        )
         sys.exit(launch_result.returncode)
 
     if packaged_executable is None:

--- a/hermes_cli/npm_engine.py
+++ b/hermes_cli/npm_engine.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from hermes_constants import (
     bootstrap_hermes_managed_node,
     get_hermes_home,
+    node_cli_launch_for_shim,
     with_hermes_node_path,
 )
 
@@ -190,7 +191,7 @@ def upgrade_managed_npm(
         with tempfile.TemporaryDirectory(prefix="hermes-npm-upgrade-") as tmp:
             result = subprocess.run(
                 [
-                    npm,
+                    *node_cli_launch_for_shim(npm),
                     "install",
                     "--global",
                     "--prefix",
@@ -230,7 +231,7 @@ def upgrade_managed_npm(
 def _probe_version(npm: str) -> str | None:
     try:
         result = subprocess.run(
-            [npm, "--version"],
+            [*node_cli_launch_for_shim(npm), "--version"],
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -322,6 +322,43 @@ _managed_node_heal_attempted = False
 _NODE_BOOTSTRAP_SCRIPT = Path(__file__).resolve().parent / "scripts" / "lib" / "node-bootstrap.sh"
 
 
+def node_cli_launch_for_shim(path: str, *, windows: bool | None = None) -> list[str]:
+    """Windows: run npm/npx through ``node.exe`` instead of the ``.cmd`` shim.
+
+    ``CreateProcess`` cannot execute a ``.cmd``/``.bat`` batch file directly,
+    so Python's subprocess routes the launch through ``cmd.exe``. cmd.exe's
+    tokenizer treats Unicode whitespace — notably U+00A0 (non-breaking space),
+    which can appear in a Windows profile path such as
+    ``C:\\Users\\First<U+00A0>Last\\`` — as a word delimiter and truncates the
+    shim's own path, so the launch fails with rc 1 and "not recognized as an
+    internal or external command" even though the same command works from
+    PowerShell and the tree's ``node.exe`` runs fine (native executables are
+    launched by CreateProcess directly and handle Unicode paths).
+
+    Resolve the shim's real target instead — ``node.exe`` + the npm/npx CLI
+    script under ``<shim dir>/node_modules/<cli>/bin/<cli>-cli.js`` — which is
+    exactly what the shim itself executes. The layout is identical for
+    Hermes-managed trees (``$HERMES_HOME/node``), the Node.js installer
+    (``Program Files``), and nvm-windows. Falls back to the shim path when
+    the target files are missing, so every non-Windows and odd-layout caller
+    is unchanged.
+    """
+    if windows is None:
+        windows = sys.platform == "win32"
+    if not windows:
+        return [path]
+    shim = Path(path)
+    name = shim.name.lower()
+    for stem, cli_name in (("npm", "npm-cli.js"), ("npx", "npx-cli.js")):
+        if name in (f"{stem}.cmd", f"{stem}.bat", stem):
+            node_exe = shim.parent / "node.exe"
+            cli_js = shim.parent / "node_modules" / stem / "bin" / cli_name
+            if node_exe.is_file() and cli_js.is_file():
+                return [str(node_exe), str(cli_js)]
+            break
+    return [path]
+
+
 def node_tool_runnable(path: str | None) -> bool:
     """Return True only when *path* is a Node/npm/npx binary that actually runs.
 
@@ -349,8 +386,12 @@ def node_tool_runnable(path: str | None) -> bool:
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        # Launch .cmd/.bat shims via their node.exe target so cmd.exe never
+        # gets a chance to mangle the shim's own path (Unicode whitespace
+        # like U+00A0 in a profile path truncates under cmd.exe — see
+        # node_cli_launch_for_shim).
         result = subprocess.run(
-            [path, "--version"],
+            [*node_cli_launch_for_shim(path), "--version"],
             capture_output=True,
             timeout=10,
             env=with_hermes_node_path(),
@@ -715,8 +756,12 @@ def agent_browser_runnable(path: str | None) -> bool:
     try:
         from hermes_cli._subprocess_compat import windows_hide_flags
 
+        # Launch .cmd/.bat shims via their node.exe target so cmd.exe never
+        # gets a chance to mangle the shim's own path (Unicode whitespace
+        # like U+00A0 in a profile path truncates under cmd.exe — see
+        # node_cli_launch_for_shim).
         result = subprocess.run(
-            [path, "--version"],
+            [*node_cli_launch_for_shim(path), "--version"],
             capture_output=True,
             timeout=10,
             env=with_hermes_node_path(),

--- a/tests/hermes_cli/test_node_cli_launch.py
+++ b/tests/hermes_cli/test_node_cli_launch.py
@@ -1,0 +1,61 @@
+"""Unit tests for hermes_constants.node_cli_launch_for_shim.
+
+Regression for the Windows NBSP-in-profile-path bug: cmd.exe truncates batch
+shim paths containing Unicode whitespace (U+00A0), so npm/npx launches must
+be rewritten to node.exe + the CLI script, which CreateProcess runs natively
+(Unicode-safe). The ``windows`` flag keeps the derivation testable on POSIX.
+"""
+
+from hermes_constants import node_cli_launch_for_shim
+
+
+def _fake_node_tree(tmp_path):
+    node = tmp_path / "node"
+    (node / "node_modules" / "npm" / "bin").mkdir(parents=True)
+    (node / "node_modules" / "npx" / "bin").mkdir(parents=True)
+    (node / "node_modules" / "npm" / "bin" / "npm-cli.js").write_text("", encoding="utf-8")
+    (node / "node_modules" / "npx" / "bin" / "npx-cli.js").write_text("", encoding="utf-8")
+    (node / "node.exe").write_text("", encoding="utf-8")
+    (node / "npm.cmd").write_text("", encoding="utf-8")
+    (node / "npx.cmd").write_text("", encoding="utf-8")
+    return node
+
+
+def test_posix_path_never_rewritten():
+    assert node_cli_launch_for_shim("/usr/bin/npm", windows=False) == ["/usr/bin/npm"]
+
+
+def test_windows_npm_shim_resolves_to_node_launch(tmp_path):
+    node = _fake_node_tree(tmp_path)
+    shim = str(node / "npm.cmd")
+    assert node_cli_launch_for_shim(shim, windows=True) == [
+        str(node / "node.exe"),
+        str(node / "node_modules" / "npm" / "bin" / "npm-cli.js"),
+    ]
+
+
+def test_windows_npx_shim_resolves_to_node_launch(tmp_path):
+    node = _fake_node_tree(tmp_path)
+    shim = str(node / "npx.cmd")
+    assert node_cli_launch_for_shim(shim, windows=True) == [
+        str(node / "node.exe"),
+        str(node / "node_modules" / "npx" / "bin" / "npx-cli.js"),
+    ]
+
+
+def test_windows_native_exe_unchanged(tmp_path):
+    node = _fake_node_tree(tmp_path)
+    node_exe = str(node / "node.exe")
+    assert node_cli_launch_for_shim(node_exe, windows=True) == [node_exe]
+
+
+def test_windows_missing_targets_fall_back_to_shim(tmp_path):
+    shim = tmp_path / "npm.cmd"
+    shim.write_text("", encoding="utf-8")
+    assert node_cli_launch_for_shim(str(shim), windows=True) == [str(shim)]
+
+
+def test_windows_other_batch_shim_unchanged(tmp_path):
+    other = tmp_path / "tool.bat"
+    other.write_text("", encoding="utf-8")
+    assert node_cli_launch_for_shim(str(other), windows=True) == [str(other)]


### PR DESCRIPTION
## Summary

Fixes the Windows desktop update failure where the rebuild stage always dies with
"UPDATE DIDN'T FINISH — Rebuilding the desktop app failed (exit Some(1))" and
`hermes desktop` reports **"npm was not found on PATH"** — even though a complete,
healthy managed Node tree exists and npm works fine from PowerShell.

Root cause: the Windows profile path contains a **non-breaking space (U+00A0)**.
Every npm/npx launch through Python's subprocess routes the `.cmd` shim through
`cmd.exe`, whose tokenizer treats U+00A0 as a word delimiter and truncates the
shim's own path:

```
'C:\Users\LuisGustavoCouto' não é reconhecido como um comando interno ou externo...
(rc= 1, empty stdout — the path after the NBSP is silently dropped)
```

The managed-node probe (`node_tool_runnable`) then reports npm as not runnable,
the self-heal redownloads the same tree with the same result, and because a
managed tree is present, `find_node_executable` deliberately refuses the
system-PATH fallback (`hermes_constants.py:664`) — so every desktop rebuild
fails, every time. Native executables are unaffected: `node.exe --version` via
the same Python launch returns `rc= 0`.

## Fix

Resolve npm/npx batch shims to their real target and launch that instead:

```
node.exe <shim dir>/node_modules/<cli>/bin/<cli>-cli.js
```

`CreateProcess` launches native executables directly and handles Unicode paths,
so this sidesteps cmd.exe entirely. The layout is identical for Hermes-managed
trees (`$HERMES_HOME/node`), the Node.js installer (`Program Files`), and
nvm-windows; non-Windows platforms and missing-target layouts fall back to the
shim path unchanged.

New helper `node_cli_launch_for_shim()` in `hermes_constants.py`, applied at
every npm launch site in the desktop/update path:

- `node_tool_runnable()` and `agent_browser_runnable()` probes
- `_run_npm_install_deterministic()` (the `npm ci` / `npm install` helper used by web/TUI/desktop installs)
- the desktop build and source-launch invocations in `cmd_gui` (install, pack, retry, mirror fallback, `npm exec`)
- `npm_engine` upgrade and version probes

## Tests

- New: `tests/hermes_cli/test_node_cli_launch.py` — 6 unit tests covering the
  rewrite (npm/npx shims), native-exe passthrough, missing-target fallback, and
  POSIX no-op. All pass.
- Regression: `tests/hermes_cli/test_npm_engine.py` (20/20) and
  `tests/hermes_cli/test_tui_npm_install.py` (3/3) pass.
- Manual on the affected machine: `node.exe` + `npm-cli.js` launch works;
  the `.cmd` shim fails with rc 1 and the cmd.exe truncation error.

Fixes: https://github.com/NousResearch/hermes-agent/issues/80499