### PR TITLE
fix(hindsight): flush final append batches reliably

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -790,6 +790,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # futures after interpreter shutdown" / "Unclosed client session".
         self._retain_queue: queue.Queue = queue.Queue()
         self._writer_thread: threading.Thread | None = None
+        self._writer_lock = threading.Lock()
         self._shutting_down = threading.Event()
         self._atexit_registered = False
         # Server-side async retain operations still in flight. With
@@ -837,10 +838,15 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
-        # How many turns the last append-mode retain already shipped. Used to
-        # send only the new delta on subsequent retains when the API supports
-        # update_mode='append' (legacy/overwrite path still sends everything).
-        self._last_retained_turn_count = 0
+        self._session_state_lock = threading.RLock()
+        # Append-mode work is queued asynchronously. Track reservations and
+        # confirmed writes per local buffer epoch. A stable Hindsight document
+        # can be revisited after /resume or reset in place; generation-scoped
+        # progress prevents the prior epoch's watermark from dropping new turns.
+        self._append_progress_lock = threading.Lock()
+        self._append_epoch = 0
+        self._append_enqueued_turn_counts: Dict[tuple[str, int], int] = {}
+        self._append_retained_turn_counts: Dict[tuple[str, int], int] = {}
 
         # Recall controls
         self._auto_recall = True
@@ -1281,28 +1287,29 @@ class HindsightMemoryProvider(MemoryProvider):
             )
         )
 
-    def _ensure_writer(self) -> None:
+    def _ensure_writer(self) -> bool:
         """Lazy-start the single retain-writer thread.
 
         We don't start the writer in initialize() so providers that never
         retain (e.g. tools-only mode) don't pay for an idle thread.
         """
-        thread = self._writer_thread
-        if thread is not None and thread.is_alive():
-            return
-        # If the previous writer exited (e.g. after a prior shutdown), reset
-        # the flag so this fresh writer is allowed to drain new jobs.
-        self._shutting_down.clear()
-        thread = threading.Thread(
-            target=self._writer_loop,
-            daemon=True,
-            name="hindsight-writer",
-        )
-        self._writer_thread = thread
-        # Keep the legacy _sync_thread alias pointing at the writer so any
-        # external code that joins _sync_thread keeps working.
-        self._sync_thread = thread
-        thread.start()
+        with self._writer_lock:
+            if self._shutting_down.is_set():
+                return False
+            thread = self._writer_thread
+            if thread is not None and thread.is_alive():
+                return True
+            thread = threading.Thread(
+                target=self._writer_loop,
+                daemon=True,
+                name="hindsight-writer",
+            )
+            self._writer_thread = thread
+            # Keep the legacy _sync_thread alias pointing at the writer so any
+            # external code that joins _sync_thread keeps working.
+            self._sync_thread = thread
+            thread.start()
+            return True
 
     def _track_retain_ops(self, retain_response, bank_id: str) -> None:
         """Record server-side async operation id(s) from an aretain_batch reply.
@@ -1614,7 +1621,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
-        self._last_retained_turn_count = 0
+        with self._append_progress_lock:
+            self._append_epoch = 0
+            self._append_enqueued_turn_counts.clear()
+            self._append_retained_turn_counts.clear()
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -2048,6 +2058,191 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
+    def _append_progress_key(
+        self, document_id: str, epoch: int | None = None
+    ) -> tuple[str, int]:
+        return (
+            document_id,
+            self._append_epoch if epoch is None else epoch,
+        )
+
+    def _append_enqueued_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_enqueued_turn_counts.get(key, 0)
+
+    def _append_retained_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_retained_turn_counts.get(key, 0)
+
+    def _reserve_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_enqueued_turn_counts[key] = max(
+                self._append_enqueued_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _confirm_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_retained_turn_counts[key] = max(
+                self._append_retained_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _release_failed_append_reservation(
+        self,
+        document_id: str,
+        target_count: int,
+        epoch: int | None = None,
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            enqueued = self._append_enqueued_turn_counts.get(key, 0)
+            if enqueued <= target_count:
+                retained = self._append_retained_turn_counts.get(key, 0)
+                self._append_enqueued_turn_counts[key] = retained
+
+    def _enqueue_session_retain(
+        self,
+        turns: List[str],
+        *,
+        document_id: str,
+        update_mode: str | None,
+        session_id: str,
+        parent_session_id: str,
+        turn_index: int,
+        reason: str,
+        append_backup: bool = False,
+    ) -> bool:
+        """Queue one serialized session retain and track append durability.
+
+        Append-capable servers need only the delta after the last confirmed
+        write in the current local buffer epoch. Reservations prevent
+        overlapping jobs from duplicating deltas, while confirmation happens
+        only after ``aretain_batch`` succeeds. ``append_backup`` queues a
+        no-op-or-retry job for finalization paths when an earlier append may
+        still be in flight.
+        """
+        if not turns or self._shutting_down.is_set():
+            return False
+
+        target_count = len(turns)
+        append_epoch = 0
+        if update_mode == "append":
+            with self._append_progress_lock:
+                append_epoch = self._append_epoch
+            enqueued_count = self._append_enqueued_count(document_id, append_epoch)
+            retained_count = self._append_retained_count(document_id, append_epoch)
+            if enqueued_count >= target_count:
+                if not append_backup or retained_count >= target_count:
+                    return False
+            self._reserve_append_turns(document_id, target_count, append_epoch)
+
+        lineage_tags: list[str] = []
+        if session_id:
+            lineage_tags.append(f"session:{session_id}")
+        if parent_session_id:
+            lineage_tags.append(f"parent:{parent_session_id}")
+
+        metadata_base = self._build_metadata(
+            message_count=target_count * 2,
+            turn_index=turn_index,
+        )
+        if session_id:
+            metadata_base["session_id"] = session_id
+        else:
+            metadata_base.pop("session_id", None)
+        bank_id = self._bank_id
+        retain_async_flag = self._retain_async
+        retain_context = self._retain_context
+
+        def _do_retain() -> None:
+            if update_mode == "append":
+                start = self._append_retained_count(document_id, append_epoch)
+                turns_to_retain = turns[start:target_count]
+                if not turns_to_retain:
+                    logger.debug(
+                        "Hindsight %s: append already confirmed for doc=%s",
+                        reason,
+                        document_id,
+                    )
+                    return
+            else:
+                turns_to_retain = turns
+
+            content = "[" + ",".join(turns_to_retain) + "]"
+            metadata = dict(metadata_base)
+            metadata["message_count"] = str(len(turns_to_retain) * 2)
+            item = self._build_retain_kwargs(
+                content,
+                context=retain_context,
+                metadata=metadata,
+                tags=lineage_tags or None,
+            )
+            item.pop("bank_id", None)
+            item.pop("retain_async", None)
+            if update_mode is not None:
+                item["update_mode"] = update_mode
+
+            logger.debug(
+                "Hindsight %s: bank=%s, doc=%s, mode=%s, async=%s, num_turns=%d",
+                reason,
+                bank_id,
+                document_id,
+                update_mode,
+                retain_async_flag,
+                len(turns_to_retain),
+            )
+            try:
+                resp = self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=retain_async_flag,
+                    )
+                )
+                if retain_async_flag:
+                    self._track_retain_ops(resp, bank_id)
+            except Exception:
+                if update_mode == "append":
+                    self._release_failed_append_reservation(
+                        document_id, target_count, append_epoch
+                    )
+                raise
+            if update_mode == "append":
+                self._confirm_append_turns(
+                    document_id, target_count, append_epoch
+                )
+
+        try:
+            if not self._ensure_writer():
+                if update_mode == "append":
+                    self._release_failed_append_reservation(
+                        document_id, target_count, append_epoch
+                    )
+                return False
+            self._register_atexit()
+            self._retain_queue.put(_do_retain)
+        except Exception:
+            if update_mode == "append":
+                self._release_failed_append_reservation(
+                    document_id, target_count, append_epoch
+                )
+            raise
+        return True
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
@@ -2056,101 +2251,51 @@ class HindsightMemoryProvider(MemoryProvider):
         further sync_turn() calls are dropped — this prevents post-exit
         retains from reaching aiohttp after interpreter shutdown begins.
         """
-        if not self._auto_retain:
-            logger.debug("sync_turn: skipped (auto_retain disabled)")
-            return
-        if self._shutting_down.is_set():
-            logger.debug("sync_turn: skipped (shutting down)")
-            return
-
-        if session_id:
-            self._session_id = str(session_id).strip()
-
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
-        self._session_turns.append(turn)
-        self._turn_counter += 1
-        self._turn_index = self._turn_counter
-
-        if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
-                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
-            return
-
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
-
-        # On append-capable APIs each retain only needs to ship the turns
-        # accumulated since the last retain — the server appends them to the
-        # existing document. On legacy/overwrite APIs we must resend the whole
-        # session because each retain replaces the document.
-        if update_mode == "append":
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
-            if not turns_to_retain:
-                logger.debug("sync_turn: skipped append retain; no new turns since last retain")
+        with self._session_state_lock:
+            if not self._auto_retain:
+                logger.debug("sync_turn: skipped (auto_retain disabled)")
                 return
-        else:
-            turns_to_retain = list(self._session_turns)
+            if self._shutting_down.is_set():
+                logger.debug("sync_turn: skipped (shutting down)")
+                return
 
-        logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
-                     len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
+            if session_id:
+                self._session_id = str(session_id).strip()
 
-        lineage_tags: list[str] = []
-        if self._session_id:
-            lineage_tags.append(f"session:{self._session_id}")
-        if self._parent_session_id:
-            lineage_tags.append(f"parent:{self._parent_session_id}")
-
-        # Snapshot the state needed for the retain. The writer may run after
-        # _session_turns / _turn_index are mutated by a later sync_turn().
-        metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
-            turn_index=self._turn_index,
-        )
-        num_turns = len(turns_to_retain)
-        bank_id = self._bank_id
-        retain_async_flag = self._retain_async
-        retain_context = self._retain_context
-
-        def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
+            turn = json.dumps(
+                self._build_turn_messages(user_content, assistant_content),
+                ensure_ascii=False,
             )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            resp = self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
+            self._session_turns.append(turn)
+            self._turn_counter += 1
+            self._turn_index = self._turn_counter
+
+            if self._turn_counter % self._retain_every_n_turns != 0:
+                logger.debug(
+                    "sync_turn: buffered turn %d (will retain at turn %d)",
+                    self._turn_counter,
+                    self._turn_counter
+                    + (
+                        self._retain_every_n_turns
+                        - self._turn_counter % self._retain_every_n_turns
+                    ),
                 )
-            )
-            # For async retains the write is only *accepted* here; track the
-            # returned operation id(s) so the next-turn prefetch can wait for
-            # true server-side completion (read-after-write) before recalling.
-            if retain_async_flag:
-                self._track_retain_ops(resp, bank_id)
-            logger.debug("Hindsight retain succeeded")
+                return
 
-        self._ensure_writer()
-        self._register_atexit()
-        # Deterministic "saving to memory" indicator — emitted the moment a
-        # real retain is dispatched (past every skip/buffer gate above), so it
-        # only fires on turns that actually persist.
-        self._emit_saving_indicator()
-        self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+            document_id, update_mode = self._resolve_retain_target(self._document_id)
+            enqueued = self._enqueue_session_retain(
+                list(self._session_turns),
+                document_id=document_id,
+                update_mode=update_mode,
+                session_id=self._session_id,
+                parent_session_id=self._parent_session_id,
+                turn_index=self._turn_index,
+                reason="retain",
+            )
+            # Deterministic "saving to memory" indicator — emitted only after
+            # a real retain job passes all skip/reservation gates and is queued.
+            if enqueued:
+                self._emit_saving_indicator()
 
     def _emit_saving_indicator(self) -> None:
         """Surface a model-independent "saving to memory" status line.
@@ -2245,6 +2390,46 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def _finalize_session_buffer(self, *, reason: str) -> None:
+        """Queue the current suffix and start a fresh local append epoch."""
+        if (
+            not self._auto_retain
+            or self._shutting_down.is_set()
+            or not self._session_turns
+        ):
+            return
+
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        # Legacy servers overwrite the whole document at each boundary. An
+        # exact-boundary retain is already queued, so only partial batches need
+        # another overwrite. Append mode also needs a backup job: an exact-
+        # boundary append may still be queued and can fail before shutdown.
+        needs_retain = (
+            update_mode == "append"
+            or self._turn_counter % self._retain_every_n_turns != 0
+        )
+        if needs_retain:
+            self._enqueue_session_retain(
+                list(self._session_turns),
+                document_id=document_id,
+                update_mode=update_mode,
+                session_id=self._session_id,
+                parent_session_id=self._parent_session_id,
+                turn_index=self._turn_index,
+                reason=reason,
+                append_backup=update_mode == "append",
+            )
+        with self._append_progress_lock:
+            self._append_epoch += 1
+        self._session_turns = []
+        self._turn_counter = 0
+        self._turn_index = 0
+
+    def on_session_end(self, messages: list, **kwargs) -> None:
+        """Flush turns left below the retain boundary before provider shutdown."""
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-end")
+
     def on_session_switch(
         self,
         new_session_id: str,
@@ -2288,97 +2473,37 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
-
-        # 2. Drain any in-flight prefetch from the old session and drop
+        # 1. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
 
-        # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
-        self._session_id = new_id
-        start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        self._document_id = f"{self._session_id}-{start_ts}"
-        self._session_turns = []
-        self._turn_counter = 0
-        self._turn_index = 0
-        self._last_retained_turn_count = 0
-        logger.debug(
-            "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
-            self._session_id, self._parent_session_id, reset, self._document_id,
-        )
+        # 2. Flush and rotate atomically with sync_turn(). Stable Hindsight
+        # document IDs may be revisited (A -> B -> A) or unchanged by an
+        # in-place reset, so each newly empty local buffer needs a fresh epoch.
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-switch")
+            if parent_session_id:
+                self._parent_session_id = str(parent_session_id).strip()
+            self._session_id = new_id
+            start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            self._document_id = f"{self._session_id}-{start_ts}"
+            logger.debug(
+                "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
+                self._session_id, self._parent_session_id, reset, self._document_id,
+            )
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting new retain jobs first so anyone still calling
-        # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
+        # MemoryManager drains its FIFO before calling provider shutdown. Flush
+        # once more here because a queued sync_turn may have arrived after the
+        # earlier on_session_end hook. Setting the event under the same lock
+        # prevents a new turn from appearing between finalization and teardown.
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-shutdown")
+            self._shutting_down.set()
         # Drain the writer: it will finish in-flight work, then exit on
         # the sentinel. Bounded join keeps shutdown predictable even if
         # the daemon is wedged.

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -727,6 +727,7 @@ class HindsightMemoryProvider(MemoryProvider):
         # futures after interpreter shutdown" / "Unclosed client session".
         self._retain_queue: queue.Queue = queue.Queue()
         self._writer_thread: threading.Thread | None = None
+        self._writer_lock = threading.Lock()
         self._shutting_down = threading.Event()
         self._atexit_registered = False
         # Server-side async retain operations still in flight. With
@@ -774,10 +775,15 @@ class HindsightMemoryProvider(MemoryProvider):
         self._retain_context = "conversation between Hermes Agent and the User"
         self._turn_counter = 0
         self._session_turns: list[str] = []  # accumulates ALL turns for the session
-        # How many turns the last append-mode retain already shipped. Used to
-        # send only the new delta on subsequent retains when the API supports
-        # update_mode='append' (legacy/overwrite path still sends everything).
-        self._last_retained_turn_count = 0
+        self._session_state_lock = threading.RLock()
+        # Append-mode work is queued asynchronously. Track reservations and
+        # confirmed writes per local buffer epoch. A stable Hindsight document
+        # can be revisited after /resume or reset in place; generation-scoped
+        # progress prevents the prior epoch's watermark from dropping new turns.
+        self._append_progress_lock = threading.Lock()
+        self._append_epoch = 0
+        self._append_enqueued_turn_counts: Dict[tuple[str, int], int] = {}
+        self._append_retained_turn_counts: Dict[tuple[str, int], int] = {}
 
         # Recall controls
         self._auto_recall = True
@@ -1170,28 +1176,29 @@ class HindsightMemoryProvider(MemoryProvider):
             )
         )
 
-    def _ensure_writer(self) -> None:
+    def _ensure_writer(self) -> bool:
         """Lazy-start the single retain-writer thread.
 
         We don't start the writer in initialize() so providers that never
         retain (e.g. tools-only mode) don't pay for an idle thread.
         """
-        thread = self._writer_thread
-        if thread is not None and thread.is_alive():
-            return
-        # If the previous writer exited (e.g. after a prior shutdown), reset
-        # the flag so this fresh writer is allowed to drain new jobs.
-        self._shutting_down.clear()
-        thread = threading.Thread(
-            target=self._writer_loop,
-            daemon=True,
-            name="hindsight-writer",
-        )
-        self._writer_thread = thread
-        # Keep the legacy _sync_thread alias pointing at the writer so any
-        # external code that joins _sync_thread keeps working.
-        self._sync_thread = thread
-        thread.start()
+        with self._writer_lock:
+            if self._shutting_down.is_set():
+                return False
+            thread = self._writer_thread
+            if thread is not None and thread.is_alive():
+                return True
+            thread = threading.Thread(
+                target=self._writer_loop,
+                daemon=True,
+                name="hindsight-writer",
+            )
+            self._writer_thread = thread
+            # Keep the legacy _sync_thread alias pointing at the writer so any
+            # external code that joins _sync_thread keeps working.
+            self._sync_thread = thread
+            thread.start()
+            return True
 
     def _track_retain_ops(self, retain_response, bank_id: str) -> None:
         """Record server-side async operation id(s) from an aretain_batch reply.
@@ -1498,7 +1505,10 @@ class HindsightMemoryProvider(MemoryProvider):
         self._agent_workspace = str(kwargs.get("agent_workspace") or "").strip()
         self._turn_index = 0
         self._session_turns = []
-        self._last_retained_turn_count = 0
+        with self._append_progress_lock:
+            self._append_epoch = 0
+            self._append_enqueued_turn_counts.clear()
+            self._append_retained_turn_counts.clear()
         self._mode = self._config.get("mode", "cloud")
         # Read timeout from config or env var, fall back to default
         self._timeout = _parse_int_setting(
@@ -1859,6 +1869,191 @@ class HindsightMemoryProvider(MemoryProvider):
             kwargs["observation_scopes"] = self._observation_scopes
         return kwargs
 
+    def _append_progress_key(
+        self, document_id: str, epoch: int | None = None
+    ) -> tuple[str, int]:
+        return (
+            document_id,
+            self._append_epoch if epoch is None else epoch,
+        )
+
+    def _append_enqueued_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_enqueued_turn_counts.get(key, 0)
+
+    def _append_retained_count(
+        self, document_id: str, epoch: int | None = None
+    ) -> int:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            return self._append_retained_turn_counts.get(key, 0)
+
+    def _reserve_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_enqueued_turn_counts[key] = max(
+                self._append_enqueued_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _confirm_append_turns(
+        self, document_id: str, target_count: int, epoch: int | None = None
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            self._append_retained_turn_counts[key] = max(
+                self._append_retained_turn_counts.get(key, 0),
+                target_count,
+            )
+
+    def _release_failed_append_reservation(
+        self,
+        document_id: str,
+        target_count: int,
+        epoch: int | None = None,
+    ) -> None:
+        with self._append_progress_lock:
+            key = self._append_progress_key(document_id, epoch)
+            enqueued = self._append_enqueued_turn_counts.get(key, 0)
+            if enqueued <= target_count:
+                retained = self._append_retained_turn_counts.get(key, 0)
+                self._append_enqueued_turn_counts[key] = retained
+
+    def _enqueue_session_retain(
+        self,
+        turns: List[str],
+        *,
+        document_id: str,
+        update_mode: str | None,
+        session_id: str,
+        parent_session_id: str,
+        turn_index: int,
+        reason: str,
+        append_backup: bool = False,
+    ) -> bool:
+        """Queue one serialized session retain and track append durability.
+
+        Append-capable servers need only the delta after the last confirmed
+        write in the current local buffer epoch. Reservations prevent
+        overlapping jobs from duplicating deltas, while confirmation happens
+        only after ``aretain_batch`` succeeds. ``append_backup`` queues a
+        no-op-or-retry job for finalization paths when an earlier append may
+        still be in flight.
+        """
+        if not turns or self._shutting_down.is_set():
+            return False
+
+        target_count = len(turns)
+        append_epoch = 0
+        if update_mode == "append":
+            with self._append_progress_lock:
+                append_epoch = self._append_epoch
+            enqueued_count = self._append_enqueued_count(document_id, append_epoch)
+            retained_count = self._append_retained_count(document_id, append_epoch)
+            if enqueued_count >= target_count:
+                if not append_backup or retained_count >= target_count:
+                    return False
+            self._reserve_append_turns(document_id, target_count, append_epoch)
+
+        lineage_tags: list[str] = []
+        if session_id:
+            lineage_tags.append(f"session:{session_id}")
+        if parent_session_id:
+            lineage_tags.append(f"parent:{parent_session_id}")
+
+        metadata_base = self._build_metadata(
+            message_count=target_count * 2,
+            turn_index=turn_index,
+        )
+        if session_id:
+            metadata_base["session_id"] = session_id
+        else:
+            metadata_base.pop("session_id", None)
+        bank_id = self._bank_id
+        retain_async_flag = self._retain_async
+        retain_context = self._retain_context
+
+        def _do_retain() -> None:
+            if update_mode == "append":
+                start = self._append_retained_count(document_id, append_epoch)
+                turns_to_retain = turns[start:target_count]
+                if not turns_to_retain:
+                    logger.debug(
+                        "Hindsight %s: append already confirmed for doc=%s",
+                        reason,
+                        document_id,
+                    )
+                    return
+            else:
+                turns_to_retain = turns
+
+            content = "[" + ",".join(turns_to_retain) + "]"
+            metadata = dict(metadata_base)
+            metadata["message_count"] = str(len(turns_to_retain) * 2)
+            item = self._build_retain_kwargs(
+                content,
+                context=retain_context,
+                metadata=metadata,
+                tags=lineage_tags or None,
+            )
+            item.pop("bank_id", None)
+            item.pop("retain_async", None)
+            if update_mode is not None:
+                item["update_mode"] = update_mode
+
+            logger.debug(
+                "Hindsight %s: bank=%s, doc=%s, mode=%s, async=%s, num_turns=%d",
+                reason,
+                bank_id,
+                document_id,
+                update_mode,
+                retain_async_flag,
+                len(turns_to_retain),
+            )
+            try:
+                resp = self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(
+                        bank_id=bank_id,
+                        items=[item],
+                        document_id=document_id,
+                        retain_async=retain_async_flag,
+                    )
+                )
+                if retain_async_flag:
+                    self._track_retain_ops(resp, bank_id)
+            except Exception:
+                if update_mode == "append":
+                    self._release_failed_append_reservation(
+                        document_id, target_count, append_epoch
+                    )
+                raise
+            if update_mode == "append":
+                self._confirm_append_turns(
+                    document_id, target_count, append_epoch
+                )
+
+        try:
+            if not self._ensure_writer():
+                if update_mode == "append":
+                    self._release_failed_append_reservation(
+                        document_id, target_count, append_epoch
+                    )
+                return False
+            self._register_atexit()
+            self._retain_queue.put(_do_retain)
+        except Exception:
+            if update_mode == "append":
+                self._release_failed_append_reservation(
+                    document_id, target_count, append_epoch
+                )
+            raise
+        return True
+
     def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
         """Enqueue a retain for the current turn. Non-blocking.
 
@@ -1867,97 +2062,40 @@ class HindsightMemoryProvider(MemoryProvider):
         further sync_turn() calls are dropped — this prevents post-exit
         retains from reaching aiohttp after interpreter shutdown begins.
         """
-        if not self._auto_retain:
-            logger.debug("sync_turn: skipped (auto_retain disabled)")
-            return
-        if self._shutting_down.is_set():
-            logger.debug("sync_turn: skipped (shutting down)")
-            return
-
-        if session_id:
-            self._session_id = str(session_id).strip()
-
-        turn = json.dumps(self._build_turn_messages(user_content, assistant_content), ensure_ascii=False)
-        self._session_turns.append(turn)
-        self._turn_counter += 1
-        self._turn_index = self._turn_counter
-
-        if self._turn_counter % self._retain_every_n_turns != 0:
-            logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
-                         self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
-            return
-
-        document_id, update_mode = self._resolve_retain_target(self._document_id)
-
-        # On append-capable APIs each retain only needs to ship the turns
-        # accumulated since the last retain — the server appends them to the
-        # existing document. On legacy/overwrite APIs we must resend the whole
-        # session because each retain replaces the document.
-        if update_mode == "append":
-            turns_to_retain = self._session_turns[self._last_retained_turn_count:]
-            if not turns_to_retain:
-                logger.debug("sync_turn: skipped append retain; no new turns since last retain")
+        with self._session_state_lock:
+            if not self._auto_retain:
+                logger.debug("sync_turn: skipped (auto_retain disabled)")
                 return
-        else:
-            turns_to_retain = list(self._session_turns)
+            if self._shutting_down.is_set():
+                logger.debug("sync_turn: skipped (shutting down)")
+                return
 
-        logger.debug("sync_turn: retaining %d/%d turns, payload %d chars",
-                     len(turns_to_retain), len(self._session_turns),
-                     sum(len(t) for t in turns_to_retain))
-        content = "[" + ",".join(turns_to_retain) + "]"
+            if session_id:
+                self._session_id = str(session_id).strip()
 
-        lineage_tags: list[str] = []
-        if self._session_id:
-            lineage_tags.append(f"session:{self._session_id}")
-        if self._parent_session_id:
-            lineage_tags.append(f"parent:{self._parent_session_id}")
-
-        # Snapshot the state needed for the retain. The writer may run after
-        # _session_turns / _turn_index are mutated by a later sync_turn().
-        metadata_snapshot = self._build_metadata(
-            message_count=len(turns_to_retain) * 2,
-            turn_index=self._turn_index,
-        )
-        num_turns = len(turns_to_retain)
-        bank_id = self._bank_id
-        retain_async_flag = self._retain_async
-        retain_context = self._retain_context
-
-        def _do_retain() -> None:
-            item = self._build_retain_kwargs(
-                content,
-                context=retain_context,
-                metadata=metadata_snapshot,
-                tags=lineage_tags or None,
+            turn = json.dumps(
+                self._build_turn_messages(user_content, assistant_content),
+                ensure_ascii=False,
             )
-            item.pop("bank_id", None)
-            item.pop("retain_async", None)
-            if update_mode is not None:
-                item["update_mode"] = update_mode
-            logger.debug("Hindsight retain: bank=%s, doc=%s, mode=%s, async=%s, content_len=%d, num_turns=%d",
-                         bank_id, document_id, update_mode, retain_async_flag, len(content), num_turns)
-            resp = self._run_hindsight_operation(
-                lambda client: client.aretain_batch(
-                    bank_id=bank_id,
-                    items=[item],
-                    document_id=document_id,
-                    retain_async=retain_async_flag,
-                )
-            )
-            # For async retains the write is only *accepted* here; track the
-            # returned operation id(s) so the next-turn prefetch can wait for
-            # true server-side completion (read-after-write) before recalling.
-            if retain_async_flag:
-                self._track_retain_ops(resp, bank_id)
-            logger.debug("Hindsight retain succeeded")
+            self._session_turns.append(turn)
+            self._turn_counter += 1
+            self._turn_index = self._turn_counter
 
-        self._ensure_writer()
-        self._register_atexit()
-        self._retain_queue.put(_do_retain)
-        # Advance the append watermark only after the delta is queued, so a
-        # later retain doesn't re-ship turns we've already handed to the writer.
-        if update_mode == "append":
-            self._last_retained_turn_count = len(self._session_turns)
+            if self._turn_counter % self._retain_every_n_turns != 0:
+                logger.debug("sync_turn: buffered turn %d (will retain at turn %d)",
+                             self._turn_counter, self._turn_counter + (self._retain_every_n_turns - self._turn_counter % self._retain_every_n_turns))
+                return
+
+            document_id, update_mode = self._resolve_retain_target(self._document_id)
+            self._enqueue_session_retain(
+                list(self._session_turns),
+                document_id=document_id,
+                update_mode=update_mode,
+                session_id=self._session_id,
+                parent_session_id=self._parent_session_id,
+                turn_index=self._turn_index,
+                reason="retain",
+            )
 
     def get_tool_schemas(self) -> List[Dict[str, Any]]:
         if self._memory_mode == "context":
@@ -2037,6 +2175,46 @@ class HindsightMemoryProvider(MemoryProvider):
 
         return tool_error(f"Unknown tool: {tool_name}")
 
+    def _finalize_session_buffer(self, *, reason: str) -> None:
+        """Queue the current suffix and start a fresh local append epoch."""
+        if (
+            not self._auto_retain
+            or self._shutting_down.is_set()
+            or not self._session_turns
+        ):
+            return
+
+        document_id, update_mode = self._resolve_retain_target(self._document_id)
+        # Legacy servers overwrite the whole document at each boundary. An
+        # exact-boundary retain is already queued, so only partial batches need
+        # another overwrite. Append mode also needs a backup job: an exact-
+        # boundary append may still be queued and can fail before shutdown.
+        needs_retain = (
+            update_mode == "append"
+            or self._turn_counter % self._retain_every_n_turns != 0
+        )
+        if needs_retain:
+            self._enqueue_session_retain(
+                list(self._session_turns),
+                document_id=document_id,
+                update_mode=update_mode,
+                session_id=self._session_id,
+                parent_session_id=self._parent_session_id,
+                turn_index=self._turn_index,
+                reason=reason,
+                append_backup=update_mode == "append",
+            )
+        with self._append_progress_lock:
+            self._append_epoch += 1
+        self._session_turns = []
+        self._turn_counter = 0
+        self._turn_index = 0
+
+    def on_session_end(self, messages: list, **kwargs) -> None:
+        """Flush turns left below the retain boundary before provider shutdown."""
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-end")
+
     def on_session_switch(
         self,
         new_session_id: str,
@@ -2080,97 +2258,37 @@ class HindsightMemoryProvider(MemoryProvider):
         if not new_id:
             return
 
-        # 1. Flush any buffered turns under the OLD identifiers. Snapshot
-        # everything before mutating self._* so metadata + tags + doc_id
-        # all reference the old session consistently.
-        if self._session_turns:
-            old_turns = list(self._session_turns)
-            old_session_id = self._session_id
-            old_parent_session_id = self._parent_session_id
-            old_turn_index = self._turn_index
-            old_metadata = self._build_metadata(
-                message_count=len(old_turns) * 2,
-                turn_index=old_turn_index,
-            )
-            old_lineage_tags: list[str] = []
-            if old_session_id:
-                old_lineage_tags.append(f"session:{old_session_id}")
-            if old_parent_session_id:
-                old_lineage_tags.append(f"parent:{old_parent_session_id}")
-            old_content = "[" + ",".join(old_turns) + "]"
-            # Resolve doc_id + update_mode against the OLD session BEFORE
-            # we rotate _session_id, so the flush lands in the old
-            # session's document either way (legacy: per-process unique;
-            # ≥0.5.0: stable session-scoped + append).
-            old_document_id, old_update_mode = self._resolve_retain_target(
-                self._document_id
-            )
-
-            def _flush():
-                try:
-                    item = self._build_retain_kwargs(
-                        old_content,
-                        context=self._retain_context,
-                        metadata=old_metadata,
-                        tags=old_lineage_tags or None,
-                    )
-                    item.pop("bank_id", None)
-                    item.pop("retain_async", None)
-                    if old_update_mode is not None:
-                        item["update_mode"] = old_update_mode
-                    logger.debug(
-                        "Hindsight flush-on-switch: bank=%s, doc=%s, mode=%s, num_turns=%d",
-                        self._bank_id, old_document_id, old_update_mode, len(old_turns),
-                    )
-                    self._run_hindsight_operation(
-                        lambda client: client.aretain_batch(
-                            bank_id=self._bank_id,
-                            items=[item],
-                            document_id=old_document_id,
-                            retain_async=self._retain_async,
-                        )
-                    )
-                except Exception as e:
-                    logger.warning("Hindsight flush-on-switch failed: %s", e, exc_info=True)
-
-            # Route the flush through the same writer queue sync_turn
-            # uses. That serializes it behind any still-queued retains
-            # from the old session (FIFO by document_id), avoids racing
-            # two threads on aretain_batch against the same document, and
-            # keeps shutdown's drain semantics intact. Skip enqueue if
-            # shutdown has already fired — the writer is draining/gone.
-            if not self._shutting_down.is_set():
-                self._ensure_writer()
-                self._register_atexit()
-                self._retain_queue.put(_flush)
-
-        # 2. Drain any in-flight prefetch from the old session and drop
+        # 1. Drain any in-flight prefetch from the old session and drop
         # its cached result so the new session doesn't see stale recall.
         if self._prefetch_thread and self._prefetch_thread.is_alive():
             self._prefetch_thread.join(timeout=3.0)
         with self._prefetch_lock:
             self._prefetch_result = ""
 
-        # 3. Now rotate to the new session.
-        if parent_session_id:
-            self._parent_session_id = str(parent_session_id).strip()
-        self._session_id = new_id
-        start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
-        self._document_id = f"{self._session_id}-{start_ts}"
-        self._session_turns = []
-        self._turn_counter = 0
-        self._turn_index = 0
-        self._last_retained_turn_count = 0
-        logger.debug(
-            "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
-            self._session_id, self._parent_session_id, reset, self._document_id,
-        )
+        # 2. Flush and rotate atomically with sync_turn(). Stable Hindsight
+        # document IDs may be revisited (A -> B -> A) or unchanged by an
+        # in-place reset, so each newly empty local buffer needs a fresh epoch.
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-switch")
+            if parent_session_id:
+                self._parent_session_id = str(parent_session_id).strip()
+            self._session_id = new_id
+            start_ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+            self._document_id = f"{self._session_id}-{start_ts}"
+            logger.debug(
+                "Hindsight on_session_switch: new_session=%s parent=%s reset=%s doc=%s",
+                self._session_id, self._parent_session_id, reset, self._document_id,
+            )
 
     def shutdown(self) -> None:
         logger.debug("Hindsight shutdown: stopping writer + waiting for background threads")
-        # Stop accepting new retain jobs first so anyone still calling
-        # sync_turn() during teardown is dropped, not enqueued.
-        self._shutting_down.set()
+        # MemoryManager drains its FIFO before calling provider shutdown. Flush
+        # once more here because a queued sync_turn may have arrived after the
+        # earlier on_session_end hook. Setting the event under the same lock
+        # prevents a new turn from appearing between finalization and teardown.
+        with self._session_state_lock:
+            self._finalize_session_buffer(reason="flush-on-shutdown")
+            self._shutting_down.set()
         # Drain the writer: it will finish in-flight work, then exit on
         # the sentinel. Bounded join keeps shutdown predictable even if
         # the daemon is wedged.

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -166,6 +166,13 @@ def _make_hindsight_provider():
     provider._session_turns = ["turn-1", "turn-2"]
     provider._turn_counter = 2
     provider._turn_index = 2
+    provider._auto_retain = True
+    provider._retain_every_n_turns = 3
+    provider._session_state_lock = threading.RLock()
+    provider._append_progress_lock = threading.Lock()
+    provider._append_epoch = 0
+    provider._append_enqueued_turn_counts = {}
+    provider._append_retained_turn_counts = {}
     # Attrs read by _build_metadata / _build_retain_kwargs when the
     # buffer-flush path on session switch fires. Empty strings keep the
     # metadata minimal but well-formed.
@@ -198,7 +205,7 @@ def _make_hindsight_provider():
     provider._retain_queue = _queue.Queue()
     provider._shutting_down = threading.Event()
     provider._atexit_registered = True
-    provider._ensure_writer = lambda: None
+    provider._ensure_writer = lambda: True
     provider._register_atexit = lambda: None
     # Mode + API state used by _resolve_retain_target; stub the resolver
     # so tests don't actually probe the API. Real probe behavior is

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1014,6 +1014,144 @@ class TestShutdownRace:
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
 
+    def test_shutdown_flushes_turn_queued_after_session_end(self, provider_with_config):
+        """Provider shutdown catches manager turns drained after on_session_end."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.on_session_end([])
+        p.sync_turn("late-user", "late-asst")
+
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        item = client.aretain_batch.call_args.kwargs["items"][0]
+        assert "late-user" in item["content"]
+        assert p._session_turns == []
+
+    def test_shutdown_flushes_exact_boundary_in_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """A late exact-boundary turn is not hidden by the prior epoch watermark."""
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+        client = p._client
+        monkeypatch.setattr(
+            p,
+            "_resolve_retain_target",
+            lambda document_id: ("test-session", "append"),
+        )
+        p.sync_turn("first-user", "first-asst")
+        p._retain_queue.join()
+        p.on_session_end([])
+        p.sync_turn("late-user", "late-asst")
+
+        p.shutdown()
+
+        assert client.aretain_batch.call_count == 2
+        calls = client.aretain_batch.call_args_list
+        assert "first-user" in calls[0].kwargs["items"][0]["content"]
+        assert "late-user" in calls[1].kwargs["items"][0]["content"]
+        assert p._session_turns == []
+
+    def test_manager_shutdown_flushes_sync_turn_drained_after_session_end(
+        self, provider_with_config
+    ):
+        """The manager's FIFO drain cannot strand a post-finalize provider turn."""
+        from threading import Event
+
+        from agent.memory_manager import MemoryManager
+
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        original_sync_turn = p.sync_turn
+        entered = Event()
+        release = Event()
+
+        def _delayed_sync_turn(*args, **kwargs):
+            entered.set()
+            assert release.wait(timeout=5)
+            original_sync_turn(*args, **kwargs)
+
+        p.sync_turn = _delayed_sync_turn
+        manager = MemoryManager()
+        manager.add_provider(p)
+        manager.sync_all("late-user", "late-asst", session_id="test-session")
+        assert entered.wait(timeout=5)
+
+        manager.on_session_end([])
+        release.set()
+        manager.shutdown_all()
+
+        client.aretain_batch.assert_called_once()
+        item = client.aretain_batch.call_args.kwargs["items"][0]
+        assert "late-user" in item["content"]
+        assert p._session_turns == []
+
+    def test_concurrent_first_writer_start_creates_one_thread(self, provider, monkeypatch):
+        """Concurrent first enqueues cannot create competing queue consumers."""
+        import threading as _threading
+
+        original_thread = _threading.Thread
+        created = []
+        start_barrier = _threading.Barrier(3)
+        results = []
+
+        def _start_writer():
+            start_barrier.wait(timeout=5)
+            results.append(provider._ensure_writer())
+
+        workers = [original_thread(target=_start_writer) for _ in range(2)]
+
+        def _counting_thread(*args, **kwargs):
+            thread = original_thread(*args, **kwargs)
+            created.append(thread)
+            return thread
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread",
+            _counting_thread,
+        )
+        for worker in workers:
+            worker.start()
+        start_barrier.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=5)
+
+        assert results == [True, True]
+        assert len(created) == 1
+        assert provider._writer_thread is created[0]
+        provider.shutdown()
+
+    def test_session_end_flushes_buffered_partial_retain_batch(self, provider_with_config):
+        """Session finalization must persist a partial retain_every_n buffer."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.sync_turn("last-user", "last-asst")
+        assert p._sync_thread is None
+        client.aretain_batch.assert_not_called()
+
+        p.on_session_end([{"role": "user", "content": "last-user"}])
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        kw = client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == p._document_id
+        assert kw["retain_async"] is False
+        item = kw["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: last-user"
+        assert content[0][1]["content"] == "Assistant: last-asst"
+        assert "session:test-session" in item["tags"]
+        assert item["metadata"]["session_id"] == "test-session"
+        assert item["metadata"]["message_count"] == "2"
+        assert item["metadata"]["turn_index"] == "1"
+
+    def test_shutdown_is_idempotent(self, provider):
+        provider.sync_turn("a", "b")
+        provider.shutdown()
+        # Second shutdown shouldn't blow up or re-close the client.
+        provider.shutdown()
+        assert provider._shutting_down.is_set()
 
 # ---------------------------------------------------------------------------
 # on_session_switch — flush + prefetch reset behavior
@@ -1188,6 +1326,299 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_modern_api_append_retries_failed_boundary_on_next_retain(
+        self, provider_with_config, monkeypatch
+    ):
+        """A failed append retain must not advance confirmed progress."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        for idx in range(4, 7):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 6
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn6-user"
+
+    def test_modern_api_append_failure_during_immediate_drain_rolls_back_reservation(
+        self, provider_with_config, monkeypatch
+    ):
+        """Queued progress must be reserved before an eager writer runs the job."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+        p._client.aretain_batch.side_effect = RuntimeError("network error")
+        p._ensure_writer = lambda: True
+
+        class _ImmediateQueue:
+            def put(self, job):
+                try:
+                    job()
+                except RuntimeError:
+                    pass
+
+            def join(self):
+                pass
+
+        p._retain_queue = _ImmediateQueue()
+        p.sync_turn("turn1-user", "turn1-asst")
+
+        assert p._append_enqueued_count("test-session") == 0
+        assert p._append_retained_count("test-session") == 0
+
+    def test_modern_api_session_end_retries_failed_exact_boundary_append(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization retries an exact-boundary append that failed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        assert p._client.aretain_batch.call_count == 1
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_retries_in_flight_boundary_failure(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization queues a retry behind an append that is still in flight."""
+        import threading
+
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        started = threading.Event()
+        release = threading.Event()
+        attempts = 0
+
+        async def _retain(**kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                started.set()
+                release.wait(timeout=5.0)
+                raise RuntimeError("network error")
+
+        p._client.aretain_batch = AsyncMock(side_effect=_retain)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        assert started.wait(timeout=5.0)
+
+        p.on_session_end([])
+        release.set()
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_skips_confirmed_exact_boundary(
+        self, provider_with_config, monkeypatch
+    ):
+        """A successful exact-boundary append is not duplicated at finalization."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_not_called()
+
+    def test_modern_api_session_end_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Final partial flush appends only turns not confirmed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert content[0][1]["content"] == "Assistant: turn4-asst"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_session_switch_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Session-switch append flush does not duplicate earlier boundaries."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_same_id_switch_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """A same-ID buffer reset must not reuse the prior append watermark."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+
+        p.sync_turn("before-rewind", "before-asst")
+        p._retain_queue.join()
+        p.on_session_switch("test-session")
+        p.sync_turn("after-rewind", "after-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        content = json.loads(kw["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: after-rewind"
+
+    def test_modern_api_revisited_session_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """Returning A -> B -> A must retain A's new local-buffer epoch."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        p.sync_turn("first-a", "first-a-asst")
+        p.on_session_switch("session-b", parent_session_id="test-session")
+        p.sync_turn("only-b", "only-b-asst")
+        p.on_session_switch("test-session", parent_session_id="session-b")
+        p.sync_turn("second-a", "second-a-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 3
+        calls = p._client.aretain_batch.call_args_list
+        assert [call.kwargs["document_id"] for call in calls] == [
+            "test-session",
+            "session-b",
+            "test-session",
+        ]
+        content = json.loads(calls[-1].kwargs["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: second-a"
+
+    def test_capability_cached_per_url(self, provider, monkeypatch):
+        """The /version probe must run at most once per (process, api_url)."""
+        self._clear_capability_cache()
+        calls = {"n": 0}
+
+        def _spy(*a, **kw):
+            calls["n"] += 1
+            return "0.5.6"
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version", _spy
+        )
+        provider.sync_turn("a", "b")
+        provider._retain_queue.join()
+        provider.sync_turn("c", "d")
+        provider._retain_queue.join()
+        assert calls["n"] == 1
+
+    def test_legacy_warning_emitted_once(self, provider, monkeypatch, caplog):
+        """One-time WARN nudges users to upgrade Hindsight."""
+        import logging
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.4.22",
+        )
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            provider.sync_turn("a", "b")
+            provider._retain_queue.join()
+            provider.sync_turn("c", "d")
+            provider._retain_queue.join()
+        warns = [r for r in caplog.records
+                 if r.levelno == logging.WARNING
+                 and "older than 0.5.0" in r.getMessage()]
+        # Cache hit on the second call → no second warn.
+        assert len(warns) == 1
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -826,6 +826,144 @@ class TestShutdownRace:
         assert client.aretain_batch.call_count == 2
         assert provider._retain_queue.empty()
 
+    def test_shutdown_flushes_turn_queued_after_session_end(self, provider_with_config):
+        """Provider shutdown catches manager turns drained after on_session_end."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.on_session_end([])
+        p.sync_turn("late-user", "late-asst")
+
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        item = client.aretain_batch.call_args.kwargs["items"][0]
+        assert "late-user" in item["content"]
+        assert p._session_turns == []
+
+    def test_shutdown_flushes_exact_boundary_in_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """A late exact-boundary turn is not hidden by the prior epoch watermark."""
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+        client = p._client
+        monkeypatch.setattr(
+            p,
+            "_resolve_retain_target",
+            lambda document_id: ("test-session", "append"),
+        )
+        p.sync_turn("first-user", "first-asst")
+        p._retain_queue.join()
+        p.on_session_end([])
+        p.sync_turn("late-user", "late-asst")
+
+        p.shutdown()
+
+        assert client.aretain_batch.call_count == 2
+        calls = client.aretain_batch.call_args_list
+        assert "first-user" in calls[0].kwargs["items"][0]["content"]
+        assert "late-user" in calls[1].kwargs["items"][0]["content"]
+        assert p._session_turns == []
+
+    def test_manager_shutdown_flushes_sync_turn_drained_after_session_end(
+        self, provider_with_config
+    ):
+        """The manager's FIFO drain cannot strand a post-finalize provider turn."""
+        from threading import Event
+
+        from agent.memory_manager import MemoryManager
+
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        original_sync_turn = p.sync_turn
+        entered = Event()
+        release = Event()
+
+        def _delayed_sync_turn(*args, **kwargs):
+            entered.set()
+            assert release.wait(timeout=5)
+            original_sync_turn(*args, **kwargs)
+
+        p.sync_turn = _delayed_sync_turn
+        manager = MemoryManager()
+        manager.add_provider(p)
+        manager.sync_all("late-user", "late-asst", session_id="test-session")
+        assert entered.wait(timeout=5)
+
+        manager.on_session_end([])
+        release.set()
+        manager.shutdown_all()
+
+        client.aretain_batch.assert_called_once()
+        item = client.aretain_batch.call_args.kwargs["items"][0]
+        assert "late-user" in item["content"]
+        assert p._session_turns == []
+
+    def test_concurrent_first_writer_start_creates_one_thread(self, provider, monkeypatch):
+        """Concurrent first enqueues cannot create competing queue consumers."""
+        import threading as _threading
+
+        original_thread = _threading.Thread
+        created = []
+        start_barrier = _threading.Barrier(3)
+        results = []
+
+        def _start_writer():
+            start_barrier.wait(timeout=5)
+            results.append(provider._ensure_writer())
+
+        workers = [original_thread(target=_start_writer) for _ in range(2)]
+
+        def _counting_thread(*args, **kwargs):
+            thread = original_thread(*args, **kwargs)
+            created.append(thread)
+            return thread
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.threading.Thread",
+            _counting_thread,
+        )
+        for worker in workers:
+            worker.start()
+        start_barrier.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=5)
+
+        assert results == [True, True]
+        assert len(created) == 1
+        assert provider._writer_thread is created[0]
+        provider.shutdown()
+
+    def test_session_end_flushes_buffered_partial_retain_batch(self, provider_with_config):
+        """Session finalization must persist a partial retain_every_n buffer."""
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        client = p._client
+        p.sync_turn("last-user", "last-asst")
+        assert p._sync_thread is None
+        client.aretain_batch.assert_not_called()
+
+        p.on_session_end([{"role": "user", "content": "last-user"}])
+        p.shutdown()
+
+        client.aretain_batch.assert_called_once()
+        kw = client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == p._document_id
+        assert kw["retain_async"] is False
+        item = kw["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: last-user"
+        assert content[0][1]["content"] == "Assistant: last-asst"
+        assert "session:test-session" in item["tags"]
+        assert item["metadata"]["session_id"] == "test-session"
+        assert item["metadata"]["message_count"] == "2"
+        assert item["metadata"]["turn_index"] == "1"
+
+    def test_shutdown_is_idempotent(self, provider):
+        provider.sync_turn("a", "b")
+        provider.shutdown()
+        # Second shutdown shouldn't blow up or re-close the client.
+        provider.shutdown()
+        assert provider._shutting_down.is_set()
 
 # ---------------------------------------------------------------------------
 # on_session_switch — flush + prefetch reset behavior
@@ -1000,6 +1138,299 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_modern_api_append_retries_failed_boundary_on_next_retain(
+        self, provider_with_config, monkeypatch
+    ):
+        """A failed append retain must not advance confirmed progress."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        for idx in range(4, 7):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 6
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn6-user"
+
+    def test_modern_api_append_failure_during_immediate_drain_rolls_back_reservation(
+        self, provider_with_config, monkeypatch
+    ):
+        """Queued progress must be reserved before an eager writer runs the job."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+        p._client.aretain_batch.side_effect = RuntimeError("network error")
+        p._ensure_writer = lambda: True
+
+        class _ImmediateQueue:
+            def put(self, job):
+                try:
+                    job()
+                except RuntimeError:
+                    pass
+
+            def join(self):
+                pass
+
+        p._retain_queue = _ImmediateQueue()
+        p.sync_turn("turn1-user", "turn1-asst")
+
+        assert p._append_enqueued_count("test-session") == 0
+        assert p._append_retained_count("test-session") == 0
+
+    def test_modern_api_session_end_retries_failed_exact_boundary_append(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization retries an exact-boundary append that failed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        p._client.aretain_batch.side_effect = [RuntimeError("network error"), None]
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        assert p._client.aretain_batch.call_count == 1
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_retries_in_flight_boundary_failure(
+        self, provider_with_config, monkeypatch
+    ):
+        """Finalization queues a retry behind an append that is still in flight."""
+        import threading
+
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        started = threading.Event()
+        release = threading.Event()
+        attempts = 0
+
+        async def _retain(**kwargs):
+            nonlocal attempts
+            attempts += 1
+            if attempts == 1:
+                started.set()
+                release.wait(timeout=5.0)
+                raise RuntimeError("network error")
+
+        p._client.aretain_batch = AsyncMock(side_effect=_retain)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        assert started.wait(timeout=5.0)
+
+        p.on_session_end([])
+        release.set()
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        content = json.loads(item["content"])
+        assert len(content) == 3
+        assert content[0][0]["content"] == "User: turn1-user"
+        assert content[-1][0]["content"] == "User: turn3-user"
+
+    def test_modern_api_session_end_skips_confirmed_exact_boundary(
+        self, provider_with_config, monkeypatch
+    ):
+        """A successful exact-boundary append is not duplicated at finalization."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        p._client.aretain_batch.assert_not_called()
+
+    def test_modern_api_session_end_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Final partial flush appends only turns not confirmed earlier."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert content[0][1]["content"] == "Assistant: turn4-asst"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_session_switch_flushes_only_append_remainder(
+        self, provider_with_config, monkeypatch
+    ):
+        """Session-switch append flush does not duplicate earlier boundaries."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        for idx in range(1, 4):
+            p.sync_turn(f"turn{idx}-user", f"turn{idx}-asst")
+        p._retain_queue.join()
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn4-user", "turn4-asst")
+        p.on_session_switch("new-sid", parent_session_id="test-session", reset=True)
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        item = kw["items"][0]
+        assert item["update_mode"] == "append"
+        content = json.loads(item["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: turn4-user"
+        assert "turn1-user" not in item["content"]
+
+    def test_modern_api_same_id_switch_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """A same-ID buffer reset must not reuse the prior append watermark."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=1, retain_async=False)
+
+        p.sync_turn("before-rewind", "before-asst")
+        p._retain_queue.join()
+        p.on_session_switch("test-session")
+        p.sync_turn("after-rewind", "after-asst")
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 2
+        kw = p._client.aretain_batch.call_args.kwargs
+        assert kw["document_id"] == "test-session"
+        content = json.loads(kw["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: after-rewind"
+
+    def test_modern_api_revisited_session_starts_new_append_epoch(
+        self, provider_with_config, monkeypatch
+    ):
+        """Returning A -> B -> A must retain A's new local-buffer epoch."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=3, retain_async=False)
+
+        p.sync_turn("first-a", "first-a-asst")
+        p.on_session_switch("session-b", parent_session_id="test-session")
+        p.sync_turn("only-b", "only-b-asst")
+        p.on_session_switch("test-session", parent_session_id="session-b")
+        p.sync_turn("second-a", "second-a-asst")
+        p.on_session_end([])
+        p._retain_queue.join()
+
+        assert p._client.aretain_batch.call_count == 3
+        calls = p._client.aretain_batch.call_args_list
+        assert [call.kwargs["document_id"] for call in calls] == [
+            "test-session",
+            "session-b",
+            "test-session",
+        ]
+        content = json.loads(calls[-1].kwargs["items"][0]["content"])
+        assert len(content) == 1
+        assert content[0][0]["content"] == "User: second-a"
+
+    def test_capability_cached_per_url(self, provider, monkeypatch):
+        """The /version probe must run at most once per (process, api_url)."""
+        self._clear_capability_cache()
+        calls = {"n": 0}
+
+        def _spy(*a, **kw):
+            calls["n"] += 1
+            return "0.5.6"
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version", _spy
+        )
+        provider.sync_turn("a", "b")
+        provider._retain_queue.join()
+        provider.sync_turn("c", "d")
+        provider._retain_queue.join()
+        assert calls["n"] == 1
+
+    def test_legacy_warning_emitted_once(self, provider, monkeypatch, caplog):
+        """One-time WARN nudges users to upgrade Hindsight."""
+        import logging
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.4.22",
+        )
+        with caplog.at_level(logging.WARNING, logger="plugins.memory.hindsight"):
+            provider.sync_turn("a", "b")
+            provider._retain_queue.join()
+            provider.sync_turn("c", "d")
+            provider._retain_queue.join()
+        warns = [r for r in caplog.records
+                 if r.levelno == logging.WARNING
+                 and "older than 0.5.0" in r.getMessage()]
+        # Cache hit on the second call → no second warn.
+        assert len(warns) == 1
 
     def test_session_switch_flush_picks_capability_against_old_session(
         self, provider_with_config, monkeypatch


### PR DESCRIPTION
## Summary

Rebuilds the surviving Hindsight durability fix from current `main` and narrows the old PR #34859 from 8 files to the provider and focused lifecycle tests only.

- flushes a final partial `retain_every_n_turns` batch at session end;
- performs a second provider-side finalization after `MemoryManager` drains queued `sync_turn` work during shutdown;
- tracks append progress as **confirmed** rather than merely queued;
- retries a failed append suffix on the next retain instead of silently skipping it;
- snapshots old session/document lineage before a session switch clears state;
- scopes append progress to a local buffer epoch so resets cannot inherit stale watermarks;
- makes session-buffer finalization atomic and serializes lazy writer creation;
- preserves async retain-operation tracking used by next-turn read-after-write waits;
- keeps legacy overwrite-mode behavior unchanged.

## Root cause

The append watermark advanced when work was placed on the writer queue. A failed background retain could therefore make later appends start after data the server never accepted. Separately, session finalization could run before `MemoryManager` drained its queued `sync_turn`; the late terminal suffix was then buffered after `on_session_end()` and never flushed by provider shutdown. Session buffer mutation and lazy writer creation also lacked synchronization around those races.

The provider now reserves an append range when it queues work, advances the confirmed watermark only after the retain succeeds, and releases a failed reservation so a later retain covers the missing suffix. Session finalization and switching run under one state lock, provider shutdown performs a last flush after the manager FIFO drain, and lazy writer creation is serialized.

## Why a replacement PR

#34859 accumulated stale one-shot CLI and agent-lifecycle plumbing while `main` changed those ownership boundaries. This branch is reconstructed from current `main` and intentionally changes only:

- `plugins/memory/hindsight/__init__.py`
- `tests/agent/test_memory_session_switch.py`
- `tests/plugins/memory/test_hindsight_provider.py`

After this PR is open, #34859 can be closed as superseded rather than force-rewriting its old review surface.

Fixes #15497.
Related: #15073.

## Verification

- `scripts/run_tests.sh tests/plugins/memory/ -- -q` → **302 passed**
- focused Hindsight provider file → **74 passed**
- provider + session-switch focused files → **78 passed**
- Ruff on all three changed files → passed
- scoped mypy on the provider and provider-test files → passed
- `scripts/check-windows-footguns.py --all` → passed
- `git diff --check origin/main...HEAD` → passed
- `git merge-tree --write-tree origin/main HEAD` → clean
