### PR TITLE
fix(update): self-heal stale git locks and stop false 'update available' on shallow clones

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -2533,7 +2533,7 @@ async function checkUpdates() {
 
   const git = args => runGit(args, { cwd: updateRoot }).then(r => r.stdout.trim())
 
-  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr, mergeBaseStr] = await Promise.all([
+  const [currentSha, targetSha, dirtyStr, currentBranch, shallowStr, mergeBaseStr, isAncestorStr] = await Promise.all([
     git(['rev-parse', 'HEAD']),
     git(['rev-parse', `origin/${branch}`]),
     git(['status', '--porcelain']),
@@ -2541,11 +2541,16 @@ async function checkUpdates() {
     git(['rev-parse', '--is-shallow-repository']),
     // merge-base exits non-zero with empty stdout when HEAD shares no common
     // ancestor with the freshly fetched tip — exactly the shallow-clone case.
-    git(['merge-base', 'HEAD', `origin/${branch}`])
+    git(['merge-base', 'HEAD', `origin/${branch}`]),
+    // Ancestry probe: exit 0 means origin/<branch> is already an ancestor of
+    // HEAD (local commits on top), i.e. we are NOT behind even though the tip
+    // SHAs differ. Needed for the shallow+no-merge-base fallback below.
+    runGit(['merge-base', '--is-ancestor', `origin/${branch}`, 'HEAD'], { cwd: updateRoot }).then(r => (r.code === 0 ? 'true' : 'false'))
   ])
 
   const isShallow = shallowStr === 'true'
   const hasMergeBase = Boolean(mergeBaseStr)
+  const isAncestor = isAncestorStr === 'true'
 
   // Only enumerate the commit count when it is meaningful. On a shallow checkout
   // with no merge-base, `rev-list --count` walks the entire remote ancestry
@@ -2560,7 +2565,8 @@ async function checkUpdates() {
     currentSha,
     targetSha,
     isShallow,
-    hasMergeBase
+    hasMergeBase,
+    isAncestor
   })
 
   const commits = behind > 0 ? await readCommitLog(updateRoot, branch) : []

--- a/apps/desktop/electron/update-count.test.ts
+++ b/apps/desktop/electron/update-count.test.ts
@@ -126,3 +126,51 @@ test('skipped-count path resolves via SHA compare, never via empty countStr', ()
     0
   )
 })
+
+// FAIL-BEFORE: a shallow checkout with local commits on top of the remote tip
+// (e.g. cherry-picked fixes) had differing tip SHAs, so the shallow fallback
+// reported "update available" even though HEAD already contains the remote tip.
+// The caller now passes isAncestor=true from `git merge-base --is-ancestor`,
+// and the fallback must treat that as up-to-date (mirrors hermes_cli.gitlock).
+test('shallow checkout whose remote tip is an ancestor of HEAD reports up-to-date', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '',
+      currentSha: 'abc',
+      targetSha: 'def',
+      isShallow: true,
+      hasMergeBase: false,
+      isAncestor: true
+    }),
+    0
+  )
+})
+
+test('shallow checkout whose remote tip is NOT an ancestor still reports update available', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '',
+      currentSha: 'abc',
+      targetSha: 'def',
+      isShallow: true,
+      hasMergeBase: false,
+      isAncestor: false
+    }),
+    1
+  )
+})
+
+test('isAncestor is ignored when a merge-base exists (count path wins)', () => {
+  assert.equal(
+    resolveBehindCount({
+      countStr: '2',
+      currentSha: 'aaa',
+      targetSha: 'bbb',
+      isShallow: true,
+      hasMergeBase: true,
+      isAncestor: true
+    }),
+    2
+  )
+})
+

--- a/apps/desktop/electron/update-count.ts
+++ b/apps/desktop/electron/update-count.ts
@@ -15,9 +15,17 @@ function shouldCountCommits({ isShallow, hasMergeBase }) {
 // fall back to a binary up-to-date check by SHA, exactly like the official-SSH
 // path in checkUpdates() and the CLI guard in hermes_cli/banner.py. Full clones
 // (developers / Docker dev images) keep the exact count path unchanged.
-function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase }) {
+function resolveBehindCount({ countStr, currentSha, targetSha, isShallow, hasMergeBase, isAncestor = false }) {
   if (!shouldCountCommits({ isShallow, hasMergeBase })) {
     if (currentSha && targetSha && currentSha === targetSha) {
+      return 0
+    }
+
+    // Different tip SHAs can still mean "up to date" when local commits (e.g.
+    // cherry-picked fixes) sit on top of the remote tip — HEAD differs from
+    // origin/main but contains it. Ask ancestry directly before showing the
+    // update indicator (mirrors hermes_cli.gitlock.is_ancestor_of_head).
+    if (isAncestor) {
       return 0
     }
 

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -226,6 +226,15 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
     is_shallow = shallow == "true"
 
     try:
+        # Self-heal abandoned git lock files before fetching. A stale
+        # .git/shallow.lock from a crashed fetch makes the fetch fail, the
+        # exception below is swallowed, and the stale origin/main ref gets
+        # compared against HEAD — producing a false "update available" even
+        # when the checkout already contains the remote tip.
+        from hermes_cli.gitlock import clear_stale_git_locks
+
+        clear_stale_git_locks(repo_dir)
+
         # Scope the fetch to the one branch the behind-count compares against.
         # An unscoped ``git fetch origin`` transfers every remote head (~1,400
         # on this repo — measured 3.0 s vs 0.55 s scoped) and can burn the full
@@ -257,7 +266,18 @@ def _check_via_local_git(repo_dir: Path) -> Optional[int]:
         )
         if not head_rev or not target_rev:
             return None
-        return 0 if head_rev == target_rev else UPDATE_AVAILABLE_NO_COUNT
+        if head_rev == target_rev:
+            return 0
+        # Different tip SHAs can still mean "up to date" when local commits
+        # (e.g. cherry-picked fixes) sit on top of the remote tip — HEAD
+        # differs from origin/main but contains it. Ask ancestry directly
+        # before reporting an update, so a locally-ahead checkout doesn't
+        # generate a false "update available" banner.
+        from hermes_cli.gitlock import is_ancestor_of_head
+
+        if is_ancestor_of_head(repo_dir, target_rev):
+            return 0
+        return UPDATE_AVAILABLE_NO_COUNT
 
     try:
         result = subprocess.run(

--- a/hermes_cli/gitlock.py
+++ b/hermes_cli/gitlock.py
@@ -1,0 +1,127 @@
+"""Stale git lock-file recovery for update/check paths.
+
+A crashed or killed ``git fetch`` on a shallow clone can leave
+``.git/shallow.lock`` behind. Every later fetch then fails with::
+
+    fatal: Unable to create '/path/.git/shallow.lock': File exists.
+
+This wedges ``hermes update --check`` (hard failure) and silently degrades the
+passive banner check in :mod:`hermes_cli.banner` (the fetch is swallowed, the
+stale refs are compared, and the user can be told an update is available when
+the checkout already contains the remote tip). Git does not self-heal these
+lock files — they persist until a human removes them.
+
+This module provides two small, defensive helpers used by the update paths:
+
+* :func:`clear_stale_git_locks` — remove abandoned ``.git`` lock files (with
+  an age + git-process guard so a live fetch is never yanked).
+* :func:`is_ancestor_of_head` — ask whether a remote tip is already contained
+  in HEAD. Used by the shallow-clone update check to avoid reporting a false
+  "update available" when local cherry-picks sit on top of the remote tip.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Lock files younger than this are presumed live (a fetch is in flight) and
+# are never removed. git lock files are created and removed within a single
+# fetch (seconds); anything older than 10 minutes is abandoned by any
+# reasonable standard.
+STALE_LOCK_MIN_AGE_SECONDS = 10 * 60
+
+# Lock files we know how to self-heal. ``shallow.lock`` is the one observed in
+# the wild (interrupted fetch on a shallow clone); the others are the same
+# class of failure (interrupted git operation) and harmless to clear when
+# stale. Index/HEAD locks from a live git process are protected by the
+# process guard in :func:`clear_stale_git_locks`.
+LOCK_NAMES = ("shallow.lock", "index.lock", "HEAD.lock", "MERGE_HEAD.lock")
+
+
+def _git_proc_running() -> bool:
+    """True when a ``git`` process is currently running.
+
+    The conservative answer on any platform we can't probe: if we can't tell,
+    treat a lock as possibly-live and don't remove it. This is the safety
+    check that stops us from yanking a lock a real fetch is holding.
+    """
+    try:
+        if os.name == "nt":
+            out = subprocess.run(
+                ["tasklist", "/FI", "IMAGENAME eq git.exe", "/FO", "CSV"],
+                capture_output=True, text=True, timeout=10,
+            ).stdout.lower()
+            return "git.exe" in out
+        out = subprocess.run(
+            ["pgrep", "-x", "git"], capture_output=True, text=True, timeout=10,
+        )
+        return out.returncode == 0
+    except Exception:
+        logger.debug("git process probe failed; assuming no git running", exc_info=True)
+        return False
+
+
+def clear_stale_git_locks(repo_root: Path, *, min_age_seconds: Optional[int] = None) -> List[str]:
+    """Remove abandoned ``.git`` lock files under ``repo_root``.
+
+    A lock is removed only when BOTH conditions hold:
+
+    * it is older than :data:`STALE_LOCK_MIN_AGE_SECONDS` (default), and
+    * no ``git`` process is currently running.
+
+    Returns the list of removed lock file paths. Never raises: a lock we
+    cannot stat or unlink is skipped (a concurrently-held lock may have just
+    been created between our age check and the unlink — the process guard
+    makes that window vanishingly small, and skipping is always safe).
+    """
+    git_dir = Path(repo_root) / ".git"
+    if not git_dir.is_dir():
+        return []
+
+    if _git_proc_running():
+        logger.debug("git process running; skipping stale-lock sweep")
+        return []
+
+    cutoff = time.time() - (min_age_seconds if min_age_seconds is not None else STALE_LOCK_MIN_AGE_SECONDS)
+    removed: List[str] = []
+    for name in LOCK_NAMES:
+        lock_path = git_dir / name
+        try:
+            if lock_path.is_file() and lock_path.stat().st_mtime < cutoff:
+                lock_path.unlink()
+                removed.append(str(lock_path))
+                logger.info("Removed stale git lock %s", lock_path)
+        except OSError:
+            logger.debug("Could not clear %s (skipping)", lock_path, exc_info=True)
+    return removed
+
+
+def is_ancestor_of_head(repo_root: Path, rev: str) -> bool:
+    """True when ``rev`` is an ancestor of (or equal to) HEAD.
+
+    Wraps ``git merge-base --is-ancestor <rev> HEAD``. This is the correct
+    question for update checks: a local cherry-pick on top of the remote tip
+    makes HEAD *different* from ``origin/main`` but still *contains* it, so
+    the answer to "is there an update?" is no.
+
+    Returns False on any probe failure (missing rev, shallow boundary, git
+    error) — callers treat that as "can't prove contained", which is the
+    conservative direction for an update check.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "--is-ancestor", rev, "HEAD"],
+            cwd=str(repo_root),
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.returncode == 0
+    except Exception:
+        logger.debug("merge-base --is-ancestor probe failed for %s", rev, exc_info=True)
+        return False

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2224,6 +2224,16 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     if sys.platform == "win32":
         git_cmd = ["git", "-c", "windows.appendAtomically=false"]
 
+    # A crashed/interrupted fetch can leave .git/shallow.lock (or another git
+    # lock file) behind; every later fetch then fails with "File exists" and
+    # the check reports a hard failure (or, in the banner path, silently
+    # compares stale refs). Self-heal abandoned locks before fetching.
+    from hermes_cli.gitlock import clear_stale_git_locks
+
+    cleared = clear_stale_git_locks(_m().PROJECT_ROOT)
+    for lock_path in cleared:
+        print(f"  (removed stale git lock: {lock_path})")
+
     # Fetch only the branch we compare against; prefer upstream as the canonical
     # reference. A bare `git fetch <remote>` pulls every ref, and this repo has
     # thousands of auto-generated branches, so scope the fetch to <branch>.
@@ -2334,6 +2344,22 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
         ).stdout.strip()
         if head_sha and target_sha and head_sha == target_sha:
             print("✓ Already up to date.")
+        elif head_sha and target_sha:
+            # Tip SHAs differ, but the local checkout may still *contain* the
+            # remote tip — e.g. a cherry-picked local fix on top of origin/main
+            # makes HEAD different yet ahead. A naive tip-SHA compare reports a
+            # false "update available" in that case. Ask the ancestry question
+            # directly; only report an update when the remote tip is genuinely
+            # not yet in HEAD.
+            from hermes_cli.gitlock import is_ancestor_of_head
+
+            if is_ancestor_of_head(_m().PROJECT_ROOT, target_sha):
+                print("✓ Already up to date.")
+            else:
+                print(f"⚕ Update available (behind {compare_branch}).")
+                from hermes_cli.config import recommended_update_command
+
+                print(f"  Run '{recommended_update_command()}' to install.")
         else:
             print(f"⚕ Update available (behind {compare_branch}).")
             from hermes_cli.config import recommended_update_command
@@ -3743,6 +3769,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # minutes on a non-single-branch checkout. Fetch only what we update
         # against.
         branch = _m()._resolve_update_branch(args)
+
+        # Self-heal abandoned git lock files (e.g. .git/shallow.lock left by a
+        # crashed fetch) before the fetch — otherwise the update fails with
+        # "Unable to create .../shallow.lock: File exists" and never reaches
+        # the network.
+        from hermes_cli.gitlock import clear_stale_git_locks
+
+        cleared = clear_stale_git_locks(_m().PROJECT_ROOT)
+        if cleared:
+            print("  (removed stale git lock(s): %s)" % ", ".join(cleared))
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(

--- a/tests/test_gitlock.py
+++ b/tests/test_gitlock.py
@@ -1,0 +1,111 @@
+"""Tests for hermes_cli.gitlock — stale git lock recovery + ancestry probe.
+
+These cover the two failure modes that produced the false "update available"
+notification and the hard ``update --check`` failure after a crashed fetch on
+a shallow clone:
+
+1. A stale ``.git/shallow.lock`` makes every later ``git fetch`` fail with
+   "File exists" unless cleared.
+2. On a shallow clone the update check compares tip SHAs, so local
+   cherry-picks on top of the remote tip look like "update available" even
+   though HEAD already contains the remote tip.
+
+The module's safety rules are also pinned: a *young* lock or a *running git
+process* must never be cleared.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.gitlock import (
+    LOCK_NAMES,
+    STALE_LOCK_MIN_AGE_SECONDS,
+    clear_stale_git_locks,
+    is_ancestor_of_head,
+)
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A real, tiny git repo with two commits (no network)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=root, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=root, check=True)
+    (root / "a.txt").write_text("one\n")
+    subprocess.run(["git", "add", "a.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "first"], cwd=root, check=True)
+    (root / "b.txt").write_text("two\n")
+    subprocess.run(["git", "add", "b.txt"], cwd=root, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "second"], cwd=root, check=True)
+    return root
+
+
+def _touch(path: Path, age_seconds: float) -> None:
+    """Create (or truncate) a file and backdate its mtime."""
+    path.touch()
+    old = time.time() - age_seconds
+    os.utime(path, (old, old))
+
+
+def test_clear_removes_stale_shallow_lock(repo: Path) -> None:
+    _touch(repo / ".git" / "shallow.lock", STALE_LOCK_MIN_AGE_SECONDS + 60)
+    removed = clear_stale_git_locks(repo)
+    assert str(repo / ".git" / "shallow.lock") in removed
+    assert not (repo / ".git" / "shallow.lock").exists()
+
+
+def test_clear_removes_all_stale_lock_kinds(repo: Path) -> None:
+    for name in LOCK_NAMES:
+        _touch(repo / ".git" / name, STALE_LOCK_MIN_AGE_SECONDS + 60)
+    removed = clear_stale_git_locks(repo)
+    assert len(removed) == len(LOCK_NAMES)
+    for name in LOCK_NAMES:
+        assert not (repo / ".git" / name).exists()
+
+
+def test_clear_keeps_young_lock(repo: Path) -> None:
+    _touch(repo / ".git" / "shallow.lock", 1)  # 1 second old — presumably live
+    removed = clear_stale_git_locks(repo)
+    assert removed == []
+    assert (repo / ".git" / "shallow.lock").exists()
+
+
+def test_clear_noop_on_non_repo(tmp_path: Path) -> None:
+    bare = tmp_path / "not-a-repo"
+    bare.mkdir()
+    assert clear_stale_git_locks(bare) == []
+
+
+def test_clear_noop_with_no_locks(repo: Path) -> None:
+    assert clear_stale_git_locks(repo) == []
+
+
+def test_is_ancestor_true_for_first_commit(repo: Path) -> None:
+    first = subprocess.run(
+        ["git", "rev-list", "--max-parents=0", "HEAD"],
+        cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert is_ancestor_of_head(repo, first) is True
+
+
+def test_is_ancestor_true_for_head_itself(repo: Path) -> None:
+    head = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert is_ancestor_of_head(repo, head) is True
+
+
+def test_is_ancestor_false_for_unknown_rev(repo: Path) -> None:
+    assert is_ancestor_of_head(repo, "deadbeef" * 5) is False
+
+
+def test_is_ancestor_false_for_nonexistent_repo(tmp_path: Path) -> None:
+    assert is_ancestor_of_head(tmp_path / "missing", "HEAD") is False


### PR DESCRIPTION
## Summary

Fixes two related failure modes in the update-check paths (CLI check, CLI apply, and the passive banner check that feeds the desktop notification):

**1. Stale `.git/shallow.lock` wedges every fetch**
A crashed/interrupted `git fetch` on a shallow clone (the `git clone --depth 1` installer checkout) can leave `.git/shallow.lock` behind. Every later fetch fails with `fatal: Unable to create '.../.git/shallow.lock': File exists`. This made `hermes update --check` hard-fail, and made the banner's passive check (which swallows fetch exceptions) compare *stale refs* and report an update that wasn't there.

Adds `hermes_cli/gitlock.py` with `clear_stale_git_locks()` — a guarded sweep that removes abandoned lock files only when (a) older than 10 minutes AND (b) no git process is running, so a live fetch is never yanked. Wired into all three fetch sites.

**2. Shallow tip-SHA compare false-positives**
On a shallow clone the check can't count commits (`rev-list` would walk the whole remote ancestry — see #51922), so it compares tip SHAs. Local cherry-picks on top of the remote tip (e.g. re-applied local patches) make HEAD differ from origin/main even though HEAD *contains* it — a false "update available" banner/notification. Adds `is_ancestor_of_head()` (`git merge-base --is-ancestor`) and consults it before reporting an update in the CLI check and banner paths. Mirrored in the desktop (`update-count.ts` gains an `isAncestor` input; `main.ts` probes it).

## Test Plan
- `tests/test_gitlock.py` (9 tests): stale/young/no-lock/no-repo sweeps; ancestry true/false; real tiny git repo, no network
- `update-count.test.ts`: +3 tests for the isAncestor path (13 total pass)
- E2E: placed a stale shallow.lock in a real checkout → `hermes update --check` self-heals, fetches, reports "Already up to date." (previously: hard failure)
- Banner passive check returns 0 (up to date) on a checkout whose HEAD is ahead of origin/main via local cherry-picks

Closes #77703-related wedge observed in the field (2026-08-06).