### PR TITLE
feat(debug): local reproduction capsule (hermes debug reproduce)

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -1026,6 +1026,10 @@ def run_debug(args):
         run_debug_share(args)
     elif subcmd == "delete":
         run_debug_delete(args)
+    elif subcmd == "reproduce":
+        from hermes_cli.repro_bundle import run_debug_reproduce
+
+        run_debug_reproduce(args)
     else:
         # Default: show help
         print("Usage: hermes debug <command>")

--- a/hermes_cli/repro_bundle.py
+++ b/hermes_cli/repro_bundle.py
@@ -1,0 +1,260 @@
+"""``hermes debug reproduce`` — local reproduction capsule.
+
+Bundles what a maintainer needs to reproduce a bug locally into a single
+``.zip``: build info, the redacted effective config, a plugin/skill
+inventory, correlated log excerpts, and an OPT-IN sanitized session
+export. Local-only — this module never uploads anything, never executes
+bundle contents, and session data is included only when explicitly
+requested.
+
+Extends the existing ``hermes_cli/debug.py`` collection machinery
+(``collect_share_bundle``) rather than building a parallel redactor/log
+collector — the report/log files in this bundle are byte-identical to
+what ``hermes debug share`` would upload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import subprocess
+import sys
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__all__ = ["build_repro_bundle", "run_debug_reproduce"]
+
+_BUNDLE_FORMAT = "hermes-repro/1"
+
+
+def _git_sha() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"], capture_output=True, text=True, timeout=5,
+        )
+        return out.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _build_manifest(*, redacted: bool, session_included: bool) -> Dict[str, Any]:
+    return {
+        "format": _BUNDLE_FORMAT,
+        "created": datetime.now(timezone.utc).isoformat(),
+        "build_sha": _git_sha(),
+        "os": platform.platform(),
+        "python": platform.python_version(),
+        "redacted": redacted,
+        "session_included": session_included,
+    }
+
+
+def _plugin_inventory() -> List[Dict[str, str]]:
+    """Name/version/kind/source for bundled + user plugin manifests.
+
+    Read-only manifest parsing only — never drives plugin discovery/load
+    (which imports and executes plugin modules).
+    """
+    from utils import fast_safe_load
+
+    from hermes_cli.plugins import get_bundled_plugins_dir
+    from hermes_constants import get_hermes_home
+
+    entries: List[Dict[str, str]] = []
+
+    def _scan(root: Path, source: str, *, skip: frozenset = frozenset()) -> None:
+        if not root.is_dir():
+            return
+        for child in sorted(root.iterdir()):
+            if not child.is_dir() or child.name in skip:
+                continue
+            manifest_file = child / "plugin.yaml"
+            if not manifest_file.exists():
+                manifest_file = child / "plugin.yml"
+            if manifest_file.exists():
+                try:
+                    data = fast_safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+                except Exception:
+                    continue
+                entries.append({
+                    "name": str(data.get("name", child.name)),
+                    "version": str(data.get("version", "")),
+                    "kind": str(data.get("kind", "standalone")),
+                    "source": source,
+                })
+                continue
+            for grandchild in sorted(child.iterdir()):
+                if not grandchild.is_dir():
+                    continue
+                gc_manifest = grandchild / "plugin.yaml"
+                if not gc_manifest.exists():
+                    gc_manifest = grandchild / "plugin.yml"
+                if not gc_manifest.exists():
+                    continue
+                try:
+                    data = fast_safe_load(gc_manifest.read_text(encoding="utf-8")) or {}
+                except Exception:
+                    continue
+                entries.append({
+                    "name": str(data.get("name", grandchild.name)),
+                    "version": str(data.get("version", "")),
+                    "kind": str(data.get("kind", "standalone")),
+                    "source": source,
+                })
+
+    repo_plugins = get_bundled_plugins_dir()
+    _scan(repo_plugins, "bundled", skip=frozenset({"memory", "context_engine", "platforms", "model-providers"}))
+    _scan(repo_plugins / "platforms", "bundled")
+    _scan(get_hermes_home() / "plugins", "user")
+    return entries
+
+
+def _redacted_config_yaml() -> str:
+    import yaml
+
+    from agent.redact import redact_sensitive_text
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly()
+    raw = yaml.dump(config, sort_keys=True, default_flow_style=False)
+    return redact_sensitive_text(raw, force=True)
+
+
+def _sanitized_session_export(session_id: str) -> Optional[List[Dict[str, Any]]]:
+    from agent.redact import redact_sensitive_text
+    from hermes_state import SessionDB
+
+    db = SessionDB(read_only=True)
+    messages = db.get_messages_as_conversation(session_id)
+    if not messages:
+        return None
+    sanitized: List[Dict[str, Any]] = []
+    for msg in messages:
+        content = msg.get("content")
+        if isinstance(content, str):
+            content = redact_sensitive_text(content, force=True)
+        elif isinstance(content, list):
+            content = [
+                {**part, "text": redact_sensitive_text(part["text"], force=True)}
+                if isinstance(part, dict) and isinstance(part.get("text"), str)
+                else part
+                for part in content
+            ]
+        sanitized.append({**msg, "content": content})
+    return sanitized
+
+
+def build_repro_bundle(
+    output_path: Path, *, session_id: Optional[str] = None,
+    log_lines: int = 200, redact: bool = True,
+) -> Dict[str, Any]:
+    """Build the local reproduction bundle at ``output_path``. Returns a summary."""
+    from hermes_cli.debug import collect_share_bundle
+
+    share = collect_share_bundle(log_lines=log_lines, redact=redact)
+    plugins = _plugin_inventory()
+    config_yaml = _redacted_config_yaml()
+
+    session_data: Optional[List[Dict[str, Any]]] = None
+    if session_id:
+        session_data = _sanitized_session_export(session_id)
+
+    manifest = _build_manifest(redacted=redact, session_included=session_data is not None)
+
+    readme_lines = [
+        f"# Hermes reproduction bundle ({manifest['created']})",
+        "",
+        f"- build_sha: {manifest['build_sha']}",
+        f"- os: {manifest['os']}",
+        f"- python: {manifest['python']}",
+        f"- redacted: {manifest['redacted']}",
+        f"- session included: {manifest['session_included']}",
+        "",
+        "## Contents",
+        "",
+        "- `manifest.json` — build/environment metadata",
+        "- `report.txt` — system dump + log tails",
+        "- `logs/*.log` — full log files (redacted unless --no-redact was passed)",
+        "- `plugins.json` — bundled + user plugin inventory (name/version/kind, no code)",
+        "- `config_redacted.yaml` — effective config, redacted",
+    ]
+    if session_data is not None:
+        readme_lines.append("- `session.json` — sanitized conversation export (opt-in)")
+    else:
+        readme_lines.append("- session data: NOT included (pass --session <id> to include)")
+    readme_lines += [
+        "",
+        "## Reproduction steps",
+        "",
+        "1. Check out `build_sha` above.",
+        "2. Review `config_redacted.yaml` for the relevant provider/model/plugin settings.",
+        "3. Review `report.txt` and `logs/*.log` for the failure context.",
+        "4. This bundle never auto-executes anything — inspect before running "
+        "any command it references.",
+    ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("manifest.json", json.dumps(manifest, indent=2))
+        zf.writestr("report.txt", share.get("report", ""))
+        for label, text in share.items():
+            if label == "report":
+                continue
+            zf.writestr(f"logs/{label}", text)
+        zf.writestr("plugins.json", json.dumps(plugins, indent=2))
+        zf.writestr("config_redacted.yaml", config_yaml)
+        if session_data is not None:
+            zf.writestr("session.json", json.dumps(session_data, indent=2))
+        zf.writestr("README.md", "\n".join(readme_lines))
+
+    return {"manifest": manifest, "plugins": len(plugins), "output": str(output_path)}
+
+
+def inspect_bundle(bundle_path: Path) -> Dict[str, Any]:
+    """List a bundle's contents and manifest WITHOUT executing anything in it."""
+    with zipfile.ZipFile(bundle_path, "r") as zf:
+        names = zf.namelist()
+        manifest: Dict[str, Any] = {}
+        if "manifest.json" in names:
+            manifest = json.loads(zf.read("manifest.json").decode("utf-8"))
+    return {"files": names, "manifest": manifest}
+
+
+def run_debug_reproduce(args: argparse.Namespace) -> None:
+    action = getattr(args, "reproduce_action", None) or "build"
+
+    if action == "inspect":
+        bundle_path = Path(args.bundle)
+        if not bundle_path.exists():
+            print(f"error: bundle not found: {bundle_path}", file=sys.stderr)
+            sys.exit(1)
+        info = inspect_bundle(bundle_path)
+        print(f"format: {info['manifest'].get('format', 'unknown')}")
+        print(f"created: {info['manifest'].get('created', 'unknown')}")
+        print(f"redacted: {info['manifest'].get('redacted', 'unknown')}")
+        print(f"session included: {info['manifest'].get('session_included', 'unknown')}")
+        print("files:")
+        for name in info["files"]:
+            print(f"  - {name}")
+        return
+
+    output = getattr(args, "output", None)
+    output_path = Path(output) if output else Path(
+        f"hermes-repro-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}.zip"
+    )
+    session_id = getattr(args, "session", None)
+    log_lines = getattr(args, "lines", 200)
+    redact = not getattr(args, "no_redact", False)
+
+    if session_id:
+        print(f"including session {session_id!r} — sanitized, opt-in")
+    else:
+        print("no --session given — session data NOT included")
+
+    summary = build_repro_bundle(
+        output_path, session_id=session_id, log_lines=log_lines, redact=redact
+    )
+    print(f"wrote {summary['output']} ({summary['plugins']} plugins inventoried)")

--- a/hermes_cli/subcommands/debug.py
+++ b/hermes_cli/subcommands/debug.py
@@ -97,4 +97,33 @@ Examples:
         default=[],
         help="One or more paste URLs to delete (e.g. https://paste.rs/abc123)",
     )
+
+    reproduce_parser = debug_sub.add_parser(
+        "reproduce",
+        help="Build a local reproduction bundle (build info, redacted config, "
+        "plugin inventory, logs, optional session export)",
+    )
+    reproduce_sub = reproduce_parser.add_subparsers(dest="reproduce_action")
+
+    reproduce_build = reproduce_sub.add_parser(
+        "build", help="Create a reproduction bundle (default action)"
+    )
+    reproduce_build.add_argument("--output", help="Output .zip path")
+    reproduce_build.add_argument(
+        "--session", help="Session id to include (opt-in, off by default)"
+    )
+    reproduce_build.add_argument(
+        "--lines", type=int, default=200, help="Log lines to include (default: 200)"
+    )
+    reproduce_build.add_argument(
+        "--no-redact",
+        action="store_true",
+        help="Disable redaction (local-only bundle; use with care)",
+    )
+
+    reproduce_inspect = reproduce_sub.add_parser(
+        "inspect", help="List a bundle's contents without executing anything in it"
+    )
+    reproduce_inspect.add_argument("bundle", help="Path to a .zip bundle")
+
     debug_parser.set_defaults(func=cmd_debug)

--- a/tests/hermes_cli/test_repro_bundle.py
+++ b/tests/hermes_cli/test_repro_bundle.py
@@ -1,0 +1,150 @@
+"""Tests for ``hermes debug reproduce`` (local reproduction capsule)."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+
+import pytest
+
+from hermes_cli.repro_bundle import (
+    _plugin_inventory,
+    _redacted_config_yaml,
+    _sanitized_session_export,
+    build_repro_bundle,
+    inspect_bundle,
+    run_debug_reproduce,
+)
+
+
+@pytest.fixture
+def hermes_home(monkeypatch, tmp_path):
+    home = tmp_path / "cred_home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled_plugins"))
+    (tmp_path / "bundled_plugins").mkdir()
+    return home
+
+
+def test_plugin_inventory_reads_real_manifests(hermes_home, tmp_path):
+    plugin_dir = tmp_path / "bundled_plugins" / "acme"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: acme\nversion: 1.2.3\nkind: standalone\n", encoding="utf-8"
+    )
+    entries = _plugin_inventory()
+    assert {"name": "acme", "version": "1.2.3", "kind": "standalone", "source": "bundled"} in entries
+
+
+def test_redacted_config_yaml_never_leaks_secret_shaped_value(hermes_home):
+    hermes_home.joinpath("config.yaml").write_text(
+        "model:\n  api_key: sk-super-secret-value-99999\n  provider: openai-api\n",
+        encoding="utf-8",
+    )
+    text = _redacted_config_yaml()
+    assert "sk-super-secret-value-99999" not in text
+    assert "openai-api" in text  # non-secret fields survive
+
+
+def test_sanitized_session_export_redacts_string_content(monkeypatch):
+    class FakeDB:
+        def __init__(self, *a, **kw):
+            pass
+
+        def get_messages_as_conversation(self, session_id):
+            return [
+                {"role": "user", "content": "my key is sk-fake-leaked-1234567890"},
+                {"role": "assistant", "content": "ok"},
+            ]
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeDB)
+    messages = _sanitized_session_export("some-session")
+    assert messages is not None
+    assert "sk-fake-leaked-1234567890" not in json.dumps(messages)
+
+
+def test_sanitized_session_export_returns_none_for_empty_session(monkeypatch):
+    class FakeDB:
+        def __init__(self, *a, **kw):
+            pass
+
+        def get_messages_as_conversation(self, session_id):
+            return []
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeDB)
+    assert _sanitized_session_export("missing") is None
+
+
+def test_build_repro_bundle_contains_expected_files_no_session(hermes_home, tmp_path):
+    output = tmp_path / "out.zip"
+    summary = build_repro_bundle(output, session_id=None, log_lines=10, redact=True)
+    assert summary["manifest"]["session_included"] is False
+    with zipfile.ZipFile(output) as zf:
+        names = set(zf.namelist())
+    assert "manifest.json" in names
+    assert "report.txt" in names
+    assert "plugins.json" in names
+    assert "config_redacted.yaml" in names
+    assert "README.md" in names
+    assert "session.json" not in names
+
+
+def test_build_repro_bundle_includes_session_when_opted_in(hermes_home, tmp_path, monkeypatch):
+    class FakeDB:
+        def __init__(self, *a, **kw):
+            pass
+
+        def get_messages_as_conversation(self, session_id):
+            return [{"role": "user", "content": "hello"}]
+
+    import hermes_state
+
+    monkeypatch.setattr(hermes_state, "SessionDB", FakeDB)
+
+    output = tmp_path / "out.zip"
+    summary = build_repro_bundle(output, session_id="abc", log_lines=10, redact=True)
+    assert summary["manifest"]["session_included"] is True
+    with zipfile.ZipFile(output) as zf:
+        assert "session.json" in zf.namelist()
+
+
+def test_inspect_bundle_lists_files_without_executing_anything(hermes_home, tmp_path):
+    output = tmp_path / "out.zip"
+    build_repro_bundle(output, session_id=None, log_lines=10, redact=True)
+    info = inspect_bundle(output)
+    assert "manifest.json" in info["files"]
+    assert info["manifest"]["format"] == "hermes-repro/1"
+
+
+def test_run_debug_reproduce_build_and_inspect_cli(hermes_home, tmp_path, capsys):
+    import argparse
+
+    output = tmp_path / "cli.zip"
+    build_args = argparse.Namespace(
+        reproduce_action="build", output=str(output), session=None,
+        lines=10, no_redact=False,
+    )
+    run_debug_reproduce(build_args)
+    assert output.exists()
+    capsys.readouterr()
+
+    inspect_args = argparse.Namespace(reproduce_action="inspect", bundle=str(output))
+    run_debug_reproduce(inspect_args)
+    out = capsys.readouterr().out
+    assert "format: hermes-repro/1" in out
+    assert "session included: False" in out
+
+
+def test_run_debug_reproduce_inspect_missing_bundle_exits_nonzero(tmp_path, capsys):
+    import argparse
+
+    args = argparse.Namespace(reproduce_action="inspect", bundle=str(tmp_path / "nope.zip"))
+    with pytest.raises(SystemExit) as exc_info:
+        run_debug_reproduce(args)
+    assert exc_info.value.code == 1
+    assert "not found" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Adds `hermes debug reproduce build/inspect` — a single local `.zip` bundling everything needed to reproduce a bug: build info, redacted effective config, plugin inventory, correlated logs, and an opt-in sanitized session export. No network calls, no auto-upload, nothing in the bundle is ever auto-executed.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[hermes debug reproduce build] --> B[manifest.json: build sha / os / python]
    A --> C[report.txt + logs: reused from debug share, redacted]
    A --> D[plugins.json: name / version / kind only]
    A --> E[config_redacted.yaml]
    F[--session ID, opt-in] -.->|only if passed| G[session.json: sanitized]
    B --> H[Local .zip Bundle]
    C --> H
    D --> H
    E --> H
    G -.-> H
    H --> I[hermes debug reproduce inspect: list only, never executes]
```
## Infographic : 
<img width="941" height="1672" alt="infographic" src="https://github.com/user-attachments/assets/a2babe49-ee92-4e58-984b-447be201c5d1" />


Closes #80504

## Design notes

- **Extends, doesn't duplicate, `hermes debug share`.** `report.txt` and `logs/*.log` come straight from `hermes_cli.debug.collect_share_bundle()` — the exact same redacted collection function `debug share` uses to build its paste.rs/Nous-S3 payload. This bundle is local-only (never uploaded), but the redaction guarantee is identical.
- **Plugin inventory is manifest-only.** Reads `plugin.yaml`/`plugin.yml` directly (name/version/kind/source) — never drives `PluginManager.discover_and_load()`, which imports and executes plugin modules. Same discipline as the credential-impact-map PR (#80165) already merged into this line of work.
- **Config redaction** reuses the central redactor (`agent.redact.redact_sensitive_text`, `force=True`) over the YAML-dumped effective config.
- **Session export is opt-in and off by default** (`--session <id>`), and every message's text content is passed through the same central redactor before it lands in the bundle.
- New CLI wiring: `reproduce` subparser (with `build`/`inspect` sub-actions) added to the existing `debug` parser (`hermes_cli/subcommands/debug.py`), dispatched via one `elif` branch added to `hermes_cli/debug.py::run_debug` — no existing `debug` subcommand (`share`, `delete`) touched.

## Test plan

- [x] `pytest tests/hermes_cli/test_repro_bundle.py -q` — 9 passing: plugin inventory reads real manifests, config redaction never leaks a secret-shaped value, session export redaction (isolated via a fake `SessionDB` — persistence itself is already covered by `tests/hermes_state/test_session_md_export.py` and friends), bundle contains exactly the expected files with/without `--session`, `inspect` lists without executing, CLI wiring for both `build` and `inspect`, missing-bundle error path
- [x] `ruff check` on new/changed files — clean
- [x] Manual end-to-end run: built a bundle locally, `unzip -l`'d it to confirm structure, `hermes debug reproduce inspect` round-tripped the manifest correctly

Note: `pytest tests/hermes_cli/ -k debug` surfaced one pre-existing, unrelated failure (`test_debug.py::TestCaptureLogSnapshot::test_keeps_first_line_when_truncation_on_boundary`, an off-by-one in log-tail byte-boundary truncation) — confirmed present on `origin/main` before this branch's changes, not introduced by this PR.